### PR TITLE
Fixed MSAmanda DDA search crashing when Logs subdir is removed externally

### DIFF
--- a/pwiz_tools/Skyline/Model/DdaSearch/MSAmandaSearchWrapper.cs
+++ b/pwiz_tools/Skyline/Model/DdaSearch/MSAmandaSearchWrapper.cs
@@ -137,6 +137,7 @@ namespace pwiz.Skyline.Model.DdaSearch
                 Directory.CreateDirectory(Path.Combine(_baseDir.DirPath, @"Logs"));
                 helper.WriteMessage(message, true);
             }
+// ReSharper disable once EmptyGeneralCatchClause
             catch
             {
                 // ignore: search is already failing; don't let a logging glitch mask the cause

--- a/pwiz_tools/Skyline/Model/DdaSearch/MSAmandaSearchWrapper.cs
+++ b/pwiz_tools/Skyline/Model/DdaSearch/MSAmandaSearchWrapper.cs
@@ -122,6 +122,27 @@ namespace pwiz.Skyline.Model.DdaSearch
             base.Dispose();
         }
 
+        // Issue #4193: MSHelper.WriteMessage opens its log file unconditionally; if the
+        // Logs subdirectory created by InitLogWriter has been removed externally (e.g.
+        // by antivirus or Storage Sense cleaning up an empty temp folder), it throws
+        // DirectoryNotFoundException. The wrapper's exception-handling catch blocks
+        // call WriteMessage to report the underlying error, so a secondary failure
+        // there masks the real error and crashes the search before it can finish.
+        // Re-create the directory defensively and swallow any secondary failure so the
+        // original error survives in the search log and _success/SearchFinished still run.
+        private void SafeWriteMessage(string message)
+        {
+            try
+            {
+                Directory.CreateDirectory(Path.Combine(_baseDir.DirPath, @"Logs"));
+                helper.WriteMessage(message, true);
+            }
+            catch
+            {
+                // ignore: search is already failing; don't let a logging glitch mask the cause
+            }
+        }
+
         private void Helper_SearchProgressChanged(string message)
         {
             if (message.Contains(@"Identifying Peptides") || message.Contains(@"decoy peptide hits"))
@@ -298,7 +319,7 @@ namespace pwiz.Skyline.Model.DdaSearch
             {
                 if (e.InnerException is TaskCanceledException)
                 {
-                    helper.WriteMessage(DdaSearchResources.DdaSearch_Search_is_canceled, true);
+                    SafeWriteMessage(DdaSearchResources.DdaSearch_Search_is_canceled);
                 }
                 else
                     Program.ReportException(e);
@@ -306,12 +327,12 @@ namespace pwiz.Skyline.Model.DdaSearch
             }
             catch (OperationCanceledException)
             {
-                helper.WriteMessage(DdaSearchResources.DdaSearch_Search_is_canceled, true);
+                SafeWriteMessage(DdaSearchResources.DdaSearch_Search_is_canceled);
                 _success = false;
             }
             catch (Exception ex)
             {
-                helper.WriteMessage(string.Format(DdaSearchResources.DdaSearch_Search_failed__0, ex.Message), true);
+                SafeWriteMessage(string.Format(DdaSearchResources.DdaSearch_Search_failed__0, ex.Message));
                 _success = false;
             }
             finally


### PR DESCRIPTION
## Summary

* MSAmanda's `MSHelper.WriteMessage` opens its log file unconditionally; if the `Logs` subdirectory created by `InitLogWriter` has been removed between wrapper construction and search-time (commonly by antivirus or Storage Sense cleaning up the empty folder), it throws `DirectoryNotFoundException`.
* The wrapper's three catch blocks call `WriteMessage` to report the underlying search error. With `Logs` gone, that secondary call throws unhandled, the search dies before `SearchFinished` can fire, and Skyline surfaces a crash report instead of a "Search failed" message in the log.
* Routed all three `helper.WriteMessage` calls in the wrapper through a new `SafeWriteMessage` helper that re-creates the `Logs` subdirectory defensively before writing and swallows any secondary failure so the original error survives.

Fixes #4193

## Test plan

- [x] `TestDdaSearch` (existing) — passes with the fix (no regression).
- [x] Manually verified with a local repro test that deletes `<temp>/~SK*/<random>/Logs` between wrapper construction and the search click. Before the fix this reproduced the user's stack trace exactly (`DirectoryNotFoundException` at `MSHelper.WriteMessage` from `MSAmandaSearchWrapper.Run` line 314, called from `DDASearchControl.RunSearchAsync` line 69). After the fix the search ends gracefully with "Search failed: ..." in the search log and `SearchFinished` fires normally.

Co-Authored-By: Claude <noreply@anthropic.com>