### PR TITLE
OspreySharp Stage 5 → Stage 6 boundary writes + workflow restructure

### DIFF
--- a/pwiz_tools/OspreySharp/Osprey-workflow.html
+++ b/pwiz_tools/OspreySharp/Osprey-workflow.html
@@ -58,33 +58,25 @@
   <h1>Osprey / OspreySharp DIA pipeline workflow</h1>
   <p class="sub">
     Top-to-bottom data flow from mzML + spectral library to BiblioSpecLite
-    output. Color indicates port status of the OspreySharp (C#) implementation
-    against the Osprey (Rust) reference. Stages 1-4 match within the
-    <code>Test-Features.ps1</code> 1e-6 tolerance gate on Stellar + Astral
-    (21 PIN features, 317K matched entries); a 0.5% row-count gap and a
-    ~2% per-CWT-candidate ULP-level <code>area</code> drift remain to be
-    explained or upgraded to true bit-identity. Stage 5 is bit-identical
-    on Stellar 1-file AND 3-file (end-of-stage dump: score + pep + 4
-    q-values across 1,388,872 FdrEntry rows at max_diff = 0; multi-file
-    required an experiment_precursor_qvalue propagation fix in C#'s
-    Percolator FDR). Stage 6 planning + reconciliation planner output
-    are bit-identical with Rust across all nine cross-impl dumps on
-    Stellar (172,548 reconciliation actions) AND Astral (248,711) 3-file.
-    The 168-cell Astral <code>experiment_precursor_q</code> diff seen in
-    earlier runs was identified as a Rust ryu vs .NET R formatter
-    tie-break choice (same f64 bits, different shortest-roundtrip
-    decimal); the harness now does a bit-aware fallback comparison that
-    correctly accepts these as equal. Remaining Stage 6 substages are
-    the second-pass re-score (per-file rescoring at locked boundaries
-    plus gap-fill) and the second-pass Percolator SVM (gray boxes
-    below); once those land and their cross-impl dumps go byte-identical,
-    Stage 6 closes. Green badges = regression tests; purple badges =
-    C#/Rust perf ratio.
+    output. Pipeline restructured 2026-04-30 to align stages with the
+    join / per-file-fan-out boundaries that matter for HPC distribution.
+    Stages 1-4 (per-file scoring) match within the
+    <code>Test-Features.ps1</code> 1e-6 tolerance gate on Stellar +
+    Astral. Stage 5 (first-pass FDR + reconciliation planning — the
+    first join) is bit-identical on Stellar + Astral 3-file across all
+    nine cross-impl dumps. Stage 6 (per-file rescore + gap-fill +
+    reconciled parquet write-back — the second per-file fan-out) is
+    in progress: orchestrator landed in OspreySharp but not yet exercised
+    end-to-end. Stages 7 (second-pass Percolator) and 8 (protein FDR +
+    .blib output) are the remaining joins. Color indicates port status
+    of the OspreySharp (C#) implementation against the Osprey (Rust)
+    reference. Green badges = regression tests; purple badges = C#/Rust
+    perf ratio.
   </p>
 </header>
 
 <main>
-<svg class="pipeline" viewBox="0 0 1200 2240" xmlns="http://www.w3.org/2000/svg">
+<svg class="pipeline" viewBox="0 0 1200 2540" xmlns="http://www.w3.org/2000/svg">
 <defs>
   <!-- Arrowhead for control flow between stages -->
   <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5"
@@ -105,6 +97,12 @@
                    text-transform: uppercase; letter-spacing: 1.5px; }
     .phase-title { font-size: 16px; font-weight: 600; fill: #1a237e; }
     .phase-note  { font-size: 11px; fill: #546e7a; font-style: italic; }
+    .phase-shape-fanout { font-size: 11px; font-weight: 700;
+                          fill: #1565c0; text-transform: uppercase;
+                          letter-spacing: 1px; }
+    .phase-shape-join   { font-size: 11px; font-weight: 700;
+                          fill: #c62828; text-transform: uppercase;
+                          letter-spacing: 1px; }
 
     .stage-title { font-size: 13px; font-weight: 600; fill: #263238; }
     .stage-desc  { font-size: 11px; fill: #455a64; }
@@ -155,7 +153,7 @@
 <g transform="translate(40, 40)">
   <text class="title">Osprey / OspreySharp DIA search pipeline</text>
   <text class="subtitle" y="22">
-    Rust reference (Osprey) vs C# port (OspreySharp)  -  status as of 2026-04-16, Session 16 (Stages 1-4 complete; 21 PIN features bit-identical on Stellar + Astral; 3-file parallel = 0.59x Rust on Stellar / 0.12x Rust on Astral)
+    Rust reference (Osprey) vs C# port (OspreySharp)  -  status as of 2026-04-30: Stages 1-4 + Stage 5 (with reconciliation planning) bit-identical on Stellar + Astral 3-file. Stage 6 per-file rescore orchestrator landed; gap-fill + parquet write-back next.
   </text>
 </g>
 
@@ -339,88 +337,106 @@
 </g>
 
 <!-- ================================================================= -->
-<!-- STAGE 4 -> 5 SEAM: HPC scoring split                               -->
+<!-- STAGE 4 -> 5 SEAM: HPC fan-out / first join                        -->
 <!-- ================================================================= -->
 <g transform="translate(0, 1310)">
   <text x="600" y="14" text-anchor="middle" style="font-size: 10px; fill: #555;">
-    --no-join exits here (per-file .scores.parquet on disk); --join-only resumes from those parquets on a merge node
+    --no-join exits here (per-file .scores.parquet on disk); --join-at-pass=1 resumes here on a coordinator node
   </text>
 </g>
 
 <!-- ================================================================= -->
-<!-- STAGE 5 FIRST-PASS FDR                                             -->
+<!-- STAGE 5 FIRST-PASS FDR + RECONCILIATION PLANNING (FIRST JOIN)      -->
 <!-- ================================================================= -->
 <path class="flow" d="M 600 1300 L 600 1340" marker-end="url(#arrow)"/>
 
 <g transform="translate(0, 1340)">
-  <rect class="phase-bg" x="40" y="0" width="1120" height="260" rx="8"/>
+  <rect class="phase-bg" x="40" y="0" width="1120" height="500" rx="8"/>
   <text class="phase-label" x="60" y="24">stage 5</text>
-  <text class="phase-title" x="60" y="42">First-pass FDR (Percolator SVM)</text>
-  <text class="phase-note"  x="60" y="58">Semi-supervised SVM training with target-decoy competition. Produces precursor-level and peptide-level q-values at run and experiment levels.</text>
-  <text class="phase-note"  x="60" y="72">Stellar 1-file AND 3-file: bit-identical cross-impl on score + pep + 4 q-values, max_diff = 0. Multi-file required experiment_precursor_qvalue propagation by base_id (a2972ab6d).</text>
+  <text class="phase-title" x="60" y="42">First-pass FDR + reconciliation planning</text>
+  <text class="phase-shape-join" x="1115" y="24" text-anchor="end">join — needs all-file representation</text>
+  <text class="phase-note"  x="60" y="58">First join in the pipeline. Runs Percolator SVM on the joined per-file scores, computes cross-run consensus RTs,</text>
+  <text class="phase-note"  x="60" y="72">refits per-file calibration, and emits a per-(file, entry) reconciliation plan. All work that needs all-file representation lives here.</text>
 
-  <!-- Stage 5 perf badge (C# join-only wall clock on single-file Stellar;
-       Rust measured 2026-04-22 = 66s at dump-exit point). -->
-  <text x="1115" y="24" text-anchor="end"><tspan class="badge-label badge-perf">Perf: </tspan><tspan class="badge-value badge-perf">137s (2.1x Rust)</tspan></text>
+  <!-- Sub-phase 1: first-pass Percolator -->
+  <text class="phase-label" x="80" y="92" fill="#2e7d32">first-pass percolator</text>
 
-  <rect class="st-done" x="80" y="80" width="1040" height="42" rx="4"/>
-  <text class="stage-title" x="600" y="100" text-anchor="middle">Best-per-precursor subsampling (across files)</text>
-  <text class="stage-desc"  x="600" y="114" text-anchor="middle">subsample + fold dump matches byte-for-byte on single-file Stellar (3-file pending)</text>
+  <rect class="st-done" x="80" y="102" width="1040" height="42" rx="4"/>
+  <text class="stage-title" x="600" y="122" text-anchor="middle">Best-per-precursor subsampling (across files)</text>
+  <text class="stage-desc"  x="600" y="136" text-anchor="middle">subsample + fold dump bit-identical on Stellar 3-file (1,388,872 rows)</text>
 
-  <rect class="st-done" x="80" y="140" width="1040" height="60" rx="4"/>
-  <text class="stage-title" x="600" y="160" text-anchor="middle">Iterative non-negative SVM (3-fold stratified CV by peptide)</text>
-  <text class="stage-desc"  x="600" y="176" text-anchor="middle">grid search for C; Percolator-style positive training set; per-fold SVM weights match byte-for-byte</text>
-  <text class="stage-desc"  x="600" y="190" text-anchor="middle">cross-fold score calibration (Granholm 2012); standardizer mean/std match within 1e-12</text>
+  <rect class="st-done" x="80" y="162" width="1040" height="56" rx="4"/>
+  <text class="stage-title" x="600" y="182" text-anchor="middle">Iterative non-negative SVM (3-fold stratified CV by peptide)</text>
+  <text class="stage-desc"  x="600" y="196" text-anchor="middle">grid search for C; Percolator-style positive training set; per-fold SVM weights match byte-for-byte</text>
+  <text class="stage-desc"  x="600" y="210" text-anchor="middle">cross-fold score calibration (Granholm 2012); standardizer mean/std match within 1e-12</text>
 
-  <rect class="st-done" x="80" y="218" width="1040" height="32" rx="4"/>
-  <text class="stage-title" x="600" y="238" text-anchor="middle">Target-decoy competition + q-values (run + experiment x precursor + peptide) + FDR compaction</text>
+  <rect class="st-done" x="80" y="236" width="1040" height="32" rx="4"/>
+  <text class="stage-title" x="600" y="256" text-anchor="middle">Target-decoy competition + q-values (run + experiment x precursor + peptide) + first-pass compaction + first-pass protein FDR</text>
 
-  <path class="flow" d="M 600 122 L 600 138" marker-end="url(#arrow)"/>
-  <path class="flow" d="M 600 200 L 600 216" marker-end="url(#arrow)"/>
+  <!-- Sub-phase 2: reconciliation planning -->
+  <text class="phase-label" x="80" y="296" fill="#ef6c00">reconciliation planning</text>
+
+  <rect class="st-done" x="80" y="306" width="1040" height="42" rx="4"/>
+  <text class="stage-title" x="600" y="326" text-anchor="middle">Multi-charge consensus per file (post-compaction)</text>
+  <text class="stage-desc"  x="600" y="340" text-anchor="middle">SelectRescoreTargets dump bit-identical (31,270 rows on Stellar 3-file)</text>
+
+  <rect class="st-done" x="80" y="366" width="1040" height="56" rx="4"/>
+  <text class="stage-title" x="600" y="386" text-anchor="middle">Cross-run consensus RTs + per-file calibration refit</text>
+  <text class="stage-desc"  x="600" y="400" text-anchor="middle">sigmoid(score)-weighted median, hard run_precursor_qvalue gate, optional protein-FDR rescue</text>
+  <text class="stage-desc"  x="600" y="414" text-anchor="middle">consensus + inv_predict + loess_fit + refit dumps bit-identical on Stellar + Astral 3-file</text>
+
+  <rect class="st-done" x="80" y="440" width="1040" height="42" rx="4"/>
+  <text class="stage-title" x="600" y="460" text-anchor="middle">Reconciliation plan: per-(file, entry) {Keep | UseCwtPeak | ForcedIntegration}</text>
+  <text class="stage-desc"  x="600" y="474" text-anchor="middle">reconciliation dump bit-identical on Stellar (172,548 actions) + Astral (248,711 actions)</text>
+
+  <!-- Inter-substep arrows (sub-phase 1) -->
+  <path class="flow" d="M 600 144 L 600 160" marker-end="url(#arrow)"/>
+  <path class="flow" d="M 600 218 L 600 234" marker-end="url(#arrow)"/>
+  <!-- Inter-substep arrows (sub-phase 2) -->
+  <path class="flow" d="M 600 348 L 600 364" marker-end="url(#arrow)"/>
+  <path class="flow" d="M 600 422 L 600 438" marker-end="url(#arrow)"/>
 </g>
 
 <!-- ================================================================= -->
-<!-- STAGE 6 REFINEMENT                                                 -->
+<!-- STAGE 5 -> 6 SEAM: planning result drives per-file fan-out          -->
 <!-- ================================================================= -->
-<path class="flow" d="M 600 1600 L 600 1640" marker-end="url(#arrow)"/>
+<g transform="translate(0, 1850)">
+  <text x="600" y="14" text-anchor="middle" style="font-size: 10px; fill: #555;">
+    --join-at-pass=1 --join-only would stop here (future: plan files to disk for HPC fan-back-out); --join-at-pass=1 continues
+  </text>
+</g>
 
-<g transform="translate(0, 1640)">
+<!-- ================================================================= -->
+<!-- STAGE 6 PER-FILE RESCORE (SECOND PER-FILE FAN-OUT)                  -->
+<!-- ================================================================= -->
+<path class="flow" d="M 600 1840 L 600 1880" marker-end="url(#arrow)"/>
+
+<g transform="translate(0, 1880)">
   <rect class="phase-bg-active" x="40" y="0" width="1120" height="260" rx="6"/>
   <text class="phase-label" x="60" y="24">stage 6</text>
-  <text class="phase-title" x="60" y="42">Refinement (post-FDR)</text>
-  <text class="phase-note"  x="60" y="58">
-    Multi-charge consensus + cross-run reconciliation adjust peak boundaries
-    across replicates, then re-score at locked boundaries and re-run FDR.
-    Planning checkpoint + reconciliation planner output byte-identical with
-    Rust on Stellar + Astral 3-file; per-file re-score and second-pass
-    Percolator are the remaining substages.
-  </text>
+  <text class="phase-title" x="60" y="42">Per-file rescore + gap-fill + parquet write-back</text>
+  <text class="phase-shape-fanout" x="1115" y="24" text-anchor="end">per-file — N nodes</text>
+  <text class="phase-note"  x="60" y="58">Second per-file fan-out. Each file independently reloads its mzML, re-invokes the search engine with the reconciled boundary overrides,</text>
+  <text class="phase-note"  x="60" y="72">runs the gap-fill two-pass for missing precursors, and writes reconciled scores back to its .scores.parquet. No cross-file work.</text>
 
-  <rect class="st-done" x="80" y="80" width="1040" height="42" rx="4"/>
-  <text class="stage-title" x="600" y="100" text-anchor="middle">Multi-charge consensus</text>
-  <text class="stage-desc"  x="600" y="114" text-anchor="middle">SelectRescoreTargets ported; rescore-target dump bit-identical with Rust by entry_id (31,270 rows on Stellar 3-file, after first-pass compaction)</text>
+  <rect class="st-partial" x="80" y="90" width="1040" height="42" rx="4"/>
+  <text class="stage-title" x="600" y="110" text-anchor="middle">Per-file rescore at reconciled boundaries</text>
+  <text class="stage-desc"  x="600" y="124" text-anchor="middle">RescorePerFile orchestrator landed (consensus + reconciliation); not yet validated</text>
 
-  <rect class="st-done" x="80" y="140" width="1040" height="42" rx="4"/>
-  <text class="stage-title" x="600" y="160" text-anchor="middle">Cross-run reconciliation</text>
-  <text class="stage-desc"  x="600" y="174" text-anchor="middle">ConsensusRts.Compute + CalibrationRefit.Refit + ReconciliationPlanner.Plan wired; 9/9 cross-impl Stage 6 dumps byte-identical with Rust on Stellar (172,548 reconciliation actions) + Astral (248,711) 3-file</text>
+  <rect class="st-missing" x="80" y="148" width="1040" height="42" rx="4"/>
+  <text class="stage-title" x="600" y="168" text-anchor="middle">Gap-fill (two-pass: CWT with prefilter off, then forced integration)</text>
+  <text class="stage-desc"  x="600" y="182" text-anchor="middle">port IdentifyGapFillTargets; append gap-fill stubs with parquet_index = uint.MaxValue</text>
 
-  <rect class="st-missing" x="80" y="200" width="1040" height="42" rx="4"/>
-  <text class="stage-title" x="600" y="220" text-anchor="middle">Second-pass re-score</text>
-  <text class="stage-desc"  x="600" y="234" text-anchor="middle">re-invoke search engine with reconciled boundary overrides; gap-fill missing precursors via two-pass CWT + forced integration; write reconciled scores back to per-file .scores.parquet</text>
+  <rect class="st-missing" x="80" y="206" width="1040" height="42" rx="4"/>
+  <text class="stage-title" x="600" y="226" text-anchor="middle">Reconciled parquet write-back (replace by ParquetIndex, append gap-fill, write reconciliation metadata)</text>
+  <text class="stage-desc"  x="600" y="240" text-anchor="middle">final per-file parquet output of Phase C — feeds Stage 7 second-pass Percolator</text>
 
-  <rect class="st-missing" x="80" y="260" width="1040" height="42" rx="4"/>
-  <text class="stage-title" x="600" y="280" text-anchor="middle">Second-pass Percolator SVM</text>
-  <text class="stage-desc"  x="600" y="294" text-anchor="middle">single Percolator pass on the re-scored + gap-filled pool; final run + experiment q-values at precursor + peptide levels</text>
+  <path class="flow" d="M 600 132 L 600 146" marker-end="url(#arrow)"/>
+  <path class="flow" d="M 600 190 L 600 204" marker-end="url(#arrow)"/>
 
-  <path class="flow" d="M 600 122 L 600 138" marker-end="url(#arrow)"/>
-  <path class="flow" d="M 600 182 L 600 198" marker-end="url(#arrow)"/>
-  <path class="flow" d="M 600 242 L 600 258" marker-end="url(#arrow)"/>
-
-  <!-- "You are here" callout — pointing at the second-pass re-score box.
-       Multi-charge consensus, cross-run reconciliation, and the
-       reconciliation planner output all shipped byte-identical;
-       per-file re-score is next. -->
-  <g transform="translate(820, 195)">
+  <!-- "You are here" callout — currently working the per-file rescore
+       row. Gap-fill and parquet write-back are still missing/stubbed. -->
+  <g transform="translate(820, 85)">
     <path class="flow-you" d="M 130 20 L 30 20" marker-end="url(#arrow-thick)"/>
     <text class="you-are-here" x="136" y="10">YOU ARE</text>
     <text class="you-are-here" x="136" y="26">HERE</text>
@@ -428,32 +444,49 @@
 </g>
 
 <!-- ================================================================= -->
-<!-- STAGE 7 PROTEIN FDR                                                -->
+<!-- STAGE 6 -> 7 SEAM: reconciled parquets feed second-pass Percolator -->
 <!-- ================================================================= -->
-<path class="flow" d="M 600 1960 L 600 2000" marker-end="url(#arrow)"/>
-
-<g transform="translate(0, 2000)">
-  <rect class="phase-bg" x="40" y="0" width="1120" height="100" rx="6"/>
-  <text class="phase-label" x="60" y="24">stage 7</text>
-  <text class="phase-title" x="60" y="42">Protein FDR</text>
-
-  <rect class="st-unverif" x="80" y="50" width="1040" height="42" rx="4"/>
-  <text class="stage-title" x="600" y="70" text-anchor="middle">Parsimony + picked-protein FDR (TDC on best peptide scores)</text>
-  <text class="stage-desc"  x="600" y="84" text-anchor="middle">bipartite graph, subset elimination, greedy razor assignment</text>
+<g transform="translate(0, 2150)">
+  <text x="600" y="14" text-anchor="middle" style="font-size: 10px; fill: #555;">
+    --join-at-pass=2 --input-scores ... resumes here from reconciled per-file parquets (second join begins)
+  </text>
 </g>
 
 <!-- ================================================================= -->
-<!-- STAGE 8 OUTPUT                                                     -->
+<!-- STAGE 7 SECOND-PASS PERCOLATOR (SECOND JOIN)                        -->
 <!-- ================================================================= -->
-<path class="flow" d="M 600 2100 L 600 2140" marker-end="url(#arrow)"/>
+<path class="flow" d="M 600 2140 L 600 2180" marker-end="url(#arrow)"/>
 
-<g transform="translate(0, 2140)">
-  <rect class="phase-bg" x="40" y="0" width="1120" height="90" rx="6"/>
+<g transform="translate(0, 2180)">
+  <rect class="phase-bg" x="40" y="0" width="1120" height="120" rx="6"/>
+  <text class="phase-label" x="60" y="24">stage 7</text>
+  <text class="phase-title" x="60" y="42">Second-pass Percolator SVM</text>
+  <text class="phase-shape-join" x="1115" y="24" text-anchor="end">join — needs all-file representation</text>
+
+  <rect class="st-missing" x="80" y="62" width="1040" height="46" rx="4"/>
+  <text class="stage-title" x="600" y="82" text-anchor="middle">Single Percolator pass on the reconciled + gap-filled pool</text>
+  <text class="stage-desc"  x="600" y="96" text-anchor="middle">final run + experiment q-values at precursor + peptide levels; OSPREY_DUMP_REFINED_FDR cross-impl bisection dump (planned)</text>
+</g>
+
+<!-- ================================================================= -->
+<!-- STAGE 8 PROTEIN FDR + OUTPUT (FINAL JOIN)                          -->
+<!-- ================================================================= -->
+<path class="flow" d="M 600 2300 L 600 2340" marker-end="url(#arrow)"/>
+
+<g transform="translate(0, 2340)">
+  <rect class="phase-bg" x="40" y="0" width="1120" height="160" rx="6"/>
   <text class="phase-label" x="60" y="24">stage 8</text>
-  <text class="phase-title" x="60" y="42">Output</text>
+  <text class="phase-title" x="60" y="42">Protein FDR + output</text>
+  <text class="phase-shape-join" x="1115" y="24" text-anchor="end">join — final coordinator phase</text>
 
-  <rect class="st-partial" x="80" y="50" width="1040" height="32" rx="4"/>
-  <text class="stage-title" x="600" y="70" text-anchor="middle">BiblioSpecLite .blib (RefSpectra, RetentionTimes, Modifications, Proteins, Osprey fragment tables)</text>
+  <rect class="st-unverif" x="80" y="62" width="1040" height="42" rx="4"/>
+  <text class="stage-title" x="600" y="82" text-anchor="middle">Parsimony + picked-protein FDR (Savitski 2015, TDC on best peptide score)</text>
+  <text class="stage-desc"  x="600" y="96" text-anchor="middle">bipartite graph, identical-set grouping, subset elimination, greedy razor assignment</text>
+
+  <rect class="st-partial" x="80" y="118" width="1040" height="32" rx="4"/>
+  <text class="stage-title" x="600" y="138" text-anchor="middle">BiblioSpecLite .blib (RefSpectra, RetentionTimes, Modifications, Proteins, Osprey fragment tables)</text>
+
+  <path class="flow" d="M 600 104 L 600 116" marker-end="url(#arrow)"/>
 </g>
 
 </svg>
@@ -518,39 +551,46 @@
     1,388,872 row dump byte-identical on Stellar 3-file.
   </p>
   <p>
-    <strong>Stage 6 planning checkpoint (2026-04-25):</strong> the
-    Stage 6 entry block in OspreySharp now runs first-pass protein FDR,
-    multi-charge consensus, cross-run consensus RTs, and per-file
-    calibration refit. Three new diagnostic dumps land on each side
-    (<code>OSPREY_DUMP_CONSENSUS</code> /
-    <code>OSPREY_DUMP_MULTICHARGE</code> /
-    <code>OSPREY_DUMP_REFIT</code>, with matching <code>_ONLY</code>
-    early-exits) and a sibling harness
-    <code>Compare-Stage6-Planning.ps1</code> byte-compares the four
-    dumps (Stage 5 percolator + the three Stage 6 planning dumps).
-    On Stellar 3-file: stage5_percolator + multicharge + calibration are
-    bit-identical; consensus is 99.999% bit-identical (1/87343 rows on
-    a borderline protein-FDR rescue); inv_predict is 99.99966%
-    (1/292512 rows, same root cause); refit ULP at LOESS-fit residual
-    stats. The InversePredict ULP that previously diverged on every
-    consensus row was traced to <code>serde_json</code>'s default f64
-    parser disagreeing with .NET's correctly-rounded
-    <code>double.Parse</code> on full-precision values; routing Rust
-    f64 array deserialization through <code>f64::from_str</code>
-    closes the arithmetic gap. Driver branches:
-    <code>maccoss/osprey:feature/stage6-planning-diagnostics</code>
-    and <code>ProteoWizard/pwiz:Skyline/work/20260423_osprey_sharp_stage6</code>.
+    <strong>Stage 5 reconciliation planning (2026-04-29):</strong> after
+    the 2026-04-30 pipeline restructure, what was previously called
+    "Stage 6 planning" now lives in Stage 5 alongside first-pass
+    Percolator. Multi-charge consensus, cross-run consensus RTs, per-file
+    calibration refit, and the reconciliation planner all run in the
+    same join phase that ends at the per-(file, entry) reconciliation
+    plan. Nine cross-impl dumps (<code>stage5_percolator</code>,
+    <code>protein_fdr</code>, <code>calibration</code>,
+    <code>inv_predict</code>, <code>consensus</code>,
+    <code>multicharge</code>, <code>loess_fit</code>, <code>refit</code>,
+    <code>reconciliation</code>) byte-identical on Stellar (172,548
+    reconciliation actions) and Astral (248,711) 3-file. The harness
+    <code>Compare-Stage6-Planning.ps1</code> drives all nine via
+    <code>--join-at-pass=1</code> with per-dump <code>_ONLY</code>
+    early-exits.
   </p>
   <p>
-    Next targets: localize the borderline first-pass-protein-FDR rescue
-    that produces the 1-row consensus / inv_predict diff (likely a
-    tie-break in protein-group construction at exactly 1% q-value);
-    bisect the LOESS-fit ULP that affects refit r²/sd/mad
-    (independent of InversePredict). Then wire
-    <code>ReconciliationPlanner.Plan</code>, gap-fill, and second-pass
-    Percolator. Stage 7 protein FDR + Stage 8 .blib output parity
-    follow once Stage 6 is fully proven. See
-    <code>ai/todos/active/TODO-20260423_osprey_sharp_stage6.md</code>.
+    <strong>Pipeline restructure + CLI rename (2026-04-30):</strong>
+    stages renumbered to align with join / per-file-fan-out boundaries
+    that matter for HPC distribution. Stage 5 absorbs reconciliation
+    planning (single first-join phase). Stage 6 is now per-file rescore
+    only (second per-file fan-out). Stage 7 is the second join
+    (second-pass Percolator). Stage 8 absorbs Protein FDR + .blib
+    output (final coordinator phase). CLI matrix: <code>--no-join</code>
+    runs only per-file work, <code>--join-only</code> runs only joined
+    work, <code>--join-at-pass=&lt;1|2&gt;</code> selects entry-point
+    parquets (Stage 4 outputs vs reconciled Stage 6 outputs).
+    Plan-file persistence between Stage 5 and Stage 6 deferred to a
+    future sprint — single-machine flow runs them in one process for
+    now.
+  </p>
+  <p>
+    <strong>Next targets:</strong> exercise the new Stage 6
+    <code>RescorePerFile</code> orchestrator end-to-end (gap-fill +
+    parquet write-back not yet implemented). Add
+    <code>OSPREY_DUMP_REFINED_RESCORE</code> intermediate dump or
+    diff reconciled parquets directly. Once Stage 6 is byte-identical,
+    advance into Stage 7 (second-pass Percolator + new
+    <code>OSPREY_DUMP_REFINED_FDR</code>) then Stage 8. See
+    <code>ai/todos/active/TODO-20260429_osprey_sharp_stage6.md</code>.
   </p>
 </footer>
 </body>

--- a/pwiz_tools/OspreySharp/OspreySharp.Core/OspreyConfig.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Core/OspreyConfig.cs
@@ -112,6 +112,16 @@ namespace pwiz.OspreySharp.Core
         public List<string> InputScores { get; set; }
 
         /// <summary>
+        /// HPC: when true, exit after Stage 5 + reconciliation planning,
+        /// having written the boundary files
+        /// (<c>&lt;stem&gt;.&lt;phase&gt;-pass.fdr_scores.bin</c> and
+        /// <c>&lt;stem&gt;.reconciliation.json</c>) for each input file.
+        /// Skips Stage 6 + 7 + 8. Set by the
+        /// <c>--join-at-pass=1 --join-only</c> flag combination.
+        /// </summary>
+        public bool StopAfterStage5 { get; set; }
+
+        /// <summary>
         /// How many files will actually run concurrently in the current
         /// invocation. Set by the pipeline before per-file ProcessFile()
         /// calls; used to divide the inner main-search thread budget so

--- a/pwiz_tools/OspreySharp/OspreySharp.Core/OspreyEnvironment.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Core/OspreyEnvironment.cs
@@ -87,6 +87,17 @@ namespace pwiz.OspreySharp.Core
         /// </summary>
         public static readonly string LoadCalibrationPath = Environment.GetEnvironmentVariable(@"OSPREY_LOAD_CALIBRATION");
 
+        /// <summary>
+        /// OSPREY_CROSS_IMPL_FDR_SIDECAR_OUT: when a unit test is run under
+        /// the cross-impl harness, the round-trip test for the v2
+        /// .fdr_scores.bin format also copies its output to this path, so a
+        /// sibling Rust unit test (with the same hardcoded inputs) can be
+        /// byte-compared against ours. Test-only hook; never set in
+        /// production. The harness verifies cross-impl byte parity once both
+        /// sides have written their copy.
+        /// </summary>
+        public static readonly string CrossImplFdrSidecarOut = Environment.GetEnvironmentVariable(@"OSPREY_CROSS_IMPL_FDR_SIDECAR_OUT");
+
         private static int ParseIntOrZero(string name)
         {
             string v = Environment.GetEnvironmentVariable(name);

--- a/pwiz_tools/OspreySharp/OspreySharp.Core/OspreyEnvironment.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Core/OspreyEnvironment.cs
@@ -98,6 +98,14 @@ namespace pwiz.OspreySharp.Core
         /// </summary>
         public static readonly string CrossImplFdrSidecarOut = Environment.GetEnvironmentVariable(@"OSPREY_CROSS_IMPL_FDR_SIDECAR_OUT");
 
+        /// <summary>
+        /// OSPREY_CROSS_IMPL_RECONCILIATION_OUT: same idea as
+        /// CrossImplFdrSidecarOut but for the per-file
+        /// .reconciliation.json boundary file. Test-only hook; never set
+        /// in production.
+        /// </summary>
+        public static readonly string CrossImplReconciliationOut = Environment.GetEnvironmentVariable(@"OSPREY_CROSS_IMPL_RECONCILIATION_OUT");
+
         private static int ParseIntOrZero(string name)
         {
             string v = Environment.GetEnvironmentVariable(name);

--- a/pwiz_tools/OspreySharp/OspreySharp.FDR/Reconciliation/GapFillTarget.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.FDR/Reconciliation/GapFillTarget.cs
@@ -1,0 +1,43 @@
+/*
+ * Original author: Brendan MacLean <brendanx .at. uw.edu>,
+ *                  MacCoss Lab, Department of Genome Sciences, UW
+ * AI assistance: Claude Code (Claude Opus 4) <noreply .at. anthropic.com>
+ *
+ * Based on osprey (https://github.com/MacCossLab/osprey)
+ *   by Michael J. MacCoss, MacCoss Lab, Department of Genome Sciences, UW
+ *
+ * Copyright 2026 University of Washington - Seattle, WA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace pwiz.OspreySharp.FDR.Reconciliation
+{
+    /// <summary>
+    /// A precursor that passed FDR in some sibling replicate but was
+    /// missing from a particular file, so the Stage 6 worker should score
+    /// it at the consensus RT and contribute a per-file boundary to the
+    /// blib. Maps to <c>GapFillTarget</c> in
+    /// <c>osprey/crates/osprey/src/reconciliation.rs</c>. The wire form for
+    /// <c>reconciliation.json</c> is <c>OspreySharp.IO.GapFillEntry</c>.
+    /// </summary>
+    public class GapFillTarget
+    {
+        public uint TargetEntryId { get; set; }
+        public uint DecoyEntryId { get; set; }
+        public double ExpectedRt { get; set; }
+        public double HalfWidth { get; set; }
+        public string ModifiedSequence { get; set; }
+        public byte Charge { get; set; }
+    }
+}

--- a/pwiz_tools/OspreySharp/OspreySharp.FDR/Reconciliation/GapFillTargetIdentifier.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.FDR/Reconciliation/GapFillTargetIdentifier.cs
@@ -1,0 +1,212 @@
+/*
+ * Original author: Brendan MacLean <brendanx .at. uw.edu>,
+ *                  MacCoss Lab, Department of Genome Sciences, UW
+ * AI assistance: Claude Code (Claude Opus 4) <noreply .at. anthropic.com>
+ *
+ * Based on osprey (https://github.com/MacCossLab/osprey)
+ *   by Michael J. MacCoss, MacCoss Lab, Department of Genome Sciences, UW
+ *
+ * Copyright 2026 University of Washington - Seattle, WA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
+using System.Collections.Generic;
+using pwiz.OspreySharp.Chromatography;
+using pwiz.OspreySharp.Core;
+
+namespace pwiz.OspreySharp.FDR.Reconciliation
+{
+    /// <summary>
+    /// Identifies precursors that passed FDR in some sibling replicate but
+    /// were missing from a given file, so the Stage 6 worker can score them
+    /// at the consensus RT and contribute per-file boundaries to the blib.
+    ///
+    /// Ports <c>identify_gap_fill_targets</c> from
+    /// <c>osprey/crates/osprey/src/reconciliation.rs</c>.
+    /// </summary>
+    public static class GapFillTargetIdentifier
+    {
+        /// <summary>
+        /// For each input file, return the list of <see cref="GapFillTarget"/>
+        /// records to write into <c>reconciliation.json</c>'s
+        /// <c>gap_fill_targets</c> array. The result is sorted by
+        /// <c>target_entry_id</c> so the JSON output matches Rust byte for
+        /// byte. Files with no gap-fill candidates are omitted.
+        /// </summary>
+        /// <param name="consensus">Per-peptide consensus RTs from
+        /// <see cref="ConsensusRts"/>.</param>
+        /// <param name="perFileEntries">Post-compaction FDR stubs per file.</param>
+        /// <param name="perFileRefinedCal">Per-file refined RT calibrations
+        /// (LOESS refit on consensus peptides). Preferred over original.</param>
+        /// <param name="perFileOriginalCal">Per-file first-pass RT calibrations.
+        /// Used as a fallback when no refined calibration is available.</param>
+        /// <param name="experimentFdr">FDR threshold; precursors are eligible
+        /// for gap-fill when any of their four q-values is &lt;= this.</param>
+        /// <param name="libLookup"><c>(modified_sequence, charge) →
+        /// (target_entry_id, decoy_entry_id)</c> from the library. Decoy IDs
+        /// follow the <c>target_id | 0x80000000</c> convention.</param>
+        /// <param name="libPrecursorMz"><c>target_entry_id → precursor m/z</c>;
+        /// only consulted when an isolation-window filter is supplied.</param>
+        /// <param name="perFileIsolationMz">Optional per-file
+        /// <c>(lo, hi)</c> isolation window intervals. When supplied,
+        /// candidates whose library precursor m/z falls outside every window
+        /// are filtered out (essential for GPF datasets with disjoint m/z
+        /// ranges). May be <c>null</c> to disable the filter; an empty list
+        /// for a file similarly disables the filter for that file.</param>
+        public static IReadOnlyDictionary<string, IReadOnlyList<GapFillTarget>> Identify(
+            IReadOnlyList<PeptideConsensusRT> consensus,
+            IReadOnlyList<KeyValuePair<string, IReadOnlyList<FdrEntry>>> perFileEntries,
+            IReadOnlyDictionary<string, RTCalibration> perFileRefinedCal,
+            IReadOnlyDictionary<string, RTCalibration> perFileOriginalCal,
+            double experimentFdr,
+            IReadOnlyDictionary<(string ModifiedSequence, byte Charge),
+                (uint TargetEntryId, uint DecoyEntryId)> libLookup,
+            IReadOnlyDictionary<uint, double> libPrecursorMz,
+            IReadOnlyDictionary<string, IReadOnlyList<(double Lo, double Hi)>> perFileIsolationMz)
+        {
+            if (consensus == null)
+                throw new ArgumentNullException(nameof(consensus));
+            if (perFileEntries == null)
+                throw new ArgumentNullException(nameof(perFileEntries));
+            if (perFileRefinedCal == null)
+                throw new ArgumentNullException(nameof(perFileRefinedCal));
+            if (perFileOriginalCal == null)
+                throw new ArgumentNullException(nameof(perFileOriginalCal));
+            if (libLookup == null)
+                throw new ArgumentNullException(nameof(libLookup));
+            if (libPrecursorMz == null)
+                throw new ArgumentNullException(nameof(libPrecursorMz));
+
+            // 1. Build passing precursors. Targets only — paired decoys ride
+            //    along via the same library lookup. Match the Rust rationale
+            //    at reconciliation.rs:870-891: a precursor is eligible if ANY
+            //    of the four q-values clears the threshold so a peptide that
+            //    passes peptide-level FDR (even with middling precursor q)
+            //    still gets its missing charge states gap-filled.
+            var passingPrecursors = new HashSet<(string ModifiedSequence, byte Charge)>();
+            foreach (var fileKvp in perFileEntries)
+            {
+                foreach (var entry in fileKvp.Value)
+                {
+                    if (entry.IsDecoy)
+                        continue;
+                    double bestQ = Math.Min(
+                        Math.Min(entry.RunPrecursorQvalue, entry.RunPeptideQvalue),
+                        Math.Min(entry.ExperimentPrecursorQvalue, entry.ExperimentPeptideQvalue));
+                    if (bestQ <= experimentFdr)
+                        passingPrecursors.Add((entry.ModifiedSequence, entry.Charge));
+                }
+            }
+
+            var result = new Dictionary<string, IReadOnlyList<GapFillTarget>>();
+            if (passingPrecursors.Count == 0)
+                return result;
+
+            // 2. Consensus lookup by (modified_sequence, is_decoy=false).
+            var consensusMap = new Dictionary<string, PeptideConsensusRT>();
+            foreach (var c in consensus)
+            {
+                if (c.IsDecoy)
+                    continue;
+                consensusMap[c.ModifiedSequence] = c;
+            }
+
+            // 3. Per-file: find missing precursors, optionally filter by
+            //    isolation-window m/z, look up consensus RT, and emit
+            //    GapFillTarget records.
+            foreach (var fileKvp in perFileEntries)
+            {
+                string fileName = fileKvp.Key;
+                var entries = fileKvp.Value;
+
+                RTCalibration cal = null;
+                if (!perFileRefinedCal.TryGetValue(fileName, out cal))
+                    perFileOriginalCal.TryGetValue(fileName, out cal);
+                if (cal == null)
+                    continue;
+
+                IReadOnlyList<(double Lo, double Hi)> isoWindows = null;
+                if (perFileIsolationMz != null)
+                    perFileIsolationMz.TryGetValue(fileName, out isoWindows);
+
+                var present = new HashSet<(string ModifiedSequence, byte Charge)>();
+                foreach (var e in entries)
+                {
+                    if (e.IsDecoy)
+                        continue;
+                    present.Add((e.ModifiedSequence, e.Charge));
+                }
+
+                var targets = new List<GapFillTarget>();
+                foreach (var key in passingPrecursors)
+                {
+                    if (present.Contains(key))
+                        continue;
+
+                    if (!libLookup.TryGetValue(key, out var ids))
+                        continue;
+
+                    // m/z range filter: skip precursors whose m/z is not
+                    // covered by any isolation window in this file. Strict
+                    // upper bound (precursor_mz < hi) matches Rust at
+                    // reconciliation.rs:954-956.
+                    if (isoWindows != null && isoWindows.Count > 0)
+                    {
+                        if (!libPrecursorMz.TryGetValue(ids.TargetEntryId, out double precursorMz))
+                            continue;
+                        bool inRange = false;
+                        for (int i = 0; i < isoWindows.Count; i++)
+                        {
+                            var w = isoWindows[i];
+                            if (precursorMz >= w.Lo && precursorMz < w.Hi)
+                            {
+                                inRange = true;
+                                break;
+                            }
+                        }
+                        if (!inRange)
+                            continue;
+                    }
+
+                    if (!consensusMap.TryGetValue(key.ModifiedSequence, out var consensusEntry))
+                        continue;
+
+                    double expectedRt = cal.Predict(consensusEntry.ConsensusLibraryRt);
+                    double halfWidth = consensusEntry.MedianPeakWidth / 2.0;
+
+                    targets.Add(new GapFillTarget
+                    {
+                        Charge = key.Charge,
+                        DecoyEntryId = ids.DecoyEntryId,
+                        ExpectedRt = expectedRt,
+                        HalfWidth = halfWidth,
+                        ModifiedSequence = key.ModifiedSequence,
+                        TargetEntryId = ids.TargetEntryId,
+                    });
+                }
+
+                if (targets.Count == 0)
+                    continue;
+
+                // Sort by target_entry_id for deterministic output (matches
+                // Rust serializer in reconciliation_io.rs line 167).
+                targets.Sort((a, b) => a.TargetEntryId.CompareTo(b.TargetEntryId));
+                result[fileName] = targets;
+            }
+
+            return result;
+        }
+    }
+}

--- a/pwiz_tools/OspreySharp/OspreySharp.IO/FdrScoresSidecar.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.IO/FdrScoresSidecar.cs
@@ -1,0 +1,217 @@
+/*
+ * Original author: Brendan MacLean <brendanx .at. uw.edu>,
+ *                  MacCoss Lab, Department of Genome Sciences, UW
+ * AI assistance: Claude Code (Claude Opus 4) <noreply .at. anthropic.com>
+ *
+ * Based on osprey (https://github.com/MacCossLab/osprey)
+ *   by Michael J. MacCoss, MacCoss Lab, Department of Genome Sciences, UW
+ *
+ * Copyright 2026 University of Washington - Seattle, WA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using pwiz.OspreySharp.Core;
+
+namespace pwiz.OspreySharp.IO
+{
+    /// <summary>
+    /// Reader / writer for the per-file <c>.&lt;phase&gt;-pass.fdr_scores.bin</c>
+    /// sidecar: the v2 binary format that persists the full FDR statistics
+    /// for an entry (SVM discriminant + 4 q-values + PEP). Used at the
+    /// Stage 5 → Stage 6 boundary so a Stage 6 worker can run without
+    /// re-running first-pass Percolator.
+    ///
+    /// Mirrors <c>write_fdr_scores_sidecar</c> + <c>load_fdr_scores_sidecar</c>
+    /// in <c>osprey/crates/osprey/src/pipeline.rs</c>. Cross-impl byte
+    /// parity is verified by a separate harness script.
+    ///
+    /// Format (32-byte header + N × 48-byte records, all little-endian):
+    /// <code>
+    ///   magic         [0..8]   = b"OSPRYFDR"
+    ///   version       [8]      = u8 (= 2)
+    ///   pass          [9]      = u8 (1 = first-pass, 2 = second-pass)
+    ///   reserved      [10..16] = 6 bytes (zero)
+    ///   entry_count   [16..24] = u64
+    ///   reserved      [24..32] = 8 bytes (zero)
+    ///   body          [32..]   = entry_count * 48 bytes:
+    ///                            f64 svm_score
+    ///                            f64 run_precursor_qvalue
+    ///                            f64 run_peptide_qvalue
+    ///                            f64 experiment_precursor_qvalue
+    ///                            f64 experiment_peptide_qvalue
+    ///                            f64 pep
+    /// </code>
+    /// Records are positional + post-compaction: index <c>i</c> in the
+    /// file corresponds to the in-memory <see cref="FdrEntry"/> at index
+    /// <c>i</c>, which has already been filtered to passing entries.
+    /// </summary>
+    public static class FdrScoresSidecar
+    {
+        // 8-byte magic. ASCII "OSPRYFDR" — same as Rust.
+        private static readonly byte[] Magic =
+            { (byte)'O', (byte)'S', (byte)'P', (byte)'R', (byte)'Y', (byte)'F', (byte)'D', (byte)'R' };
+
+        public const byte FormatVersion = 2;
+        public const int HeaderLength = 32;
+        public const int RecordLength = 48;
+
+        /// <summary>
+        /// Pass identifier embedded in the header. Mirrors the Rust pass
+        /// byte semantics: 1 = first-pass Percolator, 2 = second-pass
+        /// Percolator.
+        /// </summary>
+        public enum Pass : byte
+        {
+            FirstPass = 1,
+            SecondPass = 2,
+        }
+
+        /// <summary>
+        /// Path for the first-pass FDR scores sidecar of a given input
+        /// file: <c>&lt;dir&gt;/&lt;stem&gt;.1st-pass.fdr_scores.bin</c>.
+        /// Mirrors Rust's <c>fdr_scores_path_pass1</c>.
+        /// </summary>
+        public static string Pass1Path(string inputPath)
+        {
+            return ScoresPath(inputPath, "1st-pass");
+        }
+
+        /// <summary>Path for the second-pass FDR scores sidecar.</summary>
+        public static string Pass2Path(string inputPath)
+        {
+            return ScoresPath(inputPath, "2nd-pass");
+        }
+
+        private static string ScoresPath(string inputPath, string passLabel)
+        {
+            string stem = Path.GetFileNameWithoutExtension(inputPath) ?? "unknown";
+            string parent = Path.GetDirectoryName(inputPath);
+            string filename = string.Format("{0}.{1}.fdr_scores.bin", stem, passLabel);
+            return string.IsNullOrEmpty(parent) ? filename : Path.Combine(parent, filename);
+        }
+
+        /// <summary>
+        /// Write per-file FDR scores to <paramref name="path"/>. Stages
+        /// through a temp file in the same directory, then atomically
+        /// renames. The pass byte distinguishes first- vs second-pass
+        /// outputs at the Percolator level.
+        /// </summary>
+        public static void Write(string path, IReadOnlyList<FdrEntry> entries, Pass pass)
+        {
+            if (path == null) throw new ArgumentNullException(nameof(path));
+            if (entries == null) throw new ArgumentNullException(nameof(entries));
+
+            string parent = Path.GetDirectoryName(Path.GetFullPath(path));
+            if (!string.IsNullOrEmpty(parent))
+                Directory.CreateDirectory(parent);
+
+            // Stage to sibling tmp file then atomically rename. Avoids
+            // partial-file corruption if the writer is interrupted.
+            string tmpPath = path + ".tmp";
+            try
+            {
+                using (var fs = new FileStream(tmpPath, FileMode.Create, FileAccess.Write, FileShare.None))
+                using (var bw = new BinaryWriter(fs))
+                {
+                    // Header
+                    bw.Write(Magic);                                  // [0..8]
+                    bw.Write(FormatVersion);                          // [8]
+                    bw.Write((byte)pass);                             // [9]
+                    bw.Write(new byte[6]);                            // [10..16] reserved
+                    bw.Write((ulong)entries.Count);                   // [16..24]
+                    bw.Write(new byte[8]);                            // [24..32] reserved
+
+                    // Body: 48 bytes per entry
+                    foreach (var e in entries)
+                    {
+                        bw.Write(e.Score);                            // [0..8]
+                        bw.Write(e.RunPrecursorQvalue);               // [8..16]
+                        bw.Write(e.RunPeptideQvalue);                 // [16..24]
+                        bw.Write(e.ExperimentPrecursorQvalue);        // [24..32]
+                        bw.Write(e.ExperimentPeptideQvalue);          // [32..40]
+                        bw.Write(e.Pep);                              // [40..48]
+                    }
+                }
+
+                if (File.Exists(path))
+                    File.Delete(path);
+                File.Move(tmpPath, path);
+            }
+            finally
+            {
+                if (File.Exists(tmpPath))
+                    File.Delete(tmpPath);
+            }
+        }
+
+        /// <summary>
+        /// Read per-file FDR scores from <paramref name="path"/> into
+        /// <paramref name="entries"/>. Returns true on success, false on
+        /// any of: missing file, bad magic, unsupported version, count
+        /// mismatch, or size mismatch. Records are positional, so the
+        /// caller's <paramref name="entries"/> Vec must already be sized
+        /// to match the post-compaction stub set.
+        /// </summary>
+        public static bool TryRead(string path, IList<FdrEntry> entries)
+        {
+            if (path == null) throw new ArgumentNullException(nameof(path));
+            if (entries == null) throw new ArgumentNullException(nameof(entries));
+
+            byte[] data;
+            try
+            {
+                data = File.ReadAllBytes(path);
+            }
+            catch
+            {
+                return false;
+            }
+
+            if (data.Length < HeaderLength)
+                return false;
+            for (int i = 0; i < Magic.Length; i++)
+            {
+                if (data[i] != Magic[i])
+                    return false;
+            }
+            byte version = data[8];
+            if (version != FormatVersion)
+                return false;
+            // bytes 10..16 reserved, ignored
+            ulong headerCount = BitConverter.ToUInt64(data, 16);
+            if (headerCount != (ulong)entries.Count)
+                return false;
+
+            int expectedLen = HeaderLength + entries.Count * RecordLength;
+            if (data.Length != expectedLen)
+                return false;
+
+            for (int i = 0; i < entries.Count; i++)
+            {
+                int off = HeaderLength + i * RecordLength;
+                var e = entries[i];
+                e.Score                       = BitConverter.ToDouble(data, off + 0);
+                e.RunPrecursorQvalue          = BitConverter.ToDouble(data, off + 8);
+                e.RunPeptideQvalue            = BitConverter.ToDouble(data, off + 16);
+                e.ExperimentPrecursorQvalue   = BitConverter.ToDouble(data, off + 24);
+                e.ExperimentPeptideQvalue     = BitConverter.ToDouble(data, off + 32);
+                e.Pep                         = BitConverter.ToDouble(data, off + 40);
+            }
+            return true;
+        }
+    }
+}

--- a/pwiz_tools/OspreySharp/OspreySharp.IO/FdrScoresSidecar.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.IO/FdrScoresSidecar.cs
@@ -56,15 +56,23 @@ namespace pwiz.OspreySharp.IO
     ///                            f64 experiment_peptide_qvalue
     ///                            f64 pep
     /// </code>
-    /// Records are post-compaction: every record corresponds to a stub
-    /// that passed first-pass FDR. The <c>entry_id</c> on each record
-    /// lets a Stage 6 worker assemble the post-compaction stub set by
-    /// joining the full parquet against the sidecar's entry_id set —
-    /// the worker does not need to re-run Percolator. In skip-Percolator
-    /// mode the order also matches the in-memory list position-for-
-    /// position, so the per-position
-    /// <c>entries[i].EntryId == record.entry_id</c> check doubles as a
-    /// corruption detector.
+    /// Records are written pre-compaction at the Stage 5 → Stage 6
+    /// boundary: every input entry contributes one record so q-values
+    /// are preserved even for entries that may not survive later
+    /// compaction. The pre-compaction call site is at the bottom of the
+    /// first-pass FDR block, just before the compaction loop runs,
+    /// mirroring Rust's <c>persist_fdr_scores</c> at
+    /// <c>pipeline.rs</c>. Each record carries the entry's
+    /// <c>entry_id</c> for identity verification (the per-position
+    /// <c>entries[i].EntryId == record.entry_id</c> check during load
+    /// doubles as a corruption detector); the loader matches records
+    /// to stubs by position + count rather than by joining on
+    /// <c>entry_id</c>. A Stage 6 worker therefore consumes the
+    /// sidecar by reloading the same FdrEntry sequence from the
+    /// per-file parquet cache and applying records in order. The
+    /// loader also rejects mismatches on the header <c>pass</c> byte
+    /// so a 2nd-pass sidecar can never silently scramble 1st-pass
+    /// stubs (or vice versa).
     /// </summary>
     public static class FdrScoresSidecar
     {
@@ -113,9 +121,16 @@ namespace pwiz.OspreySharp.IO
 
         /// <summary>
         /// Write per-file FDR scores to <paramref name="path"/>. Stages
-        /// through a temp file in the same directory, then atomically
-        /// renames. The pass byte distinguishes first- vs second-pass
-        /// outputs at the Percolator level.
+        /// through a sibling <c>.tmp</c> file in the same directory and
+        /// renames into place; this avoids leaving a partially-written
+        /// destination on writer failure, but the rename is not strictly
+        /// atomic when the destination already exists (the existing file
+        /// is removed first). A crash between the remove and the rename
+        /// leaves the <c>.tmp</c> next to the missing destination, which
+        /// the next run either overwrites or — if the writer fails
+        /// identically — leaves recoverable by hand. The pass byte
+        /// distinguishes first- vs second-pass outputs at the Percolator
+        /// level.
         /// </summary>
         public static void Write(string path, IReadOnlyList<FdrEntry> entries, Pass pass)
         {
@@ -126,8 +141,9 @@ namespace pwiz.OspreySharp.IO
             if (!string.IsNullOrEmpty(parent))
                 Directory.CreateDirectory(parent);
 
-            // Stage to sibling tmp file then atomically rename. Avoids
-            // partial-file corruption if the writer is interrupted.
+            // Stage to sibling .tmp file then rename. Avoids partial-file
+            // corruption if the writer is interrupted; not strictly
+            // atomic on overwrite (delete + move), see Write() doc.
             string tmpPath = path + ".tmp";
             try
             {
@@ -169,12 +185,14 @@ namespace pwiz.OspreySharp.IO
         /// <summary>
         /// Read per-file FDR scores from <paramref name="path"/> into
         /// <paramref name="entries"/>. Returns true on success, false on
-        /// any of: missing file, bad magic, unsupported version, count
+        /// any of: missing file, bad magic, unsupported version, pass-byte
+        /// mismatch against <paramref name="expectedPass"/>, count
         /// mismatch, or size mismatch. Records are positional, so the
-        /// caller's <paramref name="entries"/> Vec must already be sized
-        /// to match the post-compaction stub set.
+        /// caller's <paramref name="entries"/> list must already be sized
+        /// to match the FdrEntry sequence the sidecar was written from
+        /// (pre-compaction at the Stage 5 → Stage 6 boundary).
         /// </summary>
-        public static bool TryRead(string path, IList<FdrEntry> entries)
+        public static bool TryRead(string path, IList<FdrEntry> entries, Pass expectedPass)
         {
             if (path == null) throw new ArgumentNullException(nameof(path));
             if (entries == null) throw new ArgumentNullException(nameof(entries));
@@ -198,6 +216,12 @@ namespace pwiz.OspreySharp.IO
             }
             byte version = data[8];
             if (version != FormatVersion)
+                return false;
+            // Reject mismatched pass bytes so a 2nd-pass sidecar can never
+            // be silently loaded into 1st-pass stubs (or vice versa) — the
+            // q-values would scramble without any visible error.
+            byte passByte = data[9];
+            if (passByte != (byte)expectedPass)
                 return false;
             // bytes 10..16 reserved, ignored
             ulong headerCount = BitConverter.ToUInt64(data, 16);

--- a/pwiz_tools/OspreySharp/OspreySharp.IO/FdrScoresSidecar.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.IO/FdrScoresSidecar.cs
@@ -39,7 +39,7 @@ namespace pwiz.OspreySharp.IO
     /// in <c>osprey/crates/osprey/src/pipeline.rs</c>. Cross-impl byte
     /// parity is verified by a separate harness script.
     ///
-    /// Format (32-byte header + N × 48-byte records, all little-endian):
+    /// Format (32-byte header + N × 52-byte records, all little-endian):
     /// <code>
     ///   magic         [0..8]   = b"OSPRYFDR"
     ///   version       [8]      = u8 (= 2)
@@ -47,7 +47,8 @@ namespace pwiz.OspreySharp.IO
     ///   reserved      [10..16] = 6 bytes (zero)
     ///   entry_count   [16..24] = u64
     ///   reserved      [24..32] = 8 bytes (zero)
-    ///   body          [32..]   = entry_count * 48 bytes:
+    ///   body          [32..]   = entry_count * 52 bytes:
+    ///                            u32 entry_id
     ///                            f64 svm_score
     ///                            f64 run_precursor_qvalue
     ///                            f64 run_peptide_qvalue
@@ -55,9 +56,15 @@ namespace pwiz.OspreySharp.IO
     ///                            f64 experiment_peptide_qvalue
     ///                            f64 pep
     /// </code>
-    /// Records are positional + post-compaction: index <c>i</c> in the
-    /// file corresponds to the in-memory <see cref="FdrEntry"/> at index
-    /// <c>i</c>, which has already been filtered to passing entries.
+    /// Records are post-compaction: every record corresponds to a stub
+    /// that passed first-pass FDR. The <c>entry_id</c> on each record
+    /// lets a Stage 6 worker assemble the post-compaction stub set by
+    /// joining the full parquet against the sidecar's entry_id set —
+    /// the worker does not need to re-run Percolator. In skip-Percolator
+    /// mode the order also matches the in-memory list position-for-
+    /// position, so the per-position
+    /// <c>entries[i].EntryId == record.entry_id</c> check doubles as a
+    /// corruption detector.
     /// </summary>
     public static class FdrScoresSidecar
     {
@@ -67,7 +74,7 @@ namespace pwiz.OspreySharp.IO
 
         public const byte FormatVersion = 2;
         public const int HeaderLength = 32;
-        public const int RecordLength = 48;
+        public const int RecordLength = 52;
 
         /// <summary>
         /// Pass identifier embedded in the header. Mirrors the Rust pass
@@ -135,15 +142,16 @@ namespace pwiz.OspreySharp.IO
                     bw.Write((ulong)entries.Count);                   // [16..24]
                     bw.Write(new byte[8]);                            // [24..32] reserved
 
-                    // Body: 48 bytes per entry
+                    // Body: 52 bytes per entry (entry_id + 6 f64s)
                     foreach (var e in entries)
                     {
-                        bw.Write(e.Score);                            // [0..8]
-                        bw.Write(e.RunPrecursorQvalue);               // [8..16]
-                        bw.Write(e.RunPeptideQvalue);                 // [16..24]
-                        bw.Write(e.ExperimentPrecursorQvalue);        // [24..32]
-                        bw.Write(e.ExperimentPeptideQvalue);          // [32..40]
-                        bw.Write(e.Pep);                              // [40..48]
+                        bw.Write(e.EntryId);                          // [0..4]
+                        bw.Write(e.Score);                            // [4..12]
+                        bw.Write(e.RunPrecursorQvalue);               // [12..20]
+                        bw.Write(e.RunPeptideQvalue);                 // [20..28]
+                        bw.Write(e.ExperimentPrecursorQvalue);        // [28..36]
+                        bw.Write(e.ExperimentPeptideQvalue);          // [36..44]
+                        bw.Write(e.Pep);                              // [44..52]
                     }
                 }
 
@@ -204,12 +212,15 @@ namespace pwiz.OspreySharp.IO
             {
                 int off = HeaderLength + i * RecordLength;
                 var e = entries[i];
-                e.Score                       = BitConverter.ToDouble(data, off + 0);
-                e.RunPrecursorQvalue          = BitConverter.ToDouble(data, off + 8);
-                e.RunPeptideQvalue            = BitConverter.ToDouble(data, off + 16);
-                e.ExperimentPrecursorQvalue   = BitConverter.ToDouble(data, off + 24);
-                e.ExperimentPeptideQvalue     = BitConverter.ToDouble(data, off + 32);
-                e.Pep                         = BitConverter.ToDouble(data, off + 40);
+                uint recordEntryId = BitConverter.ToUInt32(data, off + 0);
+                if (recordEntryId != e.EntryId)
+                    return false;
+                e.Score                       = BitConverter.ToDouble(data, off + 4);
+                e.RunPrecursorQvalue          = BitConverter.ToDouble(data, off + 12);
+                e.RunPeptideQvalue            = BitConverter.ToDouble(data, off + 20);
+                e.ExperimentPrecursorQvalue   = BitConverter.ToDouble(data, off + 28);
+                e.ExperimentPeptideQvalue     = BitConverter.ToDouble(data, off + 36);
+                e.Pep                         = BitConverter.ToDouble(data, off + 44);
             }
             return true;
         }

--- a/pwiz_tools/OspreySharp/OspreySharp.IO/OspreySharp.IO.csproj
+++ b/pwiz_tools/OspreySharp/OspreySharp.IO/OspreySharp.IO.csproj
@@ -12,6 +12,7 @@
   <ItemGroup>
     <PackageReference Include="Parquet.Net" Version="3.10.0" />
     <PackageReference Include="System.Data.SQLite.Core" Version="1.0.118" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
 
   <!-- net472 needs System.Memory explicitly; net8 has it built in. -->

--- a/pwiz_tools/OspreySharp/OspreySharp.IO/ReconciliationFile.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.IO/ReconciliationFile.cs
@@ -38,11 +38,15 @@ namespace pwiz.OspreySharp.IO
     /// gap-fill targets for the file, and the refined RT calibration.
     ///
     /// Mirrors <c>osprey/crates/osprey/src/reconciliation_io.rs</c>.
-    /// Field declaration order is alphabetical at every nesting level so
-    /// Newtonsoft's <c>Formatting.Indented</c> emits keys in alphabetical
-    /// order and matches Rust's <c>serde_json::to_writer_pretty</c> byte
-    /// for byte. Cross-impl byte parity is verified by a sibling test in
-    /// each language.
+    /// Field declaration order is alphabetical at every nesting level
+    /// (matches Rust). All <see cref="double"/> values are routed through
+    /// <see cref="RoundtripDoubleConverter"/> on this side and through a
+    /// matching custom <c>serde_json</c> formatter on the Rust side, so
+    /// every f64 is emitted as the same canonical fixed-point decimal
+    /// form on both runtimes — sidestepping the
+    /// Newtonsoft-<c>R</c>/Grisu vs. Rust-<c>ryu</c> threshold
+    /// disagreement on small values like <c>4.58e-5</c>. Cross-impl byte
+    /// parity is verified by a sibling test in each language.
     /// </summary>
     public class ReconciliationFile
     {
@@ -111,7 +115,11 @@ namespace pwiz.OspreySharp.IO
             if (!string.IsNullOrEmpty(parent))
                 Directory.CreateDirectory(parent);
 
-            string json = JsonConvert.SerializeObject(file, Formatting.Indented);
+            var settings = new JsonSerializerSettings
+            {
+                Converters = { new RoundtripDoubleConverter() },
+            };
+            string json = JsonConvert.SerializeObject(file, Formatting.Indented, settings);
             // Newtonsoft's Formatting.Indented emits CRLF on Windows by
             // default; normalize to LF so cross-impl byte parity with the
             // Rust side (which always emits LF via serde_json) holds. Also

--- a/pwiz_tools/OspreySharp/OspreySharp.IO/ReconciliationFile.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.IO/ReconciliationFile.cs
@@ -1,0 +1,236 @@
+/*
+ * Original author: Brendan MacLean <brendanx .at. uw.edu>,
+ *                  MacCoss Lab, Department of Genome Sciences, UW
+ * AI assistance: Claude Code (Claude Opus 4) <noreply .at. anthropic.com>
+ *
+ * Based on osprey (https://github.com/MacCossLab/osprey)
+ *   by Michael J. MacCoss, MacCoss Lab, Department of Genome Sciences, UW
+ *
+ * Copyright 2026 University of Washington - Seattle, WA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Newtonsoft.Json;
+
+namespace pwiz.OspreySharp.IO
+{
+    /// <summary>
+    /// Per-file <c>&lt;stem&gt;.reconciliation.json</c> Stage 5 → Stage 6
+    /// boundary file. Carries everything a Stage 6 worker needs to do
+    /// per-file rescore + gap-fill + reconciled parquet write-back without
+    /// re-running any of the joined Stage 5 work: the non-Keep
+    /// reconciliation actions for the file (split into two homogeneous
+    /// arrays so the JSON has no discriminator field gymnastics), the
+    /// gap-fill targets for the file, and the refined RT calibration.
+    ///
+    /// Mirrors <c>osprey/crates/osprey/src/reconciliation_io.rs</c>.
+    /// Field declaration order is alphabetical at every nesting level so
+    /// Newtonsoft's <c>Formatting.Indented</c> emits keys in alphabetical
+    /// order and matches Rust's <c>serde_json::to_writer_pretty</c> byte
+    /// for byte. Cross-impl byte parity is verified by a sibling test in
+    /// each language.
+    /// </summary>
+    public class ReconciliationFile
+    {
+        /// <summary>Current schema version. Bump on incompatible changes.</summary>
+        public const int CurrentFormatVersion = 1;
+
+        [JsonProperty("forced_integration_actions", Order = 0)]
+        public List<ForcedIntegrationEntry> ForcedIntegrationActions { get; set; }
+
+        [JsonProperty("format_version", Order = 1)]
+        public int FormatVersion { get; set; }
+
+        [JsonProperty("gap_fill_targets", Order = 2)]
+        public List<GapFillEntry> GapFillTargets { get; set; }
+
+        [JsonProperty("library_hash", Order = 3)]
+        public string LibraryHash { get; set; }
+
+        [JsonProperty("refined_rt_calibration", Order = 4, NullValueHandling = NullValueHandling.Include)]
+        public RefinedRtCalibrationJson RefinedRtCalibration { get; set; }
+
+        [JsonProperty("search_hash", Order = 5)]
+        public string SearchHash { get; set; }
+
+        [JsonProperty("use_cwt_peak_actions", Order = 6)]
+        public List<UseCwtPeakEntry> UseCwtPeakActions { get; set; }
+
+        /// <summary>
+        /// Read a reconciliation file and validate its
+        /// <c>format_version</c>. Throws on missing file, malformed JSON,
+        /// or unsupported version.
+        /// </summary>
+        public static ReconciliationFile Load(string path)
+        {
+            if (string.IsNullOrEmpty(path))
+                throw new ArgumentException("path must not be null or empty", nameof(path));
+            if (!File.Exists(path))
+                throw new FileNotFoundException("Reconciliation file not found: " + path, path);
+
+            string json = File.ReadAllText(path);
+            var parsed = JsonConvert.DeserializeObject<ReconciliationFile>(json);
+            if (parsed == null)
+                throw new InvalidDataException("Reconciliation file parsed as null: " + path);
+            if (parsed.FormatVersion != CurrentFormatVersion)
+            {
+                throw new InvalidDataException(string.Format(
+                    "Reconciliation file {0} has unsupported format_version {1} (expected {2})",
+                    path, parsed.FormatVersion, CurrentFormatVersion));
+            }
+            return parsed;
+        }
+
+        /// <summary>
+        /// Write the reconciliation file as pretty 2-space-indented JSON
+        /// with LF line endings. Stages through a sibling .tmp file then
+        /// atomically renames so partial writes don't corrupt the output.
+        /// </summary>
+        public static void Save(string path, ReconciliationFile file)
+        {
+            if (string.IsNullOrEmpty(path))
+                throw new ArgumentException("path must not be null or empty", nameof(path));
+            if (file == null)
+                throw new ArgumentNullException(nameof(file));
+
+            string parent = Path.GetDirectoryName(Path.GetFullPath(path));
+            if (!string.IsNullOrEmpty(parent))
+                Directory.CreateDirectory(parent);
+
+            string json = JsonConvert.SerializeObject(file, Formatting.Indented);
+            // Newtonsoft's Formatting.Indented emits CRLF on Windows by
+            // default; normalize to LF so cross-impl byte parity with the
+            // Rust side (which always emits LF via serde_json) holds. Also
+            // emit a trailing newline so the file ends with `}\n`,
+            // matching the explicit newline Rust appends after the
+            // serializer.
+            json = json.Replace("\r\n", "\n");
+            if (!json.EndsWith("\n", StringComparison.Ordinal))
+                json += "\n";
+
+            string tmpPath = path + ".tmp";
+            try
+            {
+                File.WriteAllText(tmpPath, json);
+                if (File.Exists(path))
+                    File.Delete(path);
+                File.Move(tmpPath, path);
+            }
+            finally
+            {
+                if (File.Exists(tmpPath))
+                    File.Delete(tmpPath);
+            }
+        }
+
+        /// <summary>
+        /// Compute the per-file reconciliation JSON path: sibling to the
+        /// input mzML at <c>&lt;dir&gt;/&lt;stem&gt;.reconciliation.json</c>.
+        /// Mirrors the existing pattern used for
+        /// <c>&lt;stem&gt;.calibration.json</c>, etc.
+        /// </summary>
+        public static string PathForInput(string inputPath)
+        {
+            string stem = Path.GetFileNameWithoutExtension(inputPath) ?? "unknown";
+            string parent = Path.GetDirectoryName(inputPath);
+            string filename = stem + ".reconciliation.json";
+            return string.IsNullOrEmpty(parent) ? filename : Path.Combine(parent, filename);
+        }
+    }
+
+    /// <summary>
+    /// Wire form of an <c>UseCwtPeak</c> reconciliation action for a
+    /// single entry. Field order alphabetical.
+    /// </summary>
+    public class UseCwtPeakEntry
+    {
+        [JsonProperty("apex_rt", Order = 0)]
+        public double ApexRt { get; set; }
+
+        [JsonProperty("candidate_idx", Order = 1)]
+        public uint CandidateIdx { get; set; }
+
+        [JsonProperty("end_rt", Order = 2)]
+        public double EndRt { get; set; }
+
+        [JsonProperty("entry_id", Order = 3)]
+        public uint EntryId { get; set; }
+
+        [JsonProperty("start_rt", Order = 4)]
+        public double StartRt { get; set; }
+    }
+
+    /// <summary>
+    /// Wire form of a <c>ForcedIntegration</c> reconciliation action.
+    /// Field order alphabetical.
+    /// </summary>
+    public class ForcedIntegrationEntry
+    {
+        [JsonProperty("entry_id", Order = 0)]
+        public uint EntryId { get; set; }
+
+        [JsonProperty("expected_rt", Order = 1)]
+        public double ExpectedRt { get; set; }
+
+        [JsonProperty("half_width", Order = 2)]
+        public double HalfWidth { get; set; }
+    }
+
+    /// <summary>
+    /// Wire form of a <c>GapFillTarget</c>. Field order alphabetical.
+    /// </summary>
+    public class GapFillEntry
+    {
+        [JsonProperty("charge", Order = 0)]
+        public byte Charge { get; set; }
+
+        [JsonProperty("decoy_entry_id", Order = 1)]
+        public uint DecoyEntryId { get; set; }
+
+        [JsonProperty("expected_rt", Order = 2)]
+        public double ExpectedRt { get; set; }
+
+        [JsonProperty("half_width", Order = 3)]
+        public double HalfWidth { get; set; }
+
+        [JsonProperty("modified_sequence", Order = 4)]
+        public string ModifiedSequence { get; set; }
+
+        [JsonProperty("target_entry_id", Order = 5)]
+        public uint TargetEntryId { get; set; }
+    }
+
+    /// <summary>
+    /// Wire form of the refined per-file RT calibration. Carries the
+    /// LOESS model parameters; Stage 6 workers reconstruct an in-memory
+    /// calibration via <c>RTCalibration.FromModelParams</c>.
+    /// </summary>
+    public class RefinedRtCalibrationJson
+    {
+        [JsonProperty("abs_residuals", Order = 0)]
+        public double[] AbsResiduals { get; set; }
+
+        [JsonProperty("fitted_rts", Order = 1)]
+        public double[] FittedRts { get; set; }
+
+        [JsonProperty("library_rts", Order = 2)]
+        public double[] LibraryRts { get; set; }
+
+        [JsonProperty("residual_sd", Order = 3)]
+        public double ResidualSd { get; set; }
+    }
+}

--- a/pwiz_tools/OspreySharp/OspreySharp.IO/ReconciliationFile.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.IO/ReconciliationFile.cs
@@ -101,8 +101,14 @@ namespace pwiz.OspreySharp.IO
 
         /// <summary>
         /// Write the reconciliation file as pretty 2-space-indented JSON
-        /// with LF line endings. Stages through a sibling .tmp file then
-        /// atomically renames so partial writes don't corrupt the output.
+        /// with LF line endings. Stages through a sibling <c>.tmp</c>
+        /// file in the same directory and renames into place; this
+        /// avoids leaving a partially-written destination on writer
+        /// failure, but the rename is not strictly atomic when the
+        /// destination already exists (the existing file is removed
+        /// first). A crash between the remove and the rename leaves
+        /// the <c>.tmp</c> next to the missing destination, recoverable
+        /// by hand or by re-running.
         /// </summary>
         public static void Save(string path, ReconciliationFile file)
         {

--- a/pwiz_tools/OspreySharp/OspreySharp.IO/RoundtripDoubleConverter.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.IO/RoundtripDoubleConverter.cs
@@ -1,0 +1,70 @@
+/*
+ * Original author: Brendan MacLean <brendanx .at. uw.edu>,
+ *                  MacCoss Lab, Department of Genome Sciences, UW
+ * AI assistance: Claude Code (Claude Opus 4) <noreply .at. anthropic.com>
+ *
+ * Based on osprey (https://github.com/MacCossLab/osprey)
+ *   by Michael J. MacCoss, MacCoss Lab, Department of Genome Sciences, UW
+ *
+ * Copyright 2026 University of Washington - Seattle, WA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
+using System.Globalization;
+using Newtonsoft.Json;
+using pwiz.OspreySharp.Core;
+
+namespace pwiz.OspreySharp.IO
+{
+    /// <summary>
+    /// Newtonsoft converter that emits every <see cref="double"/> via
+    /// <see cref="Diagnostics.FormatF64Roundtrip"/>, so cross-impl JSON
+    /// files (e.g., the Stage 5 → Stage 6 boundary
+    /// <c>reconciliation.json</c>) carry a single canonical fixed-point
+    /// decimal form for f64s on both runtimes. Newtonsoft's default
+    /// <c>R</c>/Grisu output and Rust's default <c>ryu</c> output disagree
+    /// on the decimal-vs-scientific threshold for small values (e.g.,
+    /// <c>4.58e-5</c>), so neither default is suitable for byte-identical
+    /// cross-impl comparison; routing both sides through
+    /// <c>format_f64_roundtrip</c> sidesteps the disagreement.
+    ///
+    /// Reading is symmetric and lossless: numbers parse back to f64
+    /// regardless of whether they were written via this converter or the
+    /// Newtonsoft default.
+    /// </summary>
+    public class RoundtripDoubleConverter : JsonConverter<double>
+    {
+        public override void WriteJson(JsonWriter writer, double value, JsonSerializer serializer)
+        {
+            // Diagnostics.FormatF64Roundtrip returns "NaN" / "inf" / "-inf"
+            // for non-finite values, none of which are valid JSON tokens.
+            // Reconciliation arrays should never carry non-finite f64s, but
+            // guard anyway so a malformed JSON file is never silently
+            // produced.
+            if (double.IsNaN(value) || double.IsInfinity(value))
+            {
+                throw new JsonWriterException(string.Format(CultureInfo.InvariantCulture,
+                    "Non-finite f64 in JSON output: {0}", value));
+            }
+            writer.WriteRawValue(Diagnostics.FormatF64Roundtrip(value));
+        }
+
+        public override double ReadJson(JsonReader reader, Type objectType, double existingValue,
+            bool hasExistingValue, JsonSerializer serializer)
+        {
+            return Convert.ToDouble(reader.Value, CultureInfo.InvariantCulture);
+        }
+    }
+}

--- a/pwiz_tools/OspreySharp/OspreySharp.IO/RoundtripDoubleConverter.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.IO/RoundtripDoubleConverter.cs
@@ -64,6 +64,19 @@ namespace pwiz.OspreySharp.IO
         public override double ReadJson(JsonReader reader, Type objectType, double existingValue,
             bool hasExistingValue, JsonSerializer serializer)
         {
+            // Newtonsoft's default `Convert.ToDouble(reader.Value)` happily
+            // returns 0.0 for `JsonToken.Null` (because `Convert.ToDouble`
+            // accepts null), and silently truncates non-numeric tokens via
+            // `ToString` paths. Both would let malformed cross-impl input
+            // pass through without surfacing — reject explicitly so a
+            // future schema drift produces a parse error instead of zeros.
+            if (reader.TokenType != JsonToken.Integer && reader.TokenType != JsonToken.Float)
+            {
+                throw new JsonSerializationException(string.Format(CultureInfo.InvariantCulture,
+                    "Expected number token for double, got {0}", reader.TokenType));
+            }
+            if (reader.Value == null)
+                throw new JsonSerializationException("Null value for numeric token");
             return Convert.ToDouble(reader.Value, CultureInfo.InvariantCulture);
         }
     }

--- a/pwiz_tools/OspreySharp/OspreySharp.Test/IOTest.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Test/IOTest.cs
@@ -1557,5 +1557,163 @@ namespace pwiz.OspreySharp.Test
         }
 
         #endregion
+
+        #region FdrScoresSidecar Tests
+
+        private static FdrEntry MakeFdrEntry(uint id, double score, double q, double pep)
+        {
+            return new FdrEntry
+            {
+                EntryId = id,
+                ParquetIndex = id,
+                IsDecoy = false,
+                Charge = 2,
+                ScanNumber = 0,
+                Score = score,
+                RunPrecursorQvalue = q,
+                RunPeptideQvalue = q + 1.0e-9,
+                RunProteinQvalue = 1.0,
+                ExperimentPrecursorQvalue = q + 2.0e-9,
+                ExperimentPeptideQvalue = q + 3.0e-9,
+                ExperimentProteinQvalue = 1.0,
+                Pep = pep,
+                ModifiedSequence = "PEPTIDE",
+            };
+        }
+
+        /// <summary>
+        /// Round-trip: write entries via Write, then read them back via
+        /// TryRead and verify every numeric field survives bit-for-bit.
+        /// </summary>
+        [TestMethod]
+        public void TestFdrScoresSidecarRoundTrip()
+        {
+            string dir = Path.Combine(Path.GetTempPath(), "fdr_sidecar_rt_" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(dir);
+            try
+            {
+                string path = Path.Combine(dir, "test.1st-pass.fdr_scores.bin");
+                var entries = new List<FdrEntry>
+                {
+                    MakeFdrEntry(0, -3.5, 0.001, 0.02),
+                    MakeFdrEntry(1, -3.4, 0.002, 0.05),
+                    MakeFdrEntry(2, -3.3, 0.003, 0.08),
+                };
+
+                FdrScoresSidecar.Write(path, entries, FdrScoresSidecar.Pass.FirstPass);
+
+                // Cross-impl byte-parity hook: when the harness runs this test
+                // with OSPREY_CROSS_IMPL_FDR_SIDECAR_OUT=<path> set, copy our
+                // output to that path so a sibling test on the Rust osprey
+                // side (using the same input data) can be byte-compared
+                // against ours. Same hardcoded entries on both sides; same
+                // format spec; the output files must match bit-for-bit.
+                if (!string.IsNullOrEmpty(OspreyEnvironment.CrossImplFdrSidecarOut))
+                    File.Copy(path, OspreyEnvironment.CrossImplFdrSidecarOut, overwrite: true);
+
+                // File size sanity check.
+                long size = new FileInfo(path).Length;
+                Assert.AreEqual(
+                    FdrScoresSidecar.HeaderLength + entries.Count * FdrScoresSidecar.RecordLength,
+                    size);
+
+                // Stubs with cleared FDR fields — TryRead must repopulate them.
+                var loaded = new List<FdrEntry>
+                {
+                    MakeFdrEntry(0, 0.0, 0.0, 0.0),
+                    MakeFdrEntry(1, 0.0, 0.0, 0.0),
+                    MakeFdrEntry(2, 0.0, 0.0, 0.0),
+                };
+                Assert.IsTrue(FdrScoresSidecar.TryRead(path, loaded));
+
+                for (int i = 0; i < entries.Count; i++)
+                {
+                    Assert.AreEqual(BitConverter.DoubleToInt64Bits(entries[i].Score),
+                                    BitConverter.DoubleToInt64Bits(loaded[i].Score));
+                    Assert.AreEqual(BitConverter.DoubleToInt64Bits(entries[i].RunPrecursorQvalue),
+                                    BitConverter.DoubleToInt64Bits(loaded[i].RunPrecursorQvalue));
+                    Assert.AreEqual(BitConverter.DoubleToInt64Bits(entries[i].RunPeptideQvalue),
+                                    BitConverter.DoubleToInt64Bits(loaded[i].RunPeptideQvalue));
+                    Assert.AreEqual(BitConverter.DoubleToInt64Bits(entries[i].ExperimentPrecursorQvalue),
+                                    BitConverter.DoubleToInt64Bits(loaded[i].ExperimentPrecursorQvalue));
+                    Assert.AreEqual(BitConverter.DoubleToInt64Bits(entries[i].ExperimentPeptideQvalue),
+                                    BitConverter.DoubleToInt64Bits(loaded[i].ExperimentPeptideQvalue));
+                    Assert.AreEqual(BitConverter.DoubleToInt64Bits(entries[i].Pep),
+                                    BitConverter.DoubleToInt64Bits(loaded[i].Pep));
+                }
+            }
+            finally
+            {
+                try { Directory.Delete(dir, true); } catch (IOException) { }
+            }
+        }
+
+        /// <summary>
+        /// Pre-v2 sidecar files (no magic header, just raw f64 scores)
+        /// must be rejected by the v2 reader.
+        /// </summary>
+        [TestMethod]
+        public void TestFdrScoresSidecarV1FormatRejected()
+        {
+            string dir = Path.Combine(Path.GetTempPath(), "fdr_sidecar_v1_" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(dir);
+            try
+            {
+                string path = Path.Combine(dir, "test.1st-pass.fdr_scores.bin");
+                using (var fs = new FileStream(path, FileMode.Create))
+                using (var bw = new BinaryWriter(fs))
+                {
+                    bw.Write(0.1);
+                    bw.Write(0.2);
+                    bw.Write(0.3);
+                }
+
+                var entries = new List<FdrEntry>
+                {
+                    MakeFdrEntry(0, 0.0, 0.0, 0.0),
+                    MakeFdrEntry(1, 0.0, 0.0, 0.0),
+                    MakeFdrEntry(2, 0.0, 0.0, 0.0),
+                };
+                Assert.IsFalse(FdrScoresSidecar.TryRead(path, entries));
+                foreach (var e in entries)
+                    Assert.AreEqual(0.0, e.Score);
+            }
+            finally
+            {
+                try { Directory.Delete(dir, true); } catch (IOException) { }
+            }
+        }
+
+        /// <summary>
+        /// If the sidecar's header entry-count disagrees with the
+        /// caller's stub list, the reader must refuse rather than silently
+        /// truncate or pad.
+        /// </summary>
+        [TestMethod]
+        public void TestFdrScoresSidecarCountMismatchRejected()
+        {
+            string dir = Path.Combine(Path.GetTempPath(), "fdr_sidecar_cm_" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(dir);
+            try
+            {
+                string path = Path.Combine(dir, "test.1st-pass.fdr_scores.bin");
+                FdrScoresSidecar.Write(path,
+                    new List<FdrEntry> { MakeFdrEntry(0, -3.5, 0.001, 0.02) },
+                    FdrScoresSidecar.Pass.FirstPass);
+
+                var wrongCount = new List<FdrEntry>
+                {
+                    MakeFdrEntry(0, 0.0, 0.0, 0.0),
+                    MakeFdrEntry(1, 0.0, 0.0, 0.0),
+                };
+                Assert.IsFalse(FdrScoresSidecar.TryRead(path, wrongCount));
+            }
+            finally
+            {
+                try { Directory.Delete(dir, true); } catch (IOException) { }
+            }
+        }
+
+        #endregion
     }
 }

--- a/pwiz_tools/OspreySharp/OspreySharp.Test/IOTest.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Test/IOTest.cs
@@ -1624,7 +1624,7 @@ namespace pwiz.OspreySharp.Test
                     MakeFdrEntry(1, 0.0, 0.0, 0.0),
                     MakeFdrEntry(2, 0.0, 0.0, 0.0),
                 };
-                Assert.IsTrue(FdrScoresSidecar.TryRead(path, loaded));
+                Assert.IsTrue(FdrScoresSidecar.TryRead(path, loaded, FdrScoresSidecar.Pass.FirstPass));
 
                 for (int i = 0; i < entries.Count; i++)
                 {
@@ -1674,7 +1674,7 @@ namespace pwiz.OspreySharp.Test
                     MakeFdrEntry(1, 0.0, 0.0, 0.0),
                     MakeFdrEntry(2, 0.0, 0.0, 0.0),
                 };
-                Assert.IsFalse(FdrScoresSidecar.TryRead(path, entries));
+                Assert.IsFalse(FdrScoresSidecar.TryRead(path, entries, FdrScoresSidecar.Pass.FirstPass));
                 foreach (var e in entries)
                     Assert.AreEqual(0.0, e.Score);
             }
@@ -1706,7 +1706,44 @@ namespace pwiz.OspreySharp.Test
                     MakeFdrEntry(0, 0.0, 0.0, 0.0),
                     MakeFdrEntry(1, 0.0, 0.0, 0.0),
                 };
-                Assert.IsFalse(FdrScoresSidecar.TryRead(path, wrongCount));
+                Assert.IsFalse(FdrScoresSidecar.TryRead(path, wrongCount, FdrScoresSidecar.Pass.FirstPass));
+            }
+            finally
+            {
+                try { Directory.Delete(dir, true); } catch (IOException) { }
+            }
+        }
+
+        /// <summary>
+        /// A 1st-pass sidecar must NOT load into a TryRead call that
+        /// expects 2nd-pass (and vice versa) — would otherwise scramble
+        /// q-values silently because the records are positionally
+        /// compatible but semantically different.
+        /// </summary>
+        [TestMethod]
+        public void TestFdrScoresSidecarPassMismatchRejected()
+        {
+            string dir = Path.Combine(Path.GetTempPath(), "fdr_sidecar_pm_" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(dir);
+            try
+            {
+                string path = Path.Combine(dir, "test.fdr_scores.bin");
+                FdrScoresSidecar.Write(path,
+                    new List<FdrEntry>
+                    {
+                        MakeFdrEntry(0, -3.5, 0.001, 0.02),
+                        MakeFdrEntry(1, -2.1, 0.005, 0.04),
+                    },
+                    FdrScoresSidecar.Pass.FirstPass);
+
+                var stubs = new List<FdrEntry>
+                {
+                    MakeFdrEntry(0, 0.0, 0.0, 0.0),
+                    MakeFdrEntry(1, 0.0, 0.0, 0.0),
+                };
+                Assert.IsFalse(FdrScoresSidecar.TryRead(path, stubs, FdrScoresSidecar.Pass.SecondPass));
+                foreach (var s in stubs)
+                    Assert.AreEqual(0.0, s.Score);
             }
             finally
             {

--- a/pwiz_tools/OspreySharp/OspreySharp.Test/IOTest.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Test/IOTest.cs
@@ -1715,5 +1715,133 @@ namespace pwiz.OspreySharp.Test
         }
 
         #endregion
+
+        #region ReconciliationFile Tests
+
+        private static ReconciliationFile MakeSampleReconciliationFile()
+        {
+            return new ReconciliationFile
+            {
+                ForcedIntegrationActions = new List<ForcedIntegrationEntry>
+                {
+                    new ForcedIntegrationEntry { EntryId = 200, ExpectedRt = 41.125, HalfWidth = 0.075 },
+                    new ForcedIntegrationEntry { EntryId = 201, ExpectedRt = 18.5,   HalfWidth = 0.05  },
+                },
+                FormatVersion = ReconciliationFile.CurrentFormatVersion,
+                GapFillTargets = new List<GapFillEntry>
+                {
+                    new GapFillEntry
+                    {
+                        Charge = 2,
+                        DecoyEntryId = 0x80000003u,
+                        ExpectedRt = 33.5,
+                        HalfWidth = 0.08,
+                        ModifiedSequence = "PEPTIDE",
+                        TargetEntryId = 3,
+                    },
+                },
+                LibraryHash = "lib-hash-abc",
+                RefinedRtCalibration = new RefinedRtCalibrationJson
+                {
+                    AbsResiduals = new[] { 0.01, 0.02, 0.015 },
+                    FittedRts    = new[] { 10.5, 20.5, 30.5 },
+                    LibraryRts   = new[] { 10.0, 20.0, 30.0 },
+                    ResidualSd   = 0.123,
+                },
+                SearchHash = "search-hash-xyz",
+                UseCwtPeakActions = new List<UseCwtPeakEntry>
+                {
+                    new UseCwtPeakEntry { ApexRt = 23.45, CandidateIdx = 1, EndRt = 23.80, EntryId = 100, StartRt = 23.10 },
+                    new UseCwtPeakEntry { ApexRt = 8.07,  CandidateIdx = 0, EndRt = 8.20,  EntryId = 101, StartRt = 7.95  },
+                },
+            };
+        }
+
+        /// <summary>
+        /// Round-trip: save a sample reconciliation file, reload it, and
+        /// verify every field survives bit-for-bit. Also exposes the
+        /// cross-impl byte-parity hook so the same hardcoded sample can
+        /// be byte-compared against the Rust sibling test's output.
+        /// </summary>
+        [TestMethod]
+        public void TestReconciliationFileRoundTrip()
+        {
+            string dir = Path.Combine(Path.GetTempPath(), "recon_rt_" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(dir);
+            try
+            {
+                string path = Path.Combine(dir, "round_trip.reconciliation.json");
+                var file = MakeSampleReconciliationFile();
+
+                ReconciliationFile.Save(path, file);
+
+                if (!string.IsNullOrEmpty(OspreyEnvironment.CrossImplReconciliationOut))
+                    File.Copy(path, OspreyEnvironment.CrossImplReconciliationOut, overwrite: true);
+
+                var parsed = ReconciliationFile.Load(path);
+
+                Assert.AreEqual(file.FormatVersion, parsed.FormatVersion);
+                Assert.AreEqual(file.SearchHash, parsed.SearchHash);
+                Assert.AreEqual(file.LibraryHash, parsed.LibraryHash);
+                Assert.AreEqual(file.UseCwtPeakActions.Count, parsed.UseCwtPeakActions.Count);
+                Assert.AreEqual(file.ForcedIntegrationActions.Count, parsed.ForcedIntegrationActions.Count);
+                Assert.AreEqual(file.GapFillTargets.Count, parsed.GapFillTargets.Count);
+
+                // Spot-check bit-exact f64 round-trip on a non-trivial value.
+                var origCwt = file.UseCwtPeakActions[0];
+                var gotCwt = parsed.UseCwtPeakActions[0];
+                Assert.AreEqual(BitConverter.DoubleToInt64Bits(origCwt.ApexRt),
+                                BitConverter.DoubleToInt64Bits(gotCwt.ApexRt));
+                Assert.AreEqual(BitConverter.DoubleToInt64Bits(origCwt.StartRt),
+                                BitConverter.DoubleToInt64Bits(gotCwt.StartRt));
+                Assert.AreEqual(BitConverter.DoubleToInt64Bits(origCwt.EndRt),
+                                BitConverter.DoubleToInt64Bits(gotCwt.EndRt));
+            }
+            finally
+            {
+                try { Directory.Delete(dir, true); } catch (IOException) { }
+            }
+        }
+
+        /// <summary>
+        /// A reconciliation file with an unsupported format_version must
+        /// be rejected with a clear error rather than silently parsed.
+        /// </summary>
+        [TestMethod]
+        public void TestReconciliationFileFormatVersionMismatchRejected()
+        {
+            string dir = Path.Combine(Path.GetTempPath(), "recon_ver_" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(dir);
+            try
+            {
+                string path = Path.Combine(dir, "bad_version.reconciliation.json");
+                File.WriteAllText(path,
+                    "{\n" +
+                    "  \"forced_integration_actions\": [],\n" +
+                    "  \"format_version\": 99,\n" +
+                    "  \"gap_fill_targets\": [],\n" +
+                    "  \"library_hash\": \"x\",\n" +
+                    "  \"refined_rt_calibration\": null,\n" +
+                    "  \"search_hash\": \"y\",\n" +
+                    "  \"use_cwt_peak_actions\": []\n" +
+                    "}\n");
+
+                try
+                {
+                    ReconciliationFile.Load(path);
+                    Assert.Fail("expected InvalidDataException");
+                }
+                catch (InvalidDataException ex)
+                {
+                    StringAssert.Contains(ex.Message, "unsupported format_version");
+                }
+            }
+            finally
+            {
+                try { Directory.Delete(dir, true); } catch (IOException) { }
+            }
+        }
+
+        #endregion
     }
 }

--- a/pwiz_tools/OspreySharp/OspreySharp.Test/ProgramTests.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Test/ProgramTests.cs
@@ -181,7 +181,7 @@ namespace pwiz.OspreySharp.Test
         public void TestNormalizeJoinAtPass1MapsToJoinOnly()
         {
             bool noJoin = false, joinOnly = false;
-            string err = Program.NormalizeHpcArgs(joinAtPass: 1, noJoinFlag: ref noJoin, joinOnlyFlag: ref joinOnly);
+            string err = Program.NormalizeHpcArgs(joinAtPass: 1, noJoinFlag: ref noJoin, joinOnlyFlag: ref joinOnly, joinOnlyModifier: out _);
             Assert.IsNull(err);
             Assert.IsTrue(joinOnly, "joinOnly should be set to true so existing Stage 5+ path runs");
             Assert.IsFalse(noJoin);
@@ -191,7 +191,7 @@ namespace pwiz.OspreySharp.Test
         public void TestNormalizeJoinAtPass2ErrorsUntilImplemented()
         {
             bool noJoin = false, joinOnly = false;
-            string err = Program.NormalizeHpcArgs(joinAtPass: 2, noJoinFlag: ref noJoin, joinOnlyFlag: ref joinOnly);
+            string err = Program.NormalizeHpcArgs(joinAtPass: 2, noJoinFlag: ref noJoin, joinOnlyFlag: ref joinOnly, joinOnlyModifier: out _);
             Assert.IsNotNull(err);
             StringAssert.Contains(err, "not yet implemented");
         }
@@ -200,19 +200,25 @@ namespace pwiz.OspreySharp.Test
         public void TestNormalizeJoinAtPassInvalidValueErrors()
         {
             bool noJoin = false, joinOnly = false;
-            string err = Program.NormalizeHpcArgs(joinAtPass: 3, noJoinFlag: ref noJoin, joinOnlyFlag: ref joinOnly);
+            string err = Program.NormalizeHpcArgs(joinAtPass: 3, noJoinFlag: ref noJoin, joinOnlyFlag: ref joinOnly, joinOnlyModifier: out _);
             Assert.IsNotNull(err);
             StringAssert.Contains(err, "must be 1 or 2");
         }
 
         [TestMethod]
-        public void TestNormalizeJoinAtPass1WithJoinOnlyModifierErrorsUntilImplemented()
+        public void TestNormalizeJoinAtPass1WithJoinOnlyModifierSetsStopFlag()
         {
-            // PR 2 will implement "run only Stage 5" via persisted plan files.
+            // `--join-at-pass=1 --join-only` means "run only Stage 5 + planning,
+            // write boundary files, exit." Both joinOnly (existing
+            // Stage 5+ entry path) and joinOnlyModifier (post-planning
+            // early exit signal) should be set.
             bool noJoin = false, joinOnly = true;
-            string err = Program.NormalizeHpcArgs(joinAtPass: 1, noJoinFlag: ref noJoin, joinOnlyFlag: ref joinOnly);
-            Assert.IsNotNull(err);
-            StringAssert.Contains(err, "not yet implemented");
+            string err = Program.NormalizeHpcArgs(
+                joinAtPass: 1, noJoinFlag: ref noJoin, joinOnlyFlag: ref joinOnly,
+                joinOnlyModifier: out bool joinOnlyModifier);
+            Assert.IsNull(err);
+            Assert.IsTrue(joinOnly);
+            Assert.IsTrue(joinOnlyModifier);
         }
 
         [TestMethod]
@@ -220,7 +226,7 @@ namespace pwiz.OspreySharp.Test
         {
             // PR 2 will implement "run only Stage 6 from persisted Stage 5 outputs."
             bool noJoin = true, joinOnly = false;
-            string err = Program.NormalizeHpcArgs(joinAtPass: 1, noJoinFlag: ref noJoin, joinOnlyFlag: ref joinOnly);
+            string err = Program.NormalizeHpcArgs(joinAtPass: 1, noJoinFlag: ref noJoin, joinOnlyFlag: ref joinOnly, joinOnlyModifier: out _);
             Assert.IsNotNull(err);
             StringAssert.Contains(err, "not yet implemented");
         }
@@ -229,7 +235,7 @@ namespace pwiz.OspreySharp.Test
         public void TestNormalizeJoinOnlyAloneErrorsNoEntryPoint()
         {
             bool noJoin = false, joinOnly = true;
-            string err = Program.NormalizeHpcArgs(joinAtPass: null, noJoinFlag: ref noJoin, joinOnlyFlag: ref joinOnly);
+            string err = Program.NormalizeHpcArgs(joinAtPass: null, noJoinFlag: ref noJoin, joinOnlyFlag: ref joinOnly, joinOnlyModifier: out _);
             Assert.IsNotNull(err);
             StringAssert.Contains(err, "modifier");
         }
@@ -238,7 +244,7 @@ namespace pwiz.OspreySharp.Test
         public void TestNormalizeNoJoinAndJoinOnlyModifiersAreMutex()
         {
             bool noJoin = true, joinOnly = true;
-            string err = Program.NormalizeHpcArgs(joinAtPass: 1, noJoinFlag: ref noJoin, joinOnlyFlag: ref joinOnly);
+            string err = Program.NormalizeHpcArgs(joinAtPass: 1, noJoinFlag: ref noJoin, joinOnlyFlag: ref joinOnly, joinOnlyModifier: out _);
             Assert.IsNotNull(err);
             StringAssert.Contains(err, "mutually exclusive");
         }
@@ -249,7 +255,7 @@ namespace pwiz.OspreySharp.Test
             // Stage 1 entry path with `-i ...` + `--no-join` keeps its
             // existing meaning: do per-file work only = Stages 1-4.
             bool noJoin = true, joinOnly = false;
-            string err = Program.NormalizeHpcArgs(joinAtPass: null, noJoinFlag: ref noJoin, joinOnlyFlag: ref joinOnly);
+            string err = Program.NormalizeHpcArgs(joinAtPass: null, noJoinFlag: ref noJoin, joinOnlyFlag: ref joinOnly, joinOnlyModifier: out _);
             Assert.IsNull(err);
             Assert.IsTrue(noJoin);
             Assert.IsFalse(joinOnly);
@@ -259,7 +265,7 @@ namespace pwiz.OspreySharp.Test
         public void TestNormalizeDefaultModeIsNoop()
         {
             bool noJoin = false, joinOnly = false;
-            string err = Program.NormalizeHpcArgs(joinAtPass: null, noJoinFlag: ref noJoin, joinOnlyFlag: ref joinOnly);
+            string err = Program.NormalizeHpcArgs(joinAtPass: null, noJoinFlag: ref noJoin, joinOnlyFlag: ref joinOnly, joinOnlyModifier: out _);
             Assert.IsNull(err);
             Assert.IsFalse(noJoin);
             Assert.IsFalse(joinOnly);

--- a/pwiz_tools/OspreySharp/OspreySharp.Test/ProgramTests.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Test/ProgramTests.cs
@@ -49,7 +49,7 @@ namespace pwiz.OspreySharp.Test
         public void TestValidateNoJoinAndJoinOnlyIsMutex()
         {
             var config = new OspreyConfig();
-            string err = Program.ValidateArgs(config, noJoinFlag: true, joinOnlyFlag: true);
+            string err = Program.ValidateArgs(config, noJoinFlag: true, joinOnlyFlag: true, joinOnlyModifier: false);
             Assert.IsNotNull(err);
             StringAssert.Contains(err, "mutually exclusive");
         }
@@ -62,7 +62,7 @@ namespace pwiz.OspreySharp.Test
                 LibrarySource = LibrarySource.FromPath("ref.blib"),
                 OutputBlib = "out.blib"
             };
-            string err = Program.ValidateArgs(config, noJoinFlag: false, joinOnlyFlag: true);
+            string err = Program.ValidateArgs(config, noJoinFlag: false, joinOnlyFlag: true, joinOnlyModifier: false);
             Assert.IsNotNull(err);
             // Error refers to the canonical flag the user typed.
             StringAssert.Contains(err, "--join-at-pass=1");
@@ -79,7 +79,7 @@ namespace pwiz.OspreySharp.Test
                 LibrarySource = LibrarySource.FromPath("ref.blib"),
                 OutputBlib = "out.blib"
             };
-            string err = Program.ValidateArgs(config, noJoinFlag: false, joinOnlyFlag: true);
+            string err = Program.ValidateArgs(config, noJoinFlag: false, joinOnlyFlag: true, joinOnlyModifier: false);
             Assert.IsNotNull(err);
             StringAssert.Contains(err, "--join-at-pass=1");
             StringAssert.Contains(err, "cannot be combined with --input");
@@ -92,7 +92,7 @@ namespace pwiz.OspreySharp.Test
             {
                 InputScores = new List<string> { "a.scores.parquet" }
             };
-            string err = Program.ValidateArgs(config, noJoinFlag: false, joinOnlyFlag: true);
+            string err = Program.ValidateArgs(config, noJoinFlag: false, joinOnlyFlag: true, joinOnlyModifier: false);
             Assert.IsNotNull(err);
             StringAssert.Contains(err, "--join-at-pass=1");
             StringAssert.Contains(err, "--library and --output");
@@ -106,7 +106,7 @@ namespace pwiz.OspreySharp.Test
                 NoJoin = true,
                 LibrarySource = LibrarySource.FromPath("ref.blib")
             };
-            string err = Program.ValidateArgs(config, noJoinFlag: true, joinOnlyFlag: false);
+            string err = Program.ValidateArgs(config, noJoinFlag: true, joinOnlyFlag: false, joinOnlyModifier: false);
             Assert.IsNotNull(err);
             StringAssert.Contains(err, "--input <mzML");
         }
@@ -121,7 +121,7 @@ namespace pwiz.OspreySharp.Test
                 InputScores = new List<string> { "a.scores.parquet" },
                 LibrarySource = LibrarySource.FromPath("ref.blib")
             };
-            string err = Program.ValidateArgs(config, noJoinFlag: true, joinOnlyFlag: false);
+            string err = Program.ValidateArgs(config, noJoinFlag: true, joinOnlyFlag: false, joinOnlyModifier: false);
             Assert.IsNotNull(err);
             StringAssert.Contains(err, "--input-scores");
         }
@@ -135,7 +135,7 @@ namespace pwiz.OspreySharp.Test
                 InputFiles = new List<string> { "a.mzML" },
                 LibrarySource = LibrarySource.FromPath("ref.blib")
             };
-            Assert.IsNull(Program.ValidateArgs(config, noJoinFlag: true, joinOnlyFlag: false));
+            Assert.IsNull(Program.ValidateArgs(config, noJoinFlag: true, joinOnlyFlag: false, joinOnlyModifier: false));
         }
 
         [TestMethod]
@@ -147,7 +147,59 @@ namespace pwiz.OspreySharp.Test
                 LibrarySource = LibrarySource.FromPath("ref.blib"),
                 OutputBlib = "out.blib"
             };
-            Assert.IsNull(Program.ValidateArgs(config, noJoinFlag: false, joinOnlyFlag: true));
+            Assert.IsNull(Program.ValidateArgs(config, noJoinFlag: false, joinOnlyFlag: true, joinOnlyModifier: false));
+        }
+
+        [TestMethod]
+        public void TestValidateJoinOnlyModifierRejectsSingleFile()
+        {
+            // --join-at-pass=1 --join-only writes the Stage 5 → Stage 6
+            // boundary file pair; that's only meaningful with siblings,
+            // so a single-file invocation should error fast rather than
+            // running Stages 1-5 and silently producing nothing useful.
+            var config = new OspreyConfig
+            {
+                InputScores = new List<string> { "only.scores.parquet" },
+                LibrarySource = LibrarySource.FromPath("ref.blib"),
+                OutputBlib = "out.blib"
+            };
+            string err = Program.ValidateArgs(config,
+                noJoinFlag: false, joinOnlyFlag: true, joinOnlyModifier: true);
+            Assert.IsNotNull(err);
+            StringAssert.Contains(err, "--join-at-pass=1 --join-only");
+            StringAssert.Contains(err, "2+ parquet files");
+        }
+
+        [TestMethod]
+        public void TestValidateJoinOnlyModifierRequiresReconciliationEnabled()
+        {
+            var config = new OspreyConfig
+            {
+                InputScores = new List<string> { "a.scores.parquet", "b.scores.parquet" },
+                LibrarySource = LibrarySource.FromPath("ref.blib"),
+                OutputBlib = "out.blib"
+            };
+            config.Reconciliation.Enabled = false;
+            string err = Program.ValidateArgs(config,
+                noJoinFlag: false, joinOnlyFlag: true, joinOnlyModifier: true);
+            Assert.IsNotNull(err);
+            StringAssert.Contains(err, "Reconciliation.Enabled");
+        }
+
+        [TestMethod]
+        public void TestValidateJoinOnlyPlainAcceptsSingleFile()
+        {
+            // Plain --join-at-pass=1 (no modifier) runs Stages 5-8 from
+            // the parquet entry point; a 1-file run is a degenerate but
+            // legal case and shouldn't be rejected here.
+            var config = new OspreyConfig
+            {
+                InputScores = new List<string> { "only.scores.parquet" },
+                LibrarySource = LibrarySource.FromPath("ref.blib"),
+                OutputBlib = "out.blib"
+            };
+            Assert.IsNull(Program.ValidateArgs(config,
+                noJoinFlag: false, joinOnlyFlag: true, joinOnlyModifier: false));
         }
 
         [TestMethod]
@@ -159,7 +211,7 @@ namespace pwiz.OspreySharp.Test
                 LibrarySource = LibrarySource.FromPath("ref.blib"),
                 OutputBlib = "out.blib"
             };
-            Assert.IsNull(Program.ValidateArgs(config, noJoinFlag: false, joinOnlyFlag: false));
+            Assert.IsNull(Program.ValidateArgs(config, noJoinFlag: false, joinOnlyFlag: false, joinOnlyModifier: false));
         }
 
         [TestMethod]
@@ -170,7 +222,7 @@ namespace pwiz.OspreySharp.Test
                 LibrarySource = LibrarySource.FromPath("ref.blib"),
                 OutputBlib = "out.blib"
             };
-            string err = Program.ValidateArgs(config, noJoinFlag: false, joinOnlyFlag: false);
+            string err = Program.ValidateArgs(config, noJoinFlag: false, joinOnlyFlag: false, joinOnlyModifier: false);
             Assert.IsNotNull(err);
             StringAssert.Contains(err, "No input files");
         }

--- a/pwiz_tools/OspreySharp/OspreySharp/AnalysisPipeline.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/AnalysisPipeline.cs
@@ -759,18 +759,13 @@ namespace pwiz.OspreySharp
                     // companion was already written above pre-compaction).
                     // Pairs with the --join-at-pass=1 --no-join Stage 6
                     // worker mode (next sprint).
-                    //
-                    // NOTE on gap_fill_targets: the C# port of
-                    // IdentifyGapFillTargets is still pending (TODO
-                    // Priority 1.3). Until it lands, this side emits an
-                    // empty gap_fill_targets array, which means cross-
-                    // impl byte parity for reconciliation.json will fail
-                    // on that array alone — fdr_scores.bin and the rest
-                    // of the JSON should match.
                     WriteReconciliationFiles(
                         perFileEntries,
                         reconciliationActions,
+                        consensus,
                         refinedCalibrations,
+                        perFileCalibrations,
+                        fullLibrary,
                         perFileParquetPaths,
                         config);
 
@@ -1355,7 +1350,10 @@ namespace pwiz.OspreySharp
         private void WriteReconciliationFiles(
             List<KeyValuePair<string, List<FdrEntry>>> perFileEntries,
             IReadOnlyDictionary<(string File, int Index), ReconcileAction> reconciliationActions,
+            IReadOnlyList<PeptideConsensusRT> consensus,
             Dictionary<string, RTCalibration> refinedCalibrations,
+            IReadOnlyDictionary<string, RTCalibration> perFileCalibrations,
+            List<LibraryEntry> fullLibrary,
             Dictionary<string, string> perFileParquetPaths,
             OspreyConfig config)
         {
@@ -1363,6 +1361,44 @@ namespace pwiz.OspreySharp
             string libraryHash = config.LibraryIdentityHash();
             var actions = reconciliationActions
                 ?? new Dictionary<(string File, int Index), ReconcileAction>();
+
+            // Build the (modified_sequence, charge) → (target_id, decoy_id)
+            // and entry_id → precursor_mz lookups from the library. Decoy
+            // ID convention: target_id | 0x80000000 (mirrors Rust at
+            // pipeline.rs:3330-3340).
+            var libLookup = new Dictionary<(string ModifiedSequence, byte Charge),
+                (uint TargetEntryId, uint DecoyEntryId)>();
+            var libPrecursorMz = new Dictionary<uint, double>();
+            foreach (var entry in fullLibrary)
+            {
+                if (entry.IsDecoy)
+                    continue;
+                uint decoyId = entry.Id | 0x80000000u;
+                libLookup[(entry.ModifiedSequence, entry.Charge)] = (entry.Id, decoyId);
+                libPrecursorMz[entry.Id] = entry.PrecursorMz;
+            }
+
+            // Compute per-file gap-fill targets. Per-file isolation-window
+            // m/z intervals are not yet plumbed through C# (Stellar
+            // calibration.json carries no isolation_scheme today, so the
+            // filter is a no-op there); when extended to GPF datasets,
+            // pass a non-null dictionary here.
+            var perFileForGapFill = new List<KeyValuePair<string,
+                IReadOnlyList<FdrEntry>>>(perFileEntries.Count);
+            foreach (var kvp in perFileEntries)
+            {
+                perFileForGapFill.Add(new KeyValuePair<string,
+                    IReadOnlyList<FdrEntry>>(kvp.Key, kvp.Value));
+            }
+            var gapFillByFile = GapFillTargetIdentifier.Identify(
+                consensus,
+                perFileForGapFill,
+                refinedCalibrations,
+                perFileCalibrations,
+                config.Reconciliation.ConsensusFdr,
+                libLookup,
+                libPrecursorMz,
+                perFileIsolationMz: null);
 
             foreach (var kvp in perFileEntries)
             {
@@ -1377,8 +1413,12 @@ namespace pwiz.OspreySharp
                     continue;
                 }
                 string reconPath = ReconciliationFile.PathForInput(sidecarBase);
+                IReadOnlyList<GapFillTarget> fileGapFill;
+                if (!gapFillByFile.TryGetValue(fileName, out fileGapFill))
+                    fileGapFill = Array.Empty<GapFillTarget>();
                 var reconFile = BuildReconciliationFile(
-                    fileName, fileEntries, actions, refinedCalibrations, searchHash, libraryHash);
+                    fileName, fileEntries, actions, fileGapFill,
+                    refinedCalibrations, searchHash, libraryHash);
                 try
                 {
                     ReconciliationFile.Save(reconPath, reconFile);
@@ -1443,14 +1483,15 @@ namespace pwiz.OspreySharp
         /// per-file <see cref="ReconciliationFile"/> wire format: filter to
         /// this file's actions, resolve each Vec index to its entry_id,
         /// split non-Keep actions into homogeneous use_cwt_peak / forced
-        /// arrays, and snapshot the refined RT calibration. Gap-fill
-        /// targets are emitted as empty until the C# port of
-        /// IdentifyGapFillTargets lands.
+        /// arrays, snapshot the refined RT calibration, and emit the
+        /// gap-fill targets for this file (already sorted by
+        /// <c>target_entry_id</c> by the identifier).
         /// </summary>
         private static ReconciliationFile BuildReconciliationFile(
             string fileName,
             IReadOnlyList<FdrEntry> fileEntries,
             IReadOnlyDictionary<(string File, int Index), ReconcileAction> actions,
+            IReadOnlyList<GapFillTarget> gapFillTargets,
             Dictionary<string, RTCalibration> refinedCalibrations,
             string searchHash,
             string libraryHash)
@@ -1506,11 +1547,30 @@ namespace pwiz.OspreySharp
                 };
             }
 
+            // Map per-file GapFillTarget records (already sorted by
+            // target_entry_id) to the wire form. Field-for-field copy.
+            var gap = new List<GapFillEntry>(gapFillTargets?.Count ?? 0);
+            if (gapFillTargets != null)
+            {
+                foreach (var g in gapFillTargets)
+                {
+                    gap.Add(new GapFillEntry
+                    {
+                        Charge = g.Charge,
+                        DecoyEntryId = g.DecoyEntryId,
+                        ExpectedRt = g.ExpectedRt,
+                        HalfWidth = g.HalfWidth,
+                        ModifiedSequence = g.ModifiedSequence,
+                        TargetEntryId = g.TargetEntryId,
+                    });
+                }
+            }
+
             return new ReconciliationFile
             {
                 ForcedIntegrationActions = forced,
                 FormatVersion = ReconciliationFile.CurrentFormatVersion,
-                GapFillTargets = new List<GapFillEntry>(), // TODO: port IdentifyGapFillTargets
+                GapFillTargets = gap,
                 LibraryHash = libraryHash,
                 RefinedRtCalibration = refinedJson,
                 SearchHash = searchHash,

--- a/pwiz_tools/OspreySharp/OspreySharp/AnalysisPipeline.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/AnalysisPipeline.cs
@@ -494,7 +494,16 @@ namespace pwiz.OspreySharp
                 // re-derive the post-compaction set by applying the q-value
                 // threshold themselves, so they need every entry's q-values
                 // — not just the survivors.
-                WriteFdrScoresSidecars(perFileEntries, perFileParquetPaths, config);
+                int fdrSidecarFailures = WriteFdrScoresSidecars(
+                    perFileEntries, perFileParquetPaths, config);
+                if (fdrSidecarFailures > 0 && config.StopAfterStage5)
+                {
+                    LogError(string.Format(
+                        "--join-at-pass=1 --join-only: {0}/{1} 1st-pass fdr_scores.bin sidecar " +
+                        "writes failed; boundary file pair is incomplete. See warnings above.",
+                        fdrSidecarFailures, perFileEntries.Count));
+                    return 1;
+                }
 
                 if (perFileEntries.Count > 0)
                 {
@@ -759,7 +768,7 @@ namespace pwiz.OspreySharp
                     // companion was already written above pre-compaction).
                     // Pairs with the --join-at-pass=1 --no-join Stage 6
                     // worker mode (next sprint).
-                    WriteReconciliationFiles(
+                    int reconWriteFailures = WriteReconciliationFiles(
                         perFileEntries,
                         reconciliationActions,
                         consensus,
@@ -771,9 +780,19 @@ namespace pwiz.OspreySharp
 
                     if (config.StopAfterStage5)
                     {
+                        if (reconWriteFailures > 0)
+                        {
+                            LogError(string.Format(
+                                "--join-at-pass=1 --join-only: {0}/{1} reconciliation.json " +
+                                "writes failed; boundary file pair is incomplete. See warnings above.",
+                                reconWriteFailures, perFileEntries.Count));
+                            return 1;
+                        }
                         LogInfo(string.Format(
                             "--join-at-pass=1 --join-only: Stage 5 + reconciliation planning " +
-                            "complete; boundary files written. Exiting before Stage 6 rescore."));
+                            "complete; wrote {0} reconciliation.json + matching fdr_scores.bin " +
+                            "sidecar pair(s). Exiting before Stage 6 rescore.",
+                            perFileEntries.Count));
                         return 0;
                     }
 
@@ -1309,11 +1328,20 @@ namespace pwiz.OspreySharp
         /// protein FDR). Stage 6 workers re-apply the q-value threshold
         /// themselves to derive the post-compaction passing set.
         /// </summary>
-        private void WriteFdrScoresSidecars(
+        /// <returns>
+        /// Number of files for which the sidecar write failed (0 means
+        /// success). Callers in <see cref="OspreyConfig.StopAfterStage5"/>
+        /// mode treat any failure as fatal — see the StopAfterStage5
+        /// block at the end of the reconciliation phase — because the
+        /// downstream Stage 6 worker would otherwise be missing a
+        /// sidecar.
+        /// </returns>
+        private int WriteFdrScoresSidecars(
             List<KeyValuePair<string, List<FdrEntry>>> perFileEntries,
             Dictionary<string, string> perFileParquetPaths,
             OspreyConfig config)
         {
+            int failures = 0;
             foreach (var kvp in perFileEntries)
             {
                 string fileName = kvp.Key;
@@ -1322,6 +1350,7 @@ namespace pwiz.OspreySharp
                 {
                     LogWarning(string.Format(
                         "No sidecar base path for `{0}` — skipping fdr_scores.bin write", fileName));
+                    failures++;
                     continue;
                 }
                 string fdrPath = FdrScoresSidecar.Pass1Path(sidecarBase);
@@ -1333,8 +1362,10 @@ namespace pwiz.OspreySharp
                 {
                     LogWarning(string.Format(
                         "Failed to write 1st-pass fdr_scores.bin for {0}: {1}", fileName, ex.Message));
+                    failures++;
                 }
             }
+            return failures;
         }
 
         /// <summary>
@@ -1347,7 +1378,15 @@ namespace pwiz.OspreySharp
         /// the input mzML (or, in --join-only mode, the synthetic input
         /// path derived from the parquet stem).
         /// </summary>
-        private void WriteReconciliationFiles(
+        /// <returns>
+        /// Number of files for which the reconciliation.json write failed
+        /// (0 means success). Callers in
+        /// <see cref="OspreyConfig.StopAfterStage5"/> mode treat any
+        /// failure as fatal — the Stage 6 worker would otherwise be
+        /// missing an envelope and either refuse to start or score the
+        /// wrong files.
+        /// </returns>
+        private int WriteReconciliationFiles(
             List<KeyValuePair<string, List<FdrEntry>>> perFileEntries,
             IReadOnlyDictionary<(string File, int Index), ReconcileAction> reconciliationActions,
             IReadOnlyList<PeptideConsensusRT> consensus,
@@ -1361,6 +1400,22 @@ namespace pwiz.OspreySharp
             string libraryHash = config.LibraryIdentityHash();
             var actions = reconciliationActions
                 ?? new Dictionary<(string File, int Index), ReconcileAction>();
+
+            // Pre-group reconciliation actions by file name to avoid the
+            // O(num_files * num_actions) walk that the previous
+            // implementation performed inside BuildReconciliationFile
+            // (one full Dictionary traversal per file).
+            var actionsByFile = new Dictionary<string, List<KeyValuePair<int, ReconcileAction>>>(
+                StringComparer.Ordinal);
+            foreach (var kvp in actions)
+            {
+                if (!actionsByFile.TryGetValue(kvp.Key.File, out var list))
+                {
+                    list = new List<KeyValuePair<int, ReconcileAction>>();
+                    actionsByFile[kvp.Key.File] = list;
+                }
+                list.Add(new KeyValuePair<int, ReconcileAction>(kvp.Key.Index, kvp.Value));
+            }
 
             // Build the (modified_sequence, charge) → (target_id, decoy_id)
             // and entry_id → precursor_mz lookups from the library. Decoy
@@ -1400,6 +1455,7 @@ namespace pwiz.OspreySharp
                 libPrecursorMz,
                 perFileIsolationMz: null);
 
+            int failures = 0;
             foreach (var kvp in perFileEntries)
             {
                 string fileName = kvp.Key;
@@ -1410,15 +1466,18 @@ namespace pwiz.OspreySharp
                 {
                     LogWarning(string.Format(
                         "No sidecar base path for `{0}` — skipping reconciliation.json write", fileName));
+                    failures++;
                     continue;
                 }
                 string reconPath = ReconciliationFile.PathForInput(sidecarBase);
                 IReadOnlyList<GapFillTarget> fileGapFill;
                 if (!gapFillByFile.TryGetValue(fileName, out fileGapFill))
                     fileGapFill = Array.Empty<GapFillTarget>();
+                actionsByFile.TryGetValue(fileName, out var fileActions);
                 var reconFile = BuildReconciliationFile(
-                    fileName, fileEntries, actions, fileGapFill,
-                    refinedCalibrations, searchHash, libraryHash);
+                    fileEntries, fileActions, fileGapFill,
+                    refinedCalibrations.TryGetValue(fileName, out var fileCal) ? fileCal : null,
+                    searchHash, libraryHash);
                 try
                 {
                     ReconciliationFile.Save(reconPath, reconFile);
@@ -1433,8 +1492,10 @@ namespace pwiz.OspreySharp
                 {
                     LogWarning(string.Format(
                         "Failed to write reconciliation.json for {0}: {1}", fileName, ex.Message));
+                    failures++;
                 }
             }
+            return failures;
         }
 
         /// <summary>
@@ -1479,54 +1540,56 @@ namespace pwiz.OspreySharp
         }
 
         /// <summary>
-        /// Convert the per-(file, vec_idx) reconciliation actions into the
-        /// per-file <see cref="ReconciliationFile"/> wire format: filter to
-        /// this file's actions, resolve each Vec index to its entry_id,
-        /// split non-Keep actions into homogeneous use_cwt_peak / forced
-        /// arrays, snapshot the refined RT calibration, and emit the
-        /// gap-fill targets for this file (already sorted by
-        /// <c>target_entry_id</c> by the identifier).
+        /// Convert pre-grouped reconciliation actions for one file into
+        /// the <see cref="ReconciliationFile"/> wire format: resolve each
+        /// Vec index to its entry_id, split non-Keep actions into
+        /// homogeneous use_cwt_peak / forced arrays, snapshot the
+        /// refined RT calibration if present, and emit the gap-fill
+        /// targets for this file (already sorted by
+        /// <c>target_entry_id</c> by the identifier). The caller pre-
+        /// groups actions by file so the per-file cost stays
+        /// O(actions_for_this_file) rather than O(total_actions).
         /// </summary>
         private static ReconciliationFile BuildReconciliationFile(
-            string fileName,
             IReadOnlyList<FdrEntry> fileEntries,
-            IReadOnlyDictionary<(string File, int Index), ReconcileAction> actions,
+            IReadOnlyList<KeyValuePair<int, ReconcileAction>> fileActions,
             IReadOnlyList<GapFillTarget> gapFillTargets,
-            Dictionary<string, RTCalibration> refinedCalibrations,
+            RTCalibration refinedCalibration,
             string searchHash,
             string libraryHash)
         {
             var useCwt = new List<UseCwtPeakEntry>();
             var forced = new List<ForcedIntegrationEntry>();
-            foreach (var kvp in actions)
+            if (fileActions != null)
             {
-                if (!string.Equals(kvp.Key.File, fileName, StringComparison.Ordinal))
-                    continue;
-                int idx = kvp.Key.Index;
-                if (idx < 0 || idx >= fileEntries.Count)
-                    continue;
-                uint entryId = fileEntries[idx].EntryId;
-                var useCwtAction = kvp.Value as ReconcileAction.UseCwtPeak;
-                var forcedAction = kvp.Value as ReconcileAction.ForcedIntegration;
-                if (useCwtAction != null)
+                foreach (var kvp in fileActions)
                 {
-                    useCwt.Add(new UseCwtPeakEntry
+                    int idx = kvp.Key;
+                    if (idx < 0 || idx >= fileEntries.Count)
+                        continue;
+                    uint entryId = fileEntries[idx].EntryId;
+                    var useCwtAction = kvp.Value as ReconcileAction.UseCwtPeak;
+                    var forcedAction = kvp.Value as ReconcileAction.ForcedIntegration;
+                    if (useCwtAction != null)
                     {
-                        ApexRt = useCwtAction.ApexRt,
-                        CandidateIdx = (uint)useCwtAction.CandidateIndex,
-                        EndRt = useCwtAction.EndRt,
-                        EntryId = entryId,
-                        StartRt = useCwtAction.StartRt,
-                    });
-                }
-                else if (forcedAction != null)
-                {
-                    forced.Add(new ForcedIntegrationEntry
+                        useCwt.Add(new UseCwtPeakEntry
+                        {
+                            ApexRt = useCwtAction.ApexRt,
+                            CandidateIdx = (uint)useCwtAction.CandidateIndex,
+                            EndRt = useCwtAction.EndRt,
+                            EntryId = entryId,
+                            StartRt = useCwtAction.StartRt,
+                        });
+                    }
+                    else if (forcedAction != null)
                     {
-                        EntryId = entryId,
-                        ExpectedRt = forcedAction.ExpectedRt,
-                        HalfWidth = forcedAction.HalfWidth,
-                    });
+                        forced.Add(new ForcedIntegrationEntry
+                        {
+                            EntryId = entryId,
+                            ExpectedRt = forcedAction.ExpectedRt,
+                            HalfWidth = forcedAction.HalfWidth,
+                        });
+                    }
                 }
             }
             // Sort by entry_id for deterministic output (matches Rust).
@@ -1534,16 +1597,14 @@ namespace pwiz.OspreySharp
             forced.Sort((a, b) => a.EntryId.CompareTo(b.EntryId));
 
             RefinedRtCalibrationJson refinedJson = null;
-            if (refinedCalibrations != null
-                && refinedCalibrations.TryGetValue(fileName, out RTCalibration cal)
-                && cal != null)
+            if (refinedCalibration != null)
             {
                 refinedJson = new RefinedRtCalibrationJson
                 {
-                    AbsResiduals = (double[])cal.AbsResiduals.Clone(),
-                    FittedRts = (double[])cal.FittedValues.Clone(),
-                    LibraryRts = (double[])cal.LibraryRts.Clone(),
-                    ResidualSd = cal.ResidualSD,
+                    AbsResiduals = (double[])refinedCalibration.AbsResiduals.Clone(),
+                    FittedRts = (double[])refinedCalibration.FittedValues.Clone(),
+                    LibraryRts = (double[])refinedCalibration.LibraryRts.Clone(),
+                    ResidualSd = refinedCalibration.ResidualSD,
                 };
             }
 

--- a/pwiz_tools/OspreySharp/OspreySharp/AnalysisPipeline.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/AnalysisPipeline.cs
@@ -487,6 +487,15 @@ namespace pwiz.OspreySharp
                 // includes non-passing charge states that Rust has already
                 // dropped, producing different rescore-target sets and
                 // different per-file Vec positions.
+                // Persist the per-file `.1st-pass.fdr_scores.bin` sidecars
+                // BEFORE compaction so every stub (passing or not) carries
+                // its q-values into the file. Mirrors osprey/src/pipeline.rs
+                // around persist_fdr_scores at line ~3180. Stage 6 workers
+                // re-derive the post-compaction set by applying the q-value
+                // threshold themselves, so they need every entry's q-values
+                // — not just the survivors.
+                WriteFdrScoresSidecars(perFileEntries, perFileParquetPaths, config);
+
                 if (perFileEntries.Count > 0)
                 {
                     var firstPassBaseIds = new HashSet<uint>();
@@ -664,24 +673,28 @@ namespace pwiz.OspreySharp
                             {
                                 var cwtRows = ParquetScoreCache
                                     .LoadCwtCandidatesFromParquet(parquetPath);
-                                // The planner indexes CWT lists by the entry's
-                                // position in perFileEntries[file] (the same
-                                // order LoadFdrStubsFromParquet returns). If
-                                // the row counts disagree the loaded lists
-                                // would be misaligned with the FdrEntry stubs,
-                                // which would hand the planner empty
-                                // candidate sets for entries whose actual
-                                // candidates exist further down the file.
-                                // Skip planning for this file with a clear
-                                // warning rather than letting that happen
-                                // silently.
-                                if (cwtRows.Count != kvp.Value.Count)
+                                // The planner indexes CWT lists by
+                                // entry.ParquetIndex (mirrors Rust at
+                                // reconciliation.rs:672). cwtRows.Count is
+                                // the parquet's raw Stage-4 row count;
+                                // kvp.Value.Count is the post-first-pass-
+                                // compaction stub count. They are not
+                                // equal by design — what we actually need
+                                // to validate is that every stub's
+                                // ParquetIndex falls within cwtRows.
+                                uint maxIdx = 0;
+                                foreach (var entry in kvp.Value)
+                                {
+                                    if (entry.ParquetIndex > maxIdx)
+                                        maxIdx = entry.ParquetIndex;
+                                }
+                                if (kvp.Value.Count > 0 && maxIdx >= cwtRows.Count)
                                 {
                                     LogWarning(string.Format(
-                                        "CWT candidate row count mismatch for {0}: " +
-                                        "parquet has {1} rows, FdrEntry stubs have {2} -- " +
+                                        "CWT candidate row count out of range for {0}: " +
+                                        "max stub ParquetIndex={1}, parquet has {2} rows -- " +
                                         "skipping reconciliation planning for this file",
-                                        kvp.Key, cwtRows.Count, kvp.Value.Count));
+                                        kvp.Key, maxIdx, cwtRows.Count));
                                     continue;
                                 }
                                 var converted = new List<IReadOnlyList<CwtCandidate>>(cwtRows.Count);
@@ -739,6 +752,34 @@ namespace pwiz.OspreySharp
                             dumpActions, perFileForPlan);
                         if (OspreyDiagnostics.ReconciliationOnly)
                             OspreyDiagnostics.ExitAfterDump(@"OSPREY_RECONCILIATION_ONLY");
+                    }
+
+                    // Stage 5 → Stage 6 boundary: write the per-file
+                    // .reconciliation.json envelope (the .fdr_scores.bin
+                    // companion was already written above pre-compaction).
+                    // Pairs with the --join-at-pass=1 --no-join Stage 6
+                    // worker mode (next sprint).
+                    //
+                    // NOTE on gap_fill_targets: the C# port of
+                    // IdentifyGapFillTargets is still pending (TODO
+                    // Priority 1.3). Until it lands, this side emits an
+                    // empty gap_fill_targets array, which means cross-
+                    // impl byte parity for reconciliation.json will fail
+                    // on that array alone — fdr_scores.bin and the rest
+                    // of the JSON should match.
+                    WriteReconciliationFiles(
+                        perFileEntries,
+                        reconciliationActions,
+                        refinedCalibrations,
+                        perFileParquetPaths,
+                        config);
+
+                    if (config.StopAfterStage5)
+                    {
+                        LogInfo(string.Format(
+                            "--join-at-pass=1 --join-only: Stage 5 + reconciliation planning " +
+                            "complete; boundary files written. Exiting before Stage 6 rescore."));
+                        return 0;
                     }
 
                     // Per-file rescore + gap-fill + second-pass FDR are
@@ -1262,6 +1303,219 @@ namespace pwiz.OspreySharp
             }
 
             return scoredEntries;
+        }
+
+        /// <summary>
+        /// Write the per-file <c>.1st-pass.fdr_scores.bin</c> sidecars at
+        /// the pre-compaction Stage 5 boundary (every stub, passing or
+        /// not, gets persisted with its q-values + SVM score). Mirrors
+        /// the persist_fdr_scores call in osprey/src/pipeline.rs at line
+        /// ~3180 (immediately after first-pass FDR, before compaction or
+        /// protein FDR). Stage 6 workers re-apply the q-value threshold
+        /// themselves to derive the post-compaction passing set.
+        /// </summary>
+        private void WriteFdrScoresSidecars(
+            List<KeyValuePair<string, List<FdrEntry>>> perFileEntries,
+            Dictionary<string, string> perFileParquetPaths,
+            OspreyConfig config)
+        {
+            foreach (var kvp in perFileEntries)
+            {
+                string fileName = kvp.Key;
+                string sidecarBase = ResolveSidecarBasePath(fileName, perFileParquetPaths, config);
+                if (string.IsNullOrEmpty(sidecarBase))
+                {
+                    LogWarning(string.Format(
+                        "No sidecar base path for `{0}` — skipping fdr_scores.bin write", fileName));
+                    continue;
+                }
+                string fdrPath = FdrScoresSidecar.Pass1Path(sidecarBase);
+                try
+                {
+                    FdrScoresSidecar.Write(fdrPath, kvp.Value, FdrScoresSidecar.Pass.FirstPass);
+                }
+                catch (Exception ex)
+                {
+                    LogWarning(string.Format(
+                        "Failed to write 1st-pass fdr_scores.bin for {0}: {1}", fileName, ex.Message));
+                }
+            }
+        }
+
+        /// <summary>
+        /// Write the per-file <c>.reconciliation.json</c> envelope for
+        /// each input — the second half of the Stage 5 → Stage 6 boundary
+        /// (the <c>.fdr_scores.bin</c> companion is written earlier,
+        /// pre-compaction). Mirrors the matching block in
+        /// osprey/src/pipeline.rs immediately after
+        /// dump_stage6_reconciliation. The file is written sibling to
+        /// the input mzML (or, in --join-only mode, the synthetic input
+        /// path derived from the parquet stem).
+        /// </summary>
+        private void WriteReconciliationFiles(
+            List<KeyValuePair<string, List<FdrEntry>>> perFileEntries,
+            IReadOnlyDictionary<(string File, int Index), ReconcileAction> reconciliationActions,
+            Dictionary<string, RTCalibration> refinedCalibrations,
+            Dictionary<string, string> perFileParquetPaths,
+            OspreyConfig config)
+        {
+            string searchHash = config.SearchParameterHash();
+            string libraryHash = config.LibraryIdentityHash();
+            var actions = reconciliationActions
+                ?? new Dictionary<(string File, int Index), ReconcileAction>();
+
+            foreach (var kvp in perFileEntries)
+            {
+                string fileName = kvp.Key;
+                var fileEntries = kvp.Value;
+
+                string sidecarBase = ResolveSidecarBasePath(fileName, perFileParquetPaths, config);
+                if (string.IsNullOrEmpty(sidecarBase))
+                {
+                    LogWarning(string.Format(
+                        "No sidecar base path for `{0}` — skipping reconciliation.json write", fileName));
+                    continue;
+                }
+                string reconPath = ReconciliationFile.PathForInput(sidecarBase);
+                var reconFile = BuildReconciliationFile(
+                    fileName, fileEntries, actions, refinedCalibrations, searchHash, libraryHash);
+                try
+                {
+                    ReconciliationFile.Save(reconPath, reconFile);
+                    LogInfo(string.Format(
+                        "Wrote reconciliation.json for {0} ({1} use_cwt + {2} forced + {3} gap-fill)",
+                        fileName,
+                        reconFile.UseCwtPeakActions.Count,
+                        reconFile.ForcedIntegrationActions.Count,
+                        reconFile.GapFillTargets.Count));
+                }
+                catch (Exception ex)
+                {
+                    LogWarning(string.Format(
+                        "Failed to write reconciliation.json for {0}: {1}", fileName, ex.Message));
+                }
+            }
+        }
+
+        /// <summary>
+        /// Resolve a path whose stem matches <paramref name="fileName"/>, used
+        /// only as the base for sidecar file naming (the path itself need
+        /// not exist). In normal mode this is the input mzML; in
+        /// --join-only mode where InputFiles is empty we synthesize the
+        /// path from the matching .scores.parquet by replacing the
+        /// `.scores.parquet` suffix with `.mzML`. Mirrors the Rust
+        /// `synthetic_input_from_parquet` helper.
+        /// </summary>
+        private static string ResolveSidecarBasePath(
+            string fileName,
+            Dictionary<string, string> perFileParquetPaths,
+            OspreyConfig config)
+        {
+            // Normal mode: prefer the actual input mzML path so sidecars
+            // land next to the source mzML.
+            if (config.InputFiles != null)
+            {
+                foreach (string inputPath in config.InputFiles)
+                {
+                    if (string.Equals(
+                        Path.GetFileNameWithoutExtension(inputPath),
+                        fileName,
+                        StringComparison.Ordinal))
+                    {
+                        return inputPath;
+                    }
+                }
+            }
+            // --join-only fallback: derive a synthetic mzML path from the
+            // matching parquet stem so all the existing sidecar path
+            // helpers keep working without conditional branches.
+            if (perFileParquetPaths != null
+                && perFileParquetPaths.TryGetValue(fileName, out string parquetPath))
+            {
+                string parent = Path.GetDirectoryName(parquetPath) ?? ".";
+                return Path.Combine(parent, fileName + ".mzML");
+            }
+            return null;
+        }
+
+        /// <summary>
+        /// Convert the per-(file, vec_idx) reconciliation actions into the
+        /// per-file <see cref="ReconciliationFile"/> wire format: filter to
+        /// this file's actions, resolve each Vec index to its entry_id,
+        /// split non-Keep actions into homogeneous use_cwt_peak / forced
+        /// arrays, and snapshot the refined RT calibration. Gap-fill
+        /// targets are emitted as empty until the C# port of
+        /// IdentifyGapFillTargets lands.
+        /// </summary>
+        private static ReconciliationFile BuildReconciliationFile(
+            string fileName,
+            IReadOnlyList<FdrEntry> fileEntries,
+            IReadOnlyDictionary<(string File, int Index), ReconcileAction> actions,
+            Dictionary<string, RTCalibration> refinedCalibrations,
+            string searchHash,
+            string libraryHash)
+        {
+            var useCwt = new List<UseCwtPeakEntry>();
+            var forced = new List<ForcedIntegrationEntry>();
+            foreach (var kvp in actions)
+            {
+                if (!string.Equals(kvp.Key.File, fileName, StringComparison.Ordinal))
+                    continue;
+                int idx = kvp.Key.Index;
+                if (idx < 0 || idx >= fileEntries.Count)
+                    continue;
+                uint entryId = fileEntries[idx].EntryId;
+                var useCwtAction = kvp.Value as ReconcileAction.UseCwtPeak;
+                var forcedAction = kvp.Value as ReconcileAction.ForcedIntegration;
+                if (useCwtAction != null)
+                {
+                    useCwt.Add(new UseCwtPeakEntry
+                    {
+                        ApexRt = useCwtAction.ApexRt,
+                        CandidateIdx = (uint)useCwtAction.CandidateIndex,
+                        EndRt = useCwtAction.EndRt,
+                        EntryId = entryId,
+                        StartRt = useCwtAction.StartRt,
+                    });
+                }
+                else if (forcedAction != null)
+                {
+                    forced.Add(new ForcedIntegrationEntry
+                    {
+                        EntryId = entryId,
+                        ExpectedRt = forcedAction.ExpectedRt,
+                        HalfWidth = forcedAction.HalfWidth,
+                    });
+                }
+            }
+            // Sort by entry_id for deterministic output (matches Rust).
+            useCwt.Sort((a, b) => a.EntryId.CompareTo(b.EntryId));
+            forced.Sort((a, b) => a.EntryId.CompareTo(b.EntryId));
+
+            RefinedRtCalibrationJson refinedJson = null;
+            if (refinedCalibrations != null
+                && refinedCalibrations.TryGetValue(fileName, out RTCalibration cal)
+                && cal != null)
+            {
+                refinedJson = new RefinedRtCalibrationJson
+                {
+                    AbsResiduals = (double[])cal.AbsResiduals.Clone(),
+                    FittedRts = (double[])cal.FittedValues.Clone(),
+                    LibraryRts = (double[])cal.LibraryRts.Clone(),
+                    ResidualSd = cal.ResidualSD,
+                };
+            }
+
+            return new ReconciliationFile
+            {
+                ForcedIntegrationActions = forced,
+                FormatVersion = ReconciliationFile.CurrentFormatVersion,
+                GapFillTargets = new List<GapFillEntry>(), // TODO: port IdentifyGapFillTargets
+                LibraryHash = libraryHash,
+                RefinedRtCalibration = refinedJson,
+                SearchHash = searchHash,
+                UseCwtPeakActions = useCwt,
+            };
         }
 
         /// <summary>

--- a/pwiz_tools/OspreySharp/OspreySharp/Program.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/Program.cs
@@ -105,7 +105,7 @@ namespace pwiz.OspreySharp
 
                 OspreyConfig config = ParseArgs(args);
                 config.StopAfterStage5 = joinOnlyModifier;
-                string err = ValidateArgs(config, noJoinFlag, joinOnlyFlag);
+                string err = ValidateArgs(config, noJoinFlag, joinOnlyFlag, joinOnlyModifier);
                 if (err != null)
                 {
                     LogError(err);
@@ -527,12 +527,13 @@ namespace pwiz.OspreySharp
         /// fan-out. <c>--join-at-pass=1</c> selects the post-Stage-4 entry
         /// point; <c>--join-at-pass=2</c> the post-Stage-6 entry point.
         ///
-        /// PR 1 wires the rename only — combinations that need the
-        /// Stage 5 → Stage 6 boundary persistence (--join-at-pass=1 with
-        /// either modifier) error as "not yet implemented", and
-        /// --join-at-pass=2 errors the same way until the Stage 6 →
-        /// Stage 7 path lands. Mirrors normalize_hpc_args() in
-        /// osprey/src/main.rs.
+        /// Status (post-PR-2): --join-at-pass=1 with --join-only is now
+        /// supported and writes the Stage 5 → Stage 6 boundary file pair
+        /// before exiting. Plain --join-at-pass=1 (no modifier) runs
+        /// Stages 5-8 from a Stage-4-parquet entry point. The remaining
+        /// "not yet implemented" combinations are --join-at-pass=1 with
+        /// --no-join (Stage 6 worker mode) and --join-at-pass=2. Mirrors
+        /// normalize_hpc_args() in osprey/src/main.rs.
         ///
         /// Returns null on success, or an error message string on failure.
         /// Internal so OspreySharp.Test can exercise it.
@@ -592,7 +593,8 @@ namespace pwiz.OspreySharp
         /// message string on failure. Does not log warnings (those stay in
         /// <see cref="Main"/>). Internal so OspreySharp.Test can exercise it.
         /// </summary>
-        internal static string ValidateArgs(OspreyConfig config, bool noJoinFlag, bool joinOnlyFlag)
+        internal static string ValidateArgs(OspreyConfig config, bool noJoinFlag, bool joinOnlyFlag,
+            bool joinOnlyModifier)
         {
             if (noJoinFlag && joinOnlyFlag)
                 return "--no-join and --join-only are mutually exclusive.";
@@ -619,6 +621,26 @@ namespace pwiz.OspreySharp
                     return "--join-at-pass=1 cannot be combined with --input. Use --input-scores instead.";
                 if (config.LibrarySource == null || string.IsNullOrEmpty(config.OutputBlib))
                     return "--join-at-pass=1 requires --library and --output.";
+                // `--join-at-pass=1 --join-only` (modifier present) writes the
+                // Stage 5 → Stage 6 boundary file pair, which is only
+                // meaningful when (a) there are siblings to reconcile against
+                // and (b) reconciliation is enabled. Reject early — running
+                // Stages 1-5 only to silently produce nothing useful (or to
+                // fall through to Stage 8 in single-file misconfigurations)
+                // is worse than failing fast with a clear message.
+                if (joinOnlyModifier)
+                {
+                    if (config.InputScores.Count < 2)
+                        return string.Format(
+                            "--join-at-pass=1 --join-only requires --input-scores with 2+ parquet files " +
+                            "(got {0}). The Stage 5 → Stage 6 boundary file pair is only meaningful for " +
+                            "multi-file fan-back-in.",
+                            config.InputScores.Count);
+                    if (!config.Reconciliation.Enabled)
+                        return "--join-at-pass=1 --join-only requires Reconciliation.Enabled = true " +
+                               "(got false from config). The Stage 5 → Stage 6 boundary file pair is " +
+                               "only meaningful when reconciliation runs.";
+                }
                 return null;
             }
 

--- a/pwiz_tools/OspreySharp/OspreySharp/Program.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/Program.cs
@@ -96,7 +96,7 @@ namespace pwiz.OspreySharp
                     }
                 }
 
-                string normErr = NormalizeHpcArgs(joinAtPass, ref noJoinFlag, ref joinOnlyFlag);
+                string normErr = NormalizeHpcArgs(joinAtPass, ref noJoinFlag, ref joinOnlyFlag, out bool joinOnlyModifier);
                 if (normErr != null)
                 {
                     LogError(normErr);
@@ -104,6 +104,7 @@ namespace pwiz.OspreySharp
                 }
 
                 OspreyConfig config = ParseArgs(args);
+                config.StopAfterStage5 = joinOnlyModifier;
                 string err = ValidateArgs(config, noJoinFlag, joinOnlyFlag);
                 if (err != null)
                 {
@@ -536,8 +537,10 @@ namespace pwiz.OspreySharp
         /// Returns null on success, or an error message string on failure.
         /// Internal so OspreySharp.Test can exercise it.
         /// </summary>
-        internal static string NormalizeHpcArgs(int? joinAtPass, ref bool noJoinFlag, ref bool joinOnlyFlag)
+        internal static string NormalizeHpcArgs(int? joinAtPass, ref bool noJoinFlag, ref bool joinOnlyFlag, out bool joinOnlyModifier)
         {
+            joinOnlyModifier = false;
+
             // Modifiers are mutually exclusive: can't be both per-file-only
             // and join-only simultaneously.
             if (noJoinFlag && joinOnlyFlag)
@@ -563,14 +566,17 @@ namespace pwiz.OspreySharp
             switch (joinAtPass.Value)
             {
                 case 1:
-                    // PR 2 will implement these modifier combinations
-                    // against persisted Stage 5 → Stage 6 boundary files.
-                    if (joinOnlyFlag)
-                        return "--join-at-pass=1 --join-only (run only Stage 5) is not yet implemented.";
                     if (noJoinFlag)
                         return "--join-at-pass=1 --no-join (run only Stage 6 from persisted Stage 5 outputs) is not yet implemented.";
-                    // Plain --join-at-pass=1: route through the existing
-                    // Stage 5+ entry path that reads joinOnlyFlag.
+                    // `--join-at-pass=1 --join-only` (modifier present) means
+                    // "run only the Stage 5 join phase, write boundary
+                    // files, exit before Stage 6 rescore." Plain
+                    // `--join-at-pass=1` (no modifier) runs Stages 5-8.
+                    // In both cases joinOnlyFlag drives the existing Stage
+                    // 5+ entry path; the modifier-vs-plain distinction is
+                    // captured separately for the post-planning early
+                    // exit decision.
+                    joinOnlyModifier = joinOnlyFlag;
                     joinOnlyFlag = true;
                     return null;
                 case 2:


### PR DESCRIPTION
## Summary

* Implements the OspreySharp side of the Stage 5 → Stage 6 boundary file pair so a future Stage 6 worker can resume from the per-file `.fdr_scores.bin` + `.reconciliation.json` without re-running joined Stage 5 work
* Pipeline restructure: Stage 5 absorbs reconciliation planning (it's all join-phase work), Stage 6 is per-file rescore + gap-fill + parquet write-back, Stage 7 is second-pass Percolator, Stage 8 absorbs protein FDR + .blib output
* `Osprey-workflow.html` SVG redrawn with phase-shape labels (PER-FILE blue / JOIN red); "YOU ARE HERE" arrow advanced into the new Stage 6 (per-file rescore) row
* Ported `identify_gap_fill_targets` to `OspreySharp.FDR.Reconciliation.GapFillTargetIdentifier` (algorithm POCO `GapFillTarget`, wire form `OspreySharp.IO.GapFillEntry`)
* New `RoundtripDoubleConverter` in `OspreySharp.IO` routes every JSON f64 through `Diagnostics.FormatF64Roundtrip`, sidestepping the Newtonsoft-R/Grisu vs Rust-ryu threshold mismatch on values like `4.58e-5`
* Stellar 6/6 + Astral 6/6 byte-identical at the boundary; cross-impl invariant established for all future Stage-N JSON envelopes

Branch contents (will be squash-merged):

1. `Added FdrScoresSidecar v2 read+write for Stage 5 boundary` — 32-byte header + N×52-byte records with per-record `entry_id`
2. `Added ReconciliationFile JSON read/write to OspreySharp.IO` — alphabetical field order at every level; CRLF→LF normalization for cross-impl byte parity
3. `Wired Stage 5 → Stage 6 boundary writes for --join-at-pass=1 --join-only` — fixes the post-PR-#4173 planner gate (`maxParquetIndex < cwtRows.Count` range check, not strict equality); workflow.html restructure pulled in here
4. `Ported IdentifyGapFillTargets and locked Stage 5 boundary 6/6 byte parity` — gap-fill port + RoundtripDoubleConverter

Companion PR (Rust side): https://github.com/maccoss/osprey/pull/27

See `ai/todos/active/TODO-20260429_osprey_sharp_stage6.md` for the full sprint context.

## Test plan

- [x] `Build-OspreySharp.ps1 -RunInspection -RunTests` — all green (incl. `TestReconciliationFileRoundTrip` cross-impl byte-parity hook)
- [x] `Compare-Stage5-Boundary.ps1 -Dataset Stellar -Clean` → 6/6 byte-identical
- [x] `Compare-Stage5-Boundary.ps1 -Dataset Astral  -Clean` → 6/6 byte-identical

Co-Authored-By: Claude <noreply@anthropic.com>