### PR TITLE
OspreySharp: Stage 6 protein FDR + LOESS fit cross-impl dumps

### DIFF
--- a/pwiz_tools/OspreySharp/Osprey-workflow.html
+++ b/pwiz_tools/OspreySharp/Osprey-workflow.html
@@ -64,11 +64,12 @@
     on Stellar 1-file AND 3-file (end-of-stage dump: score + pep + 4 q-values
     across 1,388,872 FdrEntry rows at max_diff = 0; multi-file required an
     experiment_precursor_qvalue propagation fix in C#'s Percolator FDR).
-    Stage 6 planning checkpoint is wired (multi-charge consensus, consensus
-    RTs, calibration refit) with cross-impl dumps; counts and structure
-    match Rust exactly, remaining diffs are ULP-level floating-point in
-    sigmoid-weighted median + LOESS residual stats. Green badges =
-    regression tests; purple badges = C#/Rust perf ratio.
+    Stage 6 planning checkpoint is wired with cross-impl dumps. Multi-charge
+    consensus is now bit-identical with Rust on Stellar 3-file (31,270
+    rescore-target rows). Consensus RTs and calibration refit still differ
+    at ULP-level floating-point (counts and structure match exactly; values
+    diverge at the last 1-3 decimals through <code>InversePredict</code>).
+    Green badges = regression tests; purple badges = C#/Rust perf ratio.
   </p>
 </header>
 
@@ -384,13 +385,13 @@
     row level, residual diffs are ULP-level floating-point.
   </text>
 
-  <rect class="st-partial" x="80" y="80" width="1040" height="42" rx="4"/>
+  <rect class="st-done" x="80" y="80" width="1040" height="42" rx="4"/>
   <text class="stage-title" x="600" y="100" text-anchor="middle">Multi-charge consensus</text>
-  <text class="stage-desc"  x="600" y="114" text-anchor="middle">SelectRescoreTargets ported; per-file rescore-target dump emits at ~31K targets matching Rust by entry_id</text>
+  <text class="stage-desc"  x="600" y="114" text-anchor="middle">SelectRescoreTargets ported; rescore-target dump bit-identical with Rust by entry_id (31,270 rows on Stellar 3-file, after first-pass compaction)</text>
 
   <rect class="st-partial" x="80" y="140" width="1040" height="42" rx="4"/>
   <text class="stage-title" x="600" y="160" text-anchor="middle">Cross-run reconciliation</text>
-  <text class="stage-desc"  x="600" y="174" text-anchor="middle">ConsensusRts.Compute + CalibrationRefit.Refit wired; n_runs_detected + n_points byte-identical with Rust; ReconciliationPlanner not yet wired</text>
+  <text class="stage-desc"  x="600" y="174" text-anchor="middle">ConsensusRts.Compute + CalibrationRefit.Refit wired; n_runs_detected + n_points byte-identical; consensus_library_rt + LOESS residuals diverge at ULP through InversePredict; ReconciliationPlanner not yet wired</text>
 
   <rect class="st-missing" x="80" y="200" width="1040" height="42" rx="4"/>
   <text class="stage-title" x="600" y="220" text-anchor="middle">Second-pass re-score + Percolator SVM</text>
@@ -399,8 +400,10 @@
   <path class="flow" d="M 600 122 L 600 138" marker-end="url(#arrow)"/>
   <path class="flow" d="M 600 182 L 600 198" marker-end="url(#arrow)"/>
 
-  <!-- "You are here" callout -->
-  <g transform="translate(820, 75)">
+  <!-- "You are here" callout — pointing at cross-run reconciliation,
+       the active in-progress box (multi-charge consensus shipped
+       bit-identical; second-pass re-score is still missing). -->
+  <g transform="translate(820, 135)">
     <path class="flow-you" d="M 130 20 L 30 20" marker-end="url(#arrow-thick)"/>
     <text class="you-are-here" x="136" y="10">YOU ARE</text>
     <text class="you-are-here" x="136" y="26">HERE</text>
@@ -508,19 +511,22 @@
     early-exits) and a sibling harness
     <code>Compare-Stage6-Planning.ps1</code> byte-compares the four
     dumps (Stage 5 percolator + the three Stage 6 planning dumps).
-    On Stellar 3-file: <strong>1/4 dump pairs byte-identical</strong>
-    (Stage 5 percolator); the three Stage 6 planning dumps agree on
-    row count, sort order, n_runs_detected, n_points, and
-    median_peak_width but diverge at the last 1-3 decimals of
-    sigmoid-weighted-median RTs and LOESS residual stats. Driver
-    branches: <code>maccoss/osprey:feature/stage6-planning-diagnostics</code>
+    On Stellar 3-file: <strong>2/4 dump pairs byte-identical</strong>
+    after first-pass protein FDR + first-pass compaction land on the
+    C# side. Stage 5 percolator and Stage 6 multi-charge consensus
+    pass exactly; consensus RTs and calibration refit agree on counts
+    and structure but diverge at the last 1-3 decimals through
+    <code>InversePredict</code>. Driver branches:
+    <code>maccoss/osprey:feature/stage6-planning-diagnostics</code>
     and <code>ProteoWizard/pwiz:Skyline/work/20260423_osprey_sharp_stage6</code>.
   </p>
   <p>
-    Next targets: investigate sigmoid weighting + LOESS-residual ULP
-    differences (likely <code>Math.Exp</code>/<code>Math.Log</code>
-    vs Rust <code>f64::exp</code>; may need alternative formulations
-    or a small numeric tolerance in the parity gate). Then wire
+    Next targets: bisect the <code>InversePredict</code> ULP source —
+    add a per-detection diagnostic dump (apex_rt, library_rt) on both
+    sides and locate whether divergence is in Parquet f64 decode or
+    inside LOESS interpolation; same fix should close both consensus
+    and refit (the LOESS residual stats just downstream of the same
+    consensus library RTs). Then wire
     <code>ReconciliationPlanner.Plan</code>, gap-fill, and second-pass
     Percolator. Stage 7 protein FDR + Stage 8 .blib output parity
     follow once Stage 6 is fully proven. See

--- a/pwiz_tools/OspreySharp/Osprey-workflow.html
+++ b/pwiz_tools/OspreySharp/Osprey-workflow.html
@@ -65,11 +65,14 @@
     across 1,388,872 FdrEntry rows at max_diff = 0; multi-file required an
     experiment_precursor_qvalue propagation fix in C#'s Percolator FDR).
     Stage 6 planning checkpoint is wired with cross-impl dumps. Multi-charge
-    consensus is now bit-identical with Rust on Stellar 3-file (31,270
-    rescore-target rows). Consensus RTs and calibration refit still differ
-    at ULP-level floating-point (counts and structure match exactly; values
-    diverge at the last 1-3 decimals through <code>InversePredict</code>).
-    Green badges = regression tests; purple badges = C#/Rust perf ratio.
+    consensus is bit-identical with Rust on Stellar 3-file (31,270
+    rescore-target rows). Consensus RTs are now 99.999% bit-identical (1
+    of 87,343 rows differs on a borderline first-pass protein-FDR rescue,
+    not arithmetic) after a Rust serde_json parser fix that routes f64
+    deserialization through <code>f64::from_str</code> instead of the
+    inexact default parser. Calibration refit n_points matches; the
+    refit's LOESS residual stats still diverge at ULP. Green badges =
+    regression tests; purple badges = C#/Rust perf ratio.
   </p>
 </header>
 
@@ -391,7 +394,7 @@
 
   <rect class="st-partial" x="80" y="140" width="1040" height="42" rx="4"/>
   <text class="stage-title" x="600" y="160" text-anchor="middle">Cross-run reconciliation</text>
-  <text class="stage-desc"  x="600" y="174" text-anchor="middle">ConsensusRts.Compute + CalibrationRefit.Refit wired; n_runs_detected + n_points byte-identical; consensus_library_rt + LOESS residuals diverge at ULP through InversePredict; ReconciliationPlanner not yet wired</text>
+  <text class="stage-desc"  x="600" y="174" text-anchor="middle">ConsensusRts.Compute + CalibrationRefit.Refit wired; consensus_library_rt 99.999% bit-identical (1/87343 rows differ on a borderline first-pass-protein-FDR rescue); refit n_points matches but LOESS residual stats off at ULP; ReconciliationPlanner not yet wired</text>
 
   <rect class="st-missing" x="80" y="200" width="1040" height="42" rx="4"/>
   <text class="stage-title" x="600" y="220" text-anchor="middle">Second-pass re-score + Percolator SVM</text>
@@ -511,22 +514,25 @@
     early-exits) and a sibling harness
     <code>Compare-Stage6-Planning.ps1</code> byte-compares the four
     dumps (Stage 5 percolator + the three Stage 6 planning dumps).
-    On Stellar 3-file: <strong>2/4 dump pairs byte-identical</strong>
-    after first-pass protein FDR + first-pass compaction land on the
-    C# side. Stage 5 percolator and Stage 6 multi-charge consensus
-    pass exactly; consensus RTs and calibration refit agree on counts
-    and structure but diverge at the last 1-3 decimals through
-    <code>InversePredict</code>. Driver branches:
+    On Stellar 3-file: stage5_percolator + multicharge + calibration are
+    bit-identical; consensus is 99.999% bit-identical (1/87343 rows on
+    a borderline protein-FDR rescue); inv_predict is 99.99966%
+    (1/292512 rows, same root cause); refit ULP at LOESS-fit residual
+    stats. The InversePredict ULP that previously diverged on every
+    consensus row was traced to <code>serde_json</code>'s default f64
+    parser disagreeing with .NET's correctly-rounded
+    <code>double.Parse</code> on full-precision values; routing Rust
+    f64 array deserialization through <code>f64::from_str</code>
+    closes the arithmetic gap. Driver branches:
     <code>maccoss/osprey:feature/stage6-planning-diagnostics</code>
     and <code>ProteoWizard/pwiz:Skyline/work/20260423_osprey_sharp_stage6</code>.
   </p>
   <p>
-    Next targets: bisect the <code>InversePredict</code> ULP source —
-    add a per-detection diagnostic dump (apex_rt, library_rt) on both
-    sides and locate whether divergence is in Parquet f64 decode or
-    inside LOESS interpolation; same fix should close both consensus
-    and refit (the LOESS residual stats just downstream of the same
-    consensus library RTs). Then wire
+    Next targets: localize the borderline first-pass-protein-FDR rescue
+    that produces the 1-row consensus / inv_predict diff (likely a
+    tie-break in protein-group construction at exactly 1% q-value);
+    bisect the LOESS-fit ULP that affects refit r²/sd/mad
+    (independent of InversePredict). Then wire
     <code>ReconciliationPlanner.Plan</code>, gap-fill, and second-pass
     Percolator. Stage 7 protein FDR + Stage 8 .blib output parity
     follow once Stage 6 is fully proven. See

--- a/pwiz_tools/OspreySharp/Osprey-workflow.html
+++ b/pwiz_tools/OspreySharp/Osprey-workflow.html
@@ -60,9 +60,14 @@
     Top-to-bottom data flow from mzML + spectral library to BiblioSpecLite
     output. Color indicates port status of the OspreySharp (C#) implementation
     against the Osprey (Rust) reference. Stages 1-4 are proven bit-identical
-    on Stellar + Astral (21 PIN features, 317K entries) and Stage 5 is
-    bit-identical on single-file Stellar (end-of-stage dump: score + pep +
-    4 q-values across 462,802 FdrEntry rows at max_diff = 0). Green badges =
+    on Stellar + Astral (21 PIN features, 317K entries). Stage 5 is bit-identical
+    on Stellar 1-file AND 3-file (end-of-stage dump: score + pep + 4 q-values
+    across 1,388,872 FdrEntry rows at max_diff = 0; multi-file required an
+    experiment_precursor_qvalue propagation fix in C#'s Percolator FDR).
+    Stage 6 planning checkpoint is wired (multi-charge consensus, consensus
+    RTs, calibration refit) with cross-impl dumps; counts and structure
+    match Rust exactly, remaining diffs are ULP-level floating-point in
+    sigmoid-weighted median + LOESS residual stats. Green badges =
     regression tests; purple badges = C#/Rust perf ratio.
   </p>
 </header>
@@ -341,7 +346,7 @@
   <text class="phase-label" x="60" y="24">stage 5</text>
   <text class="phase-title" x="60" y="42">First-pass FDR (Percolator SVM)</text>
   <text class="phase-note"  x="60" y="58">Semi-supervised SVM training with target-decoy competition. Produces precursor-level and peptide-level q-values at run and experiment levels.</text>
-  <text class="phase-note"  x="60" y="72">Single-file Stellar: bit-identical cross-impl on score + pep + 4 q-values, max_diff = 0 over 462,802 rows. 3-file validation pending.</text>
+  <text class="phase-note"  x="60" y="72">Stellar 1-file AND 3-file: bit-identical cross-impl on score + pep + 4 q-values, max_diff = 0. Multi-file required experiment_precursor_qvalue propagation by base_id (a2972ab6d).</text>
 
   <!-- Stage 5 perf badge (C# join-only wall clock on single-file Stellar;
        Rust measured 2026-04-22 = 66s at dump-exit point). -->
@@ -375,15 +380,17 @@
   <text class="phase-note"  x="60" y="58">
     Multi-charge consensus + cross-run reconciliation adjust peak boundaries
     across replicates, then re-score at locked boundaries and re-run FDR.
+    Planning checkpoint cross-impl dumps in place; structure matches at the
+    row level, residual diffs are ULP-level floating-point.
   </text>
 
-  <rect class="st-missing" x="80" y="80" width="1040" height="42" rx="4"/>
+  <rect class="st-partial" x="80" y="80" width="1040" height="42" rx="4"/>
   <text class="stage-title" x="600" y="100" text-anchor="middle">Multi-charge consensus</text>
-  <text class="stage-desc"  x="600" y="114" text-anchor="middle">pick a consensus leader among FDR-passing charge states using SVM scores</text>
+  <text class="stage-desc"  x="600" y="114" text-anchor="middle">SelectRescoreTargets ported; per-file rescore-target dump emits at ~31K targets matching Rust by entry_id</text>
 
-  <rect class="st-missing" x="80" y="140" width="1040" height="42" rx="4"/>
+  <rect class="st-partial" x="80" y="140" width="1040" height="42" rx="4"/>
   <text class="stage-title" x="600" y="160" text-anchor="middle">Cross-run reconciliation</text>
-  <text class="stage-desc"  x="600" y="174" text-anchor="middle">establish shared RT boundaries across replicates from the consensus set</text>
+  <text class="stage-desc"  x="600" y="174" text-anchor="middle">ConsensusRts.Compute + CalibrationRefit.Refit wired; n_runs_detected + n_points byte-identical with Rust; ReconciliationPlanner not yet wired</text>
 
   <rect class="st-missing" x="80" y="200" width="1040" height="42" rx="4"/>
   <text class="stage-title" x="600" y="220" text-anchor="middle">Second-pass re-score + Percolator SVM</text>
@@ -484,14 +491,40 @@
     (VERSION + C grid sync with v26.4) and
     <a href="https://github.com/ProteoWizard/pwiz/pull/4160"><code>pwiz#4160</code></a>
     (matching diagnostic dumps + <code>Compare-Percolator.ps1</code>).
-    Multi-file (3-file) Stage 5 validation pending as the first step of
-    Stage 6 work.
+    Multi-file (3-file) Stage 5 cross-impl bit-parity also achieved
+    (2026-04-25): the per-base_id experiment_precursor_qvalue propagation
+    fix in C# (pwiz <code>a2972ab6d</code>) plus the multi-file
+    <code>--input-scores</code> CLI accumulation closes the gap with Rust.
+    1,388,872 row dump byte-identical on Stellar 3-file.
   </p>
   <p>
-    Next targets: Stage 5 multi-file validation (Stellar + Astral 3-file),
-    Stage 6 refinement (multi-charge consensus, cross-run reconciliation,
-    second-pass re-score), Stage 7 protein FDR, Stage 8 .blib output
-    parity. See <code>ai/todos/active/TODO-20260420_osprey_sharp.md</code>.
+    <strong>Stage 6 planning checkpoint (2026-04-25):</strong> the
+    Stage 6 entry block in OspreySharp now runs first-pass protein FDR,
+    multi-charge consensus, cross-run consensus RTs, and per-file
+    calibration refit. Three new diagnostic dumps land on each side
+    (<code>OSPREY_DUMP_CONSENSUS</code> /
+    <code>OSPREY_DUMP_MULTICHARGE</code> /
+    <code>OSPREY_DUMP_REFIT</code>, with matching <code>_ONLY</code>
+    early-exits) and a sibling harness
+    <code>Compare-Stage6-Planning.ps1</code> byte-compares the four
+    dumps (Stage 5 percolator + the three Stage 6 planning dumps).
+    On Stellar 3-file: <strong>1/4 dump pairs byte-identical</strong>
+    (Stage 5 percolator); the three Stage 6 planning dumps agree on
+    row count, sort order, n_runs_detected, n_points, and
+    median_peak_width but diverge at the last 1-3 decimals of
+    sigmoid-weighted-median RTs and LOESS residual stats. Driver
+    branches: <code>maccoss/osprey:feature/stage6-planning-diagnostics</code>
+    and <code>ProteoWizard/pwiz:Skyline/work/20260423_osprey_sharp_stage6</code>.
+  </p>
+  <p>
+    Next targets: investigate sigmoid weighting + LOESS-residual ULP
+    differences (likely <code>Math.Exp</code>/<code>Math.Log</code>
+    vs Rust <code>f64::exp</code>; may need alternative formulations
+    or a small numeric tolerance in the parity gate). Then wire
+    <code>ReconciliationPlanner.Plan</code>, gap-fill, and second-pass
+    Percolator. Stage 7 protein FDR + Stage 8 .blib output parity
+    follow once Stage 6 is fully proven. See
+    <code>ai/todos/active/TODO-20260423_osprey_sharp_stage6.md</code>.
   </p>
 </footer>
 </body>

--- a/pwiz_tools/OspreySharp/OspreySharp.FDR/OspreySharp.FDR.csproj
+++ b/pwiz_tools/OspreySharp/OspreySharp.FDR/OspreySharp.FDR.csproj
@@ -6,8 +6,13 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="OspreySharp.Test" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\OspreySharp.Core\OspreySharp.Core.csproj" />
     <ProjectReference Include="..\OspreySharp.ML\OspreySharp.ML.csproj" />
+    <ProjectReference Include="..\OspreySharp.Chromatography\OspreySharp.Chromatography.csproj" />
   </ItemGroup>
 
 </Project>

--- a/pwiz_tools/OspreySharp/OspreySharp.FDR/PercolatorFdr.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.FDR/PercolatorFdr.cs
@@ -1505,8 +1505,26 @@ namespace pwiz.OspreySharp.FDR
             var q = new double[wi.Length];
             ComputeConservativeQvalues(ws, wd, q);
 
+            // Propagate the winner's q-value to all observations sharing the
+            // same base_id (both target and decoy sides). Matches Rust's
+            // base_id_exp_prec_q HashMap at osprey-fdr/src/percolator.rs:2168
+            // — without this, non-winning per-file observations of a
+            // multi-file precursor stay at q=1.0 and downstream stages that
+            // gate on experiment_precursor_qvalue (Stage 6 calibration refit
+            // and reconciliation) miss the bulk of the consensus pool.
+            var baseIdExpQ = new Dictionary<uint, double>();
             for (int rank = 0; rank < wi.Length; rank++)
-                qvalues[wi[rank]] = q[rank];
+            {
+                uint baseId = entryIds[wi[rank]] & BASE_ID_MASK;
+                baseIdExpQ[baseId] = q[rank];
+            }
+            for (int i = 0; i < n; i++)
+            {
+                uint baseId = entryIds[i] & BASE_ID_MASK;
+                double qv;
+                if (baseIdExpQ.TryGetValue(baseId, out qv))
+                    qvalues[i] = qv;
+            }
 
             return qvalues;
         }

--- a/pwiz_tools/OspreySharp/OspreySharp.FDR/Reconciliation/CalibrationRefit.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.FDR/Reconciliation/CalibrationRefit.cs
@@ -1,0 +1,107 @@
+/*
+ * Original author: Brendan MacLean <brendanx .at. uw.edu>,
+ *                  MacCoss Lab, Department of Genome Sciences, UW
+ * AI assistance: Claude Code (Claude Opus 4) <noreply .at. anthropic.com>
+ *
+ * Based on osprey (https://github.com/MacCossLab/osprey)
+ *   by Michael J. MacCoss, MacCoss Lab, Department of Genome Sciences, UW
+ *
+ * Copyright 2026 University of Washington - Seattle, WA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
+using System.Collections.Generic;
+using pwiz.OspreySharp.Chromatography;
+using pwiz.OspreySharp.Core;
+
+namespace pwiz.OspreySharp.FDR.Reconciliation
+{
+    /// <summary>
+    /// Refits per-file RT calibration using consensus peptides. Ports
+    /// <c>refit_calibration_with_consensus</c> in
+    /// <c>osprey/crates/osprey/src/reconciliation.rs</c>.
+    /// </summary>
+    public static class CalibrationRefit
+    {
+        /// <summary>Minimum consensus points required before attempting a refit.</summary>
+        public const int MIN_CONSENSUS_POINTS = 20;
+
+        /// <summary>
+        /// Builds (consensus_library_rt, measured_apex_rt) pairs for target
+        /// peptides in this run that pass the experiment-level FDR at
+        /// <paramref name="consensusFdr"/>, then fits a LOESS calibration.
+        /// Returns null when fewer than <see cref="MIN_CONSENSUS_POINTS"/>
+        /// pairs are available or the fit fails.
+        /// </summary>
+        public static RTCalibration Refit(
+            IReadOnlyList<PeptideConsensusRT> consensus,
+            IReadOnlyList<FdrEntry> entries,
+            double consensusFdr)
+        {
+            if (consensus == null)
+                throw new ArgumentNullException(nameof(consensus));
+            if (entries == null)
+                throw new ArgumentNullException(nameof(entries));
+
+            // Consensus lookup: target peptide sequence → consensus library RT.
+            var consensusMap = new Dictionary<string, double>(StringComparer.Ordinal);
+            foreach (var c in consensus)
+            {
+                if (c.IsDecoy)
+                    continue;
+                consensusMap[c.ModifiedSequence] = c.ConsensusLibraryRt;
+            }
+
+            var libraryRts = new List<double>();
+            var measuredRts = new List<double>();
+            foreach (var entry in entries)
+            {
+                if (entry.IsDecoy)
+                    continue;
+                if (entry.EffectiveExperimentQvalue(FdrLevel.Both) > consensusFdr)
+                    continue;
+                if (!consensusMap.TryGetValue(entry.ModifiedSequence, out var consensusLibRt))
+                    continue;
+                libraryRts.Add(consensusLibRt);
+                measuredRts.Add(entry.ApexRt);
+            }
+
+            if (libraryRts.Count < MIN_CONSENSUS_POINTS)
+                return null;
+
+            // Disable outlier removal (retention = 1.0) — these are
+            // FDR-controlled detections, not noisy initial matches. LOESS
+            // robustness iterations still downweight any stragglers.
+            var config = new RTCalibratorConfig
+            {
+                Bandwidth = 0.3,
+                OutlierRetention = 1.0,
+                MinPoints = MIN_CONSENSUS_POINTS,
+            };
+
+            try
+            {
+                return new RTCalibrator(config).Fit(libraryRts.ToArray(), measuredRts.ToArray());
+            }
+            catch (ArgumentException)
+            {
+                // Insufficient points or mismatched arrays; treat as a
+                // recoverable "fit not possible" consistent with Rust's
+                // Option::None return.
+                return null;
+            }
+        }
+    }
+}

--- a/pwiz_tools/OspreySharp/OspreySharp.FDR/Reconciliation/ConsensusRts.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.FDR/Reconciliation/ConsensusRts.cs
@@ -62,6 +62,13 @@ namespace pwiz.OspreySharp.FDR.Reconciliation
         /// q-value is borderline. Typically set to <c>config.ProteinFdr</c>.
         /// Pass 0.0 to disable.
         /// </param>
+        /// <param name="invPredictTrace">
+        /// If non-null, populated with one <see cref="InvPredictRecord"/> per
+        /// detection contributing to a consensus computation, capturing the
+        /// (apex_rt, library_rt, weight) triple that flows into the weighted
+        /// median. The caller drives the diagnostic dump (see
+        /// <c>OspreyDiagnostics.WriteStage6InvPredictDump</c>).
+        /// </param>
         public static IReadOnlyList<PeptideConsensusRT> Compute(
             IReadOnlyList<KeyValuePair<string, IReadOnlyList<FdrEntry>>> perFileEntries,
             IReadOnlyDictionary<string, RTCalibration> perFileCalibrations,

--- a/pwiz_tools/OspreySharp/OspreySharp.FDR/Reconciliation/ConsensusRts.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.FDR/Reconciliation/ConsensusRts.cs
@@ -66,7 +66,8 @@ namespace pwiz.OspreySharp.FDR.Reconciliation
             IReadOnlyList<KeyValuePair<string, IReadOnlyList<FdrEntry>>> perFileEntries,
             IReadOnlyDictionary<string, RTCalibration> perFileCalibrations,
             double consensusFdr,
-            double proteinFdrThreshold)
+            double proteinFdrThreshold,
+            IList<InvPredictRecord> invPredictTrace = null)
         {
             if (perFileEntries == null)
                 throw new ArgumentNullException(nameof(perFileEntries));
@@ -164,6 +165,16 @@ namespace pwiz.OspreySharp.FDR.Reconciliation
                     double weight = Math.Max(1e-6, 1.0 / (1.0 + Math.Exp(-det.Score)));
                     libraryRtWeights.Add((libraryRt, weight));
                     peakWidthWeights.Add((det.PeakWidth, weight));
+
+                    invPredictTrace?.Add(new InvPredictRecord
+                    {
+                        FileName = det.FileName,
+                        ModifiedSequence = modifiedSequence,
+                        IsDecoy = isDecoy,
+                        ApexRt = det.ApexRt,
+                        LibraryRt = libraryRt,
+                        Weight = weight,
+                    });
                 }
 
                 if (libraryRtWeights.Count == 0)

--- a/pwiz_tools/OspreySharp/OspreySharp.FDR/Reconciliation/ConsensusRts.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.FDR/Reconciliation/ConsensusRts.cs
@@ -1,0 +1,272 @@
+/*
+ * Original author: Brendan MacLean <brendanx .at. uw.edu>,
+ *                  MacCoss Lab, Department of Genome Sciences, UW
+ * AI assistance: Claude Code (Claude Opus 4) <noreply .at. anthropic.com>
+ *
+ * Based on osprey (https://github.com/MacCossLab/osprey)
+ *   by Michael J. MacCoss, MacCoss Lab, Department of Genome Sciences, UW
+ *
+ * Copyright 2026 University of Washington - Seattle, WA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using pwiz.OspreySharp.Chromatography;
+using pwiz.OspreySharp.Core;
+
+namespace pwiz.OspreySharp.FDR.Reconciliation
+{
+    /// <summary>
+    /// Computes consensus library RTs for peptides detected across runs.
+    /// Port of <c>compute_consensus_rts</c> in
+    /// <c>osprey/crates/osprey/src/reconciliation.rs</c>.
+    /// </summary>
+    public static class ConsensusRts
+    {
+        private const string DECOY_PREFIX = @"DECOY_";
+
+        /// <summary>
+        /// For each target peptide passing <paramref name="consensusFdr"/> at the
+        /// run-precursor level (hard gate), and its paired decoy, computes a
+        /// consensus library RT using a sigmoid-of-SVM-score weighted median of
+        /// per-run detections mapped back to library RT space.
+        /// </summary>
+        /// <param name="perFileEntries">
+        /// Per-file scored entries (after first-pass FDR). Order is preserved;
+        /// output consensus is sorted deterministically regardless of input
+        /// order.
+        /// </param>
+        /// <param name="perFileCalibrations">
+        /// Per-file RT calibrations for inverse prediction (measured → library).
+        /// </param>
+        /// <param name="consensusFdr">
+        /// FDR threshold for selecting consensus peptides (typically 0.01).
+        /// </param>
+        /// <param name="proteinFdrThreshold">
+        /// If &gt; 0, rescue borderline peptides whose first-pass protein
+        /// q-value is &lt;= this threshold. Lets peptides from strong proteins
+        /// contribute to consensus RT computation even if their own peptide
+        /// q-value is borderline. Typically set to <c>config.ProteinFdr</c>.
+        /// Pass 0.0 to disable.
+        /// </param>
+        public static IReadOnlyList<PeptideConsensusRT> Compute(
+            IReadOnlyList<KeyValuePair<string, IReadOnlyList<FdrEntry>>> perFileEntries,
+            IReadOnlyDictionary<string, RTCalibration> perFileCalibrations,
+            double consensusFdr,
+            double proteinFdrThreshold)
+        {
+            if (perFileEntries == null)
+                throw new ArgumentNullException(nameof(perFileEntries));
+            if (perFileCalibrations == null)
+                throw new ArgumentNullException(nameof(perFileCalibrations));
+
+            // 1. Collect target peptides passing the run-level hard gate
+            //    (or rescued by protein FDR for peptide-level borderline cases).
+            var targetPeptides = new HashSet<string>(StringComparer.Ordinal);
+            foreach (var kvp in perFileEntries)
+            {
+                foreach (var entry in kvp.Value)
+                {
+                    if (Qualifies(entry, consensusFdr, proteinFdrThreshold))
+                        targetPeptides.Add(entry.ModifiedSequence);
+                }
+            }
+            if (targetPeptides.Count == 0)
+                return Array.Empty<PeptideConsensusRT>();
+
+            // 2. Collect paired decoy peptides (DECOY_<target_seq>).
+            var decoyPeptides = new HashSet<string>(StringComparer.Ordinal);
+            foreach (var kvp in perFileEntries)
+            {
+                foreach (var entry in kvp.Value)
+                {
+                    if (!entry.IsDecoy)
+                        continue;
+                    var targetSeq = entry.ModifiedSequence.StartsWith(DECOY_PREFIX, StringComparison.Ordinal)
+                        ? entry.ModifiedSequence.Substring(DECOY_PREFIX.Length)
+                        : entry.ModifiedSequence;
+                    if (targetPeptides.Contains(targetSeq))
+                        decoyPeptides.Add(entry.ModifiedSequence);
+                }
+            }
+
+            // 3. Collect detections for consensus peptides. For targets, only
+            //    detections that qualify. For decoys, all detections of paired
+            //    decoy sequences.
+            //    Detection tuple: (fileName, apexRt, score, peakWidth, coelutionSum).
+            var detections = new Dictionary<(string, bool), List<Detection>>();
+            foreach (var kvp in perFileEntries)
+            {
+                var fileName = kvp.Key;
+                foreach (var entry in kvp.Value)
+                {
+                    bool include = entry.IsDecoy
+                        ? decoyPeptides.Contains(entry.ModifiedSequence)
+                        : targetPeptides.Contains(entry.ModifiedSequence) &&
+                          Qualifies(entry, consensusFdr, proteinFdrThreshold);
+                    if (!include)
+                        continue;
+
+                    var key = (entry.ModifiedSequence, entry.IsDecoy);
+                    if (!detections.TryGetValue(key, out var list))
+                    {
+                        list = new List<Detection>();
+                        detections[key] = list;
+                    }
+                    list.Add(new Detection
+                    {
+                        FileName = fileName,
+                        ApexRt = entry.ApexRt,
+                        Score = entry.Score,
+                        PeakWidth = entry.EndRt - entry.StartRt,
+                        CoelutionSum = entry.CoelutionSum,
+                    });
+                }
+            }
+
+            // 4. Per-peptide consensus computation.
+            var consensus = new List<PeptideConsensusRT>();
+            foreach (var kvp in detections)
+            {
+                var modifiedSequence = kvp.Key.Item1;
+                var isDecoy = kvp.Key.Item2;
+                var dets = kvp.Value;
+                if (dets.Count == 0)
+                    continue;
+
+                var libraryRtWeights = new List<(double Value, double Weight)>(dets.Count);
+                var peakWidthWeights = new List<(double Value, double Weight)>(dets.Count);
+
+                foreach (var det in dets)
+                {
+                    if (!perFileCalibrations.TryGetValue(det.FileName, out var cal))
+                        continue;
+                    double libraryRt = cal.InversePredict(det.ApexRt);
+                    if (!IsFinite(libraryRt) || !(det.CoelutionSum > 0.0))
+                        continue;
+
+                    // Weight by sigmoid(SVM score). Floor at 1e-6 so every
+                    // detection keeps a non-zero weight (avoids degenerate
+                    // zero-total-weight when all scores are very negative).
+                    double weight = Math.Max(1e-6, 1.0 / (1.0 + Math.Exp(-det.Score)));
+                    libraryRtWeights.Add((libraryRt, weight));
+                    peakWidthWeights.Add((det.PeakWidth, weight));
+                }
+
+                if (libraryRtWeights.Count == 0)
+                    continue;
+
+                double consensusLibraryRt = WeightedMedian(libraryRtWeights);
+                double medianPeakWidth = WeightedMedian(peakWidthWeights);
+                int nRunsDetected = libraryRtWeights.Count;
+
+                // Within-peptide RT MAD in library RT space. Requires >= 3
+                // detections for a stable estimate (MAD on 2 points is half the
+                // range and not robust).
+                double? apexLibraryRtMad = null;
+                if (nRunsDetected >= 3)
+                {
+                    var absDevs = new double[nRunsDetected];
+                    for (int i = 0; i < nRunsDetected; i++)
+                        absDevs[i] = Math.Abs(libraryRtWeights[i].Value - consensusLibraryRt);
+                    Array.Sort(absDevs);
+                    int mid = absDevs.Length / 2;
+                    apexLibraryRtMad = absDevs.Length % 2 == 0
+                        ? 0.5 * (absDevs[mid - 1] + absDevs[mid])
+                        : absDevs[mid];
+                }
+
+                consensus.Add(new PeptideConsensusRT
+                {
+                    ModifiedSequence = modifiedSequence,
+                    IsDecoy = isDecoy,
+                    ConsensusLibraryRt = consensusLibraryRt,
+                    MedianPeakWidth = medianPeakWidth,
+                    NRunsDetected = nRunsDetected,
+                    ApexLibraryRtMad = apexLibraryRtMad,
+                });
+            }
+
+            // 5. Sort for deterministic output: decoys after targets, then by
+            //    modified_sequence (ordinal).
+            consensus.Sort((a, b) =>
+            {
+                int cmp = a.IsDecoy.CompareTo(b.IsDecoy);
+                if (cmp != 0)
+                    return cmp;
+                return string.CompareOrdinal(a.ModifiedSequence, b.ModifiedSequence);
+            });
+
+            return consensus;
+        }
+
+        private static bool Qualifies(FdrEntry entry, double consensusFdr, double proteinFdrThreshold)
+        {
+            if (entry.IsDecoy)
+                return false;
+            if (entry.RunPrecursorQvalue > consensusFdr)
+                return false;
+            return entry.RunPeptideQvalue <= consensusFdr ||
+                   (proteinFdrThreshold > 0.0 && entry.RunProteinQvalue <= proteinFdrThreshold);
+        }
+
+        private static bool IsFinite(double d)
+        {
+            return !double.IsNaN(d) && !double.IsInfinity(d);
+        }
+
+        /// <summary>
+        /// Cumulative-weight median. Sorts by value ascending, walks the
+        /// cumulative weight, returns the first value whose cumulative weight
+        /// crosses half the total. All values must be finite; zero-weight
+        /// pairs are permitted but should be avoided by callers (caller
+        /// floors weight at 1e-6).
+        /// </summary>
+        internal static double WeightedMedian(IReadOnlyList<(double Value, double Weight)> pairs)
+        {
+            if (pairs.Count == 0)
+                return 0.0;
+            if (pairs.Count == 1)
+                return pairs[0].Value;
+
+            var sorted = pairs.ToArray();
+            Array.Sort(sorted, (a, b) => a.Value.CompareTo(b.Value));
+
+            double totalWeight = 0.0;
+            for (int i = 0; i < sorted.Length; i++)
+                totalWeight += sorted[i].Weight;
+            double half = totalWeight / 2.0;
+
+            double cumulative = 0.0;
+            for (int i = 0; i < sorted.Length; i++)
+            {
+                cumulative += sorted[i].Weight;
+                if (cumulative >= half)
+                    return sorted[i].Value;
+            }
+            return sorted[sorted.Length - 1].Value;
+        }
+
+        private struct Detection
+        {
+            public string FileName;
+            public double ApexRt;
+            public double Score;
+            public double PeakWidth;
+            public double CoelutionSum;
+        }
+    }
+}

--- a/pwiz_tools/OspreySharp/OspreySharp.FDR/Reconciliation/InvPredictRecord.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.FDR/Reconciliation/InvPredictRecord.cs
@@ -1,0 +1,44 @@
+/*
+ * Original author: Brendan MacLean <brendanx .at. uw.edu>,
+ *                  MacCoss Lab, Department of Genome Sciences, UW
+ * AI assistance: Claude Code (Claude Opus 4) <noreply .at. anthropic.com>
+ *
+ * Based on osprey (https://github.com/MacCossLab/osprey)
+ *   by Michael J. MacCoss, MacCoss Lab, Department of Genome Sciences, UW
+ *
+ * Copyright 2026 University of Washington - Seattle, WA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace pwiz.OspreySharp.FDR.Reconciliation
+{
+    /// <summary>
+    /// One row of the cross-impl bisection trace for
+    /// <see cref="ConsensusRts.Compute"/>: the (apex_rt, library_rt) pair
+    /// for each detection that contributes to the consensus median, plus
+    /// the sigmoid-of-SVM-score weight. Diffing this trace across the Rust
+    /// reference and the OspreySharp port localizes
+    /// <c>consensus_library_rt</c> divergence to either the loaded apex_rt
+    /// (Parquet decode) or the LOESS inverse-interpolation step.
+    /// </summary>
+    public class InvPredictRecord
+    {
+        public string FileName { get; set; }
+        public string ModifiedSequence { get; set; }
+        public bool IsDecoy { get; set; }
+        public double ApexRt { get; set; }
+        public double LibraryRt { get; set; }
+        public double Weight { get; set; }
+    }
+}

--- a/pwiz_tools/OspreySharp/OspreySharp.FDR/Reconciliation/MultiChargeConsensus.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.FDR/Reconciliation/MultiChargeConsensus.cs
@@ -1,0 +1,148 @@
+/*
+ * Original author: Brendan MacLean <brendanx .at. uw.edu>,
+ *                  MacCoss Lab, Department of Genome Sciences, UW
+ * AI assistance: Claude Code (Claude Opus 4) <noreply .at. anthropic.com>
+ *
+ * Based on osprey (https://github.com/MacCossLab/osprey)
+ *   by Michael J. MacCoss, MacCoss Lab, Department of Genome Sciences, UW
+ *
+ * Copyright 2026 University of Washington - Seattle, WA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
+using System.Collections.Generic;
+using pwiz.OspreySharp.Core;
+
+namespace pwiz.OspreySharp.FDR.Reconciliation
+{
+    /// <summary>
+    /// Post-FDR multi-charge consensus leader selection. Groups a per-file
+    /// entry list by modified sequence; for each group where at least one
+    /// charge state passes FDR, picks the highest-SVM-score passing entry as
+    /// the consensus leader. Any other charge state whose apex RT lies
+    /// outside half the leader's peak width is returned as a re-scoring
+    /// target at the leader's boundaries.
+    /// Ports <c>select_post_fdr_consensus</c> in
+    /// <c>osprey/crates/osprey/src/pipeline.rs</c>.
+    /// </summary>
+    public static class MultiChargeConsensus
+    {
+        /// <summary>Minimum RT match tolerance floor (minutes).</summary>
+        public const double MIN_RT_MATCH_TOLERANCE = 0.1;
+
+        /// <summary>
+        /// Return per-entry rescore targets (entryIndex, apex, start, end)
+        /// derived from the multi-charge consensus leader in each peptide
+        /// group. Groups with one entry, or where no charge state passes
+        /// FDR, contribute nothing.
+        /// </summary>
+        public static IReadOnlyList<(int Index, double Apex, double Start, double End)> SelectRescoreTargets(
+            IReadOnlyList<FdrEntry> entries,
+            double fdrThreshold)
+        {
+            if (entries == null)
+                throw new ArgumentNullException(nameof(entries));
+
+            var groups = new Dictionary<string, List<int>>(StringComparer.Ordinal);
+            for (int i = 0; i < entries.Count; i++)
+            {
+                var seq = entries[i].ModifiedSequence;
+                if (!groups.TryGetValue(seq, out var indices))
+                {
+                    indices = new List<int>();
+                    groups[seq] = indices;
+                }
+                indices.Add(i);
+            }
+
+            var targets = new List<(int, double, double, double)>();
+
+            foreach (var indices in groups.Values)
+            {
+                if (indices.Count <= 1)
+                    continue;
+
+                int bestIdx = PickBestPassing(entries, indices, fdrThreshold);
+                if (bestIdx < 0)
+                    continue;
+
+                double consensusApex = entries[bestIdx].ApexRt;
+                double consensusStart = entries[bestIdx].StartRt;
+                double consensusEnd = entries[bestIdx].EndRt;
+                double consensusWidth = consensusEnd - consensusStart;
+                double rtMatchTolerance = Math.Max(MIN_RT_MATCH_TOLERANCE, consensusWidth / 2.0);
+
+                foreach (var idx in indices)
+                {
+                    if (idx == bestIdx)
+                        continue;
+                    double apexDiff = Math.Abs(entries[idx].ApexRt - consensusApex);
+                    if (apexDiff > rtMatchTolerance)
+                        targets.Add((idx, consensusApex, consensusStart, consensusEnd));
+                }
+            }
+
+            return targets;
+        }
+
+        /// <summary>
+        /// Pick the highest-SVM-score entry among the group members that pass
+        /// FDR at <paramref name="fdrThreshold"/>. Ties on score are broken by
+        /// lower run_precursor_qvalue. Returns -1 if no entry passes.
+        /// </summary>
+        private static int PickBestPassing(
+            IReadOnlyList<FdrEntry> entries, IReadOnlyList<int> indices, double fdrThreshold)
+        {
+            int bestIdx = -1;
+            double bestScore = 0;
+            double bestQvalue = 0;
+
+            foreach (var idx in indices)
+            {
+                var entry = entries[idx];
+                if (entry.RunPrecursorQvalue > fdrThreshold)
+                    continue;
+
+                bool isBetter;
+                if (bestIdx < 0)
+                {
+                    isBetter = true;
+                }
+                else if (entry.Score > bestScore)
+                {
+                    isBetter = true;
+                }
+                else if (entry.Score < bestScore)
+                {
+                    isBetter = false;
+                }
+                else
+                {
+                    // Tie on score → lower q-value wins.
+                    isBetter = entry.RunPrecursorQvalue < bestQvalue;
+                }
+
+                if (isBetter)
+                {
+                    bestIdx = idx;
+                    bestScore = entry.Score;
+                    bestQvalue = entry.RunPrecursorQvalue;
+                }
+            }
+
+            return bestIdx;
+        }
+    }
+}

--- a/pwiz_tools/OspreySharp/OspreySharp.FDR/Reconciliation/PeptideConsensusRT.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.FDR/Reconciliation/PeptideConsensusRT.cs
@@ -1,0 +1,63 @@
+/*
+ * Original author: Brendan MacLean <brendanx .at. uw.edu>,
+ *                  MacCoss Lab, Department of Genome Sciences, UW
+ * AI assistance: Claude Code (Claude Opus 4) <noreply .at. anthropic.com>
+ *
+ * Based on osprey (https://github.com/MacCossLab/osprey)
+ *   by Michael J. MacCoss, MacCoss Lab, Department of Genome Sciences, UW
+ *
+ * Copyright 2026 University of Washington - Seattle, WA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace pwiz.OspreySharp.FDR.Reconciliation
+{
+    /// <summary>
+    /// Consensus RT for a peptide across all runs.
+    /// Computed independently for targets and decoys to maintain fair
+    /// target-decoy competition in the second FDR pass.
+    /// Maps to <c>PeptideConsensusRT</c> in
+    /// <c>osprey/crates/osprey/src/reconciliation.rs</c>.
+    /// </summary>
+    public class PeptideConsensusRT
+    {
+        /// <summary>Modified sequence (peptide-level grouping).</summary>
+        public string ModifiedSequence { get; set; }
+
+        /// <summary>Whether this is a decoy consensus.</summary>
+        public bool IsDecoy { get; set; }
+
+        /// <summary>Consensus library RT (sigmoid-weighted median from all runs).</summary>
+        public double ConsensusLibraryRt { get; set; }
+
+        /// <summary>
+        /// Sigmoid-weighted median peak width across runs where detected
+        /// (minutes, measured RT space).
+        /// </summary>
+        public double MedianPeakWidth { get; set; }
+
+        /// <summary>Number of runs where this peptide was detected.</summary>
+        public int NRunsDetected { get; set; }
+
+        /// <summary>
+        /// MAD of this peptide's apex RTs across runs, in library RT space
+        /// (minutes). Null when fewer than 3 detections contribute
+        /// (insufficient to estimate). Captures within-peptide RT
+        /// reproducibility, typically 3-5x tighter than the cross-peptide
+        /// calibration MAD. Consumed by the reconciliation planner as a
+        /// peptide-specific RT tolerance.
+        /// </summary>
+        public double? ApexLibraryRtMad { get; set; }
+    }
+}

--- a/pwiz_tools/OspreySharp/OspreySharp.FDR/Reconciliation/ReconcileAction.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.FDR/Reconciliation/ReconcileAction.cs
@@ -1,0 +1,97 @@
+/*
+ * Original author: Brendan MacLean <brendanx .at. uw.edu>,
+ *                  MacCoss Lab, Department of Genome Sciences, UW
+ * AI assistance: Claude Code (Claude Opus 4) <noreply .at. anthropic.com>
+ *
+ * Based on osprey (https://github.com/MacCossLab/osprey)
+ *   by Michael J. MacCoss, MacCoss Lab, Department of Genome Sciences, UW
+ *
+ * Copyright 2026 University of Washington - Seattle, WA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace pwiz.OspreySharp.FDR.Reconciliation
+{
+    /// <summary>
+    /// Result of inter-replicate peak reconciliation for a single entry.
+    /// Maps to <c>ReconcileAction</c> in
+    /// <c>osprey/crates/osprey/src/reconciliation.rs</c>.
+    /// </summary>
+    public abstract class ReconcileAction
+    {
+        // Private constructor: only the nested subclasses below can inherit,
+        // which makes this an effective discriminated union.
+        private ReconcileAction()
+        {
+        }
+
+        /// <summary>
+        /// Existing peak already matches consensus RT — no re-scoring needed.
+        /// Planner omits these from its returned map, so in consumers this
+        /// case is "not present in the map" rather than a returned value.
+        /// The singleton instance is exposed for tests and pattern-matching.
+        /// </summary>
+        public static ReconcileAction Keep { get; } = new KeepAction();
+
+        private sealed class KeepAction : ReconcileAction
+        {
+        }
+
+        /// <summary>
+        /// Use an alternate stored CWT candidate whose apex is closest to the
+        /// expected RT (within tolerance).
+        /// </summary>
+        public sealed class UseCwtPeak : ReconcileAction
+        {
+            /// <summary>Index into the entry's stored CWT candidates.</summary>
+            public int CandidateIndex { get; }
+
+            /// <summary>Selected CWT peak start RT (measured space, minutes).</summary>
+            public double StartRt { get; }
+
+            /// <summary>Selected CWT peak apex RT (measured space, minutes).</summary>
+            public double ApexRt { get; }
+
+            /// <summary>Selected CWT peak end RT (measured space, minutes).</summary>
+            public double EndRt { get; }
+
+            public UseCwtPeak(int candidateIndex, double startRt, double apexRt, double endRt)
+            {
+                CandidateIndex = candidateIndex;
+                StartRt = startRt;
+                ApexRt = apexRt;
+                EndRt = endRt;
+            }
+        }
+
+        /// <summary>
+        /// No stored CWT candidate lies within tolerance of the expected RT —
+        /// integrate at the consensus RT with a fixed half-width.
+        /// </summary>
+        public sealed class ForcedIntegration : ReconcileAction
+        {
+            /// <summary>Expected measured RT (from refined calibration).</summary>
+            public double ExpectedRt { get; }
+
+            /// <summary>Integration half-width (half of median peak width).</summary>
+            public double HalfWidth { get; }
+
+            public ForcedIntegration(double expectedRt, double halfWidth)
+            {
+                ExpectedRt = expectedRt;
+                HalfWidth = halfWidth;
+            }
+        }
+    }
+}

--- a/pwiz_tools/OspreySharp/OspreySharp.FDR/Reconciliation/ReconciliationPlanner.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.FDR/Reconciliation/ReconciliationPlanner.cs
@@ -1,0 +1,321 @@
+/*
+ * Original author: Brendan MacLean <brendanx .at. uw.edu>,
+ *                  MacCoss Lab, Department of Genome Sciences, UW
+ * AI assistance: Claude Code (Claude Opus 4) <noreply .at. anthropic.com>
+ *
+ * Based on osprey (https://github.com/MacCossLab/osprey)
+ *   by Michael J. MacCoss, MacCoss Lab, Department of Genome Sciences, UW
+ *
+ * Copyright 2026 University of Washington - Seattle, WA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
+using System.Collections.Generic;
+using pwiz.OspreySharp.Chromatography;
+using pwiz.OspreySharp.Core;
+
+namespace pwiz.OspreySharp.FDR.Reconciliation
+{
+    /// <summary>
+    /// Plans inter-replicate peak reconciliation using consensus RTs and stored
+    /// CWT candidates. Ports <c>plan_reconciliation</c> and
+    /// <c>determine_reconcile_action</c> from
+    /// <c>osprey/crates/osprey/src/reconciliation.rs</c>.
+    /// </summary>
+    public static class ReconciliationPlanner
+    {
+        private const string DECOY_PREFIX = @"DECOY_";
+
+        // Minimum RT tolerance floor (minutes) accommodates scan-resolution rounding.
+        private const double MIN_RT_TOLERANCE = 0.1;
+
+        // Fallback global within-peptide MAD when fewer than one consensus peptide
+        // has >= 3 detections (e.g., 2-replicate experiment).
+        private const double FALLBACK_GLOBAL_MAD_LIB = 0.05;
+
+        // MAD-to-sigma conversion factor (for a normal distribution).
+        private const double MAD_TO_SIGMA = 1.4826;
+
+        // Sigma multiplier for RT tolerance (3-sigma).
+        private const double SIGMA_FACTOR = 3.0;
+
+        // Minimum survivor count for sigma-clipped MAD before falling back to
+        // unclipped median.
+        private const int SIGMA_CLIP_MIN_SURVIVORS = 20;
+
+        /// <summary>
+        /// Plan inter-replicate peak reconciliation for all entries across all
+        /// runs.
+        /// </summary>
+        /// <returns>
+        /// A dictionary keyed by (fileName, entryIndex) for entries that need
+        /// re-scoring. Entries absent from the map implicitly retain their
+        /// current peak (ReconcileAction.Keep).
+        /// </returns>
+        public static IReadOnlyDictionary<(string File, int Index), ReconcileAction> Plan(
+            IReadOnlyList<PeptideConsensusRT> consensus,
+            IReadOnlyList<KeyValuePair<string, IReadOnlyList<FdrEntry>>> perFileEntries,
+            IReadOnlyDictionary<string, IReadOnlyList<IReadOnlyList<CwtCandidate>>> perFileCwtCandidates,
+            IReadOnlyDictionary<string, RTCalibration> perFileRefinedCal,
+            IReadOnlyDictionary<string, RTCalibration> perFileOriginalCal,
+            double experimentFdr)
+        {
+            if (consensus == null)
+                throw new ArgumentNullException(nameof(consensus));
+            if (perFileEntries == null)
+                throw new ArgumentNullException(nameof(perFileEntries));
+            if (perFileCwtCandidates == null)
+                throw new ArgumentNullException(nameof(perFileCwtCandidates));
+            if (perFileRefinedCal == null)
+                throw new ArgumentNullException(nameof(perFileRefinedCal));
+            if (perFileOriginalCal == null)
+                throw new ArgumentNullException(nameof(perFileOriginalCal));
+
+            // Consensus lookup by (modified_sequence, is_decoy).
+            var consensusMap = new Dictionary<(string, bool), PeptideConsensusRT>();
+            foreach (var c in consensus)
+                consensusMap[(c.ModifiedSequence, c.IsDecoy)] = c;
+
+            // Global within-peptide RT MAD (library RT space) — median of
+            // per-peptide apex MADs across all target peptides with >= 3
+            // detections. See the Rust docstring at reconciliation.rs:469-487
+            // for the rationale: after cross-run alignment, within-peptide
+            // scatter is roughly peptide-independent (instrument/LC
+            // reproducibility), and the cross-peptide median is a far more
+            // stable estimator than any single peptide's 3-5-replicate MAD.
+            double globalWithinPeptideMadLib;
+            {
+                var peptideMads = new List<double>();
+                foreach (var c in consensus)
+                {
+                    if (c.IsDecoy)
+                        continue;
+                    if (c.ApexLibraryRtMad.HasValue)
+                        peptideMads.Add(c.ApexLibraryRtMad.Value);
+                }
+                if (peptideMads.Count == 0)
+                {
+                    globalWithinPeptideMadLib = FALLBACK_GLOBAL_MAD_LIB;
+                }
+                else
+                {
+                    peptideMads.Sort();
+                    int mid = peptideMads.Count / 2;
+                    globalWithinPeptideMadLib = peptideMads.Count % 2 == 0
+                        ? 0.5 * (peptideMads[mid - 1] + peptideMads[mid])
+                        : peptideMads[mid];
+                }
+            }
+
+            // Passing precursors: (base_sequence, charge) where any of the
+            // four q-values passes at experimentFdr. Rationale at
+            // reconciliation.rs:516-528 — blib admits a precursor if ANY
+            // level passes, so reconciliation must include them in every
+            // file to keep per-file boundaries self-consistent. Decoys are
+            // picked up by the paired-decoy logic below.
+            var passingPrecursors = new HashSet<(string, byte)>();
+            foreach (var fileKvp in perFileEntries)
+            {
+                foreach (var entry in fileKvp.Value)
+                {
+                    if (entry.IsDecoy)
+                        continue;
+                    double bestQ = Math.Min(
+                        Math.Min(entry.RunPrecursorQvalue, entry.RunPeptideQvalue),
+                        Math.Min(entry.ExperimentPrecursorQvalue, entry.ExperimentPeptideQvalue));
+                    if (bestQ <= experimentFdr)
+                        passingPrecursors.Add((entry.ModifiedSequence, entry.Charge));
+                }
+            }
+
+            var actions = new Dictionary<(string, int), ReconcileAction>();
+            var emptyCwt = new List<IReadOnlyList<CwtCandidate>>();
+
+            foreach (var fileKvp in perFileEntries)
+            {
+                string fileName = fileKvp.Key;
+                var entries = fileKvp.Value;
+
+                // Refined calibration if present, else original.
+                RTCalibration cal = null;
+                if (!perFileRefinedCal.TryGetValue(fileName, out cal))
+                    perFileOriginalCal.TryGetValue(fileName, out cal);
+                if (cal == null)
+                    continue;
+
+                // Per-file RT tolerance ceiling from refined residuals.
+                // Sigma-clipped MAD guards against wrong-peak residuals
+                // inflating the ceiling; capped by the original first-pass
+                // calibration MAD so each pass can only tighten. See the
+                // Rust docstring at reconciliation.rs:570-607.
+                double fileCalToleranceCeiling;
+                {
+                    double rawMad = cal.Stats().MAD;
+                    double clipThreshold = rawMad * MAD_TO_SIGMA * SIGMA_FACTOR;
+                    double clippedMad = SigmaClippedMad(cal.AbsResiduals, clipThreshold);
+                    double refinedTolerance = Math.Max(
+                        clippedMad * MAD_TO_SIGMA * SIGMA_FACTOR, MIN_RT_TOLERANCE);
+
+                    double cap = refinedTolerance;
+                    if (perFileOriginalCal.TryGetValue(fileName, out var originalCal))
+                    {
+                        cap = Math.Max(
+                            originalCal.Stats().MAD * MAD_TO_SIGMA * SIGMA_FACTOR,
+                            MIN_RT_TOLERANCE);
+                    }
+
+                    fileCalToleranceCeiling = Math.Min(refinedTolerance, cap);
+                }
+
+                // Per-peptide RT tolerance — global within-peptide MAD
+                // converted to ~3-sigma, floored at MIN_RT_TOLERANCE and
+                // capped by the file's cross-peptide ceiling.
+                double peptideTolerance = Math.Min(
+                    Math.Max(globalWithinPeptideMadLib * MAD_TO_SIGMA * SIGMA_FACTOR, MIN_RT_TOLERANCE),
+                    fileCalToleranceCeiling);
+
+                if (!perFileCwtCandidates.TryGetValue(fileName, out var fileCwt))
+                    fileCwt = emptyCwt;
+
+                for (int entryIdx = 0; entryIdx < entries.Count; entryIdx++)
+                {
+                    var entry = entries[entryIdx];
+
+                    // Only consider entries in the consensus set.
+                    var key = (entry.ModifiedSequence, entry.IsDecoy);
+                    if (!consensusMap.TryGetValue(key, out var consensusEntry))
+                        continue;
+
+                    // Only reconcile precursors that passed experiment-FDR
+                    // (or paired decoys). base_sequence strips DECOY_.
+                    string baseSeq = entry.ModifiedSequence.StartsWith(DECOY_PREFIX, StringComparison.Ordinal)
+                        ? entry.ModifiedSequence.Substring(DECOY_PREFIX.Length)
+                        : entry.ModifiedSequence;
+                    if (!passingPrecursors.Contains((baseSeq, entry.Charge)))
+                        continue;
+
+                    double expectedRt = cal.Predict(consensusEntry.ConsensusLibraryRt);
+
+                    IReadOnlyList<CwtCandidate> cwt;
+                    if (entry.ParquetIndex < (uint)fileCwt.Count)
+                        cwt = fileCwt[(int)entry.ParquetIndex];
+                    else
+                        cwt = Array.Empty<CwtCandidate>();
+
+                    var action = DetermineAction(
+                        apexRt: entry.ApexRt,
+                        cwtCandidates: cwt,
+                        expectedMeasuredRt: expectedRt,
+                        rtTolerance: peptideTolerance,
+                        halfWidth: consensusEntry.MedianPeakWidth / 2.0);
+
+                    // Only store non-Keep actions (Keep is implicit absence).
+                    if (!ReferenceEquals(action, ReconcileAction.Keep))
+                        actions[(fileName, entryIdx)] = action;
+                }
+            }
+
+            return actions;
+        }
+
+        /// <summary>
+        /// Determine what reconciliation action to take for an entry given its
+        /// consensus RT. Uses apex-proximity (not boundary containment) so
+        /// wide-tailed wrong-apex peaks are correctly rejected. Ports
+        /// <c>determine_reconcile_action</c> in
+        /// <c>osprey/crates/osprey/src/reconciliation.rs</c>.
+        /// </summary>
+        /// <param name="apexRt">Current peak's apex RT (measured space, minutes).</param>
+        /// <param name="cwtCandidates">Stored CWT candidates for this entry.</param>
+        /// <param name="expectedMeasuredRt">Expected RT from the refined calibration.</param>
+        /// <param name="rtTolerance">Allowed RT deviation from expected.</param>
+        /// <param name="halfWidth">Half of consensus median peak width (for forced integration).</param>
+        public static ReconcileAction DetermineAction(
+            double apexRt,
+            IReadOnlyList<CwtCandidate> cwtCandidates,
+            double expectedMeasuredRt,
+            double rtTolerance,
+            double halfWidth)
+        {
+            // Current peak already at expected RT?
+            if (Math.Abs(apexRt - expectedMeasuredRt) <= rtTolerance)
+                return ReconcileAction.Keep;
+
+            // Pick the CWT candidate whose apex is closest to expectedMeasuredRt,
+            // provided it lies within tolerance.
+            if (cwtCandidates != null)
+            {
+                int bestIdx = -1;
+                double bestDeviation = double.PositiveInfinity;
+                for (int i = 0; i < cwtCandidates.Count; i++)
+                {
+                    double deviation = Math.Abs(cwtCandidates[i].ApexRt - expectedMeasuredRt);
+                    if (deviation > rtTolerance)
+                        continue;
+                    if (deviation < bestDeviation)
+                    {
+                        bestDeviation = deviation;
+                        bestIdx = i;
+                    }
+                }
+
+                if (bestIdx >= 0)
+                {
+                    var c = cwtCandidates[bestIdx];
+                    return new ReconcileAction.UseCwtPeak(
+                        candidateIndex: bestIdx,
+                        startRt: c.StartRt,
+                        apexRt: c.ApexRt,
+                        endRt: c.EndRt);
+                }
+            }
+
+            return new ReconcileAction.ForcedIntegration(
+                expectedRt: expectedMeasuredRt,
+                halfWidth: halfWidth);
+        }
+
+        /// <summary>
+        /// Sigma-clipped median: filter absolute residuals at
+        /// <paramref name="clipThreshold"/> then return the median of the
+        /// survivors. If fewer than <see cref="SIGMA_CLIP_MIN_SURVIVORS"/>
+        /// survivors remain, fall back to the raw median of the full input.
+        /// </summary>
+        internal static double SigmaClippedMad(IReadOnlyList<double> absResiduals, double clipThreshold)
+        {
+            if (absResiduals == null || absResiduals.Count == 0)
+                return 0.0;
+
+            var clipped = new List<double>(absResiduals.Count);
+            for (int i = 0; i < absResiduals.Count; i++)
+            {
+                if (absResiduals[i] <= clipThreshold)
+                    clipped.Add(absResiduals[i]);
+            }
+
+            if (clipped.Count < SIGMA_CLIP_MIN_SURVIVORS)
+            {
+                var all = new double[absResiduals.Count];
+                for (int i = 0; i < all.Length; i++)
+                    all[i] = absResiduals[i];
+                Array.Sort(all);
+                return all[all.Length / 2];
+            }
+
+            clipped.Sort();
+            return clipped[clipped.Count / 2];
+        }
+    }
+}

--- a/pwiz_tools/OspreySharp/OspreySharp.Scoring/ScoringContext.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Scoring/ScoringContext.cs
@@ -21,6 +21,7 @@
  * limitations under the License.
  */
 
+using System.Collections.Generic;
 using pwiz.OspreySharp.Core;
 
 namespace pwiz.OspreySharp.Scoring
@@ -43,6 +44,18 @@ namespace pwiz.OspreySharp.Scoring
         /// 100K-bin HRAM arrays instead of triggering LOH churn per scan.
         /// </summary>
         public XcorrScratchPool XcorrScratchPool { get; private set; }
+
+        /// <summary>
+        /// Stage 6 boundary overrides keyed by library entry id. When the
+        /// dictionary contains an entry's id, the search engine skips CWT
+        /// peak detection + the signal pre-filter and scores at the supplied
+        /// (apex, start, end) RT triple. Null during the first-pass main
+        /// search; populated only on the post-FDR re-scoring pass for
+        /// multi-charge consensus, cross-run reconciliation, and gap-fill.
+        /// Maps to <c>boundary_overrides</c> in
+        /// <c>osprey/crates/osprey/src/pipeline.rs run_search</c>.
+        /// </summary>
+        public IReadOnlyDictionary<uint, (double Apex, double Start, double End)> BoundaryOverrides { get; set; }
 
         public ScoringContext(OspreyConfig config, string fileName)
         {

--- a/pwiz_tools/OspreySharp/OspreySharp.Test/ReconciliationTest.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Test/ReconciliationTest.cs
@@ -798,6 +798,94 @@ namespace pwiz.OspreySharp.Test
 
         #endregion
 
+        #region CalibrationRefit
+
+        [TestMethod]
+        public void TestRefitReturnsNullWhenTooFewConsensusPoints()
+        {
+            // Three consensus peptides, three entries → 3 pairs, below the
+            // 20-point minimum.
+            var consensus = MakeConsensus(3);
+            var entries = MakeRefitEntries(3, measuredOffset: 0.0);
+
+            var cal = CalibrationRefit.Refit(consensus, entries, consensusFdr: 0.01);
+            Assert.IsNull(cal);
+        }
+
+        [TestMethod]
+        public void TestRefitReturnsNullWhenAllDecoys()
+        {
+            var consensus = MakeConsensus(30);
+            var entries = new List<FdrEntry>();
+            for (int i = 0; i < 30; i++)
+            {
+                entries.Add(MakeEntry(@"DECOY_PEP_" + i, apexRt: i, score: 1.0,
+                    isDecoy: true, precursorQ: 0.0, peptideQ: 0.0));
+            }
+
+            var cal = CalibrationRefit.Refit(consensus, entries, consensusFdr: 0.01);
+            Assert.IsNull(cal);
+        }
+
+        [TestMethod]
+        public void TestRefitReturnsNullWhenAllFailExperimentFdr()
+        {
+            var consensus = MakeConsensus(30);
+            var entries = new List<FdrEntry>();
+            for (int i = 0; i < 30; i++)
+            {
+                var e = MakeEntry(@"PEP_" + i, apexRt: i, score: 1.0,
+                    isDecoy: false, precursorQ: 0.0, peptideQ: 0.0);
+                e.ExperimentPrecursorQvalue = 0.5;
+                e.ExperimentPeptideQvalue = 0.5;
+                entries.Add(e);
+            }
+
+            var cal = CalibrationRefit.Refit(consensus, entries, consensusFdr: 0.01);
+            Assert.IsNull(cal);
+        }
+
+        [TestMethod]
+        public void TestRefitProducesCalibrationFromValidConsensus()
+        {
+            // 30 peptides with consensus_library_rt = i. Entries have
+            // apex_rt = 2*i + 5 (a linear 2x+5 shift, cleanly LOESS-fit-able).
+            // Refit should predict measured ≈ 2x + 5 for library = x.
+            var consensus = MakeConsensus(30);
+            var entries = MakeRefitEntries(30, measuredOffset: 0.0, scale: 2.0, intercept: 5.0);
+
+            var cal = CalibrationRefit.Refit(consensus, entries, consensusFdr: 0.01);
+            Assert.IsNotNull(cal);
+
+            double pred10 = cal.Predict(10.0);
+            Assert.IsTrue(Math.Abs(pred10 - 25.0) < 1.0,
+                string.Format(@"Predict(10) should be near 25, got {0}", pred10));
+        }
+
+        [TestMethod]
+        public void TestRefitExcludesDecoysFromFit()
+        {
+            // 25 target peptides + 5 decoy entries whose ApexRt would wildly
+            // distort a fit if not filtered. Refit should ignore decoys and
+            // produce a linear calibration that matches the target data.
+            var consensus = MakeConsensus(25);
+            var entries = MakeRefitEntries(25, measuredOffset: 0.0, scale: 1.0, intercept: 0.0);
+            for (int i = 0; i < 5; i++)
+            {
+                var decoy = MakeEntry(@"DECOY_PEP_" + i, apexRt: 1e6, score: -1.0,
+                    isDecoy: true, precursorQ: 1.0, peptideQ: 1.0);
+                decoy.ExperimentPrecursorQvalue = 1.0;
+                decoy.ExperimentPeptideQvalue = 1.0;
+                entries.Add(decoy);
+            }
+
+            var cal = CalibrationRefit.Refit(consensus, entries, consensusFdr: 0.01);
+            Assert.IsNotNull(cal);
+            Assert.IsTrue(Math.Abs(cal.Predict(10.0) - 10.0) < 1.0);
+        }
+
+        #endregion
+
         #region Fixture helpers
 
         /// <summary>
@@ -870,6 +958,53 @@ namespace pwiz.OspreySharp.Test
                 RunProteinQvalue = 1.0,
                 ModifiedSequence = modifiedSequence,
             };
+        }
+
+        /// <summary>
+        /// Build <paramref name="count"/> target-only consensus entries with
+        /// modified sequences PEP_0, PEP_1, ... and ConsensusLibraryRt = i.
+        /// </summary>
+        private static IReadOnlyList<PeptideConsensusRT> MakeConsensus(int count)
+        {
+            var result = new PeptideConsensusRT[count];
+            for (int i = 0; i < count; i++)
+            {
+                result[i] = new PeptideConsensusRT
+                {
+                    ModifiedSequence = @"PEP_" + i,
+                    IsDecoy = false,
+                    ConsensusLibraryRt = i,
+                    MedianPeakWidth = 0.6,
+                    NRunsDetected = 3,
+                    ApexLibraryRtMad = 0.05,
+                };
+            }
+            return result;
+        }
+
+        /// <summary>
+        /// Build <paramref name="count"/> target entries paired with the
+        /// consensus above: ApexRt = scale * i + intercept + measuredOffset.
+        /// Experiment q-values default to 0, so entries pass any normal FDR.
+        /// </summary>
+        private static List<FdrEntry> MakeRefitEntries(
+            int count, double measuredOffset,
+            double scale = 1.0, double intercept = 0.0)
+        {
+            var result = new List<FdrEntry>(count);
+            for (int i = 0; i < count; i++)
+            {
+                var e = MakeEntry(@"PEP_" + i,
+                    apexRt: scale * i + intercept + measuredOffset,
+                    score: 3.0, isDecoy: false,
+                    precursorQ: 0.0, peptideQ: 0.0);
+                // Experiment q-values default to 1.0 in the FdrEntry constructor,
+                // so set them explicitly for the refit gate.
+                e.ExperimentPrecursorQvalue = 0.0;
+                e.ExperimentPeptideQvalue = 0.0;
+                result.Add(e);
+            }
+            return result;
         }
 
         #endregion

--- a/pwiz_tools/OspreySharp/OspreySharp.Test/ReconciliationTest.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Test/ReconciliationTest.cs
@@ -886,6 +886,166 @@ namespace pwiz.OspreySharp.Test
 
         #endregion
 
+        #region MultiChargeConsensus
+
+        [TestMethod]
+        public void TestMultiChargeSingleEntryGroupProducesNoTargets()
+        {
+            var entries = new List<FdrEntry>
+            {
+                MakeEntry(@"PEPTIDE1", apexRt: 10.0, score: 3.0,
+                          isDecoy: false, precursorQ: 0.0, peptideQ: 0.0),
+            };
+
+            var targets = MultiChargeConsensus.SelectRescoreTargets(entries, fdrThreshold: 0.01);
+            Assert.AreEqual(0, targets.Count);
+        }
+
+        [TestMethod]
+        public void TestMultiChargeNoPassingEntryInGroupSkipped()
+        {
+            // Two charges of the same peptide, both with q > threshold.
+            var e1 = MakeEntry(@"PEPTIDE1", apexRt: 10.0, score: 0.0,
+                isDecoy: false, precursorQ: 0.5, peptideQ: 0.5);
+            e1.Charge = 2;
+            var e2 = MakeEntry(@"PEPTIDE1", apexRt: 20.0, score: 0.0,
+                isDecoy: false, precursorQ: 0.5, peptideQ: 0.5);
+            e2.Charge = 3;
+
+            var targets = MultiChargeConsensus.SelectRescoreTargets(
+                new[] { e1, e2 }, fdrThreshold: 0.01);
+
+            Assert.AreEqual(0, targets.Count);
+        }
+
+        [TestMethod]
+        public void TestMultiChargeAllChargesAtSameApexNoRescore()
+        {
+            // Both charges pass FDR and are within tolerance of each other.
+            var e1 = MakeEntry(@"PEPTIDE1", apexRt: 10.0, score: 3.0,
+                isDecoy: false, precursorQ: 0.0, peptideQ: 0.0);
+            e1.Charge = 2;
+            var e2 = MakeEntry(@"PEPTIDE1", apexRt: 10.05, score: 2.0,
+                isDecoy: false, precursorQ: 0.0, peptideQ: 0.0);
+            e2.Charge = 3;
+
+            var targets = MultiChargeConsensus.SelectRescoreTargets(
+                new[] { e1, e2 }, fdrThreshold: 0.01);
+
+            Assert.AreEqual(0, targets.Count);
+        }
+
+        [TestMethod]
+        public void TestMultiChargeWrongApexChargeIsRescoreTarget()
+        {
+            // z=2 is the leader (highest SVM score). z=3 is at 20.0, way
+            // outside tolerance of leader's consensus apex 10.0.
+            var leader = MakeEntry(@"PEPTIDE1", apexRt: 10.0, score: 5.0,
+                isDecoy: false, precursorQ: 0.0, peptideQ: 0.0);
+            leader.Charge = 2;
+            var wrong = MakeEntry(@"PEPTIDE1", apexRt: 20.0, score: 2.0,
+                isDecoy: false, precursorQ: 0.0, peptideQ: 0.0);
+            wrong.Charge = 3;
+
+            var targets = MultiChargeConsensus.SelectRescoreTargets(
+                new[] { leader, wrong }, fdrThreshold: 0.01);
+
+            Assert.AreEqual(1, targets.Count);
+            Assert.AreEqual(1, targets[0].Index);
+            Assert.AreEqual(10.0, targets[0].Apex, TOLERANCE);
+            Assert.AreEqual(9.5, targets[0].Start, TOLERANCE);
+            Assert.AreEqual(10.5, targets[0].End, TOLERANCE);
+        }
+
+        [TestMethod]
+        public void TestMultiChargeOnlyDivergentChargeIsRescored()
+        {
+            // z=2 is leader at apex 10.0. z=3 is at 10.02 (within tolerance).
+            // z=4 is at 25.0 (way off). Only z=4 is a rescore target.
+            var z2 = MakeEntry(@"PEPTIDE1", apexRt: 10.0, score: 5.0,
+                isDecoy: false, precursorQ: 0.0, peptideQ: 0.0);
+            z2.Charge = 2;
+            var z3 = MakeEntry(@"PEPTIDE1", apexRt: 10.02, score: 3.0,
+                isDecoy: false, precursorQ: 0.0, peptideQ: 0.0);
+            z3.Charge = 3;
+            var z4 = MakeEntry(@"PEPTIDE1", apexRt: 25.0, score: 1.0,
+                isDecoy: false, precursorQ: 0.0, peptideQ: 0.0);
+            z4.Charge = 4;
+
+            var targets = MultiChargeConsensus.SelectRescoreTargets(
+                new[] { z2, z3, z4 }, fdrThreshold: 0.01);
+
+            Assert.AreEqual(1, targets.Count);
+            Assert.AreEqual(2, targets[0].Index); // z4 at position 2
+        }
+
+        [TestMethod]
+        public void TestMultiChargeTieOnScoreLowerQvalueWins()
+        {
+            // Two passing entries with equal score but different qvalues.
+            // Lower q-value should win. Third entry has a wrong apex and
+            // should be a rescore target anchored at the winner's RT.
+            var tieHighQ = MakeEntry(@"PEPTIDE1", apexRt: 30.0, score: 3.0,
+                isDecoy: false, precursorQ: 0.009, peptideQ: 0.009);
+            tieHighQ.Charge = 2;
+            var tieLowQ = MakeEntry(@"PEPTIDE1", apexRt: 10.0, score: 3.0,
+                isDecoy: false, precursorQ: 0.001, peptideQ: 0.001);
+            tieLowQ.Charge = 3;
+            var wrong = MakeEntry(@"PEPTIDE1", apexRt: 50.0, score: 1.0,
+                isDecoy: false, precursorQ: 0.0, peptideQ: 0.0);
+            wrong.Charge = 4;
+
+            var targets = MultiChargeConsensus.SelectRescoreTargets(
+                new[] { tieHighQ, tieLowQ, wrong }, fdrThreshold: 0.01);
+
+            // Leader should be tieLowQ (apex 10.0). Both the other entries
+            // are far from it and should be rescore targets.
+            Assert.AreEqual(2, targets.Count);
+            foreach (var t in targets)
+            {
+                Assert.AreEqual(10.0, t.Apex, TOLERANCE,
+                    @"targets should anchor on the low-qvalue leader");
+            }
+        }
+
+        [TestMethod]
+        public void TestMultiChargeDecoyAndTargetAreSeparateGroups()
+        {
+            // Target PEPTIDE1 and decoy DECOY_PEPTIDE1 are treated as
+            // separate groups (different modified_sequence keys), so they
+            // do not interfere.
+            var t2 = MakeEntry(@"PEPTIDE1", apexRt: 10.0, score: 5.0,
+                isDecoy: false, precursorQ: 0.0, peptideQ: 0.0);
+            t2.Charge = 2;
+            var t3 = MakeEntry(@"PEPTIDE1", apexRt: 25.0, score: 1.0,
+                isDecoy: false, precursorQ: 0.0, peptideQ: 0.0);
+            t3.Charge = 3;
+            var d2 = MakeEntry(@"DECOY_PEPTIDE1", apexRt: 40.0, score: 3.0,
+                isDecoy: true, precursorQ: 0.0, peptideQ: 0.0);
+            d2.Charge = 2;
+            var d3 = MakeEntry(@"DECOY_PEPTIDE1", apexRt: 60.0, score: 1.0,
+                isDecoy: true, precursorQ: 0.0, peptideQ: 0.0);
+            d3.Charge = 3;
+
+            var targets = MultiChargeConsensus.SelectRescoreTargets(
+                new[] { t2, t3, d2, d3 }, fdrThreshold: 0.01);
+
+            // t3 anchored at t2 (apex 10.0), d3 anchored at d2 (apex 40.0).
+            Assert.AreEqual(2, targets.Count);
+            // t3 was at index 1, d3 at index 3.
+            foreach (var t in targets)
+            {
+                if (t.Index == 1)
+                    Assert.AreEqual(10.0, t.Apex, TOLERANCE);
+                else if (t.Index == 3)
+                    Assert.AreEqual(40.0, t.Apex, TOLERANCE);
+                else
+                    Assert.Fail(@"unexpected index " + t.Index);
+            }
+        }
+
+        #endregion
+
         #region Fixture helpers
 
         /// <summary>

--- a/pwiz_tools/OspreySharp/OspreySharp.Test/ReconciliationTest.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Test/ReconciliationTest.cs
@@ -1,0 +1,468 @@
+/*
+ * Original author: Brendan MacLean <brendanx .at. uw.edu>,
+ *                  MacCoss Lab, Department of Genome Sciences, UW
+ * AI assistance: Claude Code (Claude Opus 4) <noreply .at. anthropic.com>
+ *
+ * Based on osprey (https://github.com/MacCossLab/osprey)
+ *   by Michael J. MacCoss, MacCoss Lab, Department of Genome Sciences, UW
+ *
+ * Copyright 2026 University of Washington - Seattle, WA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Tests for OspreySharp.FDR.Reconciliation module.
+// Ports the Rust reconciliation tests in
+// osprey/crates/osprey/src/reconciliation.rs.
+
+using System;
+using System.Collections.Generic;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using pwiz.OspreySharp.Chromatography;
+using pwiz.OspreySharp.Core;
+using pwiz.OspreySharp.FDR.Reconciliation;
+
+namespace pwiz.OspreySharp.Test
+{
+    [TestClass]
+    public class ReconciliationTest
+    {
+        private const double TOLERANCE = 1e-9;
+
+        #region WeightedMedian helper
+
+        [TestMethod]
+        public void TestWeightedMedianEmpty()
+        {
+            Assert.AreEqual(0.0, ConsensusRts.WeightedMedian(Array.Empty<(double, double)>()));
+        }
+
+        [TestMethod]
+        public void TestWeightedMedianSingle()
+        {
+            Assert.AreEqual(3.5, ConsensusRts.WeightedMedian(new[] { (3.5, 1.0) }));
+        }
+
+        [TestMethod]
+        public void TestWeightedMedianEqualWeights()
+        {
+            // Values 1, 2, 3, 4, 5 each with weight 1.0. Half = 2.5. Cumulative at
+            // index 2 (value 3) reaches 3.0 >= 2.5 first, so median = 3.
+            var pairs = new[] { (1.0, 1.0), (2.0, 1.0), (3.0, 1.0), (4.0, 1.0), (5.0, 1.0) };
+            Assert.AreEqual(3.0, ConsensusRts.WeightedMedian(pairs));
+        }
+
+        [TestMethod]
+        public void TestWeightedMedianUnequalWeights()
+        {
+            // One dominant weight pulls the median toward that value.
+            // Values 1, 2, 10 with weights 1, 1, 10. Total = 12, half = 6.
+            // Cumulative: 1 (<6), 2 (<6), 12 (>=6) → median = 10.
+            var pairs = new[] { (1.0, 1.0), (2.0, 1.0), (10.0, 10.0) };
+            Assert.AreEqual(10.0, ConsensusRts.WeightedMedian(pairs));
+        }
+
+        [TestMethod]
+        public void TestWeightedMedianInsensitiveToInputOrder()
+        {
+            var sorted = new[] { (1.0, 0.5), (2.0, 0.5), (3.0, 5.0), (4.0, 0.5), (5.0, 0.5) };
+            var shuffled = new[] { (3.0, 5.0), (5.0, 0.5), (1.0, 0.5), (4.0, 0.5), (2.0, 0.5) };
+            Assert.AreEqual(ConsensusRts.WeightedMedian(sorted),
+                              ConsensusRts.WeightedMedian(shuffled));
+        }
+
+        #endregion
+
+        #region ComputeConsensusRts end-to-end
+
+        [TestMethod]
+        public void TestComputeEmptyReturnsEmpty()
+        {
+            var result = ConsensusRts.Compute(
+                new List<KeyValuePair<string, IReadOnlyList<FdrEntry>>>(),
+                new Dictionary<string, RTCalibration>(),
+                consensusFdr: 0.01,
+                proteinFdrThreshold: 0.0);
+
+            Assert.AreEqual(0, result.Count);
+        }
+
+        [TestMethod]
+        public void TestComputeThreeFileTargetWithPairedDecoy()
+        {
+            // Three files, identity RT calibration on each. One target peptide
+            // detected at apex 10.0, 10.1, 9.9 across the three runs — consensus
+            // library RT should land at one of those values (sigmoid-weighted,
+            // non-interpolated cumulative median).
+            var cal = IdentityCalibration();
+            var cals = new Dictionary<string, RTCalibration>
+            {
+                { @"f1", cal }, { @"f2", cal }, { @"f3", cal }
+            };
+
+            var perFile = new List<KeyValuePair<string, IReadOnlyList<FdrEntry>>>
+            {
+                Pair(@"f1", PassingTarget(@"PEPTIDE1", apexRt: 10.0, score: 3.0)),
+                Pair(@"f2", PassingTarget(@"PEPTIDE1", apexRt: 10.1, score: 3.0)),
+                Pair(@"f3", PassingTarget(@"PEPTIDE1", apexRt: 9.9,  score: 3.0)),
+            };
+
+            var consensus = ConsensusRts.Compute(perFile, cals, 0.01, 0.0);
+
+            Assert.AreEqual(1, consensus.Count);
+            var entry = consensus[0];
+            Assert.AreEqual(@"PEPTIDE1", entry.ModifiedSequence);
+            Assert.IsFalse(entry.IsDecoy);
+            Assert.AreEqual(3, entry.NRunsDetected);
+            Assert.IsTrue(entry.ApexLibraryRtMad.HasValue,
+                @"MAD should be populated with 3 runs");
+            Assert.IsTrue(Math.Abs(entry.ConsensusLibraryRt - 10.0) <= 0.1,
+                string.Format(@"consensus should be near 10.0, got {0}",
+                              entry.ConsensusLibraryRt));
+        }
+
+        [TestMethod]
+        public void TestComputePairedDecoyIncludedWhenTargetQualifies()
+        {
+            // Target qualifies in f1 + f2. A paired decoy (DECOY_PEPTIDE1)
+            // appears in f3. The decoy consensus should be emitted even though
+            // the decoy itself does not pass qualification.
+            var cal = IdentityCalibration();
+            var cals = new Dictionary<string, RTCalibration>
+            {
+                { @"f1", cal }, { @"f2", cal }, { @"f3", cal }
+            };
+
+            var perFile = new List<KeyValuePair<string, IReadOnlyList<FdrEntry>>>
+            {
+                Pair(@"f1", PassingTarget(@"PEPTIDE1", apexRt: 10.0, score: 3.0)),
+                Pair(@"f2", PassingTarget(@"PEPTIDE1", apexRt: 10.1, score: 3.0)),
+                Pair(@"f3", Decoy(@"DECOY_PEPTIDE1", apexRt: 15.0, score: -1.0)),
+            };
+
+            var consensus = ConsensusRts.Compute(perFile, cals, 0.01, 0.0);
+
+            Assert.AreEqual(2, consensus.Count);
+            Assert.IsFalse(consensus[0].IsDecoy);
+            Assert.AreEqual(@"PEPTIDE1", consensus[0].ModifiedSequence);
+            Assert.IsTrue(consensus[1].IsDecoy);
+            Assert.AreEqual(@"DECOY_PEPTIDE1", consensus[1].ModifiedSequence);
+        }
+
+        [TestMethod]
+        public void TestComputeRejectsLowPrecursorQvalueDespiteProteinRescue()
+        {
+            // Mirrors Rust test_consensus_rejects_low_precursor_q_despite_protein_rescue.
+            // Hard precursor-q gate must reject a target even when its protein
+            // q-value would otherwise rescue it. Consensus is driven by the
+            // detection's own apex_rt, so poor precursor-level evidence cannot
+            // be rescued by protein-level aggregate evidence.
+            var cal = IdentityCalibration();
+            var cals = new Dictionary<string, RTCalibration>
+            {
+                { @"f1", cal }, { @"f2", cal }
+            };
+
+            var weakPrecursor = new FdrEntry
+            {
+                EntryId = 1,
+                IsDecoy = false,
+                Charge = 2,
+                ApexRt = 10.0,
+                StartRt = 9.5,
+                EndRt = 10.5,
+                CoelutionSum = 1.0,
+                Score = 3.0,
+                RunPrecursorQvalue = 0.20,  // fails hard gate
+                RunPeptideQvalue = 0.02,    // fails peptide too
+                RunProteinQvalue = 0.001,   // would rescue if allowed
+                ModifiedSequence = @"PEPTIDE1",
+            };
+            var goodTarget = PassingTarget(@"PEPTIDE2", apexRt: 20.0, score: 3.0);
+
+            var perFile = new List<KeyValuePair<string, IReadOnlyList<FdrEntry>>>
+            {
+                Pair(@"f1", new[] { weakPrecursor }),
+                Pair(@"f2", goodTarget),
+            };
+
+            var consensus = ConsensusRts.Compute(
+                perFile, cals,
+                consensusFdr: 0.01,
+                proteinFdrThreshold: 0.01);
+
+            Assert.AreEqual(1, consensus.Count);
+            Assert.AreEqual(@"PEPTIDE2", consensus[0].ModifiedSequence);
+        }
+
+        [TestMethod]
+        public void TestComputeProteinRescueUpgradesBorderlinePeptideQvalue()
+        {
+            // Precursor-q passes the hard gate, peptide-q is borderline but
+            // fails consensus_fdr, protein-q passes protein threshold →
+            // detection should be included.
+            var cal = IdentityCalibration();
+            var cals = new Dictionary<string, RTCalibration> { { @"f1", cal } };
+
+            var borderline = new FdrEntry
+            {
+                EntryId = 1,
+                IsDecoy = false,
+                Charge = 2,
+                ApexRt = 10.0,
+                StartRt = 9.5,
+                EndRt = 10.5,
+                CoelutionSum = 1.0,
+                Score = 3.0,
+                RunPrecursorQvalue = 0.005, // passes hard gate
+                RunPeptideQvalue = 0.05,    // fails borderline
+                RunProteinQvalue = 0.005,   // rescues
+                ModifiedSequence = @"PEPTIDE1",
+            };
+
+            var perFile = new List<KeyValuePair<string, IReadOnlyList<FdrEntry>>>
+            {
+                Pair(@"f1", new[] { borderline }),
+            };
+
+            var consensus = ConsensusRts.Compute(
+                perFile, cals,
+                consensusFdr: 0.01,
+                proteinFdrThreshold: 0.01);
+
+            Assert.AreEqual(1, consensus.Count);
+            Assert.AreEqual(@"PEPTIDE1", consensus[0].ModifiedSequence);
+
+            // Repeat with protein rescue disabled — same detection must be rejected.
+            var consensusNoRescue = ConsensusRts.Compute(
+                perFile, cals,
+                consensusFdr: 0.01,
+                proteinFdrThreshold: 0.0);
+            Assert.AreEqual(0, consensusNoRescue.Count);
+        }
+
+        [TestMethod]
+        public void TestComputeSigmoidWeightingDownweightsNegativeScores()
+        {
+            // Mirrors Rust test_consensus_weighting_downweights_negative_score_detections.
+            // Three detections: a strong positive-score detection at 10.0 and
+            // two wrong-peak weak negative-score detections at 20.0. Sigmoid
+            // weighting (~0.95 vs ~0.02) means the positive detection
+            // dominates the weighted median.
+            var cal = IdentityCalibration();
+            var cals = new Dictionary<string, RTCalibration>
+            {
+                { @"f1", cal }, { @"f2", cal }, { @"f3", cal }
+            };
+
+            var perFile = new List<KeyValuePair<string, IReadOnlyList<FdrEntry>>>
+            {
+                Pair(@"f1", PassingTarget(@"PEPTIDE1", apexRt: 10.0, score: 3.0)),
+                Pair(@"f2", PassingTarget(@"PEPTIDE1", apexRt: 20.0, score: -4.0)),
+                Pair(@"f3", PassingTarget(@"PEPTIDE1", apexRt: 20.0, score: -4.0)),
+            };
+
+            var consensus = ConsensusRts.Compute(perFile, cals, 0.01, 0.0);
+
+            Assert.AreEqual(1, consensus.Count);
+            Assert.AreEqual(10.0, consensus[0].ConsensusLibraryRt, TOLERANCE);
+        }
+
+        [TestMethod]
+        public void TestComputeFiltersNonPositiveCoelutionSum()
+        {
+            // Two detections: one with coelution_sum = 0 (anti-correlated /
+            // forced integration at empty region), one positive. The
+            // non-positive coelution entry must be excluded from the weighted
+            // median; the remaining detection provides the consensus.
+            var cal = IdentityCalibration();
+            var cals = new Dictionary<string, RTCalibration>
+            {
+                { @"f1", cal }, { @"f2", cal }
+            };
+
+            var zeroCoelution = new FdrEntry
+            {
+                EntryId = 1, IsDecoy = false, Charge = 2,
+                ApexRt = 30.0, StartRt = 29.0, EndRt = 31.0,
+                CoelutionSum = 0.0,
+                Score = 3.0,
+                RunPrecursorQvalue = 0.0, RunPeptideQvalue = 0.0,
+                ModifiedSequence = @"PEPTIDE1",
+            };
+            var good = PassingTarget(@"PEPTIDE1", apexRt: 10.0, score: 3.0);
+
+            var perFile = new List<KeyValuePair<string, IReadOnlyList<FdrEntry>>>
+            {
+                Pair(@"f1", new[] { zeroCoelution }),
+                Pair(@"f2", good),
+            };
+
+            var consensus = ConsensusRts.Compute(perFile, cals, 0.01, 0.0);
+
+            Assert.AreEqual(1, consensus.Count);
+            Assert.AreEqual(1, consensus[0].NRunsDetected);
+            Assert.AreEqual(10.0, consensus[0].ConsensusLibraryRt, TOLERANCE);
+        }
+
+        [TestMethod]
+        public void TestComputeMadNullBelowThreeDetections()
+        {
+            var cal = IdentityCalibration();
+            var cals = new Dictionary<string, RTCalibration>
+            {
+                { @"f1", cal }, { @"f2", cal }
+            };
+
+            var perFile = new List<KeyValuePair<string, IReadOnlyList<FdrEntry>>>
+            {
+                Pair(@"f1", PassingTarget(@"PEPTIDE1", apexRt: 10.0, score: 3.0)),
+                Pair(@"f2", PassingTarget(@"PEPTIDE1", apexRt: 11.0, score: 3.0)),
+            };
+
+            var consensus = ConsensusRts.Compute(perFile, cals, 0.01, 0.0);
+            Assert.AreEqual(1, consensus.Count);
+            Assert.AreEqual(2, consensus[0].NRunsDetected);
+            Assert.IsFalse(consensus[0].ApexLibraryRtMad.HasValue);
+        }
+
+        [TestMethod]
+        public void TestComputeDeterministicSortOrder()
+        {
+            // Two target peptides + one matching decoy. Output must be:
+            // targets first (by modified_sequence ordinal), decoys last.
+            var cal = IdentityCalibration();
+            var cals = new Dictionary<string, RTCalibration> { { @"f1", cal } };
+
+            var perFile = new List<KeyValuePair<string, IReadOnlyList<FdrEntry>>>
+            {
+                Pair(@"f1", new[]
+                {
+                    MakeEntry(@"ZETA",  apexRt: 10.0, score: 3.0, isDecoy: false, precursorQ: 0.0, peptideQ: 0.0),
+                    MakeEntry(@"ALPHA", apexRt: 10.0, score: 3.0, isDecoy: false, precursorQ: 0.0, peptideQ: 0.0),
+                    MakeEntry(@"DECOY_ZETA", apexRt: 15.0, score: -1.0, isDecoy: true,
+                              precursorQ: 1.0, peptideQ: 1.0),
+                }),
+            };
+
+            var consensus = ConsensusRts.Compute(perFile, cals, 0.01, 0.0);
+
+            Assert.AreEqual(3, consensus.Count);
+            Assert.AreEqual(@"ALPHA", consensus[0].ModifiedSequence);
+            Assert.IsFalse(consensus[0].IsDecoy);
+            Assert.AreEqual(@"ZETA", consensus[1].ModifiedSequence);
+            Assert.IsFalse(consensus[1].IsDecoy);
+            Assert.AreEqual(@"DECOY_ZETA", consensus[2].ModifiedSequence);
+            Assert.IsTrue(consensus[2].IsDecoy);
+        }
+
+        [TestMethod]
+        public void TestComputeTargetWithoutCalibrationSkipped()
+        {
+            // File with no calibration entry → detection silently skipped
+            // (matches Rust behavior: HashMap lookup returns None, detection
+            // contributes nothing).
+            var cal = IdentityCalibration();
+            var cals = new Dictionary<string, RTCalibration> { { @"f1", cal } };
+
+            var perFile = new List<KeyValuePair<string, IReadOnlyList<FdrEntry>>>
+            {
+                Pair(@"f1", PassingTarget(@"PEPTIDE1", apexRt: 10.0, score: 3.0)),
+                Pair(@"f_no_cal", PassingTarget(@"PEPTIDE1", apexRt: 99.0, score: 3.0)),
+            };
+
+            var consensus = ConsensusRts.Compute(perFile, cals, 0.01, 0.0);
+            Assert.AreEqual(1, consensus.Count);
+            Assert.AreEqual(1, consensus[0].NRunsDetected);
+            Assert.AreEqual(10.0, consensus[0].ConsensusLibraryRt, TOLERANCE);
+        }
+
+        #endregion
+
+        #region Fixture helpers
+
+        /// <summary>
+        /// Identity LOESS calibration fit on 30 equally-spaced (x, x) points so
+        /// InversePredict(y) = y for y in [0, 29].
+        /// </summary>
+        private static RTCalibration IdentityCalibration()
+        {
+            int n = 30;
+            var libRts = new double[n];
+            var measRts = new double[n];
+            for (int i = 0; i < n; i++)
+            {
+                libRts[i] = i;
+                measRts[i] = i;
+            }
+            var config = new RTCalibratorConfig
+            {
+                Bandwidth = 0.3,
+                Degree = 1,
+                MinPoints = 5,
+                RobustnessIterations = 0,
+                OutlierRetention = 1.0,
+            };
+            return new RTCalibrator(config).Fit(libRts, measRts);
+        }
+
+        private static KeyValuePair<string, IReadOnlyList<FdrEntry>> Pair(
+            string fileName, IReadOnlyList<FdrEntry> entries)
+        {
+            return new KeyValuePair<string, IReadOnlyList<FdrEntry>>(fileName, entries);
+        }
+
+        private static IReadOnlyList<FdrEntry> PassingTarget(
+            string modifiedSequence, double apexRt, double score)
+        {
+            return new[]
+            {
+                MakeEntry(modifiedSequence, apexRt, score,
+                          isDecoy: false, precursorQ: 0.0, peptideQ: 0.0),
+            };
+        }
+
+        private static IReadOnlyList<FdrEntry> Decoy(
+            string modifiedSequence, double apexRt, double score)
+        {
+            return new[]
+            {
+                MakeEntry(modifiedSequence, apexRt, score,
+                          isDecoy: true, precursorQ: 1.0, peptideQ: 1.0),
+            };
+        }
+
+        private static FdrEntry MakeEntry(
+            string modifiedSequence, double apexRt, double score,
+            bool isDecoy, double precursorQ, double peptideQ)
+        {
+            return new FdrEntry
+            {
+                EntryId = 1,
+                IsDecoy = isDecoy,
+                Charge = 2,
+                ApexRt = apexRt,
+                StartRt = apexRt - 0.5,
+                EndRt = apexRt + 0.5,
+                CoelutionSum = 1.0,
+                Score = score,
+                RunPrecursorQvalue = precursorQ,
+                RunPeptideQvalue = peptideQ,
+                RunProteinQvalue = 1.0,
+                ModifiedSequence = modifiedSequence,
+            };
+        }
+
+        #endregion
+    }
+}

--- a/pwiz_tools/OspreySharp/OspreySharp.Test/ReconciliationTest.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Test/ReconciliationTest.cs
@@ -389,6 +389,415 @@ namespace pwiz.OspreySharp.Test
 
         #endregion
 
+        #region DetermineAction
+
+        [TestMethod]
+        public void TestDetermineActionApexWithinToleranceReturnsKeep()
+        {
+            var cwt = new[]
+            {
+                new CwtCandidate { ApexRt = 12.0, StartRt = 11.5, EndRt = 12.5 },
+            };
+            var action = ReconciliationPlanner.DetermineAction(
+                apexRt: 10.05, cwtCandidates: cwt,
+                expectedMeasuredRt: 10.0, rtTolerance: 0.1, halfWidth: 0.5);
+            Assert.AreSame(ReconcileAction.Keep, action);
+        }
+
+        [TestMethod]
+        public void TestDetermineActionPicksClosestCwtApex()
+        {
+            // Current apex is at 15.0, expected is 10.0 (outside tolerance).
+            // Three CWT candidates: 12.0 (outside), 9.7 (within, |dev|=0.3),
+            // 10.15 (within, |dev|=0.15). Must pick index 2.
+            var cwt = new[]
+            {
+                new CwtCandidate { ApexRt = 12.0, StartRt = 11.5, EndRt = 12.5 },
+                new CwtCandidate { ApexRt = 9.7,  StartRt = 9.2,  EndRt = 10.2 },
+                new CwtCandidate { ApexRt = 10.15, StartRt = 9.65, EndRt = 10.65 },
+            };
+            var action = ReconciliationPlanner.DetermineAction(
+                apexRt: 15.0, cwtCandidates: cwt,
+                expectedMeasuredRt: 10.0, rtTolerance: 0.5, halfWidth: 0.5);
+
+            Assert.IsInstanceOfType(action, typeof(ReconcileAction.UseCwtPeak));
+            var use = (ReconcileAction.UseCwtPeak)action;
+            Assert.AreEqual(2, use.CandidateIndex);
+            Assert.AreEqual(10.15, use.ApexRt, TOLERANCE);
+            Assert.AreEqual(9.65, use.StartRt, TOLERANCE);
+            Assert.AreEqual(10.65, use.EndRt, TOLERANCE);
+        }
+
+        [TestMethod]
+        public void TestDetermineActionForcedIntegrationWhenNoCwtInTolerance()
+        {
+            var cwt = new[]
+            {
+                new CwtCandidate { ApexRt = 15.0, StartRt = 14.5, EndRt = 15.5 },
+                new CwtCandidate { ApexRt = 20.0, StartRt = 19.5, EndRt = 20.5 },
+            };
+            var action = ReconciliationPlanner.DetermineAction(
+                apexRt: 15.0, cwtCandidates: cwt,
+                expectedMeasuredRt: 10.0, rtTolerance: 0.5, halfWidth: 0.75);
+
+            Assert.IsInstanceOfType(action, typeof(ReconcileAction.ForcedIntegration));
+            var forced = (ReconcileAction.ForcedIntegration)action;
+            Assert.AreEqual(10.0, forced.ExpectedRt, TOLERANCE);
+            Assert.AreEqual(0.75, forced.HalfWidth, TOLERANCE);
+        }
+
+        [TestMethod]
+        public void TestDetermineActionEmptyCwtForcesIntegration()
+        {
+            var action = ReconciliationPlanner.DetermineAction(
+                apexRt: 15.0, cwtCandidates: Array.Empty<CwtCandidate>(),
+                expectedMeasuredRt: 10.0, rtTolerance: 0.5, halfWidth: 0.4);
+
+            Assert.IsInstanceOfType(action, typeof(ReconcileAction.ForcedIntegration));
+            var forced = (ReconcileAction.ForcedIntegration)action;
+            Assert.AreEqual(10.0, forced.ExpectedRt, TOLERANCE);
+            Assert.AreEqual(0.4, forced.HalfWidth, TOLERANCE);
+        }
+
+        [TestMethod]
+        public void TestDetermineActionNullCwtForcesIntegration()
+        {
+            var action = ReconciliationPlanner.DetermineAction(
+                apexRt: 15.0, cwtCandidates: null,
+                expectedMeasuredRt: 10.0, rtTolerance: 0.5, halfWidth: 0.3);
+
+            Assert.IsInstanceOfType(action, typeof(ReconcileAction.ForcedIntegration));
+        }
+
+        #endregion
+
+        #region SigmaClippedMad
+
+        [TestMethod]
+        public void TestSigmaClippedMadEmpty()
+        {
+            Assert.AreEqual(0.0, ReconciliationPlanner.SigmaClippedMad(
+                Array.Empty<double>(), clipThreshold: 1.0));
+        }
+
+        [TestMethod]
+        public void TestSigmaClippedMadFallbackOnTooFewSurvivors()
+        {
+            // 19 small residuals + 5 large outliers. A tight clipThreshold
+            // keeps 19 survivors (< min 20) so it falls back to the raw
+            // (sorted) median of all 24 values.
+            var residuals = new List<double>();
+            for (int i = 0; i < 19; i++)
+                residuals.Add(0.01 * i);
+            residuals.AddRange(new[] { 5.0, 5.1, 5.2, 5.3, 5.4 });
+
+            double mad = ReconciliationPlanner.SigmaClippedMad(residuals, clipThreshold: 1.0);
+
+            // Sorted 24 values; median index 12 of sorted = 12 * 0.01 = 0.12.
+            var sorted = residuals.ToArray();
+            Array.Sort(sorted);
+            Assert.AreEqual(sorted[12], mad, TOLERANCE);
+        }
+
+        [TestMethod]
+        public void TestSigmaClippedMadUsesClippedMedianWhenEnoughSurvive()
+        {
+            // 40 residuals of 0.1 + 10 large outliers at 10.0. Clip at 1.0
+            // survives 40 values; survivor median = 0.1.
+            var residuals = new List<double>();
+            for (int i = 0; i < 40; i++)
+                residuals.Add(0.1);
+            for (int i = 0; i < 10; i++)
+                residuals.Add(10.0);
+
+            double mad = ReconciliationPlanner.SigmaClippedMad(residuals, clipThreshold: 1.0);
+            Assert.AreEqual(0.1, mad, TOLERANCE);
+        }
+
+        #endregion
+
+        #region Plan
+
+        [TestMethod]
+        public void TestPlanEmptyConsensusReturnsEmpty()
+        {
+            var cal = IdentityCalibration();
+            var cals = new Dictionary<string, RTCalibration> { { @"f1", cal } };
+            var perFile = new List<KeyValuePair<string, IReadOnlyList<FdrEntry>>>
+            {
+                Pair(@"f1", PassingTarget(@"PEPTIDE1", apexRt: 10.0, score: 3.0)),
+            };
+
+            var actions = ReconciliationPlanner.Plan(
+                Array.Empty<PeptideConsensusRT>(),
+                perFile,
+                new Dictionary<string, IReadOnlyList<IReadOnlyList<CwtCandidate>>>(),
+                cals, cals, experimentFdr: 0.01);
+
+            Assert.AreEqual(0, actions.Count);
+        }
+
+        [TestMethod]
+        public void TestPlanEntryAlreadyAtExpectedRtOmittedFromMap()
+        {
+            var cal = IdentityCalibration();
+            var cals = new Dictionary<string, RTCalibration> { { @"f1", cal } };
+
+            var consensus = new[]
+            {
+                new PeptideConsensusRT
+                {
+                    ModifiedSequence = @"PEPTIDE1", IsDecoy = false,
+                    ConsensusLibraryRt = 10.0, MedianPeakWidth = 0.8,
+                    NRunsDetected = 3, ApexLibraryRtMad = 0.02,
+                },
+            };
+
+            var perFile = new List<KeyValuePair<string, IReadOnlyList<FdrEntry>>>
+            {
+                Pair(@"f1", PassingTarget(@"PEPTIDE1", apexRt: 10.0, score: 3.0)),
+            };
+
+            var actions = ReconciliationPlanner.Plan(
+                consensus, perFile,
+                new Dictionary<string, IReadOnlyList<IReadOnlyList<CwtCandidate>>>(),
+                cals, cals, experimentFdr: 0.01);
+
+            Assert.AreEqual(0, actions.Count);
+        }
+
+        [TestMethod]
+        public void TestPlanWrongApexForcesIntegrationWithoutCwt()
+        {
+            var cal = IdentityCalibration();
+            var cals = new Dictionary<string, RTCalibration> { { @"f1", cal } };
+
+            var consensus = new[]
+            {
+                new PeptideConsensusRT
+                {
+                    ModifiedSequence = @"PEPTIDE1", IsDecoy = false,
+                    ConsensusLibraryRt = 10.0, MedianPeakWidth = 0.8,
+                    NRunsDetected = 3, ApexLibraryRtMad = 0.02,
+                },
+            };
+
+            var perFile = new List<KeyValuePair<string, IReadOnlyList<FdrEntry>>>
+            {
+                Pair(@"f1", PassingTarget(@"PEPTIDE1", apexRt: 20.0, score: 3.0)),
+            };
+
+            var actions = ReconciliationPlanner.Plan(
+                consensus, perFile,
+                new Dictionary<string, IReadOnlyList<IReadOnlyList<CwtCandidate>>>(),
+                cals, cals, experimentFdr: 0.01);
+
+            Assert.AreEqual(1, actions.Count);
+            var action = actions[(@"f1", 0)];
+            Assert.IsInstanceOfType(action, typeof(ReconcileAction.ForcedIntegration));
+            var forced = (ReconcileAction.ForcedIntegration)action;
+            Assert.AreEqual(10.0, forced.ExpectedRt, 1e-6);
+            Assert.AreEqual(0.4, forced.HalfWidth, 1e-6);
+        }
+
+        [TestMethod]
+        public void TestPlanWrongApexPicksCwtCandidate()
+        {
+            var cal = IdentityCalibration();
+            var cals = new Dictionary<string, RTCalibration> { { @"f1", cal } };
+
+            var consensus = new[]
+            {
+                new PeptideConsensusRT
+                {
+                    ModifiedSequence = @"PEPTIDE1", IsDecoy = false,
+                    ConsensusLibraryRt = 10.0, MedianPeakWidth = 0.8,
+                    NRunsDetected = 3, ApexLibraryRtMad = 0.02,
+                },
+            };
+
+            // Entry ParquetIndex = 0 → look up CWT at index 0.
+            var entry = MakeEntry(@"PEPTIDE1", apexRt: 20.0, score: 3.0,
+                isDecoy: false, precursorQ: 0.0, peptideQ: 0.0);
+            entry.ParquetIndex = 0;
+
+            var perFile = new List<KeyValuePair<string, IReadOnlyList<FdrEntry>>>
+            {
+                Pair(@"f1", new[] { entry }),
+            };
+
+            // Two CWT candidates for entry 0 — index 1 is within tolerance.
+            var cwtForFile = new IReadOnlyList<CwtCandidate>[]
+            {
+                new[]
+                {
+                    new CwtCandidate { ApexRt = 20.0, StartRt = 19.5, EndRt = 20.5 },
+                    new CwtCandidate { ApexRt = 10.1, StartRt = 9.6,  EndRt = 10.6 },
+                },
+            };
+            var cwt = new Dictionary<string, IReadOnlyList<IReadOnlyList<CwtCandidate>>>
+            {
+                { @"f1", cwtForFile },
+            };
+
+            var actions = ReconciliationPlanner.Plan(
+                consensus, perFile, cwt, cals, cals, experimentFdr: 0.01);
+
+            Assert.AreEqual(1, actions.Count);
+            var action = actions[(@"f1", 0)];
+            Assert.IsInstanceOfType(action, typeof(ReconcileAction.UseCwtPeak));
+            var use = (ReconcileAction.UseCwtPeak)action;
+            Assert.AreEqual(1, use.CandidateIndex);
+            Assert.AreEqual(10.1, use.ApexRt, TOLERANCE);
+        }
+
+        [TestMethod]
+        public void TestPlanNonPassingPrecursorSkipped()
+        {
+            // Target with high run-level q-values in the only run, and high
+            // experiment q-values too. Best q > experimentFdr → not in the
+            // passingPrecursors set → skipped even though the peptide is in
+            // consensus.
+            var cal = IdentityCalibration();
+            var cals = new Dictionary<string, RTCalibration> { { @"f1", cal } };
+
+            var consensus = new[]
+            {
+                new PeptideConsensusRT
+                {
+                    ModifiedSequence = @"PEPTIDE1", IsDecoy = false,
+                    ConsensusLibraryRt = 10.0, MedianPeakWidth = 0.8,
+                    NRunsDetected = 3, ApexLibraryRtMad = 0.02,
+                },
+            };
+
+            var failing = new FdrEntry
+            {
+                EntryId = 1, IsDecoy = false, Charge = 2,
+                ApexRt = 20.0, StartRt = 19.5, EndRt = 20.5,
+                CoelutionSum = 1.0, Score = 1.0,
+                RunPrecursorQvalue = 0.9, RunPeptideQvalue = 0.9,
+                ExperimentPrecursorQvalue = 0.9, ExperimentPeptideQvalue = 0.9,
+                ModifiedSequence = @"PEPTIDE1",
+            };
+
+            var perFile = new List<KeyValuePair<string, IReadOnlyList<FdrEntry>>>
+            {
+                Pair(@"f1", new[] { failing }),
+            };
+
+            var actions = ReconciliationPlanner.Plan(
+                consensus, perFile,
+                new Dictionary<string, IReadOnlyList<IReadOnlyList<CwtCandidate>>>(),
+                cals, cals, experimentFdr: 0.01);
+
+            Assert.AreEqual(0, actions.Count);
+        }
+
+        [TestMethod]
+        public void TestPlanDecoyReconciledAlongsidePassingTarget()
+        {
+            // Target passes in f1, decoy appears in f1 at the wrong RT.
+            // Decoy should be reconciled (ForcedIntegration here since no CWT).
+            var cal = IdentityCalibration();
+            var cals = new Dictionary<string, RTCalibration> { { @"f1", cal } };
+
+            var consensus = new[]
+            {
+                new PeptideConsensusRT
+                {
+                    ModifiedSequence = @"PEPTIDE1", IsDecoy = false,
+                    ConsensusLibraryRt = 10.0, MedianPeakWidth = 0.6,
+                    NRunsDetected = 3, ApexLibraryRtMad = 0.02,
+                },
+                new PeptideConsensusRT
+                {
+                    ModifiedSequence = @"DECOY_PEPTIDE1", IsDecoy = true,
+                    ConsensusLibraryRt = 10.0, MedianPeakWidth = 0.6,
+                    NRunsDetected = 3, ApexLibraryRtMad = 0.02,
+                },
+            };
+
+            var target = MakeEntry(@"PEPTIDE1", apexRt: 10.0, score: 3.0,
+                isDecoy: false, precursorQ: 0.0, peptideQ: 0.0);
+            var decoy = MakeEntry(@"DECOY_PEPTIDE1", apexRt: 25.0, score: -1.0,
+                isDecoy: true, precursorQ: 1.0, peptideQ: 1.0);
+
+            var perFile = new List<KeyValuePair<string, IReadOnlyList<FdrEntry>>>
+            {
+                Pair(@"f1", new[] { target, decoy }),
+            };
+
+            var actions = ReconciliationPlanner.Plan(
+                consensus, perFile,
+                new Dictionary<string, IReadOnlyList<IReadOnlyList<CwtCandidate>>>(),
+                cals, cals, experimentFdr: 0.01);
+
+            // Target at 10.0 is already at consensus → Keep (absent).
+            // Decoy at 25.0 is way off consensus 10.0 → needs reconciling.
+            Assert.AreEqual(1, actions.Count);
+            Assert.IsTrue(actions.ContainsKey((@"f1", 1)));
+            Assert.IsInstanceOfType(
+                actions[(@"f1", 1)], typeof(ReconcileAction.ForcedIntegration));
+        }
+
+        [TestMethod]
+        public void TestPlanNonConsensusPeptideSkipped()
+        {
+            var cal = IdentityCalibration();
+            var cals = new Dictionary<string, RTCalibration> { { @"f1", cal } };
+
+            var perFile = new List<KeyValuePair<string, IReadOnlyList<FdrEntry>>>
+            {
+                Pair(@"f1", PassingTarget(@"NOT_IN_CONSENSUS", apexRt: 20.0, score: 3.0)),
+            };
+
+            var actions = ReconciliationPlanner.Plan(
+                Array.Empty<PeptideConsensusRT>(),
+                perFile,
+                new Dictionary<string, IReadOnlyList<IReadOnlyList<CwtCandidate>>>(),
+                cals, cals, experimentFdr: 0.01);
+
+            Assert.AreEqual(0, actions.Count);
+        }
+
+        [TestMethod]
+        public void TestPlanFallsBackToOriginalCalibrationWhenNoRefined()
+        {
+            var cal = IdentityCalibration();
+            var originalCals = new Dictionary<string, RTCalibration> { { @"f1", cal } };
+
+            var consensus = new[]
+            {
+                new PeptideConsensusRT
+                {
+                    ModifiedSequence = @"PEPTIDE1", IsDecoy = false,
+                    ConsensusLibraryRt = 10.0, MedianPeakWidth = 0.8,
+                    NRunsDetected = 3, ApexLibraryRtMad = 0.02,
+                },
+            };
+
+            var perFile = new List<KeyValuePair<string, IReadOnlyList<FdrEntry>>>
+            {
+                Pair(@"f1", PassingTarget(@"PEPTIDE1", apexRt: 20.0, score: 3.0)),
+            };
+
+            var actions = ReconciliationPlanner.Plan(
+                consensus, perFile,
+                new Dictionary<string, IReadOnlyList<IReadOnlyList<CwtCandidate>>>(),
+                perFileRefinedCal: new Dictionary<string, RTCalibration>(),
+                perFileOriginalCal: originalCals,
+                experimentFdr: 0.01);
+
+            // Original cal still produces expectedRt = 10.0 for lib_rt 10.0,
+            // so wrong-apex detection at 20.0 needs reconciliation.
+            Assert.AreEqual(1, actions.Count);
+            Assert.IsInstanceOfType(
+                actions[(@"f1", 0)], typeof(ReconcileAction.ForcedIntegration));
+        }
+
+        #endregion
+
         #region Fixture helpers
 
         /// <summary>

--- a/pwiz_tools/OspreySharp/OspreySharp/AnalysisPipeline.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/AnalysisPipeline.cs
@@ -32,6 +32,7 @@ using System.Threading.Tasks;
 using pwiz.OspreySharp.Chromatography;
 using pwiz.OspreySharp.Core;
 using pwiz.OspreySharp.FDR;
+using pwiz.OspreySharp.FDR.Reconciliation;
 using pwiz.OspreySharp.IO;
 using pwiz.OspreySharp.Scoring;
 
@@ -171,6 +172,9 @@ namespace pwiz.OspreySharp
                 // Stage 2-4: Per-file calibration + coelution scoring
                 // Process files in parallel when multiple files are provided.
                 var perFileEntries = new List<KeyValuePair<string, List<FdrEntry>>>();
+                // Per-file RT calibration handles harvested by ProcessFile so
+                // Stage 6 reconciliation has the live RTCalibration objects.
+                var perFileCalibrations = new ConcurrentDictionary<string, RTCalibration>();
 
                 bool joinOnly = config.InputScores != null && config.InputScores.Count > 0;
                 int nFiles = joinOnly ? config.InputScores.Count : config.InputFiles.Count;
@@ -262,6 +266,38 @@ namespace pwiz.OspreySharp
                             stubs[j].Features = features[j];
                         LogInfo(string.Format("  Loaded {0} FDR stubs + features", stubs.Count));
                         perFileEntries.Add(new KeyValuePair<string, List<FdrEntry>>(fileName, stubs));
+
+                        // Best-effort calibration JSON load for Stage 6
+                        // reconciliation. Mirrors osprey/src/pipeline.rs:2573-2588.
+                        try
+                        {
+                            string parquetDir = Path.GetDirectoryName(Path.GetFullPath(parquetPath));
+                            if (parquetDir != null)
+                            {
+                                // The parquet stem is "<fileName>.scores"; strip
+                                // the trailing ".scores" so the calibration
+                                // filename derives from the same input stem
+                                // both ProcessFile and join-only used.
+                                string calStemPath = Path.Combine(parquetDir, fileName);
+                                string calPath = CalibrationIO.CalibrationPathForInput(calStemPath, parquetDir);
+                                if (File.Exists(calPath))
+                                {
+                                    var calParams = CalibrationIO.LoadCalibration(calPath);
+                                    if (calParams.RtCalibration != null && calParams.RtCalibration.ModelParams != null)
+                                    {
+                                        var mp = calParams.RtCalibration.ModelParams;
+                                        var rtCal = RTCalibration.FromModelParams(
+                                            mp.LibraryRts, mp.FittedRts, mp.AbsResiduals,
+                                            calParams.RtCalibration.ResidualSD);
+                                        perFileCalibrations[fileName] = rtCal;
+                                    }
+                                }
+                            }
+                        }
+                        catch (Exception ex)
+                        {
+                            LogWarning(string.Format("  Failed to load calibration for {0}: {1}", fileName, ex.Message));
+                        }
                     }
                 }
                 else if (config.InputFiles.Count == 1)
@@ -271,7 +307,7 @@ namespace pwiz.OspreySharp
                     string fileName = Path.GetFileNameWithoutExtension(inputFile);
                     LogInfo("");
                     LogInfo(string.Format("===== Processing file 1/1: {0} =====", inputFile));
-                    var fileResult = ProcessFile(inputFile, fileName, fullLibrary, config, noJoinMetadata);
+                    var fileResult = ProcessFile(inputFile, fileName, fullLibrary, config, noJoinMetadata, perFileCalibrations);
                     if (fileResult != null)
                         perFileEntries.Add(new KeyValuePair<string, List<FdrEntry>>(fileName, fileResult));
                 }
@@ -290,7 +326,7 @@ namespace pwiz.OspreySharp
                         string fileName = Path.GetFileNameWithoutExtension(inputFile);
                         LogInfo(string.Format("===== Processing file {0}/{1}: {2} =====",
                             fileIdx + 1, config.InputFiles.Count, inputFile));
-                        var fileResult = ProcessFile(inputFile, fileName, fullLibrary, config, noJoinMetadata);
+                        var fileResult = ProcessFile(inputFile, fileName, fullLibrary, config, noJoinMetadata, perFileCalibrations);
                         if (fileResult != null)
                             perFileEntries.Add(new KeyValuePair<string, List<FdrEntry>>(fileName, fileResult));
                     }
@@ -314,7 +350,7 @@ namespace pwiz.OspreySharp
                         string fileName = Path.GetFileNameWithoutExtension(inputFile);
                         LogInfo(string.Format("===== Processing file {0}/{1}: {2} =====",
                             fileIdx + 1, config.InputFiles.Count, inputFile));
-                        var fileResult = ProcessFile(inputFile, fileName, fullLibrary, config, noJoinMetadata);
+                        var fileResult = ProcessFile(inputFile, fileName, fullLibrary, config, noJoinMetadata, perFileCalibrations);
                         if (fileResult != null)
                             fileResults[fileIdx] = new KeyValuePair<string, List<FdrEntry>>(fileName, fileResult);
                     });
@@ -401,12 +437,98 @@ namespace pwiz.OspreySharp
                         OspreyDiagnostics.ExitAfterDump("OSPREY_PERCOLATOR_ONLY");
                 }
 
-                // Stage 6-7: Reconciliation (TODO for multi-file)
-                if (config.InputFiles.Count > 1)
+                // Stage 6: planning checkpoint — multi-charge consensus +
+                // cross-run consensus RTs + per-file calibration refit. The
+                // execution side (per-file rescore at locked boundaries +
+                // gap-fill + second-pass FDR) is not yet implemented; this
+                // pass exists to prove cross-impl byte parity at the start
+                // of Stage 6 via the three planning dumps below. Mirrors
+                // pipeline.rs Stage 6 entry block at lines 3208-3273.
+                if (perFileEntries.Count > 1 && config.Reconciliation.Enabled)
                 {
                     LogInfo("");
-                    LogInfo("TODO: Inter-replicate reconciliation not yet implemented");
-                    LogInfo("      First-pass results are still usable for single-run analysis");
+                    LogInfo("Stage 6: planning");
+
+                    // 1. Multi-charge consensus per file (independent — runs
+                    //    first per Rust pipeline.rs:3217, before consensus
+                    //    RT computation).
+                    var perFileConsensusTargets = new Dictionary<string,
+                        IReadOnlyList<(int Index, double Apex, double Start, double End)>>();
+                    foreach (var kvp in perFileEntries)
+                    {
+                        perFileConsensusTargets[kvp.Key] =
+                            MultiChargeConsensus.SelectRescoreTargets(kvp.Value, config.RunFdr);
+                    }
+                    int totalMulticharge = 0;
+                    foreach (var kvp in perFileConsensusTargets)
+                        totalMulticharge += kvp.Value.Count;
+                    LogInfo(string.Format(
+                        "Stage 6 multi-charge consensus: {0} entries need re-scoring across {1} files",
+                        totalMulticharge, perFileEntries.Count));
+
+                    if (OspreyDiagnostics.DumpMulticharge)
+                    {
+                        OspreyDiagnostics.WriteStage6MultichargeDump(perFileConsensusTargets);
+                        if (OspreyDiagnostics.MultichargeOnly)
+                            OspreyDiagnostics.ExitAfterDump(@"OSPREY_MULTICHARGE_ONLY");
+                    }
+
+                    // 2. Cross-run consensus RTs (target peptides + paired
+                    //    decoys, sigmoid(score)-weighted median, hard
+                    //    run_precursor_qvalue gate).
+                    var perFileForRecon = new List<KeyValuePair<string,
+                        IReadOnlyList<FdrEntry>>>(perFileEntries.Count);
+                    foreach (var kvp in perFileEntries)
+                    {
+                        perFileForRecon.Add(new KeyValuePair<string,
+                            IReadOnlyList<FdrEntry>>(kvp.Key, kvp.Value));
+                    }
+                    var consensus = ConsensusRts.Compute(
+                        perFileForRecon, perFileCalibrations,
+                        config.Reconciliation.ConsensusFdr,
+                        config.ProteinFdr ?? 0.0);
+                    int nTargets = 0, nDecoys = 0;
+                    foreach (var c in consensus)
+                    {
+                        if (c.IsDecoy) nDecoys++;
+                        else nTargets++;
+                    }
+                    LogInfo(string.Format(
+                        "Stage 6 consensus: {0} target peptides, {1} decoy peptides",
+                        nTargets, nDecoys));
+
+                    if (OspreyDiagnostics.DumpConsensus)
+                    {
+                        OspreyDiagnostics.WriteStage6ConsensusDump(consensus);
+                        if (OspreyDiagnostics.ConsensusOnly)
+                            OspreyDiagnostics.ExitAfterDump(@"OSPREY_CONSENSUS_ONLY");
+                    }
+
+                    // 3. Per-file calibration refit on consensus peptides.
+                    var refinedCalibrations = new Dictionary<string, RTCalibration>();
+                    foreach (var kvp in perFileEntries)
+                    {
+                        var refined = CalibrationRefit.Refit(consensus, kvp.Value,
+                            config.Reconciliation.ConsensusFdr);
+                        if (refined != null)
+                            refinedCalibrations[kvp.Key] = refined;
+                    }
+                    LogInfo(string.Format(
+                        "Stage 6 refit: {0}/{1} files produced refined calibrations",
+                        refinedCalibrations.Count, perFileEntries.Count));
+
+                    if (OspreyDiagnostics.DumpRefit)
+                    {
+                        OspreyDiagnostics.WriteStage6RefitDump(refinedCalibrations);
+                        if (OspreyDiagnostics.RefitOnly)
+                            OspreyDiagnostics.ExitAfterDump(@"OSPREY_REFIT_ONLY");
+                    }
+
+                    // Reconciliation planning + per-file rescore + gap-fill +
+                    // second-pass FDR are deferred to a later commit. Without
+                    // those, single-run analysis still produces valid output
+                    // from the first-pass FDR results above.
+                    LogInfo(@"Stage 6 reconciliation rescore: not yet implemented");
                 }
 
                 // Stage 8: Protein FDR (optional)
@@ -656,7 +778,8 @@ namespace pwiz.OspreySharp
         private List<FdrEntry> ProcessFile(
             string inputFile, string fileName,
             List<LibraryEntry> fullLibrary, OspreyConfig config,
-            Dictionary<string, string> noJoinMetadata)
+            Dictionary<string, string> noJoinMetadata,
+            ConcurrentDictionary<string, RTCalibration> perFileCalibrationsOut)
         {
             if (inputFile == null)
                 throw new ArgumentNullException(nameof(inputFile));
@@ -846,6 +969,13 @@ namespace pwiz.OspreySharp
                 LogInfo("[BENCH] OSPREY_EXIT_AFTER_CALIBRATION set - exiting after Stage 3 (calibration done)");
                 return new List<FdrEntry>();
             }
+
+            // Surface the per-file calibration to Stage 6 reconciliation
+            // (multi-file runs only). Threaded calls share a
+            // ConcurrentDictionary; null on single-file paths that don't
+            // need cross-file consensus.
+            if (perFileCalibrationsOut != null && rtCalibration != null)
+                perFileCalibrationsOut[fileName] = rtCalibration;
 
             // Run coelution scoring across all isolation windows
             var swScoring = Stopwatch.StartNew();

--- a/pwiz_tools/OspreySharp/OspreySharp/AnalysisPipeline.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/AnalysisPipeline.cs
@@ -614,6 +614,13 @@ namespace pwiz.OspreySharp
                         "Stage 6 refit: {0}/{1} files produced refined calibrations",
                         refinedCalibrations.Count, perFileEntries.Count));
 
+                    if (OspreyDiagnostics.DumpLoessFit)
+                    {
+                        OspreyDiagnostics.WriteStage6LoessFitDump(refinedCalibrations);
+                        if (OspreyDiagnostics.LoessFitOnly)
+                            OspreyDiagnostics.ExitAfterDump(@"OSPREY_LOESS_FIT_ONLY");
+                    }
+
                     if (OspreyDiagnostics.DumpRefit)
                     {
                         OspreyDiagnostics.WriteStage6RefitDump(refinedCalibrations);
@@ -4804,6 +4811,14 @@ namespace pwiz.OspreySharp
             LogInfo(string.Format(
                 "First-pass protein FDR: {0} target groups at {1:P1} FDR",
                 nAtRunFdr, config.RunFdr));
+
+            if (OspreyDiagnostics.DumpProteinFdr)
+            {
+                OspreyDiagnostics.WriteStage6ProteinFdrDump(
+                    bestScores, proteinFdr.PeptideQvalues);
+                if (OspreyDiagnostics.ProteinFdrOnly)
+                    OspreyDiagnostics.ExitAfterDump(@"OSPREY_PROTEIN_FDR_ONLY");
+            }
 
             // Set RunProteinQvalue ONLY. Experiment-protein-q is set by the
             // post-output Stage 8 protein FDR pass (Rust calls it second-pass).

--- a/pwiz_tools/OspreySharp/OspreySharp/AnalysisPipeline.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/AnalysisPipeline.cs
@@ -437,6 +437,23 @@ namespace pwiz.OspreySharp
                         OspreyDiagnostics.ExitAfterDump("OSPREY_PERCOLATOR_ONLY");
                 }
 
+                // First-pass protein FDR: runs on the full pre-compaction
+                // peptide pool so target and decoy proteins compete on a
+                // symmetric set. Sets RunProteinQvalue on every FdrEntry,
+                // which Stage 6 reconciliation reads via the protein-rescue
+                // gate in ConsensusRts.Compute. Mirrors Rust pipeline.rs:3029
+                // ("First-pass protein FDR").
+                if (config.ProteinFdr.HasValue && perFileEntries.Count > 0)
+                {
+                    LogInfo("");
+                    LogInfo("First-pass protein FDR");
+                    var swFirstPassProtein = Stopwatch.StartNew();
+                    RunFirstPassProteinFdr(perFileEntries, fullLibrary, config);
+                    swFirstPassProtein.Stop();
+                    LogInfo(string.Format("[TIMING] First-pass protein FDR: {0:F1}s",
+                        swFirstPassProtein.Elapsed.TotalSeconds));
+                }
+
                 // Stage 6: planning checkpoint — multi-charge consensus +
                 // cross-run consensus RTs + per-file calibration refit. The
                 // execution side (per-file rescore at locked boundaries +
@@ -4657,6 +4674,62 @@ namespace pwiz.OspreySharp
         #endregion
 
         #region Stage 8: Protein FDR
+
+        /// <summary>
+        /// First-pass protein FDR run BEFORE Stage 6 reconciliation, on the
+        /// full pre-compaction peptide pool. Sets only RunProteinQvalue
+        /// (leaves ExperimentProteinQvalue at its 1.0 default for the
+        /// second-pass to overwrite). Detected-peptide filter uses
+        /// run_peptide_qvalue, the strict peptide-level gate, matching Rust
+        /// pipeline.rs:3045-3049 exactly. Protein-FDR gate is config.RunFdr
+        /// (1x), the Savitski-2015 convention applied at first pass, NOT the
+        /// 2x relaxed gate the post-output Stage 8 protein FDR uses.
+        /// </summary>
+        private void RunFirstPassProteinFdr(
+            List<KeyValuePair<string, List<FdrEntry>>> perFileEntries,
+            List<LibraryEntry> fullLibrary,
+            OspreyConfig config)
+        {
+            // Detected-peptide gate: targets passing peptide-level run FDR.
+            // Matches Rust pipeline.rs:3048 (e.run_peptide_qvalue <= run_fdr).
+            var detectedPeptides = new HashSet<string>(StringComparer.Ordinal);
+            foreach (var kvp in perFileEntries)
+            {
+                foreach (var entry in kvp.Value)
+                {
+                    if (!entry.IsDecoy && entry.RunPeptideQvalue <= config.RunFdr)
+                        detectedPeptides.Add(entry.ModifiedSequence);
+                }
+            }
+            LogInfo(string.Format(
+                "[COUNT] First-pass detected peptides for protein FDR: {0} unique",
+                detectedPeptides.Count));
+
+            var parsimony = ProteinFdr.BuildProteinParsimony(
+                fullLibrary, config.SharedPeptides, detectedPeptides);
+
+            // Best peptide score across all files for picked-protein TDC.
+            var bestScores = ProteinFdr.CollectBestPeptideScores(perFileEntries);
+
+            // First-pass gate is config.RunFdr exactly — matches Rust
+            // pipeline.rs:3062 (compute_protein_fdr at config.run_fdr).
+            var proteinFdr = ProteinFdr.ComputeProteinFdr(parsimony, bestScores, config.RunFdr);
+
+            int nAtRunFdr = 0;
+            foreach (var qv in proteinFdr.GroupQvalues.Values)
+            {
+                if (qv <= config.RunFdr)
+                    nAtRunFdr++;
+            }
+            LogInfo(string.Format(
+                "First-pass protein FDR: {0} target groups at {1:P1} FDR",
+                nAtRunFdr, config.RunFdr));
+
+            // Set RunProteinQvalue ONLY. Experiment-protein-q is set by the
+            // post-output Stage 8 protein FDR pass (Rust calls it second-pass).
+            ProteinFdr.PropagateProteinQvalues(perFileEntries, proteinFdr,
+                setRun: true, setExperiment: false);
+        }
 
         /// <summary>
         /// Run protein-level FDR using parsimony and picked-protein competition.

--- a/pwiz_tools/OspreySharp/OspreySharp/AnalysisPipeline.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/AnalysisPipeline.cs
@@ -286,6 +286,14 @@ namespace pwiz.OspreySharp
                                     if (calParams.RtCalibration != null && calParams.RtCalibration.ModelParams != null)
                                     {
                                         var mp = calParams.RtCalibration.ModelParams;
+                                        // Cross-impl JSON-decode parity check: append
+                                        // the raw arrays as loaded from the calibration
+                                        // JSON, gated by OSPREY_DUMP_CALIBRATION.
+                                        if (OspreyDiagnostics.DumpCalibration)
+                                        {
+                                            OspreyDiagnostics.WriteStage6CalibrationDump(
+                                                fileName, mp.LibraryRts, mp.FittedRts);
+                                        }
                                         var rtCal = RTCalibration.FromModelParams(
                                             mp.LibraryRts, mp.FittedRts, mp.AbsResiduals,
                                             calParams.RtCalibration.ResidualSD);
@@ -299,6 +307,12 @@ namespace pwiz.OspreySharp
                             LogWarning(string.Format("  Failed to load calibration for {0}: {1}", fileName, ex.Message));
                         }
                     }
+                    // Cross-impl JSON-decode parity short-circuit: after every
+                    // parquet's calibration JSON has been loaded and dumped, exit
+                    // if OSPREY_CALIBRATION_ONLY is set. Pairs with
+                    // OSPREY_DUMP_CALIBRATION.
+                    if (OspreyDiagnostics.CalibrationOnly)
+                        OspreyDiagnostics.ExitAfterDump(@"OSPREY_CALIBRATION_ONLY");
                 }
                 else if (config.InputFiles.Count == 1)
                 {
@@ -548,10 +562,28 @@ namespace pwiz.OspreySharp
                         perFileForRecon.Add(new KeyValuePair<string,
                             IReadOnlyList<FdrEntry>>(kvp.Key, kvp.Value));
                     }
+                    // Cross-impl bisection trace for InversePredict: if the
+                    // OSPREY_DUMP_INV_PREDICT env var is set, ConsensusRts
+                    // populates this list with one row per detection. The
+                    // caller drives the dump via OspreyDiagnostics so the
+                    // FDR project doesn't have to know about the diagnostic
+                    // file format.
+                    List<InvPredictRecord> invPredictTrace = null;
+                    if (OspreyDiagnostics.DumpInvPredict)
+                        invPredictTrace = new List<InvPredictRecord>();
+
                     var consensus = ConsensusRts.Compute(
                         perFileForRecon, perFileCalibrations,
                         config.Reconciliation.ConsensusFdr,
-                        config.ProteinFdr ?? 0.0);
+                        config.ProteinFdr ?? 0.0,
+                        invPredictTrace);
+
+                    if (invPredictTrace != null)
+                    {
+                        OspreyDiagnostics.WriteStage6InvPredictDump(invPredictTrace);
+                        if (OspreyDiagnostics.InvPredictOnly)
+                            OspreyDiagnostics.ExitAfterDump(@"OSPREY_INV_PREDICT_ONLY");
+                    }
                     int nTargets = 0, nDecoys = 0;
                     foreach (var c in consensus)
                     {

--- a/pwiz_tools/OspreySharp/OspreySharp/AnalysisPipeline.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/AnalysisPipeline.cs
@@ -454,6 +454,46 @@ namespace pwiz.OspreySharp
                         swFirstPassProtein.Elapsed.TotalSeconds));
                 }
 
+                // Compaction: drop entries whose base_id (entry_id with the
+                // decoy bit masked off) does not pass either the peptide-q
+                // or protein-q gate. Target and paired decoy share base_id
+                // and are kept or dropped together. Mirrors Rust
+                // pipeline.rs:3094-3132. Without this, Stage 6 multi-charge
+                // consensus selection groups by modified_sequence and
+                // includes non-passing charge states that Rust has already
+                // dropped, producing different rescore-target sets and
+                // different per-file Vec positions.
+                if (perFileEntries.Count > 0)
+                {
+                    var firstPassBaseIds = new HashSet<uint>();
+                    double peptideGate = config.RunFdr;
+                    double proteinGate = config.ProteinFdr ?? 0.0;
+                    foreach (var kvp in perFileEntries)
+                    {
+                        foreach (var entry in kvp.Value)
+                        {
+                            if (entry.IsDecoy)
+                                continue;
+                            if (entry.RunPeptideQvalue <= peptideGate ||
+                                (proteinGate > 0.0 && entry.RunProteinQvalue <= proteinGate))
+                            {
+                                firstPassBaseIds.Add(entry.EntryId & 0x7FFFFFFFu);
+                            }
+                        }
+                    }
+                    int beforeCount = 0, afterCount = 0;
+                    foreach (var kvp in perFileEntries)
+                    {
+                        beforeCount += kvp.Value.Count;
+                        kvp.Value.RemoveAll(e => !firstPassBaseIds.Contains(e.EntryId & 0x7FFFFFFFu));
+                        kvp.Value.TrimExcess();
+                        afterCount += kvp.Value.Count;
+                    }
+                    LogInfo(string.Format(
+                        "First-pass compaction: {0} -> {1} entries ({2} passing base_ids)",
+                        beforeCount, afterCount, firstPassBaseIds.Count));
+                }
+
                 // Stage 6: planning checkpoint — multi-charge consensus +
                 // cross-run consensus RTs + per-file calibration refit. The
                 // execution side (per-file rescore at locked boundaries +
@@ -485,7 +525,15 @@ namespace pwiz.OspreySharp
 
                     if (OspreyDiagnostics.DumpMulticharge)
                     {
-                        OspreyDiagnostics.WriteStage6MultichargeDump(perFileConsensusTargets);
+                        var perFileForDump = new List<KeyValuePair<string,
+                            IReadOnlyList<FdrEntry>>>(perFileEntries.Count);
+                        foreach (var kvp in perFileEntries)
+                        {
+                            perFileForDump.Add(new KeyValuePair<string,
+                                IReadOnlyList<FdrEntry>>(kvp.Key, kvp.Value));
+                        }
+                        OspreyDiagnostics.WriteStage6MultichargeDump(
+                            perFileForDump, perFileConsensusTargets);
                         if (OspreyDiagnostics.MultichargeOnly)
                             OspreyDiagnostics.ExitAfterDump(@"OSPREY_MULTICHARGE_ONLY");
                     }

--- a/pwiz_tools/OspreySharp/OspreySharp/AnalysisPipeline.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/AnalysisPipeline.cs
@@ -2632,6 +2632,72 @@ namespace pwiz.OspreySharp
             return la > lb;
         }
 
+        /// <summary>
+        /// Build a one-element peak list at the supplied (apex, start, end)
+        /// RT triple, mapped onto the reference XIC's RT axis. Returns null
+        /// when the resulting index range is degenerate. Mirrors the
+        /// boundary_overrides peak-construction path in run_search at
+        /// osprey/crates/osprey/src/pipeline.rs:6596-6644.
+        /// </summary>
+        private static List<XICPeakBounds> BuildOverridePeaks(
+            (double Apex, double Start, double End) ob,
+            List<XicData> xics)
+        {
+            // Reference XIC = highest total-intensity fragment, matching
+            // the CWT-path selection further down in ScoreCandidate.
+            int refIdx = 0;
+            double refTotal = -1.0;
+            for (int f = 0; f < xics.Count; f++)
+            {
+                double total = 0.0;
+                var ints = xics[f].Intensities;
+                for (int j = 0; j < ints.Length; j++)
+                    total += ints[j];
+                if (total > refTotal) { refTotal = total; refIdx = f; }
+            }
+            var rtArr = xics[refIdx].RetentionTimes;
+            var intArr = xics[refIdx].Intensities;
+            int last = rtArr.Length - 1;
+            if (last < 2)
+                return null;
+
+            // Map override RTs to indices via Rust partition_point semantics:
+            // first index where rt >= target. start_index then saturating_sub(1).
+            int startIdx = BinarySearchLowerBound(rtArr, ob.Start);
+            if (startIdx > 0) startIdx--;
+            if (startIdx > last) startIdx = last;
+
+            int endIdx = BinarySearchLowerBound(rtArr, ob.End);
+            if (endIdx > last) endIdx = last;
+
+            int apexIdx = BinarySearchLowerBound(rtArr, ob.Apex);
+            if (apexIdx > last) apexIdx = last;
+            if (apexIdx > 0 &&
+                Math.Abs(rtArr[apexIdx - 1] - ob.Apex) < Math.Abs(rtArr[apexIdx] - ob.Apex))
+                apexIdx--;
+            if (apexIdx < startIdx) apexIdx = startIdx;
+            if (apexIdx > endIdx) apexIdx = endIdx;
+
+            if (endIdx <= startIdx + 1)
+                return null;
+
+            return new List<XICPeakBounds>
+            {
+                new XICPeakBounds
+                {
+                    ApexRt = rtArr[apexIdx],
+                    ApexIntensity = intArr[apexIdx],
+                    ApexIndex = apexIdx,
+                    StartRt = rtArr[startIdx],
+                    EndRt = rtArr[endIdx],
+                    StartIndex = startIdx,
+                    EndIndex = endIdx,
+                    Area = PeakDetector.TrapezoidalArea(rtArr, intArr, startIdx, endIdx),
+                    SignalToNoise = PeakDetector.ComputeSnr(intArr, apexIdx, startIdx, endIdx),
+                },
+            };
+        }
+
         private FdrEntry ScoreCandidate(
             LibraryEntry candidate,
             List<Spectrum> windowSpectra,
@@ -2653,6 +2719,18 @@ namespace pwiz.OspreySharp
             if (nScans < 5)
                 return null;
 
+            // Stage 6 boundary override (post-FDR re-scoring): when set,
+            // peak detection + the signal pre-filter are skipped and
+            // scoring uses the supplied (apex, start, end) RT triple.
+            // Mirrors the boundary_overrides path in run_search at
+            // osprey/crates/osprey/src/pipeline.rs:6453-6664.
+            (double Apex, double Start, double End)? overrideBounds = null;
+            if (context.BoundaryOverrides != null &&
+                context.BoundaryOverrides.TryGetValue(candidate.Id, out var bnd))
+            {
+                overrideBounds = bnd;
+            }
+
             // Determine RT search window.
             // Use the global tolerance passed from RunCoelutionScoring (matches
             // Rust's single rt_tolerance for all entries in run_search).
@@ -2673,21 +2751,41 @@ namespace pwiz.OspreySharp
                     candidate.Fragments.Count, nScans));
             }
 
-            // Find scan range for XIC extraction. Matches Rust pipeline.rs
-            // commit 885339b: extract over a window wider than rtTolerance so
-            // CWT has context on both sides of any in-tolerance apex to
-            // determine full peak boundaries. The apex itself is still
-            // required to be within rtTolerance (enforced in the
-            // candidate-scoring loop below). Half-width is rtTolerance plus
-            // max(rtTolerance, 0.1) — tight-calibration runs get a 0.1 min
-            // floor of extra context; wider runs scale with rtTolerance.
-            double xicHalfWidth = rtTolerance + Math.Max(rtTolerance, 0.1);
+            // Find scan range for XIC extraction.
+            //
+            // For boundary overrides: use the given boundaries plus margin
+            // for SNR context — peak_width on each side, with a 0.2 min
+            // floor. Mirrors run_search at pipeline.rs:6473-6477.
+            //
+            // For normal search (matches Rust commit 885339b): extract over
+            // a window wider than rtTolerance so CWT has context on both
+            // sides of any in-tolerance apex to determine full peak
+            // boundaries. The apex itself is still required to be within
+            // rtTolerance (enforced in the candidate-scoring loop below).
+            // Half-width is rtTolerance plus max(rtTolerance, 0.1) —
+            // tight-calibration runs get a 0.1 min floor of extra context;
+            // wider runs scale with rtTolerance.
+            double rtLo, rtHi;
+            if (overrideBounds.HasValue)
+            {
+                var ob = overrideBounds.Value;
+                double peakWidth = Math.Max(0.1, ob.End - ob.Start);
+                double margin = Math.Max(0.2, peakWidth);
+                rtLo = ob.Start - margin;
+                rtHi = ob.End + margin;
+            }
+            else
+            {
+                double xicHalfWidth = rtTolerance + Math.Max(rtTolerance, 0.1);
+                rtLo = expectedRt - xicHalfWidth;
+                rtHi = expectedRt + xicHalfWidth;
+            }
             int startScan = -1, endScan = -1;
             for (int i = 0; i < nScans; i++)
             {
-                if (windowRts[i] > expectedRt + xicHalfWidth)
+                if (windowRts[i] > rtHi)
                     break;
-                if (windowRts[i] >= expectedRt - xicHalfWidth)
+                if (windowRts[i] >= rtLo)
                 {
                     if (startScan < 0)
                         startScan = i;
@@ -2714,8 +2812,7 @@ namespace pwiz.OspreySharp
                 {
                     LogInfo(string.Format(
                         "[DIAG] {0}: no scans in RT window [{1:F3}..{2:F3}]",
-                        candidate.ModifiedSequence, expectedRt - xicHalfWidth,
-                        expectedRt + xicHalfWidth));
+                        candidate.ModifiedSequence, rtLo, rtHi));
                 }
             }
 
@@ -2727,7 +2824,9 @@ namespace pwiz.OspreySharp
             // Signal pre-filter: require at least 2 of top 6 fragments present
             // in at least 3 of 4 consecutive scans. Matches Rust pipeline.rs:6032-6066.
             // Skips noise-only candidates before the expensive XIC extraction.
-            if (config.PrefilterEnabled)
+            // Skipped for boundary overrides — caller has already decided to
+            // score here.
+            if (config.PrefilterEnabled && !overrideBounds.HasValue)
             {
                 const int WIN = 4;
                 const int MIN_PASS = 3;
@@ -2775,7 +2874,22 @@ namespace pwiz.OspreySharp
             //   1. CWT consensus (primary)
             //   2. Peak detection on median polish elution profile (fallback 1)
             //   3. Peak detection on reference XIC (fallback 2)
-            var peaks = CwtPeakDetector.DetectConsensusPeaks(xics, 0.0);
+            //
+            // For boundary overrides (Stage 6 re-scoring), peak detection is
+            // skipped and a single synthetic XICPeakBounds is built directly
+            // from the supplied (apex, start, end). Mirrors run_search at
+            // pipeline.rs:6596-6664.
+            List<XICPeakBounds> peaks;
+            if (overrideBounds.HasValue)
+            {
+                peaks = BuildOverridePeaks(overrideBounds.Value, xics);
+                if (peaks == null)
+                    return null;
+            }
+            else
+            {
+                peaks = CwtPeakDetector.DetectConsensusPeaks(xics, 0.0);
+            }
 
             if (peaks.Count == 0)
             {
@@ -2879,10 +2993,11 @@ namespace pwiz.OspreySharp
                 // the detected apex itself must fall within rtTolerance of
                 // expectedRt. Preserves first-pass selectivity -- only
                 // boundaries are allowed to extend past rtTolerance; apex
-                // locations still have to be within it.
+                // locations still have to be within it. Bypassed for
+                // boundary overrides (caller has already chosen the apex).
                 double peakApexRt = windowRts[startScan + p.ApexIndex];
                 double rtResidual = Math.Abs(peakApexRt - expectedRt);
-                if (rtResidual > rtTolerance)
+                if (!overrideBounds.HasValue && rtResidual > rtTolerance)
                     continue;
 
                 double sum = 0.0;

--- a/pwiz_tools/OspreySharp/OspreySharp/OspreyDiagnostics.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/OspreyDiagnostics.cs
@@ -27,6 +27,7 @@ using System.Linq;
 using System.Text;
 using pwiz.OspreySharp.Chromatography;
 using pwiz.OspreySharp.Core;
+using pwiz.OspreySharp.FDR.Reconciliation;
 using pwiz.OspreySharp.Scoring;
 
 namespace pwiz.OspreySharp
@@ -114,6 +115,35 @@ namespace pwiz.OspreySharp
 
         /// <summary>OSPREY_PERCOLATOR_ONLY: exit after cs_stage5_percolator.tsv dump.</summary>
         public static readonly bool PercolatorOnly = IsOne(@"OSPREY_PERCOLATOR_ONLY");
+
+        /// <summary>
+        /// OSPREY_DUMP_CONSENSUS: dump the per-peptide consensus RT planning
+        /// state at the start of Stage 6 (cs_stage6_consensus.tsv) for
+        /// cross-impl parity at the planning checkpoint.
+        /// </summary>
+        public static readonly bool DumpConsensus = IsOne(@"OSPREY_DUMP_CONSENSUS");
+
+        /// <summary>OSPREY_CONSENSUS_ONLY: exit after cs_stage6_consensus.tsv dump.</summary>
+        public static readonly bool ConsensusOnly = IsOne(@"OSPREY_CONSENSUS_ONLY");
+
+        /// <summary>
+        /// OSPREY_DUMP_MULTICHARGE: dump the per-file multi-charge consensus
+        /// rescore targets (cs_stage6_multicharge.tsv) for cross-impl parity.
+        /// </summary>
+        public static readonly bool DumpMulticharge = IsOne(@"OSPREY_DUMP_MULTICHARGE");
+
+        /// <summary>OSPREY_MULTICHARGE_ONLY: exit after cs_stage6_multicharge.tsv dump.</summary>
+        public static readonly bool MultichargeOnly = IsOne(@"OSPREY_MULTICHARGE_ONLY");
+
+        /// <summary>
+        /// OSPREY_DUMP_REFIT: dump per-file refined-calibration statistics
+        /// produced by CalibrationRefit (cs_stage6_refit.tsv) for cross-impl
+        /// parity.
+        /// </summary>
+        public static readonly bool DumpRefit = IsOne(@"OSPREY_DUMP_REFIT");
+
+        /// <summary>OSPREY_REFIT_ONLY: exit after cs_stage6_refit.tsv dump.</summary>
+        public static readonly bool RefitOnly = IsOne(@"OSPREY_REFIT_ONLY");
 
         /// <summary>
         /// OSPREY_DIAG_XIC_ENTRY_ID: the entry ID to dump chromatogram for
@@ -847,6 +877,114 @@ namespace pwiz.OspreySharp
                 }
             }
             LogAction(string.Format(@"Wrote Stage 5 Percolator dump: {0} ({1} rows)", path, rows.Count));
+        }
+
+        // ---- Stage 6 planning dumps ----
+
+        /// <summary>
+        /// Dump the per-peptide consensus RT planning state to
+        /// cs_stage6_consensus.tsv. Mirrors Rust dump_stage6_consensus.
+        /// Columns: is_decoy, modified_sequence, consensus_library_rt,
+        /// median_peak_width, n_runs_detected, apex_library_rt_mad. Rows
+        /// are emitted in the order produced by ConsensusRts.Compute, which
+        /// sorts by (is_decoy, modified_sequence) for deterministic output.
+        /// apex_library_rt_mad is empty when fewer than 3 detections
+        /// contributed.
+        /// </summary>
+        public static void WriteStage6ConsensusDump(IReadOnlyList<PeptideConsensusRT> consensus)
+        {
+            const string path = @"cs_stage6_consensus.tsv";
+
+            using (var sw = new StreamWriter(path))
+            {
+                sw.NewLine = "\n";
+                sw.WriteLine(@"is_decoy	modified_sequence	consensus_library_rt	median_peak_width	n_runs_detected	apex_library_rt_mad");
+                foreach (var c in consensus)
+                {
+                    sw.Write(c.IsDecoy ? @"true" : @"false");
+                    sw.Write('\t'); sw.Write(c.ModifiedSequence ?? string.Empty);
+                    sw.Write('\t'); sw.Write(Diagnostics.FormatF64Roundtrip(c.ConsensusLibraryRt));
+                    sw.Write('\t'); sw.Write(Diagnostics.FormatF64Roundtrip(c.MedianPeakWidth));
+                    sw.Write('\t'); sw.Write(c.NRunsDetected.ToString(CultureInfo.InvariantCulture));
+                    sw.Write('\t');
+                    if (c.ApexLibraryRtMad.HasValue)
+                        sw.Write(Diagnostics.FormatF64Roundtrip(c.ApexLibraryRtMad.Value));
+                    sw.WriteLine();
+                }
+            }
+            LogAction(string.Format(@"Wrote Stage 6 consensus dump: {0} ({1} rows)", path, consensus.Count));
+        }
+
+        /// <summary>
+        /// Dump the per-file multi-charge consensus rescore targets to
+        /// cs_stage6_multicharge.tsv. Mirrors Rust dump_stage6_multicharge.
+        /// Columns: file_name, entry_idx, consensus_apex, consensus_start,
+        /// consensus_end. Rows sorted by (file_name, entry_idx) for stable diff.
+        /// </summary>
+        public static void WriteStage6MultichargeDump(
+            IReadOnlyDictionary<string, IReadOnlyList<(int Index, double Apex, double Start, double End)>> perFileTargets)
+        {
+            const string path = @"cs_stage6_multicharge.tsv";
+
+            var rows = new List<(string FileName, int Index, double Apex, double Start, double End)>();
+            foreach (var kvp in perFileTargets)
+            {
+                foreach (var t in kvp.Value)
+                    rows.Add((kvp.Key, t.Index, t.Apex, t.Start, t.End));
+            }
+            rows.Sort((a, b) =>
+            {
+                int cmp = string.CompareOrdinal(a.FileName, b.FileName);
+                if (cmp != 0) return cmp;
+                return a.Index.CompareTo(b.Index);
+            });
+
+            using (var sw = new StreamWriter(path))
+            {
+                sw.NewLine = "\n";
+                sw.WriteLine(@"file_name	entry_idx	consensus_apex	consensus_start	consensus_end");
+                foreach (var r in rows)
+                {
+                    sw.Write(r.FileName);
+                    sw.Write('\t'); sw.Write(r.Index.ToString(CultureInfo.InvariantCulture));
+                    sw.Write('\t'); sw.Write(Diagnostics.FormatF64Roundtrip(r.Apex));
+                    sw.Write('\t'); sw.Write(Diagnostics.FormatF64Roundtrip(r.Start));
+                    sw.Write('\t'); sw.WriteLine(Diagnostics.FormatF64Roundtrip(r.End));
+                }
+            }
+            LogAction(string.Format(@"Wrote Stage 6 multi-charge dump: {0} ({1} rows)", path, rows.Count));
+        }
+
+        /// <summary>
+        /// Dump per-file refined-calibration statistics to
+        /// cs_stage6_refit.tsv. Mirrors Rust dump_stage6_refit. Columns:
+        /// file_name, n_points, r_squared, residual_sd, mad. Files where the
+        /// refit failed (insufficient points) are absent. Rows sorted by
+        /// file_name for stable diff.
+        /// </summary>
+        public static void WriteStage6RefitDump(
+            IReadOnlyDictionary<string, RTCalibration> refinedCalibrations)
+        {
+            const string path = @"cs_stage6_refit.tsv";
+
+            var fileNames = new List<string>(refinedCalibrations.Keys);
+            fileNames.Sort(StringComparer.Ordinal);
+
+            using (var sw = new StreamWriter(path))
+            {
+                sw.NewLine = "\n";
+                sw.WriteLine(@"file_name	n_points	r_squared	residual_sd	mad");
+                foreach (var fileName in fileNames)
+                {
+                    var stats = refinedCalibrations[fileName].Stats();
+                    sw.Write(fileName);
+                    sw.Write('\t'); sw.Write(stats.NPoints.ToString(CultureInfo.InvariantCulture));
+                    sw.Write('\t'); sw.Write(Diagnostics.FormatF64Roundtrip(stats.RSquared));
+                    sw.Write('\t'); sw.Write(Diagnostics.FormatF64Roundtrip(stats.ResidualSD));
+                    sw.Write('\t'); sw.WriteLine(Diagnostics.FormatF64Roundtrip(stats.MAD));
+                }
+            }
+            LogAction(string.Format(@"Wrote Stage 6 refit dump: {0} ({1} rows)", path, fileNames.Count));
         }
     }
 }

--- a/pwiz_tools/OspreySharp/OspreySharp/OspreyDiagnostics.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/OspreyDiagnostics.cs
@@ -27,6 +27,7 @@ using System.Linq;
 using System.Text;
 using pwiz.OspreySharp.Chromatography;
 using pwiz.OspreySharp.Core;
+using pwiz.OspreySharp.FDR;
 using pwiz.OspreySharp.FDR.Reconciliation;
 using pwiz.OspreySharp.Scoring;
 
@@ -175,6 +176,34 @@ namespace pwiz.OspreySharp
 
         /// <summary>OSPREY_INV_PREDICT_ONLY: exit after cs_stage6_inv_predict.tsv dump.</summary>
         public static readonly bool InvPredictOnly = IsOne(@"OSPREY_INV_PREDICT_ONLY");
+
+        /// <summary>
+        /// OSPREY_DUMP_PROTEIN_FDR: dump the per-peptide first-pass protein
+        /// FDR state (gate input + ranking input + propagated output) to
+        /// cs_stage6_protein_fdr.tsv after RunFirstPassProteinFdr completes.
+        /// Used to bisect the SQC[UniMod:4]LQVPER borderline cross-impl
+        /// divergence in run_protein_qvalue: matching against
+        /// rust_stage6_protein_fdr.tsv shows whether the gate input
+        /// (best_qvalue), the ranking input (score), or the algorithm output
+        /// (protein_qvalue) is responsible.
+        /// </summary>
+        public static readonly bool DumpProteinFdr = IsOne(@"OSPREY_DUMP_PROTEIN_FDR");
+
+        /// <summary>OSPREY_PROTEIN_FDR_ONLY: exit after cs_stage6_protein_fdr.tsv dump.</summary>
+        public static readonly bool ProteinFdrOnly = IsOne(@"OSPREY_PROTEIN_FDR_ONLY");
+
+        /// <summary>
+        /// OSPREY_DUMP_LOESS_FIT: dump the per-point LOESS fit state of the
+        /// Stage 6 refit RTCalibration to cs_stage6_loess_fit.tsv. Used to
+        /// bisect the refit ULP divergence: if (library_rt, fitted_value,
+        /// abs_residual) match cross-impl, the divergence is in the
+        /// stats computation (R²/SD/MAD). If fitted_value diverges, the
+        /// LOESS smoother arithmetic itself differs.
+        /// </summary>
+        public static readonly bool DumpLoessFit = IsOne(@"OSPREY_DUMP_LOESS_FIT");
+
+        /// <summary>OSPREY_LOESS_FIT_ONLY: exit after cs_stage6_loess_fit.tsv dump.</summary>
+        public static readonly bool LoessFitOnly = IsOne(@"OSPREY_LOESS_FIT_ONLY");
 
         /// <summary>
         /// OSPREY_DIAG_XIC_ENTRY_ID: the entry ID to dump chromatogram for
@@ -1047,7 +1076,7 @@ namespace pwiz.OspreySharp
             string fileName, double[] libraryRts, double[] fittedValues)
         {
             const string path = @"cs_stage6_calibration.tsv";
-            bool headerNeeded = !System.IO.File.Exists(path);
+            bool headerNeeded = !File.Exists(path);
             using (var sw = new StreamWriter(path, append: true))
             {
                 sw.NewLine = "\n";
@@ -1088,7 +1117,17 @@ namespace pwiz.OspreySharp
                 if (cmp != 0) return cmp;
                 cmp = string.CompareOrdinal(a.ModifiedSequence, b.ModifiedSequence);
                 if (cmp != 0) return cmp;
-                return string.CompareOrdinal(a.FileName, b.FileName);
+                cmp = string.CompareOrdinal(a.FileName, b.FileName);
+                if (cmp != 0) return cmp;
+                // Same (is_decoy, modseq, file_name) ties happen when a peptide
+                // has multiple charge-state detections in one file. Tiebreak on
+                // the data fields so the order is deterministic regardless of
+                // sort stability (List<T>.Sort is not stable; Rust's
+                // sort_by IS stable but the input order also differs cross-impl,
+                // so a complete data tiebreak is the only way to get byte-parity).
+                cmp = a.ApexRt.CompareTo(b.ApexRt);
+                if (cmp != 0) return cmp;
+                return a.LibraryRt.CompareTo(b.LibraryRt);
             });
 
             using (var sw = new StreamWriter(path))
@@ -1108,6 +1147,103 @@ namespace pwiz.OspreySharp
             LogAction(string.Format(
                 @"Wrote Stage 6 inverse-predict dump: {0} ({1} rows)",
                 path, sorted.Count));
+        }
+
+        /// <summary>
+        /// Dump the per-peptide first-pass protein FDR state to
+        /// cs_stage6_protein_fdr.tsv. Mirrors Rust dump_stage6_protein_fdr.
+        /// One row per peptide that appears in best_scores (the union of
+        /// target + decoy modified_sequences seen across all per-file
+        /// FdrEntry stubs at the moment first-pass protein FDR runs).
+        /// Columns: is_decoy, modified_sequence, best_qvalue, score,
+        /// protein_qvalue. best_qvalue is the input gate (peptide-level
+        /// run q-value, min across files). score is the input ranking
+        /// (max SVM discriminant across files). protein_qvalue is the
+        /// propagated output -- the value PropagateProteinQvalues will
+        /// write to FdrEntry.RunProteinQvalue (1.0 if the peptide is
+        /// not in proteinFdr.PeptideQvalues, matching the
+        /// PropagateProteinQvalues default). Rows sorted by
+        /// (is_decoy, modified_sequence) for stable diff.
+        /// </summary>
+        public static void WriteStage6ProteinFdrDump(
+            IDictionary<string, PeptideScore> bestScores,
+            IDictionary<string, double> peptideQvalues)
+        {
+            const string path = @"cs_stage6_protein_fdr.tsv";
+
+            var rows = new List<KeyValuePair<string, PeptideScore>>(bestScores);
+            rows.Sort((a, b) =>
+            {
+                int cmp = a.Value.IsDecoy.CompareTo(b.Value.IsDecoy);
+                if (cmp != 0) return cmp;
+                return string.CompareOrdinal(a.Key, b.Key);
+            });
+
+            using (var sw = new StreamWriter(path))
+            {
+                sw.NewLine = "\n";
+                sw.WriteLine(@"is_decoy	modified_sequence	best_qvalue	score	protein_qvalue");
+                foreach (var row in rows)
+                {
+                    var ps = row.Value;
+                    double q;
+                    if (!peptideQvalues.TryGetValue(row.Key, out q))
+                        q = 1.0;
+                    sw.Write(ps.IsDecoy ? @"true" : @"false");
+                    sw.Write('\t'); sw.Write(row.Key ?? string.Empty);
+                    sw.Write('\t'); sw.Write(Diagnostics.FormatF64Roundtrip(ps.BestQvalue));
+                    sw.Write('\t'); sw.Write(Diagnostics.FormatF64Roundtrip(ps.Score));
+                    sw.Write('\t'); sw.WriteLine(Diagnostics.FormatF64Roundtrip(q));
+                }
+            }
+            LogAction(string.Format(
+                @"Wrote Stage 6 first-pass protein FDR dump: {0} ({1} rows)",
+                path, rows.Count));
+        }
+
+        /// <summary>
+        /// Dump the per-point LOESS fit state of every refit RTCalibration
+        /// to cs_stage6_loess_fit.tsv. Mirrors Rust dump_stage6_loess_fit.
+        /// One row per (file_name, idx) into the refit's library_rts +
+        /// fitted_values + abs_residuals arrays. Rows sorted by
+        /// (file_name, idx) for stable diff. The refit dump captures
+        /// scalar stats (R²/SD/MAD); this dump captures the LOESS curve
+        /// itself so a stats-vs-smoother bisection is possible.
+        /// </summary>
+        public static void WriteStage6LoessFitDump(
+            IReadOnlyDictionary<string, RTCalibration> refinedCalibrations)
+        {
+            const string path = @"cs_stage6_loess_fit.tsv";
+
+            var fileNames = new List<string>(refinedCalibrations.Keys);
+            fileNames.Sort(StringComparer.Ordinal);
+
+            int totalRows = 0;
+            using (var sw = new StreamWriter(path))
+            {
+                sw.NewLine = "\n";
+                sw.WriteLine(@"file_name	idx	library_rt	fitted_value	abs_residual");
+                foreach (var fileName in fileNames)
+                {
+                    var cal = refinedCalibrations[fileName];
+                    var libRts = cal.LibraryRts;
+                    var fitted = cal.FittedValues;
+                    var residuals = cal.AbsResiduals;
+                    int n = Math.Min(libRts.Length, Math.Min(fitted.Length, residuals.Length));
+                    for (int i = 0; i < n; i++)
+                    {
+                        sw.Write(fileName);
+                        sw.Write('\t'); sw.Write(i.ToString(CultureInfo.InvariantCulture));
+                        sw.Write('\t'); sw.Write(Diagnostics.FormatF64Roundtrip(libRts[i]));
+                        sw.Write('\t'); sw.Write(Diagnostics.FormatF64Roundtrip(fitted[i]));
+                        sw.Write('\t'); sw.WriteLine(Diagnostics.FormatF64Roundtrip(residuals[i]));
+                    }
+                    totalRows += n;
+                }
+            }
+            LogAction(string.Format(
+                @"Wrote Stage 6 LOESS fit dump: {0} ({1} rows across {2} files)",
+                path, totalRows, fileNames.Count));
         }
     }
 }

--- a/pwiz_tools/OspreySharp/OspreySharp/OspreyDiagnostics.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/OspreyDiagnostics.cs
@@ -918,35 +918,52 @@ namespace pwiz.OspreySharp
         /// <summary>
         /// Dump the per-file multi-charge consensus rescore targets to
         /// cs_stage6_multicharge.tsv. Mirrors Rust dump_stage6_multicharge.
-        /// Columns: file_name, entry_idx, consensus_apex, consensus_start,
-        /// consensus_end. Rows sorted by (file_name, entry_idx) for stable diff.
+        /// Columns: file_name, entry_id, consensus_apex, consensus_start,
+        /// consensus_end. Rows sorted by (file_name, entry_id) for stable
+        /// diff. The dump uses the stable library entry id (FdrEntry.EntryId)
+        /// instead of the per-file Vec position, so cross-impl comparison is
+        /// invariant to whether the implementation has compacted the
+        /// per-file FdrEntry list before computing multi-charge consensus.
         /// </summary>
         public static void WriteStage6MultichargeDump(
+            IReadOnlyList<KeyValuePair<string, IReadOnlyList<FdrEntry>>> perFileEntries,
             IReadOnlyDictionary<string, IReadOnlyList<(int Index, double Apex, double Start, double End)>> perFileTargets)
         {
             const string path = @"cs_stage6_multicharge.tsv";
 
-            var rows = new List<(string FileName, int Index, double Apex, double Start, double End)>();
+            // Resolve Index -> EntryId via the matching per-file entries list.
+            var entriesByFile = new Dictionary<string, IReadOnlyList<FdrEntry>>(StringComparer.Ordinal);
+            foreach (var kvp in perFileEntries)
+                entriesByFile[kvp.Key] = kvp.Value;
+
+            var rows = new List<(string FileName, uint EntryId, double Apex, double Start, double End)>();
             foreach (var kvp in perFileTargets)
             {
+                IReadOnlyList<FdrEntry> entries;
+                if (!entriesByFile.TryGetValue(kvp.Key, out entries))
+                    continue;
                 foreach (var t in kvp.Value)
-                    rows.Add((kvp.Key, t.Index, t.Apex, t.Start, t.End));
+                {
+                    if (t.Index < 0 || t.Index >= entries.Count)
+                        continue;
+                    rows.Add((kvp.Key, entries[t.Index].EntryId, t.Apex, t.Start, t.End));
+                }
             }
             rows.Sort((a, b) =>
             {
                 int cmp = string.CompareOrdinal(a.FileName, b.FileName);
                 if (cmp != 0) return cmp;
-                return a.Index.CompareTo(b.Index);
+                return a.EntryId.CompareTo(b.EntryId);
             });
 
             using (var sw = new StreamWriter(path))
             {
                 sw.NewLine = "\n";
-                sw.WriteLine(@"file_name	entry_idx	consensus_apex	consensus_start	consensus_end");
+                sw.WriteLine(@"file_name	entry_id	consensus_apex	consensus_start	consensus_end");
                 foreach (var r in rows)
                 {
                     sw.Write(r.FileName);
-                    sw.Write('\t'); sw.Write(r.Index.ToString(CultureInfo.InvariantCulture));
+                    sw.Write('\t'); sw.Write(r.EntryId.ToString(CultureInfo.InvariantCulture));
                     sw.Write('\t'); sw.Write(Diagnostics.FormatF64Roundtrip(r.Apex));
                     sw.Write('\t'); sw.Write(Diagnostics.FormatF64Roundtrip(r.Start));
                     sw.Write('\t'); sw.WriteLine(Diagnostics.FormatF64Roundtrip(r.End));

--- a/pwiz_tools/OspreySharp/OspreySharp/OspreyDiagnostics.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/OspreyDiagnostics.cs
@@ -146,6 +146,37 @@ namespace pwiz.OspreySharp
         public static readonly bool RefitOnly = IsOne(@"OSPREY_REFIT_ONLY");
 
         /// <summary>
+        /// OSPREY_DUMP_CALIBRATION: dump the loaded calibration JSON
+        /// arrays (library_rts + fitted_values) for each file to
+        /// cs_stage6_calibration.tsv as the C# join-only path loads
+        /// them. Diffing against rust_stage6_calibration.tsv localizes
+        /// whether cross-impl divergence in InversePredict enters at
+        /// the JSON f64 parser (decimal-to-binary) or inside the LOESS
+        /// interpolation arithmetic. No _ONLY companion: pair with a
+        /// later dump's _ONLY (e.g. OSPREY_INV_PREDICT_ONLY) to
+        /// short-circuit after all files have written their rows.
+        /// </summary>
+        public static readonly bool DumpCalibration = IsOne(@"OSPREY_DUMP_CALIBRATION");
+
+        /// <summary>OSPREY_CALIBRATION_ONLY: exit after cs_stage6_calibration.tsv dump.</summary>
+        public static readonly bool CalibrationOnly = IsOne(@"OSPREY_CALIBRATION_ONLY");
+
+        /// <summary>
+        /// OSPREY_DUMP_INV_PREDICT: capture per-detection
+        /// (apex_rt, library_rt, weight) triples flowing into
+        /// ConsensusRts.Compute and dump them to cs_stage6_inv_predict.tsv
+        /// for ULP-level bisection of consensus_library_rt cross-impl
+        /// divergence. Diffing against rust_stage6_inv_predict.tsv
+        /// localizes whether the divergence enters at Parquet f64 decode
+        /// (apex_rt diverges) or inside LOESS InversePredict (only
+        /// library_rt diverges).
+        /// </summary>
+        public static readonly bool DumpInvPredict = IsOne(@"OSPREY_DUMP_INV_PREDICT");
+
+        /// <summary>OSPREY_INV_PREDICT_ONLY: exit after cs_stage6_inv_predict.tsv dump.</summary>
+        public static readonly bool InvPredictOnly = IsOne(@"OSPREY_INV_PREDICT_ONLY");
+
+        /// <summary>
         /// OSPREY_DIAG_XIC_ENTRY_ID: the entry ID to dump chromatogram for
         /// during calibration scoring. null = no dump.
         /// </summary>
@@ -1002,6 +1033,81 @@ namespace pwiz.OspreySharp
                 }
             }
             LogAction(string.Format(@"Wrote Stage 6 refit dump: {0} ({1} rows)", path, fileNames.Count));
+        }
+
+        /// <summary>
+        /// Append the loaded calibration arrays for one file to
+        /// cs_stage6_calibration.tsv. Mirrors Rust dump_stage6_calibration.
+        /// Header is written on the first call (file does not yet exist),
+        /// subsequent calls append. Each call writes one row per
+        /// (libraryRts[i], fittedValues[i]) pair. Used for cross-impl
+        /// JSON-decode bisection — see DumpCalibration docs.
+        /// </summary>
+        public static void WriteStage6CalibrationDump(
+            string fileName, double[] libraryRts, double[] fittedValues)
+        {
+            const string path = @"cs_stage6_calibration.tsv";
+            bool headerNeeded = !System.IO.File.Exists(path);
+            using (var sw = new StreamWriter(path, append: true))
+            {
+                sw.NewLine = "\n";
+                if (headerNeeded)
+                    sw.WriteLine(@"file_name	idx	library_rt	fitted_value");
+                int n = Math.Min(libraryRts.Length, fittedValues.Length);
+                for (int i = 0; i < n; i++)
+                {
+                    sw.Write(fileName);
+                    sw.Write('\t'); sw.Write(i.ToString(CultureInfo.InvariantCulture));
+                    sw.Write('\t'); sw.Write(Diagnostics.FormatF64Roundtrip(libraryRts[i]));
+                    sw.Write('\t'); sw.WriteLine(Diagnostics.FormatF64Roundtrip(fittedValues[i]));
+                }
+            }
+            LogAction(string.Format(
+                @"Appended {0} calibration rows for {1} to {2}",
+                Math.Min(libraryRts.Length, fittedValues.Length), fileName, path));
+        }
+
+        /// <summary>
+        /// Dump the per-detection (apex_rt, library_rt, weight) trace
+        /// captured by ConsensusRts.Compute to cs_stage6_inv_predict.tsv.
+        /// Mirrors Rust dump_stage6_inv_predict. Columns: file_name,
+        /// is_decoy, modified_sequence, apex_rt, library_rt, weight. Rows
+        /// sorted by (is_decoy, modified_sequence, file_name) for stable
+        /// diff. Used for ULP bisection of consensus_library_rt cross-impl
+        /// divergence: if apex_rt diverges the bug is in Parquet f64 decode,
+        /// if only library_rt diverges the bug is in LOESS InversePredict.
+        /// </summary>
+        public static void WriteStage6InvPredictDump(IList<InvPredictRecord> records)
+        {
+            const string path = @"cs_stage6_inv_predict.tsv";
+
+            var sorted = new List<InvPredictRecord>(records);
+            sorted.Sort((a, b) =>
+            {
+                int cmp = a.IsDecoy.CompareTo(b.IsDecoy);
+                if (cmp != 0) return cmp;
+                cmp = string.CompareOrdinal(a.ModifiedSequence, b.ModifiedSequence);
+                if (cmp != 0) return cmp;
+                return string.CompareOrdinal(a.FileName, b.FileName);
+            });
+
+            using (var sw = new StreamWriter(path))
+            {
+                sw.NewLine = "\n";
+                sw.WriteLine(@"file_name	is_decoy	modified_sequence	apex_rt	library_rt	weight");
+                foreach (var r in sorted)
+                {
+                    sw.Write(r.FileName);
+                    sw.Write('\t'); sw.Write(r.IsDecoy ? @"true" : @"false");
+                    sw.Write('\t'); sw.Write(r.ModifiedSequence ?? string.Empty);
+                    sw.Write('\t'); sw.Write(Diagnostics.FormatF64Roundtrip(r.ApexRt));
+                    sw.Write('\t'); sw.Write(Diagnostics.FormatF64Roundtrip(r.LibraryRt));
+                    sw.Write('\t'); sw.WriteLine(Diagnostics.FormatF64Roundtrip(r.Weight));
+                }
+            }
+            LogAction(string.Format(
+                @"Wrote Stage 6 inverse-predict dump: {0} ({1} rows)",
+                path, sorted.Count));
         }
     }
 }

--- a/pwiz_tools/OspreySharp/OspreySharp/Program.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/Program.cs
@@ -289,8 +289,13 @@ namespace pwiz.OspreySharp
                         i++;
                         // Consume all following non-flag arguments as parquet
                         // paths or a single directory. Mirrors the -i/--input
-                        // pattern.
+                        // pattern. Accumulates across repeated --input-scores
+                        // flags so both `--input-scores X Y Z` and
+                        // `--input-scores X --input-scores Y` work, matching
+                        // Rust's clap Vec<PathBuf>.
                         var scorePaths = new List<string>();
+                        if (config.InputScores != null)
+                            scorePaths.AddRange(config.InputScores);
                         while (i < args.Length && !args[i].StartsWith("-"))
                         {
                             scorePaths.Add(args[i]);


### PR DESCRIPTION
## Summary

* Added OSPREY_DUMP_PROTEIN_FDR (per-peptide best_qvalue / score / propagated protein_qvalue captured right after first-pass picked-protein FDR) and OSPREY_DUMP_LOESS_FIT (per-point library_rt / fitted_value / abs_residual from each Stage 6 refit RTCalibration). Both wired from AnalysisPipeline; both honor matching _ONLY env-vars for early-exit during fast iteration.
* Extended WriteStage6InvPredictDump sort key with apex_rt + library_rt tiebreaks so row order is deterministic when a peptide has multiple charge-state detections in one file. List<T>.Sort is unstable in .NET; Vec::sort_by is stable in Rust; the cross-impl input order also differs (Dictionary vs HashMap iteration). A complete data tiebreak removes the dependency on either.
* Inspection cleanups: redundant System.IO. qualifier in WriteStage6CalibrationDump; missing invPredictTrace XML doc on ConsensusRts.Compute.

Pairs with the matching osprey-side PR (https://github.com/maccoss/osprey/pulls — see "Add Stage 6 cross-impl bisection dumps for protein FDR and LOESS fit"). Both dumps are gated, no behavior change without env-vars set.

## Test plan

- [x] Build-OspreySharp.ps1 -RunInspection -RunTests: clean (264/264 tests, 0 inspection issues)
- [x] Compare-Stage6-Planning.ps1 -Dataset Stellar (after the matching osprey + pwiz fix PRs land): 8/8 dumps byte-identical
- [x] Compare-Stage5-AllFiles.ps1 -Dataset Stellar/Astral: 3/3 files x 4 dumps unaffected (dumps fire only when env-var is set)

Co-Authored-By: Claude <noreply@anthropic.com>