### PR TITLE
Stage 6 C# port: cross-impl byte-parity end-to-end on Stellar + Astral

### DIFF
--- a/pwiz_tools/OspreySharp/Osprey-workflow.html
+++ b/pwiz_tools/OspreySharp/Osprey-workflow.html
@@ -153,7 +153,7 @@
 <g transform="translate(40, 40)">
   <text class="title">Osprey / OspreySharp DIA search pipeline</text>
   <text class="subtitle" y="22">
-    Rust reference (Osprey) vs C# port (OspreySharp)  -  status as of 2026-04-30: Stages 1-4 + Stage 5 (with reconciliation planning) bit-identical on Stellar + Astral 3-file. Stage 6 per-file rescore orchestrator landed; gap-fill + parquet write-back next.
+    Rust reference (Osprey) vs C# port (OspreySharp)  -  status as of 2026-05-06: Stages 1-6 cross-impl byte-parity end-to-end on Stellar + Astral 3-file (post-rescore q-values match max_diff=0; reconciled .scores.parquet diff 3/3 PASS modulo six allowlisted blob columns the C# scoring path doesn't yet write). Stage 7 second-pass Percolator is the next cross-impl validation target.
   </text>
 </g>
 
@@ -412,35 +412,27 @@
 <path class="flow" d="M 600 1840 L 600 1880" marker-end="url(#arrow)"/>
 
 <g transform="translate(0, 1880)">
-  <rect class="phase-bg-active" x="40" y="0" width="1120" height="260" rx="6"/>
+  <rect class="phase-bg" x="40" y="0" width="1120" height="260" rx="6"/>
   <text class="phase-label" x="60" y="24">stage 6</text>
   <text class="phase-title" x="60" y="42">Per-file rescore + gap-fill + parquet write-back</text>
   <text class="phase-shape-fanout" x="1115" y="24" text-anchor="end">per-file — N nodes</text>
   <text class="phase-note"  x="60" y="58">Second per-file fan-out. Each file independently reloads its mzML, re-invokes the search engine with the reconciled boundary overrides,</text>
   <text class="phase-note"  x="60" y="72">runs the gap-fill two-pass for missing precursors, and writes reconciled scores back to its .scores.parquet. No cross-file work.</text>
 
-  <rect class="st-partial" x="80" y="90" width="1040" height="42" rx="4"/>
+  <rect class="st-done" x="80" y="90" width="1040" height="42" rx="4"/>
   <text class="stage-title" x="600" y="110" text-anchor="middle">Per-file rescore at reconciled boundaries</text>
-  <text class="stage-desc"  x="600" y="124" text-anchor="middle">RescorePerFile orchestrator landed (consensus + reconciliation); not yet validated</text>
+  <text class="stage-desc"  x="600" y="124" text-anchor="middle">consensus + reconciliation overlay; cross-impl byte-parity validated on Stellar + Astral</text>
 
-  <rect class="st-missing" x="80" y="148" width="1040" height="42" rx="4"/>
+  <rect class="st-done" x="80" y="148" width="1040" height="42" rx="4"/>
   <text class="stage-title" x="600" y="168" text-anchor="middle">Gap-fill (two-pass: CWT with prefilter off, then forced integration)</text>
-  <text class="stage-desc"  x="600" y="182" text-anchor="middle">port IdentifyGapFillTargets; append gap-fill stubs with parquet_index = uint.MaxValue</text>
+  <text class="stage-desc"  x="600" y="182" text-anchor="middle">IdentifyGapFillTargets ported; gap-fill stubs appended with parquet_index = uint.MaxValue</text>
 
-  <rect class="st-missing" x="80" y="206" width="1040" height="42" rx="4"/>
+  <rect class="st-done" x="80" y="206" width="1040" height="42" rx="4"/>
   <text class="stage-title" x="600" y="226" text-anchor="middle">Reconciled parquet write-back (replace by ParquetIndex, append gap-fill, write reconciliation metadata)</text>
   <text class="stage-desc"  x="600" y="240" text-anchor="middle">final per-file parquet output of Phase C — feeds Stage 7 second-pass Percolator</text>
 
   <path class="flow" d="M 600 132 L 600 146" marker-end="url(#arrow)"/>
   <path class="flow" d="M 600 190 L 600 204" marker-end="url(#arrow)"/>
-
-  <!-- "You are here" callout — currently working the per-file rescore
-       row. Gap-fill and parquet write-back are still missing/stubbed. -->
-  <g transform="translate(820, 85)">
-    <path class="flow-you" d="M 130 20 L 30 20" marker-end="url(#arrow-thick)"/>
-    <text class="you-are-here" x="136" y="10">YOU ARE</text>
-    <text class="you-are-here" x="136" y="26">HERE</text>
-  </g>
 </g>
 
 <!-- ================================================================= -->
@@ -458,7 +450,7 @@
 <path class="flow" d="M 600 2140 L 600 2180" marker-end="url(#arrow)"/>
 
 <g transform="translate(0, 2180)">
-  <rect class="phase-bg" x="40" y="0" width="1120" height="120" rx="6"/>
+  <rect class="phase-bg-active" x="40" y="0" width="1120" height="120" rx="6"/>
   <text class="phase-label" x="60" y="24">stage 7</text>
   <text class="phase-title" x="60" y="42">Second-pass Percolator SVM</text>
   <text class="phase-shape-join" x="1115" y="24" text-anchor="end">join — needs all-file representation</text>
@@ -466,6 +458,15 @@
   <rect class="st-missing" x="80" y="62" width="1040" height="46" rx="4"/>
   <text class="stage-title" x="600" y="82" text-anchor="middle">Single Percolator pass on the reconciled + gap-filled pool</text>
   <text class="stage-desc"  x="600" y="96" text-anchor="middle">final run + experiment q-values at precursor + peptide levels; OSPREY_DUMP_REFINED_FDR cross-impl bisection dump (planned)</text>
+
+  <!-- "You are here" callout — Stage 6 cross-impl byte-parity landed
+       (Stellar + Astral); Stage 7 second-pass Percolator is the next
+       per-stage cross-impl validation target. -->
+  <g transform="translate(820, 57)">
+    <path class="flow-you" d="M 130 20 L 30 20" marker-end="url(#arrow-thick)"/>
+    <text class="you-are-here" x="136" y="10">YOU ARE</text>
+    <text class="you-are-here" x="136" y="26">HERE</text>
+  </g>
 </g>
 
 <!-- ================================================================= -->

--- a/pwiz_tools/OspreySharp/OspreySharp.Chromatography/CwtPeakDetector.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Chromatography/CwtPeakDetector.cs
@@ -23,6 +23,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using pwiz.OspreySharp.Core;
 
 namespace pwiz.OspreySharp.Chromatography
@@ -167,12 +168,20 @@ namespace pwiz.OspreySharp.Chromatography
                 if (intensities.Length < 5)
                     continue;
 
-                // Find apex
+                // Find apex. Rust at cwt.rs:97-102 uses
+                // `intensities.iter().enumerate().max_by(|a, b| a.1.total_cmp(b.1))`,
+                // which returns the LAST equal element on ties (per
+                // Iterator::max_by docs). Use `>=` here to match — the
+                // strict `>` form would keep the FIRST equal element and
+                // produce divergent FWHM estimates whenever two scans
+                // share the f64 max intensity (rare but visible on flat
+                // tops or when intensities round to the same f64 after
+                // f32 widening).
                 int apexIdx = 0;
                 double apexVal = intensities[0];
                 for (int i = 1; i < intensities.Length; i++)
                 {
-                    if (intensities[i] > apexVal)
+                    if (intensities[i] >= apexVal)
                     {
                         apexIdx = i;
                         apexVal = intensities[i];
@@ -322,11 +331,17 @@ namespace pwiz.OspreySharp.Chromatography
                 apexCoeffs.Add(consensus[nScans - 1]);
             }
 
-            // Sort by consensus coefficient descending
-            int[] sortOrder = new int[apexIndices.Count];
-            for (int i = 0; i < sortOrder.Length; i++)
-                sortOrder[i] = i;
-            Array.Sort(sortOrder, (a, b) => apexCoeffs[b].CompareTo(apexCoeffs[a]));
+            // Sort by consensus coefficient descending. Rust at
+            // cwt.rs:295-296 uses `apex_indices.sort_by(|a, b|
+            // b.1.total_cmp(&a.1))`, which is STABLE (slice::sort_by is
+            // stable). Array.Sort with a Comparison<T> is introsort
+            // (unstable) and reorders ties; switch to LINQ
+            // OrderByDescending (stable per .NET contract) so that two
+            // apexes at the same consensus coefficient stay in
+            // detection order across both impls.
+            int[] sortOrder = Enumerable.Range(0, apexIndices.Count)
+                .OrderByDescending(i => apexCoeffs[i])
+                .ToArray();
 
             List<XICPeakBounds> peaks = new List<XICPeakBounds>();
 
@@ -404,12 +419,19 @@ namespace pwiz.OspreySharp.Chromatography
                 if (endIdx - startIdx + 1 < 3)
                     continue;
 
-                // Find the actual apex in the reference signal within boundaries
+                // Find the actual apex in the reference signal within
+                // boundaries. Rust at cwt.rs:374-380 uses
+                // `ref_signal[start_idx..=end_idx].iter().enumerate().max_by(|a, b| a.1.total_cmp(b.1))`,
+                // which returns the LAST equal element on ties. Use `>=`
+                // here to match — strict `>` would keep the FIRST equal
+                // element and produce divergent peak_apex / area / SNR
+                // when ref_signal has flat-top maxima (sums of f32
+                // intensities round into the same f64).
                 int refApexIdx = startIdx;
                 double refApexIntensity = refSignal[startIdx];
                 for (int i = startIdx + 1; i <= endIdx; i++)
                 {
-                    if (refSignal[i] > refApexIntensity)
+                    if (refSignal[i] >= refApexIntensity)
                     {
                         refApexIdx = i;
                         refApexIntensity = refSignal[i];
@@ -437,6 +459,39 @@ namespace pwiz.OspreySharp.Chromatography
             }
 
             return peaks;
+        }
+
+        /// <summary>
+        /// Diagnostic helper: run the first half of
+        /// <see cref="DetectConsensusPeaks"/> (sigma, kernel, convolve,
+        /// median consensus) and return the consensus signal so a
+        /// cross-impl bisection dump can compare it directly. Returns
+        /// null when the input is too small for CWT (matches the
+        /// validation in <see cref="DetectConsensusPeaks"/>).
+        /// </summary>
+        /// <param name="xics">Fragment XICs (all must share the same time axis).</param>
+        /// <param name="sigma">Out: estimated CWT scale used to build the kernel.</param>
+        /// <returns>Consensus CWT signal (size = nScans), or null on validation failure.</returns>
+        public static double[] GetConsensusSignal(List<XicData> xics, out double sigma)
+        {
+            sigma = 0.0;
+            if (xics == null || xics.Count < 2)
+                return null;
+            int nScans = xics[0].Intensities.Length;
+            if (nScans < 5)
+                return null;
+            for (int i = 1; i < xics.Count; i++)
+            {
+                if (xics[i].Intensities.Length != nScans)
+                    return null;
+            }
+            sigma = EstimateScale(xics);
+            int kernelRadius = Math.Min((int)Math.Ceiling(5.0 * sigma), nScans / 2);
+            double[] kernel = MexicanHatKernel(sigma, kernelRadius);
+            double[][] cwtCoeffs = new double[xics.Count][];
+            for (int f = 0; f < xics.Count; f++)
+                cwtCoeffs[f] = Convolve(xics[f].Intensities, kernel);
+            return ConsensusMedianCwt(cwtCoeffs, nScans);
         }
 
         /// <summary>

--- a/pwiz_tools/OspreySharp/OspreySharp.Core/OspreyConfig.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Core/OspreyConfig.cs
@@ -225,6 +225,60 @@ namespace pwiz.OspreySharp.Core
                 return result.ToString();
             }
         }
+
+        /// <summary>
+        /// SHA-256 of (search hash + reconciliation parameters + run FDR
+        /// + sorted file stems). Mirrors Rust
+        /// <c>OspreyConfig::reconciliation_parameter_hash</c> in
+        /// <c>crates/osprey-core/src/config.rs</c> and is written into
+        /// reconciled <c>.scores.parquet</c> footer metadata under
+        /// <c>osprey.reconciliation_hash</c>. The hash invalidates the
+        /// cache on any reconciliation parameter change OR on any change
+        /// to the multi-file set (file_stems are sorted to make the
+        /// hash invariant to invocation order).
+        /// </summary>
+        public string ReconciliationParameterHash()
+        {
+            using (var sha256 = SHA256.Create())
+            {
+                var ic = System.Globalization.CultureInfo.InvariantCulture;
+                var sb = new StringBuilder();
+                sb.Append(SearchParameterHash());
+                sb.AppendFormat(ic, "reconciliation.enabled:{0}\n",
+                    Reconciliation.Enabled ? "true" : "false");
+                sb.AppendFormat(ic, "reconciliation.consensus_fdr:{0}\n",
+                    Reconciliation.ConsensusFdr);
+                sb.AppendFormat(ic, "run_fdr:{0}\n", RunFdr);
+                // Mirror Rust's `format!("file_stems:{:?}\n", stems)` output
+                // exactly. {:?} on Vec<String> yields ["a", "b"] with the
+                // brackets and double-quoted, comma-space-separated values.
+                var stems = new List<string>(InputFiles?.Count ?? 0);
+                if (InputFiles != null)
+                {
+                    foreach (var path in InputFiles)
+                    {
+                        string stem = Path.GetFileNameWithoutExtension(path);
+                        if (!string.IsNullOrEmpty(stem))
+                            stems.Add(stem);
+                    }
+                }
+                stems.Sort(StringComparer.Ordinal);
+                var stemsList = new StringBuilder("[");
+                for (int i = 0; i < stems.Count; i++)
+                {
+                    if (i > 0) stemsList.Append(", ");
+                    stemsList.Append('"').Append(stems[i]).Append('"');
+                }
+                stemsList.Append(']');
+                sb.AppendFormat(ic, "file_stems:{0}\n", stemsList.ToString());
+
+                byte[] hashBytes = sha256.ComputeHash(Encoding.UTF8.GetBytes(sb.ToString()));
+                var result = new StringBuilder(64);
+                for (int i = 0; i < hashBytes.Length; i++)
+                    result.Append(hashBytes[i].ToString("x2"));
+                return result.ToString();
+            }
+        }
     }
 
     /// <summary>

--- a/pwiz_tools/OspreySharp/OspreySharp.IO/FdrScoresSidecar.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.IO/FdrScoresSidecar.cs
@@ -30,38 +30,43 @@ namespace pwiz.OspreySharp.IO
 {
     /// <summary>
     /// Reader / writer for the per-file <c>.&lt;phase&gt;-pass.fdr_scores.bin</c>
-    /// sidecar: the v2 binary format that persists the full FDR statistics
-    /// for an entry (SVM discriminant + 4 q-values + PEP). Used at the
-    /// Stage 5 → Stage 6 boundary so a Stage 6 worker can run without
-    /// re-running first-pass Percolator.
+    /// sidecar: the v3 binary format that persists the full FDR statistics
+    /// for an entry (SVM discriminant + 4 q-values + PEP +
+    /// <c>run_protein_qvalue</c>). Used at the Stage 5 → Stage 6 boundary
+    /// so a Stage 6 worker can run without re-running first-pass Percolator
+    /// AND apply the same protein-rescue compaction predicate the in-process
+    /// pipeline uses.
     ///
     /// Mirrors <c>write_fdr_scores_sidecar</c> + <c>load_fdr_scores_sidecar</c>
     /// in <c>osprey/crates/osprey/src/pipeline.rs</c>. Cross-impl byte
-    /// parity is verified by a separate harness script.
+    /// parity is verified by a separate harness script via the
+    /// <c>OSPREY_CROSS_IMPL_FDR_SIDECAR_OUT</c> test hook.
     ///
-    /// Format (32-byte header + N × 52-byte records, all little-endian):
+    /// Format (32-byte header + N × 60-byte records, all little-endian):
     /// <code>
     ///   magic         [0..8]   = b"OSPRYFDR"
-    ///   version       [8]      = u8 (= 2)
+    ///   version       [8]      = u8 (= 3)
     ///   pass          [9]      = u8 (1 = first-pass, 2 = second-pass)
     ///   reserved      [10..16] = 6 bytes (zero)
     ///   entry_count   [16..24] = u64
     ///   reserved      [24..32] = 8 bytes (zero)
-    ///   body          [32..]   = entry_count * 52 bytes:
-    ///                            u32 entry_id
-    ///                            f64 svm_score
-    ///                            f64 run_precursor_qvalue
-    ///                            f64 run_peptide_qvalue
-    ///                            f64 experiment_precursor_qvalue
-    ///                            f64 experiment_peptide_qvalue
-    ///                            f64 pep
+    ///   body          [32..]   = entry_count * 60 bytes:
+    ///                            [0..4]   u32 entry_id
+    ///                            [4..12]  f64 svm_score
+    ///                            [12..20] f64 run_precursor_qvalue
+    ///                            [20..28] f64 run_peptide_qvalue
+    ///                            [28..36] f64 experiment_precursor_qvalue
+    ///                            [36..44] f64 experiment_peptide_qvalue
+    ///                            [44..52] f64 pep
+    ///                            [52..60] f64 run_protein_qvalue
     /// </code>
-    /// Records are written pre-compaction at the Stage 5 → Stage 6
-    /// boundary: every input entry contributes one record so q-values
-    /// are preserved even for entries that may not survive later
-    /// compaction. The pre-compaction call site is at the bottom of the
-    /// first-pass FDR block, just before the compaction loop runs,
-    /// mirroring Rust's <c>persist_fdr_scores</c> at
+    /// Records are written pre-compaction but POST first-pass protein
+    /// FDR at the Stage 5 → Stage 6 boundary: every input entry
+    /// contributes one record so q-values are preserved even for
+    /// entries that may not survive later compaction, AND so
+    /// <c>run_protein_qvalue</c> carries real values rather than the
+    /// default 1.0. Mirrors the post-protein-FDR
+    /// <c>persist_fdr_scores</c> call site in Rust's
     /// <c>pipeline.rs</c>. Each record carries the entry's
     /// <c>entry_id</c> for identity verification (the per-position
     /// <c>entries[i].EntryId == record.entry_id</c> check during load
@@ -73,6 +78,15 @@ namespace pwiz.OspreySharp.IO
     /// loader also rejects mismatches on the header <c>pass</c> byte
     /// so a 2nd-pass sidecar can never silently scramble 1st-pass
     /// stubs (or vice versa).
+    ///
+    /// v2 → v3 (2026-05-02): added <c>run_protein_qvalue</c> to
+    /// support the Stage 6 worker's compaction step. The in-process
+    /// pipeline filters pre-Stage-6 entries by
+    /// <c>run_peptide_qvalue ≤ 0.01</c> OR
+    /// <c>run_protein_qvalue ≤ 0.01</c> (the protein-rescue branch);
+    /// the v2 sidecar carried only the first half of that predicate,
+    /// so a rehydrated worker couldn't reproduce in-process compaction
+    /// when <c>--protein-fdr</c> is set. v3 closes that gap.
     /// </summary>
     public static class FdrScoresSidecar
     {
@@ -80,9 +94,9 @@ namespace pwiz.OspreySharp.IO
         private static readonly byte[] Magic =
             { (byte)'O', (byte)'S', (byte)'P', (byte)'R', (byte)'Y', (byte)'F', (byte)'D', (byte)'R' };
 
-        public const byte FormatVersion = 2;
+        public const byte FormatVersion = 3;
         public const int HeaderLength = 32;
-        public const int RecordLength = 52;
+        public const int RecordLength = 60;
 
         /// <summary>
         /// Pass identifier embedded in the header. Mirrors the Rust pass
@@ -158,7 +172,7 @@ namespace pwiz.OspreySharp.IO
                     bw.Write((ulong)entries.Count);                   // [16..24]
                     bw.Write(new byte[8]);                            // [24..32] reserved
 
-                    // Body: 52 bytes per entry (entry_id + 6 f64s)
+                    // Body: 60 bytes per entry (entry_id + 7 f64s)
                     foreach (var e in entries)
                     {
                         bw.Write(e.EntryId);                          // [0..4]
@@ -168,6 +182,7 @@ namespace pwiz.OspreySharp.IO
                         bw.Write(e.ExperimentPrecursorQvalue);        // [28..36]
                         bw.Write(e.ExperimentPeptideQvalue);          // [36..44]
                         bw.Write(e.Pep);                              // [44..52]
+                        bw.Write(e.RunProteinQvalue);                 // [52..60]
                     }
                 }
 
@@ -245,6 +260,7 @@ namespace pwiz.OspreySharp.IO
                 e.ExperimentPrecursorQvalue   = BitConverter.ToDouble(data, off + 28);
                 e.ExperimentPeptideQvalue     = BitConverter.ToDouble(data, off + 36);
                 e.Pep                         = BitConverter.ToDouble(data, off + 44);
+                e.RunProteinQvalue            = BitConverter.ToDouble(data, off + 52);
             }
             return true;
         }

--- a/pwiz_tools/OspreySharp/OspreySharp.IO/ParquetScoreCache.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.IO/ParquetScoreCache.cs
@@ -343,12 +343,25 @@ namespace pwiz.OspreySharp.IO
                 endRts[i] = entry.EndRt;
                 fileNames[i] = fileName ?? string.Empty;
 
-                // Encode CWT candidate list (mirrors Rust binary layout).
-                // Leave the cell null when the entry has no captured candidates
-                // -- LoadCwtCandidatesFromParquet treats null/short cells as
-                // empty, matching the Rust loader's tolerance.
-                if (entry.CwtCandidates != null && entry.CwtCandidates.Count > 0)
-                    cwtCandidates[i] = CwtCandidateCodec.Encode(entry.CwtCandidates);
+                // Mirror Rust's invariant: every row carries a cwt_candidates
+                // blob, even when the candidate list is empty. Rust's
+                // pipeline.rs::write_scores_parquet (at the cwt_candidates
+                // serialization site) unconditionally appends a 4-byte
+                // little-endian count prefix, so an entry with zero
+                // candidates becomes a 4-byte zero-length blob, never a
+                // null cell. ~57k post-compaction stubs per Stellar file
+                // had no peaks; without this normalization C# emitted
+                // null cells while Rust emitted empty blobs, producing
+                // a spurious cross-impl parquet diff at end-of-Stage-6.
+                //
+                // TODO(osprey-rust): the proper fix is on the Rust side --
+                // pipeline.rs should write null for empty candidate lists,
+                // which is more parquet-idiomatic and saves 4 bytes per
+                // empty row for downstream consumers. When that lands in
+                // maccoss/osprey, revert this branch to the original
+                // "skip null/empty" form.
+                cwtCandidates[i] = CwtCandidateCodec.Encode(
+                    entry.CwtCandidates ?? new List<CwtCandidate>());
 
                 LibraryEntry libEntry = null;
                 if (libraryById != null)
@@ -570,6 +583,95 @@ namespace pwiz.OspreySharp.IO
         /// Load only the 21 PIN feature columns from a Parquet cache.
         /// Returns a list of feature vectors (one double[] per row).
         /// </summary>
+        /// <summary>
+        /// Load FdrEntry stubs + 21-feature PIN vectors + CWT candidate
+        /// lists from a Parquet cache, joined per row. Returns
+        /// <see cref="FdrEntry"/> objects with <see cref="FdrEntry.Features"/>
+        /// and <see cref="FdrEntry.CwtCandidates"/> populated, ready to
+        /// feed into the Phase 3 reconciled parquet write-back step.
+        ///
+        /// Equivalent to calling <see cref="LoadFdrStubsFromParquet"/>,
+        /// <see cref="LoadPinFeaturesFromParquet"/>, and
+        /// <see cref="LoadCwtCandidatesFromParquet"/> separately and
+        /// zipping them by row index — but does it in a single parquet
+        /// open. Mirrors the columns Rust's <c>load_scores_parquet</c>
+        /// loads, minus the binary blob columns
+        /// (<c>fragment_mzs</c>, <c>fragment_intensities</c>,
+        /// <c>reference_xic_rts</c>, <c>reference_xic_intensities</c>)
+        /// which have no <see cref="FdrEntry"/> field counterpart and
+        /// are NOT round-tripped by the write-back path today. The
+        /// resulting reconciled parquet will have those four columns
+        /// null/empty even for rows whose source parquet had them
+        /// populated; this is a known C# limitation tracked for a
+        /// follow-up.
+        /// </summary>
+        public static List<FdrEntry> LoadFullFdrEntries(string path)
+        {
+            var entries = new List<FdrEntry>();
+            var featureFields = BuildFeatureFields();
+
+            using (var stream = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.Read))
+            using (var reader = new ParquetReader(stream))
+            {
+                for (int g = 0; g < reader.RowGroupCount; g++)
+                {
+                    using (var groupReader = reader.OpenRowGroupReader(g))
+                    {
+                        var entryIdCol = groupReader.ReadColumn(FIELD_ENTRY_ID).Data as uint[];
+                        var isDecoyCol = groupReader.ReadColumn(FIELD_IS_DECOY).Data as bool[];
+                        var chargeCol = groupReader.ReadColumn(FIELD_CHARGE).Data as byte[];
+                        var scanCol = groupReader.ReadColumn(FIELD_SCAN_NUMBER).Data as uint[];
+                        var modseqCol = groupReader.ReadColumn(FIELD_MODIFIED_SEQUENCE).Data as string[];
+                        var apexCol = groupReader.ReadColumn(FIELD_APEX_RT).Data as double[];
+                        var startCol = groupReader.ReadColumn(FIELD_START_RT).Data as double[];
+                        var endCol = groupReader.ReadColumn(FIELD_END_RT).Data as double[];
+                        var coelutionCol = groupReader.ReadColumn(FIELD_COELUTION_SUM).Data as double[];
+                        var cwtCol = groupReader.ReadColumn(FIELD_CWT_CANDIDATES).Data as byte[][];
+
+                        if (entryIdCol == null || isDecoyCol == null)
+                            continue;
+
+                        var featureCols = new double[NUM_PIN_FEATURES][];
+                        for (int f = 0; f < NUM_PIN_FEATURES; f++)
+                            featureCols[f] = groupReader.ReadColumn(featureFields[f]).Data as double[];
+
+                        int rowCount = entryIdCol.Length;
+                        for (int row = 0; row < rowCount; row++)
+                        {
+                            var features = new double[NUM_PIN_FEATURES];
+                            for (int f = 0; f < NUM_PIN_FEATURES; f++)
+                            {
+                                double v = featureCols[f] != null ? featureCols[f][row] : 0.0;
+                                features[f] = double.IsNaN(v) || double.IsInfinity(v) ? 0.0 : v;
+                            }
+
+                            List<CwtCandidate> cwt = null;
+                            if (cwtCol != null && cwtCol[row] != null && cwtCol[row].Length > 0)
+                                cwt = CwtCandidateCodec.Decode(cwtCol[row]);
+
+                            entries.Add(new FdrEntry
+                            {
+                                EntryId = entryIdCol[row],
+                                ParquetIndex = (uint)entries.Count,
+                                IsDecoy = isDecoyCol[row],
+                                Charge = chargeCol != null ? chargeCol[row] : (byte)0,
+                                ScanNumber = scanCol != null ? scanCol[row] : 0u,
+                                ApexRt = apexCol != null ? apexCol[row] : 0.0,
+                                StartRt = startCol != null ? startCol[row] : 0.0,
+                                EndRt = endCol != null ? endCol[row] : 0.0,
+                                CoelutionSum = coelutionCol != null ? coelutionCol[row] : 0.0,
+                                ModifiedSequence = modseqCol != null ? modseqCol[row] : string.Empty,
+                                Features = features,
+                                CwtCandidates = cwt,
+                            });
+                        }
+                    }
+                }
+            }
+
+            return entries;
+        }
+
         public static List<double[]> LoadPinFeaturesFromParquet(string path)
         {
             var allFeatures = new List<double[]>();

--- a/pwiz_tools/OspreySharp/OspreySharp.IO/ParquetScoreCache.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.IO/ParquetScoreCache.cs
@@ -21,6 +21,7 @@
  * limitations under the License.
  */
 
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
@@ -177,7 +178,7 @@ namespace pwiz.OspreySharp.IO
             Dictionary<string, string> metadata)
         {
             if (path == null)
-                throw new System.ArgumentNullException(nameof(path));
+                throw new ArgumentNullException(nameof(path));
             if (entries == null || entries.Count == 0)
                 return;
 
@@ -294,7 +295,7 @@ namespace pwiz.OspreySharp.IO
             string fileName)
         {
             if (path == null)
-                throw new System.ArgumentNullException(nameof(path));
+                throw new ArgumentNullException(nameof(path));
             if (entries == null || entries.Count == 0)
                 return;
 
@@ -360,8 +361,13 @@ namespace pwiz.OspreySharp.IO
                 // empty row for downstream consumers. When that lands in
                 // maccoss/osprey, revert this branch to the original
                 // "skip null/empty" form.
+                // Use Array.Empty<>() (not `new List<>()`) on the null
+                // branch so we still emit the 4-byte zero-count blob
+                // without allocating a fresh List per empty row.
+                // CwtCandidateCodec.Encode takes IReadOnlyList<CwtCandidate>
+                // which both List<T> and T[] satisfy.
                 cwtCandidates[i] = CwtCandidateCodec.Encode(
-                    entry.CwtCandidates ?? new List<CwtCandidate>());
+                    entry.CwtCandidates ?? (IReadOnlyList<CwtCandidate>)Array.Empty<CwtCandidate>());
 
                 LibraryEntry libEntry = null;
                 if (libraryById != null)
@@ -580,10 +586,6 @@ namespace pwiz.OspreySharp.IO
         #region Load PIN Features
 
         /// <summary>
-        /// Load only the 21 PIN feature columns from a Parquet cache.
-        /// Returns a list of feature vectors (one double[] per row).
-        /// </summary>
-        /// <summary>
         /// Load FdrEntry stubs + 21-feature PIN vectors + CWT candidate
         /// lists from a Parquet cache, joined per row. Returns
         /// <see cref="FdrEntry"/> objects with <see cref="FdrEntry.Features"/>
@@ -672,6 +674,10 @@ namespace pwiz.OspreySharp.IO
             return entries;
         }
 
+        /// <summary>
+        /// Load only the 21 PIN feature columns from a Parquet cache.
+        /// Returns a list of feature vectors (one double[] per row).
+        /// </summary>
         public static List<double[]> LoadPinFeaturesFromParquet(string path)
         {
             var allFeatures = new List<double[]>();
@@ -969,7 +975,7 @@ namespace pwiz.OspreySharp.IO
             IEnumerable<string> paths,
             OspreyConfig config,
             string currentVersion,
-            System.Action<string> logWarning)
+            Action<string> logWarning)
         {
             string expectedSearch = config.SearchParameterHash();
             string expectedLibrary = config.LibraryIdentityHash();
@@ -981,7 +987,7 @@ namespace pwiz.OspreySharp.IO
                 {
                     kv = LoadFooterMetadata(path);
                 }
-                catch (System.Exception ex)
+                catch (Exception ex)
                 {
                     return string.Format("{0}: cannot read parquet metadata: {1}", path, ex.Message);
                 }

--- a/pwiz_tools/OspreySharp/OspreySharp.Scoring/ScoringContext.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Scoring/ScoringContext.cs
@@ -57,6 +57,21 @@ namespace pwiz.OspreySharp.Scoring
         /// </summary>
         public IReadOnlyDictionary<uint, (double Apex, double Start, double End)> BoundaryOverrides { get; set; }
 
+        /// <summary>
+        /// The first-pass RT MAD (median absolute deviation of residuals)
+        /// from the per-file <c>.calibration.json</c>, kept separate from
+        /// any refined calibration's <c>abs_residuals</c>. The Stage 6
+        /// rescore search uses this value -- not the refined cal's stats
+        /// MAD -- to derive <c>rt_tolerance</c>, mirroring Rust's
+        /// <c>run_search</c> which reads
+        /// <c>cal_params.rt_calibration.mad</c> from the calibration JSON
+        /// (see <c>osprey/crates/osprey/src/pipeline.rs:6776-6815</c>).
+        /// Null when the JSON omits the MAD field; <c>RunCoelutionScoring</c>
+        /// then falls back to computing MAD from the rt calibration's
+        /// abs_residuals.
+        /// </summary>
+        public double? OriginalRtMad { get; set; }
+
         public ScoringContext(OspreyConfig config, string fileName)
         {
             Config = config;

--- a/pwiz_tools/OspreySharp/OspreySharp.Test/IOTest.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Test/IOTest.cs
@@ -24,9 +24,11 @@
 using System;
 using System.Collections.Generic;
 using System.Data.SQLite;
+using System.Globalization;
 using System.IO;
 using System.IO.Compression;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Newtonsoft.Json;
 using pwiz.OspreySharp.Core;
 using pwiz.OspreySharp.IO;
 
@@ -1336,7 +1338,7 @@ namespace pwiz.OspreySharp.Test
             if (hasPrecursor)
             {
                 precursorBlock = string.Format(
-                    System.Globalization.CultureInfo.InvariantCulture,
+                    CultureInfo.InvariantCulture,
                     @"
         <precursorList count=""1"">
           <precursor>
@@ -1356,7 +1358,7 @@ namespace pwiz.OspreySharp.Test
             }
 
             return string.Format(
-                System.Globalization.CultureInfo.InvariantCulture,
+                CultureInfo.InvariantCulture,
                 @"
       <spectrum index=""{0}"" defaultArrayLength=""{1}"" id=""scan={0}"">
         <cvParam cvRef=""MS"" accession=""MS:1000511"" value=""{2}"" />
@@ -1876,6 +1878,79 @@ namespace pwiz.OspreySharp.Test
             finally
             {
                 try { Directory.Delete(dir, true); } catch (IOException) { }
+            }
+        }
+
+        /// <summary>
+        /// Mirror of the Rust regression test
+        /// <c>reconciliation_io::tests::serde_json_f64_roundtrip_is_bit_exact</c>.
+        /// On the Rust side, serde_json's default f64 parser is best-effort
+        /// and loses 1 ULP on some shortest-roundtrip strings (e.g.,
+        /// "3.1575921556296254" parses to 0x...878 instead of the correct
+        /// 0x...877). The fix on the Rust side is the `float_roundtrip`
+        /// feature flag on serde_json.
+        ///
+        /// .NET's <see cref="JsonTextReader"/> for <see cref="JsonToken.Float"/>
+        /// uses <c>double.Parse</c> internally, which has been correctly
+        /// rounded since Core 3.0. This test asserts that the same six
+        /// known-tricky values round-trip bit-exactly through Newtonsoft so
+        /// the C# Stage-N JSON path inherits the same byte-parity invariant
+        /// the Rust side now enforces. If a future Newtonsoft upgrade
+        /// regresses the f64 parser, this test surfaces it before any
+        /// cross-impl harness diff is taken.
+        /// </summary>
+        [TestMethod]
+        public void TestNewtonsoftJsonF64RoundtripIsBitExact()
+        {
+            double[] candidates =
+            {
+                3.1575921556296254,
+                3.1585537473115846,
+                3.1741410573166426,
+                BitConverter.Int64BitsToDouble(0x0010_0000_0000_0000L), // smallest normal
+                1.0,
+                0.0123,
+            };
+            foreach (var v in candidates)
+            {
+                string s = Diagnostics.FormatF64Roundtrip(v);
+
+                // Path 1: low-level JsonTextReader, the underlying f64
+                // parser used by every Newtonsoft deserialization path.
+                // FormatF64Roundtrip emits whole numbers as "1" (no
+                // decimal point), so the token type can be Integer or
+                // Float depending on the value -- both are valid sources
+                // of an f64 per JSON spec.
+                using (var sr = new StringReader(s))
+                using (var reader = new JsonTextReader(sr))
+                {
+                    Assert.IsTrue(reader.Read(),
+                        "JsonTextReader.Read returned false for {0}", s);
+                    Assert.IsTrue(reader.TokenType == JsonToken.Float ||
+                                  reader.TokenType == JsonToken.Integer,
+                        "Expected numeric token for {0}, got {1}", s, reader.TokenType);
+                    double parsed = Convert.ToDouble(reader.Value, CultureInfo.InvariantCulture);
+                    Assert.AreEqual(BitConverter.DoubleToInt64Bits(v),
+                                    BitConverter.DoubleToInt64Bits(parsed),
+                        "JsonTextReader lost bits: input={0} ({1:X16}) -> str={2} -> parsed={3} ({4:X16})",
+                        v,
+                        BitConverter.DoubleToInt64Bits(v),
+                        s,
+                        parsed,
+                        BitConverter.DoubleToInt64Bits(parsed));
+                }
+
+                // Path 2: JsonConvert.DeserializeObject, the high-level
+                // path ReconciliationFile.Load goes through.
+                double parsedHi = JsonConvert.DeserializeObject<double>(s);
+                Assert.AreEqual(BitConverter.DoubleToInt64Bits(v),
+                                BitConverter.DoubleToInt64Bits(parsedHi),
+                    "JsonConvert.DeserializeObject lost bits: input={0} ({1:X16}) -> str={2} -> parsed={3} ({4:X16})",
+                    v,
+                    BitConverter.DoubleToInt64Bits(v),
+                    s,
+                    parsedHi,
+                    BitConverter.DoubleToInt64Bits(parsedHi));
             }
         }
 

--- a/pwiz_tools/OspreySharp/OspreySharp.Test/IOTest.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Test/IOTest.cs
@@ -30,6 +30,7 @@ using System.IO.Compression;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Newtonsoft.Json;
 using pwiz.OspreySharp.Core;
+using pwiz.OspreySharp.FDR.Reconciliation;
 using pwiz.OspreySharp.IO;
 
 namespace pwiz.OspreySharp.Test
@@ -1959,6 +1960,272 @@ namespace pwiz.OspreySharp.Test
                     s,
                     parsedHi,
                     BitConverter.DoubleToInt64Bits(parsedHi));
+            }
+        }
+
+        #endregion
+
+        #region RescoreHydration Tests
+
+        /// <summary>
+        /// End-to-end round-trip: write a synthetic Stage 5 → Stage 6
+        /// boundary file pair (.scores.parquet + .1st-pass.fdr_scores.bin
+        /// + .reconciliation.json) for a single file, hydrate it via
+        /// <see cref="RescoreHydration.HydrateForRescore"/>, and assert
+        /// every piece of the in-memory state matches what was written.
+        /// Mirrors what the worker does at startup before driving the
+        /// rescore engine.
+        /// </summary>
+        [TestMethod]
+        public void TestRescoreHydrationRoundTrip()
+        {
+            string dir = Path.Combine(Path.GetTempPath(),
+                "rescore_hydrate_" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(dir);
+            try
+            {
+                const string stem = "sample1";
+                string parquetPath = Path.Combine(dir, stem + ".scores.parquet");
+                string mzmlSynthetic = Path.Combine(dir, stem + ".mzML");
+                string sidecarPath = FdrScoresSidecar.Pass1Path(mzmlSynthetic);
+                string reconPath = ReconciliationFile.PathForInput(mzmlSynthetic);
+
+                // 1. Build 3 synthetic scored entries and write the parquet.
+                var scoredEntries = new List<CoelutionScoredEntry>();
+                for (int i = 0; i < 3; i++)
+                {
+                    scoredEntries.Add(new CoelutionScoredEntry
+                    {
+                        EntryId = (uint)(100 + i),
+                        IsDecoy = i == 1,
+                        Sequence = "PEPTIDE",
+                        ModifiedSequence = "PEPTIDE",
+                        Charge = 2,
+                        PrecursorMz = 500.0 + i,
+                        ScanNumber = (uint)(1000 + i),
+                        ApexRt = 5.0 + i * 0.5,
+                        FileName = stem + ".mzML",
+                        PeakBounds = new XICPeakBounds
+                        {
+                            StartRt = 4.5 + i * 0.5,
+                            EndRt = 5.5 + i * 0.5,
+                        },
+                        Features = new CoelutionFeatureSet
+                        {
+                            CoelutionSum = 0.9 + i * 0.01,
+                            CoelutionMax = 0.95,
+                            NCoelutingFragments = 5,
+                            PeakApex = 1000.0,
+                            PeakArea = 5000.0,
+                            PeakSharpness = 0.8,
+                            Xcorr = 2.5,
+                            ConsecutiveIons = 3,
+                            ExplainedIntensity = 0.75,
+                            MassAccuracyMean = -0.5,
+                            AbsMassAccuracyMean = 0.5,
+                            RtDeviation = 0.1,
+                            AbsRtDeviation = 0.1,
+                            Ms1PrecursorCoelution = 0.85,
+                            Ms1IsotopeCosine = 0.92,
+                            MedianPolishCosine = 0.88,
+                            MedianPolishResidualRatio = 0.15,
+                            SgWeightedXcorr = 2.3,
+                            SgWeightedCosine = 0.87,
+                            MedianPolishMinFragmentR2 = 0.7,
+                            MedianPolishResidualCorrelation = 0.3,
+                        },
+                    });
+                }
+                ParquetScoreCache.WriteScoresParquet(parquetPath, scoredEntries,
+                    new Dictionary<string, string>
+                    {
+                        { "osprey.version", "1.0.0" },
+                        { "osprey.search_hash", "abc123" },
+                    });
+
+                // 2. Build matching FdrEntry list (same EntryId order +
+                //    distinct field values per record) and write the v3
+                //    sidecar.
+                var sidecarEntries = new List<FdrEntry>
+                {
+                    MakeFdrEntry(100, -3.5, 0.001, 0.02, runProteinQvalue: 0.42),
+                    MakeFdrEntry(101, -3.4, 0.002, 0.05, runProteinQvalue: 0.43),
+                    MakeFdrEntry(102, -3.3, 0.003, 0.08, runProteinQvalue: 0.44),
+                };
+                FdrScoresSidecar.Write(sidecarPath, sidecarEntries,
+                    FdrScoresSidecar.Pass.FirstPass);
+
+                // 3. Build a reconciliation.json envelope: one
+                //    UseCwtPeak action on entry 100, one ForcedIntegration
+                //    on entry 102, plus a refined cal and a single
+                //    gap-fill target.
+                var reconFile = new ReconciliationFile
+                {
+                    FormatVersion = ReconciliationFile.CurrentFormatVersion,
+                    SearchHash = "abc123",
+                    LibraryHash = "lib-h",
+                    UseCwtPeakActions = new List<UseCwtPeakEntry>
+                    {
+                        new UseCwtPeakEntry
+                        {
+                            ApexRt = 5.07, CandidateIdx = 1,
+                            EndRt = 5.40, EntryId = 100, StartRt = 4.70,
+                        },
+                    },
+                    ForcedIntegrationActions = new List<ForcedIntegrationEntry>
+                    {
+                        new ForcedIntegrationEntry
+                            { EntryId = 102, ExpectedRt = 6.10, HalfWidth = 0.075 },
+                    },
+                    RefinedRtCalibration = new RefinedRtCalibrationJson
+                    {
+                        AbsResiduals = new[] { 0.01, 0.02, 0.015 },
+                        FittedRts = new[] { 10.5, 20.5, 30.5 },
+                        LibraryRts = new[] { 10.0, 20.0, 30.0 },
+                        ResidualSd = 0.123,
+                    },
+                    GapFillTargets = new List<GapFillEntry>
+                    {
+                        new GapFillEntry
+                        {
+                            Charge = 2,
+                            DecoyEntryId = 0x80000005u,
+                            ExpectedRt = 33.5,
+                            HalfWidth = 0.08,
+                            ModifiedSequence = "PEPTIDE",
+                            TargetEntryId = 5,
+                        },
+                    },
+                };
+                ReconciliationFile.Save(reconPath, reconFile);
+
+                // 4. Hydrate.
+                var inputs = RescoreHydration.HydrateForRescore(new[] { parquetPath });
+
+                // 5. Assert per-file entries: same fileName, same count,
+                //    Score / RunProteinQvalue overlaid bit-exactly.
+                Assert.AreEqual(1, inputs.PerFileEntries.Count);
+                Assert.AreEqual(stem, inputs.PerFileEntries[0].Key);
+                var got = inputs.PerFileEntries[0].Value;
+                Assert.AreEqual(3, got.Count);
+                for (int i = 0; i < 3; i++)
+                {
+                    Assert.AreEqual(sidecarEntries[i].EntryId, got[i].EntryId);
+                    Assert.AreEqual(BitConverter.DoubleToInt64Bits(sidecarEntries[i].Score),
+                                    BitConverter.DoubleToInt64Bits(got[i].Score));
+                    Assert.AreEqual(
+                        BitConverter.DoubleToInt64Bits(sidecarEntries[i].RunProteinQvalue),
+                        BitConverter.DoubleToInt64Bits(got[i].RunProteinQvalue));
+                }
+
+                // 6. Assert reconciliation actions: keyed by
+                //    (fileName, vec_idx) where vec_idx is the row index
+                //    in PerFileEntries[0].Value.
+                Assert.AreEqual(2, inputs.ReconciliationActions.Count);
+                var useCwt = inputs.ReconciliationActions[(stem, 0)] as ReconcileAction.UseCwtPeak;
+                Assert.IsNotNull(useCwt, "expected UseCwtPeak at (stem, 0)");
+                Assert.AreEqual(1, useCwt.CandidateIndex);
+                Assert.AreEqual(5.07, useCwt.ApexRt);
+                Assert.AreEqual(4.70, useCwt.StartRt);
+                Assert.AreEqual(5.40, useCwt.EndRt);
+
+                var forced = inputs.ReconciliationActions[(stem, 2)]
+                    as ReconcileAction.ForcedIntegration;
+                Assert.IsNotNull(forced, "expected ForcedIntegration at (stem, 2)");
+                Assert.AreEqual(6.10, forced.ExpectedRt);
+                Assert.AreEqual(0.075, forced.HalfWidth);
+
+                // 7. Assert refined RT calibration is reconstructed.
+                Assert.IsTrue(inputs.RefinedCalibrations.ContainsKey(stem));
+
+                // 8. Assert gap-fill target round-trip.
+                Assert.IsTrue(inputs.PerFileGapFill.ContainsKey(stem));
+                var gap = inputs.PerFileGapFill[stem];
+                Assert.AreEqual(1, gap.Count);
+                Assert.AreEqual(5u, gap[0].TargetEntryId);
+                Assert.AreEqual(0x80000005u, gap[0].DecoyEntryId);
+                Assert.AreEqual(33.5, gap[0].ExpectedRt);
+                Assert.AreEqual(0.08, gap[0].HalfWidth);
+                Assert.AreEqual("PEPTIDE", gap[0].ModifiedSequence);
+                Assert.AreEqual((byte)2, gap[0].Charge);
+            }
+            finally
+            {
+                try { Directory.Delete(dir, true); } catch (IOException) { }
+            }
+        }
+
+        /// <summary>
+        /// If the planner emits an entry_id that doesn't appear in the
+        /// stub list (e.g., parquet/boundary mismatch from a botched
+        /// rebuild), the hydrator must throw rather than silently
+        /// skipping the action — a Stage 6 worker proceeding with
+        /// missing actions would scramble gap-fill results.
+        /// </summary>
+        [TestMethod]
+        public void TestRescoreHydrationRejectsActionEntryIdNotInStubs()
+        {
+            string dir = Path.Combine(Path.GetTempPath(),
+                "rescore_hyd_drift_" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(dir);
+            try
+            {
+                const string stem = "sample1";
+                string parquetPath = Path.Combine(dir, stem + ".scores.parquet");
+                string mzmlSynthetic = Path.Combine(dir, stem + ".mzML");
+                string sidecarPath = FdrScoresSidecar.Pass1Path(mzmlSynthetic);
+                string reconPath = ReconciliationFile.PathForInput(mzmlSynthetic);
+
+                var scored = new List<CoelutionScoredEntry>
+                {
+                    new CoelutionScoredEntry
+                    {
+                        EntryId = 100, ModifiedSequence = "PEPTIDE", Sequence = "PEPTIDE",
+                        Charge = 2, PrecursorMz = 500.0, ScanNumber = 1000, ApexRt = 5.0,
+                        FileName = stem + ".mzML",
+                        PeakBounds = new XICPeakBounds { StartRt = 4.5, EndRt = 5.5 },
+                        Features = new CoelutionFeatureSet { CoelutionSum = 0.9 },
+                    },
+                };
+                ParquetScoreCache.WriteScoresParquet(parquetPath, scored,
+                    new Dictionary<string, string> { { "osprey.version", "1.0.0" } });
+                FdrScoresSidecar.Write(sidecarPath,
+                    new List<FdrEntry> { MakeFdrEntry(100, -3.5, 0.001, 0.02) },
+                    FdrScoresSidecar.Pass.FirstPass);
+
+                // entry_id 999 is NOT in the parquet/sidecar — drift!
+                var reconFile = new ReconciliationFile
+                {
+                    FormatVersion = ReconciliationFile.CurrentFormatVersion,
+                    SearchHash = "x",
+                    LibraryHash = "y",
+                    UseCwtPeakActions = new List<UseCwtPeakEntry>
+                    {
+                        new UseCwtPeakEntry
+                        {
+                            ApexRt = 5.0, CandidateIdx = 0, EndRt = 5.5,
+                            EntryId = 999, StartRt = 4.5,
+                        },
+                    },
+                    ForcedIntegrationActions = new List<ForcedIntegrationEntry>(),
+                    GapFillTargets = new List<GapFillEntry>(),
+                };
+                ReconciliationFile.Save(reconPath, reconFile);
+
+                try
+                {
+                    RescoreHydration.HydrateForRescore(new[] { parquetPath });
+                    Assert.Fail("expected InvalidDataException for entry_id drift");
+                }
+                catch (InvalidDataException ex)
+                {
+                    StringAssert.Contains(ex.Message, "999");
+                    StringAssert.Contains(ex.Message, "not found in stubs");
+                }
+            }
+            finally
+            {
+                try { Directory.Delete(dir, true); } catch (IOException) { }
             }
         }
 

--- a/pwiz_tools/OspreySharp/OspreySharp.Test/IOTest.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Test/IOTest.cs
@@ -29,6 +29,7 @@ using System.IO;
 using System.IO.Compression;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Newtonsoft.Json;
+using pwiz.OspreySharp.Chromatography;
 using pwiz.OspreySharp.Core;
 using pwiz.OspreySharp.FDR.Reconciliation;
 using pwiz.OspreySharp.IO;
@@ -2227,6 +2228,155 @@ namespace pwiz.OspreySharp.Test
             {
                 try { Directory.Delete(dir, true); } catch (IOException) { }
             }
+        }
+
+        #endregion
+
+        #region RescoreCompaction Tests
+
+        /// <summary>
+        /// Worker compaction: drop non-passing entries by base_id and
+        /// re-key reconciliation actions from pre-compaction vec_idx to
+        /// post-compaction vec_idx. Mirrors what the in-process flow
+        /// does between first-pass FDR and Stage 6 — see
+        /// AnalysisPipeline's "First-pass compaction" block.
+        ///
+        /// Test layout (single file, five entries):
+        ///   idx 0: target id=1, peptide_q=0.005 (PASS peptide)
+        ///   idx 1: decoy  id=0x80000001, base=1 (retained via target's base_id)
+        ///   idx 2: target id=2, peptide_q=0.5  (FAIL — non-passing)
+        ///   idx 3: decoy  id=0x80000002, base=2 (dropped because base=2 not in pass set)
+        ///   idx 4: target id=3, peptide_q=0.5, protein_q=0.005 (PASS via protein-rescue)
+        ///
+        /// With ProteinFdr=0.01, base_ids {1, 3} pass. After compaction:
+        ///   idx 0: id=1, idx 1: id=0x80000001, idx 2: id=3.
+        ///
+        /// Reconciliation actions are seeded at:
+        ///   (f, 0) on id=1  → should remain at (f, 0)
+        ///   (f, 4) on id=3  → should move to (f, 2)
+        ///   (f, 2) on id=2  → should be dropped (entry compacted away)
+        /// </summary>
+        [TestMethod]
+        public void TestRescoreCompactionRekeysActionsAndDropsNonpassing()
+        {
+            const string fileName = "f1";
+            var perFile = new List<KeyValuePair<string, List<FdrEntry>>>
+            {
+                new KeyValuePair<string, List<FdrEntry>>(fileName, new List<FdrEntry>
+                {
+                    MakeFdrEntryWithProteinQ(1u,           runPeptideQ: 0.005, runProteinQ: 1.0),
+                    MakeFdrEntryWithProteinQ(0x80000001u,  runPeptideQ: 0.5,   runProteinQ: 1.0),
+                    MakeFdrEntryWithProteinQ(2u,           runPeptideQ: 0.5,   runProteinQ: 1.0),
+                    MakeFdrEntryWithProteinQ(0x80000002u,  runPeptideQ: 0.5,   runProteinQ: 1.0),
+                    MakeFdrEntryWithProteinQ(3u,           runPeptideQ: 0.5,   runProteinQ: 0.005),
+                }),
+            };
+
+            var actions = new Dictionary<(string, int), ReconcileAction>
+            {
+                { (fileName, 0), new ReconcileAction.UseCwtPeak(0, 1.0, 2.0, 3.0) },
+                { (fileName, 4), new ReconcileAction.ForcedIntegration(7.0, 0.05) },
+                { (fileName, 2), new ReconcileAction.UseCwtPeak(1, 5.0, 6.0, 7.0) },
+            };
+
+            var inputs = new RescoreInputs
+            {
+                PerFileEntries = perFile,
+                ReconciliationActions = actions,
+                RefinedCalibrations = new Dictionary<string, RTCalibration>(),
+                PerFileGapFill = new Dictionary<string, List<GapFillTarget>>(),
+            };
+
+            var stats = RescoreCompaction.Apply(inputs, new OspreyConfig
+            {
+                RunFdr = 0.01,
+                ProteinFdr = 0.01,
+            });
+
+            // Compaction stats.
+            Assert.AreEqual(5, stats.EntriesBefore);
+            Assert.AreEqual(3, stats.EntriesAfter);
+            Assert.AreEqual(2, stats.FirstPassBaseIds);   // base_ids {1, 3}
+            Assert.AreEqual(1, stats.DroppedActions);     // the (f, 2) action
+
+            // Per-file list compacted.
+            Assert.AreEqual(1, inputs.PerFileEntries.Count);
+            var got = inputs.PerFileEntries[0].Value;
+            Assert.AreEqual(3, got.Count);
+            Assert.AreEqual(1u, got[0].EntryId);
+            Assert.AreEqual(0x80000001u, got[1].EntryId);
+            Assert.AreEqual(3u, got[2].EntryId);
+
+            // Reconciliation actions re-keyed.
+            Assert.AreEqual(2, inputs.ReconciliationActions.Count);
+            Assert.IsInstanceOfType(
+                inputs.ReconciliationActions[(fileName, 0)], typeof(ReconcileAction.UseCwtPeak));
+            Assert.IsInstanceOfType(
+                inputs.ReconciliationActions[(fileName, 2)],
+                typeof(ReconcileAction.ForcedIntegration));
+            // The action at the dropped entry is gone, NOT silently re-keyed
+            // to a different surviving entry.
+            Assert.IsFalse(inputs.ReconciliationActions.ContainsKey((fileName, 1)));
+        }
+
+        /// <summary>
+        /// With ProteinFdr=null (--protein-fdr not passed), the
+        /// protein-rescue branch is skipped entirely. An entry that
+        /// would have been retained via protein rescue (peptide_q
+        /// fails, protein_q passes) gets compacted away, taking any
+        /// action keyed to it with it.
+        /// </summary>
+        [TestMethod]
+        public void TestRescoreCompactionWithoutProteinFdrSkipsRescue()
+        {
+            const string fileName = "f1";
+            var perFile = new List<KeyValuePair<string, List<FdrEntry>>>
+            {
+                new KeyValuePair<string, List<FdrEntry>>(fileName, new List<FdrEntry>
+                {
+                    MakeFdrEntryWithProteinQ(1u, runPeptideQ: 0.005, runProteinQ: 1.0),
+                    MakeFdrEntryWithProteinQ(2u, runPeptideQ: 0.5,   runProteinQ: 0.005),
+                }),
+            };
+
+            var inputs = new RescoreInputs
+            {
+                PerFileEntries = perFile,
+                ReconciliationActions = new Dictionary<(string, int), ReconcileAction>(),
+                RefinedCalibrations = new Dictionary<string, RTCalibration>(),
+                PerFileGapFill = new Dictionary<string, List<GapFillTarget>>(),
+            };
+
+            var stats = RescoreCompaction.Apply(inputs, new OspreyConfig
+            {
+                RunFdr = 0.01,
+                ProteinFdr = null,
+            });
+
+            // Only entry 1 passes; entry 2 dropped (no protein rescue).
+            Assert.AreEqual(1, stats.EntriesAfter);
+            Assert.AreEqual(1, stats.FirstPassBaseIds);
+            Assert.AreEqual(1u, inputs.PerFileEntries[0].Value[0].EntryId);
+        }
+
+        /// <summary>
+        /// Helper: build a minimal FdrEntry usable in compaction tests.
+        /// Sets the FDR fields the predicate inspects and leaves the
+        /// rest at their defaults.
+        /// </summary>
+        private static FdrEntry MakeFdrEntryWithProteinQ(uint id, double runPeptideQ,
+            double runProteinQ)
+        {
+            return new FdrEntry
+            {
+                EntryId = id,
+                ParquetIndex = id,
+                IsDecoy = (id & 0x80000000u) != 0,
+                Charge = 2,
+                RunPeptideQvalue = runPeptideQ,
+                RunProteinQvalue = runProteinQ,
+                ModifiedSequence = "PEPTIDE",
+            };
         }
 
         #endregion

--- a/pwiz_tools/OspreySharp/OspreySharp.Test/IOTest.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Test/IOTest.cs
@@ -2360,6 +2360,57 @@ namespace pwiz.OspreySharp.Test
         }
 
         /// <summary>
+        /// Decoys are excluded from the predicate by design: a passing
+        /// target retains its paired decoy automatically via the
+        /// base_id retain step. If decoys WERE allowed in the
+        /// predicate, a decoy peptide whose paired-target's protein
+        /// passes protein-FDR would self-rescue via the protein-rescue
+        /// clause, inflating the base_id set beyond what the
+        /// in-process pipeline produces (AnalysisPipeline.cs:517 has
+        /// the matching `if (entry.IsDecoy) continue;` filter; Rust
+        /// rescore.rs:457 has the matching `!e.is_decoy &&`).
+        ///
+        /// Test layout: a single decoy with a passing protein_q AND a
+        /// failing peptide_q. Without the decoy filter, the decoy's
+        /// base_id would land in firstPassBaseIds via protein-rescue.
+        /// With the filter, the decoy is skipped — and since no target
+        /// shares its base_id, no entries survive at all.
+        /// </summary>
+        [TestMethod]
+        public void TestRescoreCompactionSkipsDecoysInPredicate()
+        {
+            const string fileName = "f1";
+            var perFile = new List<KeyValuePair<string, List<FdrEntry>>>
+            {
+                new KeyValuePair<string, List<FdrEntry>>(fileName, new List<FdrEntry>
+                {
+                    // Lone decoy with a passing protein_q. No paired target.
+                    MakeFdrEntryWithProteinQ(0x80000007u, runPeptideQ: 0.5, runProteinQ: 0.005),
+                }),
+            };
+
+            var inputs = new RescoreInputs
+            {
+                PerFileEntries = perFile,
+                ReconciliationActions = new Dictionary<(string, int), ReconcileAction>(),
+                RefinedCalibrations = new Dictionary<string, RTCalibration>(),
+                PerFileGapFill = new Dictionary<string, List<GapFillTarget>>(),
+            };
+
+            var stats = RescoreCompaction.Apply(inputs, new OspreyConfig
+            {
+                RunFdr = 0.01,
+                ProteinFdr = 0.01,
+            });
+
+            // Decoy is filtered before predicate; no base_ids passed; the
+            // entry is then dropped by the base_id retain step.
+            Assert.AreEqual(0, stats.FirstPassBaseIds);
+            Assert.AreEqual(0, stats.EntriesAfter);
+            Assert.AreEqual(0, inputs.PerFileEntries[0].Value.Count);
+        }
+
+        /// <summary>
         /// Helper: build a minimal FdrEntry usable in compaction tests.
         /// Sets the FDR fields the predicate inspects and leaves the
         /// rest at their defaults.

--- a/pwiz_tools/OspreySharp/OspreySharp.Test/IOTest.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Test/IOTest.cs
@@ -1562,7 +1562,8 @@ namespace pwiz.OspreySharp.Test
 
         #region FdrScoresSidecar Tests
 
-        private static FdrEntry MakeFdrEntry(uint id, double score, double q, double pep)
+        private static FdrEntry MakeFdrEntry(uint id, double score, double q, double pep,
+            double runProteinQvalue = 1.0)
         {
             return new FdrEntry
             {
@@ -1574,7 +1575,7 @@ namespace pwiz.OspreySharp.Test
                 Score = score,
                 RunPrecursorQvalue = q,
                 RunPeptideQvalue = q + 1.0e-9,
-                RunProteinQvalue = 1.0,
+                RunProteinQvalue = runProteinQvalue,
                 ExperimentPrecursorQvalue = q + 2.0e-9,
                 ExperimentPeptideQvalue = q + 3.0e-9,
                 ExperimentProteinQvalue = 1.0,
@@ -1595,11 +1596,16 @@ namespace pwiz.OspreySharp.Test
             try
             {
                 string path = Path.Combine(dir, "test.1st-pass.fdr_scores.bin");
+                // Distinct run_protein_qvalue per entry catches a writer that
+                // drops the v3 field. Values match Rust's
+                // fdr_scores_sidecar_v3_round_trip exactly so the
+                // OSPREY_CROSS_IMPL_FDR_SIDECAR_OUT byte-parity gate compares
+                // identical inputs on both sides.
                 var entries = new List<FdrEntry>
                 {
-                    MakeFdrEntry(0, -3.5, 0.001, 0.02),
-                    MakeFdrEntry(1, -3.4, 0.002, 0.05),
-                    MakeFdrEntry(2, -3.3, 0.003, 0.08),
+                    MakeFdrEntry(0, -3.5, 0.001, 0.02, runProteinQvalue: 0.0042),
+                    MakeFdrEntry(1, -3.4, 0.002, 0.05, runProteinQvalue: 0.0123),
+                    MakeFdrEntry(2, -3.3, 0.003, 0.08, runProteinQvalue: 0.95),
                 };
 
                 FdrScoresSidecar.Write(path, entries, FdrScoresSidecar.Pass.FirstPass);
@@ -1642,6 +1648,8 @@ namespace pwiz.OspreySharp.Test
                                     BitConverter.DoubleToInt64Bits(loaded[i].ExperimentPeptideQvalue));
                     Assert.AreEqual(BitConverter.DoubleToInt64Bits(entries[i].Pep),
                                     BitConverter.DoubleToInt64Bits(loaded[i].Pep));
+                    Assert.AreEqual(BitConverter.DoubleToInt64Bits(entries[i].RunProteinQvalue),
+                                    BitConverter.DoubleToInt64Bits(loaded[i].RunProteinQvalue));
                 }
             }
             finally

--- a/pwiz_tools/OspreySharp/OspreySharp.Test/ProgramTests.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Test/ProgramTests.cs
@@ -127,6 +127,40 @@ namespace pwiz.OspreySharp.Test
         }
 
         [TestMethod]
+        public void TestValidateNoJoinWorkerHappyPath()
+        {
+            // --join-at-pass=1 --no-join (per-file rescore worker):
+            // requires --input-scores, --library, and --output. No
+            // --input mzML.
+            var config = new OspreyConfig
+            {
+                NoJoin = true,
+                InputScores = new List<string> { "a.scores.parquet" },
+                LibrarySource = LibrarySource.FromPath("ref.blib"),
+                OutputBlib = "out.blib",
+            };
+            Assert.IsNull(
+                Program.ValidateArgs(config, noJoinFlag: true, joinOnlyFlag: false, joinOnlyModifier: false));
+        }
+
+        [TestMethod]
+        public void TestValidateNoJoinWorkerRequiresLibraryAndOutput()
+        {
+            // Worker mode without --library or --output — like the in-process
+            // --join-at-pass=1 path, both are required so the per-file
+            // parquet write-back has somewhere to go.
+            var config = new OspreyConfig
+            {
+                NoJoin = true,
+                InputScores = new List<string> { "a.scores.parquet" },
+                // missing LibrarySource and OutputBlib
+            };
+            string err = Program.ValidateArgs(config, noJoinFlag: true, joinOnlyFlag: false, joinOnlyModifier: false);
+            Assert.IsNotNull(err);
+            StringAssert.Contains(err, "--library and --output");
+        }
+
+        [TestMethod]
         public void TestValidateNoJoinHappyPath()
         {
             var config = new OspreyConfig
@@ -274,13 +308,18 @@ namespace pwiz.OspreySharp.Test
         }
 
         [TestMethod]
-        public void TestNormalizeJoinAtPass1WithNoJoinModifierErrorsUntilImplemented()
+        public void TestNormalizeJoinAtPass1WithNoJoinModifierKeepsBothFlags()
         {
-            // PR 2 will implement "run only Stage 6 from persisted Stage 5 outputs."
+            // --join-at-pass=1 --no-join is the per-file rescore worker
+            // mode. Normalize keeps noJoinFlag true and joinOnlyFlag false
+            // (they're not flipped); Main routes the combination to
+            // RescoreWorker.Run.
             bool noJoin = true, joinOnly = false;
-            string err = Program.NormalizeHpcArgs(joinAtPass: 1, noJoinFlag: ref noJoin, joinOnlyFlag: ref joinOnly, joinOnlyModifier: out _);
-            Assert.IsNotNull(err);
-            StringAssert.Contains(err, "not yet implemented");
+            string err = Program.NormalizeHpcArgs(joinAtPass: 1, noJoinFlag: ref noJoin, joinOnlyFlag: ref joinOnly, joinOnlyModifier: out bool joinOnlyModifier);
+            Assert.IsNull(err, "got: {0}", err);
+            Assert.IsTrue(noJoin, "noJoinFlag should remain true");
+            Assert.IsFalse(joinOnly, "joinOnlyFlag should remain false");
+            Assert.IsFalse(joinOnlyModifier, "joinOnlyModifier should be false");
         }
 
         [TestMethod]

--- a/pwiz_tools/OspreySharp/OspreySharp/AnalysisPipeline.Stage6Rescore.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/AnalysisPipeline.Stage6Rescore.cs
@@ -1,0 +1,688 @@
+/*
+ * Original author: Brendan MacLean <brendanx .at. uw.edu>,
+ *                  MacCoss Lab, Department of Genome Sciences, UW
+ * AI assistance: Claude Code (Claude Opus 4) <noreply .at. anthropic.com>
+ *
+ * Based on osprey (https://github.com/MacCossLab/osprey)
+ *   by Michael J. MacCoss, MacCoss Lab, Department of Genome Sciences, UW
+ *
+ * Copyright 2026 University of Washington - Seattle, WA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using pwiz.OspreySharp.Chromatography;
+using pwiz.OspreySharp.Core;
+using pwiz.OspreySharp.FDR.Reconciliation;
+using pwiz.OspreySharp.IO;
+using pwiz.OspreySharp.Scoring;
+
+namespace pwiz.OspreySharp
+{
+    /// <summary>
+    /// Aggregate counts returned by <see cref="AnalysisPipeline.ExecuteStage6Rescore"/>.
+    /// Mirrors <c>RescoreStats</c> in
+    /// <c>osprey/crates/osprey/src/pipeline.rs</c>.
+    /// </summary>
+    public class RescoreStats
+    {
+        /// <summary>
+        /// Total entries re-scored across all files: existing
+        /// (consensus + reconciliation) plus gap-fill (CWT + forced).
+        /// </summary>
+        public int TotalRescored { get; set; }
+
+        /// <summary>
+        /// Number of non-Keep reconciliation actions executed across all files.
+        /// </summary>
+        public int TotalReconciliation { get; set; }
+
+        /// <summary>
+        /// Gap-fill targets that landed via the CWT-detected pass.
+        /// Phase 2 of the port; zero today.
+        /// </summary>
+        public int TotalGapCwt { get; set; }
+
+        /// <summary>
+        /// Gap-fill targets that landed via the forced-integration pass.
+        /// Phase 2 of the port; zero today.
+        /// </summary>
+        public int TotalGapForced { get; set; }
+    }
+
+    public partial class AnalysisPipeline
+    {
+        /// <summary>
+        /// Top-level entry point for the <c>--join-at-pass=1 --no-join</c>
+        /// per-file rescore worker. Mirrors <c>run_rescore</c> in
+        /// <c>osprey/crates/osprey/src/rescore.rs</c>.
+        ///
+        /// Synthesizes <c>config.InputFiles</c> from <c>config.InputScores</c>
+        /// (mzML stems derived from parquet stems), loads the spectral
+        /// library, hydrates the boundary file pair via
+        /// <see cref="RescoreHydration.HydrateForRescore"/>, applies worker
+        /// compaction via <see cref="RescoreCompaction.Apply"/>, computes
+        /// per-file multi-charge consensus targets from the compacted
+        /// stubs, builds the per-file original RT calibration map by
+        /// loading each sibling <c>.calibration.json</c>, then dispatches
+        /// to <see cref="ExecuteStage6Rescore"/>.
+        ///
+        /// PHASE 1 of the C# port: existing entries (consensus +
+        /// reconciliation overlay) re-scored from the v3 sidecar inputs.
+        /// Gap-fill two-pass and reconciled .scores.parquet write-back are
+        /// the next porting phases; today the worker exits with a clear
+        /// pointer message after the rescore loop completes.
+        /// </summary>
+        internal int RunWorker(OspreyConfig config)
+        {
+            if (config == null) throw new ArgumentNullException(nameof(config));
+            if (config.InputScores == null || config.InputScores.Count == 0)
+            {
+                Program.LogError(
+                    "--join-at-pass=1 --no-join requires --input-scores <path...>.");
+                return 1;
+            }
+
+            // Synthesize config.InputFiles from --input-scores so
+            // ExecuteStage6Rescore's file_name_to_idx can map file_name
+            // back to a real (synthetic) input path. Mirrors Rust's
+            // run_analysis idempotent synthesis at pipeline.rs ~line 3144.
+            if (config.InputFiles == null || config.InputFiles.Count == 0)
+            {
+                var synthetic = new List<string>(config.InputScores.Count);
+                foreach (var p in config.InputScores)
+                    synthetic.Add(RescoreHydration.SyntheticInputFromParquet(p));
+                config.InputFiles = synthetic;
+            }
+
+            Program.LogInfo(string.Format(
+                "--join-at-pass=1 --no-join: per-file rescore worker starting on {0} parquet(s)",
+                config.InputScores.Count));
+
+            // Library loading uses the same path the in-process pipeline does,
+            // including the .libcache fast-path.
+            List<LibraryEntry> fullLibrary;
+            try
+            {
+                fullLibrary = LoadLibrary(config);
+            }
+            catch (Exception ex)
+            {
+                Program.LogError(string.Format(
+                    "--join-at-pass=1 --no-join: library load failed: {0}", ex.Message));
+                return 1;
+            }
+            // Decoy generation (mirror the in-process flow's call site at
+            // AnalysisPipeline.Run line 132). Worker needs the decoys in
+            // fullLibrary so subset_library produces the full target+decoy
+            // set ScoreCandidate expects.
+            if (!config.DecoysInLibrary)
+            {
+                List<LibraryEntry> validTargets;
+                var decoys = GenerateDecoys(fullLibrary, config, out validTargets);
+                fullLibrary = new List<LibraryEntry>(validTargets.Count + decoys.Count);
+                fullLibrary.AddRange(validTargets);
+                fullLibrary.AddRange(decoys);
+            }
+
+            // Hydrate boundary file pair -> RescoreInputs.
+            RescoreInputs inputs;
+            try
+            {
+                inputs = RescoreHydration.HydrateForRescore(config.InputScores);
+            }
+            catch (Exception ex)
+            {
+                Program.LogError(string.Format(
+                    "--join-at-pass=1 --no-join: hydration failed: {0}", ex.Message));
+                return 1;
+            }
+            Program.LogInfo(string.Format(
+                "Hydrated {0} file(s); {1} pre-compaction stubs, {2} reconciliation actions, " +
+                "{3} gap-fill candidates, {4} refined RT calibration(s)",
+                inputs.PerFileEntries.Count,
+                inputs.TotalStubs,
+                inputs.TotalActions,
+                inputs.TotalGapFillTargets,
+                inputs.RefinedCalibrations.Count));
+
+            // Cross-impl bisection seam: dump the per-precursor q-values
+            // so the result can be diffed against Rust's
+            // rust_stage5_percolator.tsv via Compare-Percolator.ps1.
+            if (OspreyDiagnostics.DumpPercolator)
+                OspreyDiagnostics.WriteStage5PercolatorDump(inputs.PerFileEntries);
+
+            // Worker compaction (mirror in-process first-pass FDR drop).
+            RescoreCompaction.Stats compactStats;
+            try
+            {
+                compactStats = RescoreCompaction.Apply(inputs, config);
+            }
+            catch (Exception ex)
+            {
+                Program.LogError(string.Format(
+                    "--join-at-pass=1 --no-join: compaction failed: {0}", ex.Message));
+                return 1;
+            }
+            Program.LogInfo(string.Format(
+                "Worker compaction: {0} -> {1} entries ({2} surviving base_ids), " +
+                "{3} reconciliation actions retained ({4} dropped)",
+                compactStats.EntriesBefore,
+                compactStats.EntriesAfter,
+                compactStats.FirstPassBaseIds,
+                inputs.ReconciliationActions.Count,
+                compactStats.DroppedActions));
+
+            // Compute per-file multi-charge consensus targets from the
+            // compacted stubs. This is fresh per-file work — the planner's
+            // reconciliation actions cover cross-run targets, but
+            // multi-charge consensus is a within-file decision and the
+            // worker recomputes it from the same FDR threshold the
+            // in-process flow uses.
+            var perFileConsensusTargets =
+                new Dictionary<string,
+                    IReadOnlyList<(int Index, double Apex, double Start, double End)>>();
+            int totalConsensusTargets = 0;
+            foreach (var kvp in inputs.PerFileEntries)
+            {
+                var targets = MultiChargeConsensus.SelectRescoreTargets(kvp.Value, config.RunFdr);
+                perFileConsensusTargets[kvp.Key] = targets;
+                totalConsensusTargets += targets.Count;
+            }
+            Program.LogInfo(string.Format(
+                "Worker multi-charge consensus: {0} entries to re-score across {1} files",
+                totalConsensusTargets, inputs.PerFileEntries.Count));
+
+            // Build per-file original RT calibration map from sibling
+            // .calibration.json. The refinedCalibrations dict (from the
+            // reconciliation envelope) is the preferred source inside the
+            // rescore loop, but the original cal is the fallback when no
+            // refined cal was persisted for a file (Stage 5 LOESS refit
+            // failed). Mirrors the per-file calibration load in
+            // rescore::run_rescore at lines 367-413.
+            var perFileCalibrations = new Dictionary<string, RTCalibration>();
+            foreach (var kvp in inputs.PerFileEntries)
+            {
+                string fileName = kvp.Key;
+                int inputIdx;
+                bool found = false;
+                for (int i = 0; i < config.InputFiles.Count; i++)
+                {
+                    if (Path.GetFileNameWithoutExtension(config.InputFiles[i]) == fileName)
+                    {
+                        inputIdx = i;
+                        found = true;
+                        AddIfNotNull(perFileCalibrations, fileName,
+                            LoadOriginalRtCalibration(config.InputFiles[inputIdx]));
+                        break;
+                    }
+                }
+                if (!found)
+                {
+                    Program.LogWarning(string.Format(
+                        "Worker: no input_files entry for {0} (no original cal loaded)", fileName));
+                }
+            }
+            Program.LogInfo(string.Format(
+                "Worker original calibrations: {0}/{1} files loaded",
+                perFileCalibrations.Count, inputs.PerFileEntries.Count));
+
+            // PHASE 1 dispatch: existing-entry rescore (consensus +
+            // reconciliation overlay) only. Phases 2 (gap-fill) and 3
+            // (parquet write-back) land in subsequent commits.
+            RescoreStats stats;
+            try
+            {
+                stats = ExecuteStage6Rescore(
+                    inputs.PerFileEntries,
+                    perFileConsensusTargets,
+                    inputs.ReconciliationActions,
+                    inputs.RefinedCalibrations,
+                    perFileCalibrations,
+                    inputs.PerFileGapFill,
+                    fullLibrary,
+                    config);
+            }
+            catch (Exception ex)
+            {
+                Program.LogError(string.Format(
+                    "--join-at-pass=1 --no-join: rescore failed: {0}", ex.Message));
+                Program.LogError(ex.StackTrace);
+                return 1;
+            }
+
+            Program.LogInfo(string.Format(
+                "Stage 6 rescore: {0} entries re-scored ({1} reconciliation actions executed)",
+                stats.TotalRescored, stats.TotalReconciliation));
+
+            // Phase 1 success: in-memory state matches what the in-process
+            // pipeline holds at the same seam. Phases 2 (gap-fill) and
+            // 3 (parquet write-back) are the next steps; until then, the
+            // worker can't produce reconciled .scores.parquet output, so
+            // exit non-zero with a pointer rather than letting downstream
+            // consumers see stale Stage 4 parquets.
+            Program.LogError(
+                "--join-at-pass=1 --no-join: PHASE 1 (consensus + reconciliation rescore) " +
+                "completed cleanly. Phases 2 (gap-fill) and 3 (reconciled parquet write-back) " +
+                "are not yet ported; the worker has not written reconciled .scores.parquet " +
+                "output. Both will land in subsequent commits.");
+            return 2;
+        }
+
+        /// <summary>
+        /// Insert <paramref name="value"/> into <paramref name="dict"/> at
+        /// <paramref name="key"/> only when <paramref name="value"/> is
+        /// non-null. Lifts the null-check out of the call site so
+        /// ReSharper's null-flow analysis doesn't flag the indexer
+        /// assignment for an unannotated possibly-null source.
+        /// </summary>
+        private static void AddIfNotNull(Dictionary<string, RTCalibration> dict,
+            string key, RTCalibration value)
+        {
+            if (value != null)
+                dict[key] = value;
+        }
+
+        /// <summary>
+        /// Load the original (Stage 1-2) RT calibration for a file from its
+        /// sibling .calibration.json. Returns null if the JSON is missing,
+        /// has no model_params, or fails to parse.
+        /// </summary>
+        private RTCalibration LoadOriginalRtCalibration(string inputFile)
+        {
+            string parent = Path.GetDirectoryName(Path.GetFullPath(inputFile));
+            if (string.IsNullOrEmpty(parent))
+                return null;
+            string calPath = CalibrationIO.CalibrationPathForInput(inputFile, parent);
+            if (!File.Exists(calPath))
+                return null;
+            try
+            {
+                var calParams = CalibrationIO.LoadCalibration(calPath);
+                if (calParams.RtCalibration?.ModelParams == null)
+                    return null;
+                var mp = calParams.RtCalibration.ModelParams;
+                return RTCalibration.FromModelParams(
+                    mp.LibraryRts, mp.FittedRts, mp.AbsResiduals,
+                    calParams.RtCalibration.ResidualSD);
+            }
+            catch
+            {
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// Execute the per-file Stage 6 rescore loop. Mirrors
+        /// <c>rescore_per_file_loop</c> in
+        /// <c>osprey/crates/osprey/src/pipeline.rs</c>.
+        ///
+        /// Today this method covers PHASE 1 of the port: existing
+        /// re-scoring (multi-charge consensus + cross-run reconciliation
+        /// targets, merged with reconciliation winning on conflict).
+        /// The (target, decoy) gap-fill two-pass and reconciled
+        /// .scores.parquet write-back are the next porting phases.
+        ///
+        /// For each file with at least one re-scoring target:
+        /// <list type="number">
+        ///   <item>Build boundary_overrides keyed by entry_id.</item>
+        ///   <item>Subset the library to the entries that need re-scoring.</item>
+        ///   <item>Reload spectra from the .spectra.bin cache or the mzML.</item>
+        ///   <item>Reload MS2/MS1 mass calibration from the sibling .calibration.json.</item>
+        ///   <item>Pick the refined RT calibration when present, else fall back to
+        ///       the original first-pass calibration.</item>
+        ///   <item>Call <see cref="RunCoelutionScoring"/> with the override-aware
+        ///       <see cref="ScoringContext"/>.</item>
+        ///   <item>Overlay the re-scored entries back onto the per-file
+        ///       FdrEntry stubs by entry_id, preserving ParquetIndex.</item>
+        /// </list>
+        ///
+        /// The mutable <paramref name="perFileEntries"/> is updated in place
+        /// (Score, Pep, q-values, Features, ApexRt/StartRt/EndRt, etc.).
+        /// Returns <see cref="RescoreStats"/> with the per-stage counts.
+        /// </summary>
+        internal RescoreStats ExecuteStage6Rescore(
+            List<KeyValuePair<string, List<FdrEntry>>> perFileEntries,
+            IReadOnlyDictionary<string, IReadOnlyList<(int Index, double Apex, double Start, double End)>> perFileConsensusTargets,
+            IReadOnlyDictionary<(string FileName, int Index), ReconcileAction> reconciliationActions,
+            IReadOnlyDictionary<string, RTCalibration> refinedCalibrations,
+            IReadOnlyDictionary<string, RTCalibration> perFileCalibrations,
+            IReadOnlyDictionary<string, List<GapFillTarget>> perFileGapFill,
+            List<LibraryEntry> fullLibrary,
+            OspreyConfig config)
+        {
+            // Pre-group reconciliation actions by file. Mirrors the Rust
+            // pre-grouping at pipeline.rs:2719-2744 — a single pass over
+            // the action map produces (file -> [(idx, apex, start, end)])
+            // so the per-file loop below just looks up its slice.
+            var perFileReconTargets =
+                new Dictionary<string, List<(int Index, double Apex, double Start, double End)>>();
+            int totalReconciliation = 0;
+            foreach (var kvp in reconciliationActions)
+            {
+                var fileName = kvp.Key.FileName;
+                var idx = kvp.Key.Index;
+                double apex, start, end;
+                if (kvp.Value is ReconcileAction.UseCwtPeak useCwt)
+                {
+                    apex = useCwt.ApexRt;
+                    start = useCwt.StartRt;
+                    end = useCwt.EndRt;
+                }
+                else if (kvp.Value is ReconcileAction.ForcedIntegration forced)
+                {
+                    apex = forced.ExpectedRt;
+                    start = forced.ExpectedRt - forced.HalfWidth;
+                    end = forced.ExpectedRt + forced.HalfWidth;
+                }
+                else
+                {
+                    // Keep: planner omits these from the map by design,
+                    // but stay defensive — skip rather than crash.
+                    continue;
+                }
+                if (!perFileReconTargets.TryGetValue(fileName, out var list))
+                {
+                    list = new List<(int, double, double, double)>();
+                    perFileReconTargets[fileName] = list;
+                }
+                list.Add((idx, apex, start, end));
+                totalReconciliation++;
+            }
+
+            // file_name -> input_files index. Used to pick the right mzML
+            // path for spectra cache load + sibling .calibration.json.
+            // For the worker, config.InputFiles was synthesized from
+            // --input-scores parquet stems by Program.Main; for in-process,
+            // it's the user's -i mzML list. Either way the stem matches
+            // the file_name keys in perFileEntries.
+            var fileNameToIdx = new Dictionary<string, int>();
+            for (int i = 0; i < config.InputFiles.Count; i++)
+                fileNameToIdx[Path.GetFileNameWithoutExtension(config.InputFiles[i])] = i;
+
+            int totalRescored = 0;
+            int nTotalFiles = perFileEntries.Count;
+
+            for (int fileNum = 0; fileNum < nTotalFiles; fileNum++)
+            {
+                var fileName = perFileEntries[fileNum].Key;
+                var fdrEntries = perFileEntries[fileNum].Value;
+
+                IReadOnlyList<(int Index, double Apex, double Start, double End)> consensusTargets;
+                if (!perFileConsensusTargets.TryGetValue(fileName, out consensusTargets))
+                    consensusTargets = new List<(int, double, double, double)>();
+
+                List<(int Index, double Apex, double Start, double End)> reconTargets;
+                if (!perFileReconTargets.TryGetValue(fileName, out reconTargets))
+                    reconTargets = new List<(int, double, double, double)>();
+
+                // PHASE 2 (gap-fill): per-file gap-fill targets land here.
+                List<GapFillTarget> gapFillTargets;
+                if (perFileGapFill == null ||
+                    !perFileGapFill.TryGetValue(fileName, out gapFillTargets))
+                {
+                    gapFillTargets = new List<GapFillTarget>();
+                }
+
+                // Merge consensus + reconciliation into a per-(idx, override)
+                // map. Reconciliation wins on conflict — the inter-replicate
+                // peak boundary is more authoritative than the multi-charge
+                // consensus boundary.
+                var combinedTargets =
+                    new Dictionary<int, (double Apex, double Start, double End)>();
+                foreach (var t in consensusTargets)
+                    combinedTargets[t.Index] = (t.Apex, t.Start, t.End);
+                foreach (var t in reconTargets)
+                    combinedTargets[t.Index] = (t.Apex, t.Start, t.End);
+
+                // Skip files with no work to do.
+                if (combinedTargets.Count == 0 && gapFillTargets.Count == 0)
+                    continue;
+
+                if (!fileNameToIdx.TryGetValue(fileName, out int inputIdx))
+                {
+                    LogWarning(string.Format(
+                        "Stage 6 rescore: no input_files entry for {0} (skipping)", fileName));
+                    continue;
+                }
+                string inputFile = config.InputFiles[inputIdx];
+
+                LogInfo(string.Format(
+                    "Re-scoring file {0}/{1}: {2}", fileNum + 1, nTotalFiles, fileName));
+                LogInfo(string.Format(
+                    "  {0} entries ({1} consensus, {2} reconciliation, {3} gap-fill, {4} unique after dedup)",
+                    combinedTargets.Count + gapFillTargets.Count * 2,
+                    consensusTargets.Count,
+                    reconTargets.Count,
+                    gapFillTargets.Count,
+                    combinedTargets.Count));
+
+                // Build boundary_overrides keyed by entry_id + entry_id->idx
+                // map for the post-scoring overlay step. Also collect the
+                // subset of library ids the search engine needs to score.
+                var boundaryOverrides = new Dictionary<uint, (double Apex, double Start, double End)>();
+                var entryIdToIdx = new Dictionary<uint, int>();
+                var subsetIds = new HashSet<uint>();
+                foreach (var kvp in combinedTargets)
+                {
+                    int idx = kvp.Key;
+                    uint entryId = fdrEntries[idx].EntryId;
+                    boundaryOverrides[entryId] = kvp.Value;
+                    entryIdToIdx[entryId] = idx;
+                    subsetIds.Add(entryId);
+                }
+
+                // Build the subset library for re-scoring. The same library
+                // entries the original Stage 1-4 scoring used; we just hand
+                // RunCoelutionScoring a smaller list so it doesn't waste
+                // work on entries we're not re-scoring.
+                List<LibraryEntry> subsetLibrary;
+                if (subsetIds.Count == 0)
+                {
+                    subsetLibrary = new List<LibraryEntry>();
+                }
+                else
+                {
+                    subsetLibrary = new List<LibraryEntry>(subsetIds.Count);
+                    foreach (var libEntry in fullLibrary)
+                    {
+                        if (subsetIds.Contains(libEntry.Id))
+                            subsetLibrary.Add(libEntry);
+                    }
+                }
+
+                // Load spectra: prefer the .spectra.bin cache the original
+                // Stage 1 wrote; fall back to mzML if the cache is missing
+                // or unreadable.
+                List<Spectrum> spectra;
+                List<MS1Spectrum> ms1Spectra;
+                LoadSpectraForRescore(inputFile, fileName, out spectra, out ms1Spectra);
+
+                // Load the sibling .calibration.json so the search uses the
+                // same MS2/MS1 mass calibrations the original Stage 1-4 run
+                // used. The file is written by the original ProcessFile call
+                // and read here — same disk-roundtrip path the worker uses.
+                LoadMassCalibrations(inputFile,
+                    out MzCalibrationResult ms2Cal,
+                    out MzCalibrationResult ms1Cal);
+
+                // Pick the RT calibration: refined (from Stage 6 planning's
+                // calibration refit) wins; original first-pass falls back.
+                if (!refinedCalibrations.TryGetValue(fileName, out RTCalibration rtCal))
+                    perFileCalibrations.TryGetValue(fileName, out rtCal);
+
+                // Build the scoring context with the boundary overrides.
+                // RunCoelutionScoring inspects context.BoundaryOverrides
+                // inside ScoreCandidate and routes through the override
+                // peak-construction path.
+                var context = new ScoringContext(config, fileName);
+                context.BoundaryOverrides = boundaryOverrides;
+
+                // Build isolation windows from the loaded spectra (same as
+                // the first-pass ProcessFile path).
+                var isolationWindows = ExtractIsolationWindows(spectra);
+
+                // Re-score the subset.
+                var swRescore = Stopwatch.StartNew();
+                List<FdrEntry> rescored;
+                if (subsetLibrary.Count > 0)
+                {
+                    rescored = RunCoelutionScoring(
+                        subsetLibrary, spectra, ms1Spectra,
+                        isolationWindows, rtCal,
+                        ms2Cal, ms1Cal,
+                        context);
+                }
+                else
+                {
+                    rescored = new List<FdrEntry>();
+                }
+                swRescore.Stop();
+
+                // Overlay re-scored entries back onto fdr_entries by
+                // entry_id. Preserve the original ParquetIndex so the
+                // future write-back step can target the right Parquet row
+                // (post-compaction Vec position != Parquet row index).
+                int nOverlay = 0;
+                foreach (var entry in rescored)
+                {
+                    if (entryIdToIdx.TryGetValue(entry.EntryId, out int idx))
+                    {
+                        entry.ParquetIndex = fdrEntries[idx].ParquetIndex;
+                        fdrEntries[idx] = entry;
+                        nOverlay++;
+                    }
+                }
+                totalRescored += nOverlay;
+
+                LogInfo(string.Format(
+                    "  {0} of {1} existing entries re-scored ({2:F1}s)",
+                    nOverlay, combinedTargets.Count, swRescore.Elapsed.TotalSeconds));
+
+                // PHASE 2 (gap-fill) and PHASE 3 (parquet write-back) are
+                // the next steps in the C# port. The Rust side has both at
+                // pipeline.rs:2924-3110.
+            }
+
+            return new RescoreStats
+            {
+                TotalRescored = totalRescored,
+                TotalReconciliation = totalReconciliation,
+                TotalGapCwt = 0,
+                TotalGapForced = 0,
+            };
+        }
+
+        /// <summary>
+        /// Load MS2 spectra + MS1 spectra for the rescore loop. Prefers the
+        /// .spectra.bin cache the original Stage 1 wrote; falls back to
+        /// re-parsing the mzML on cache miss / read error. Mirrors the
+        /// Rust spectra-load block at pipeline.rs:2851-2872.
+        /// </summary>
+        private void LoadSpectraForRescore(string inputFile, string fileName,
+            out List<Spectrum> spectra, out List<MS1Spectrum> ms1Spectra)
+        {
+            string cachePath = SpectraCache.GetCachePath(inputFile);
+            if (File.Exists(cachePath))
+            {
+                try
+                {
+                    var result = SpectraCache.LoadSpectraCache(cachePath);
+                    spectra = result.Ms2Spectra;
+                    ms1Spectra = result.Ms1Spectra;
+                    LogInfo(string.Format(
+                        "  Loaded {0} MS2 + {1} MS1 spectra from cache for {2}",
+                        spectra.Count, ms1Spectra.Count, fileName));
+                    return;
+                }
+                catch (Exception ex)
+                {
+                    LogWarning(string.Format(
+                        "Failed to load spectra cache {0}: {1}; falling back to mzML",
+                        cachePath, ex.Message));
+                }
+            }
+            var fresh = MzmlReader.LoadAllSpectra(inputFile);
+            spectra = fresh.Ms2Spectra;
+            ms1Spectra = fresh.Ms1Spectra;
+            LogInfo(string.Format(
+                "  Loaded {0} MS2 + {1} MS1 spectra from mzML for {2}",
+                spectra.Count, ms1Spectra.Count, fileName));
+        }
+
+        /// <summary>
+        /// Load MS2 + MS1 mass calibrations from the sibling
+        /// .calibration.json that the original Stage 2 wrote. Returns
+        /// uncalibrated results if the file is missing or the relevant
+        /// section is absent. Mirrors the Rust load_calibration block at
+        /// pipeline.rs:2893-2900 + the ms2/ms1 unpacking the in-process
+        /// AnalysisPipeline does at lines 1154-1183.
+        /// </summary>
+        private void LoadMassCalibrations(string inputFile,
+            out MzCalibrationResult ms2Cal, out MzCalibrationResult ms1Cal)
+        {
+            ms2Cal = MzCalibrationResult.Uncalibrated();
+            ms1Cal = MzCalibrationResult.Uncalibrated();
+
+            string parent = Path.GetDirectoryName(Path.GetFullPath(inputFile));
+            if (string.IsNullOrEmpty(parent))
+                return;
+            string calPath = CalibrationIO.CalibrationPathForInput(inputFile, parent);
+            if (!File.Exists(calPath))
+                return;
+
+            CalibrationParams calParams;
+            try
+            {
+                calParams = CalibrationIO.LoadCalibration(calPath);
+            }
+            catch (Exception ex)
+            {
+                LogWarning(string.Format(
+                    "Failed to load calibration JSON {0}: {1}", calPath, ex.Message));
+                return;
+            }
+
+            if (calParams.Ms2Calibration != null && calParams.Ms2Calibration.Calibrated)
+            {
+                ms2Cal = new MzCalibrationResult
+                {
+                    Mean = calParams.Ms2Calibration.Mean,
+                    Median = calParams.Ms2Calibration.Median,
+                    SD = calParams.Ms2Calibration.SD,
+                    Count = calParams.Ms2Calibration.Count,
+                    Unit = calParams.Ms2Calibration.Unit,
+                    AdjustedTolerance = calParams.Ms2Calibration.AdjustedTolerance,
+                    Calibrated = true
+                };
+            }
+            if (calParams.Ms1Calibration != null && calParams.Ms1Calibration.Calibrated)
+            {
+                ms1Cal = new MzCalibrationResult
+                {
+                    Mean = calParams.Ms1Calibration.Mean,
+                    Median = calParams.Ms1Calibration.Median,
+                    SD = calParams.Ms1Calibration.SD,
+                    Count = calParams.Ms1Calibration.Count,
+                    Unit = calParams.Ms1Calibration.Unit,
+                    AdjustedTolerance = calParams.Ms1Calibration.AdjustedTolerance,
+                    Calibrated = true
+                };
+            }
+        }
+    }
+}

--- a/pwiz_tools/OspreySharp/OspreySharp/AnalysisPipeline.Stage6Rescore.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/AnalysisPipeline.Stage6Rescore.cs
@@ -269,6 +269,16 @@ namespace pwiz.OspreySharp
                 "Stage 6 rescore: {0} entries re-scored ({1} reconciliation actions executed)",
                 stats.TotalRescored, stats.TotalReconciliation));
 
+            // Cross-impl bisection seam: dump per-precursor state
+            // immediately after the rescore loop. Mirrors Rust's
+            // dump_stage6_rescored call from rescore::run_rescore.
+            if (OspreyDiagnostics.DumpRescored)
+            {
+                OspreyDiagnostics.WriteStage6RescoredDump(inputs.PerFileEntries);
+                if (OspreyDiagnostics.RescoredOnly)
+                    OspreyDiagnostics.ExitAfterDump(@"OSPREY_RESCORED_ONLY");
+            }
+
             // Phase 1 success: in-memory state matches what the in-process
             // pipeline holds at the same seam. Phases 2 (gap-fill) and
             // 3 (parquet write-back) are the next steps; until then, the
@@ -415,6 +425,8 @@ namespace pwiz.OspreySharp
                 fileNameToIdx[Path.GetFileNameWithoutExtension(config.InputFiles[i])] = i;
 
             int totalRescored = 0;
+            int totalGapCwt = 0;
+            int totalGapForced = 0;
             int nTotalFiles = perFileEntries.Count;
 
             for (int fileNum = 0; fileNum < nTotalFiles; fileNum++)
@@ -557,11 +569,28 @@ namespace pwiz.OspreySharp
                 // entry_id. Preserve the original ParquetIndex so the
                 // future write-back step can target the right Parquet row
                 // (post-compaction Vec position != Parquet row index).
+                //
+                // Mirror Rust's to_fdr_entry semantics: post-rescore stubs
+                // carry default Score (0.0), q-values (1.0), and Pep
+                // (1.0). Percolator (Stage 7, second-pass FDR) recomputes
+                // these from the new Features. Without this reset the
+                // OspreySharp ScoreCandidate's `Score = coelutionSum`
+                // initializer (AnalysisPipeline.cs ~line 4088) bleeds
+                // through, producing 173k rows of post-rescore divergence
+                // vs the Rust worker's rust_stage6_rescored.tsv.
                 int nOverlay = 0;
                 foreach (var entry in rescored)
                 {
                     if (entryIdToIdx.TryGetValue(entry.EntryId, out int idx))
                     {
+                        entry.Score = 0.0;
+                        entry.RunPrecursorQvalue = 1.0;
+                        entry.RunPeptideQvalue = 1.0;
+                        entry.RunProteinQvalue = 1.0;
+                        entry.ExperimentPrecursorQvalue = 1.0;
+                        entry.ExperimentPeptideQvalue = 1.0;
+                        entry.ExperimentProteinQvalue = 1.0;
+                        entry.Pep = 1.0;
                         entry.ParquetIndex = fdrEntries[idx].ParquetIndex;
                         fdrEntries[idx] = entry;
                         nOverlay++;
@@ -573,17 +602,177 @@ namespace pwiz.OspreySharp
                     "  {0} of {1} existing entries re-scored ({2:F1}s)",
                     nOverlay, combinedTargets.Count, swRescore.Elapsed.TotalSeconds));
 
-                // PHASE 2 (gap-fill) and PHASE 3 (parquet write-back) are
-                // the next steps in the C# port. The Rust side has both at
-                // pipeline.rs:2924-3110.
+                // PHASE 2 — gap-fill two-pass.
+                //
+                // For each gap-fill target the planner identified (peptides
+                // confidently identified in sibling replicates but missing
+                // here), score both the TARGET and the paired DECOY against
+                // the spectra at the consensus RT. Two-pass strategy:
+                //
+                //   Pass 1 — CWT: PrefilterEnabled=false, no boundary
+                //   overrides. Lets CWT peak detection find a natural peak
+                //   inside the rt-tolerance window around the consensus RT.
+                //   Catches the easy gap-fills where there's a real peak we
+                //   just missed in Stage 4.
+                //
+                //   Pass 2 — Forced: for entries CWT didn't find, force an
+                //   integration window at expected_rt +- half_width via
+                //   boundary overrides. Catches the hard gap-fills where
+                //   no peak rises above CWT's threshold but we want to
+                //   integrate at the expected RT for quantification.
+                //
+                // Both passes append new FdrEntry stubs to fdr_entries with
+                // ParquetIndex = uint.MaxValue (the gap-fill sentinel).
+                // Phase 3 (parquet write-back) reassigns the sentinel to a
+                // real row index as the entries are appended to the per-file
+                // .scores.parquet. Mirrors the Rust gap-fill block at
+                // pipeline.rs:2924-3014.
+                int nGapCwt = 0;
+                int nGapForced = 0;
+                if (gapFillTargets.Count > 0)
+                {
+                    // Build target+decoy id set from gap_fill_targets.
+                    var gapFillIds = new HashSet<uint>();
+                    foreach (var gf in gapFillTargets)
+                    {
+                        gapFillIds.Add(gf.TargetEntryId);
+                        gapFillIds.Add(gf.DecoyEntryId);
+                    }
+                    var gapFillLibrary = new List<LibraryEntry>(gapFillIds.Count);
+                    foreach (var libEntry in fullLibrary)
+                    {
+                        if (gapFillIds.Contains(libEntry.Id))
+                            gapFillLibrary.Add(libEntry);
+                    }
+
+                    HashSet<uint> cwtHitIds;
+                    if (gapFillLibrary.Count > 0)
+                    {
+                        // Pass 1: CWT pass with prefilter disabled. Clone
+                        // config so the disable doesn't bleed into other
+                        // files (OspreyConfig.ShallowClone gives us a new
+                        // instance whose mutations are local to this file).
+                        var cwtConfig = config.ShallowClone();
+                        cwtConfig.PrefilterEnabled = false;
+                        var cwtContext = new ScoringContext(cwtConfig, fileName);
+                        // No BoundaryOverrides — CWT picks peaks freely.
+
+                        var swCwt = Stopwatch.StartNew();
+                        var cwtResults = RunCoelutionScoring(
+                            gapFillLibrary, spectra, ms1Spectra,
+                            isolationWindows, rtCal,
+                            ms2Cal, ms1Cal,
+                            cwtContext);
+                        swCwt.Stop();
+
+                        cwtHitIds = new HashSet<uint>();
+                        foreach (var entry in cwtResults)
+                            cwtHitIds.Add(entry.EntryId);
+                        nGapCwt = cwtResults.Count;
+
+                        // Append CWT results as new FdrEntry stubs with the
+                        // gap-fill sentinel + score-reset (mirroring Rust
+                        // to_fdr_entry semantics for new stubs).
+                        foreach (var entry in cwtResults)
+                        {
+                            entry.ParquetIndex = uint.MaxValue;
+                            entry.Score = 0.0;
+                            entry.RunPrecursorQvalue = 1.0;
+                            entry.RunPeptideQvalue = 1.0;
+                            entry.RunProteinQvalue = 1.0;
+                            entry.ExperimentPrecursorQvalue = 1.0;
+                            entry.ExperimentPeptideQvalue = 1.0;
+                            entry.ExperimentProteinQvalue = 1.0;
+                            entry.Pep = 1.0;
+                            fdrEntries.Add(entry);
+                        }
+
+                        LogInfo(string.Format(
+                            "  Gap-fill CWT: {0} hits ({1:F1}s)",
+                            nGapCwt, swCwt.Elapsed.TotalSeconds));
+                    }
+                    else
+                    {
+                        cwtHitIds = new HashSet<uint>();
+                    }
+
+                    // Pass 2: Forced integration for entries CWT missed.
+                    // For each gap-fill target, check both the target_id
+                    // and decoy_id; either or both may have missed the CWT
+                    // pass.
+                    var forcedOverrides = new Dictionary<uint, (double Apex, double Start, double End)>();
+                    var forcedIds = new HashSet<uint>();
+                    foreach (var gf in gapFillTargets)
+                    {
+                        double start = gf.ExpectedRt - gf.HalfWidth;
+                        double end = gf.ExpectedRt + gf.HalfWidth;
+                        if (!cwtHitIds.Contains(gf.TargetEntryId))
+                        {
+                            forcedOverrides[gf.TargetEntryId] = (gf.ExpectedRt, start, end);
+                            forcedIds.Add(gf.TargetEntryId);
+                        }
+                        if (!cwtHitIds.Contains(gf.DecoyEntryId))
+                        {
+                            forcedOverrides[gf.DecoyEntryId] = (gf.ExpectedRt, start, end);
+                            forcedIds.Add(gf.DecoyEntryId);
+                        }
+                    }
+
+                    if (forcedOverrides.Count > 0)
+                    {
+                        var forcedLibrary = new List<LibraryEntry>(forcedIds.Count);
+                        foreach (var libEntry in gapFillLibrary)
+                        {
+                            if (forcedIds.Contains(libEntry.Id))
+                                forcedLibrary.Add(libEntry);
+                        }
+
+                        var forcedContext = new ScoringContext(config, fileName);
+                        forcedContext.BoundaryOverrides = forcedOverrides;
+
+                        var swForced = Stopwatch.StartNew();
+                        var forcedResults = RunCoelutionScoring(
+                            forcedLibrary, spectra, ms1Spectra,
+                            isolationWindows, rtCal,
+                            ms2Cal, ms1Cal,
+                            forcedContext);
+                        swForced.Stop();
+                        nGapForced = forcedResults.Count;
+
+                        foreach (var entry in forcedResults)
+                        {
+                            entry.ParquetIndex = uint.MaxValue;
+                            entry.Score = 0.0;
+                            entry.RunPrecursorQvalue = 1.0;
+                            entry.RunPeptideQvalue = 1.0;
+                            entry.RunProteinQvalue = 1.0;
+                            entry.ExperimentPrecursorQvalue = 1.0;
+                            entry.ExperimentPeptideQvalue = 1.0;
+                            entry.ExperimentProteinQvalue = 1.0;
+                            entry.Pep = 1.0;
+                            fdrEntries.Add(entry);
+                        }
+
+                        LogInfo(string.Format(
+                            "  Gap-fill forced: {0} integrated ({1:F1}s)",
+                            nGapForced, swForced.Elapsed.TotalSeconds));
+                    }
+
+                    totalGapCwt += nGapCwt;
+                    totalGapForced += nGapForced;
+                    totalRescored += nGapCwt + nGapForced;
+                }
+
+                // PHASE 3 (reconciled parquet write-back) is the next step.
+                // Rust does this at pipeline.rs:3050-3110.
             }
 
             return new RescoreStats
             {
                 TotalRescored = totalRescored,
                 TotalReconciliation = totalReconciliation,
-                TotalGapCwt = 0,
-                TotalGapForced = 0,
+                TotalGapCwt = totalGapCwt,
+                TotalGapForced = totalGapForced,
             };
         }
 

--- a/pwiz_tools/OspreySharp/OspreySharp/AnalysisPipeline.Stage6Rescore.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/AnalysisPipeline.Stage6Rescore.cs
@@ -241,9 +241,22 @@ namespace pwiz.OspreySharp
                 "Worker original calibrations: {0}/{1} files loaded",
                 perFileCalibrations.Count, inputs.PerFileEntries.Count));
 
-            // PHASE 1 dispatch: existing-entry rescore (consensus +
-            // reconciliation overlay) only. Phases 2 (gap-fill) and 3
-            // (parquet write-back) land in subsequent commits.
+            // Per-file parquet paths from --input-scores. Stage 6
+            // write-back rewrites these in place with reconciliation
+            // metadata, mirroring how Rust's worker uses
+            // per_file_cache_paths.
+            var perFileParquetPaths = new Dictionary<string, string>();
+            for (int i = 0; i < config.InputScores.Count; i++)
+            {
+                string parquetPath = config.InputScores[i];
+                string fileName = RescoreHydration.SyntheticInputFromParquet(parquetPath);
+                fileName = Path.GetFileNameWithoutExtension(fileName);
+                if (!string.IsNullOrEmpty(fileName))
+                    perFileParquetPaths[fileName] = parquetPath;
+            }
+
+            // Phases 1 + 2 + 3 of the rescore engine. Phase 3 rewrites
+            // each per-file .scores.parquet with reconciliation metadata.
             RescoreStats stats;
             try
             {
@@ -254,6 +267,7 @@ namespace pwiz.OspreySharp
                     inputs.RefinedCalibrations,
                     perFileCalibrations,
                     inputs.PerFileGapFill,
+                    perFileParquetPaths,
                     fullLibrary,
                     config);
             }
@@ -266,8 +280,10 @@ namespace pwiz.OspreySharp
             }
 
             Program.LogInfo(string.Format(
-                "Stage 6 rescore: {0} entries re-scored ({1} reconciliation actions executed)",
-                stats.TotalRescored, stats.TotalReconciliation));
+                "Stage 6 rescore: {0} entries re-scored ({1} reconciliation actions, " +
+                "{2} gap-fill via CWT, {3} gap-fill via forced)",
+                stats.TotalRescored, stats.TotalReconciliation,
+                stats.TotalGapCwt, stats.TotalGapForced));
 
             // Cross-impl bisection seam: dump per-precursor state
             // immediately after the rescore loop. Mirrors Rust's
@@ -279,18 +295,23 @@ namespace pwiz.OspreySharp
                     OspreyDiagnostics.ExitAfterDump(@"OSPREY_RESCORED_ONLY");
             }
 
-            // Phase 1 success: in-memory state matches what the in-process
-            // pipeline holds at the same seam. Phases 2 (gap-fill) and
-            // 3 (parquet write-back) are the next steps; until then, the
-            // worker can't produce reconciled .scores.parquet output, so
-            // exit non-zero with a pointer rather than letting downstream
-            // consumers see stale Stage 4 parquets.
-            Program.LogError(
-                "--join-at-pass=1 --no-join: PHASE 1 (consensus + reconciliation rescore) " +
-                "completed cleanly. Phases 2 (gap-fill) and 3 (reconciled parquet write-back) " +
-                "are not yet ported; the worker has not written reconciled .scores.parquet " +
-                "output. Both will land in subsequent commits.");
-            return 2;
+            // Flush the median-polish inputs dump (no-op when
+            // OSPREY_DUMP_MP_INPUTS is unset).
+            OspreyDiagnostics.CloseMpInputsDump();
+
+            // Flush the predict() inputs/outputs dump (no-op when
+            // OSPREY_DUMP_PREDICT_RT is unset).
+            OspreyDiagnostics.ClosePredictRtDump();
+
+            // Flush the CWT path summary dump (no-op when
+            // OSPREY_DUMP_CWT_PATH is unset).
+            OspreyDiagnostics.CloseCwtPathDump();
+
+            Program.LogInfo(
+                "--join-at-pass=1 --no-join: rescore complete. Reconciled .scores.parquet " +
+                "files written. (C# parity gap: fragment_mzs / fragment_intensities / " +
+                "ref_xic_* / bounds_area / bounds_snr columns null, tracked for follow-up.)");
+            return 0;
         }
 
         /// <summary>
@@ -305,6 +326,130 @@ namespace pwiz.OspreySharp
         {
             if (value != null)
                 dict[key] = value;
+        }
+
+        /// <summary>
+        /// Phase 3 — write the reconciled per-file <c>.scores.parquet</c>.
+        ///
+        /// Reload the original Stage 4 parquet's full per-row data
+        /// (identity, boundaries, 21 PIN features, CWT candidate lists),
+        /// replace re-scored rows in place by <see cref="FdrEntry.ParquetIndex"/>
+        /// (NOT by post-compaction Vec position; the two diverge after
+        /// first-pass FDR drops non-passing entries), append gap-fill
+        /// rows at the end, reassign each gap-fill stub's
+        /// <see cref="FdrEntry.ParquetIndex"/> to the actual row it now
+        /// occupies, then write back via
+        /// <see cref="ParquetScoreCache.WriteScoresParquet(string, List{FdrEntry}, Dictionary{string, string}, Dictionary{uint, LibraryEntry}, string)"/>
+        /// with reconciliation metadata
+        /// (<c>osprey.reconciled = "true"</c> +
+        /// <c>osprey.reconciliation_hash = config.ReconciliationParameterHash()</c>).
+        /// Mirrors Rust pipeline.rs:3050-3110.
+        ///
+        /// Known C# parity gap (tracked for follow-up): the binary blob
+        /// columns <c>fragment_mzs</c>, <c>fragment_intensities</c>,
+        /// <c>reference_xic_rts</c>, <c>reference_xic_intensities</c>,
+        /// plus <c>bounds_area</c> and <c>bounds_snr</c>, are NOT carried
+        /// through by <see cref="FdrEntry"/> today and the
+        /// WriteScoresParquet FdrEntry overload writes them as null/zero.
+        /// Rust's reconciled parquet has them populated. End-of-Stage-6
+        /// byte-parity will report a diff on these columns until the C#
+        /// scoring path is extended to populate them.
+        /// </summary>
+        private void WriteReconciledParquet(string parquetPath, List<FdrEntry> fdrEntries,
+            string fileName, List<LibraryEntry> fullLibrary, OspreyConfig config)
+        {
+            // 1. Reload the original parquet's per-row state.
+            List<FdrEntry> fullEntries;
+            try
+            {
+                fullEntries = ParquetScoreCache.LoadFullFdrEntries(parquetPath);
+            }
+            catch (Exception ex)
+            {
+                LogWarning(string.Format(
+                    "Stage 6 write-back: failed to reload {0}: {1} (skipping)",
+                    parquetPath, ex.Message));
+                return;
+            }
+            int origRowCount = fullEntries.Count;
+
+            // 2. Replace re-scored rows (Phase 1 + Phase 2 existing-entry
+            //    overlay) by ParquetIndex. Detect rescored entries by
+            //    Features != null — hydration's LoadFdrStubsFromParquet
+            //    does NOT populate Features, so unchanged post-compaction
+            //    stubs have Features=null and we leave their corresponding
+            //    fullEntries row alone (preserving Features + CwtCandidates
+            //    + the binary blob columns loaded from the original
+            //    parquet). Rescored entries have Features populated by
+            //    RunCoelutionScoring. Gap-fill stubs have ParquetIndex =
+            //    uint.MaxValue and are appended next.
+            int nReplaced = 0;
+            foreach (var entry in fdrEntries)
+            {
+                if (entry.ParquetIndex == uint.MaxValue)
+                    continue;
+                if (entry.Features == null)
+                    continue;  // hydrated stub, never re-scored
+                int pqIdx = (int)entry.ParquetIndex;
+                if (pqIdx < 0 || pqIdx >= fullEntries.Count)
+                {
+                    LogWarning(string.Format(
+                        "Stage 6 write-back: ParquetIndex {0} out of range for {1} ({2} rows)",
+                        pqIdx, fileName, fullEntries.Count));
+                    continue;
+                }
+                fullEntries[pqIdx] = entry;
+                nReplaced++;
+            }
+
+            // 3. Append gap-fill rows at the end. Reassign each gap-fill
+            //    stub's ParquetIndex to its new row position so a
+            //    downstream --join-at-pass=2 worker can locate its
+            //    features.
+            int nAppended = 0;
+            foreach (var entry in fdrEntries)
+            {
+                if (entry.ParquetIndex != uint.MaxValue)
+                    continue;
+                entry.ParquetIndex = (uint)fullEntries.Count;
+                fullEntries.Add(entry);
+                nAppended++;
+            }
+
+            // 4. Build libraryById for the WriteScoresParquet sequence /
+            //    precursor_mz / protein_ids columns.
+            var libraryById = new Dictionary<uint, LibraryEntry>(fullLibrary.Count);
+            foreach (var libEntry in fullLibrary)
+                libraryById[libEntry.Id] = libEntry;
+
+            // 5. Reconciliation metadata (mirrors Rust
+            //    build_reconciled_metadata). osprey.version is what the
+            //    next reload's CacheValidity check compares against.
+            var metadata = new Dictionary<string, string>
+            {
+                { @"osprey.version", Program.VERSION },
+                { @"osprey.search_hash", config.SearchParameterHash() },
+                { @"osprey.library_hash", config.LibraryIdentityHash() },
+                { @"osprey.reconciled", @"true" },
+                { @"osprey.reconciliation_hash", config.ReconciliationParameterHash() },
+            };
+
+            try
+            {
+                ParquetScoreCache.WriteScoresParquet(parquetPath, fullEntries,
+                    metadata, libraryById, fileName);
+            }
+            catch (Exception ex)
+            {
+                LogWarning(string.Format(
+                    "Stage 6 write-back: failed to write reconciled scores for {0}: {1}",
+                    fileName, ex.Message));
+                return;
+            }
+
+            LogInfo(string.Format(
+                "  Wrote reconciled parquet for {0}: {1} rows ({2} replaced + {3} appended; original {4} rows)",
+                fileName, fullEntries.Count, nReplaced, nAppended, origRowCount));
         }
 
         /// <summary>
@@ -372,6 +517,7 @@ namespace pwiz.OspreySharp
             IReadOnlyDictionary<string, RTCalibration> refinedCalibrations,
             IReadOnlyDictionary<string, RTCalibration> perFileCalibrations,
             IReadOnlyDictionary<string, List<GapFillTarget>> perFileGapFill,
+            IReadOnlyDictionary<string, string> perFileParquetPaths,
             List<LibraryEntry> fullLibrary,
             OspreyConfig config)
         {
@@ -530,12 +676,31 @@ namespace pwiz.OspreySharp
                 // and read here — same disk-roundtrip path the worker uses.
                 LoadMassCalibrations(inputFile,
                     out MzCalibrationResult ms2Cal,
-                    out MzCalibrationResult ms1Cal);
+                    out MzCalibrationResult ms1Cal,
+                    out double? rtMadFromCalJson);
 
                 // Pick the RT calibration: refined (from Stage 6 planning's
                 // calibration refit) wins; original first-pass falls back.
                 if (!refinedCalibrations.TryGetValue(fileName, out RTCalibration rtCal))
                     perFileCalibrations.TryGetValue(fileName, out rtCal);
+
+                // Set the original .calibration.json MAD on the scoring
+                // context so RunCoelutionScoring picks it up for the
+                // rt_tolerance derivation. Mirrors Rust run_search at
+                // pipeline.rs:6776-6815, which reads
+                // `cal_params.rt_calibration.mad` (the first-pass MAD)
+                // -- not the refined cal's stats MAD, which would give
+                // a much smaller (and hence MinRtTolerance-clamped)
+                // tolerance and produce divergent windows.
+
+                // Bisection seam: dump the cal's library_rts +
+                // fitted_values once per file. Mirrors Rust's
+                // dump_predict_rt_arrays at pipeline.rs ~2886.
+                if (rtCal != null)
+                {
+                    OspreyDiagnostics.WritePredictRtArrays(
+                        fileName, rtCal.LibraryRts, rtCal.FittedValues);
+                }
 
                 // Build the scoring context with the boundary overrides.
                 // RunCoelutionScoring inspects context.BoundaryOverrides
@@ -543,6 +708,7 @@ namespace pwiz.OspreySharp
                 // peak-construction path.
                 var context = new ScoringContext(config, fileName);
                 context.BoundaryOverrides = boundaryOverrides;
+                context.OriginalRtMad = rtMadFromCalJson;
 
                 // Build isolation windows from the loaded spectra (same as
                 // the first-pass ProcessFile path).
@@ -655,6 +821,7 @@ namespace pwiz.OspreySharp
                         var cwtConfig = config.ShallowClone();
                         cwtConfig.PrefilterEnabled = false;
                         var cwtContext = new ScoringContext(cwtConfig, fileName);
+                        cwtContext.OriginalRtMad = rtMadFromCalJson;
                         // No BoundaryOverrides — CWT picks peaks freely.
 
                         var swCwt = Stopwatch.StartNew();
@@ -729,6 +896,7 @@ namespace pwiz.OspreySharp
 
                         var forcedContext = new ScoringContext(config, fileName);
                         forcedContext.BoundaryOverrides = forcedOverrides;
+                        forcedContext.OriginalRtMad = rtMadFromCalJson;
 
                         var swForced = Stopwatch.StartNew();
                         var forcedResults = RunCoelutionScoring(
@@ -763,8 +931,23 @@ namespace pwiz.OspreySharp
                     totalRescored += nGapCwt + nGapForced;
                 }
 
-                // PHASE 3 (reconciled parquet write-back) is the next step.
-                // Rust does this at pipeline.rs:3050-3110.
+                // PHASE 3 — reconciled parquet write-back.
+                //
+                // Reload the original Stage 4 parquet, replace re-scored
+                // rows by ParquetIndex (NOT vec position; post-compaction
+                // Vec position diverges from Parquet row), append gap-fill
+                // rows, reassign each gap-fill stub's ParquetIndex to its
+                // actual new row in the rewritten parquet, and write the
+                // merged list back with reconciliation metadata
+                // (osprey.reconciled = "true" + osprey.reconciliation_hash).
+                // Mirrors Rust pipeline.rs:3050-3110.
+                if (perFileParquetPaths != null &&
+                    perFileParquetPaths.TryGetValue(fileName, out string parquetPath) &&
+                    File.Exists(parquetPath))
+                {
+                    WriteReconciledParquet(parquetPath, fdrEntries, fileName,
+                        fullLibrary, config);
+                }
             }
 
             return new RescoreStats
@@ -814,18 +997,30 @@ namespace pwiz.OspreySharp
         }
 
         /// <summary>
-        /// Load MS2 + MS1 mass calibrations from the sibling
-        /// .calibration.json that the original Stage 2 wrote. Returns
-        /// uncalibrated results if the file is missing or the relevant
-        /// section is absent. Mirrors the Rust load_calibration block at
-        /// pipeline.rs:2893-2900 + the ms2/ms1 unpacking the in-process
-        /// AnalysisPipeline does at lines 1154-1183.
+        /// Load MS2 + MS1 mass calibrations and the original Stage-4 RT
+        /// calibration MAD from the sibling .calibration.json that
+        /// Stage 2 wrote. Returns uncalibrated results / null MAD if the
+        /// file is missing or the relevant section is absent. Mirrors
+        /// the Rust load_calibration block at pipeline.rs:2893-2900 +
+        /// the ms2/ms1 unpacking the in-process AnalysisPipeline does
+        /// at lines 1154-1183.
+        ///
+        /// The <paramref name="rtMadFromCalJson"/> output carries the
+        /// original first-pass MAD of absolute residuals -- this is the
+        /// value Rust's run_search uses to derive `rt_tolerance` (see
+        /// pipeline.rs:6776-6815). It must come from the per-file
+        /// .calibration.json, NOT from the refined calibration's
+        /// abs_residuals (which post-Stage-5 LOESS refit is roughly an
+        /// order of magnitude tighter and would clamp the tolerance to
+        /// MinRtTolerance = 0.5, ~28% smaller than what Rust uses).
         /// </summary>
         private void LoadMassCalibrations(string inputFile,
-            out MzCalibrationResult ms2Cal, out MzCalibrationResult ms1Cal)
+            out MzCalibrationResult ms2Cal, out MzCalibrationResult ms1Cal,
+            out double? rtMadFromCalJson)
         {
             ms2Cal = MzCalibrationResult.Uncalibrated();
             ms1Cal = MzCalibrationResult.Uncalibrated();
+            rtMadFromCalJson = null;
 
             string parent = Path.GetDirectoryName(Path.GetFullPath(inputFile));
             if (string.IsNullOrEmpty(parent))
@@ -871,6 +1066,14 @@ namespace pwiz.OspreySharp
                     AdjustedTolerance = calParams.Ms1Calibration.AdjustedTolerance,
                     Calibrated = true
                 };
+            }
+            // The MAD is what Rust's run_search uses for rt_tolerance
+            // derivation; emit it from here (not from the refined cal's
+            // abs_residuals) so the C# rescore matches Rust's window
+            // size byte-for-byte.
+            if (calParams.RtCalibration != null && calParams.RtCalibration.MAD.HasValue)
+            {
+                rtMadFromCalJson = calParams.RtCalibration.MAD.Value;
             }
         }
     }

--- a/pwiz_tools/OspreySharp/OspreySharp/AnalysisPipeline.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/AnalysisPipeline.cs
@@ -49,7 +49,7 @@ namespace pwiz.OspreySharp
     /// 4. Protein FDR (optional)
     /// 5. Write blib output
     /// </summary>
-    public class AnalysisPipeline
+    public partial class AnalysisPipeline
     {
         private const int NUM_PIN_FEATURES = 21;
 
@@ -796,11 +796,23 @@ namespace pwiz.OspreySharp
                         return 0;
                     }
 
-                    // Per-file rescore + gap-fill + second-pass FDR are
-                    // deferred to a later commit. Without those, single-run
-                    // analysis still produces valid output from the
-                    // first-pass FDR results above.
-                    LogInfo(@"Stage 6 per-file rescore: not yet implemented");
+                    // Stage 6 per-file rescore: PHASE 1 of the C# port —
+                    // existing entries (consensus + reconciliation overlay).
+                    // Gap-fill two-pass + reconciled .scores.parquet
+                    // write-back are the next porting phases. Mirrors the
+                    // Rust call site at pipeline.rs:run_analysis ~line 3850.
+                    var rescoreStats = ExecuteStage6Rescore(
+                        perFileEntries,
+                        perFileConsensusTargets,
+                        reconciliationActions ?? new Dictionary<(string, int), ReconcileAction>(),
+                        refinedCalibrations,
+                        perFileCalibrations,
+                        perFileGapFill: null,
+                        fullLibrary,
+                        config);
+                    LogInfo(string.Format(
+                        "Stage 6 rescore: {0} entries re-scored ({1} reconciliation actions executed)",
+                        rescoreStats.TotalRescored, rescoreStats.TotalReconciliation));
                 }
 
                 // Stage 8: Protein FDR (optional)
@@ -846,7 +858,7 @@ namespace pwiz.OspreySharp
         /// Load spectral library from the configured source, using binary cache
         /// when available. Matches Rust's .libcache mechanism for fast reload.
         /// </summary>
-        private List<LibraryEntry> LoadLibrary(OspreyConfig config)
+        internal List<LibraryEntry> LoadLibrary(OspreyConfig config)
         {
             string path = config.LibrarySource.Path;
             string cachePath = path + ".libcache";
@@ -930,7 +942,7 @@ namespace pwiz.OspreySharp
         /// Modifies <paramref name="validTargets"/> to contain only targets that
         /// produced valid decoys (Rust: library = valid_targets; library.extend(decoys)).
         /// </summary>
-        private List<LibraryEntry> GenerateDecoys(
+        internal List<LibraryEntry> GenerateDecoys(
             List<LibraryEntry> targets, OspreyConfig config,
             out List<LibraryEntry> validTargets)
         {

--- a/pwiz_tools/OspreySharp/OspreySharp/AnalysisPipeline.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/AnalysisPipeline.cs
@@ -813,6 +813,16 @@ namespace pwiz.OspreySharp
                     LogInfo(string.Format(
                         "Stage 6 rescore: {0} entries re-scored ({1} reconciliation actions executed)",
                         rescoreStats.TotalRescored, rescoreStats.TotalReconciliation));
+
+                    // Cross-impl bisection seam: dump per-precursor state
+                    // immediately after the rescore loop. Mirrors Rust's
+                    // dump_stage6_rescored call from pipeline.rs.
+                    if (OspreyDiagnostics.DumpRescored)
+                    {
+                        OspreyDiagnostics.WriteStage6RescoredDump(perFileEntries);
+                        if (OspreyDiagnostics.RescoredOnly)
+                            OspreyDiagnostics.ExitAfterDump(@"OSPREY_RESCORED_ONLY");
+                    }
                 }
 
                 // Stage 8: Protein FDR (optional)

--- a/pwiz_tools/OspreySharp/OspreySharp/AnalysisPipeline.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/AnalysisPipeline.cs
@@ -4705,52 +4705,66 @@ namespace pwiz.OspreySharp
             massAccuracyMean = 0.0;
             absMassAccuracyMean = 0.0;
 
-            if (apexSpectrum.Mzs == null || apexSpectrum.Mzs.Length == 0 ||
-                candidate.Fragments == null || candidate.Fragments.Count == 0)
-                return;
-
+            // Do NOT early-return when apex spectrum or candidate fragments
+            // are empty. Rust's compute_mass_accuracy
+            // (osprey-scoring/src/lib.rs:464) handles empty inputs by
+            // returning (0.0, tolerance, tolerance) — so a candidate that
+            // reaches this function with no matchable fragments still
+            // contributes the calibrated tolerance as its abs mass error.
+            // The early-return form left absMassAccuracyMean at 0 instead,
+            // producing ~65 divergent rows on Astral (file 49: 2 rows,
+            // 55: 27 rows, 60: 36 rows). Let the matching loop run with
+            // zero iterations and fall through to the nMatched==0 fallback
+            // at the bottom of the function for cross-impl symmetry.
             double totalIntensity = 0.0;
-            for (int i = 0; i < apexSpectrum.Intensities.Length; i++)
-                totalIntensity += apexSpectrum.Intensities[i];
+            if (apexSpectrum.Intensities != null)
+            {
+                for (int i = 0; i < apexSpectrum.Intensities.Length; i++)
+                    totalIntensity += apexSpectrum.Intensities[i];
+            }
 
             double matchedIntensity = 0.0;
             double massErrSum = 0.0;
             double absMassErrSum = 0.0;
             int nMatched = 0;
 
-            foreach (var frag in candidate.Fragments)
+            if (apexSpectrum.Mzs != null && apexSpectrum.Intensities != null &&
+                candidate.Fragments != null)
             {
-                double tolDa = config.FragmentTolerance.ToleranceDa(frag.Mz);
-                double lower = frag.Mz - tolDa;
-                double upper = frag.Mz + tolDa;
-
-                int lo = BinarySearchLowerBound(apexSpectrum.Mzs, lower);
-                double bestError = double.MaxValue;
-                double bestIntensity = 0.0;
-                double bestMz = 0.0;
-                bool found = false;
-
-                // Match closest peak by m/z (not most intense).
-                // Matches Rust SpectralScorer::match_fragments in lib.rs:2239.
-                for (int k = lo; k < apexSpectrum.Mzs.Length && apexSpectrum.Mzs[k] <= upper; k++)
+                foreach (var frag in candidate.Fragments)
                 {
-                    double errorDa = Math.Abs(apexSpectrum.Mzs[k] - frag.Mz);
-                    if (errorDa < bestError)
+                    double tolDa = config.FragmentTolerance.ToleranceDa(frag.Mz);
+                    double lower = frag.Mz - tolDa;
+                    double upper = frag.Mz + tolDa;
+
+                    int lo = BinarySearchLowerBound(apexSpectrum.Mzs, lower);
+                    double bestError = double.MaxValue;
+                    double bestIntensity = 0.0;
+                    double bestMz = 0.0;
+                    bool found = false;
+
+                    // Match closest peak by m/z (not most intense).
+                    // Matches Rust SpectralScorer::match_fragments in lib.rs:2239.
+                    for (int k = lo; k < apexSpectrum.Mzs.Length && apexSpectrum.Mzs[k] <= upper; k++)
                     {
-                        bestError = errorDa;
-                        bestIntensity = apexSpectrum.Intensities[k];
-                        bestMz = apexSpectrum.Mzs[k];
-                        found = true;
+                        double errorDa = Math.Abs(apexSpectrum.Mzs[k] - frag.Mz);
+                        if (errorDa < bestError)
+                        {
+                            bestError = errorDa;
+                            bestIntensity = apexSpectrum.Intensities[k];
+                            bestMz = apexSpectrum.Mzs[k];
+                            found = true;
+                        }
                     }
-                }
 
-                if (found)
-                {
-                    matchedIntensity += bestIntensity;
-                    double err = config.FragmentTolerance.MassError(frag.Mz, bestMz);
-                    massErrSum += err;
-                    absMassErrSum += Math.Abs(err);
-                    nMatched++;
+                    if (found)
+                    {
+                        matchedIntensity += bestIntensity;
+                        double err = config.FragmentTolerance.MassError(frag.Mz, bestMz);
+                        massErrSum += err;
+                        absMassErrSum += Math.Abs(err);
+                        nMatched++;
+                    }
                 }
             }
 

--- a/pwiz_tools/OspreySharp/OspreySharp/AnalysisPipeline.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/AnalysisPipeline.cs
@@ -824,6 +824,16 @@ namespace pwiz.OspreySharp
                         if (OspreyDiagnostics.RescoredOnly)
                             OspreyDiagnostics.ExitAfterDump(@"OSPREY_RESCORED_ONLY");
                     }
+
+                    // Flush + close the persistent per-process diagnostic
+                    // dump writers (no-ops when their env vars are unset).
+                    // Mirrors the worker-mode close calls in
+                    // AnalysisPipeline.Stage6Rescore.Run; without these,
+                    // the in-process pipeline path can leave the writers
+                    // unflushed and produce truncated bisection dumps.
+                    OspreyDiagnostics.CloseMpInputsDump();
+                    OspreyDiagnostics.ClosePredictRtDump();
+                    OspreyDiagnostics.CloseCwtPathDump();
                 }
 
                 // Stage 8: Protein FDR (optional)

--- a/pwiz_tools/OspreySharp/OspreySharp/AnalysisPipeline.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/AnalysisPipeline.cs
@@ -808,6 +808,7 @@ namespace pwiz.OspreySharp
                         refinedCalibrations,
                         perFileCalibrations,
                         perFileGapFill: null,
+                        perFileParquetPaths,
                         fullLibrary,
                         config);
                     LogInfo(string.Format(
@@ -2828,13 +2829,15 @@ namespace pwiz.OspreySharp
                 }
                 else
                 {
-                    var indexed = new List<KeyValuePair<int, float>>(nFragsForErrors);
-                    for (int ti = 0; ti < nFragsForErrors; ti++)
-                        indexed.Add(new KeyValuePair<int, float>(ti, entry.Fragments[ti].RelativeIntensity));
-                    indexed.Sort((a, b) => b.Value.CompareTo(a.Value));
-                    topErrorIndices = new int[nTopForErrors];
-                    for (int ti = 0; ti < nTopForErrors; ti++)
-                        topErrorIndices[ti] = indexed[ti].Key;
+                    // LINQ OrderByDescending is stable per .NET contract;
+                    // List<T>.Sort with Comparison<T> is unstable
+                    // (introsort) and produces different top-N picks
+                    // than Rust's stable slice::sort_by on RelativeIntensity
+                    // ties. Match Rust by using the stable sort.
+                    topErrorIndices = Enumerable.Range(0, nFragsForErrors)
+                        .OrderByDescending(ti => entry.Fragments[ti].RelativeIntensity)
+                        .Take(nTopForErrors)
+                        .ToArray();
                 }
 
                 foreach (int fragIdx in topErrorIndices)
@@ -2935,13 +2938,13 @@ namespace pwiz.OspreySharp
             }
             else
             {
-                var indexed = new List<KeyValuePair<int, float>>(nFrags);
-                for (int i = 0; i < nFrags; i++)
-                    indexed.Add(new KeyValuePair<int, float>(i, entry.Fragments[i].RelativeIntensity));
-                indexed.Sort((a, b) => b.Value.CompareTo(a.Value));
-                topIndices = new int[nTop];
-                for (int i = 0; i < nTop; i++)
-                    topIndices[i] = indexed[i].Key;
+                // Stable sort matching Rust slice::sort_by on
+                // RelativeIntensity ties; List<T>.Sort with
+                // Comparison<T> is introsort and unstable.
+                topIndices = Enumerable.Range(0, nFrags)
+                    .OrderByDescending(i => entry.Fragments[i].RelativeIntensity)
+                    .Take(nTop)
+                    .ToArray();
             }
 
             int nScans = candidateSpectra.Count;
@@ -3046,9 +3049,51 @@ namespace pwiz.OspreySharp
             // never shrinks, so gen-2 keeps the arrays for the full run.
             context.EnsureXcorrScratchPool(scorer.BinConfig.NBins);
 
+            // Apply MS2 calibration to a LOCAL copy of the spectra
+            // list, mirroring Rust run_search at pipeline.rs:6750-6772
+            // which builds `calibrated_spectra` and then operates on
+            // it via `spectra_ref`. Do NOT mutate the input parameter
+            // -- the Stage 6 rescore loop calls RunCoelutionScoring
+            // multiple times per file (rescore + gap-fill CWT +
+            // gap-fill forced) sharing the same spectra list, and
+            // mutating in place applies the m/z offset cumulatively
+            // across calls (mz - mean -> mz - 2*mean -> mz - 3*mean),
+            // which produces wrong fragment matches in the second and
+            // third calls. Verified via per-entry XIC dump: scan 8
+            // for entry 10110 had Rust intensity = 0 (peak shifted
+            // out of tolerance after a single calibration) but C#
+            // intensity = 8873 (peak still in range because the
+            // accumulated calibration moved a different peak in).
+            List<Spectrum> calibratedSpectra;
+            if (ms2Calibration.Calibrated)
+            {
+                calibratedSpectra = new List<Spectrum>(spectra.Count);
+                for (int si = 0; si < spectra.Count; si++)
+                {
+                    var s = spectra[si];
+                    double[] correctedMzs = new double[s.Mzs.Length];
+                    for (int mi = 0; mi < s.Mzs.Length; mi++)
+                        correctedMzs[mi] = MzCalibration.ApplyCalibration(s.Mzs[mi], ms2Calibration);
+                    calibratedSpectra.Add(new Spectrum
+                    {
+                        ScanNumber = s.ScanNumber,
+                        RetentionTime = s.RetentionTime,
+                        PrecursorMz = s.PrecursorMz,
+                        IsolationWindow = s.IsolationWindow,
+                        Mzs = correctedMzs,
+                        Intensities = s.Intensities
+                    });
+                }
+            }
+            else
+            {
+                // No calibration -> alias the input list (no copy).
+                calibratedSpectra = spectra;
+            }
+
             // Group spectra by isolation window center (rounded key) for efficient lookup
             var spectraByWindowKey = new Dictionary<int, List<Spectrum>>();
-            foreach (var spectrum in spectra)
+            foreach (var spectrum in calibratedSpectra)
             {
                 int key = (int)Math.Round(spectrum.IsolationWindow.Center * 10.0);
                 List<Spectrum> list;
@@ -3076,16 +3121,26 @@ namespace pwiz.OspreySharp
             double rtSigmaGlobal;
             if (rtCalibration != null)
             {
-                var stats = rtCalibration.Stats();
-                double robustSd = stats.MAD * 1.4826;
+                // Mirror Rust run_search at pipeline.rs:6776-6815: prefer
+                // the per-file .calibration.json's rt_calibration.mad
+                // (the FIRST-PASS MAD), and only fall back to the
+                // calibration's stats MAD when that JSON value is absent.
+                // This is the difference between using ~0.144 (broad
+                // first-pass spread) and ~0.012 (narrow refined-cal
+                // spread that gets clamped to MinRtTolerance), which
+                // costs ~28% of window width and produces ~33k divergent
+                // best-peak picks per Stellar file.
+                double mad = context.OriginalRtMad ?? rtCalibration.Stats().MAD;
+                double robustSd = mad * 1.4826;
                 double rtToleranceMad = robustSd * 3.0;
                 rtToleranceGlobal = Math.Max(
                     config.RtCalibration.MinRtTolerance,
                     Math.Min(config.RtCalibration.MaxRtTolerance, rtToleranceMad));
                 rtSigmaGlobal = Math.Max(robustSd * 5.0, 0.1);
                 LogInfo(string.Format(
-                    "Coelution search RT tolerance: {0:F2} min (3*MAD*1.4826, MAD={1:F3})",
-                    rtToleranceGlobal, stats.MAD));
+                    "Coelution search RT tolerance: {0:F2} min (3*MAD*1.4826, MAD={1:F3}{2})",
+                    rtToleranceGlobal, mad,
+                    context.OriginalRtMad.HasValue ? " from .calibration.json" : " from cal stats"));
             }
             else
             {
@@ -3114,43 +3169,15 @@ namespace pwiz.OspreySharp
                     "Coelution search using calibrated fragment tolerance: {0:F4} {1}",
                     calTol, unitStr));
 
-                // Use calibrated tolerance for all downstream scoring
+                // Use calibrated tolerance for all downstream scoring.
+                // (Spectra were already calibrated above into the local
+                // calibratedSpectra list before spectraByWindowKey was
+                // built, so no rebuild is needed here.)
                 config.FragmentTolerance = searchFragTol;
 
-                // Apply m/z offset correction to all spectra
                 LogInfo(string.Format(
                     "Applying MS2 calibration: mean error = {0:F4} {1} -> correcting by {2:+F4;-F4;0} {1}",
                     ms2Calibration.Mean, ms2Calibration.Unit, -ms2Calibration.Mean));
-                for (int si = 0; si < spectra.Count; si++)
-                {
-                    var s = spectra[si];
-                    double[] correctedMzs = new double[s.Mzs.Length];
-                    for (int mi = 0; mi < s.Mzs.Length; mi++)
-                        correctedMzs[mi] = MzCalibration.ApplyCalibration(s.Mzs[mi], ms2Calibration);
-                    spectra[si] = new Spectrum
-                    {
-                        ScanNumber = s.ScanNumber,
-                        RetentionTime = s.RetentionTime,
-                        PrecursorMz = s.PrecursorMz,
-                        IsolationWindow = s.IsolationWindow,
-                        Mzs = correctedMzs,
-                        Intensities = s.Intensities
-                    };
-                }
-
-                // Rebuild the window lookup after m/z correction
-                spectraByWindowKey.Clear();
-                foreach (var spectrum in spectra)
-                {
-                    int key = (int)Math.Round(spectrum.IsolationWindow.Center * 10.0);
-                    List<Spectrum> list;
-                    if (!spectraByWindowKey.TryGetValue(key, out list))
-                    {
-                        list = new List<Spectrum>();
-                        spectraByWindowKey[key] = list;
-                    }
-                    list.Add(spectrum);
-                }
             }
 
             // Per-entry search XIC diagnostic: log the intent once at start.
@@ -3388,7 +3415,17 @@ namespace pwiz.OspreySharp
             List<XicData> xics)
         {
             // Reference XIC = highest total-intensity fragment, matching
-            // the CWT-path selection further down in ScoreCandidate.
+            // Rust run_search at pipeline.rs:7140-7148 which uses
+            // `xics.max_by(|a, b| sum_a.total_cmp(&sum_b))` (returns
+            // the LAST equal element on ties). Use `>=` to match -- a
+            // strict `>` would keep the FIRST equal element here while
+            // every other ref_xic selection in this file (including
+            // the rank-scoring loop further down) uses `>=`, so an
+            // override entry whose top two fragments tie on total
+            // intensity would have BuildOverridePeaks pick a different
+            // ref than the rank loop expects. That mismatch shows up
+            // as ~32k peak_apex divergent rows in the reconciled
+            // parquet vs the Rust output.
             int refIdx = 0;
             double refTotal = -1.0;
             for (int f = 0; f < xics.Count; f++)
@@ -3397,7 +3434,7 @@ namespace pwiz.OspreySharp
                 var ints = xics[f].Intensities;
                 for (int j = 0; j < ints.Length; j++)
                     total += ints[j];
-                if (total > refTotal) { refTotal = total; refIdx = f; }
+                if (total >= refTotal) { refTotal = total; refIdx = f; }
             }
             var rtArr = xics[refIdx].RetentionTimes;
             var intArr = xics[refIdx].Intensities;
@@ -3481,6 +3518,15 @@ namespace pwiz.OspreySharp
             double expectedRt = rtCalibration != null
                 ? rtCalibration.Predict(candidate.RetentionTime)
                 : candidate.RetentionTime;
+            // Bisection seam: dump (entry_id, library_rt -> expected_rt)
+            // for every per-window candidate scoring. Mirrors Rust's
+            // dump_predict_rt_call at pipeline.rs ~7014. Pair with
+            // WritePredictRtArrays at the top of the rescore loop to
+            // narrow whether RT divergences come from cal arrays
+            // diverging or from Predict() output differing on identical
+            // arrays.
+            OspreyDiagnostics.WritePredictRtCall(
+                candidate.Id, candidate.RetentionTime, expectedRt);
             double rtTolerance = globalRtTolerance;
 
             if (diag)
@@ -3509,31 +3555,47 @@ namespace pwiz.OspreySharp
             // Half-width is rtTolerance plus max(rtTolerance, 0.1) —
             // tight-calibration runs get a 0.1 min floor of extra context;
             // wider runs scale with rtTolerance.
-            double rtLo, rtHi;
+            // Two filter shapes mirroring Rust pipeline.rs:7031-7065 byte-
+            // for-byte. The override branch uses [rtLo, rtHi]; the
+            // normal-search branch uses |rt - expectedRt| <= xicHalfWidth.
+            // Mathematically identical but NOT f64-equivalent at the
+            // boundary -- writing out the precomputed `rtHi = expectedRt
+            // + xicHalfWidth` and comparing `rt <= rtHi` can include /
+            // exclude a boundary scan that the abs-diff form would not,
+            // because the two arithmetic chains round differently in the
+            // last bit. Without the abs-diff form, ~1k entries per
+            // Stellar file pick a different best apex than Rust because a
+            // single boundary spectrum slips into one side's window and
+            // not the other's, cascading through CWT peak detection.
+            int startScan = -1, endScan = -1;
             if (overrideBounds.HasValue)
             {
                 var ob = overrideBounds.Value;
                 double peakWidth = Math.Max(0.1, ob.End - ob.Start);
                 double margin = Math.Max(0.2, peakWidth);
-                rtLo = ob.Start - margin;
-                rtHi = ob.End + margin;
+                double rtLo = ob.Start - margin;
+                double rtHi = ob.End + margin;
+                for (int i = 0; i < nScans; i++)
+                {
+                    if (windowRts[i] >= rtLo && windowRts[i] <= rtHi)
+                    {
+                        if (startScan < 0)
+                            startScan = i;
+                        endScan = i;
+                    }
+                }
             }
             else
             {
                 double xicHalfWidth = rtTolerance + Math.Max(rtTolerance, 0.1);
-                rtLo = expectedRt - xicHalfWidth;
-                rtHi = expectedRt + xicHalfWidth;
-            }
-            int startScan = -1, endScan = -1;
-            for (int i = 0; i < nScans; i++)
-            {
-                if (windowRts[i] > rtHi)
-                    break;
-                if (windowRts[i] >= rtLo)
+                for (int i = 0; i < nScans; i++)
                 {
-                    if (startScan < 0)
-                        startScan = i;
-                    endScan = i;
+                    if (Math.Abs(windowRts[i] - expectedRt) <= xicHalfWidth)
+                    {
+                        if (startScan < 0)
+                            startScan = i;
+                        endScan = i;
+                    }
                 }
             }
 
@@ -3555,8 +3617,8 @@ namespace pwiz.OspreySharp
                 else
                 {
                     LogInfo(string.Format(
-                        "[DIAG] {0}: no scans in RT window [{1:F3}..{2:F3}]",
-                        candidate.ModifiedSequence, rtLo, rtHi));
+                        "[DIAG] {0}: no scans in RT window around expected_rt={1:F3}",
+                        candidate.ModifiedSequence, expectedRt));
                 }
             }
 
@@ -3602,7 +3664,11 @@ namespace pwiz.OspreySharp
             var xics = ExtractFragmentXics(
                 candidate, windowSpectra, windowRts, startScan, endScan, config);
 
-            // Per-entry search XIC diagnostic (thread-safe: unique file per entry_id)
+            // Per-entry search XIC diagnostic. Fires for every scoring
+            // path; if the entry is scored twice (consensus + override)
+            // the LAST call wins on disk. Caller can isolate by
+            // limiting OSPREY_DIAG_SEARCH_ENTRY_IDS to the right
+            // entries, or by tagging the dump filename with the path.
             if (OspreyDiagnostics.ShouldDumpSearchXicFor(candidate.Id))
             {
                 OspreyDiagnostics.WriteSearchXicDump(
@@ -3640,6 +3706,14 @@ namespace pwiz.OspreySharp
                 peaks = CwtPeakDetector.DetectConsensusPeaks(xics, 0.0);
                 peaksFromCwt = peaks.Count > 0;
             }
+            // Snapshot CWT consensus peak count for the OSPREY_DUMP_CWT_PATH
+            // dump. The dump only fires for non-override entries (the
+            // override path bypasses CWT entirely on both Rust and C#);
+            // call sites below gate on `!overrideBounds.HasValue`. Sigma
+            // + consensus-signal stats are computed inside
+            // OspreyDiagnostics.WriteCwtPathRow when the dump is active,
+            // so production callers carry only this single int.
+            int diagNCwtPeaks = peaks.Count;
 
             if (peaks.Count == 0)
             {
@@ -3699,7 +3773,15 @@ namespace pwiz.OspreySharp
                 }
             }
             if (peaks.Count == 0)
+            {
+                if (!overrideBounds.HasValue)
+                {
+                    OspreyDiagnostics.WriteCwtPathRow(
+                        context.FileName, candidate.Id,
+                        diagNCwtPeaks, 0, 0, false, xics);
+                }
                 return null;
+            }
 
             // Rust scores each candidate peak by mean pairwise fragment
             // correlation weighted by a Gaussian RT penalty and an intensity
@@ -3713,8 +3795,13 @@ namespace pwiz.OspreySharp
             // position gets RT penalty=1.0; 5-sigma away gets ~0.01.
 
             // Reference XIC = highest total-intensity fragment. Matches Rust
-            // run_search which selects ref_xic before CWT and reuses it for
-            // apex intensity lookup.
+            // run_search at pipeline.rs:7140-7148 which uses
+            // `xics.max_by(|a, b| sum_a.total_cmp(&sum_b))`. Rust's
+            // `Iterator::max_by` returns the LAST equal element on ties
+            // (per std doc), so use `>=` here, NOT `>`. Without this,
+            // ~33k Stellar entries pick the first tied fragment as ref_xic
+            // while Rust picks the last, producing divergent
+            // peak_apex / peak_sharpness in the reconciled parquet.
             int refXicIdx = 0;
             double refXicBestTotal = -1.0;
             for (int f = 0; f < xics.Count; f++)
@@ -3722,19 +3809,34 @@ namespace pwiz.OspreySharp
                 double total = 0.0;
                 for (int i = 0; i < xics[f].Intensities.Length; i++)
                     total += xics[f].Intensities[i];
-                if (total > refXicBestTotal) { refXicBestTotal = total; refXicIdx = f; }
+                if (total >= refXicBestTotal) { refXicBestTotal = total; refXicIdx = f; }
             }
             double[] refXicIntensities = xics[refXicIdx].Intensities;
 
             XICPeakBounds bestPeak = null;
             double bestRankScore = double.MinValue;
             int bestPeakIdx = -1;
+            int diagNScored = 0; // peaks that pass apex-acceptance
             double twoSigmaSq = 2.0 * rtSigma * rtSigma;
-            // Capture every CWT-passed peak with its raw coelution score and
-            // rank score for the top-N CwtCandidate list assigned below
-            // (Stage 6 reconciliation input). Mirrors Rust run_search's
-            // scored_candidates collection at pipeline.rs:6790-6806.
-            var capturedPeaks = peaksFromCwt
+            // Capture every scored peak with its raw coelution score
+            // and rank score for the top-N CwtCandidate list assigned
+            // below (Stage 6 reconciliation input). Mirrors Rust
+            // run_search's scored_candidates collection at
+            // pipeline.rs:7261-7327, which fires for the non-override
+            // path -- the override branch (pipeline.rs:7155-7223)
+            // returns at line 7223 BEFORE reaching the cwt_top_n
+            // code, so override entries leave cwt_candidates as the
+            // default empty `Vec::new()` on the rescored
+            // CoelutionScoredEntry.
+            //
+            // Build for CWT-OR-FALLBACK paths (anything reaching the
+            // rank-scoring loop without an override). Earlier C#
+            // versions gated this on `peaksFromCwt` (CWT-consensus
+            // success only) which left fallback-path entries with
+            // empty cwt_candidates blobs while Rust still populated
+            // them; that produced the last 5 / 3 / 2 cwt_candidates
+            // divergent rows per Stellar file.
+            var capturedPeaks = !overrideBounds.HasValue
                 ? new List<(XICPeakBounds peak, double coelutionScore, double rankScore)>(peaks.Count)
                 : null;
             for (int pi = 0; pi < peaks.Count; pi++)
@@ -3756,6 +3858,7 @@ namespace pwiz.OspreySharp
                 double rtResidual = Math.Abs(peakApexRt - expectedRt);
                 if (!overrideBounds.HasValue && rtResidual > rtTolerance)
                     continue;
+                diagNScored++;
 
                 double sum = 0.0;
                 int count = 0;
@@ -3861,13 +3964,72 @@ namespace pwiz.OspreySharp
             }
 
             if (bestPeak == null)
+            {
+                if (!overrideBounds.HasValue)
+                {
+                    OspreyDiagnostics.WriteCwtPathRow(
+                        context.FileName, candidate.Id,
+                        diagNCwtPeaks, peaks.Count, diagNScored, false, xics);
+                }
                 return null;
+            }
+
+            // For CWT-path entries (no override), Rust pipeline.rs:7406-7424
+            // RECOMPUTES the peak's apex_index / apex_intensity using
+            // ref_xic[si..=ei] (the highest-total-intensity single
+            // fragment), discarding the apex_index that came out of
+            // detect_cwt_consensus_peaks (which used ref_signal -- the
+            // SUM of all fragment intensities). When a peak's max in
+            // the summed signal sits at a different scan than the max
+            // in the single ref_xic, leaving the consensus apex_index
+            // in place produces divergent peak_apex / peak_sharpness
+            // vs Rust on the reconciled .scores.parquet (~32k rows on
+            // Stellar before this fix). Override entries are excluded
+            // because Rust's override branch (pipeline.rs:7155-7223)
+            // uses the override-supplied apex_index directly without
+            // refining it -- match by skipping the recompute.
+            if (!overrideBounds.HasValue)
+            {
+                int si = bestPeak.StartIndex;
+                int ei = bestPeak.EndIndex;
+                int newApexIdx = si;
+                double newApexVal = refXicIntensities[si];
+                for (int i = si + 1; i <= ei; i++)
+                {
+                    // Use `>=` to match Rust's `max_by` last-on-tie.
+                    if (refXicIntensities[i] >= newApexVal)
+                    {
+                        newApexVal = refXicIntensities[i];
+                        newApexIdx = i;
+                    }
+                }
+                bestPeak = new XICPeakBounds
+                {
+                    ApexRt = xics[refXicIdx].RetentionTimes[newApexIdx],
+                    ApexIntensity = newApexVal,
+                    ApexIndex = newApexIdx,
+                    StartRt = xics[refXicIdx].RetentionTimes[si],
+                    EndRt = xics[refXicIdx].RetentionTimes[ei],
+                    StartIndex = si,
+                    EndIndex = ei,
+                    Area = bestPeak.Area,
+                    SignalToNoise = bestPeak.SignalToNoise,
+                };
+            }
 
             int apexGlobalIdx = startScan + bestPeak.ApexIndex;
 
             // Score at the apex spectrum
             if (apexGlobalIdx < 0 || apexGlobalIdx >= windowSpectra.Count)
+            {
+                if (!overrideBounds.HasValue)
+                {
+                    OspreyDiagnostics.WriteCwtPathRow(
+                        context.FileName, candidate.Id,
+                        diagNCwtPeaks, peaks.Count, diagNScored, false, xics);
+                }
                 return null;
+            }
 
             var apexSpectrum = windowSpectra[apexGlobalIdx];
 
@@ -3976,6 +4138,14 @@ namespace pwiz.OspreySharp
                     peakXics.Add(new KeyValuePair<int, double[]>(xics[xi].FragmentIndex, slice));
                 }
 
+                // Bisection seam: dump (frag_pos, frag_idx, scan_idx, rt,
+                // intensity) for every median-polish call. Mirrors the
+                // Rust diagnostics::dump_mp_inputs at pipeline.rs:6494.
+                // Use the same input buffers passed to the median polish
+                // so we capture the exact data the algorithm sees.
+                OspreyDiagnostics.WriteMpInputsRow(
+                    candidate.Id, apexSpectrum.ScanNumber, peakXics, peakRts);
+
                 var polish = TukeyMedianPolish.Compute(peakXics, peakRts, 10, 0.01);
                 if (polish != null)
                 {
@@ -4033,12 +4203,18 @@ namespace pwiz.OspreySharp
                 : 0;
             if (capturedPeaks != null && capturedPeaks.Count > 0 && topN > 0)
             {
-                capturedPeaks.Sort((a, b) =>
-                {
-                    if (TotalOrderGreater(a.rankScore, b.rankScore)) return -1;
-                    if (TotalOrderGreater(b.rankScore, a.rankScore)) return 1;
-                    return 0;
-                });
+                // Rust scored_candidates.sort_by at pipeline.rs:7329 is
+                // STABLE (slice::sort_by is stable). List<T>.Sort with
+                // Comparison<T> is introsort, which is unstable and
+                // reorders ties; for entries where two CWT candidates
+                // tie on rank score, the unstable sort picks a
+                // different "top N" than Rust (~1 entry per Stellar
+                // file). Use LINQ OrderByDescending (stable per .NET
+                // contract) and then assign back to keep the rest of
+                // the loop unchanged.
+                capturedPeaks = capturedPeaks
+                    .OrderByDescending(p => p.rankScore)
+                    .ToList();
                 int kept = Math.Min(topN, capturedPeaks.Count);
                 cwtCandidatesOut = new List<CwtCandidate>(kept);
                 double[] refRts = xics[refXicIdx].RetentionTimes;
@@ -4091,6 +4267,12 @@ namespace pwiz.OspreySharp
                 CwtCandidates = cwtCandidatesOut
             };
 
+            if (!overrideBounds.HasValue)
+            {
+                OspreyDiagnostics.WriteCwtPathRow(
+                    context.FileName, candidate.Id,
+                    diagNCwtPeaks, peaks.Count, diagNScored, true, xics);
+            }
             return entry;
         }
 
@@ -4119,14 +4301,14 @@ namespace pwiz.OspreySharp
                     return mzs;
                 }
 
-                // Find top 6 by intensity
-                var indices = new int[frags.Count];
-                for (int i = 0; i < indices.Length; i++) indices[i] = i;
-                Array.Sort(indices, (a, b) =>
-                    frags[b].RelativeIntensity.CompareTo(frags[a].RelativeIntensity));
-                var result = new double[nTop];
-                for (int i = 0; i < nTop; i++)
-                    result[i] = frags[indices[i]].Mz;
+                // Find top 6 by intensity, stable on ties to match
+                // Rust slice::sort_by. Array.Sort with Comparison<T>
+                // is introsort and unstable.
+                var result = Enumerable.Range(0, frags.Count)
+                    .OrderByDescending(i => frags[i].RelativeIntensity)
+                    .Take(nTop)
+                    .Select(i => frags[i].Mz)
+                    .ToArray();
                 return result;
             });
         }
@@ -4200,13 +4382,20 @@ namespace pwiz.OspreySharp
             }
             else
             {
-                var indexed = new List<KeyValuePair<int, float>>(nFrags);
-                for (int i = 0; i < nFrags; i++)
-                    indexed.Add(new KeyValuePair<int, float>(i, candidate.Fragments[i].RelativeIntensity));
-                indexed.Sort((a, b) => b.Value.CompareTo(a.Value));
-                topIndices = new int[nTop];
-                for (int i = 0; i < nTop; i++)
-                    topIndices[i] = indexed[i].Key;
+                // Rust's `indexed.sort_by(|a, b| b.1.total_cmp(&a.1))` at
+                // osprey-scoring/src/lib.rs:528 is STABLE (slice::sort_by
+                // is stable). Switch from `List<T>.Sort` (introsort,
+                // unstable) to LINQ `OrderByDescending` (stable per .NET
+                // contract) so that ties on RelativeIntensity preserve
+                // the library's fragment order, matching Rust. Without
+                // this, a peptide with two fragments at equal relative
+                // intensity can land different fragments in its top-N on
+                // the C# side, which cascades through XIC extraction →
+                // peak detection → rankScore → bestPeak selection.
+                topIndices = Enumerable.Range(0, nFrags)
+                    .OrderByDescending(i => candidate.Fragments[i].RelativeIntensity)
+                    .Take(nTop)
+                    .ToArray();
             }
 
             // Build shared RT array for this range
@@ -4338,17 +4527,22 @@ namespace pwiz.OspreySharp
             if (start > end)
                 return;
 
-            // Use reference XIC (highest total intensity), matching Rust pipeline.rs.
-            // Rust computes peak_apex, peak_area, peak_sharpness from ref_xic only.
+            // Use reference XIC (highest total intensity), matching Rust
+            // pipeline.rs:7140-7148. Rust's `xics.iter().max_by(...)`
+            // returns the LAST equal element on ties (per Iterator::max_by
+            // doc), so use `>=` here, NOT `>`. Without this, the first
+            // tied fragment wins on the C# side while Rust picks the
+            // last, producing divergent peak_apex / peak_area /
+            // peak_sharpness when fragments tie on total intensity.
             int refIdx = 0;
-            double bestTotal = 0.0;
+            double bestTotal = -1.0;
             for (int f = 0; f < xics.Count; f++)
             {
                 double total = 0.0;
                 double[] inten = xics[f].Intensities;
                 for (int i = 0; i < inten.Length; i++)
                     total += inten[i];
-                if (total > bestTotal)
+                if (total >= bestTotal)
                 {
                     bestTotal = total;
                     refIdx = f;
@@ -4358,21 +4552,27 @@ namespace pwiz.OspreySharp
             double[] refInten = xics[refIdx].Intensities;
             double[] refRts = xics[refIdx].RetentionTimes;
 
-            // Apex: max intensity in the reference XIC over the peak range.
-            // Matches Rust: ref_xic[si..=ei].max_by(intensity). On ties
-            // Rust's Iterator::max_by keeps the LAST equal element (see
-            // std::cmp::max_by returning v2 on Ordering::Equal); use `>=`
-            // here to match so flat-top peaks pick the same apex scan.
-            double apexVal = 0.0;
-            int apexIdx = start;
-            for (int i = start; i <= end; i++)
-            {
-                if (refInten[i] >= apexVal)
-                {
-                    apexVal = refInten[i];
-                    apexIdx = i;
-                }
-            }
+            // peak_apex == intensity at peak.ApexIndex in the reference
+            // XIC. This matches Rust pipeline.rs:6547 which sets
+            // `peak_apex: peak.apex_intensity` (the value already
+            // assigned in BuildOverridePeaks / the CWT-path FindPeaks).
+            //
+            // Earlier C# implementations recomputed apex as the local
+            // max in `ref_xic[start..=end]`. That recomputation diverges
+            // from Rust on the OVERRIDE path: there, Rust deliberately
+            // uses the override-supplied apex_index even when a
+            // different scan in [start..=end] has higher intensity (the
+            // override is the authoritative apex for reconciliation /
+            // gap-fill scoring). The local-max approach put C# at
+            // ~32k row peak_apex / peak_sharpness divergence vs Rust on
+            // the reconciled .scores.parquet.
+            //
+            // Use peak.ApexIndex (clipped above) and look up the
+            // intensity directly. Sharpness slopes below also use this
+            // apex position so the left/right edges align with what
+            // Rust computes.
+            int apexIdx = apex;
+            double apexVal = refInten[apexIdx];
             peakApex = apexVal;
 
             // Area: trapezoidal integration on the reference XIC.
@@ -4850,14 +5050,15 @@ namespace pwiz.OspreySharp
             }
             else
             {
-                // Find top 6 indices by intensity
-                var indices = new int[entry.Fragments.Count];
-                for (int i = 0; i < indices.Length; i++) indices[i] = i;
-                Array.Sort(indices, (a, b) =>
-                    entry.Fragments[b].RelativeIntensity.CompareTo(
-                        entry.Fragments[a].RelativeIntensity));
+                // Stable top-6 by RelativeIntensity, matching Rust
+                // slice::sort_by ties (Array.Sort with Comparison<T>
+                // is introsort and unstable).
+                var indices = Enumerable.Range(0, entry.Fragments.Count)
+                    .OrderByDescending(i => entry.Fragments[i].RelativeIntensity)
+                    .Take(nTop)
+                    .ToArray();
 
-                for (int t = 0; t < nTop; t++)
+                for (int t = 0; t < indices.Length; t++)
                 {
                     if (SpectralScorer.HasMatch(entry.Fragments[indices[t]].Mz,
                         spectrum.Mzs, config.FragmentTolerance))

--- a/pwiz_tools/OspreySharp/OspreySharp/AnalysisPipeline.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/AnalysisPipeline.cs
@@ -3404,6 +3404,25 @@ namespace pwiz.OspreySharp
         }
 
         /// <summary>
+        /// IComparer&lt;double&gt; implementing IEEE 754-2008 total order
+        /// (matches Rust's f64::total_cmp). Key property versus the
+        /// default Comparer&lt;double&gt;: distinguishes -0.0 &lt; +0.0,
+        /// orders NaNs consistently. Required wherever a stable sort
+        /// needs to mirror Rust's slice::sort_by(... .total_cmp(...))
+        /// — pair with LINQ OrderBy/OrderByDescending (stable per
+        /// .NET contract) to match Rust byte-for-byte.
+        /// </summary>
+        private static readonly IComparer<double> TotalOrderComparer =
+            Comparer<double>.Create((a, b) =>
+            {
+                long la = BitConverter.DoubleToInt64Bits(a);
+                long lb = BitConverter.DoubleToInt64Bits(b);
+                if (la < 0) la ^= 0x7FFFFFFFFFFFFFFFL;
+                if (lb < 0) lb ^= 0x7FFFFFFFFFFFFFFFL;
+                return la.CompareTo(lb);
+            });
+
+        /// <summary>
         /// Build a one-element peak list at the supplied (apex, start, end)
         /// RT triple, mapped onto the reference XIC's RT axis. Returns null
         /// when the resulting index range is degenerate. Mirrors the
@@ -4204,16 +4223,18 @@ namespace pwiz.OspreySharp
             if (capturedPeaks != null && capturedPeaks.Count > 0 && topN > 0)
             {
                 // Rust scored_candidates.sort_by at pipeline.rs:7329 is
-                // STABLE (slice::sort_by is stable). List<T>.Sort with
-                // Comparison<T> is introsort, which is unstable and
-                // reorders ties; for entries where two CWT candidates
-                // tie on rank score, the unstable sort picks a
-                // different "top N" than Rust (~1 entry per Stellar
-                // file). Use LINQ OrderByDescending (stable per .NET
-                // contract) and then assign back to keep the rest of
-                // the loop unchanged.
+                // STABLE (slice::sort_by is stable) AND uses f64::total_cmp,
+                // which distinguishes -0.0 < +0.0. The default
+                // Comparer<double> treats them equal, so two peaks whose
+                // rank_score = coelution * rt_penalty * intensityWeight
+                // collapses to a signed zero (intensityWeight = 0 when
+                // ref_xic intensity at apex is 0; sign comes from
+                // coelution) compare as tied under standard <, while
+                // Rust orders them positive-then-negative. Pair LINQ
+                // OrderByDescending (stable per .NET contract) with
+                // TotalOrderComparer to match Rust byte-for-byte.
                 capturedPeaks = capturedPeaks
-                    .OrderByDescending(p => p.rankScore)
+                    .OrderByDescending(p => p.rankScore, TotalOrderComparer)
                     .ToList();
                 int kept = Math.Min(topN, capturedPeaks.Count);
                 cwtCandidatesOut = new List<CwtCandidate>(kept);

--- a/pwiz_tools/OspreySharp/OspreySharp/OspreyDiagnostics.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/OspreyDiagnostics.cs
@@ -932,7 +932,7 @@ namespace pwiz.OspreySharp
             using (var sw = new StreamWriter(path))
             {
                 sw.NewLine = "\n";
-                sw.WriteLine(@"file_name	entry_id	charge	modified_sequence	is_decoy	score	pep	run_precursor_q	run_peptide_q	experiment_precursor_q	experiment_peptide_q");
+                sw.WriteLine(@"file_name	entry_id	charge	modified_sequence	is_decoy	score	pep	run_precursor_q	run_peptide_q	run_protein_q	experiment_precursor_q	experiment_peptide_q");
                 foreach (var row in rows)
                 {
                     var e = row.Value;
@@ -945,6 +945,7 @@ namespace pwiz.OspreySharp
                     sw.Write('\t'); sw.Write(Diagnostics.FormatF64Roundtrip(e.Pep));
                     sw.Write('\t'); sw.Write(Diagnostics.FormatF64Roundtrip(e.RunPrecursorQvalue));
                     sw.Write('\t'); sw.Write(Diagnostics.FormatF64Roundtrip(e.RunPeptideQvalue));
+                    sw.Write('\t'); sw.Write(Diagnostics.FormatF64Roundtrip(e.RunProteinQvalue));
                     sw.Write('\t'); sw.Write(Diagnostics.FormatF64Roundtrip(e.ExperimentPrecursorQvalue));
                     sw.Write('\t'); sw.WriteLine(Diagnostics.FormatF64Roundtrip(e.ExperimentPeptideQvalue));
                 }

--- a/pwiz_tools/OspreySharp/OspreySharp/OspreyDiagnostics.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/OspreyDiagnostics.cs
@@ -58,6 +58,20 @@ namespace pwiz.OspreySharp
     /// </summary>
     public static class OspreyDiagnostics
     {
+        /// <summary>
+        /// Newline used by every Stage 6 cross-impl bisection dump writer.
+        /// MUST be `"\n"` (not <see cref="Environment.NewLine"/>, which is
+        /// `"\r\n"` on Windows) so headers emitted via
+        /// <see cref="System.IO.StreamWriter.WriteLine(string)"/> match the
+        /// `\n`-terminated payload rows we build manually with
+        /// <see cref="System.Text.StringBuilder.Append(char)"/>. Mixed
+        /// newlines break the byte-for-byte diff against the corresponding
+        /// `rust_*.tsv` dumps that this tooling depends on. Apply via
+        /// <c>writer.NewLine = LF;</c> immediately after constructing each
+        /// dump <see cref="System.IO.StreamWriter"/>.
+        /// </summary>
+        private const string LF = "\n";
+
         // ----- Env-var gate flags (read once at process start) -----
 
         /// <summary>
@@ -977,6 +991,7 @@ namespace pwiz.OspreySharp
                 if (_mpInputsWriter == null)
                 {
                     _mpInputsWriter = new StreamWriter(@"cs_stage6_mp_inputs.tsv");
+                    _mpInputsWriter.NewLine = LF;
                     _mpInputsWriter.WriteLine(
                         "# entry_id\tapex_scan\tfrag_pos\tfrag_idx\tscan_idx\trt\tintensity");
                     LogAction(
@@ -1022,6 +1037,7 @@ namespace pwiz.OspreySharp
             if (_predictRtWriter != null)
                 return;
             _predictRtWriter = new StreamWriter(@"cs_stage6_predict_rt.tsv");
+            _predictRtWriter.NewLine = LF;
             _predictRtWriter.WriteLine(
                 "# section\tfile_name_or_entry_id\tarray_or_apex\tidx_or_lib_rt\tvalue_or_expected_rt");
             LogAction(
@@ -1166,6 +1182,7 @@ namespace pwiz.OspreySharp
                 if (_cwtPathWriter == null)
                 {
                     _cwtPathWriter = new StreamWriter(@"cs_stage6_cwt_path.tsv");
+                    _cwtPathWriter.NewLine = LF;
                     _cwtPathWriter.WriteLine(
                         "file_name\tentry_id\tn_cwt_peaks\tn_final_peaks\tn_scored\tscored\tsigma\tconsensus_l1\tconsensus_max_abs\tconsensus_argmax");
                     LogAction(

--- a/pwiz_tools/OspreySharp/OspreySharp/OspreyDiagnostics.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/OspreyDiagnostics.cs
@@ -118,6 +118,20 @@ namespace pwiz.OspreySharp
         public static readonly bool PercolatorOnly = IsOne(@"OSPREY_PERCOLATOR_ONLY");
 
         /// <summary>
+        /// OSPREY_DUMP_RESCORED: dump per-precursor state AFTER the
+        /// per-file Stage 6 rescore loop completes (consensus +
+        /// reconciliation overlay, plus gap-fill stubs once Phase 2
+        /// lands). Same column shape as DumpPercolator so
+        /// Compare-Percolator.ps1 reuses for the diff. Output:
+        /// cs_stage6_rescored.tsv. Mirrors Rust's
+        /// dump_stage6_rescored / OSPREY_DUMP_RESCORED gate.
+        /// </summary>
+        public static readonly bool DumpRescored = IsOne(@"OSPREY_DUMP_RESCORED");
+
+        /// <summary>OSPREY_RESCORED_ONLY: exit after cs_stage6_rescored.tsv dump.</summary>
+        public static readonly bool RescoredOnly = IsOne(@"OSPREY_RESCORED_ONLY");
+
+        /// <summary>
         /// OSPREY_DUMP_CONSENSUS: dump the per-peptide consensus RT planning
         /// state at the start of Stage 6 (cs_stage6_consensus.tsv) for
         /// cross-impl parity at the planning checkpoint.
@@ -951,6 +965,74 @@ namespace pwiz.OspreySharp
                 }
             }
             LogAction(string.Format(@"Wrote Stage 5 Percolator dump: {0} ({1} rows)", path, rows.Count));
+        }
+
+        /// <summary>
+        /// Dump per-precursor state AFTER the Stage 6 per-file rescore
+        /// loop completes (consensus + reconciliation overlay applied,
+        /// gap-fill stubs appended once Phase 2 lands). Same columns as
+        /// <see cref="WriteStage5PercolatorDump"/> + same sort + same
+        /// G17 / FormatF64Roundtrip formatting so Compare-Percolator.ps1
+        /// can be reused for the diff. Output: cs_stage6_rescored.tsv,
+        /// matching Rust's rust_stage6_rescored.tsv from
+        /// dump_stage6_rescored.
+        ///
+        /// This is the high-level Phase 1 byte-parity gate: if it
+        /// passes, the boundary-overrides rescore + (eventual) gap-fill
+        /// outputs match Rust's. If it fails, drill into the
+        /// fine-grained OSPREY_DUMP_MP_INPUTS / OSPREY_DUMP_PREDICT_RT
+        /// ladder to localize the divergence (those mirrors are tracked
+        /// for the pre-PR cleanup).
+        /// </summary>
+        public static void WriteStage6RescoredDump(
+            List<KeyValuePair<string, List<FdrEntry>>> perFileEntries)
+        {
+            const string path = @"cs_stage6_rescored.tsv";
+            var inv = CultureInfo.InvariantCulture;
+
+            var rows = new List<KeyValuePair<string, FdrEntry>>();
+            foreach (var kvp in perFileEntries)
+            {
+                string fileName = kvp.Key;
+                foreach (var e in kvp.Value)
+                    rows.Add(new KeyValuePair<string, FdrEntry>(fileName, e));
+            }
+            // OrderBy/ThenBy is STABLE — preserves insertion order for ties.
+            // Required because gap-fill (Phase 2) appends new stubs with
+            // ParquetIndex = uint.MaxValue alongside an existing
+            // post-compaction stub for the same (file_name, EntryId)
+            // (e.g., decoy paired with a target that already passed
+            // first-pass FDR). Stable sort keeps the hydrated stub first
+            // and the gap-fill stub second, matching Rust's
+            // Vec::sort_by behavior. List<T>.Sort is UNSTABLE and would
+            // shuffle the dup pair non-deterministically across runs.
+            rows = rows
+                .OrderBy(r => r.Key, StringComparer.Ordinal)
+                .ThenBy(r => r.Value.EntryId)
+                .ToList();
+
+            using (var sw = new StreamWriter(path))
+            {
+                sw.NewLine = "\n";
+                sw.WriteLine(@"file_name	entry_id	charge	modified_sequence	is_decoy	score	pep	run_precursor_q	run_peptide_q	run_protein_q	experiment_precursor_q	experiment_peptide_q");
+                foreach (var row in rows)
+                {
+                    var e = row.Value;
+                    sw.Write(row.Key);
+                    sw.Write('\t'); sw.Write(e.EntryId.ToString(inv));
+                    sw.Write('\t'); sw.Write(e.Charge.ToString(inv));
+                    sw.Write('\t'); sw.Write(e.ModifiedSequence ?? string.Empty);
+                    sw.Write('\t'); sw.Write(e.IsDecoy ? @"true" : @"false");
+                    sw.Write('\t'); sw.Write(Diagnostics.FormatF64Roundtrip(e.Score));
+                    sw.Write('\t'); sw.Write(Diagnostics.FormatF64Roundtrip(e.Pep));
+                    sw.Write('\t'); sw.Write(Diagnostics.FormatF64Roundtrip(e.RunPrecursorQvalue));
+                    sw.Write('\t'); sw.Write(Diagnostics.FormatF64Roundtrip(e.RunPeptideQvalue));
+                    sw.Write('\t'); sw.Write(Diagnostics.FormatF64Roundtrip(e.RunProteinQvalue));
+                    sw.Write('\t'); sw.Write(Diagnostics.FormatF64Roundtrip(e.ExperimentPrecursorQvalue));
+                    sw.Write('\t'); sw.WriteLine(Diagnostics.FormatF64Roundtrip(e.ExperimentPeptideQvalue));
+                }
+            }
+            LogAction(string.Format(@"Wrote Stage 6 rescored dump: {0} ({1} rows)", path, rows.Count));
         }
 
         // ---- Stage 6 planning dumps ----

--- a/pwiz_tools/OspreySharp/OspreySharp/OspreyDiagnostics.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/OspreyDiagnostics.cs
@@ -132,6 +132,51 @@ namespace pwiz.OspreySharp
         public static readonly bool RescoredOnly = IsOne(@"OSPREY_RESCORED_ONLY");
 
         /// <summary>
+        /// OSPREY_DUMP_MP_INPUTS: bisection-grade diagnostic that dumps
+        /// the inputs to every per-entry tukey_median_polish call from
+        /// the Stage 6 rescore path. One row per (entry, apex_scan,
+        /// frag_pos, scan_idx) carrying (rt, intensity). Output:
+        /// cs_stage6_mp_inputs.tsv. Format mirrors Rust's
+        /// dump_mp_inputs (diagnostics.rs ~line 265) byte-for-byte so
+        /// the two files are diffable directly:
+        /// <c>diff &lt;(sort -k1,1n -k2,2n -k3,3n cs_stage6_mp_inputs.tsv) &lt;(sort ... rust)</c>.
+        /// PASS == zero diff lines after sort. FAIL == first row that
+        /// disagrees, identifying whether peak_xics divergence is
+        /// upstream (XIC extraction / peak picking) or downstream
+        /// (median polish / peak shape feature compute).
+        /// </summary>
+        public static readonly bool DumpMpInputs = IsOne(@"OSPREY_DUMP_MP_INPUTS");
+
+        /// <summary>
+        /// OSPREY_DUMP_PREDICT_RT: bisection-grade diagnostic that
+        /// captures the per-file <c>library_rts</c> /
+        /// <c>fitted_values</c> arrays of the active RT calibration AND
+        /// every (entry_id, library_rt -> expected_rt) call into
+        /// <c>RTCalibration.Predict</c> from the Stage 6 rescore search
+        /// path. Output: cs_stage6_predict_rt.tsv. Two-section TSV
+        /// sharing one five-column header; mirrors Rust's
+        /// dump_predict_rt_arrays + dump_predict_rt_call (diagnostics.rs
+        /// ~line 365 / 397). Use to narrow apex-divergence root cause:
+        /// if the cal_arrays sections diverge, JSON round-trip is
+        /// lossy; if predict_calls diverge despite identical arrays,
+        /// hidden RTCalibration state is leaking; if both match, the
+        /// divergence is downstream of RT calibration.
+        /// </summary>
+        public static readonly bool DumpPredictRt = IsOne(@"OSPREY_DUMP_PREDICT_RT");
+
+        /// <summary>
+        /// OSPREY_DUMP_CWT_PATH: per-(file, entry) dump of CWT path
+        /// counts. Six columns: file_name, entry_id, n_cwt_peaks,
+        /// n_final_peaks (after MP polish + ref_xic fallbacks),
+        /// n_scored (peaks that pass apex-acceptance filter), and a
+        /// "scored" flag (1 if ScoreCandidate returned non-null, else
+        /// 0). Use this to localize which entries diverge cross-impl
+        /// and at which seam: CWT detection, fallback path, or
+        /// apex-acceptance filter. Output: cs_stage6_cwt_path.tsv.
+        /// </summary>
+        public static readonly bool DumpCwtPath = IsOne(@"OSPREY_DUMP_CWT_PATH");
+
+        /// <summary>
         /// OSPREY_DUMP_CONSENSUS: dump the per-peptide consensus RT planning
         /// state at the start of Stage 6 (cs_stage6_consensus.tsv) for
         /// cross-impl parity at the planning checkpoint.
@@ -791,6 +836,29 @@ namespace pwiz.OspreySharp
                             xic.FragmentIndex, i, F10(xic.RetentionTimes[i]), F10(xic.Intensities[i])));
                     }
                 }
+
+                // CWT CONSENSUS: per-scan median consensus value across
+                // the fragment CWT coefficients. Cross-impl diff at this
+                // section pinpoints the first scan where the consensus
+                // signal diverges -- the seam upstream of peak detection.
+                // Use round-trip-safe formatting so f64 bits compare
+                // exactly between Rust (format_f64_roundtrip) and C#.
+                var xicList = xics is List<XicData> xicL ? xicL : new List<XicData>(xics);
+                double[] consensusSig = CwtPeakDetector.GetConsensusSignal(
+                    xicList, out double cwtSigma);
+                dw.WriteLine("# CWT CONSENSUS (sigma, scan_idx, value)");
+                dw.WriteLine(string.Format(inv,
+                    "# sigma={0}", Diagnostics.FormatF64Roundtrip(cwtSigma)));
+                if (consensusSig != null)
+                {
+                    dw.WriteLine("consensus\tscan_idx\tvalue");
+                    for (int i = 0; i < consensusSig.Length; i++)
+                    {
+                        dw.WriteLine(string.Format(inv,
+                            "consensus\t{0}\t{1}",
+                            i, Diagnostics.FormatF64Roundtrip(consensusSig[i])));
+                    }
+                }
             }
             LogAction(string.Format(inv,
                 @"[BISECT] Search XIC dump for entry {0}: {1} xics, {2} scans -> {3}",
@@ -852,6 +920,291 @@ namespace pwiz.OspreySharp
                             "input\t{0}\t{1}\t{2:F10}", xi, s, peakXics[xi].Value[s]));
             }
             LogAction(@"[BISECT] Wrote median polish diagnostic: cs_mp_diag.txt");
+        }
+
+        // ----- Median polish inputs (cross-impl bisection) -----
+
+        // Persistent thread-safe writer for cs_stage6_mp_inputs.tsv.
+        // Lazily opened on first WriteMpInputsRow call; flushed in
+        // CloseMpInputsDump when the rescore loop finishes. Holding the
+        // writer open across calls amortizes the OS-level append cost
+        // over millions of rows (peak_xics fires once per scoring call,
+        // each row is small -- per-call open/close would dominate).
+        private static StreamWriter _mpInputsWriter;
+        private static readonly object _mpInputsLock = new object();
+
+        /// <summary>
+        /// Append one tukey_median_polish input matrix to
+        /// cs_stage6_mp_inputs.tsv. Format: one row per (entry,
+        /// apex_scan, frag_pos, scan_idx) with columns
+        /// <c>entry_id</c>, <c>apex_scan</c>, <c>frag_pos</c>,
+        /// <c>frag_idx</c>, <c>scan_idx</c>, <c>rt</c>, <c>intensity</c>
+        /// -- byte-for-byte identical to Rust's
+        /// <c>diagnostics::dump_mp_inputs</c>. <paramref name="peakXics"/>
+        /// is the same <c>(frag_idx, intensity[])</c> list passed to
+        /// <c>TukeyMedianPolish.Compute</c>; <paramref name="peakRts"/>
+        /// is the shared scan-index-aligned RT vector.
+        /// </summary>
+        public static void WriteMpInputsRow(uint entryId, uint apexScan,
+            IList<KeyValuePair<int, double[]>> peakXics, double[] peakRts)
+        {
+            if (!DumpMpInputs)
+                return;
+            // Build the buffer outside the lock: each call emits 6×N_scans
+            // rows; per-call sort order doesn't matter (bisection sorts
+            // post-hoc), so multiple threads can build their buffers in
+            // parallel and only serialize on the file write.
+            var sb = new StringBuilder(peakXics.Count * peakRts.Length * 48);
+            for (int fragPos = 0; fragPos < peakXics.Count; fragPos++)
+            {
+                int fragIdx = peakXics[fragPos].Key;
+                double[] intensities = peakXics[fragPos].Value;
+                int n = Math.Min(intensities.Length, peakRts.Length);
+                for (int scanIdx = 0; scanIdx < n; scanIdx++)
+                {
+                    sb.Append(entryId).Append('\t')
+                      .Append(apexScan).Append('\t')
+                      .Append(fragPos).Append('\t')
+                      .Append(fragIdx).Append('\t')
+                      .Append(scanIdx).Append('\t')
+                      .Append(Diagnostics.FormatF64Roundtrip(peakRts[scanIdx])).Append('\t')
+                      .Append(Diagnostics.FormatF64Roundtrip(intensities[scanIdx])).Append('\n');
+                }
+            }
+            string payload = sb.ToString();
+            lock (_mpInputsLock)
+            {
+                if (_mpInputsWriter == null)
+                {
+                    _mpInputsWriter = new StreamWriter(@"cs_stage6_mp_inputs.tsv");
+                    _mpInputsWriter.WriteLine(
+                        "# entry_id\tapex_scan\tfrag_pos\tfrag_idx\tscan_idx\trt\tintensity");
+                    LogAction(
+                        @"[BISECT] OSPREY_DUMP_MP_INPUTS active: writing tukey_median_polish inputs to cs_stage6_mp_inputs.tsv");
+                }
+                _mpInputsWriter.Write(payload);
+            }
+        }
+
+        /// <summary>
+        /// Flush and close the cs_stage6_mp_inputs.tsv writer at the end
+        /// of the rescore loop. Safe to call when the writer was never
+        /// opened (no-op).
+        /// </summary>
+        public static void CloseMpInputsDump()
+        {
+            lock (_mpInputsLock)
+            {
+                if (_mpInputsWriter == null)
+                    return;
+                _mpInputsWriter.Flush();
+                _mpInputsWriter.Dispose();
+                _mpInputsWriter = null;
+            }
+        }
+
+        // ----- RT calibration predict() inputs/outputs (cross-impl bisection) -----
+
+        // Persistent thread-safe writer for cs_stage6_predict_rt.tsv.
+        // Lazily opened on first dump call. Two sections share the same
+        // header: cal_arrays rows are emitted once per file at the top
+        // of the rescore loop; predict_calls rows are emitted from
+        // every per-entry rescore search invocation. The bisection
+        // workflow handles the duplicates the predict-call site can
+        // produce (same entry_id scored across multiple windows) with
+        // post-hoc `sort -u`.
+        private static StreamWriter _predictRtWriter;
+        private static readonly object _predictRtLock = new object();
+
+        private static void OpenPredictRtWriterLocked()
+        {
+            // Caller must hold _predictRtLock.
+            if (_predictRtWriter != null)
+                return;
+            _predictRtWriter = new StreamWriter(@"cs_stage6_predict_rt.tsv");
+            _predictRtWriter.WriteLine(
+                "# section\tfile_name_or_entry_id\tarray_or_apex\tidx_or_lib_rt\tvalue_or_expected_rt");
+            LogAction(
+                @"[BISECT] OSPREY_DUMP_PREDICT_RT active: writing predict() inputs/outputs to cs_stage6_predict_rt.tsv");
+        }
+
+        /// <summary>
+        /// Dump the RT calibration's <c>library_rts</c> and
+        /// <c>fitted_values</c> arrays for a file. Append-only -- if
+        /// the rescore loop reuses a file's calibration twice, expect
+        /// duplicate cal_arrays rows. The bisection workflow uses
+        /// <c>sort -u</c> post-hoc to collapse them. Mirrors Rust's
+        /// dump_predict_rt_arrays.
+        /// </summary>
+        public static void WritePredictRtArrays(string fileName, double[] libraryRts, double[] fittedValues)
+        {
+            if (!DumpPredictRt)
+                return;
+            if (libraryRts == null || fittedValues == null)
+                return;
+            var inv = CultureInfo.InvariantCulture;
+            var sb = new StringBuilder((libraryRts.Length + fittedValues.Length) * 64);
+            for (int i = 0; i < libraryRts.Length; i++)
+            {
+                sb.Append("cal_arrays\t").Append(fileName)
+                  .Append("\tlibrary_rts\t").Append(i.ToString(inv))
+                  .Append('\t').Append(Diagnostics.FormatF64Roundtrip(libraryRts[i]))
+                  .Append('\n');
+            }
+            for (int i = 0; i < fittedValues.Length; i++)
+            {
+                sb.Append("cal_arrays\t").Append(fileName)
+                  .Append("\tfitted_values\t").Append(i.ToString(inv))
+                  .Append('\t').Append(Diagnostics.FormatF64Roundtrip(fittedValues[i]))
+                  .Append('\n');
+            }
+            string payload = sb.ToString();
+            lock (_predictRtLock)
+            {
+                OpenPredictRtWriterLocked();
+                _predictRtWriter.Write(payload);
+            }
+        }
+
+        /// <summary>
+        /// Dump a single <c>RTCalibration.Predict</c> input/output
+        /// pair. Same entry_id may appear many times (once per
+        /// per-window candidate). Mirrors Rust's dump_predict_rt_call.
+        /// </summary>
+        public static void WritePredictRtCall(uint entryId, double libraryRt, double expectedRt)
+        {
+            if (!DumpPredictRt)
+                return;
+            string line = string.Concat(
+                "predict_calls\t", entryId.ToString(CultureInfo.InvariantCulture),
+                "\t-\t", Diagnostics.FormatF64Roundtrip(libraryRt),
+                "\t", Diagnostics.FormatF64Roundtrip(expectedRt),
+                "\n");
+            lock (_predictRtLock)
+            {
+                OpenPredictRtWriterLocked();
+                _predictRtWriter.Write(line);
+            }
+        }
+
+        // ----- CWT path summary (cross-impl bisection) -----
+
+        // Persistent thread-safe writer for cs_stage6_cwt_path.tsv.
+        // Lazy-opened on first WriteCwtPathRow call. Threaded scoring
+        // serializes only on the file write itself; the row-build
+        // happens lock-free.
+        private static StreamWriter _cwtPathWriter;
+        private static readonly object _cwtPathLock = new object();
+
+        /// <summary>
+        /// Append one per-(file, entry) row to cs_stage6_cwt_path.tsv
+        /// describing how the CWT detection / fallback / apex-filter
+        /// pipeline behaved for this entry. Use to bisect the cross-
+        /// impl divergence in the rescore set: entries where Rust and
+        /// C# disagree on `scored` flag identify the seam at which
+        /// the rescore engines diverge.
+        ///
+        /// The sigma + consensus-signal stats (l1, max_abs, argmax) are
+        /// computed inside this method by re-running the first half of
+        /// <see cref="CwtPeakDetector.GetConsensusSignal"/> on
+        /// <paramref name="xics"/>, gated by the env-var check above so
+        /// production callers pay nothing when the dump is off. Mirrors
+        /// the Rust side, where <c>dump_cwt_path</c> calls
+        /// <c>get_consensus_signal</c> only after its <c>OnceLock</c>
+        /// writer probe has confirmed the dump is active.
+        /// </summary>
+        public static void WriteCwtPathRow(string fileName, uint entryId,
+            int nCwtPeaks, int nFinalPeaks, int nScored, bool scored,
+            List<XicData> xics)
+        {
+            if (!DumpCwtPath)
+                return;
+            // Recompute sigma + consensus signal here so production
+            // callers don't carry diagnostic state. consensus_l1 (sum
+            // of |consensus[i]|) gives a single-number cross-impl
+            // signature on the consensus signal -- if it matches, the
+            // divergence is in the peak finder (apex enumeration or
+            // boundary extension); if it doesn't, the divergence is
+            // upstream in convolve or median.
+            double sigma = 0.0;
+            double consensusL1 = 0.0;
+            double consensusMaxAbs = 0.0;
+            int consensusArgmax = -1;
+            if (xics != null)
+            {
+                double[] consensus = CwtPeakDetector.GetConsensusSignal(xics, out sigma);
+                if (consensus != null)
+                {
+                    double sum = 0.0;
+                    double maxAbs = 0.0;
+                    int argmax = -1;
+                    for (int i = 0; i < consensus.Length; i++)
+                    {
+                        double a = Math.Abs(consensus[i]);
+                        sum += a;
+                        if (a > maxAbs) { maxAbs = a; argmax = i; }
+                    }
+                    consensusL1 = sum;
+                    consensusMaxAbs = maxAbs;
+                    consensusArgmax = argmax;
+                }
+            }
+            var inv = CultureInfo.InvariantCulture;
+            string line = string.Concat(
+                fileName, '\t',
+                entryId.ToString(inv), '\t',
+                nCwtPeaks.ToString(inv), '\t',
+                nFinalPeaks.ToString(inv), '\t',
+                nScored.ToString(inv), '\t',
+                (scored ? "1" : "0"), '\t',
+                Diagnostics.FormatF64Roundtrip(sigma), '\t',
+                Diagnostics.FormatF64Roundtrip(consensusL1), '\t',
+                Diagnostics.FormatF64Roundtrip(consensusMaxAbs), '\t',
+                consensusArgmax.ToString(inv), '\n');
+            lock (_cwtPathLock)
+            {
+                if (_cwtPathWriter == null)
+                {
+                    _cwtPathWriter = new StreamWriter(@"cs_stage6_cwt_path.tsv");
+                    _cwtPathWriter.WriteLine(
+                        "file_name\tentry_id\tn_cwt_peaks\tn_final_peaks\tn_scored\tscored\tsigma\tconsensus_l1\tconsensus_max_abs\tconsensus_argmax");
+                    LogAction(
+                        @"[BISECT] OSPREY_DUMP_CWT_PATH active: writing CWT path summary to cs_stage6_cwt_path.tsv");
+                }
+                _cwtPathWriter.Write(line);
+            }
+        }
+
+        /// <summary>
+        /// Flush and close the cs_stage6_cwt_path.tsv writer. Safe to
+        /// call when the writer was never opened (no-op).
+        /// </summary>
+        public static void CloseCwtPathDump()
+        {
+            lock (_cwtPathLock)
+            {
+                if (_cwtPathWriter == null)
+                    return;
+                _cwtPathWriter.Flush();
+                _cwtPathWriter.Dispose();
+                _cwtPathWriter = null;
+            }
+        }
+
+        /// <summary>
+        /// Flush and close the cs_stage6_predict_rt.tsv writer. Safe
+        /// to call when the writer was never opened (no-op).
+        /// </summary>
+        public static void ClosePredictRtDump()
+        {
+            lock (_predictRtLock)
+            {
+                if (_predictRtWriter == null)
+                    return;
+                _predictRtWriter.Flush();
+                _predictRtWriter.Dispose();
+                _predictRtWriter = null;
+            }
         }
 
         // ----- Env var parsing helpers -----

--- a/pwiz_tools/OspreySharp/OspreySharp/Program.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/Program.cs
@@ -160,6 +160,16 @@ namespace pwiz.OspreySharp
                 LogInfo(string.Format("Threads: {0}", config.NThreads));
                 LogInfo("");
 
+                // Stage 6 worker mode (--join-at-pass=1 --no-join)
+                // routes to a separate entry point so the in-process
+                // AnalysisPipeline doesn't have to fan out a fourth
+                // "joinOnly with the modifier inverted" code path.
+                if (config.NoJoin && config.InputScores != null
+                    && config.InputScores.Count > 0)
+                {
+                    return RescoreWorker.Run(config);
+                }
+
                 // Run the pipeline
                 var pipeline = new AnalysisPipeline();
                 return pipeline.Run(config);
@@ -568,7 +578,14 @@ namespace pwiz.OspreySharp
             {
                 case 1:
                     if (noJoinFlag)
-                        return "--join-at-pass=1 --no-join (run only Stage 6 from persisted Stage 5 outputs) is not yet implemented.";
+                    {
+                        // `--join-at-pass=1 --no-join` is the per-file
+                        // rescore worker entry point. noJoinFlag stays
+                        // true; joinOnlyFlag stays false. Dispatch in
+                        // Main routes to RescoreWorker.Run instead of
+                        // the in-process AnalysisPipeline.Run.
+                        return null;
+                    }
                     // `--join-at-pass=1 --join-only` (modifier present) means
                     // "run only the Stage 5 join phase, write boundary
                     // files, exit before Stage 6 rescore." Plain
@@ -607,8 +624,24 @@ namespace pwiz.OspreySharp
 
             if (config.NoJoin)
             {
-                if (joinOnly)
-                    return "--no-join cannot be combined with --input-scores.";
+                // Two distinct --no-join modes (mutually exclusive):
+                //   - Standalone --no-join: Stage 1-4 worker (mzML in,
+                //     per-file .scores.parquet out).
+                //   - --join-at-pass=1 --no-join: Stage 6 worker (Stage 4
+                //     parquets + boundary files in, reconciled per-file
+                //     parquets out).
+                // The Stage 6 worker mode is identified by the presence of
+                // --input-scores; the Stage 1-4 worker mode is identified
+                // by --input. Reject the cross.
+                if (hasInputScores)
+                {
+                    if (config.InputFiles.Count > 0)
+                        return "--join-at-pass=1 --no-join cannot be combined with --input. " +
+                               "Use --input-scores; mzML paths are derived from the parquet stems.";
+                    if (config.LibrarySource == null || string.IsNullOrEmpty(config.OutputBlib))
+                        return "--join-at-pass=1 --no-join requires --library and --output.";
+                    return null;
+                }
                 if (config.InputFiles.Count == 0)
                     return "--no-join requires --input <mzML...>.";
                 if (config.LibrarySource == null)

--- a/pwiz_tools/OspreySharp/OspreySharp/Program.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/Program.cs
@@ -38,7 +38,7 @@ namespace pwiz.OspreySharp
         // Tracks the Rust Osprey upstream version this OspreySharp port
         // is aligned with. Used in parquet footer metadata; the Phase 3
         // validator requires same major.minor across cross-impl handoff.
-        internal const string VERSION = "26.4.0";
+        internal const string VERSION = "26.5.0";
         internal const string VERSION_STRING = VERSION;
 
         static int Main(string[] args)

--- a/pwiz_tools/OspreySharp/OspreySharp/Program.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/Program.cs
@@ -114,8 +114,13 @@ namespace pwiz.OspreySharp
                 bool joinOnly = joinOnlyFlag
                                 || (config.InputScores != null && config.InputScores.Count > 0);
 
-                // Non-fatal warning: --no-join with --output supplied.
-                if (config.NoJoin && !string.IsNullOrEmpty(config.OutputBlib))
+                // Non-fatal warning: --no-join with --output supplied — but
+                // ONLY for the Stage 1-4 worker mode (`--no-join --input
+                // ...`) where --output truly is ignored. The Stage 6 worker
+                // mode (`--join-at-pass=1 --no-join --input-scores ...`)
+                // requires --output (per ValidateArgs at line ~642), so
+                // the warning would be incorrect/confusing there.
+                if (config.NoJoin && !joinOnly && !string.IsNullOrEmpty(config.OutputBlib))
                 {
                     LogWarning("--no-join: --output is ignored (no blib is written). " +
                                "Per-file `.scores.parquet` files will be written next to each input mzML.");

--- a/pwiz_tools/OspreySharp/OspreySharp/RescoreCompaction.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/RescoreCompaction.cs
@@ -114,6 +114,17 @@ namespace pwiz.OspreySharp
             double? proteinGate = config.ProteinFdr;
 
             // 1. Build the passing base_id set across all files.
+            //    Decoys are excluded from the predicate by design: target/decoy
+            //    pairs share the same `base_id`, so a passing TARGET retains
+            //    its paired decoy automatically via the base_id retain step
+            //    below. Including decoys in the predicate would let a decoy
+            //    peptide whose parent protein passes protein-FDR rescue
+            //    itself via the protein-rescue clause, inflating the base_id
+            //    set beyond what the in-process pipeline's compaction
+            //    produces (AnalysisPipeline.cs:517 has the matching
+            //    `if (entry.IsDecoy) continue;` filter, and
+            //    `pipeline.rs:3879` and `rescore.rs:457` on the Rust side
+            //    have the matching `!e.is_decoy &&` predicate).
             var firstPassBaseIds = new HashSet<uint>();
             int entriesBefore = 0;
             foreach (var kvp in inputs.PerFileEntries)
@@ -121,6 +132,8 @@ namespace pwiz.OspreySharp
                 entriesBefore += kvp.Value.Count;
                 foreach (var e in kvp.Value)
                 {
+                    if (e.IsDecoy)
+                        continue;
                     if (e.RunPeptideQvalue <= peptideGate ||
                         (proteinGate.HasValue && e.RunProteinQvalue <= proteinGate.Value))
                     {

--- a/pwiz_tools/OspreySharp/OspreySharp/RescoreCompaction.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/RescoreCompaction.cs
@@ -1,0 +1,200 @@
+/*
+ * Original author: Brendan MacLean <brendanx .at. uw.edu>,
+ *                  MacCoss Lab, Department of Genome Sciences, UW
+ * AI assistance: Claude Code (Claude Opus 4) <noreply .at. anthropic.com>
+ *
+ * Based on osprey (https://github.com/MacCossLab/osprey)
+ *   by Michael J. MacCoss, MacCoss Lab, Department of Genome Sciences, UW
+ *
+ * Copyright 2026 University of Washington - Seattle, WA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
+using System.Collections.Generic;
+using pwiz.OspreySharp.Core;
+using pwiz.OspreySharp.FDR.Reconciliation;
+
+namespace pwiz.OspreySharp
+{
+    /// <summary>
+    /// Worker-side compaction for the Stage 6 per-file rescore worker.
+    /// Mirrors the inline compaction block in
+    /// <c>osprey/crates/osprey/src/rescore.rs::run_rescore</c> (the
+    /// section guarded by the comment <i>"Save (file, entry_id) → action
+    /// before per_file_entries shrinks"</i>).
+    ///
+    /// The hydration layer loads PRE-COMPACTION stubs from the parquet
+    /// (every entry in the Stage 4 cache, including non-passing
+    /// targets and decoys). The in-process pipeline drops non-passing
+    /// entries between first-pass FDR and Stage 6 — see
+    /// <c>AnalysisPipeline</c>'s <i>"First-pass compaction"</i> block.
+    /// The worker has to reproduce that drop EXACTLY, otherwise it
+    /// would re-score entries the in-process flow had already
+    /// discarded, overwriting their Stage-4 features with
+    /// Stage-6-recomputed values that diverge on the multi-scan
+    /// columns. (This is the original ~324-row Stellar divergence
+    /// described in the umbrella TODO Session 5 entry.)
+    ///
+    /// Compaction is keyed by <c>base_id</c> (the entry_id with the
+    /// high decoy bit cleared), so a passing target retains its paired
+    /// decoy automatically. The reconciliation action map is
+    /// pre-compaction (vec_idx values point into the loaded stub list);
+    /// after compaction those indices are stale, so the actions are
+    /// re-keyed via a <c>(file_name, entry_id)</c> intermediate to land
+    /// on the new vec_idx values.
+    /// </summary>
+    public static class RescoreCompaction
+    {
+        // EntryId encodes target/decoy in the high bit; base_id is the
+        // lower 31 bits, shared by a target and its paired decoy.
+        private const uint BASE_ID_MASK = 0x7FFFFFFFu;
+
+        /// <summary>
+        /// Result of <see cref="Apply"/>: compaction statistics for the
+        /// caller's log line. The <see cref="RescoreInputs"/> passed in is
+        /// mutated in place.
+        /// </summary>
+        public class Stats
+        {
+            /// <summary>Total stubs across all files BEFORE compaction.</summary>
+            public int EntriesBefore { get; set; }
+
+            /// <summary>Total stubs across all files AFTER compaction.</summary>
+            public int EntriesAfter { get; set; }
+
+            /// <summary>Distinct base_ids that passed the predicate.</summary>
+            public int FirstPassBaseIds { get; set; }
+
+            /// <summary>
+            /// Reconciliation actions whose pre-compaction entry got
+            /// dropped by compaction. Should be 0 in healthy boundary
+            /// files (the planner only emits actions for passing entries);
+            /// a non-zero count means the boundary file was written with
+            /// different config than the worker's, or by an older binary.
+            /// </summary>
+            public int DroppedActions { get; set; }
+        }
+
+        /// <summary>
+        /// Apply first-pass FDR compaction in place to
+        /// <paramref name="inputs"/>. Mutates
+        /// <see cref="RescoreInputs.PerFileEntries"/> (drops non-passing
+        /// entries) and rebuilds
+        /// <see cref="RescoreInputs.ReconciliationActions"/> with
+        /// post-compaction <c>vec_idx</c> values.
+        ///
+        /// Predicate (mirrors Rust <c>rescore::run_rescore</c>'s
+        /// compaction block): an entry's <c>base_id</c> is retained if
+        /// EITHER <c>RunPeptideQvalue ≤ peptideGate</c> OR
+        /// (<c>--protein-fdr</c> set AND <c>RunProteinQvalue ≤ proteinGate</c>).
+        /// <paramref name="config"/>'s <see cref="OspreyConfig.RunFdr"/>
+        /// supplies the peptide gate (matches the in-process flow's
+        /// <c>peptideGate = config.RunFdr</c> at the same step), and
+        /// <see cref="OspreyConfig.ProteinFdr"/> the protein-rescue
+        /// gate (skipped entirely when null).
+        /// </summary>
+        public static Stats Apply(RescoreInputs inputs, OspreyConfig config)
+        {
+            if (inputs == null) throw new ArgumentNullException(nameof(inputs));
+            if (config == null) throw new ArgumentNullException(nameof(config));
+
+            double peptideGate = config.RunFdr;
+            double? proteinGate = config.ProteinFdr;
+
+            // 1. Build the passing base_id set across all files.
+            var firstPassBaseIds = new HashSet<uint>();
+            int entriesBefore = 0;
+            foreach (var kvp in inputs.PerFileEntries)
+            {
+                entriesBefore += kvp.Value.Count;
+                foreach (var e in kvp.Value)
+                {
+                    if (e.RunPeptideQvalue <= peptideGate ||
+                        (proteinGate.HasValue && e.RunProteinQvalue <= proteinGate.Value))
+                    {
+                        firstPassBaseIds.Add(e.EntryId & BASE_ID_MASK);
+                    }
+                }
+            }
+
+            // 2. Snapshot pre-compaction (file, entry_id) -> action so
+            //    the action map can be rebuilt with post-compaction
+            //    vec_idx values. We have to do this BEFORE per_file_entries
+            //    shrinks, because the saved (file, vec_idx) keys are about
+            //    to become stale.
+            var actionsById = new Dictionary<(string FileName, uint EntryId), ReconcileAction>(
+                inputs.ReconciliationActions.Count);
+            // Build a lookup map so the per-action entry_id resolution is
+            // O(1) instead of O(num_files) per action.
+            var entriesByName = new Dictionary<string, List<FdrEntry>>(
+                inputs.PerFileEntries.Count);
+            foreach (var kvp in inputs.PerFileEntries)
+                entriesByName[kvp.Key] = kvp.Value;
+
+            foreach (var kvp in inputs.ReconciliationActions)
+            {
+                var (fileName, vecIdx) = kvp.Key;
+                if (!entriesByName.TryGetValue(fileName, out var entries))
+                    continue;
+                if (vecIdx < 0 || vecIdx >= entries.Count)
+                    continue;
+                actionsById[(fileName, entries[vecIdx].EntryId)] = kvp.Value;
+            }
+
+            // 3. Compact each per-file entry list in place.
+            foreach (var kvp in inputs.PerFileEntries)
+            {
+                kvp.Value.RemoveAll(e => !firstPassBaseIds.Contains(e.EntryId & BASE_ID_MASK));
+                kvp.Value.TrimExcess();
+            }
+            int entriesAfter = 0;
+            foreach (var kvp in inputs.PerFileEntries)
+                entriesAfter += kvp.Value.Count;
+
+            // 4. Rebuild reconciliation_actions with post-compaction
+            //    vec_idx. Walk the now-compact list, look up each entry's
+            //    (file, entry_id) in actionsById, and drop the matched
+            //    action onto its new index. Anything left in actionsById
+            //    after the walk references entries that compaction
+            //    discarded — log the count.
+            var newActions = new Dictionary<(string, int), ReconcileAction>(actionsById.Count);
+            int dropped;
+            foreach (var kvp in inputs.PerFileEntries)
+            {
+                string fileName = kvp.Key;
+                var entries = kvp.Value;
+                for (int newIdx = 0; newIdx < entries.Count; newIdx++)
+                {
+                    var key = (fileName, entries[newIdx].EntryId);
+                    if (actionsById.TryGetValue(key, out var action))
+                    {
+                        newActions[(fileName, newIdx)] = action;
+                        actionsById.Remove(key);
+                    }
+                }
+            }
+            dropped = actionsById.Count;
+            inputs.ReconciliationActions = newActions;
+
+            return new Stats
+            {
+                EntriesBefore = entriesBefore,
+                EntriesAfter = entriesAfter,
+                FirstPassBaseIds = firstPassBaseIds.Count,
+                DroppedActions = dropped,
+            };
+        }
+    }
+}

--- a/pwiz_tools/OspreySharp/OspreySharp/RescoreHydration.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/RescoreHydration.cs
@@ -1,0 +1,305 @@
+/*
+ * Original author: Brendan MacLean <brendanx .at. uw.edu>,
+ *                  MacCoss Lab, Department of Genome Sciences, UW
+ * AI assistance: Claude Code (Claude Opus 4) <noreply .at. anthropic.com>
+ *
+ * Based on osprey (https://github.com/MacCossLab/osprey)
+ *   by Michael J. MacCoss, MacCoss Lab, Department of Genome Sciences, UW
+ *
+ * Copyright 2026 University of Washington - Seattle, WA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using pwiz.OspreySharp.Chromatography;
+using pwiz.OspreySharp.Core;
+using pwiz.OspreySharp.FDR.Reconciliation;
+using pwiz.OspreySharp.IO;
+
+namespace pwiz.OspreySharp
+{
+    /// <summary>
+    /// In-memory state needed to drive a per-file Stage 6 rescore from
+    /// the Stage 5 → Stage 6 boundary files on disk. Mirrors
+    /// <c>RescoreInputs</c> in <c>osprey/crates/osprey/src/rescore.rs</c>.
+    /// The same shape the in-process pipeline holds at the boundary, so
+    /// the rescore engine can be written once and used from both the
+    /// in-process path and the worker path.
+    /// </summary>
+    public class RescoreInputs
+    {
+        /// <summary>
+        /// Per-file <see cref="FdrEntry"/> stubs from
+        /// <c>&lt;stem&gt;.scores.parquet</c>, with SVM scores + 4 q-values
+        /// + PEP + <c>RunProteinQvalue</c> overlaid from the
+        /// <c>&lt;stem&gt;.1st-pass.fdr_scores.bin</c> sidecar. File order
+        /// matches the order of <c>parquetPaths</c> passed to
+        /// <see cref="RescoreHydration.HydrateForRescore"/>.
+        /// </summary>
+        public List<KeyValuePair<string, List<FdrEntry>>> PerFileEntries { get; set; }
+
+        /// <summary>
+        /// Reconciliation actions keyed by <c>(file_name, vec_idx)</c>.
+        /// Built from the homogeneous <c>use_cwt_peak_actions</c> +
+        /// <c>forced_integration_actions</c> arrays in
+        /// <c>reconciliation.json</c> by joining each action's
+        /// <c>entry_id</c> against the loaded stub list. Keep actions
+        /// are implicitly absent (the planner never persists them).
+        /// </summary>
+        public Dictionary<(string FileName, int VecIdx), ReconcileAction> ReconciliationActions { get; set; }
+
+        /// <summary>
+        /// Refined per-file RT calibrations reconstructed from
+        /// <c>reconciliation.json</c>'s <c>refined_rt_calibration</c>
+        /// field via <see cref="RTCalibration.FromModelParams"/>. Files
+        /// whose envelope had a null calibration (e.g., refined fit
+        /// failed during Stage 5) are absent from the dictionary.
+        /// </summary>
+        public Dictionary<string, RTCalibration> RefinedCalibrations { get; set; }
+
+        /// <summary>
+        /// Per-file gap-fill targets parsed from
+        /// <c>reconciliation.json</c>'s <c>gap_fill_targets</c> array.
+        /// </summary>
+        public Dictionary<string, List<GapFillTarget>> PerFileGapFill { get; set; }
+
+        /// <summary>Total non-Keep reconciliation actions across all files.</summary>
+        public int TotalActions => ReconciliationActions.Count;
+
+        /// <summary>Total stubs across all files.</summary>
+        public int TotalStubs
+        {
+            get
+            {
+                int n = 0;
+                foreach (var kv in PerFileEntries)
+                    n += kv.Value.Count;
+                return n;
+            }
+        }
+
+        /// <summary>Total gap-fill targets across all files.</summary>
+        public int TotalGapFillTargets
+        {
+            get
+            {
+                int n = 0;
+                foreach (var kv in PerFileGapFill)
+                    n += kv.Value.Count;
+                return n;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Hydrate the Stage 5 → Stage 6 boundary file pair into the
+    /// in-memory state needed to drive a per-file rescore. Mirrors
+    /// <c>hydrate_for_rescore</c> in
+    /// <c>osprey/crates/osprey/src/rescore.rs</c>.
+    /// </summary>
+    public static class RescoreHydration
+    {
+        /// <summary>
+        /// Read each <c>&lt;stem&gt;.scores.parquet</c> in
+        /// <paramref name="parquetPaths"/>, overlay the matching
+        /// <c>&lt;stem&gt;.1st-pass.fdr_scores.bin</c> sidecar (v3 format,
+        /// pass = FirstPass), and parse the matching
+        /// <c>&lt;stem&gt;.reconciliation.json</c> envelope into the
+        /// per-file action map + refined calibration + gap-fill list.
+        ///
+        /// File names are extracted from the parquet stem with the
+        /// <c>.scores</c> suffix stripped, mirroring Rust's
+        /// <c>synthetic_input_from_parquet</c>. The output preserves the
+        /// input ordering.
+        ///
+        /// Throws <see cref="InvalidDataException"/> on any per-file boundary
+        /// file that is missing, unreadable, or fails its format-version /
+        /// count checks. Does not silently fall back to partial state — a
+        /// Stage 6 worker that proceeded with one file's planner output
+        /// missing would scramble gap-fill results across files.
+        /// </summary>
+        public static RescoreInputs HydrateForRescore(IList<string> parquetPaths)
+        {
+            if (parquetPaths == null) throw new ArgumentNullException(nameof(parquetPaths));
+            if (parquetPaths.Count == 0)
+                throw new InvalidDataException("HydrateForRescore: parquetPaths is empty");
+
+            var perFileEntries = new List<KeyValuePair<string, List<FdrEntry>>>(parquetPaths.Count);
+            var refinedCalibrations = new Dictionary<string, RTCalibration>();
+            var perFileGapFill = new Dictionary<string, List<GapFillTarget>>();
+            var reconciliationActions = new Dictionary<(string, int), ReconcileAction>();
+
+            foreach (var parquetPath in parquetPaths)
+            {
+                string syntheticInput = SyntheticInputFromParquet(parquetPath);
+                string fileName = Path.GetFileNameWithoutExtension(syntheticInput);
+                if (string.IsNullOrEmpty(fileName))
+                {
+                    throw new InvalidDataException(string.Format(
+                        "HydrateForRescore: could not derive file_name from parquet path {0}",
+                        parquetPath));
+                }
+
+                // 1. Stubs from parquet (entry_id, charge, modseq, RTs,
+                //    parquet_index assigned by LoadFdrStubsFromParquet).
+                List<FdrEntry> stubs;
+                try
+                {
+                    stubs = ParquetScoreCache.LoadFdrStubsFromParquet(parquetPath);
+                }
+                catch (Exception ex)
+                {
+                    throw new InvalidDataException(string.Format(
+                        "HydrateForRescore: failed to load stubs from {0}: {1}",
+                        parquetPath, ex.Message), ex);
+                }
+
+                // 2. Overlay SVM scores + 4 q-values + PEP +
+                //    RunProteinQvalue from .1st-pass.fdr_scores.bin v3.
+                //    expected_pass = FirstPass: the planner's actions were
+                //    computed against first-pass FDR, and the worker
+                //    compaction predicate uses first-pass q-values.
+                string sidecarPath = FdrScoresSidecar.Pass1Path(syntheticInput);
+                if (!FdrScoresSidecar.TryRead(sidecarPath, stubs, FdrScoresSidecar.Pass.FirstPass))
+                {
+                    throw new InvalidDataException(string.Format(
+                        "HydrateForRescore: failed to overlay .1st-pass.fdr_scores.bin for {0} " +
+                        "(expected at {1})", fileName, sidecarPath));
+                }
+
+                // 3. Parse reconciliation.json.
+                string reconPath = ReconciliationFile.PathForInput(syntheticInput);
+                ReconciliationFile envelope;
+                try
+                {
+                    envelope = ReconciliationFile.Load(reconPath);
+                }
+                catch (Exception ex)
+                {
+                    throw new InvalidDataException(string.Format(
+                        "HydrateForRescore: failed to read {0}: {1}",
+                        reconPath, ex.Message), ex);
+                }
+
+                // 3a. Build entry_id → vec_idx map from the loaded stubs
+                //     so the planner's entry_id-keyed actions can be
+                //     rehomed onto (file_name, vec_idx) keys the rescore
+                //     engine consumes.
+                var idToIdx = new Dictionary<uint, int>(stubs.Count);
+                for (int idx = 0; idx < stubs.Count; idx++)
+                    idToIdx[stubs[idx].EntryId] = idx;
+
+                // 3b. UseCwtPeak actions.
+                if (envelope.UseCwtPeakActions != null)
+                {
+                    foreach (var entry in envelope.UseCwtPeakActions)
+                    {
+                        if (!idToIdx.TryGetValue(entry.EntryId, out int vecIdx))
+                        {
+                            throw new InvalidDataException(string.Format(
+                                "HydrateForRescore: use_cwt_peak entry_id {0} in {1} not found " +
+                                "in stubs (parquet drift?)", entry.EntryId, reconPath));
+                        }
+                        reconciliationActions[(fileName, vecIdx)] = new ReconcileAction.UseCwtPeak(
+                            (int)entry.CandidateIdx, entry.StartRt, entry.ApexRt, entry.EndRt);
+                    }
+                }
+
+                // 3c. ForcedIntegration actions.
+                if (envelope.ForcedIntegrationActions != null)
+                {
+                    foreach (var entry in envelope.ForcedIntegrationActions)
+                    {
+                        if (!idToIdx.TryGetValue(entry.EntryId, out int vecIdx))
+                        {
+                            throw new InvalidDataException(string.Format(
+                                "HydrateForRescore: forced_integration entry_id {0} in {1} not " +
+                                "found in stubs (parquet drift?)", entry.EntryId, reconPath));
+                        }
+                        reconciliationActions[(fileName, vecIdx)] = new ReconcileAction.ForcedIntegration(
+                            entry.ExpectedRt, entry.HalfWidth);
+                    }
+                }
+
+                // 3d. Refined RT calibration (optional — null when
+                //     Stage 5's LOESS refit failed for this file).
+                if (envelope.RefinedRtCalibration != null)
+                {
+                    var cal = RTCalibration.FromModelParams(
+                        envelope.RefinedRtCalibration.LibraryRts,
+                        envelope.RefinedRtCalibration.FittedRts,
+                        envelope.RefinedRtCalibration.AbsResiduals,
+                        envelope.RefinedRtCalibration.ResidualSd);
+                    refinedCalibrations[fileName] = cal;
+                }
+
+                // 3e. Gap-fill targets.
+                if (envelope.GapFillTargets != null && envelope.GapFillTargets.Count > 0)
+                {
+                    var gapFill = new List<GapFillTarget>(envelope.GapFillTargets.Count);
+                    foreach (var g in envelope.GapFillTargets)
+                    {
+                        gapFill.Add(new GapFillTarget
+                        {
+                            TargetEntryId = g.TargetEntryId,
+                            DecoyEntryId = g.DecoyEntryId,
+                            ExpectedRt = g.ExpectedRt,
+                            HalfWidth = g.HalfWidth,
+                            ModifiedSequence = g.ModifiedSequence,
+                            Charge = g.Charge,
+                        });
+                    }
+                    perFileGapFill[fileName] = gapFill;
+                }
+
+                perFileEntries.Add(new KeyValuePair<string, List<FdrEntry>>(fileName, stubs));
+            }
+
+            return new RescoreInputs
+            {
+                PerFileEntries = perFileEntries,
+                ReconciliationActions = reconciliationActions,
+                RefinedCalibrations = refinedCalibrations,
+                PerFileGapFill = perFileGapFill,
+            };
+        }
+
+        /// <summary>
+        /// Inverse of <c>scores_path_for_input</c>: given
+        /// <c>/data/sample1.scores.parquet</c>, produce a synthetic input
+        /// path <c>/data/sample1.mzML</c> whose stem matches what the
+        /// worker used. This lets the worker reuse the existing
+        /// path-derivation helpers (FDR sidecars, calibration JSON,
+        /// reconciliation JSON) without duplicating them. The synthetic
+        /// path is never opened — only its components are inspected.
+        /// Mirrors Rust's <c>synthetic_input_from_parquet</c>.
+        /// </summary>
+        public static string SyntheticInputFromParquet(string parquetPath)
+        {
+            if (parquetPath == null) throw new ArgumentNullException(nameof(parquetPath));
+            // GetFileNameWithoutExtension returns "" not null for valid paths
+            // and throws on invalid input, so the result is never null here.
+            string stem = Path.GetFileNameWithoutExtension(parquetPath);
+            // Strip a trailing ".scores" if present.
+            const string ScoresSuffix = ".scores";
+            if (stem.EndsWith(ScoresSuffix, StringComparison.Ordinal))
+                stem = stem.Substring(0, stem.Length - ScoresSuffix.Length);
+            string parent = Path.GetDirectoryName(parquetPath);
+            string filename = stem + ".mzML";
+            return string.IsNullOrEmpty(parent) ? filename : Path.Combine(parent, filename);
+        }
+    }
+}

--- a/pwiz_tools/OspreySharp/OspreySharp/RescoreWorker.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/RescoreWorker.cs
@@ -1,0 +1,160 @@
+/*
+ * Original author: Brendan MacLean <brendanx .at. uw.edu>,
+ *                  MacCoss Lab, Department of Genome Sciences, UW
+ * AI assistance: Claude Code (Claude Opus 4) <noreply .at. anthropic.com>
+ *
+ * Based on osprey (https://github.com/MacCossLab/osprey)
+ *   by Michael J. MacCoss, MacCoss Lab, Department of Genome Sciences, UW
+ *
+ * Copyright 2026 University of Washington - Seattle, WA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
+using pwiz.OspreySharp.Core;
+
+namespace pwiz.OspreySharp
+{
+    /// <summary>
+    /// Top-level entry point for the <c>--join-at-pass=1 --no-join</c>
+    /// per-file rescore worker. Mirrors <c>run_rescore</c> in
+    /// <c>osprey/crates/osprey/src/rescore.rs</c>.
+    ///
+    /// Today this entry point handles the foundation pieces only:
+    /// hydration of the Stage 5 → Stage 6 boundary files
+    /// (<see cref="RescoreHydration.HydrateForRescore"/>) followed by
+    /// worker compaction (<see cref="RescoreCompaction.Apply"/>). The
+    /// per-file rescore engine itself (boundary-overrides search +
+    /// gap-fill two-pass + reconciled parquet write-back) is not yet
+    /// ported; the in-process pipeline at
+    /// <c>AnalysisPipeline.Run</c> also stubs it out with the same
+    /// "Stage 6 per-file rescore: not yet implemented" log line. Both
+    /// sides will lift together once the C# rescore engine port
+    /// lands.
+    ///
+    /// What this entry point does deliver today:
+    /// <list type="bullet">
+    ///   <item>
+    ///     Validates the CLI shape (<c>--input-scores</c>,
+    ///     <c>--library</c>, <c>--output</c> required;
+    ///     <c>--input</c> forbidden) — handled by
+    ///     <c>Program.ValidateArgs</c>.
+    ///   </item>
+    ///   <item>
+    ///     Loads each <c>&lt;stem&gt;.scores.parquet</c> into
+    ///     <see cref="Core.FdrEntry"/> stubs and overlays the
+    ///     <c>&lt;stem&gt;.1st-pass.fdr_scores.bin</c> sidecar (v3),
+    ///     parses the sibling <c>&lt;stem&gt;.reconciliation.json</c>
+    ///     into per-file actions + refined RT calibration + gap-fill
+    ///     targets.
+    ///   </item>
+    ///   <item>
+    ///     Reproduces the in-process compaction predicate
+    ///     (peptide-FDR OR protein-rescue) so the post-hydrate
+    ///     in-memory state matches what the in-process pipeline holds
+    ///     at the same seam.
+    ///   </item>
+    ///   <item>
+    ///     Logs the hydrated / compacted counts so a future cross-impl
+    ///     bit-parity diagnostic dump can verify both sides reach
+    ///     identical state at the Stage 5 → Stage 6 seam.
+    ///   </item>
+    /// </list>
+    ///
+    /// Returns a non-zero exit code with a clear message until the
+    /// rescore engine lands; do NOT swallow this as success.
+    /// </summary>
+    public static class RescoreWorker
+    {
+        /// <summary>
+        /// Run the per-file rescore worker on the boundary files
+        /// referenced by <see cref="OspreyConfig.InputScores"/>.
+        ///
+        /// Returns 0 on full success (foundation runs cleanly + rescore
+        /// engine completes) or non-zero with an explanatory log line
+        /// on any failure. Today's stub returns a non-zero exit code
+        /// after hydration + compaction succeed because the rescore
+        /// engine isn't ported yet.
+        /// </summary>
+        public static int Run(OspreyConfig config)
+        {
+            if (config == null) throw new ArgumentNullException(nameof(config));
+            if (config.InputScores == null || config.InputScores.Count == 0)
+            {
+                Program.LogError(
+                    "--join-at-pass=1 --no-join requires --input-scores <path...>.");
+                return 1;
+            }
+
+            Program.LogInfo(string.Format(
+                "--join-at-pass=1 --no-join: per-file rescore worker starting on {0} parquet(s)",
+                config.InputScores.Count));
+
+            RescoreInputs inputs;
+            try
+            {
+                inputs = RescoreHydration.HydrateForRescore(config.InputScores);
+            }
+            catch (Exception ex)
+            {
+                Program.LogError(string.Format(
+                    "--join-at-pass=1 --no-join: hydration failed: {0}", ex.Message));
+                return 1;
+            }
+            Program.LogInfo(string.Format(
+                "Hydrated {0} file(s); {1} pre-compaction stubs, {2} reconciliation actions, " +
+                "{3} gap-fill candidates, {4} refined RT calibration(s)",
+                inputs.PerFileEntries.Count,
+                inputs.TotalStubs,
+                inputs.TotalActions,
+                inputs.TotalGapFillTargets,
+                inputs.RefinedCalibrations.Count));
+
+            RescoreCompaction.Stats stats;
+            try
+            {
+                stats = RescoreCompaction.Apply(inputs, config);
+            }
+            catch (Exception ex)
+            {
+                Program.LogError(string.Format(
+                    "--join-at-pass=1 --no-join: compaction failed: {0}", ex.Message));
+                return 1;
+            }
+            Program.LogInfo(string.Format(
+                "Worker compaction: {0} -> {1} entries ({2} surviving base_ids), " +
+                "{3} reconciliation actions retained ({4} dropped)",
+                stats.EntriesBefore,
+                stats.EntriesAfter,
+                stats.FirstPassBaseIds,
+                inputs.ReconciliationActions.Count,
+                stats.DroppedActions));
+
+            // Foundation is in place; the rescore engine itself
+            // (boundary-overrides search + gap-fill two-pass + reconciled
+            // parquet write-back) is the next porting effort. Until it
+            // lands, the worker can't produce reconciled .scores.parquet
+            // output, so return non-zero with a clear pointer rather
+            // than letting a downstream --join-at-pass=2 invocation
+            // silently consume stale Stage 4 parquets.
+            Program.LogError(
+                "--join-at-pass=1 --no-join: hydration + compaction completed cleanly, but " +
+                "the per-file rescore engine (boundary-overrides search + gap-fill + reconciled " +
+                "parquet write-back) is not yet ported to OspreySharp. The in-process pipeline " +
+                "stubs this out with the same message. Both sides will lift together once the " +
+                "C# rescore engine port lands.");
+            return 2;
+        }
+    }
+}

--- a/pwiz_tools/OspreySharp/OspreySharp/RescoreWorker.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/RescoreWorker.cs
@@ -121,6 +121,16 @@ namespace pwiz.OspreySharp
                 inputs.TotalGapFillTargets,
                 inputs.RefinedCalibrations.Count));
 
+            // Cross-impl bisection seam: dump the per-precursor q-values
+            // that were just hydrated from .1st-pass.fdr_scores.bin so
+            // the result can be diffed against Rust's
+            // rust_stage5_percolator.tsv via Compare-Percolator.ps1.
+            // If the diff is non-empty, the divergence is in hydration
+            // (sidecar parsing); if empty, divergence (if any) is
+            // downstream of this seam (compaction or rescore).
+            if (OspreyDiagnostics.DumpPercolator)
+                OspreyDiagnostics.WriteStage5PercolatorDump(inputs.PerFileEntries);
+
             RescoreCompaction.Stats stats;
             try
             {

--- a/pwiz_tools/OspreySharp/OspreySharp/RescoreWorker.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/RescoreWorker.cs
@@ -21,7 +21,6 @@
  * limitations under the License.
  */
 
-using System;
 using pwiz.OspreySharp.Core;
 
 namespace pwiz.OspreySharp
@@ -89,82 +88,14 @@ namespace pwiz.OspreySharp
         /// </summary>
         public static int Run(OspreyConfig config)
         {
-            if (config == null) throw new ArgumentNullException(nameof(config));
-            if (config.InputScores == null || config.InputScores.Count == 0)
-            {
-                Program.LogError(
-                    "--join-at-pass=1 --no-join requires --input-scores <path...>.");
-                return 1;
-            }
-
-            Program.LogInfo(string.Format(
-                "--join-at-pass=1 --no-join: per-file rescore worker starting on {0} parquet(s)",
-                config.InputScores.Count));
-
-            RescoreInputs inputs;
-            try
-            {
-                inputs = RescoreHydration.HydrateForRescore(config.InputScores);
-            }
-            catch (Exception ex)
-            {
-                Program.LogError(string.Format(
-                    "--join-at-pass=1 --no-join: hydration failed: {0}", ex.Message));
-                return 1;
-            }
-            Program.LogInfo(string.Format(
-                "Hydrated {0} file(s); {1} pre-compaction stubs, {2} reconciliation actions, " +
-                "{3} gap-fill candidates, {4} refined RT calibration(s)",
-                inputs.PerFileEntries.Count,
-                inputs.TotalStubs,
-                inputs.TotalActions,
-                inputs.TotalGapFillTargets,
-                inputs.RefinedCalibrations.Count));
-
-            // Cross-impl bisection seam: dump the per-precursor q-values
-            // that were just hydrated from .1st-pass.fdr_scores.bin so
-            // the result can be diffed against Rust's
-            // rust_stage5_percolator.tsv via Compare-Percolator.ps1.
-            // If the diff is non-empty, the divergence is in hydration
-            // (sidecar parsing); if empty, divergence (if any) is
-            // downstream of this seam (compaction or rescore).
-            if (OspreyDiagnostics.DumpPercolator)
-                OspreyDiagnostics.WriteStage5PercolatorDump(inputs.PerFileEntries);
-
-            RescoreCompaction.Stats stats;
-            try
-            {
-                stats = RescoreCompaction.Apply(inputs, config);
-            }
-            catch (Exception ex)
-            {
-                Program.LogError(string.Format(
-                    "--join-at-pass=1 --no-join: compaction failed: {0}", ex.Message));
-                return 1;
-            }
-            Program.LogInfo(string.Format(
-                "Worker compaction: {0} -> {1} entries ({2} surviving base_ids), " +
-                "{3} reconciliation actions retained ({4} dropped)",
-                stats.EntriesBefore,
-                stats.EntriesAfter,
-                stats.FirstPassBaseIds,
-                inputs.ReconciliationActions.Count,
-                stats.DroppedActions));
-
-            // Foundation is in place; the rescore engine itself
-            // (boundary-overrides search + gap-fill two-pass + reconciled
-            // parquet write-back) is the next porting effort. Until it
-            // lands, the worker can't produce reconciled .scores.parquet
-            // output, so return non-zero with a clear pointer rather
-            // than letting a downstream --join-at-pass=2 invocation
-            // silently consume stale Stage 4 parquets.
-            Program.LogError(
-                "--join-at-pass=1 --no-join: hydration + compaction completed cleanly, but " +
-                "the per-file rescore engine (boundary-overrides search + gap-fill + reconciled " +
-                "parquet write-back) is not yet ported to OspreySharp. The in-process pipeline " +
-                "stubs this out with the same message. Both sides will lift together once the " +
-                "C# rescore engine port lands.");
-            return 2;
+            // Thin facade — all worker logic lives on AnalysisPipeline so
+            // it can share the in-process Stage 6 code path. Keeps
+            // Program.Main's dispatch unchanged while letting the heavy
+            // lifting (library load, hydration, compaction, rescore loop,
+            // future gap-fill + parquet write-back) live alongside the
+            // rest of the pipeline.
+            var pipeline = new AnalysisPipeline();
+            return pipeline.RunWorker(config);
         }
     }
 }

--- a/pwiz_tools/OspreySharp/OspreySharp/RescoreWorker.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/RescoreWorker.cs
@@ -30,19 +30,8 @@ namespace pwiz.OspreySharp
     /// per-file rescore worker. Mirrors <c>run_rescore</c> in
     /// <c>osprey/crates/osprey/src/rescore.rs</c>.
     ///
-    /// Today this entry point handles the foundation pieces only:
-    /// hydration of the Stage 5 → Stage 6 boundary files
-    /// (<see cref="RescoreHydration.HydrateForRescore"/>) followed by
-    /// worker compaction (<see cref="RescoreCompaction.Apply"/>). The
-    /// per-file rescore engine itself (boundary-overrides search +
-    /// gap-fill two-pass + reconciled parquet write-back) is not yet
-    /// ported; the in-process pipeline at
-    /// <c>AnalysisPipeline.Run</c> also stubs it out with the same
-    /// "Stage 6 per-file rescore: not yet implemented" log line. Both
-    /// sides will lift together once the C# rescore engine port
-    /// lands.
-    ///
-    /// What this entry point does deliver today:
+    /// End-to-end behavior (cross-impl byte-parity validated on
+    /// Stellar + Astral as of 2026-05-06):
     /// <list type="bullet">
     ///   <item>
     ///     Validates the CLI shape (<c>--input-scores</c>,
@@ -59,32 +48,34 @@ namespace pwiz.OspreySharp
     ///     targets.
     ///   </item>
     ///   <item>
-    ///     Reproduces the in-process compaction predicate
-    ///     (peptide-FDR OR protein-rescue) so the post-hydrate
-    ///     in-memory state matches what the in-process pipeline holds
-    ///     at the same seam.
+    ///     Reproduces the in-process compaction predicate (peptide-FDR
+    ///     OR protein-rescue) so the post-hydrate in-memory state
+    ///     matches what the in-process pipeline holds at the same seam.
     ///   </item>
     ///   <item>
-    ///     Logs the hydrated / compacted counts so a future cross-impl
-    ///     bit-parity diagnostic dump can verify both sides reach
-    ///     identical state at the Stage 5 → Stage 6 seam.
+    ///     Runs the per-file rescore engine: consensus + reconciliation
+    ///     overlay (Phase 1), gap-fill two-pass with prefilter-off CWT
+    ///     and forced-integration fallback (Phase 2), and reconciled
+    ///     parquet write-back with `osprey.reconciled` /
+    ///     `osprey.reconciliation_hash` footer metadata (Phase 3).
     ///   </item>
     /// </list>
     ///
-    /// Returns a non-zero exit code with a clear message until the
-    /// rescore engine lands; do NOT swallow this as success.
+    /// Returns 0 on full success, non-zero with an explanatory log
+    /// line on any failure (library load, hydration, compaction, or
+    /// rescore loop). Six per-row blob columns (<c>fragment_mzs</c>,
+    /// <c>fragment_intensities</c>, <c>reference_xic_rts</c>,
+    /// <c>reference_xic_intensities</c>, <c>bounds_area</c>,
+    /// <c>bounds_snr</c>) are written as null/zero today — tracked as
+    /// follow-up against
+    /// <c>ai/todos/backlog/brendanx67/TODO-ospreysharp_missing_scoring_columns.md</c>.
     /// </summary>
     public static class RescoreWorker
     {
         /// <summary>
         /// Run the per-file rescore worker on the boundary files
         /// referenced by <see cref="OspreyConfig.InputScores"/>.
-        ///
-        /// Returns 0 on full success (foundation runs cleanly + rescore
-        /// engine completes) or non-zero with an explanatory log line
-        /// on any failure. Today's stub returns a non-zero exit code
-        /// after hydration + compaction succeed because the rescore
-        /// engine isn't ported yet.
+        /// Returns 0 on success, non-zero on failure.
         /// </summary>
         public static int Run(OspreyConfig config)
         {


### PR DESCRIPTION
## Summary

* Phase 2 gap-fill (CWT + forced) and post-rescore parity dump (`OSPREY_DUMP_RESCORED`)
* Phase 3 reconciled parquet write-back (`WriteReconciledParquet` + `LoadFullFdrEntries` + `OspreyConfig.ReconciliationParameterHash`)
* Production fixes that root-caused cross-impl divergence: MS2 calibration applied to a local copy, rt_tolerance MAD sourced from `.calibration.json`, post-rank apex recompute over ref_xic, override path uses peak.ApexIndex, five `>` → `>=` tie-breaks, capturedPeaks built unconditionally for non-override paths, abs-diff RT window, five Sort → OrderByDescending stable sorts, always-emit cwt_candidates blob
* File-22 1-row fix: `TotalOrderComparer` (IEEE 754 total_cmp) for the capturedPeaks `OrderByDescending`, resolving the `-0.0 == +0.0` collision when `intensityWeight=0`
* Mode B fix: dropped early-return in `ComputeApexMatchFeatures` so the `nMatched==0` fallback (calibrated tolerance) fires for empty inputs instead of leaving zero defaults that signal "perfect mass match"
* Diagnostic dumps: `OSPREY_DUMP_MP_INPUTS`, `OSPREY_DUMP_PREDICT_RT`, `OSPREY_DUMP_CWT_PATH`, `OSPREY_DUMP_RESCORED` mirroring the Rust diagnostic seams

Companion Rust fix (`lib_cosine: counting features survive <2 in-range fragments`) goes upstream as a separate maccoss/osprey PR; required for Astral parity.

## Test plan

- [x] OspreySharp.sln Release build clean (net472 + net8.0, 8/8 projects)
- [x] OspreySharp.Test 299/299 tests pass
- [x] ReSharper code inspection 0 errors / 0 warnings
- [x] Compare-Stage6-Crossimpl Stellar: D.1 + D.2 + Diff-Parquet all PASS (3/3 files clean)
- [x] Compare-Stage6-Crossimpl Astral: D.1 + D.2 + Diff-Parquet all PASS (3/3 files clean, post Rust companion fix)

Co-Authored-By: Claude <noreply@anthropic.com>