### PR TITLE
Fixed misleading "Corrupt RAW file" error on Wine when reading via symlinked path

### DIFF
--- a/pwiz_aux/msrc/utility/vendor_api/thermo/RawFile.cpp
+++ b/pwiz_aux/msrc/utility/vendor_api/thermo/RawFile.cpp
@@ -28,6 +28,7 @@
 #include "pwiz/utility/misc/Std.hpp"
 #include <boost/bind.hpp>
 #include <boost/xpressive/xpressive.hpp>
+#include <filesystem>
 
 using namespace pwiz::vendor_api::Thermo;
 using namespace pwiz::util;
@@ -318,7 +319,10 @@ RawFileImpl::RawFileImpl(const string& filename)
         setCurrentController(Controller_MS, 1);
 
 #else // is WIN64
-        auto managedFilename = ToSystemString(filename);
+        // Canonicalize path before handing to Thermo's RawFileReader: Wine 10.6-staging mishandles
+        // symlinked paths inside the SDK's memory-mapped I/O, surfacing as a misleading "Corrupt RAW
+        // file" error. Same pattern as the WIFF2 fix in commit 521213f86c.
+        auto managedFilename = ToSystemString(std::filesystem::canonical(std::filesystem::u8path(filename)).u8string());
         rawManager_ = RawFileReaderAdapter::ThreadedFileFactory(managedFilename);
         raw_ = rawManager_->CreateThreadAccessor();
         //raw_ = RawFileReaderAdapter::FileFactory(managedFilename);

--- a/pwiz_aux/msrc/utility/vendor_api/thermo/RawFile.cpp
+++ b/pwiz_aux/msrc/utility/vendor_api/thermo/RawFile.cpp
@@ -322,7 +322,12 @@ RawFileImpl::RawFileImpl(const string& filename)
         // Canonicalize path before handing to Thermo's RawFileReader: Wine 10.6-staging mishandles
         // symlinked paths inside the SDK's memory-mapped I/O, surfacing as a misleading "Corrupt RAW
         // file" error. Same pattern as the WIFF2 fix in commit 521213f86c.
-        auto managedFilename = ToSystemString(std::filesystem::canonical(std::filesystem::u8path(filename)).u8string());
+        // Fall back to the raw filename if canonical() throws — it can fail on some filesystems
+        // (e.g., ramdisks on the EC2 build agent).
+        std::string canonicalFilename;
+        try { canonicalFilename = std::filesystem::canonical(std::filesystem::u8path(filename)).u8string(); }
+        catch (const std::filesystem::filesystem_error&) { canonicalFilename = filename; }
+        auto managedFilename = ToSystemString(canonicalFilename);
         rawManager_ = RawFileReaderAdapter::ThreadedFileFactory(managedFilename);
         raw_ = rawManager_->CreateThreadAccessor();
         //raw_ = RawFileReaderAdapter::FileFactory(managedFilename);


### PR DESCRIPTION
## Summary

* Canonicalized the filename in `RawFile.cpp:321` before handing it to Thermo's `RawFileReaderAdapter::ThreadedFileFactory`, so the SDK sees the resolved real path instead of a symlink.
* Wine 10.6-staging mishandles symlinks inside the SDK's memory-mapped I/O (`IMemMapAccessor`/`MemoryMappedFile`), causing `IsError` to be set after open. Our code then reports "Corrupt RAW file" — a misleading message because the file is intact.
* Same pattern as the WIFF2 fix in commit 521213f86c.

## Repro

In the pwiz-skyline Docker image:

1. Mount host directory containing a `.raw` file at `/raws` (read-only)
2. Create a tmpfs at `/local-raws`
3. `ln -s /raws/file.raw /local-raws/file.raw`
4. `wine msconvert.exe Z:/local-raws/file.raw --mzML`

Without the fix:
```
[RawFileImpl::ctor()] Corrupt RAW file Z:/local-raws\file.raw
Error processing file Z:/local-raws\file.raw
```

With the fix: clean conversion, byte-identical output to the direct-bind-mount path.

## Test plan

- [x] msconvert built via `build.bat` (release x64, vendor licenses enabled)
- [x] Patched `msconvert.exe` bind-mounted into `proteowizard/pwiz-skyline-i-agree-to-the-vendor-licenses:skyline_daily_26.1.1.097-922725c`
- [x] Symlink repro on a customer-reported failing file (`088_Ecl-2026-03-22_PfizerExp_15r2_60m_DIA.raw`, 910MB) — converts cleanly to a 599,560,920-byte mzML (rc=1 "Corrupt RAW file" without fix)
- [x] Verified non-symlink paths still convert correctly (regression check)

Co-Authored-By: Claude <noreply@anthropic.com>