### PR TITLE
Populated 6 OspreySharp scoring columns matching Rust byte-for-byte

### DIFF
--- a/pwiz_tools/OspreySharp/OspreySharp.Core/FdrEntry.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Core/FdrEntry.cs
@@ -68,6 +68,57 @@ namespace pwiz.OspreySharp.Core
         /// </summary>
         public List<CwtCandidate> CwtCandidates { get; set; }
 
+        /// <summary>
+        /// Library fragment m/z list for this entry, mirroring Rust
+        /// CoelutionScoredEntry::fragment_mzs. Populated at scoring time
+        /// from the candidate's full fragment list (NOT just the top-N
+        /// used by XIC extraction). Null on stubs loaded from Parquet
+        /// before the column is read back. Carried through to the
+        /// reconciled .scores.parquet's `fragment_mzs` blob column for
+        /// downstream consumers (Skyline blib export, etc.).
+        /// </summary>
+        public double[] FragmentMzs { get; set; }
+
+        /// <summary>
+        /// Library fragment relative intensities for this entry, mirroring
+        /// Rust CoelutionScoredEntry::fragment_intensities. Same length /
+        /// ordering as <see cref="FragmentMzs"/>. f32 to match the
+        /// underlying LibraryFragment representation.
+        /// </summary>
+        public float[] FragmentIntensities { get; set; }
+
+        /// <summary>
+        /// Reference XIC retention times across the WINNING peak's
+        /// boundary (i.e. ref_xic[bestPeak.StartIndex..=bestPeak.EndIndex]).
+        /// Mirrors Rust CoelutionScoredEntry::reference_xic's first
+        /// component — the per-scan RT axis the apex / peak shape was
+        /// computed from.
+        /// </summary>
+        public double[] ReferenceXicRts { get; set; }
+
+        /// <summary>
+        /// Reference XIC intensities across the WINNING peak's boundary.
+        /// Mirrors Rust CoelutionScoredEntry::reference_xic's second
+        /// component. Same length as <see cref="ReferenceXicRts"/>.
+        /// </summary>
+        public double[] ReferenceXicIntensities { get; set; }
+
+        /// <summary>
+        /// Peak area within the WINNING peak's boundary (trapezoidal
+        /// integration on the reference XIC). Distinct from Stage 4's
+        /// `peak_area` (the original CWT peak's area) — for Stage 6
+        /// override / reconciled entries this reflects the reconciled
+        /// boundary, not the original CWT detection.
+        /// </summary>
+        public double BoundsArea { get; set; }
+
+        /// <summary>
+        /// Peak SNR within the WINNING peak's boundary. Distinct from
+        /// Stage 4's `signal_to_noise` (the original CWT peak's SNR);
+        /// reflects the reconciled boundary on Stage 6 override entries.
+        /// </summary>
+        public double BoundsSnr { get; set; }
+
         public FdrEntry()
         {
             RunPrecursorQvalue = 1.0;

--- a/pwiz_tools/OspreySharp/OspreySharp.IO/ParquetScoreCache.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.IO/ParquetScoreCache.cs
@@ -514,22 +514,19 @@ namespace pwiz.OspreySharp.IO
         /// Encode an array of f32 values as a little-endian byte blob with
         /// no length prefix — bytes / 4 recovers the count on read. Mirrors
         /// Rust pipeline.rs:1626-1631 byte-for-byte. Used for
-        /// `fragment_intensities` (f32 in both impls). Uses
-        /// <see cref="BitConverter.GetBytes(float)"/> + <see cref="Buffer.BlockCopy"/>
-        /// so we get the same impl on net472 (no `SingleToInt32Bits`) and
-        /// net8.0; correctness relies on the build targeting an LE machine
-        /// (x64 / x86 — both pwiz target archs are LE).
+        /// `fragment_intensities` (f32 in both impls). Uses a single
+        /// <see cref="Buffer.BlockCopy"/> over the underlying float[] storage
+        /// (allocation-free per element); the IEEE-754 little-endian byte
+        /// layout matches the Rust blob exactly on LE hosts (x64/x86 — both
+        /// pwiz target archs are LE), avoiding net472's missing
+        /// <c>BitConverter.SingleToInt32Bits</c>.
         /// </summary>
         private static byte[] EncodeF32Blob(float[] values)
         {
             if (values == null || values.Length == 0)
                 return Array.Empty<byte>();
             var buf = new byte[values.Length * 4];
-            for (int i = 0; i < values.Length; i++)
-            {
-                byte[] bytes = BitConverter.GetBytes(values[i]);
-                Buffer.BlockCopy(bytes, 0, buf, i * 4, 4);
-            }
+            Buffer.BlockCopy(values, 0, buf, 0, buf.Length);
             return buf;
         }
 
@@ -570,8 +567,7 @@ namespace pwiz.OspreySharp.IO
                     "f32 blob length {0} is not a multiple of 4", blob.Length));
             int n = blob.Length / 4;
             var values = new float[n];
-            for (int i = 0; i < n; i++)
-                values[i] = BitConverter.ToSingle(blob, i * 4);
+            Buffer.BlockCopy(blob, 0, values, 0, blob.Length);
             return values;
         }
 

--- a/pwiz_tools/OspreySharp/OspreySharp.IO/ParquetScoreCache.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.IO/ParquetScoreCache.cs
@@ -314,14 +314,17 @@ namespace pwiz.OspreySharp.IO
             var apexRts = new double[n];
             var startRts = new double[n];
             var endRts = new double[n];
-            var boundsAreas = new double[n];   // not on FdrEntry; left at 0
-            var boundsSnrs = new double[n];    // not on FdrEntry; left at 0
+            var boundsAreas = new double[n];
+            var boundsSnrs = new double[n];
             var fileNames = new string[n];
-            // The cwt_candidates column carries the per-entry CWT peak list
-            // for Stage 6 reconciliation (encoded via CwtCandidateCodec to
-            // match Rust's binary layout). The fragments and XIC blobs are
-            // still nullable placeholders -- they're not consumed by any
-            // current Stage 6 path.
+            // The blob columns below carry per-entry binary payloads
+            // matching Rust pipeline.rs:1620-1645's encoding:
+            //   cwt_candidates             = u32 LE count + N×(6×f64 LE)
+            //   fragment_mzs               = M×f64 LE   (no count prefix)
+            //   fragment_intensities       = M×f32 LE   (no count prefix)
+            //   reference_xic_rts          = K×f64 LE
+            //   reference_xic_intensities  = K×f64 LE
+            // Length is recovered on read as bytes / sizeof(element).
             var cwtCandidates = new byte[n][];
             var fragmentMzs = new byte[n][];
             var fragmentIntensities = new byte[n][];
@@ -342,7 +345,13 @@ namespace pwiz.OspreySharp.IO
                 apexRts[i] = entry.ApexRt;
                 startRts[i] = entry.StartRt;
                 endRts[i] = entry.EndRt;
+                boundsAreas[i] = entry.BoundsArea;
+                boundsSnrs[i] = entry.BoundsSnr;
                 fileNames[i] = fileName ?? string.Empty;
+                fragmentMzs[i] = EncodeF64Blob(entry.FragmentMzs);
+                fragmentIntensities[i] = EncodeF32Blob(entry.FragmentIntensities);
+                refXicRts[i] = EncodeF64Blob(entry.ReferenceXicRts);
+                refXicIntensities[i] = EncodeF64Blob(entry.ReferenceXicIntensities);
 
                 // Mirror Rust's invariant: every row carries a cwt_candidates
                 // blob, even when the candidate list is empty. Rust's
@@ -479,6 +488,93 @@ namespace pwiz.OspreySharp.IO
             return double.IsNaN(v) || double.IsInfinity(v) ? 0.0 : v;
         }
 
+        /// <summary>
+        /// Encode an array of f64 values as a little-endian byte blob with
+        /// no length prefix — bytes / 8 recovers the count on read. Mirrors
+        /// Rust pipeline.rs:1620-1623 (`v.to_le_bytes().flat_map(...)`)
+        /// byte-for-byte. A null or empty input encodes as a zero-length
+        /// blob, NOT a null cell, so the column is non-nullable in
+        /// practice.
+        /// </summary>
+        private static byte[] EncodeF64Blob(double[] values)
+        {
+            if (values == null || values.Length == 0)
+                return Array.Empty<byte>();
+            var buf = new byte[values.Length * 8];
+            for (int i = 0; i < values.Length; i++)
+            {
+                long bits = BitConverter.DoubleToInt64Bits(values[i]);
+                System.Buffers.Binary.BinaryPrimitives.WriteInt64LittleEndian(
+                    new Span<byte>(buf, i * 8, 8), bits);
+            }
+            return buf;
+        }
+
+        /// <summary>
+        /// Encode an array of f32 values as a little-endian byte blob with
+        /// no length prefix — bytes / 4 recovers the count on read. Mirrors
+        /// Rust pipeline.rs:1626-1631 byte-for-byte. Used for
+        /// `fragment_intensities` (f32 in both impls). Uses
+        /// <see cref="BitConverter.GetBytes(float)"/> + <see cref="Buffer.BlockCopy"/>
+        /// so we get the same impl on net472 (no `SingleToInt32Bits`) and
+        /// net8.0; correctness relies on the build targeting an LE machine
+        /// (x64 / x86 — both pwiz target archs are LE).
+        /// </summary>
+        private static byte[] EncodeF32Blob(float[] values)
+        {
+            if (values == null || values.Length == 0)
+                return Array.Empty<byte>();
+            var buf = new byte[values.Length * 4];
+            for (int i = 0; i < values.Length; i++)
+            {
+                byte[] bytes = BitConverter.GetBytes(values[i]);
+                Buffer.BlockCopy(bytes, 0, buf, i * 4, 4);
+            }
+            return buf;
+        }
+
+        /// <summary>
+        /// Inverse of <see cref="EncodeF64Blob"/>. Returns an empty array
+        /// for null or empty input (preserves <see cref="EncodeF64Blob"/>'s
+        /// invariant). Throws if the byte length is not a multiple of 8.
+        /// </summary>
+        private static double[] DecodeF64Blob(byte[] blob)
+        {
+            if (blob == null || blob.Length == 0)
+                return Array.Empty<double>();
+            if (blob.Length % 8 != 0)
+                throw new InvalidDataException(string.Format(
+                    "f64 blob length {0} is not a multiple of 8", blob.Length));
+            int n = blob.Length / 8;
+            var values = new double[n];
+            for (int i = 0; i < n; i++)
+            {
+                long bits = System.Buffers.Binary.BinaryPrimitives.ReadInt64LittleEndian(
+                    new ReadOnlySpan<byte>(blob, i * 8, 8));
+                values[i] = BitConverter.Int64BitsToDouble(bits);
+            }
+            return values;
+        }
+
+        /// <summary>
+        /// Inverse of <see cref="EncodeF32Blob"/>. Returns an empty array
+        /// for null or empty input. Throws if the byte length is not a
+        /// multiple of 4.
+        /// </summary>
+        private static float[] DecodeF32Blob(byte[] blob)
+        {
+            if (blob == null || blob.Length == 0)
+                return Array.Empty<float>();
+            if (blob.Length % 4 != 0)
+                throw new InvalidDataException(string.Format(
+                    "f32 blob length {0} is not a multiple of 4", blob.Length));
+            int n = blob.Length / 4;
+            var values = new float[n];
+            for (int i = 0; i < n; i++)
+                values[i] = BitConverter.ToSingle(blob, i * 4);
+            return values;
+        }
+
         #endregion
 
         #region Load FDR Stubs
@@ -597,15 +693,12 @@ namespace pwiz.OspreySharp.IO
         /// <see cref="LoadCwtCandidatesFromParquet"/> separately and
         /// zipping them by row index — but does it in a single parquet
         /// open. Mirrors the columns Rust's <c>load_scores_parquet</c>
-        /// loads, minus the binary blob columns
-        /// (<c>fragment_mzs</c>, <c>fragment_intensities</c>,
-        /// <c>reference_xic_rts</c>, <c>reference_xic_intensities</c>)
-        /// which have no <see cref="FdrEntry"/> field counterpart and
-        /// are NOT round-tripped by the write-back path today. The
-        /// resulting reconciled parquet will have those four columns
-        /// null/empty even for rows whose source parquet had them
-        /// populated; this is a known C# limitation tracked for a
-        /// follow-up.
+        /// loads. Decodes the four binary blob columns (<c>fragment_mzs</c>,
+        /// <c>fragment_intensities</c>, <c>reference_xic_rts</c>,
+        /// <c>reference_xic_intensities</c>) and the <c>bounds_area</c> /
+        /// <c>bounds_snr</c> scalars onto the matching <see cref="FdrEntry"/>
+        /// fields so the Stage 6 reconciled parquet write-back round-
+        /// trips them for every row, not just freshly rescored rows.
         /// </summary>
         public static List<FdrEntry> LoadFullFdrEntries(string path)
         {
@@ -629,6 +722,12 @@ namespace pwiz.OspreySharp.IO
                         var endCol = groupReader.ReadColumn(FIELD_END_RT).Data as double[];
                         var coelutionCol = groupReader.ReadColumn(FIELD_COELUTION_SUM).Data as double[];
                         var cwtCol = groupReader.ReadColumn(FIELD_CWT_CANDIDATES).Data as byte[][];
+                        var boundsAreaCol = groupReader.ReadColumn(FIELD_BOUNDS_AREA).Data as double[];
+                        var boundsSnrCol = groupReader.ReadColumn(FIELD_BOUNDS_SNR).Data as double[];
+                        var fragMzCol = groupReader.ReadColumn(FIELD_FRAGMENT_MZS).Data as byte[][];
+                        var fragIntCol = groupReader.ReadColumn(FIELD_FRAGMENT_INTENSITIES).Data as byte[][];
+                        var refXicRtsCol = groupReader.ReadColumn(FIELD_REFERENCE_XIC_RTS).Data as byte[][];
+                        var refXicIntsCol = groupReader.ReadColumn(FIELD_REFERENCE_XIC_INTENSITIES).Data as byte[][];
 
                         if (entryIdCol == null || isDecoyCol == null)
                             continue;
@@ -665,6 +764,12 @@ namespace pwiz.OspreySharp.IO
                                 ModifiedSequence = modseqCol != null ? modseqCol[row] : string.Empty,
                                 Features = features,
                                 CwtCandidates = cwt,
+                                BoundsArea = boundsAreaCol != null ? boundsAreaCol[row] : 0.0,
+                                BoundsSnr = boundsSnrCol != null ? boundsSnrCol[row] : 0.0,
+                                FragmentMzs = DecodeF64Blob(fragMzCol != null ? fragMzCol[row] : null),
+                                FragmentIntensities = DecodeF32Blob(fragIntCol != null ? fragIntCol[row] : null),
+                                ReferenceXicRts = DecodeF64Blob(refXicRtsCol != null ? refXicRtsCol[row] : null),
+                                ReferenceXicIntensities = DecodeF64Blob(refXicIntsCol != null ? refXicIntsCol[row] : null),
                             });
                         }
                     }

--- a/pwiz_tools/OspreySharp/OspreySharp/AnalysisPipeline.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/AnalysisPipeline.cs
@@ -4032,17 +4032,35 @@ namespace pwiz.OspreySharp
                         newApexIdx = i;
                     }
                 }
+                // Rust pipeline.rs:7433-7444 RECOMPUTES `peak.area` and
+                // `peak.signal_to_noise` from `ref_xic[si..=ei]` here, NOT
+                // preserving the original CWT detection's values. The
+                // original area/SNR came from the consensus signal's
+                // boundary (which can differ from the CWT apex's
+                // [start..end] in the ref_xic). Preserving them produces
+                // ~560 bounds_area / ~546 bounds_snr divergent rows on
+                // Stellar where the parquet reports the WRONG (consensus-
+                // boundary) area for the WINNING (ref_xic-boundary) peak.
+                // peak_area / peak_sharpness as PIN features already
+                // recompute correctly via ComputePeakShapeFeatures; this
+                // recompute keeps the parquet's bounds_area / bounds_snr
+                // consistent with that.
+                double[] refRtsAll = xics[refXicIdx].RetentionTimes;
+                double newArea = PeakDetector.TrapezoidalArea(
+                    refRtsAll, refXicIntensities, si, ei);
+                double newSnr = PeakDetector.ComputeSnr(
+                    refXicIntensities, newApexIdx, si, ei);
                 bestPeak = new XICPeakBounds
                 {
-                    ApexRt = xics[refXicIdx].RetentionTimes[newApexIdx],
+                    ApexRt = refRtsAll[newApexIdx],
                     ApexIntensity = newApexVal,
                     ApexIndex = newApexIdx,
-                    StartRt = xics[refXicIdx].RetentionTimes[si],
-                    EndRt = xics[refXicIdx].RetentionTimes[ei],
+                    StartRt = refRtsAll[si],
+                    EndRt = refRtsAll[ei],
                     StartIndex = si,
                     EndIndex = ei,
-                    Area = bestPeak.Area,
-                    SignalToNoise = bestPeak.SignalToNoise,
+                    Area = newArea,
+                    SignalToNoise = newSnr,
                 };
             }
 
@@ -4281,7 +4299,46 @@ namespace pwiz.OspreySharp
                 }
             }
 
-            // Build FdrEntry
+            // Build FdrEntry. The six blob/scalar fields below mirror
+            // Rust CoelutionScoredEntry::{fragment_mzs, fragment_intensities,
+            // reference_xic, peak.area, peak.signal_to_noise} so the
+            // reconciled .scores.parquet write-back can produce byte-
+            // identical blob columns for cross-impl validation.
+            //
+            // FragmentMzs / FragmentIntensities iterate the FULL library
+            // fragment list (not just the top-N used by XIC extraction)
+            // because Rust's parquet writer at pipeline.rs:1620-1631
+            // serializes every library fragment.
+            int nFrags = candidate.Fragments?.Count ?? 0;
+            double[] fragMzs = new double[nFrags];
+            float[] fragInts = new float[nFrags];
+            for (int fi = 0; fi < nFrags; fi++)
+            {
+                fragMzs[fi] = candidate.Fragments[fi].Mz;
+                fragInts[fi] = candidate.Fragments[fi].RelativeIntensity;
+            }
+
+            // ReferenceXic{Rts,Intensities} are sliced from the highest-
+            // total-intensity fragment XIC across the winning peak's
+            // [si..=ei] window, matching Rust's
+            // `ref_xic[peak.start_index..=peak.end_index].to_vec()` at
+            // pipeline.rs:6538. Use the SAFE indices (clipped by the
+            // post-rank apex recompute) for non-override entries; the
+            // override path's bestPeak retains its original boundaries.
+            int refSi = Math.Max(0, Math.Min(bestPeak.StartIndex,
+                refXicIntensities.Length - 1));
+            int refEi = Math.Max(refSi, Math.Min(bestPeak.EndIndex,
+                refXicIntensities.Length - 1));
+            int refLen = refEi - refSi + 1;
+            double[] refXicRts = new double[refLen];
+            double[] refXicInts = new double[refLen];
+            double[] refXicRtsAll = xics[refXicIdx].RetentionTimes;
+            for (int i = 0; i < refLen; i++)
+            {
+                refXicRts[i] = refXicRtsAll[refSi + i];
+                refXicInts[i] = refXicIntensities[refSi + i];
+            }
+
             var entry = new FdrEntry
             {
                 EntryId = candidate.Id,
@@ -4295,7 +4352,13 @@ namespace pwiz.OspreySharp
                 Score = coelutionSum,
                 ModifiedSequence = candidate.ModifiedSequence,
                 Features = features,
-                CwtCandidates = cwtCandidatesOut
+                CwtCandidates = cwtCandidatesOut,
+                FragmentMzs = fragMzs,
+                FragmentIntensities = fragInts,
+                ReferenceXicRts = refXicRts,
+                ReferenceXicIntensities = refXicInts,
+                BoundsArea = bestPeak.Area,
+                BoundsSnr = bestPeak.SignalToNoise,
             };
 
             if (!overrideBounds.HasValue)

--- a/pwiz_tools/OspreySharp/OspreySharp/AnalysisPipeline.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/AnalysisPipeline.cs
@@ -4325,18 +4325,29 @@ namespace pwiz.OspreySharp
             // pipeline.rs:6538. Use the SAFE indices (clipped by the
             // post-rank apex recompute) for non-override entries; the
             // override path's bestPeak retains its original boundaries.
-            int refSi = Math.Max(0, Math.Min(bestPeak.StartIndex,
-                refXicIntensities.Length - 1));
-            int refEi = Math.Max(refSi, Math.Min(bestPeak.EndIndex,
-                refXicIntensities.Length - 1));
-            int refLen = refEi - refSi + 1;
-            double[] refXicRts = new double[refLen];
-            double[] refXicInts = new double[refLen];
             double[] refXicRtsAll = xics[refXicIdx].RetentionTimes;
-            for (int i = 0; i < refLen; i++)
+            int refMaxLen = Math.Min(
+                refXicRtsAll != null ? refXicRtsAll.Length : 0,
+                refXicIntensities != null ? refXicIntensities.Length : 0);
+            double[] refXicRts;
+            double[] refXicInts;
+            if (refMaxLen == 0)
             {
-                refXicRts[i] = refXicRtsAll[refSi + i];
-                refXicInts[i] = refXicIntensities[refSi + i];
+                refXicRts = new double[0];
+                refXicInts = new double[0];
+            }
+            else
+            {
+                int refSi = Math.Max(0, Math.Min(bestPeak.StartIndex, refMaxLen - 1));
+                int refEi = Math.Max(refSi, Math.Min(bestPeak.EndIndex, refMaxLen - 1));
+                int refLen = refEi - refSi + 1;
+                refXicRts = new double[refLen];
+                refXicInts = new double[refLen];
+                for (int i = 0; i < refLen; i++)
+                {
+                    refXicRts[i] = refXicRtsAll[refSi + i];
+                    refXicInts[i] = refXicIntensities[refSi + i];
+                }
             }
 
             var entry = new FdrEntry


### PR DESCRIPTION
## Summary

* Added FragmentMzs/FragmentIntensities/ReferenceXicRts/ReferenceXicIntensities/BoundsArea/BoundsSnr to `FdrEntry`; populated at the `AnalysisPipeline.ScoreCandidate` construction site from `candidate.Fragments` + `xics[refXicIdx]` + `bestPeak`
* Added `EncodeF64Blob` / `EncodeF32Blob` + Decode counterparts to `ParquetScoreCache`; FdrEntry overload of `WriteScoresParquet` now serializes the 4 byte-blob columns, `LoadFullFdrEntries` deserializes them so the Stage 6 reconciled write-back round-trips every row
* Mirrored Rust `pipeline.rs:7433-7444` by recomputing `bestPeak.Area` / `bestPeak.SignalToNoise` from `ref_xic[si..=ei]` in the post-rank apex block (was preserving the consensus-boundary values; produced ~560 `bounds_area` / ~546 `bounds_snr` divergent rows on Stellar before the fix)

Cross-impl harness now reports 0 diff cols / 0 allowlisted on both Stellar and Astral. Stage 6 cross-impl byte-parity is total — the harness's `\$expectedDiff` allowlist has been retired.

## Test plan

- [x] OspreySharp.sln Release build clean (net472 + net8.0)
- [x] OspreySharp.Test 299/299 pass
- [x] ReSharper inspection 0 errors / 0 warnings
- [x] Compare-Stage6-Crossimpl Stellar: 0 diff cols (was 6 allowlisted)
- [x] Compare-Stage6-Crossimpl Astral: 0 diff cols (was 6 allowlisted)

Co-Authored-By: Claude <noreply@anthropic.com>