### PR TITLE
OspreySharp Stage 7 .blib output: cross-impl parity end-to-end (Stellar + Astral)

### DIFF
--- a/pwiz_tools/OspreySharp/Osprey-workflow.html
+++ b/pwiz_tools/OspreySharp/Osprey-workflow.html
@@ -71,14 +71,16 @@
     Percolator, protein FDR (parsimony + picked-protein TDC), and the
     final BiblioSpecLite <code>.blib</code> SQLite output — into a single
     merge-node phase, mirroring the way Stage 5 absorbs many sub-steps
-    under the first-join phase. Stages 1-6 plus the second-pass FDR /
-    protein FDR substeps of Stage 7 are at cross-impl parity at 1e-9
-    absolute (Stellar 6204/6204 + Astral 11779/11779 protein groups via
-    <code>Compare-Stage7-Crossimpl.ps1</code>). The <code>.blib</code>
-    output substep is the remaining cross-impl validation target.
-    Color indicates port status of the OspreySharp (C#) implementation
-    against the Osprey (Rust) reference. Green badges = regression
-    tests; purple badges = C#/Rust perf ratio.
+    under the first-join phase. The protein-FDR substep is cross-impl
+    PASS at 1e-9 absolute (Stellar 6204/6204 + Astral 11779/11779 protein
+    groups via <code>Compare-Stage7-Crossimpl.ps1</code>); the
+    <code>.blib</code> output substep is cross-impl PASS at the SQL
+    row+column level (Stellar 45153 + Astral 129352 RefSpectra via
+    <code>Compare-Blib-Crossimpl.ps1</code>, including byte-identical
+    <code>RefSpectraPeaks</code> blobs). Color indicates port status of
+    the OspreySharp (C#) implementation against the Osprey (Rust)
+    reference. Green badges = regression tests; purple badges = C#/Rust
+    perf ratio.
   </p>
 </header>
 
@@ -160,7 +162,7 @@
 <g transform="translate(40, 40)">
   <text class="title">Osprey / OspreySharp DIA search pipeline</text>
   <text class="subtitle" y="22">
-    Rust reference (Osprey) vs C# port (OspreySharp)  -  status as of 2026-05-07: Stages 1-6 plus the second-pass-FDR + protein-FDR substeps of Stage 7 are at cross-impl parity end-to-end on Stellar + Astral 3-file. Stages 1-6 byte-parity (post-rescore q-values match max_diff=0; reconciled .scores.parquet 3/3 PASS, allowlist now empty after pwiz #4188 closed the six previously-allowlisted blob columns). Stage 7 protein FDR (parsimony + picked-protein TDC) numerically equivalent at 1e-9 absolute via Compare-Stage7-Crossimpl.ps1: 6204/6204 groups on Stellar and 11779/11779 on Astral, max abs diff 1.776e-15 on best_peptide_score, exact match on group_qvalue + n_unique + n_shared + is_target_winner. The .blib output substep of Stage 7 is the remaining cross-impl validation target.
+    Rust reference (Osprey) vs C# port (OspreySharp)  -  status as of 2026-05-08: end-to-end cross-impl parity from Stage 1 through Stage 7 on Stellar + Astral 3-file. Stages 1-6 byte-parity (post-rescore q-values match max_diff=0; reconciled .scores.parquet 3/3 PASS, allowlist empty after pwiz #4188). Stage 7 protein FDR (parsimony + picked-protein TDC): cross-impl PASS at 1e-9 absolute via Compare-Stage7-Crossimpl.ps1 (Stellar 6204/6204, Astral 11779/11779 protein groups; max abs diff 1.776e-15 on best_peptide_score). Stage 7 .blib output: cross-impl PASS via Compare-Blib-Crossimpl.ps1 (Stellar 45153 + Astral 129352 RefSpectra; every per-table SQL row+column matches including byte-identical RefSpectraPeaks blobs after switching the Rust flate2 backend to stock zlib and the C# writer to DotNetZip / Ionic.Zlib level 6, the same library Skyline's BlibData has used since 2009). First end-to-end OspreySharp port at full cross-impl parity.
   </text>
 </g>
 
@@ -465,7 +467,7 @@
 <path class="flow" d="M 600 2140 L 600 2180" marker-end="url(#arrow)"/>
 
 <g transform="translate(0, 2180)">
-  <rect class="phase-bg-active" x="40" y="0" width="1120" height="220" rx="6"/>
+  <rect class="phase-bg" x="40" y="0" width="1120" height="220" rx="6"/>
   <text class="phase-label" x="60" y="24">stage 7</text>
   <text class="phase-title" x="60" y="42">Post-join: second-pass Percolator + protein FDR + .blib output</text>
   <text class="phase-shape-join" x="1115" y="24" text-anchor="end">join — final merge-node phase (no further per-file fan-out)</text>
@@ -482,16 +484,8 @@
 
   <path class="flow" d="M 600 162 L 600 176" marker-end="url(#arrow)"/>
 
-  <rect class="st-partial" x="80" y="178" width="1040" height="32" rx="4"/>
-  <text class="stage-title" x="600" y="198" text-anchor="middle">BiblioSpecLite .blib (RefSpectra, RetentionTimes, Modifications, Proteins, Osprey fragment tables) — next cross-impl validation target</text>
-
-  <!-- "You are here" callout — final substep of the merge-node phase
-       (.blib SQLite output) is the next cross-impl validation target. -->
-  <g transform="translate(820, 177)">
-    <path class="flow-you" d="M 130 20 L 30 20" marker-end="url(#arrow-thick)"/>
-    <text class="you-are-here" x="136" y="10">YOU ARE</text>
-    <text class="you-are-here" x="136" y="26">HERE</text>
-  </g>
+  <rect class="st-done" x="80" y="178" width="1040" height="32" rx="4"/>
+  <text class="stage-title" x="600" y="198" text-anchor="middle">BiblioSpecLite .blib (RefSpectra, RetentionTimes, Modifications, Proteins, Osprey fragment tables) — cross-impl PASS Stellar 45153 + Astral 129352 RefSpectra via Compare-Blib-Crossimpl.ps1</text>
 </g>
 
 </svg>
@@ -594,16 +588,27 @@
     now.
   </p>
   <p>
-    <strong>Next target — Stage 7 .blib output substep:</strong>
-    Stages 1-6 plus the second-pass-FDR + protein-FDR substeps of
-    Stage 7 are at cross-impl parity. The remaining work is byte/row
-    parity on the BiblioSpecLite <code>.blib</code> SQLite output —
-    final substep of Stage 7's merge-node phase: per-table content
-    diffs (RefSpectra, RetentionTimes, Modifications, Proteins, Osprey
-    fragment tables) and the row-set semantics that drive Skyline ID
-    lines (NULL <code>retentionTime</code> for runs that don't pass
-    run-level FDR but pass experiment-level via another replicate).
-    See <code>ai/todos/active/TODO-20260507_osprey_sharp_stage8.md</code>.
+    <strong>End-to-end cross-impl parity achieved (2026-05-08):</strong>
+    Every stage of the OspreySharp pipeline matches the Rust osprey
+    reference at the documented per-stage gate on Stellar + Astral
+    3-file. Closing the .blib substep required two matching changes:
+    OspreySharp's <code>BlibWriter</code> now uses DotNetZip /
+    Ionic.Zlib level 6 (the same library Skyline's
+    <code>Util/Extensions/UtilDB.Compress</code> has used since 2009),
+    and the Rust <code>flate2</code> backend was switched from the
+    default <code>miniz_oxide</code> pure-Rust port to the vendored
+    stock zlib (<code>features = ["zlib-default"]</code>) — both sides
+    now emit identical Ionic.Zlib-compatible deflate output.
+    SHA-256 of the <code>.blib</code> file itself still differs because
+    of SQLite engine internals (rusqlite vs System.Data.SQLite produce
+    different page layouts for identical logical content), but every
+    byte we own at the SQL row+column level matches. Future work:
+    pulling Skyline's <code>Model/Lib/BlibData</code> out to
+    <code>Shared/BiblioSpec</code> so OspreySharp and Skyline share a
+    single C# BLIB writer, and (eventually) a C# port of
+    <code>pwiz_tools/BiblioSpec</code> inspired by Matt Chambers's
+    in-progress port of <code>pwiz/pwiz</code> and
+    <code>pwiz/pwiz-aux</code>.
   </p>
 </footer>
 </body>

--- a/pwiz_tools/OspreySharp/Osprey-workflow.html
+++ b/pwiz_tools/OspreySharp/Osprey-workflow.html
@@ -67,19 +67,23 @@
     nine cross-impl dumps. Stage 6 (per-file rescore + gap-fill +
     reconciled parquet write-back — the second per-file fan-out) is
     bit-identical on Stellar + Astral 3-file (allowlist empty after
-    pwiz #4188). Stage 7 (second-pass Percolator + protein FDR
-    parsimony + picked-protein TDC — the second join) is cross-impl
-    parity at 1e-9 absolute on Stellar 6204/6204 groups + Astral
-    11779/11779 groups via <code>Compare-Stage7-Crossimpl.ps1</code>.
-    Stage 8 (.blib output — final coordinator phase) is the remaining
-    join. Color indicates port status of the OspreySharp (C#)
-    implementation against the Osprey (Rust) reference. Green badges =
-    regression tests; purple badges = C#/Rust perf ratio.
+    pwiz #4188). Stage 7 absorbs all post-second-join work — second-pass
+    Percolator, protein FDR (parsimony + picked-protein TDC), and the
+    final BiblioSpecLite <code>.blib</code> SQLite output — into a single
+    merge-node phase, mirroring the way Stage 5 absorbs many sub-steps
+    under the first-join phase. Stages 1-6 plus the second-pass FDR /
+    protein FDR substeps of Stage 7 are at cross-impl parity at 1e-9
+    absolute (Stellar 6204/6204 + Astral 11779/11779 protein groups via
+    <code>Compare-Stage7-Crossimpl.ps1</code>). The <code>.blib</code>
+    output substep is the remaining cross-impl validation target.
+    Color indicates port status of the OspreySharp (C#) implementation
+    against the Osprey (Rust) reference. Green badges = regression
+    tests; purple badges = C#/Rust perf ratio.
   </p>
 </header>
 
 <main>
-<svg class="pipeline" viewBox="0 0 1200 2540" xmlns="http://www.w3.org/2000/svg">
+<svg class="pipeline" viewBox="0 0 1200 2440" xmlns="http://www.w3.org/2000/svg">
 <defs>
   <!-- Arrowhead for control flow between stages -->
   <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5"
@@ -156,7 +160,7 @@
 <g transform="translate(40, 40)">
   <text class="title">Osprey / OspreySharp DIA search pipeline</text>
   <text class="subtitle" y="22">
-    Rust reference (Osprey) vs C# port (OspreySharp)  -  status as of 2026-05-07: Stages 1-7 cross-impl parity end-to-end on Stellar + Astral 3-file. Stages 1-6 byte-parity (post-rescore q-values match max_diff=0; reconciled .scores.parquet 3/3 PASS, allowlist now empty after pwiz #4188 closed the six previously-allowlisted blob columns). Stage 7 protein FDR (parsimony + picked-protein TDC) numerically equivalent at 1e-9 absolute via Compare-Stage7-Crossimpl.ps1: 6204/6204 groups on Stellar and 11779/11779 on Astral, max abs diff 1.776e-15 on best_peptide_score, exact match on group_qvalue + n_unique + n_shared + is_target_winner. Stage 8 (.blib output) is the next cross-impl validation target.
+    Rust reference (Osprey) vs C# port (OspreySharp)  -  status as of 2026-05-07: Stages 1-6 plus the second-pass-FDR + protein-FDR substeps of Stage 7 are at cross-impl parity end-to-end on Stellar + Astral 3-file. Stages 1-6 byte-parity (post-rescore q-values match max_diff=0; reconciled .scores.parquet 3/3 PASS, allowlist now empty after pwiz #4188 closed the six previously-allowlisted blob columns). Stage 7 protein FDR (parsimony + picked-protein TDC) numerically equivalent at 1e-9 absolute via Compare-Stage7-Crossimpl.ps1: 6204/6204 groups on Stellar and 11779/11779 on Astral, max abs diff 1.776e-15 on best_peptide_score, exact match on group_qvalue + n_unique + n_shared + is_target_winner. The .blib output substep of Stage 7 is the remaining cross-impl validation target.
   </text>
 </g>
 
@@ -253,7 +257,7 @@
 <path class="flow" d="M 890 460 L 890 490 L 600 490" />
 
 <!-- ================================================================= -->
-<!-- STAGE 3 CALIBRATION (YOU ARE HERE)                                 -->
+<!-- STAGE 3 CALIBRATION                                                 -->
 <!-- ================================================================= -->
 <g transform="translate(0, 520)">
   <rect class="phase-bg" x="40" y="0" width="1120" height="540" rx="6"/>
@@ -448,45 +452,42 @@
 </g>
 
 <!-- ================================================================= -->
-<!-- STAGE 7 SECOND-PASS PERCOLATOR (SECOND JOIN)                        -->
+<!-- STAGE 7 POST-SECOND-JOIN: PERCOLATOR + PROTEIN FDR + .BLIB OUTPUT   -->
+<!-- ================================================================= -->
+<!-- One stage, three sub-steps. There is no per-file fan-out and no    -->
+<!-- sidecar / rehydration boundary between second-pass Percolator,     -->
+<!-- protein parsimony / picked-protein FDR, and .blib SQLite output;   -->
+<!-- they all run on the merge node in a single process. Mirrors the    -->
+<!-- way Stage 5 already absorbs many sub-steps (first-pass Percolator, -->
+<!-- experiment-level FDR, first-pass protein FDR, reconciliation       -->
+<!-- planning) under the first-join phase.                              -->
 <!-- ================================================================= -->
 <path class="flow" d="M 600 2140 L 600 2180" marker-end="url(#arrow)"/>
 
 <g transform="translate(0, 2180)">
-  <rect class="phase-bg" x="40" y="0" width="1120" height="120" rx="6"/>
+  <rect class="phase-bg-active" x="40" y="0" width="1120" height="220" rx="6"/>
   <text class="phase-label" x="60" y="24">stage 7</text>
-  <text class="phase-title" x="60" y="42">Second-pass Percolator SVM</text>
-  <text class="phase-shape-join" x="1115" y="24" text-anchor="end">join — needs all-file representation</text>
-
-  <rect class="st-done" x="80" y="62" width="1040" height="46" rx="4"/>
-  <text class="stage-title" x="600" y="82" text-anchor="middle">Single Percolator pass on the reconciled + gap-filled pool</text>
-  <text class="stage-desc"  x="600" y="96" text-anchor="middle">final run + experiment q-values at precursor + peptide levels (cross-impl PASS at 1e-9 via the protein-FDR-dump gate which transitively covers second-pass Percolator scores)</text>
-</g>
-
-<!-- ================================================================= -->
-<!-- STAGE 8 PROTEIN FDR + OUTPUT (FINAL JOIN)                          -->
-<!-- ================================================================= -->
-<path class="flow" d="M 600 2300 L 600 2340" marker-end="url(#arrow)"/>
-
-<g transform="translate(0, 2340)">
-  <rect class="phase-bg-active" x="40" y="0" width="1120" height="160" rx="6"/>
-  <text class="phase-label" x="60" y="24">stage 8</text>
-  <text class="phase-title" x="60" y="42">Protein FDR + output</text>
-  <text class="phase-shape-join" x="1115" y="24" text-anchor="end">join — final coordinator phase</text>
+  <text class="phase-title" x="60" y="42">Post-join: second-pass Percolator + protein FDR + .blib output</text>
+  <text class="phase-shape-join" x="1115" y="24" text-anchor="end">join — final merge-node phase (no further per-file fan-out)</text>
 
   <rect class="st-done" x="80" y="62" width="1040" height="42" rx="4"/>
-  <text class="stage-title" x="600" y="82" text-anchor="middle">Parsimony + picked-protein FDR (Savitski 2015, TDC on best peptide score)</text>
-  <text class="stage-desc"  x="600" y="96" text-anchor="middle">bipartite graph, identical-set grouping, subset elimination, greedy razor assignment (cross-impl PASS Stellar 6204/6204 + Astral 11779/11779 via Compare-Stage7-Crossimpl.ps1)</text>
+  <text class="stage-title" x="600" y="82" text-anchor="middle">Single Percolator pass on the reconciled + gap-filled pool</text>
+  <text class="stage-desc"  x="600" y="96" text-anchor="middle">final run + experiment q-values at precursor + peptide levels (cross-impl PASS at 1e-9 via the protein-FDR-dump gate which transitively covers second-pass Percolator scores)</text>
 
-  <rect class="st-partial" x="80" y="118" width="1040" height="32" rx="4"/>
-  <text class="stage-title" x="600" y="138" text-anchor="middle">BiblioSpecLite .blib (RefSpectra, RetentionTimes, Modifications, Proteins, Osprey fragment tables) — next cross-impl validation target</text>
+  <path class="flow" d="M 600 104 L 600 118" marker-end="url(#arrow)"/>
 
-  <path class="flow" d="M 600 104 L 600 116" marker-end="url(#arrow)"/>
+  <rect class="st-done" x="80" y="120" width="1040" height="42" rx="4"/>
+  <text class="stage-title" x="600" y="140" text-anchor="middle">Parsimony + picked-protein FDR (Savitski 2015, TDC on best peptide score)</text>
+  <text class="stage-desc"  x="600" y="154" text-anchor="middle">bipartite graph, identical-set grouping, subset elimination, greedy razor assignment (cross-impl PASS Stellar 6204/6204 + Astral 11779/11779 via Compare-Stage7-Crossimpl.ps1)</text>
 
-  <!-- "You are here" callout — Stage 7 protein FDR cross-impl PASS
-       (Stellar + Astral); Stage 8 .blib output is the next
-       cross-impl validation target. -->
-  <g transform="translate(820, 117)">
+  <path class="flow" d="M 600 162 L 600 176" marker-end="url(#arrow)"/>
+
+  <rect class="st-partial" x="80" y="178" width="1040" height="32" rx="4"/>
+  <text class="stage-title" x="600" y="198" text-anchor="middle">BiblioSpecLite .blib (RefSpectra, RetentionTimes, Modifications, Proteins, Osprey fragment tables) — next cross-impl validation target</text>
+
+  <!-- "You are here" callout — final substep of the merge-node phase
+       (.blib SQLite output) is the next cross-impl validation target. -->
+  <g transform="translate(820, 177)">
     <path class="flow-you" d="M 130 20 L 30 20" marker-end="url(#arrow-thick)"/>
     <text class="you-are-here" x="136" y="10">YOU ARE</text>
     <text class="you-are-here" x="136" y="26">HERE</text>
@@ -572,25 +573,32 @@
     early-exits.
   </p>
   <p>
-    <strong>Pipeline restructure + CLI rename (2026-04-30):</strong>
-    stages renumbered to align with join / per-file-fan-out boundaries
-    that matter for HPC distribution. Stage 5 absorbs reconciliation
-    planning (single first-join phase). Stage 6 is now per-file rescore
-    only (second per-file fan-out). Stage 7 is the second join
-    (second-pass Percolator). Stage 8 absorbs Protein FDR + .blib
-    output (final coordinator phase). CLI matrix: <code>--no-join</code>
-    runs only per-file work, <code>--join-only</code> runs only joined
-    work, <code>--join-at-pass=&lt;1|2&gt;</code> selects entry-point
+    <strong>Pipeline restructure (2026-04-30, refined 2026-05-07):</strong>
+    stages numbered to align with join / per-file-fan-out boundaries
+    that matter for HPC distribution AND with the sidecar /
+    rehydration boundaries that <code>--join-at-pass</code> can enter
+    at. Stage 5 absorbs all first-join work (first-pass Percolator,
+    experiment-level FDR, first-pass protein FDR, reconciliation
+    planning). Stage 6 is per-file rescore only (second per-file
+    fan-out). Stage 7 absorbs all second-join work (second-pass
+    Percolator, protein FDR parsimony + picked-protein TDC, and
+    BiblioSpecLite <code>.blib</code> SQLite output) — there is no
+    sidecar / rehydration boundary inside Stage 7, so collapsing
+    its sub-steps under one stage matches the actual code structure.
+    CLI matrix: <code>--no-join</code> runs only per-file work,
+    <code>--join-only</code> runs only joined work,
+    <code>--join-at-pass=&lt;1|2&gt;</code> selects entry-point
     parquets (Stage 4 outputs vs reconciled Stage 6 outputs).
     Plan-file persistence between Stage 5 and Stage 6 deferred to a
     future sprint — single-machine flow runs them in one process for
     now.
   </p>
   <p>
-    <strong>Next target — Stage 8 (.blib output cross-impl):</strong>
-    Stages 1-7 are now cross-impl parity end-to-end on Stellar +
-    Astral. The remaining work is byte/row parity on the
-    BiblioSpecLite <code>.blib</code> SQLite output: per-table content
+    <strong>Next target — Stage 7 .blib output substep:</strong>
+    Stages 1-6 plus the second-pass-FDR + protein-FDR substeps of
+    Stage 7 are at cross-impl parity. The remaining work is byte/row
+    parity on the BiblioSpecLite <code>.blib</code> SQLite output —
+    final substep of Stage 7's merge-node phase: per-table content
     diffs (RefSpectra, RetentionTimes, Modifications, Proteins, Osprey
     fragment tables) and the row-set semantics that drive Skyline ID
     lines (NULL <code>retentionTime</code> for runs that don't pass

--- a/pwiz_tools/OspreySharp/OspreySharp.IO/BlibWriter.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.IO/BlibWriter.cs
@@ -881,41 +881,42 @@ namespace pwiz.OspreySharp.IO
         }
 
         /// <summary>
-        /// Zlib-compress a byte buffer. Returns raw bytes when the
-        /// compressed output isn't materially smaller. BiblioSpec readers
-        /// determine compression by comparing blob length to expected
-        /// uncompressed size, so the choice of threshold doesn't affect
-        /// downstream consumers — but it MUST match Rust's
-        /// <c>compress_bytes</c> behaviour for cross-impl byte parity.
+        /// Zlib-compress a byte buffer using DotNetZip's Ionic.Zlib at
+        /// level 6 (the BiblioSpec convention — same as
+        /// <c>pwiz.Skyline.Util.Extensions.UtilDB.Compress</c>). Returns
+        /// raw bytes when the compressed output isn't smaller.
         ///
-        /// Rust's <c>flate2</c> (with <c>Compression::default()</c> = level
-        /// 6) typically produces 3-4 more bytes of deflate overhead than
-        /// .NET's <c>DeflateStream</c> on the small fragment-array inputs
-        /// (~160 bytes) Stage 7 emits. As a result, Rust falls back to
-        /// raw on inputs where C# would compress, splitting the .blib
-        /// blob bytes cross-impl. Setting the savings threshold to require
-        /// strictly more than 4 bytes of savings papers over the
-        /// flate2-vs-DeflateStream micro-difference: if C# can only save
-        /// 1-4 bytes, it falls back to raw — same choice Rust makes.
+        /// Why Ionic.Zlib and not <c>System.IO.Compression.DeflateStream</c>:
+        /// .NET's built-in DeflateStream produces a 4-byte-shorter
+        /// non-stock-zlib variant on small inputs (huffman-table /
+        /// end-of-block encoding choices), which splits cross-impl byte
+        /// parity against Rust osprey's <c>flate2</c> (stock zlib output)
+        /// AND against Skyline's existing BlibData writer (also Ionic.Zlib).
+        /// Routing through the same library Skyline uses gives both
+        /// directions of parity for free and aligns with the long-term
+        /// plan to share the BiblioSpec writer across Skyline / Osprey
+        /// (potentially Skyline's BlibData -> Shared/BiblioSpec, or a
+        /// future C# port of pwiz_tools/BiblioSpec).
         /// </summary>
         private static byte[] CompressBytes(byte[] raw)
         {
+            const int level = 6; // matches Skyline UtilDB.Compress + Rust flate2 Compression::default()
+            byte[] compressed;
             using (var ms = new MemoryStream())
             {
-                // Write 2-byte zlib header
-                ms.WriteByte(0x78);
-                ms.WriteByte(0x9C);
-                using (var deflate = new DeflateStream(ms, CompressionMode.Compress, true))
+                using (var z = new Ionic.Zlib.ZlibStream(
+                    ms, Ionic.Zlib.CompressionMode.Compress,
+                    Ionic.Zlib.CompressionLevel.Level0 + level, true))
                 {
-                    deflate.Write(raw, 0, raw.Length);
+                    z.Write(raw, 0, raw.Length);
                 }
-                byte[] compressed = ms.ToArray();
-                // Match Rust's compression-or-raw decision boundary on
-                // small inputs by requiring a >4-byte savings.
-                if (compressed.Length + 4 >= raw.Length)
-                    return raw;
-                return compressed;
+                compressed = ms.ToArray();
             }
+            // BiblioSpec reader convention: blob length < expected
+            // uncompressed size -> compressed; otherwise -> raw.
+            if (compressed.Length >= raw.Length)
+                return raw;
+            return compressed;
         }
 
         /// <summary>

--- a/pwiz_tools/OspreySharp/OspreySharp.IO/BlibWriter.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.IO/BlibWriter.cs
@@ -385,6 +385,104 @@ namespace pwiz.OspreySharp.IO
         }
 
         /// <summary>
+        /// Add a row to <c>OspreyPeakBoundaries</c> for a passing
+        /// precursor's best run. Mirrors Rust
+        /// <c>BlibWriter::add_peak_boundaries</c>; one row per
+        /// <c>RefSpectra</c> in the canonical Rust output.
+        /// </summary>
+        public void AddPeakBoundaries(long refId, string fileName,
+            double startRt, double endRt, double apexRt,
+            double apexIntensity, double integratedArea)
+        {
+            using (var cmd = new SQLiteCommand(_conn))
+            {
+                cmd.CommandText = @"INSERT INTO OspreyPeakBoundaries (
+                    RefSpectraID, FileName, StartRT, EndRT, ApexRT, ApexIntensity, IntegratedArea
+                ) VALUES (@r, @f, @s, @e, @a, @ai, @ia)";
+                cmd.Parameters.AddWithValue("@r", refId);
+                cmd.Parameters.AddWithValue("@f", fileName);
+                cmd.Parameters.AddWithValue("@s", startRt);
+                cmd.Parameters.AddWithValue("@e", endRt);
+                cmd.Parameters.AddWithValue("@a", apexRt);
+                cmd.Parameters.AddWithValue("@ai", apexIntensity);
+                cmd.Parameters.AddWithValue("@ia", integratedArea);
+                cmd.ExecuteNonQuery();
+            }
+        }
+
+        /// <summary>
+        /// Add a row to <c>OspreyRunScores</c> for a passing
+        /// precursor's best run. Mirrors Rust
+        /// <c>BlibWriter::add_run_scores</c>; one row per
+        /// <c>RefSpectra</c> in the canonical Rust output.
+        /// </summary>
+        public void AddRunScores(long refId, string fileName,
+            double runQValue, double discriminantScore, double posteriorErrorProb)
+        {
+            using (var cmd = new SQLiteCommand(_conn))
+            {
+                cmd.CommandText = @"INSERT INTO OspreyRunScores (
+                    RefSpectraID, FileName, RunQValue, DiscriminantScore, PosteriorErrorProb
+                ) VALUES (@r, @f, @q, @d, @p)";
+                cmd.Parameters.AddWithValue("@r", refId);
+                cmd.Parameters.AddWithValue("@f", fileName);
+                cmd.Parameters.AddWithValue("@q", runQValue);
+                cmd.Parameters.AddWithValue("@d", discriminantScore);
+                cmd.Parameters.AddWithValue("@p", posteriorErrorProb);
+                cmd.ExecuteNonQuery();
+            }
+        }
+
+        /// <summary>
+        /// Add a row to <c>OspreyExperimentScores</c> for a passing
+        /// precursor. Mirrors Rust
+        /// <c>BlibWriter::add_experiment_scores</c>; one row per
+        /// <c>RefSpectra</c>.
+        /// </summary>
+        public void AddExperimentScores(long refId,
+            double experimentQValue, int nRunsDetected, int nRunsSearched)
+        {
+            using (var cmd = new SQLiteCommand(_conn))
+            {
+                cmd.CommandText = @"INSERT INTO OspreyExperimentScores (
+                    RefSpectraID, ExperimentQValue, NRunsDetected, NRunsSearched
+                ) VALUES (@r, @q, @nd, @ns)";
+                cmd.Parameters.AddWithValue("@r", refId);
+                cmd.Parameters.AddWithValue("@q", experimentQValue);
+                cmd.Parameters.AddWithValue("@nd", nRunsDetected);
+                cmd.Parameters.AddWithValue("@ns", nRunsSearched);
+                cmd.ExecuteNonQuery();
+            }
+        }
+
+        /// <summary>
+        /// Add a row to <c>OspreyCoefficients</c> for a single scan
+        /// within a chromatographic peak's coefficient time series.
+        /// Mirrors Rust <c>BlibWriter::add_coefficient</c>; many rows
+        /// per <c>RefSpectra</c> (one per scan in the peak).
+        /// Currently emitted with zero rows by both implementations
+        /// (the per-scan coefficient time series is not plumbed
+        /// through Stage 7 yet); the table is reserved for the
+        /// chromatogram-export feature.
+        /// </summary>
+        public void AddCoefficient(long refId, string fileName,
+            uint scanNumber, double rt, double coefficient)
+        {
+            using (var cmd = new SQLiteCommand(_conn))
+            {
+                cmd.CommandText = @"INSERT INTO OspreyCoefficients (
+                    RefSpectraID, FileName, ScanNumber, RT, Coefficient
+                ) VALUES (@r, @f, @s, @t, @c)";
+                cmd.Parameters.AddWithValue("@r", refId);
+                cmd.Parameters.AddWithValue("@f", fileName);
+                cmd.Parameters.AddWithValue("@s", scanNumber);
+                cmd.Parameters.AddWithValue("@t", rt);
+                cmd.Parameters.AddWithValue("@c", coefficient);
+                cmd.ExecuteNonQuery();
+            }
+        }
+
+        /// <summary>
         /// Update spectrum count in LibInfo, create indices, and checkpoint WAL.
         /// </summary>
         public void FinalizeDatabase()
@@ -397,6 +495,8 @@ namespace pwiz.OspreySharp.IO
                 CREATE INDEX IF NOT EXISTS idx_refspectra_mz ON RefSpectra(precursorMZ);
                 CREATE INDEX IF NOT EXISTS idx_peaks_refid ON RefSpectraPeaks(RefSpectraID);
                 CREATE INDEX IF NOT EXISTS idx_mods_refid ON Modifications(RefSpectraID);
+                CREATE INDEX IF NOT EXISTS idx_boundaries_refid ON OspreyPeakBoundaries(RefSpectraID);
+                CREATE INDEX IF NOT EXISTS idx_runscores_refid ON OspreyRunScores(RefSpectraID);
                 CREATE INDEX IF NOT EXISTS idx_rettimes_refid ON RetentionTimes(RefSpectraID)");
 
             ExecuteNonQuery("PRAGMA wal_checkpoint(TRUNCATE)");
@@ -662,6 +762,47 @@ namespace pwiz.OspreySharp.IO
                 CREATE TABLE OspreyMetadata (
                     Key TEXT PRIMARY KEY,
                     Value TEXT
+                );
+
+                CREATE TABLE OspreyPeakBoundaries (
+                    id INTEGER PRIMARY KEY,
+                    RefSpectraID INTEGER,
+                    FileName TEXT,
+                    StartRT REAL,
+                    EndRT REAL,
+                    ApexRT REAL,
+                    ApexIntensity REAL,
+                    IntegratedArea REAL,
+                    FOREIGN KEY (RefSpectraID) REFERENCES RefSpectra(id)
+                );
+
+                CREATE TABLE OspreyRunScores (
+                    id INTEGER PRIMARY KEY,
+                    RefSpectraID INTEGER,
+                    FileName TEXT,
+                    RunQValue REAL,
+                    DiscriminantScore REAL,
+                    PosteriorErrorProb REAL,
+                    FOREIGN KEY (RefSpectraID) REFERENCES RefSpectra(id)
+                );
+
+                CREATE TABLE OspreyExperimentScores (
+                    id INTEGER PRIMARY KEY,
+                    RefSpectraID INTEGER,
+                    ExperimentQValue REAL,
+                    NRunsDetected INTEGER,
+                    NRunsSearched INTEGER,
+                    FOREIGN KEY (RefSpectraID) REFERENCES RefSpectra(id)
+                );
+
+                CREATE TABLE OspreyCoefficients (
+                    id INTEGER PRIMARY KEY,
+                    RefSpectraID INTEGER,
+                    FileName TEXT,
+                    ScanNumber INTEGER,
+                    RT REAL,
+                    Coefficient REAL,
+                    FOREIGN KEY (RefSpectraID) REFERENCES RefSpectra(id)
                 );
             ");
 

--- a/pwiz_tools/OspreySharp/OspreySharp.IO/BlibWriter.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.IO/BlibWriter.cs
@@ -900,7 +900,17 @@ namespace pwiz.OspreySharp.IO
         /// </summary>
         private static byte[] CompressBytes(byte[] raw)
         {
-            const int level = 6; // matches Skyline UtilDB.Compress + Rust flate2 Compression::default()
+            // Use DotNetZip's Ionic.Zlib at level 6, matching Skyline's
+            // pwiz.Skyline.Util.Extensions.UtilDB.Compress (the canonical
+            // ProteoWizard BlibData writer in Skyline/Util/Extensions/
+            // UtilDB.cs:109-200). Cross-impl byte parity with Rust osprey
+            // additionally requires Rust's flate2 to use the `zlib-default`
+            // backend (vendored stock zlib via libz-sys), which produces
+            // identical deflate bytes to Ionic.Zlib. Configured in
+            // crates/osprey/Cargo.toml. The combination delivers PASS on
+            // Compare-Blib-Crossimpl.ps1 for both Stellar 3-file and Astral
+            // 3-file, with byte-identical RefSpectraPeaks blobs.
+            const int level = 6;
             byte[] compressed;
             using (var ms = new MemoryStream())
             {

--- a/pwiz_tools/OspreySharp/OspreySharp.IO/BlibWriter.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.IO/BlibWriter.cs
@@ -497,6 +497,8 @@ namespace pwiz.OspreySharp.IO
                 CREATE INDEX IF NOT EXISTS idx_mods_refid ON Modifications(RefSpectraID);
                 CREATE INDEX IF NOT EXISTS idx_boundaries_refid ON OspreyPeakBoundaries(RefSpectraID);
                 CREATE INDEX IF NOT EXISTS idx_runscores_refid ON OspreyRunScores(RefSpectraID);
+                CREATE INDEX IF NOT EXISTS idx_expscores_refid ON OspreyExperimentScores(RefSpectraID);
+                CREATE INDEX IF NOT EXISTS idx_coefficients_refid ON OspreyCoefficients(RefSpectraID);
                 CREATE INDEX IF NOT EXISTS idx_rettimes_refid ON RetentionTimes(RefSpectraID)");
 
             ExecuteNonQuery("PRAGMA wal_checkpoint(TRUNCATE)");
@@ -910,13 +912,12 @@ namespace pwiz.OspreySharp.IO
             // crates/osprey/Cargo.toml. The combination delivers PASS on
             // Compare-Blib-Crossimpl.ps1 for both Stellar 3-file and Astral
             // 3-file, with byte-identical RefSpectraPeaks blobs.
-            const int level = 6;
             byte[] compressed;
             using (var ms = new MemoryStream())
             {
                 using (var z = new Ionic.Zlib.ZlibStream(
                     ms, Ionic.Zlib.CompressionMode.Compress,
-                    Ionic.Zlib.CompressionLevel.Level0 + level, true))
+                    Ionic.Zlib.CompressionLevel.Level6, true))
                 {
                     z.Write(raw, 0, raw.Length);
                 }

--- a/pwiz_tools/OspreySharp/OspreySharp.IO/BlibWriter.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.IO/BlibWriter.cs
@@ -77,6 +77,10 @@ namespace pwiz.OspreySharp.IO
         private SQLiteCommand _cmdInsertProtein;
         private SQLiteCommand _cmdInsertRefSpectraProtein;
         private SQLiteCommand _cmdInsertRetentionTime;
+        private SQLiteCommand _cmdInsertPeakBoundaries;
+        private SQLiteCommand _cmdInsertRunScores;
+        private SQLiteCommand _cmdInsertExperimentScores;
+        private SQLiteCommand _cmdInsertCoefficient;
 
         /// <summary>
         /// Creates a new blib file at the given path. If the file already exists, it is removed first.
@@ -184,6 +188,51 @@ namespace pwiz.OspreySharp.IO
             _cmdInsertRetentionTime.Parameters.Add("@score", System.Data.DbType.Double);
             _cmdInsertRetentionTime.Parameters.Add("@best", System.Data.DbType.Int32);
             _cmdInsertRetentionTime.Prepare();
+
+            _cmdInsertPeakBoundaries = new SQLiteCommand(_conn);
+            _cmdInsertPeakBoundaries.CommandText = @"INSERT INTO OspreyPeakBoundaries (
+                RefSpectraID, FileName, StartRT, EndRT, ApexRT, ApexIntensity, IntegratedArea
+            ) VALUES (@r, @f, @s, @e, @a, @ai, @ia)";
+            _cmdInsertPeakBoundaries.Parameters.Add("@r", System.Data.DbType.Int64);
+            _cmdInsertPeakBoundaries.Parameters.Add("@f", System.Data.DbType.String);
+            _cmdInsertPeakBoundaries.Parameters.Add("@s", System.Data.DbType.Double);
+            _cmdInsertPeakBoundaries.Parameters.Add("@e", System.Data.DbType.Double);
+            _cmdInsertPeakBoundaries.Parameters.Add("@a", System.Data.DbType.Double);
+            _cmdInsertPeakBoundaries.Parameters.Add("@ai", System.Data.DbType.Double);
+            _cmdInsertPeakBoundaries.Parameters.Add("@ia", System.Data.DbType.Double);
+            _cmdInsertPeakBoundaries.Prepare();
+
+            _cmdInsertRunScores = new SQLiteCommand(_conn);
+            _cmdInsertRunScores.CommandText = @"INSERT INTO OspreyRunScores (
+                RefSpectraID, FileName, RunQValue, DiscriminantScore, PosteriorErrorProb
+            ) VALUES (@r, @f, @q, @d, @p)";
+            _cmdInsertRunScores.Parameters.Add("@r", System.Data.DbType.Int64);
+            _cmdInsertRunScores.Parameters.Add("@f", System.Data.DbType.String);
+            _cmdInsertRunScores.Parameters.Add("@q", System.Data.DbType.Double);
+            _cmdInsertRunScores.Parameters.Add("@d", System.Data.DbType.Double);
+            _cmdInsertRunScores.Parameters.Add("@p", System.Data.DbType.Double);
+            _cmdInsertRunScores.Prepare();
+
+            _cmdInsertExperimentScores = new SQLiteCommand(_conn);
+            _cmdInsertExperimentScores.CommandText = @"INSERT INTO OspreyExperimentScores (
+                RefSpectraID, ExperimentQValue, NRunsDetected, NRunsSearched
+            ) VALUES (@r, @q, @nd, @ns)";
+            _cmdInsertExperimentScores.Parameters.Add("@r", System.Data.DbType.Int64);
+            _cmdInsertExperimentScores.Parameters.Add("@q", System.Data.DbType.Double);
+            _cmdInsertExperimentScores.Parameters.Add("@nd", System.Data.DbType.Int32);
+            _cmdInsertExperimentScores.Parameters.Add("@ns", System.Data.DbType.Int32);
+            _cmdInsertExperimentScores.Prepare();
+
+            _cmdInsertCoefficient = new SQLiteCommand(_conn);
+            _cmdInsertCoefficient.CommandText = @"INSERT INTO OspreyCoefficients (
+                RefSpectraID, FileName, ScanNumber, RT, Coefficient
+            ) VALUES (@r, @f, @s, @t, @c)";
+            _cmdInsertCoefficient.Parameters.Add("@r", System.Data.DbType.Int64);
+            _cmdInsertCoefficient.Parameters.Add("@f", System.Data.DbType.String);
+            _cmdInsertCoefficient.Parameters.Add("@s", System.Data.DbType.Int32);
+            _cmdInsertCoefficient.Parameters.Add("@t", System.Data.DbType.Double);
+            _cmdInsertCoefficient.Parameters.Add("@c", System.Data.DbType.Double);
+            _cmdInsertCoefficient.Prepare();
         }
 
         /// <summary>
@@ -394,20 +443,14 @@ namespace pwiz.OspreySharp.IO
             double startRt, double endRt, double apexRt,
             double apexIntensity, double integratedArea)
         {
-            using (var cmd = new SQLiteCommand(_conn))
-            {
-                cmd.CommandText = @"INSERT INTO OspreyPeakBoundaries (
-                    RefSpectraID, FileName, StartRT, EndRT, ApexRT, ApexIntensity, IntegratedArea
-                ) VALUES (@r, @f, @s, @e, @a, @ai, @ia)";
-                cmd.Parameters.AddWithValue("@r", refId);
-                cmd.Parameters.AddWithValue("@f", fileName);
-                cmd.Parameters.AddWithValue("@s", startRt);
-                cmd.Parameters.AddWithValue("@e", endRt);
-                cmd.Parameters.AddWithValue("@a", apexRt);
-                cmd.Parameters.AddWithValue("@ai", apexIntensity);
-                cmd.Parameters.AddWithValue("@ia", integratedArea);
-                cmd.ExecuteNonQuery();
-            }
+            _cmdInsertPeakBoundaries.Parameters["@r"].Value = refId;
+            _cmdInsertPeakBoundaries.Parameters["@f"].Value = fileName;
+            _cmdInsertPeakBoundaries.Parameters["@s"].Value = startRt;
+            _cmdInsertPeakBoundaries.Parameters["@e"].Value = endRt;
+            _cmdInsertPeakBoundaries.Parameters["@a"].Value = apexRt;
+            _cmdInsertPeakBoundaries.Parameters["@ai"].Value = apexIntensity;
+            _cmdInsertPeakBoundaries.Parameters["@ia"].Value = integratedArea;
+            _cmdInsertPeakBoundaries.ExecuteNonQuery();
         }
 
         /// <summary>
@@ -419,18 +462,12 @@ namespace pwiz.OspreySharp.IO
         public void AddRunScores(long refId, string fileName,
             double runQValue, double discriminantScore, double posteriorErrorProb)
         {
-            using (var cmd = new SQLiteCommand(_conn))
-            {
-                cmd.CommandText = @"INSERT INTO OspreyRunScores (
-                    RefSpectraID, FileName, RunQValue, DiscriminantScore, PosteriorErrorProb
-                ) VALUES (@r, @f, @q, @d, @p)";
-                cmd.Parameters.AddWithValue("@r", refId);
-                cmd.Parameters.AddWithValue("@f", fileName);
-                cmd.Parameters.AddWithValue("@q", runQValue);
-                cmd.Parameters.AddWithValue("@d", discriminantScore);
-                cmd.Parameters.AddWithValue("@p", posteriorErrorProb);
-                cmd.ExecuteNonQuery();
-            }
+            _cmdInsertRunScores.Parameters["@r"].Value = refId;
+            _cmdInsertRunScores.Parameters["@f"].Value = fileName;
+            _cmdInsertRunScores.Parameters["@q"].Value = runQValue;
+            _cmdInsertRunScores.Parameters["@d"].Value = discriminantScore;
+            _cmdInsertRunScores.Parameters["@p"].Value = posteriorErrorProb;
+            _cmdInsertRunScores.ExecuteNonQuery();
         }
 
         /// <summary>
@@ -442,17 +479,11 @@ namespace pwiz.OspreySharp.IO
         public void AddExperimentScores(long refId,
             double experimentQValue, int nRunsDetected, int nRunsSearched)
         {
-            using (var cmd = new SQLiteCommand(_conn))
-            {
-                cmd.CommandText = @"INSERT INTO OspreyExperimentScores (
-                    RefSpectraID, ExperimentQValue, NRunsDetected, NRunsSearched
-                ) VALUES (@r, @q, @nd, @ns)";
-                cmd.Parameters.AddWithValue("@r", refId);
-                cmd.Parameters.AddWithValue("@q", experimentQValue);
-                cmd.Parameters.AddWithValue("@nd", nRunsDetected);
-                cmd.Parameters.AddWithValue("@ns", nRunsSearched);
-                cmd.ExecuteNonQuery();
-            }
+            _cmdInsertExperimentScores.Parameters["@r"].Value = refId;
+            _cmdInsertExperimentScores.Parameters["@q"].Value = experimentQValue;
+            _cmdInsertExperimentScores.Parameters["@nd"].Value = nRunsDetected;
+            _cmdInsertExperimentScores.Parameters["@ns"].Value = nRunsSearched;
+            _cmdInsertExperimentScores.ExecuteNonQuery();
         }
 
         /// <summary>
@@ -468,18 +499,12 @@ namespace pwiz.OspreySharp.IO
         public void AddCoefficient(long refId, string fileName,
             uint scanNumber, double rt, double coefficient)
         {
-            using (var cmd = new SQLiteCommand(_conn))
-            {
-                cmd.CommandText = @"INSERT INTO OspreyCoefficients (
-                    RefSpectraID, FileName, ScanNumber, RT, Coefficient
-                ) VALUES (@r, @f, @s, @t, @c)";
-                cmd.Parameters.AddWithValue("@r", refId);
-                cmd.Parameters.AddWithValue("@f", fileName);
-                cmd.Parameters.AddWithValue("@s", scanNumber);
-                cmd.Parameters.AddWithValue("@t", rt);
-                cmd.Parameters.AddWithValue("@c", coefficient);
-                cmd.ExecuteNonQuery();
-            }
+            _cmdInsertCoefficient.Parameters["@r"].Value = refId;
+            _cmdInsertCoefficient.Parameters["@f"].Value = fileName;
+            _cmdInsertCoefficient.Parameters["@s"].Value = (int)scanNumber;
+            _cmdInsertCoefficient.Parameters["@t"].Value = rt;
+            _cmdInsertCoefficient.Parameters["@c"].Value = coefficient;
+            _cmdInsertCoefficient.ExecuteNonQuery();
         }
 
         /// <summary>
@@ -529,6 +554,10 @@ namespace pwiz.OspreySharp.IO
                 if (_cmdInsertProtein != null) { _cmdInsertProtein.Dispose(); _cmdInsertProtein = null; }
                 if (_cmdInsertRefSpectraProtein != null) { _cmdInsertRefSpectraProtein.Dispose(); _cmdInsertRefSpectraProtein = null; }
                 if (_cmdInsertRetentionTime != null) { _cmdInsertRetentionTime.Dispose(); _cmdInsertRetentionTime = null; }
+                if (_cmdInsertPeakBoundaries != null) { _cmdInsertPeakBoundaries.Dispose(); _cmdInsertPeakBoundaries = null; }
+                if (_cmdInsertRunScores != null) { _cmdInsertRunScores.Dispose(); _cmdInsertRunScores = null; }
+                if (_cmdInsertExperimentScores != null) { _cmdInsertExperimentScores.Dispose(); _cmdInsertExperimentScores = null; }
+                if (_cmdInsertCoefficient != null) { _cmdInsertCoefficient.Dispose(); _cmdInsertCoefficient = null; }
                 if (_conn != null)
                 {
                     _conn.Close();

--- a/pwiz_tools/OspreySharp/OspreySharp.IO/BlibWriter.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.IO/BlibWriter.cs
@@ -881,8 +881,22 @@ namespace pwiz.OspreySharp.IO
         }
 
         /// <summary>
-        /// Zlib-compress a byte buffer. Returns raw bytes if compression does not reduce size.
-        /// BiblioSpec readers determine compression by comparing blob length to expected uncompressed size.
+        /// Zlib-compress a byte buffer. Returns raw bytes when the
+        /// compressed output isn't materially smaller. BiblioSpec readers
+        /// determine compression by comparing blob length to expected
+        /// uncompressed size, so the choice of threshold doesn't affect
+        /// downstream consumers — but it MUST match Rust's
+        /// <c>compress_bytes</c> behaviour for cross-impl byte parity.
+        ///
+        /// Rust's <c>flate2</c> (with <c>Compression::default()</c> = level
+        /// 6) typically produces 3-4 more bytes of deflate overhead than
+        /// .NET's <c>DeflateStream</c> on the small fragment-array inputs
+        /// (~160 bytes) Stage 7 emits. As a result, Rust falls back to
+        /// raw on inputs where C# would compress, splitting the .blib
+        /// blob bytes cross-impl. Setting the savings threshold to require
+        /// strictly more than 4 bytes of savings papers over the
+        /// flate2-vs-DeflateStream micro-difference: if C# can only save
+        /// 1-4 bytes, it falls back to raw — same choice Rust makes.
         /// </summary>
         private static byte[] CompressBytes(byte[] raw)
         {
@@ -896,7 +910,9 @@ namespace pwiz.OspreySharp.IO
                     deflate.Write(raw, 0, raw.Length);
                 }
                 byte[] compressed = ms.ToArray();
-                if (compressed.Length >= raw.Length)
+                // Match Rust's compression-or-raw decision boundary on
+                // small inputs by requiring a >4-byte savings.
+                if (compressed.Length + 4 >= raw.Length)
                     return raw;
                 return compressed;
             }

--- a/pwiz_tools/OspreySharp/OspreySharp.IO/OspreySharp.IO.csproj
+++ b/pwiz_tools/OspreySharp/OspreySharp.IO/OspreySharp.IO.csproj
@@ -24,4 +24,16 @@
     <ProjectReference Include="..\OspreySharp.Core\OspreySharp.Core.csproj" />
   </ItemGroup>
 
+  <!-- DotNetZip (Ionic.Zlib) for stock-zlib-compatible deflate output.
+       Matches Skyline's BlibData writer (Util/Extensions/UtilDB.Compress)
+       so OspreySharp .blib peak blobs are byte-identical to Skyline's
+       and to Rust osprey's flate2 output. .NET's built-in DeflateStream
+       produces a 4-byte-shorter non-stock-zlib variant which would split
+       cross-impl byte parity. -->
+  <ItemGroup>
+    <Reference Include="DotNetZip">
+      <HintPath>..\..\Shared\Lib\DotNetZip\DotNetZip.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+
 </Project>

--- a/pwiz_tools/OspreySharp/OspreySharp.IO/ParquetScoreCache.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.IO/ParquetScoreCache.cs
@@ -621,8 +621,11 @@ namespace pwiz.OspreySharp.IO
         /// <summary>
         /// Load only the columns needed for FDR stubs from a Parquet cache.
         /// Reads: entry_id, is_decoy, charge, scan_number, apex_rt, start_rt, end_rt,
-        /// fragment_coelution_sum, modified_sequence.
-        /// Sets parquet_index = row index.
+        /// fragment_coelution_sum, bounds_area, modified_sequence.
+        /// Sets parquet_index = row index. <c>bounds_area</c> feeds the
+        /// .blib's <c>OspreyPeakBoundaries.IntegratedArea</c> column at
+        /// Stage 7 — without it, the stage-7 .blib write emits zero for
+        /// every IntegratedArea row and silently diverges from Rust.
         /// </summary>
         public static List<FdrEntry> LoadFdrStubsFromParquet(string path)
         {
@@ -645,6 +648,7 @@ namespace pwiz.OspreySharp.IO
                         var startCol = ReadColumnByName<double[]>(groupReader, fieldsByName, FIELD_START_RT.Name);
                         var endCol = ReadColumnByName<double[]>(groupReader, fieldsByName, FIELD_END_RT.Name);
                         var coelutionCol = ReadColumnByName<double[]>(groupReader, fieldsByName, FIELD_COELUTION_SUM.Name);
+                        var boundsAreaCol = ReadColumnByName<double[]>(groupReader, fieldsByName, FIELD_BOUNDS_AREA.Name);
 
                         if (entryIdCol == null || isDecoyCol == null)
                             continue;
@@ -663,6 +667,7 @@ namespace pwiz.OspreySharp.IO
                                 StartRt = startCol != null ? startCol[row] : 0.0,
                                 EndRt = endCol != null ? endCol[row] : 0.0,
                                 CoelutionSum = coelutionCol != null ? coelutionCol[row] : 0.0,
+                                BoundsArea = boundsAreaCol != null ? boundsAreaCol[row] : 0.0,
                                 ModifiedSequence = modseqCol != null ? modseqCol[row] : string.Empty,
                             });
                         }

--- a/pwiz_tools/OspreySharp/OspreySharp/AnalysisPipeline.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/AnalysisPipeline.cs
@@ -6039,7 +6039,12 @@ namespace pwiz.OspreySharp
                         intensities[i] = libEntry.Fragments[i].RelativeIntensity;
                     }
 
-                    double qvalue = entry.EffectiveRunQvalue(config.FdrLevel);
+                    // RefSpectra.score is the experiment-level q-value at FdrLevel.Both
+                    // (max(precursor, peptide)) — Skyline's GENERIC Q-VALUE convention.
+                    // Mirrors Rust pipeline.rs:6166 and the LightFdr.experiment_qvalue
+                    // assignment at pipeline.rs:4705 which fixes Both regardless of
+                    // the user's --fdr-level choice.
+                    double scoreQvalue = entry.EffectiveExperimentQvalue(FdrLevel.Both);
 
                     long refId = writer.AddSpectrum(
                         libEntry.Sequence,
@@ -6050,7 +6055,7 @@ namespace pwiz.OspreySharp
                         entry.StartRt,
                         entry.EndRt,
                         mzs, intensities,
-                        qvalue, fileId, 1, 0.0);
+                        scoreQvalue, fileId, 1, 0.0);
 
                     // Add modifications
                     if (libEntry.Modifications != null && libEntry.Modifications.Count > 0)
@@ -6060,36 +6065,65 @@ namespace pwiz.OspreySharp
                     if (libEntry.ProteinIds != null && libEntry.ProteinIds.Count > 0)
                         writer.AddProteinMapping(refId, libEntry.ProteinIds);
 
-                    // Add per-file retention times for cross-file observations.
-                    // Use the pre-built index for O(1) lookup by (modseq, charge).
+                    // Per-file RetentionTimes — one row for EVERY run where this
+                    // precursor was detected, including the best-run/RefSpectra-source
+                    // run itself. retentionTime (which drives Skyline ID-line
+                    // display) is populated iff the run passes run-level FDR, OR
+                    // (fallback) no run passes run-level FDR and this is the best
+                    // run by lowest run_qvalue. Mirrors Rust pipeline.rs:6191-6243
+                    // exactly. Uses FdrLevel.Both for the run-level q-value, matching
+                    // the LightFdr.run_qvalue assignment at pipeline.rs:4704.
                     string lookupKey = entry.ModifiedSequence + "|" + entry.Charge;
                     List<KeyValuePair<string, FdrEntry>> observations;
-                    int nRunsDetected = 1; // Best run is always one detection
+                    int nRunsDetected = 0;
                     if (entriesByPrecursor.TryGetValue(lookupKey, out observations))
                     {
+                        // Compute the fallback ID-line file: if NO run passes
+                        // run-level FDR (post-second-pass q-values can shift
+                        // slightly above threshold even when the precursor passes
+                        // experiment-level), the run with the lowest run_qvalue
+                        // gets the ID line so every blib RefSpectra has at least
+                        // one ID line.
+                        bool anyPassesRunFdr = false;
+                        string bestRunFile = null;
+                        double bestRunQ = double.MaxValue;
                         foreach (var obs in observations)
                         {
-                            if (obs.Key == fileName)
-                                continue;
+                            double rq = obs.Value.EffectiveRunQvalue(FdrLevel.Both);
+                            if (rq <= fdrThreshold)
+                                anyPassesRunFdr = true;
+                            if (rq < bestRunQ)
+                            {
+                                bestRunQ = rq;
+                                bestRunFile = obs.Key;
+                            }
+                        }
 
+                        foreach (var obs in observations)
+                        {
                             long srcId = sourceFileIds[obs.Key];
                             var fileEntry = obs.Value;
-                            bool passesFdr = fileEntry.EffectiveRunQvalue(config.FdrLevel)
-                                <= fdrThreshold;
+                            double runQ = fileEntry.EffectiveRunQvalue(FdrLevel.Both);
+                            bool passesFdr = runQ <= fdrThreshold;
+                            // Show an ID line if this run passes run-level FDR,
+                            // OR if no run passes and this is the fallback best.
+                            bool showIdLine = passesFdr ||
+                                (!anyPassesRunFdr && obs.Key == bestRunFile);
+                            bool isBest = obs.Key == fileName;
 
                             writer.AddRetentionTime(
                                 refId, srcId,
-                                passesFdr ? fileEntry.ApexRt : null,
+                                showIdLine ? (double?)fileEntry.ApexRt : null,
                                 fileEntry.StartRt,
                                 fileEntry.EndRt,
-                                fileEntry.EffectiveRunQvalue(config.FdrLevel),
-                                false);
-                            // Count cross-file observations that pass FDR for the
-                            // OspreyExperimentScores.NRunsDetected column.
+                                runQ,
+                                isBest);
                             if (passesFdr)
                                 nRunsDetected++;
                         }
                     }
+                    if (nRunsDetected == 0)
+                        nRunsDetected = 1; // best run is always at least one detection
 
                     // Osprey extension tables — one row per RefSpectra each, mirroring
                     // Rust pipeline.rs:6255-6272 byte-for-byte. Best-run-only semantics

--- a/pwiz_tools/OspreySharp/OspreySharp/AnalysisPipeline.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/AnalysisPipeline.cs
@@ -5915,8 +5915,20 @@ namespace pwiz.OspreySharp
                     nFallback));
             }
 
+
             // Collect passing entries for downstream best-per-precursor selection.
             // A precursor is admitted iff (modseq, charge) is in passingPrecursors.
+            //
+            // No protein-FDR gate here: Rust only filters the .blib by protein
+            // FDR when `--fdr-level=protein` (the FdrLevel::Protein variant
+            // routes through the peptide-gate's effective_experiment_qvalue).
+            // C#'s FdrLevel enum doesn't include Protein, and `--protein-fdr`
+            // is interpreted by Rust as a computation-enable flag, not a
+            // hard blib filter. Mirror that: keep the (modseq, charge)
+            // membership check from Stages 1+2 and don't apply
+            // ExperimentProteinQvalue here. Closed 22/27 only-in-Rust on
+            // Stellar 3-file (the remaining 5 have modifications upstream of
+            // perFileEntries — separate bisection).
             var passingEntries = new List<KeyValuePair<string, FdrEntry>>();
             foreach (var kvp in perFileEntries)
             {
@@ -5927,16 +5939,6 @@ namespace pwiz.OspreySharp
                     string key = entry.ModifiedSequence + "|" + entry.Charge;
                     if (!passingPrecursors.Contains(key))
                         continue;
-
-                    // If protein FDR is enabled, also check protein q-value.
-                    // Use experiment-level protein q-value so the gate is
-                    // experiment-wide, consistent with Stage 1/2 above.
-                    if (config.ProteinFdr.HasValue &&
-                        entry.ExperimentProteinQvalue > config.ProteinFdr.Value)
-                    {
-                        continue;
-                    }
-
                     passingEntries.Add(
                         new KeyValuePair<string, FdrEntry>(kvp.Key, entry));
                 }
@@ -6111,9 +6113,12 @@ namespace pwiz.OspreySharp
                                 (!anyPassesRunFdr && obs.Key == bestRunFile);
                             bool isBest = obs.Key == fileName;
 
+                            double? rtForIdLine = null;
+                            if (showIdLine)
+                                rtForIdLine = fileEntry.ApexRt;
                             writer.AddRetentionTime(
                                 refId, srcId,
-                                showIdLine ? (double?)fileEntry.ApexRt : null,
+                                rtForIdLine,
                                 fileEntry.StartRt,
                                 fileEntry.EndRt,
                                 runQ,
@@ -6153,9 +6158,20 @@ namespace pwiz.OspreySharp
                 writer.Commit();
 
                 // Add metadata
-                writer.AddMetadata("osprey_version", Program.VERSION_STRING);
-                writer.AddMetadata("search_parameter_hash", config.SearchParameterHash());
-                writer.AddMetadata("n_passing_precursors", bestByPrecursor.Count.ToString());
+                // OspreyMetadata key set must match Rust's
+                // write_blib_from_plan (pipeline.rs:6078-6081) byte-for-byte.
+                // The previous C#-only keys (search_parameter_hash,
+                // n_passing_precursors) are dropped: search_parameter_hash
+                // is already on every reconciled .scores.parquet (where it's
+                // used for cache validation, the actual purpose), and
+                // n_passing_precursors is recoverable as
+                // SELECT COUNT(*) FROM RefSpectra.
+                writer.AddMetadata(@"osprey_version", Program.VERSION_STRING);
+                writer.AddMetadata(@"search_mode", @"coelution");
+                writer.AddMetadata(@"run_fdr",
+                    config.RunFdr.ToString(System.Globalization.CultureInfo.InvariantCulture));
+                writer.AddMetadata(@"experiment_fdr",
+                    config.ExperimentFdr.ToString(System.Globalization.CultureInfo.InvariantCulture));
 
                 writer.FinalizeDatabase();
             }

--- a/pwiz_tools/OspreySharp/OspreySharp/AnalysisPipeline.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/AnalysisPipeline.cs
@@ -5863,8 +5863,12 @@ namespace pwiz.OspreySharp
                 }
             }
 
-            // Stage 2: passing precursors, with fallback to best charge per peptide
-            var passingPrecursors = new HashSet<string>(StringComparer.Ordinal);
+            // Stage 2: passing precursors, with fallback to best charge per peptide.
+            // Tuple keys (modseq, charge) avoid the separator-collision risk of
+            // string concatenation and skip a string allocation per lookup —
+            // same shape as Rust's HashMap<(Arc<str>, u8), ...> at
+            // pipeline.rs:4630.
+            var passingPrecursors = new HashSet<(string, byte)>();
             var bestChargePerPeptide = new Dictionary<string, KeyValuePair<byte, double>>(
                 StringComparer.Ordinal);
             foreach (var kvp in perFileEntries)
@@ -5873,9 +5877,8 @@ namespace pwiz.OspreySharp
                 {
                     if (e.IsDecoy || !passingPeptides.Contains(e.ModifiedSequence))
                         continue;
-                    string key = e.ModifiedSequence + "|" + e.Charge;
                     if (e.ExperimentPrecursorQvalue <= expThreshold)
-                        passingPrecursors.Add(key);
+                        passingPrecursors.Add((e.ModifiedSequence, e.Charge));
                     KeyValuePair<byte, double> existing;
                     if (!bestChargePerPeptide.TryGetValue(e.ModifiedSequence, out existing)
                         || e.ExperimentPrecursorQvalue < existing.Value)
@@ -5885,28 +5888,20 @@ namespace pwiz.OspreySharp
                     }
                 }
             }
-            // Fallback: peptides with no precursor-passing charge state keep their best
+            // Fallback: peptides with no precursor-passing charge state keep their best.
+            // The OR check (`best.Value <= expThreshold`) is the substantive one — if
+            // best has q <= threshold, the loop above already added it to passingPrecursors;
+            // the Contains check is redundant defensive belt-and-suspenders.
             int nFallback = 0;
             foreach (var peptide in passingPeptides)
             {
-                bool hasPassing = false;
                 KeyValuePair<byte, double> best;
                 if (!bestChargePerPeptide.TryGetValue(peptide, out best))
                     continue;
-                string fallbackKey = peptide + "|" + best.Key;
-                // Quick check: is any charge of this peptide already in passingPrecursors?
-                // We can derive this from whether the fallback key is already there OR
-                // any other charge for this peptide is. The exact set is small enough
-                // that a linear scan over precursors with this prefix is fine, but the
-                // simpler check suffices because best is already the lowest-qvalue
-                // charge — if it itself didn't pass, no other did either.
-                hasPassing = passingPrecursors.Contains(fallbackKey)
-                    || best.Value <= expThreshold;
-                if (!hasPassing)
-                {
-                    passingPrecursors.Add(fallbackKey);
-                    nFallback++;
-                }
+                if (best.Value <= expThreshold)
+                    continue; // already in passingPrecursors
+                passingPrecursors.Add((peptide, best.Key));
+                nFallback++;
             }
             if (nFallback > 0)
             {
@@ -5914,7 +5909,6 @@ namespace pwiz.OspreySharp
                     "{0} peptides had no charge state passing precursor-level FDR; best charge state kept as fallback",
                     nFallback));
             }
-
 
             // Collect passing entries for downstream best-per-precursor selection.
             // A precursor is admitted iff (modseq, charge) is in passingPrecursors.
@@ -5926,9 +5920,7 @@ namespace pwiz.OspreySharp
             // is interpreted by Rust as a computation-enable flag, not a
             // hard blib filter. Mirror that: keep the (modseq, charge)
             // membership check from Stages 1+2 and don't apply
-            // ExperimentProteinQvalue here. Closed 22/27 only-in-Rust on
-            // Stellar 3-file (the remaining 5 have modifications upstream of
-            // perFileEntries — separate bisection).
+            // ExperimentProteinQvalue here.
             var passingEntries = new List<KeyValuePair<string, FdrEntry>>();
             foreach (var kvp in perFileEntries)
             {
@@ -5936,8 +5928,7 @@ namespace pwiz.OspreySharp
                 {
                     if (entry.IsDecoy)
                         continue;
-                    string key = entry.ModifiedSequence + "|" + entry.Charge;
-                    if (!passingPrecursors.Contains(key))
+                    if (!passingPrecursors.Contains((entry.ModifiedSequence, entry.Charge)))
                         continue;
                     passingEntries.Add(
                         new KeyValuePair<string, FdrEntry>(kvp.Key, entry));
@@ -5960,7 +5951,7 @@ namespace pwiz.OspreySharp
             if (!string.IsNullOrEmpty(outputDir) && !Directory.Exists(outputDir))
                 Directory.CreateDirectory(outputDir);
 
-            // Deduplicate by modified_sequence + charge — keep best by
+            // Deduplicate by (modseq, charge) — keep best by
             // EffectiveRunQvalue(FdrLevel.Both). Matches Rust
             // pipeline.rs:6133-6138 which picks `best = min_by(run_qvalue)`
             // from the precursor group. The blib's downstream
@@ -5971,11 +5962,10 @@ namespace pwiz.OspreySharp
             // (Earlier this dedup keyed on ExperimentPrecursorQvalue,
             // producing a 26002+26002 only-rust/only-cs key split on
             // OspreyRunScores/PeakBoundaries.)
-            var bestByPrecursor = new Dictionary<string, KeyValuePair<string, FdrEntry>>(
-                StringComparer.Ordinal);
+            var bestByPrecursor = new Dictionary<(string, byte), KeyValuePair<string, FdrEntry>>();
             foreach (var kvp in passingEntries)
             {
-                string key = kvp.Value.ModifiedSequence + "_" + kvp.Value.Charge;
+                var key = (kvp.Value.ModifiedSequence, kvp.Value.Charge);
                 KeyValuePair<string, FdrEntry> existing;
                 if (!bestByPrecursor.TryGetValue(key, out existing) ||
                     kvp.Value.EffectiveRunQvalue(FdrLevel.Both) <
@@ -5994,13 +5984,13 @@ namespace pwiz.OspreySharp
             // columns (pipeline.rs:4670-4683 + 4795). NOT max(precursor,
             // peptide) — the experiment-level peptide q-value isn't used at
             // the .blib write site at all.
-            var bestExpPrecursorQ = new Dictionary<string, double>(StringComparer.Ordinal);
+            var bestExpPrecursorQ = new Dictionary<(string, byte), double>();
             foreach (var fileKvpExp in perFileEntries)
             {
                 foreach (var e in fileKvpExp.Value)
                 {
                     if (e.IsDecoy) continue;
-                    string keyExp = e.ModifiedSequence + "|" + e.Charge;
+                    var keyExp = (e.ModifiedSequence, e.Charge);
                     if (!passingPrecursors.Contains(keyExp)) continue;
                     double existingExp;
                     if (!bestExpPrecursorQ.TryGetValue(keyExp, out existingExp)
@@ -6022,9 +6012,9 @@ namespace pwiz.OspreySharp
             // boundary so quantification across charges integrates the same
             // RT region. Key: (modseq, fileName); value: (apexRt, startRt,
             // endRt) from the min-run-qvalue entry across charges.
-            var sharedBoundsKey = new Func<string, string, string>((modseq, fileName) =>
-                modseq + "" + fileName);
-            var sharedBounds = new Dictionary<string, double[]>(StringComparer.Ordinal);
+            // Tuple key matches Rust HashMap<(Arc<str>, u16), ...> at
+            // pipeline.rs:6027 directly — no string concat or separator needed.
+            var sharedBounds = new Dictionary<(string, string), double[]>();
             // For each (modseq, file), track the (apex, start, end, run_q) of best entry
             foreach (var fileKvpBounds in perFileEntries)
             {
@@ -6032,9 +6022,8 @@ namespace pwiz.OspreySharp
                 foreach (var e in fileKvpBounds.Value)
                 {
                     if (e.IsDecoy) continue;
-                    string keyB = e.ModifiedSequence + "|" + e.Charge;
-                    if (!passingPrecursors.Contains(keyB)) continue;
-                    string sk = sharedBoundsKey(e.ModifiedSequence, boundsFile);
+                    if (!passingPrecursors.Contains((e.ModifiedSequence, e.Charge))) continue;
+                    var sk = (e.ModifiedSequence, boundsFile);
                     double rq = e.EffectiveRunQvalue(FdrLevel.Both);
                     double[] existingB;
                     if (!sharedBounds.TryGetValue(sk, out existingB) || rq < existingB[3])
@@ -6048,8 +6037,7 @@ namespace pwiz.OspreySharp
             // lookup of cross-file observations. Without this, the inner loop below is
             // O(N_passing * N_total) which is ~70 billion ops for typical experiments.
             var entriesByPrecursor =
-                new Dictionary<string, List<KeyValuePair<string, FdrEntry>>>(
-                    StringComparer.Ordinal);
+                new Dictionary<(string, byte), List<KeyValuePair<string, FdrEntry>>>();
             int nCrossFileObservations = 0;
             foreach (var fileKvp in perFileEntries)
             {
@@ -6058,7 +6046,7 @@ namespace pwiz.OspreySharp
                 {
                     if (fileEntry.IsDecoy)
                         continue;
-                    string key = fileEntry.ModifiedSequence + "|" + fileEntry.Charge;
+                    var key = (fileEntry.ModifiedSequence, fileEntry.Charge);
                     List<KeyValuePair<string, FdrEntry>> list;
                     if (!entriesByPrecursor.TryGetValue(key, out list))
                     {
@@ -6163,7 +6151,7 @@ namespace pwiz.OspreySharp
                     // overrides with best_exp_q.get(...) which is precursor-only).
                     // The same value feeds OspreyExperimentScores.ExperimentQValue
                     // below.
-                    string lookupKey = entry.ModifiedSequence + "|" + entry.Charge;
+                    var lookupKey = (entry.ModifiedSequence, entry.Charge);
                     double scoreQvalue;
                     if (!bestExpPrecursorQ.TryGetValue(lookupKey, out scoreQvalue))
                         scoreQvalue = entry.ExperimentPrecursorQvalue;
@@ -6184,7 +6172,7 @@ namespace pwiz.OspreySharp
                     // Use shared peak boundaries when the same peptide
                     // is detected at multiple charges in this file (Rust
                     // pipeline.rs:6160-6164 + 6219-6222).
-                    string sharedKey = sharedBoundsKey(entry.ModifiedSequence, fileName);
+                    var sharedKey = (entry.ModifiedSequence, fileName);
                     double sharedApex = entry.ApexRt;
                     double sharedStart = entry.StartRt;
                     double sharedEnd = entry.EndRt;
@@ -6261,7 +6249,7 @@ namespace pwiz.OspreySharp
                             // Apply shared peak boundaries for this peptide
                             // in this run's file (cross-charge sharing —
                             // Rust pipeline.rs:6219-6222).
-                            string runSharedKey = sharedBoundsKey(fileEntry.ModifiedSequence, obs.Key);
+                            var runSharedKey = (fileEntry.ModifiedSequence, obs.Key);
                             double runApex = fileEntry.ApexRt;
                             double runStart = fileEntry.StartRt;
                             double runEnd = fileEntry.EndRt;

--- a/pwiz_tools/OspreySharp/OspreySharp/AnalysisPipeline.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/AnalysisPipeline.cs
@@ -5971,6 +5971,7 @@ namespace pwiz.OspreySharp
                     // Use the pre-built index for O(1) lookup by (modseq, charge).
                     string lookupKey = entry.ModifiedSequence + "|" + entry.Charge;
                     List<KeyValuePair<string, FdrEntry>> observations;
+                    int nRunsDetected = 1; // Best run is always one detection
                     if (entriesByPrecursor.TryGetValue(lookupKey, out observations))
                     {
                         foreach (var obs in observations)
@@ -5990,8 +5991,36 @@ namespace pwiz.OspreySharp
                                 fileEntry.EndRt,
                                 fileEntry.EffectiveRunQvalue(config.FdrLevel),
                                 false);
+                            // Count cross-file observations that pass FDR for the
+                            // OspreyExperimentScores.NRunsDetected column.
+                            if (passesFdr)
+                                nRunsDetected++;
                         }
                     }
+
+                    // Osprey extension tables — one row per RefSpectra each, mirroring
+                    // Rust pipeline.rs:6255-6272 byte-for-byte. Best-run-only semantics
+                    // for OspreyPeakBoundaries + OspreyRunScores; experiment-level for
+                    // OspreyExperimentScores. Note the four 0.0 fields below are the
+                    // same "not yet plumbed through Stage 7 plan entries" placeholders
+                    // Rust currently writes:
+                    //   PeakBoundaries.ApexIntensity (Rust: apex_coefficient = 0.0)
+                    //   RunScores.DiscriminantScore (Rust: dot_product not avail = 0.0)
+                    //   RunScores.PosteriorErrorProb (Rust: PEP not avail = 0.0)
+                    // When Rust starts plumbing real values through, this block updates
+                    // in lockstep to keep cross-impl parity.
+                    writer.AddPeakBoundaries(refId, fileName,
+                        entry.StartRt, entry.EndRt, entry.ApexRt,
+                        0.0, // ApexIntensity — matches Rust's apex_coefficient placeholder
+                        entry.BoundsArea);
+                    writer.AddRunScores(refId, fileName,
+                        entry.EffectiveRunQvalue(config.FdrLevel),
+                        0.0, // DiscriminantScore — matches Rust's dot_product placeholder
+                        0.0); // PosteriorErrorProb — matches Rust's PEP placeholder
+                    writer.AddExperimentScores(refId,
+                        entry.EffectiveExperimentQvalue(config.FdrLevel),
+                        nRunsDetected,
+                        perFileEntries.Count);
                 }
 
                 writer.Commit();

--- a/pwiz_tools/OspreySharp/OspreySharp/AnalysisPipeline.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/AnalysisPipeline.cs
@@ -6011,6 +6011,39 @@ namespace pwiz.OspreySharp
                 }
             }
 
+            // Build shared peak boundaries per (peptide, file): when the same
+            // peptide is detected at multiple charge states in the same run,
+            // all charges share the boundaries from the charge with lowest
+            // run_qvalue. Mirrors Rust pipeline.rs:6020-6063
+            // (build_shared_boundaries_from_plan). Without this, charge-N's
+            // RefSpectra row gets charge-N's own boundaries, but Rust gives
+            // charge-N the boundaries of whatever charge happened to score
+            // best in that file — Skyline wants the consistent peptide-level
+            // boundary so quantification across charges integrates the same
+            // RT region. Key: (modseq, fileName); value: (apexRt, startRt,
+            // endRt) from the min-run-qvalue entry across charges.
+            var sharedBoundsKey = new Func<string, string, string>((modseq, fileName) =>
+                modseq + "" + fileName);
+            var sharedBounds = new Dictionary<string, double[]>(StringComparer.Ordinal);
+            // For each (modseq, file), track the (apex, start, end, run_q) of best entry
+            foreach (var fileKvpBounds in perFileEntries)
+            {
+                string boundsFile = fileKvpBounds.Key;
+                foreach (var e in fileKvpBounds.Value)
+                {
+                    if (e.IsDecoy) continue;
+                    string keyB = e.ModifiedSequence + "|" + e.Charge;
+                    if (!passingPrecursors.Contains(keyB)) continue;
+                    string sk = sharedBoundsKey(e.ModifiedSequence, boundsFile);
+                    double rq = e.EffectiveRunQvalue(FdrLevel.Both);
+                    double[] existingB;
+                    if (!sharedBounds.TryGetValue(sk, out existingB) || rq < existingB[3])
+                    {
+                        sharedBounds[sk] = new[] { e.ApexRt, e.StartRt, e.EndRt, rq };
+                    }
+                }
+            }
+
             // Pre-index all per-file target entries by (ModifiedSequence, Charge) for O(1)
             // lookup of cross-file observations. Without this, the inner loop below is
             // O(N_passing * N_total) which is ~70 billion ops for typical experiments.
@@ -6139,14 +6172,29 @@ namespace pwiz.OspreySharp
                         nRunsDetected = observations.Count;
                     }
 
+                    // Use shared peak boundaries when the same peptide
+                    // is detected at multiple charges in this file (Rust
+                    // pipeline.rs:6160-6164 + 6219-6222).
+                    string sharedKey = sharedBoundsKey(entry.ModifiedSequence, fileName);
+                    double sharedApex = entry.ApexRt;
+                    double sharedStart = entry.StartRt;
+                    double sharedEnd = entry.EndRt;
+                    double[] sharedVals;
+                    if (sharedBounds.TryGetValue(sharedKey, out sharedVals))
+                    {
+                        sharedApex = sharedVals[0];
+                        sharedStart = sharedVals[1];
+                        sharedEnd = sharedVals[2];
+                    }
+
                     long refId = writer.AddSpectrum(
                         libEntry.Sequence,
                         libEntry.ModifiedSequence,
                         libEntry.PrecursorMz,
                         libEntry.Charge,
-                        entry.ApexRt,
-                        entry.StartRt,
-                        entry.EndRt,
+                        sharedApex,
+                        sharedStart,
+                        sharedEnd,
                         mzs, intensities,
                         scoreQvalue, fileId, nRunsDetected, 0.0);
 
@@ -6201,14 +6249,29 @@ namespace pwiz.OspreySharp
                                 (!anyPassesRunFdr && obs.Key == bestRunFile);
                             bool isBest = obs.Key == fileName;
 
+                            // Apply shared peak boundaries for this peptide
+                            // in this run's file (cross-charge sharing —
+                            // Rust pipeline.rs:6219-6222).
+                            string runSharedKey = sharedBoundsKey(fileEntry.ModifiedSequence, obs.Key);
+                            double runApex = fileEntry.ApexRt;
+                            double runStart = fileEntry.StartRt;
+                            double runEnd = fileEntry.EndRt;
+                            double[] runShared;
+                            if (sharedBounds.TryGetValue(runSharedKey, out runShared))
+                            {
+                                runApex = runShared[0];
+                                runStart = runShared[1];
+                                runEnd = runShared[2];
+                            }
+
                             double? rtForIdLine = null;
                             if (showIdLine)
-                                rtForIdLine = fileEntry.ApexRt;
+                                rtForIdLine = runApex;
                             writer.AddRetentionTime(
                                 refId, srcId,
                                 rtForIdLine,
-                                fileEntry.StartRt,
-                                fileEntry.EndRt,
+                                runStart,
+                                runEnd,
                                 runQ,
                                 isBest);
                         }
@@ -6225,8 +6288,10 @@ namespace pwiz.OspreySharp
                     //   RunScores.PosteriorErrorProb (Rust: PEP not avail = 0.0)
                     // When Rust starts plumbing real values through, this block updates
                     // in lockstep to keep cross-impl parity.
+                    // OspreyPeakBoundaries uses the shared boundaries for
+                    // this (peptide, file) — same source as RefSpectra above.
                     writer.AddPeakBoundaries(refId, fileName,
-                        entry.StartRt, entry.EndRt, entry.ApexRt,
+                        sharedStart, sharedEnd, sharedApex,
                         0.0, // ApexIntensity — matches Rust's apex_coefficient placeholder
                         entry.BoundsArea);
                     writer.AddRunScores(refId, fileName,

--- a/pwiz_tools/OspreySharp/OspreySharp/AnalysisPipeline.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/AnalysisPipeline.cs
@@ -5988,6 +5988,29 @@ namespace pwiz.OspreySharp
             LogInfo(string.Format(
                 "[COUNT] Best-per-precursor for blib: {0}", bestByPrecursor.Count));
 
+            // Compute best (min) experiment_precursor_qvalue per (modseq, charge)
+            // across all files. This is the value Rust writes into the .blib's
+            // RefSpectra.score and OspreyExperimentScores.ExperimentQValue
+            // columns (pipeline.rs:4670-4683 + 4795). NOT max(precursor,
+            // peptide) — the experiment-level peptide q-value isn't used at
+            // the .blib write site at all.
+            var bestExpPrecursorQ = new Dictionary<string, double>(StringComparer.Ordinal);
+            foreach (var fileKvpExp in perFileEntries)
+            {
+                foreach (var e in fileKvpExp.Value)
+                {
+                    if (e.IsDecoy) continue;
+                    string keyExp = e.ModifiedSequence + "|" + e.Charge;
+                    if (!passingPrecursors.Contains(keyExp)) continue;
+                    double existingExp;
+                    if (!bestExpPrecursorQ.TryGetValue(keyExp, out existingExp)
+                        || e.ExperimentPrecursorQvalue < existingExp)
+                    {
+                        bestExpPrecursorQ[keyExp] = e.ExperimentPrecursorQvalue;
+                    }
+                }
+            }
+
             // Pre-index all per-file target entries by (ModifiedSequence, Charge) for O(1)
             // lookup of cross-file observations. Without this, the inner loop below is
             // O(N_passing * N_total) which is ~70 billion ops for typical experiments.
@@ -6087,19 +6110,27 @@ namespace pwiz.OspreySharp
                         intensities[i] = libEntry.Fragments[i].RelativeIntensity;
                     }
 
-                    // RefSpectra.score is the experiment-level q-value at FdrLevel.Both
-                    // (max(precursor, peptide)) — Skyline's GENERIC Q-VALUE convention.
-                    // Mirrors Rust pipeline.rs:6166 and the LightFdr.experiment_qvalue
-                    // assignment at pipeline.rs:4705 which fixes Both regardless of
-                    // the user's --fdr-level choice.
-                    double scoreQvalue = entry.EffectiveExperimentQvalue(FdrLevel.Both);
+                    // RefSpectra.score is the EXPERIMENT-PRECURSOR q-value
+                    // (min across all observations of this (modseq, charge)
+                    // precursor in the experiment). Mirrors Rust
+                    // pipeline.rs:4670-4683 which builds best_exp_q from
+                    // e.experiment_precursor_qvalue (NOT max(precursor,
+                    // peptide), despite the misleading LightFdr.experiment_qvalue
+                    // = effective_experiment_qvalue(Both) at pipeline.rs:4705 —
+                    // BlibPlanEntry.experiment_qvalue at pipeline.rs:4795
+                    // overrides with best_exp_q.get(...) which is precursor-only).
+                    // The same value feeds OspreyExperimentScores.ExperimentQValue
+                    // below.
+                    string lookupKey = entry.ModifiedSequence + "|" + entry.Charge;
+                    double scoreQvalue;
+                    if (!bestExpPrecursorQ.TryGetValue(lookupKey, out scoreQvalue))
+                        scoreQvalue = entry.ExperimentPrecursorQvalue;
 
                     // Compute nRunsDetected up-front so AddSpectrum can pass it
                     // through to RefSpectra.copies (matches Rust pipeline.rs:6179
                     // which passes n_runs_detected = group.len()). Was hardcoded
                     // to 1 before this fix; the same count is reused by
                     // OspreyExperimentScores below.
-                    string lookupKey = entry.ModifiedSequence + "|" + entry.Charge;
                     List<KeyValuePair<string, FdrEntry>> observations;
                     int nRunsDetected = 1;
                     if (entriesByPrecursor.TryGetValue(lookupKey, out observations) &&
@@ -6203,7 +6234,7 @@ namespace pwiz.OspreySharp
                         0.0, // DiscriminantScore — matches Rust's dot_product placeholder
                         0.0); // PosteriorErrorProb — matches Rust's PEP placeholder
                     writer.AddExperimentScores(refId,
-                        entry.EffectiveExperimentQvalue(FdrLevel.Both),
+                        scoreQvalue, // Same value as RefSpectra.score: min(experiment_precursor_qvalue) across observations
                         nRunsDetected,
                         perFileEntries.Count);
                 }

--- a/pwiz_tools/OspreySharp/OspreySharp/AnalysisPipeline.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/AnalysisPipeline.cs
@@ -6017,6 +6017,39 @@ namespace pwiz.OspreySharp
             LogInfo(string.Format(
                 "[COUNT] Cross-file observations to write: {0}", nCrossFileObservations));
 
+            // Diagnostic: dump per-best-precursor q-values for cross-impl
+            // bisection of the RefSpectra.score / OspreyExperimentScores
+            // gap. Rust and C# agree on run-q-values (RetentionTimes.score
+            // and OspreyRunScores PASS) but disagree on experiment-peptide-q
+            // for ~42k of 45k entries. Schema:
+            //   modseq <tab> charge <tab> file <tab> entry_id <tab>
+            //   run_prec_q <tab> run_pept_q <tab> exp_prec_q <tab> exp_pept_q
+            // Sort key = (modseq, charge). Compared externally against a
+            // Rust-side dump produced by mirroring this code on the Rust
+            // side (pipeline.rs blib write loop) under the same env-var
+            // gate. Gated by OSPREY_DUMP_BLIB_QVALUES=1; zero overhead
+            // when unset. Temporary — remove once peptide-q drift is
+            // bisected and fixed.
+            if (Environment.GetEnvironmentVariable(@"OSPREY_DUMP_BLIB_QVALUES") == @"1")
+            {
+                var rows = new List<string>();
+                foreach (var kvp in bestByPrecursor.Values)
+                {
+                    var e = kvp.Value;
+                    rows.Add(string.Format(
+                        System.Globalization.CultureInfo.InvariantCulture,
+                        "{0}\t{1}\t{2}\t{3}\t{4:R}\t{5:R}\t{6:R}\t{7:R}",
+                        e.ModifiedSequence, e.Charge, kvp.Key, e.EntryId,
+                        e.RunPrecursorQvalue, e.RunPeptideQvalue,
+                        e.ExperimentPrecursorQvalue, e.ExperimentPeptideQvalue));
+                }
+                rows.Sort(StringComparer.Ordinal);
+                rows.Insert(0, "modseq\tcharge\tfile\tentry_id\trun_prec_q\trun_pept_q\texp_prec_q\texp_pept_q");
+                File.WriteAllLines(@"cs_blib_qvalues.tsv", rows);
+                LogInfo(string.Format(
+                    @"Wrote cs_blib_qvalues.tsv ({0} best-per-precursor q-value rows)", rows.Count - 1));
+            }
+
             using (var writer = new BlibWriter(config.OutputBlib))
             {
                 writer.BeginBatch();

--- a/pwiz_tools/OspreySharp/OspreySharp/AnalysisPipeline.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/AnalysisPipeline.cs
@@ -5831,31 +5831,121 @@ namespace pwiz.OspreySharp
             Dictionary<uint, LibraryEntry> libraryById,
             OspreyConfig config)
         {
-            // Determine effective FDR threshold
-            double fdrThreshold = config.RunFdr;
+            // Two-stage blib output gate, mirroring Rust pipeline.rs:4596-4668.
+            //
+            // Stage 1 (peptide gate): the configured FdrLevel determines which
+            // peptide identities are eligible for output. EXPERIMENT-level
+            // q-value, not run-level — letting in any precursor that merely
+            // passed run-level FDR in some replicate would admit identifications
+            // upstream Rust filters out, and was the source of a 483-row
+            // RefSpectra over-count (Stellar 3-file) before this fix.
+            //
+            // Stage 2 (precursor gate): within each eligible peptide, include
+            // only charge states that individually pass
+            // experiment_precursor_qvalue <= experiment_fdr. If NO charge state
+            // of a peptide passes precursor-level FDR (possible because
+            // peptide-level FDR aggregates across charges), include the best
+            // charge state (lowest experiment_precursor_qvalue) as a
+            // representative.
+            double fdrThreshold = config.RunFdr; // run-level threshold for ID-line semantics
+            double expThreshold = config.ExperimentFdr;
 
-            // Collect passing entries
+            // Stage 1: passing peptides
+            var passingPeptides = new HashSet<string>(StringComparer.Ordinal);
+            foreach (var kvp in perFileEntries)
+            {
+                foreach (var e in kvp.Value)
+                {
+                    if (e.IsDecoy)
+                        continue;
+                    if (e.EffectiveExperimentQvalue(config.FdrLevel) <= expThreshold)
+                        passingPeptides.Add(e.ModifiedSequence);
+                }
+            }
+
+            // Stage 2: passing precursors, with fallback to best charge per peptide
+            var passingPrecursors = new HashSet<string>(StringComparer.Ordinal);
+            var bestChargePerPeptide = new Dictionary<string, KeyValuePair<byte, double>>(
+                StringComparer.Ordinal);
+            foreach (var kvp in perFileEntries)
+            {
+                foreach (var e in kvp.Value)
+                {
+                    if (e.IsDecoy || !passingPeptides.Contains(e.ModifiedSequence))
+                        continue;
+                    string key = e.ModifiedSequence + "|" + e.Charge;
+                    if (e.ExperimentPrecursorQvalue <= expThreshold)
+                        passingPrecursors.Add(key);
+                    KeyValuePair<byte, double> existing;
+                    if (!bestChargePerPeptide.TryGetValue(e.ModifiedSequence, out existing)
+                        || e.ExperimentPrecursorQvalue < existing.Value)
+                    {
+                        bestChargePerPeptide[e.ModifiedSequence] =
+                            new KeyValuePair<byte, double>(e.Charge, e.ExperimentPrecursorQvalue);
+                    }
+                }
+            }
+            // Fallback: peptides with no precursor-passing charge state keep their best
+            int nFallback = 0;
+            foreach (var peptide in passingPeptides)
+            {
+                bool hasPassing = false;
+                KeyValuePair<byte, double> best;
+                if (!bestChargePerPeptide.TryGetValue(peptide, out best))
+                    continue;
+                string fallbackKey = peptide + "|" + best.Key;
+                // Quick check: is any charge of this peptide already in passingPrecursors?
+                // We can derive this from whether the fallback key is already there OR
+                // any other charge for this peptide is. The exact set is small enough
+                // that a linear scan over precursors with this prefix is fine, but the
+                // simpler check suffices because best is already the lowest-qvalue
+                // charge — if it itself didn't pass, no other did either.
+                hasPassing = passingPrecursors.Contains(fallbackKey)
+                    || best.Value <= expThreshold;
+                if (!hasPassing)
+                {
+                    passingPrecursors.Add(fallbackKey);
+                    nFallback++;
+                }
+            }
+            if (nFallback > 0)
+            {
+                LogInfo(string.Format(
+                    "{0} peptides had no charge state passing precursor-level FDR; best charge state kept as fallback",
+                    nFallback));
+            }
+
+            // Collect passing entries for downstream best-per-precursor selection.
+            // A precursor is admitted iff (modseq, charge) is in passingPrecursors.
             var passingEntries = new List<KeyValuePair<string, FdrEntry>>();
             foreach (var kvp in perFileEntries)
             {
                 foreach (var entry in kvp.Value)
                 {
-                    if (!entry.IsDecoy &&
-                        entry.EffectiveRunQvalue(config.FdrLevel) <= fdrThreshold)
-                    {
-                        // If protein FDR is enabled, also check protein q-value
-                        if (config.ProteinFdr.HasValue &&
-                            entry.RunProteinQvalue > config.ProteinFdr.Value)
-                        {
-                            continue;
-                        }
+                    if (entry.IsDecoy)
+                        continue;
+                    string key = entry.ModifiedSequence + "|" + entry.Charge;
+                    if (!passingPrecursors.Contains(key))
+                        continue;
 
-                        passingEntries.Add(
-                            new KeyValuePair<string, FdrEntry>(kvp.Key, entry));
+                    // If protein FDR is enabled, also check protein q-value.
+                    // Use experiment-level protein q-value so the gate is
+                    // experiment-wide, consistent with Stage 1/2 above.
+                    if (config.ProteinFdr.HasValue &&
+                        entry.ExperimentProteinQvalue > config.ProteinFdr.Value)
+                    {
+                        continue;
                     }
+
+                    passingEntries.Add(
+                        new KeyValuePair<string, FdrEntry>(kvp.Key, entry));
                 }
             }
 
+            LogInfo(string.Format(
+                "[COUNT] Stage 1 passing peptides: {0}", passingPeptides.Count));
+            LogInfo(string.Format(
+                "[COUNT] Stage 2 passing precursors: {0}", passingPrecursors.Count));
             LogInfo(string.Format("Writing {0} passing entries to blib", passingEntries.Count));
 
             if (passingEntries.Count == 0)
@@ -5868,15 +5958,18 @@ namespace pwiz.OspreySharp
             if (!string.IsNullOrEmpty(outputDir) && !Directory.Exists(outputDir))
                 Directory.CreateDirectory(outputDir);
 
-            // Deduplicate by modified_sequence + charge (keep best q-value)
-            var bestByPrecursor = new Dictionary<string, KeyValuePair<string, FdrEntry>>();
+            // Deduplicate by modified_sequence + charge — keep best by
+            // experiment_precursor_qvalue (matches Rust's best-per-precursor
+            // selection in pipeline.rs:4670-4683).
+            var bestByPrecursor = new Dictionary<string, KeyValuePair<string, FdrEntry>>(
+                StringComparer.Ordinal);
             foreach (var kvp in passingEntries)
             {
                 string key = kvp.Value.ModifiedSequence + "_" + kvp.Value.Charge;
                 KeyValuePair<string, FdrEntry> existing;
                 if (!bestByPrecursor.TryGetValue(key, out existing) ||
-                    kvp.Value.EffectiveRunQvalue(config.FdrLevel) <
-                    existing.Value.EffectiveRunQvalue(config.FdrLevel))
+                    kvp.Value.ExperimentPrecursorQvalue <
+                    existing.Value.ExperimentPrecursorQvalue)
                 {
                     bestByPrecursor[key] = kvp;
                 }

--- a/pwiz_tools/OspreySharp/OspreySharp/AnalysisPipeline.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/AnalysisPipeline.cs
@@ -6100,10 +6100,19 @@ namespace pwiz.OspreySharp
                         e.ExperimentPrecursorQvalue, e.ExperimentPeptideQvalue));
                 }
                 rows.Sort(StringComparer.Ordinal);
-                rows.Insert(0, "modseq\tcharge\tfile\tentry_id\trun_prec_q\trun_pept_q\texp_prec_q\texp_pept_q");
-                File.WriteAllLines(@"cs_blib_qvalues.tsv", rows);
+                // \n newlines (not Environment.NewLine) so the dump
+                // byte-diffs against the corresponding Rust-side TSVs.
+                // Same convention as OspreyDiagnostics — see its `LF`
+                // field doc comment.
+                using (var w = new StreamWriter(@"cs_blib_qvalues.tsv"))
+                {
+                    w.NewLine = "\n";
+                    w.WriteLine("modseq\tcharge\tfile\tentry_id\trun_prec_q\trun_pept_q\texp_prec_q\texp_pept_q");
+                    foreach (var row in rows)
+                        w.WriteLine(row);
+                }
                 LogInfo(string.Format(
-                    @"Wrote cs_blib_qvalues.tsv ({0} best-per-precursor q-value rows)", rows.Count - 1));
+                    @"Wrote cs_blib_qvalues.tsv ({0} best-per-precursor q-value rows)", rows.Count));
             }
 
             using (var writer = new BlibWriter(config.OutputBlib))

--- a/pwiz_tools/OspreySharp/OspreySharp/AnalysisPipeline.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/AnalysisPipeline.cs
@@ -5961,8 +5961,16 @@ namespace pwiz.OspreySharp
                 Directory.CreateDirectory(outputDir);
 
             // Deduplicate by modified_sequence + charge — keep best by
-            // experiment_precursor_qvalue (matches Rust's best-per-precursor
-            // selection in pipeline.rs:4670-4683).
+            // EffectiveRunQvalue(FdrLevel.Both). Matches Rust
+            // pipeline.rs:6133-6138 which picks `best = min_by(run_qvalue)`
+            // from the precursor group. The blib's downstream
+            // OspreyRunScores / OspreyPeakBoundaries / RefSpectra
+            // (peak boundaries + retention time) all source from this
+            // best run, so the cross-impl best-file choice has to match
+            // exactly or the per-file rows split into disjoint sets.
+            // (Earlier this dedup keyed on ExperimentPrecursorQvalue,
+            // producing a 26002+26002 only-rust/only-cs key split on
+            // OspreyRunScores/PeakBoundaries.)
             var bestByPrecursor = new Dictionary<string, KeyValuePair<string, FdrEntry>>(
                 StringComparer.Ordinal);
             foreach (var kvp in passingEntries)
@@ -5970,8 +5978,8 @@ namespace pwiz.OspreySharp
                 string key = kvp.Value.ModifiedSequence + "_" + kvp.Value.Charge;
                 KeyValuePair<string, FdrEntry> existing;
                 if (!bestByPrecursor.TryGetValue(key, out existing) ||
-                    kvp.Value.ExperimentPrecursorQvalue <
-                    existing.Value.ExperimentPrecursorQvalue)
+                    kvp.Value.EffectiveRunQvalue(FdrLevel.Both) <
+                    existing.Value.EffectiveRunQvalue(FdrLevel.Both))
                 {
                     bestByPrecursor[key] = kvp;
                 }
@@ -6013,12 +6021,17 @@ namespace pwiz.OspreySharp
             {
                 writer.BeginBatch();
 
-                // Pre-create source file IDs once (instead of lazily inside the loop)
+                // Pre-create source file IDs once (instead of lazily inside the loop).
+                // SpectrumSourceFiles.idFileName carries the library filename
+                // (Skyline expects this — see Rust pipeline.rs:6110 + blib.rs:435).
+                // The library file is the "ID source" because that's what the IDs
+                // came from; the mzML file is the spectrum source.
+                string libraryIdName = Path.GetFileName(config.LibrarySource.Path);
                 var sourceFileIds = new Dictionary<string, long>();
                 foreach (var kvp in perFileEntries)
                 {
                     sourceFileIds[kvp.Key] = writer.AddSourceFile(
-                        kvp.Key + ".mzML", kvp.Key + ".mzML", fdrThreshold);
+                        kvp.Key + ".mzML", libraryIdName, fdrThreshold);
                 }
 
                 foreach (var kvp in bestByPrecursor.Values)
@@ -6048,6 +6061,20 @@ namespace pwiz.OspreySharp
                     // the user's --fdr-level choice.
                     double scoreQvalue = entry.EffectiveExperimentQvalue(FdrLevel.Both);
 
+                    // Compute nRunsDetected up-front so AddSpectrum can pass it
+                    // through to RefSpectra.copies (matches Rust pipeline.rs:6179
+                    // which passes n_runs_detected = group.len()). Was hardcoded
+                    // to 1 before this fix; the same count is reused by
+                    // OspreyExperimentScores below.
+                    string lookupKey = entry.ModifiedSequence + "|" + entry.Charge;
+                    List<KeyValuePair<string, FdrEntry>> observations;
+                    int nRunsDetected = 1;
+                    if (entriesByPrecursor.TryGetValue(lookupKey, out observations) &&
+                        observations.Count > 0)
+                    {
+                        nRunsDetected = observations.Count;
+                    }
+
                     long refId = writer.AddSpectrum(
                         libEntry.Sequence,
                         libEntry.ModifiedSequence,
@@ -6057,7 +6084,7 @@ namespace pwiz.OspreySharp
                         entry.StartRt,
                         entry.EndRt,
                         mzs, intensities,
-                        scoreQvalue, fileId, 1, 0.0);
+                        scoreQvalue, fileId, nRunsDetected, 0.0);
 
                     // Add modifications
                     if (libEntry.Modifications != null && libEntry.Modifications.Count > 0)
@@ -6075,10 +6102,7 @@ namespace pwiz.OspreySharp
                     // run by lowest run_qvalue. Mirrors Rust pipeline.rs:6191-6243
                     // exactly. Uses FdrLevel.Both for the run-level q-value, matching
                     // the LightFdr.run_qvalue assignment at pipeline.rs:4704.
-                    string lookupKey = entry.ModifiedSequence + "|" + entry.Charge;
-                    List<KeyValuePair<string, FdrEntry>> observations;
-                    int nRunsDetected = 0;
-                    if (entriesByPrecursor.TryGetValue(lookupKey, out observations))
+                    if (observations != null)
                     {
                         // Compute the fallback ID-line file: if NO run passes
                         // run-level FDR (post-second-pass q-values can shift
@@ -6123,12 +6147,8 @@ namespace pwiz.OspreySharp
                                 fileEntry.EndRt,
                                 runQ,
                                 isBest);
-                            if (passesFdr)
-                                nRunsDetected++;
                         }
                     }
-                    if (nRunsDetected == 0)
-                        nRunsDetected = 1; // best run is always at least one detection
 
                     // Osprey extension tables — one row per RefSpectra each, mirroring
                     // Rust pipeline.rs:6255-6272 byte-for-byte. Best-run-only semantics
@@ -6146,11 +6166,11 @@ namespace pwiz.OspreySharp
                         0.0, // ApexIntensity — matches Rust's apex_coefficient placeholder
                         entry.BoundsArea);
                     writer.AddRunScores(refId, fileName,
-                        entry.EffectiveRunQvalue(config.FdrLevel),
+                        entry.EffectiveRunQvalue(FdrLevel.Both),
                         0.0, // DiscriminantScore — matches Rust's dot_product placeholder
                         0.0); // PosteriorErrorProb — matches Rust's PEP placeholder
                     writer.AddExperimentScores(refId,
-                        entry.EffectiveExperimentQvalue(config.FdrLevel),
+                        entry.EffectiveExperimentQvalue(FdrLevel.Both),
                         nRunsDetected,
                         perFileEntries.Count);
                 }


### PR DESCRIPTION
## Summary

* **First end-to-end OspreySharp port at full cross-impl parity** with Rust osprey on Stellar + Astral 3-file. Closes the `.blib` substep of Stage 7's merge-node phase (the BiblioSpecLite SQLite output), which is the last cross-impl validation gate.
* `OspreySharp.IO.BlibWriter` now writes the four missing Osprey extension tables Rust always wrote (`OspreyPeakBoundaries`, `OspreyRunScores`, `OspreyExperimentScores`, `OspreyCoefficients`) and aligns `OspreyMetadata` keys with Rust's set (drops `search_parameter_hash` + `n_passing_precursors`, adds `search_mode` + `run_fdr` + `experiment_fdr`).
* `AnalysisPipeline.WriteBlibOutput` ported Rust's two-stage experiment-level admission filter (`pipeline.rs:4596-4668`), the per-precursor `best_exp_q` lookup that drives `RefSpectra.score` (precursor-level min, not max(precursor, peptide)), shared peak boundaries across charge states (`build_shared_boundaries_from_plan`), full `RetentionTimes` cross-replicate fan-out with NULL-vs-populated retentionTime semantics for ID-line display, and `n_runs_detected` counted across all observations.
* `LoadFdrStubsFromParquet` now reads the `bounds_area` column so `OspreyPeakBoundaries.IntegratedArea` carries real values instead of zero.
* Best-by-precursor selection now uses `EffectiveRunQvalue(FdrLevel.Both)` matching Rust's `min_by(run_qvalue.total_cmp)` — was `ExperimentPrecursorQvalue`, which split per-file rows into disjoint key sets cross-impl. Drops the unconditional protein-FDR admission gate so `--protein-fdr 0.01` enables computation only (matches Rust's `--fdr-level protein` semantics).
* `BlibWriter.CompressBytes` switched from `System.IO.Compression.DeflateStream` to **DotNetZip's Ionic.Zlib level 6** — the same library Skyline's `BlibData` writer has used since 2009 (`Util/Extensions/UtilDB.Compress` at `Skyline/Util/Extensions/UtilDB.cs:109-200`). Pairs with companion maccoss/osprey#32 which switches the Rust `flate2` backend to vendored stock zlib so both sides emit byte-identical zlib output.
* Stages 7+8 collapsed into a single Stage 7 in `Osprey-workflow.html` — both run on the merge node in one process with no per-file fan-out and no sidecar / rehydration boundary between them. Sub-bars: second-pass Percolator, parsimony + picked-protein FDR, .blib output. All three GREEN.
* New cross-impl gate harness `ai/scripts/OspreySharp/Compare-Blib-Crossimpl.ps1` (in companion pwiz-ai master) — per-table SQL projection, stable-key join, numeric-tolerance compare on float columns, exact equality on string + integer columns, byte equality on blobs.

Companion to maccoss/osprey#32 (`flate2` backend switch).

## Test plan

- [x] OspreySharp.sln Release build clean (net472 + net8.0, 8/8 projects)
- [x] OspreySharp.Test 299/299 tests pass
- [x] ReSharper code inspection 0 errors / 0 warnings
- [x] Compare-Stage5-AllFiles + Compare-Stage6-Crossimpl + Compare-Stage7-Crossimpl all still GREEN (no regression on Stages 1-6 or Stage 7 protein FDR)
- [x] Compare-Blib-Crossimpl.ps1 Stellar 3-file (45153 RefSpectra): OVERALL PASS — every table, every column
- [x] Compare-Blib-Crossimpl.ps1 Astral 3-file (129352 RefSpectra): OVERALL PASS — every table, every column