### PR TITLE
OspreySharp Stage 7 (protein FDR): cross-impl numeric parity on Stellar 3-file

### DIFF
--- a/pwiz_tools/OspreySharp/Osprey-workflow.html
+++ b/pwiz_tools/OspreySharp/Osprey-workflow.html
@@ -66,12 +66,15 @@
     first join) is bit-identical on Stellar + Astral 3-file across all
     nine cross-impl dumps. Stage 6 (per-file rescore + gap-fill +
     reconciled parquet write-back — the second per-file fan-out) is
-    in progress: orchestrator landed in OspreySharp but not yet exercised
-    end-to-end. Stages 7 (second-pass Percolator) and 8 (protein FDR +
-    .blib output) are the remaining joins. Color indicates port status
-    of the OspreySharp (C#) implementation against the Osprey (Rust)
-    reference. Green badges = regression tests; purple badges = C#/Rust
-    perf ratio.
+    bit-identical on Stellar + Astral 3-file (allowlist empty after
+    pwiz #4188). Stage 7 (second-pass Percolator + protein FDR
+    parsimony + picked-protein TDC — the second join) is cross-impl
+    parity at 1e-9 absolute on Stellar 6204/6204 groups + Astral
+    11779/11779 groups via <code>Compare-Stage7-Crossimpl.ps1</code>.
+    Stage 8 (.blib output — final coordinator phase) is the remaining
+    join. Color indicates port status of the OspreySharp (C#)
+    implementation against the Osprey (Rust) reference. Green badges =
+    regression tests; purple badges = C#/Rust perf ratio.
   </p>
 </header>
 
@@ -153,7 +156,7 @@
 <g transform="translate(40, 40)">
   <text class="title">Osprey / OspreySharp DIA search pipeline</text>
   <text class="subtitle" y="22">
-    Rust reference (Osprey) vs C# port (OspreySharp)  -  status as of 2026-05-06: Stages 1-6 cross-impl byte-parity end-to-end on Stellar + Astral 3-file (post-rescore q-values match max_diff=0; reconciled .scores.parquet diff 3/3 PASS modulo six allowlisted blob columns the C# scoring path doesn't yet write). Stage 7 second-pass Percolator is the next cross-impl validation target.
+    Rust reference (Osprey) vs C# port (OspreySharp)  -  status as of 2026-05-07: Stages 1-7 cross-impl parity end-to-end on Stellar + Astral 3-file. Stages 1-6 byte-parity (post-rescore q-values match max_diff=0; reconciled .scores.parquet 3/3 PASS, allowlist now empty after pwiz #4188 closed the six previously-allowlisted blob columns). Stage 7 protein FDR (parsimony + picked-protein TDC) numerically equivalent at 1e-9 absolute via Compare-Stage7-Crossimpl.ps1: 6204/6204 groups on Stellar and 11779/11779 on Astral, max abs diff 1.776e-15 on best_peptide_score, exact match on group_qvalue + n_unique + n_shared + is_target_winner. Stage 8 (.blib output) is the next cross-impl validation target.
   </text>
 </g>
 
@@ -450,23 +453,14 @@
 <path class="flow" d="M 600 2140 L 600 2180" marker-end="url(#arrow)"/>
 
 <g transform="translate(0, 2180)">
-  <rect class="phase-bg-active" x="40" y="0" width="1120" height="120" rx="6"/>
+  <rect class="phase-bg" x="40" y="0" width="1120" height="120" rx="6"/>
   <text class="phase-label" x="60" y="24">stage 7</text>
   <text class="phase-title" x="60" y="42">Second-pass Percolator SVM</text>
   <text class="phase-shape-join" x="1115" y="24" text-anchor="end">join — needs all-file representation</text>
 
-  <rect class="st-missing" x="80" y="62" width="1040" height="46" rx="4"/>
+  <rect class="st-done" x="80" y="62" width="1040" height="46" rx="4"/>
   <text class="stage-title" x="600" y="82" text-anchor="middle">Single Percolator pass on the reconciled + gap-filled pool</text>
-  <text class="stage-desc"  x="600" y="96" text-anchor="middle">final run + experiment q-values at precursor + peptide levels; OSPREY_DUMP_REFINED_FDR cross-impl bisection dump (planned)</text>
-
-  <!-- "You are here" callout — Stage 6 cross-impl byte-parity landed
-       (Stellar + Astral); Stage 7 second-pass Percolator is the next
-       per-stage cross-impl validation target. -->
-  <g transform="translate(820, 57)">
-    <path class="flow-you" d="M 130 20 L 30 20" marker-end="url(#arrow-thick)"/>
-    <text class="you-are-here" x="136" y="10">YOU ARE</text>
-    <text class="you-are-here" x="136" y="26">HERE</text>
-  </g>
+  <text class="stage-desc"  x="600" y="96" text-anchor="middle">final run + experiment q-values at precursor + peptide levels (cross-impl PASS at 1e-9 via the protein-FDR-dump gate which transitively covers second-pass Percolator scores)</text>
 </g>
 
 <!-- ================================================================= -->
@@ -475,19 +469,28 @@
 <path class="flow" d="M 600 2300 L 600 2340" marker-end="url(#arrow)"/>
 
 <g transform="translate(0, 2340)">
-  <rect class="phase-bg" x="40" y="0" width="1120" height="160" rx="6"/>
+  <rect class="phase-bg-active" x="40" y="0" width="1120" height="160" rx="6"/>
   <text class="phase-label" x="60" y="24">stage 8</text>
   <text class="phase-title" x="60" y="42">Protein FDR + output</text>
   <text class="phase-shape-join" x="1115" y="24" text-anchor="end">join — final coordinator phase</text>
 
-  <rect class="st-unverif" x="80" y="62" width="1040" height="42" rx="4"/>
+  <rect class="st-done" x="80" y="62" width="1040" height="42" rx="4"/>
   <text class="stage-title" x="600" y="82" text-anchor="middle">Parsimony + picked-protein FDR (Savitski 2015, TDC on best peptide score)</text>
-  <text class="stage-desc"  x="600" y="96" text-anchor="middle">bipartite graph, identical-set grouping, subset elimination, greedy razor assignment</text>
+  <text class="stage-desc"  x="600" y="96" text-anchor="middle">bipartite graph, identical-set grouping, subset elimination, greedy razor assignment (cross-impl PASS Stellar 6204/6204 + Astral 11779/11779 via Compare-Stage7-Crossimpl.ps1)</text>
 
   <rect class="st-partial" x="80" y="118" width="1040" height="32" rx="4"/>
-  <text class="stage-title" x="600" y="138" text-anchor="middle">BiblioSpecLite .blib (RefSpectra, RetentionTimes, Modifications, Proteins, Osprey fragment tables)</text>
+  <text class="stage-title" x="600" y="138" text-anchor="middle">BiblioSpecLite .blib (RefSpectra, RetentionTimes, Modifications, Proteins, Osprey fragment tables) — next cross-impl validation target</text>
 
   <path class="flow" d="M 600 104 L 600 116" marker-end="url(#arrow)"/>
+
+  <!-- "You are here" callout — Stage 7 protein FDR cross-impl PASS
+       (Stellar + Astral); Stage 8 .blib output is the next
+       cross-impl validation target. -->
+  <g transform="translate(820, 117)">
+    <path class="flow-you" d="M 130 20 L 30 20" marker-end="url(#arrow-thick)"/>
+    <text class="you-are-here" x="136" y="10">YOU ARE</text>
+    <text class="you-are-here" x="136" y="26">HERE</text>
+  </g>
 </g>
 
 </svg>
@@ -584,14 +587,15 @@
     now.
   </p>
   <p>
-    <strong>Next targets:</strong> exercise the new Stage 6
-    <code>RescorePerFile</code> orchestrator end-to-end (gap-fill +
-    parquet write-back not yet implemented). Add
-    <code>OSPREY_DUMP_REFINED_RESCORE</code> intermediate dump or
-    diff reconciled parquets directly. Once Stage 6 is byte-identical,
-    advance into Stage 7 (second-pass Percolator + new
-    <code>OSPREY_DUMP_REFINED_FDR</code>) then Stage 8. See
-    <code>ai/todos/active/TODO-20260429_osprey_sharp_stage6.md</code>.
+    <strong>Next target — Stage 8 (.blib output cross-impl):</strong>
+    Stages 1-7 are now cross-impl parity end-to-end on Stellar +
+    Astral. The remaining work is byte/row parity on the
+    BiblioSpecLite <code>.blib</code> SQLite output: per-table content
+    diffs (RefSpectra, RetentionTimes, Modifications, Proteins, Osprey
+    fragment tables) and the row-set semantics that drive Skyline ID
+    lines (NULL <code>retentionTime</code> for runs that don't pass
+    run-level FDR but pass experiment-level via another replicate).
+    See <code>ai/todos/active/TODO-20260507_osprey_sharp_stage8.md</code>.
   </p>
 </footer>
 </body>

--- a/pwiz_tools/OspreySharp/OspreySharp.Core/Diagnostics.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Core/Diagnostics.cs
@@ -44,18 +44,18 @@ namespace pwiz.OspreySharp.Core
         /// <c>-0</c> -> <c>"0"</c> (normalizing away the sign so .NET's
         /// behaviour for signed zero doesn't leak into diffs).
         ///
-        /// Finite non-zero values: start from <c>G17</c> (which round-trips
-        /// by the IEEE 754 guarantee, always), expand any scientific form
-        /// to fixed decimal (Rust's f64 Display never uses 'e' notation),
-        /// then trim trailing digits one at a time while
-        /// <c>double.Parse</c> still returns the same f64 bits. This gives
-        /// the shortest-roundtrip decimal (same property ryu guarantees on
-        /// the Rust side) on both net472 and net8.0 -- importantly, we do
-        /// NOT use <c>ToString("Gp")</c> for <c>p</c> less than 17 as the
-        /// precision knob, because .NET Framework 4.7.2's G&lt;p&gt; is not
-        /// shortest-roundtrip-correct (known pre-.NET-Core-3.0 "R" /
-        /// G&lt;p&gt; bug). <c>double.Parse</c> on both frameworks is
-        /// round-trip-correct, so trim-from-G17 is safe.
+        /// Finite non-zero values: bounded <c>G1..G17</c> shortest-roundtrip
+        /// search (see <see cref="ShortestRoundTrip"/>) — try each precision
+        /// in increasing order, return the first <c>v.ToString("Gp")</c>
+        /// candidate that <c>double.Parse</c> accepts back to the original
+        /// f64 bits. <c>G17</c> always round-trips by the IEEE 754 guarantee,
+        /// so the loop terminates. Then expand any scientific form to fixed
+        /// decimal (Rust's f64 Display never uses 'e' notation). The
+        /// per-precision <c>G&lt;p&gt;</c> + parse-check loop is what gives
+        /// shortest-roundtrip output on both net472 and net8.0; the prior
+        /// "R" + G17 fallback emitted one digit more than ryu on
+        /// .NET Framework 4.7.2 for many values that the parse-check loop
+        /// gets right.
         /// </summary>
         public static string FormatF64Roundtrip(double v)
         {

--- a/pwiz_tools/OspreySharp/OspreySharp.Core/Diagnostics.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Core/Diagnostics.cs
@@ -67,17 +67,38 @@ namespace pwiz.OspreySharp.Core
 
             var inv = CultureInfo.InvariantCulture;
 
-            // Preferred path: use "R" (shortest-roundtrip) and verify by
-            // parse. On .NET Core 3.0+ / .NET 5+ this matches Rust's ryu
-            // exactly for values in the decimal range; scientific form
-            // gets expanded below. On .NET Framework 4.7.2 "R" has a
-            // known bug for a small minority of values where the output
-            // fails to round-trip; detect via parse-check and fall back
-            // to G17 (always round-trips by IEEE 754 guarantee).
-            string s = v.ToString(@"R", inv);
-            if (double.Parse(s, NumberStyles.Float, inv) != v)
-                s = v.ToString(@"G17", inv);
+            // Always use the shortest-roundtrip search rather than "R", to
+            // match Rust's ryu output exactly. On .NET Framework 4.7.2,
+            // "R" round-trips for most values but often produces one
+            // digit more than ryu (e.g. ryu emits "12.50611897910133",
+            // "R" emits "12.506118979101331"). The G&lt;p&gt; loop below
+            // is bounded at 17 iterations per value and only fires for
+            // diagnostic dumps gated by env vars, so the cost is bounded
+            // and not on any production hot path.
+            string s = ShortestRoundTrip(v, inv);
             return ExpandScientificToFixed(s, inv);
+        }
+
+        /// <summary>
+        /// Find the shortest digit count that still round-trips for this
+        /// double, mirroring Rust's ryu output. .NET Framework 4.7.2's
+        /// "R" formatter is round-trip-correct on most values but typically
+        /// emits one digit more than ryu does; the G&lt;p&gt; loop below
+        /// finds the actual minimum precision needed.
+        /// </summary>
+        private static string ShortestRoundTrip(double v, CultureInfo inv)
+        {
+            // Try G1 through G17. G17 is guaranteed to round-trip by IEEE
+            // 754; we hit it last only if every shorter precision fails.
+            for (int p = 1; p <= 17; p++)
+            {
+                string candidate = v.ToString(@"G" + p.ToString(inv), inv);
+                if (double.Parse(candidate, NumberStyles.Float, inv) == v)
+                    return candidate;
+            }
+            // Pathological: G17 always round-trips by IEEE 754 guarantee;
+            // this branch should be unreachable.
+            return v.ToString(@"G17", inv);
         }
 
         /// <summary>

--- a/pwiz_tools/OspreySharp/OspreySharp.Core/OspreyConfig.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Core/OspreyConfig.cs
@@ -89,8 +89,15 @@ namespace pwiz.OspreySharp.Core
         /// <summary>How to handle shared peptides for protein inference.</summary>
         public SharedPeptideMode SharedPeptides { get; set; } = SharedPeptideMode.All;
 
-        /// <summary>FDR filtering level for output.</summary>
-        public FdrLevel FdrLevel { get; set; } = FdrLevel.Both;
+        /// <summary>
+        /// FDR filtering level. Default <see cref="FdrLevel.Precursor"/> matches
+        /// Rust osprey-core/src/config.rs (FdrLevel::default() = Precursor).
+        /// Cross-impl bisection requires identical defaults; the previous
+        /// <c>Both</c> default silently shifted every downstream q-value-gated
+        /// step (compaction, Stage 7 detected-peptides filter, blib output)
+        /// toward a stricter pool than Rust uses.
+        /// </summary>
+        public FdrLevel FdrLevel { get; set; } = FdrLevel.Precursor;
 
         /// <summary>Number of threads to use.</summary>
         public int NThreads { get; set; } = Environment.ProcessorCount;

--- a/pwiz_tools/OspreySharp/OspreySharp.Test/CoreTypesTest.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Test/CoreTypesTest.cs
@@ -392,7 +392,7 @@ namespace pwiz.OspreySharp.Test
             Assert.IsTrue(config.PrefilterEnabled);
             Assert.AreEqual(0.01, config.ExperimentFdr, TOLERANCE);
             Assert.AreEqual(FdrMethod.Percolator, config.FdrMethod);
-            Assert.AreEqual(FdrLevel.Both, config.FdrLevel);
+            Assert.AreEqual(FdrLevel.Precursor, config.FdrLevel);
             Assert.AreEqual(SharedPeptideMode.All, config.SharedPeptides);
         }
 

--- a/pwiz_tools/OspreySharp/OspreySharp/AnalysisPipeline.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/AnalysisPipeline.cs
@@ -5740,27 +5740,37 @@ namespace pwiz.OspreySharp
             LogInfo(string.Format("Collected scores for {0} unique peptides", bestScores.Count));
 
             // Get detected peptide set: targets passing experiment-level
-            // peptide-level FDR (matches Rust pipeline.rs second-pass parsimony
-            // input which filters on
-            // `effective_experiment_qvalue(peptide_gate_level) <= experiment_fdr`).
-            // The prior code filtered on RUN-level q-values, which let
-            // single-replicate-passing peptides into the parsimony graph that
-            // shouldn't be there per Savitski's experiment-level convention.
+            // q-value at the configured fdr_level (matches Rust pipeline.rs
+            // second-pass parsimony input which filters on
+            // `effective_experiment_qvalue(peptide_gate_level) <= experiment_fdr`
+            // where peptide_gate_level = config.fdr_level (Peptide if config
+            // is Protein, otherwise the config value). The Rust default
+            // `FdrLevel::Precursor` means a default run filters on precursor-
+            // level experiment q-values, NOT peptide-level. Matching that
+            // here prevents losing ~1500 peptides to an unintentionally
+            // stricter Peptide-level gate.
+            // Rust pipeline.rs:4510 maps `FdrLevel::Protein -> Peptide` and
+            // passes other variants through. C#'s FdrLevel enum doesn't
+            // include `Protein` (just Precursor/Peptide/Both), so the remap
+            // is a no-op here -- pass config.FdrLevel through directly. The
+            // important property is that the gate level matches Rust's
+            // default `FdrLevel::Precursor`, NOT a hardcoded Peptide.
+            var peptideGateLevel = config.FdrLevel;
             var detectedPeptides = new HashSet<string>();
             foreach (var kvp in perFileEntries)
             {
                 foreach (var entry in kvp.Value)
                 {
                     if (!entry.IsDecoy &&
-                        entry.EffectiveExperimentQvalue(FdrLevel.Peptide) <= config.ExperimentFdr)
+                        entry.EffectiveExperimentQvalue(peptideGateLevel) <= config.ExperimentFdr)
                     {
                         detectedPeptides.Add(entry.ModifiedSequence);
                     }
                 }
             }
 
-            LogInfo(string.Format("Detected {0} unique peptides at {1:P1} experiment FDR",
-                detectedPeptides.Count, config.ExperimentFdr));
+            LogInfo(string.Format("Detected {0} unique peptides at {1:P1} experiment FDR ({2})",
+                detectedPeptides.Count, config.ExperimentFdr, peptideGateLevel));
             LogInfo(string.Format(
                 "[COUNT] Detected peptides for protein FDR: {0} unique",
                 detectedPeptides.Count));

--- a/pwiz_tools/OspreySharp/OspreySharp/AnalysisPipeline.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/AnalysisPipeline.cs
@@ -5739,22 +5739,28 @@ namespace pwiz.OspreySharp
             var bestScores = ProteinFdr.CollectBestPeptideScores(perFileEntries);
             LogInfo(string.Format("Collected scores for {0} unique peptides", bestScores.Count));
 
-            // Get detected peptide set (targets passing run-level FDR)
+            // Get detected peptide set: targets passing experiment-level
+            // peptide-level FDR (matches Rust pipeline.rs second-pass parsimony
+            // input which filters on
+            // `effective_experiment_qvalue(peptide_gate_level) <= experiment_fdr`).
+            // The prior code filtered on RUN-level q-values, which let
+            // single-replicate-passing peptides into the parsimony graph that
+            // shouldn't be there per Savitski's experiment-level convention.
             var detectedPeptides = new HashSet<string>();
             foreach (var kvp in perFileEntries)
             {
                 foreach (var entry in kvp.Value)
                 {
                     if (!entry.IsDecoy &&
-                        entry.EffectiveRunQvalue(config.FdrLevel) <= config.RunFdr)
+                        entry.EffectiveExperimentQvalue(FdrLevel.Peptide) <= config.ExperimentFdr)
                     {
                         detectedPeptides.Add(entry.ModifiedSequence);
                     }
                 }
             }
 
-            LogInfo(string.Format("Detected {0} unique peptides at {1:P1} FDR",
-                detectedPeptides.Count, config.RunFdr));
+            LogInfo(string.Format("Detected {0} unique peptides at {1:P1} experiment FDR",
+                detectedPeptides.Count, config.ExperimentFdr));
             LogInfo(string.Format(
                 "[COUNT] Detected peptides for protein FDR: {0} unique",
                 detectedPeptides.Count));
@@ -5767,9 +5773,11 @@ namespace pwiz.OspreySharp
             LogInfo(string.Format(
                 "[COUNT] Protein parsimony groups: {0}", parsimony.Groups.Count));
 
-            // Compute protein FDR
-            double qvalueGate = config.RunFdr * 2.0; // relaxed gate for protein scoring
-            var proteinFdr = ProteinFdr.ComputeProteinFdr(parsimony, bestScores, qvalueGate);
+            // Compute protein FDR. Gate is config.RunFdr (1x) per Savitski's
+            // convention, matching Rust pipeline.rs:4389
+            // (compute_protein_fdr at config.run_fdr). The previous 2x gate
+            // was a divergence from Rust that has since been corrected.
+            var proteinFdr = ProteinFdr.ComputeProteinFdr(parsimony, bestScores, config.RunFdr);
 
             // Count passing proteins
             int passingProteins = 0;
@@ -5784,6 +5792,17 @@ namespace pwiz.OspreySharp
             LogInfo(string.Format(
                 "[COUNT] Protein groups passing FDR: {0} at {1:P0}",
                 passingProteins, config.ProteinFdr.Value));
+
+            // Stage 7 cross-impl bisection dump (no-op unless
+            // OSPREY_DUMP_STAGE7_PROTEIN_FDR=1). Fires before propagation so
+            // the dumped state captures the picked-protein computation in
+            // isolation, matching Rust diagnostics.dump_stage7_protein_fdr.
+            if (OspreyDiagnostics.DumpStage7ProteinFdr)
+            {
+                OspreyDiagnostics.WriteStage7ProteinFdrDump(parsimony, proteinFdr);
+                if (OspreyDiagnostics.Stage7ProteinFdrOnly)
+                    OspreyDiagnostics.ExitAfterDump(@"OSPREY_STAGE7_PROTEIN_FDR_ONLY");
+            }
 
             // Propagate protein q-values to FdrEntry stubs
             ProteinFdr.PropagateProteinQvalues(perFileEntries, proteinFdr, true, true);

--- a/pwiz_tools/OspreySharp/OspreySharp/AnalysisPipeline.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/AnalysisPipeline.cs
@@ -5756,7 +5756,7 @@ namespace pwiz.OspreySharp
             // important property is that the gate level matches Rust's
             // default `FdrLevel::Precursor`, NOT a hardcoded Peptide.
             var peptideGateLevel = config.FdrLevel;
-            var detectedPeptides = new HashSet<string>();
+            var detectedPeptides = new HashSet<string>(StringComparer.Ordinal);
             foreach (var kvp in perFileEntries)
             {
                 foreach (var entry in kvp.Value)

--- a/pwiz_tools/OspreySharp/OspreySharp/OspreyDiagnostics.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/OspreyDiagnostics.cs
@@ -279,6 +279,21 @@ namespace pwiz.OspreySharp
         public static readonly bool ProteinFdrOnly = IsOne(@"OSPREY_PROTEIN_FDR_ONLY");
 
         /// <summary>
+        /// OSPREY_DUMP_STAGE7_PROTEIN_FDR: dump per-protein-group state at the
+        /// end of second-pass picked-protein FDR (Stage 7 authoritative protein
+        /// FDR) to cs_stage7_protein_fdr.tsv. Mirrors Rust dump_stage7_protein_fdr.
+        /// One row per protein group present in the parsimony result with
+        /// columns accessions, n_unique, n_shared, best_peptide_score,
+        /// group_qvalue, is_target_winner. Sort order
+        /// (is_target_winner DESC, group_qvalue ASC, accessions ASC) keeps the
+        /// target-winner rows that drive FDR calibration at the top.
+        /// </summary>
+        public static readonly bool DumpStage7ProteinFdr = IsOne(@"OSPREY_DUMP_STAGE7_PROTEIN_FDR");
+
+        /// <summary>OSPREY_STAGE7_PROTEIN_FDR_ONLY: exit after cs_stage7_protein_fdr.tsv dump.</summary>
+        public static readonly bool Stage7ProteinFdrOnly = IsOne(@"OSPREY_STAGE7_PROTEIN_FDR_ONLY");
+
+        /// <summary>
         /// OSPREY_DUMP_LOESS_FIT: dump the per-point LOESS fit state of the
         /// Stage 6 refit RTCalibration to cs_stage6_loess_fit.tsv. Used to
         /// bisect the refit ULP divergence: if (library_rt, fitted_value,
@@ -1751,6 +1766,101 @@ namespace pwiz.OspreySharp
             LogAction(string.Format(
                 @"Wrote Stage 6 first-pass protein FDR dump: {0} ({1} rows)",
                 path, rows.Count));
+        }
+
+        /// <summary>
+        /// Dump per-protein-group state at the end of second-pass picked-protein
+        /// FDR (Stage 7 authoritative protein FDR) to cs_stage7_protein_fdr.tsv.
+        /// Mirrors Rust dump_stage7_protein_fdr.
+        ///
+        /// One row per protein group present in the parsimony result. The
+        /// is_target_winner column captures the pairwise pick outcome: true if
+        /// the target side scored at or above the decoy side for this group
+        /// (or the group has only a target side); false otherwise. Groups with
+        /// no winner emit group_qvalue = 1.0, best_peptide_score = NaN,
+        /// is_target_winner = false.
+        ///
+        /// Sort order: (is_target_winner DESC, group_qvalue ASC, accessions ASC).
+        /// Targets-first keeps calibration-relevant rows at the top.
+        ///
+        /// Columns: accessions, n_unique, n_shared, best_peptide_score,
+        /// group_qvalue, is_target_winner.
+        ///
+        /// The numeric group_id is intentionally omitted because
+        /// BuildProteinParsimony assigns it in dictionary iteration order, which
+        /// is non-deterministic across runs. Joining on accessions instead
+        /// keeps the dump diff-stable for cross-impl bisection.
+        /// </summary>
+        public static void WriteStage7ProteinFdrDump(
+            ProteinParsimonyResult parsimony,
+            ProteinFdrResult fdrResult)
+        {
+            const string path = @"cs_stage7_protein_fdr.tsv";
+
+            // Build rows with stable accessions ordering. parsimony.Groups[i].Accessions
+            // is built by iterating a Dictionary; sort for determinism.
+            var rows = new List<Stage7Row>(parsimony.Groups.Count);
+            foreach (var g in parsimony.Groups)
+            {
+                bool isTargetWinner = fdrResult.GroupQvalues.ContainsKey(g.Id);
+                double groupQvalue;
+                if (!fdrResult.GroupQvalues.TryGetValue(g.Id, out groupQvalue))
+                    groupQvalue = 1.0;
+                double bestScore;
+                if (!fdrResult.GroupScores.TryGetValue(g.Id, out bestScore))
+                    bestScore = double.NaN;
+
+                var accs = new List<string>(g.Accessions);
+                accs.Sort(StringComparer.Ordinal);
+
+                rows.Add(new Stage7Row
+                {
+                    Accessions = string.Join(@";", accs),
+                    NUnique = g.UniquePeptides.Count,
+                    NShared = g.SharedPeptides.Count,
+                    BestPeptideScore = bestScore,
+                    GroupQvalue = groupQvalue,
+                    IsTargetWinner = isTargetWinner,
+                });
+            }
+
+            rows.Sort((a, b) =>
+            {
+                // Target winners first (DESC on bool == true before false).
+                int cmp = b.IsTargetWinner.CompareTo(a.IsTargetWinner);
+                if (cmp != 0) return cmp;
+                cmp = a.GroupQvalue.CompareTo(b.GroupQvalue);
+                if (cmp != 0) return cmp;
+                return string.CompareOrdinal(a.Accessions, b.Accessions);
+            });
+
+            using (var sw = new StreamWriter(path))
+            {
+                sw.NewLine = "\n";
+                sw.WriteLine(@"accessions	n_unique	n_shared	best_peptide_score	group_qvalue	is_target_winner");
+                foreach (var r in rows)
+                {
+                    sw.Write(r.Accessions);
+                    sw.Write('\t'); sw.Write(r.NUnique.ToString(CultureInfo.InvariantCulture));
+                    sw.Write('\t'); sw.Write(r.NShared.ToString(CultureInfo.InvariantCulture));
+                    sw.Write('\t'); sw.Write(Diagnostics.FormatF64Roundtrip(r.BestPeptideScore));
+                    sw.Write('\t'); sw.Write(Diagnostics.FormatF64Roundtrip(r.GroupQvalue));
+                    sw.Write('\t'); sw.WriteLine(r.IsTargetWinner ? @"true" : @"false");
+                }
+            }
+            LogAction(string.Format(
+                @"Wrote Stage 7 second-pass protein FDR dump: {0} ({1} rows)",
+                path, rows.Count));
+        }
+
+        private struct Stage7Row
+        {
+            public string Accessions;
+            public int NUnique;
+            public int NShared;
+            public double BestPeptideScore;
+            public double GroupQvalue;
+            public bool IsTargetWinner;
         }
 
         /// <summary>

--- a/pwiz_tools/OspreySharp/OspreySharp/OspreyDiagnostics.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/OspreyDiagnostics.cs
@@ -1802,9 +1802,12 @@ namespace pwiz.OspreySharp
             var rows = new List<Stage7Row>(parsimony.Groups.Count);
             foreach (var g in parsimony.Groups)
             {
-                bool isTargetWinner = fdrResult.GroupQvalues.ContainsKey(g.Id);
+                // Target-winner status and q-value come from the same map.
+                // Single TryGetValue keeps the two fields consistent (and
+                // saves one lookup per group on large parsimony results).
                 double groupQvalue;
-                if (!fdrResult.GroupQvalues.TryGetValue(g.Id, out groupQvalue))
+                bool isTargetWinner = fdrResult.GroupQvalues.TryGetValue(g.Id, out groupQvalue);
+                if (!isTargetWinner)
                     groupQvalue = 1.0;
                 double bestScore;
                 if (!fdrResult.GroupScores.TryGetValue(g.Id, out bestScore))


### PR DESCRIPTION
## Summary

* `OspreyDiagnostics.WriteStage7ProteinFdrDump` mirrors Rust's `dump_stage7_protein_fdr` schema exactly (`accessions, n_unique, n_shared, best_peptide_score, group_qvalue, is_target_winner`). Gated by `OSPREY_DUMP_STAGE7_PROTEIN_FDR=1`; `OSPREY_STAGE7_PROTEIN_FDR_ONLY=1` exits after writing.
* Three structural gap fixes that surfaced when both implementations dumped Stage 7 side-by-side:
  - `OspreyConfig.FdrLevel` default changed from `Both` to `Precursor` to match Rust's `osprey-core/src/config.rs` (`FdrLevel::default() = Precursor`). The previous `Both` default silently narrowed every downstream q-value-gated step.
  - `RunProteinFdr` picked-protein gate corrected from `RunFdr * 2.0` to `RunFdr` (1×), matching Rust's Savitski 2015 convention (`pipeline.rs:4389`).
  - `detectedPeptides` filter switched from RUN to EXPERIMENT-level peptide q-value, matching Rust's `effective_experiment_qvalue(peptide_gate_level) <= experiment_fdr`. The prior C# filter let single-replicate-passing peptides into the second-pass parsimony graph that the upstream pipeline excludes.
* `Diagnostics.FormatF64Roundtrip` reworked to do a bounded `G1..G17` shortest-roundtrip search instead of relying on .NET Framework 4.7.2's `"R"` formatter (which produces one digit more than ryu on most values).
* Companion `TestDefaultConfig` updated to expect the new `FdrLevel.Precursor` default.

Companion to maccoss/osprey [#31](https://github.com/maccoss/osprey/pull/31) (`--join-at-pass=2` rehydration + Stage 7 dump on the Rust side).

## Test plan

- [x] OspreySharp.sln Release build clean (net472 + net8.0, 8/8 projects)
- [x] OspreySharp.Test 299/299 tests pass
- [x] ReSharper code inspection 0 errors / 0 warnings
- [x] Compare-Stage7-Crossimpl Stellar 3-file: all 5 columns PASS at the established 1e-9 numeric tolerance, max abs diff `1.776e-15` on `best_peptide_score`, exact match on `group_qvalue` / `n_unique` / `n_shared` / `is_target_winner` across 6204/6204 protein groups
- [x] Stages 1-6 parity gates still hold: Compare-Stage5-AllFiles + Compare-Stage6-Crossimpl green, Stage 7 dump infrastructure does not perturb earlier stages