### PR TITLE
Switched SkylineNightly TC artifact downloads to bearer-token auth

### DIFF
--- a/pwiz_tools/Skyline/SkylineNightly/Nightly.cs
+++ b/pwiz_tools/Skyline/SkylineNightly/Nightly.cs
@@ -442,17 +442,19 @@ namespace SkylineNightly
         /// <summary>
         /// Downloads and extracts SkylineTester ZIP file and determines the branch name.
         /// </summary>
-        /// <param name="skylineTesterZipName">Name of the ZIP file to download</param>
+        /// <param name="localZipFileName">Local destination filename for the downloaded zip (relative to the SkylineTester directory). The remote artifact name is fixed by SKYLINETESTER_ZIP_NAME.</param>
         /// <returns>Branch URL</returns>
         /// <exception cref="IOException">Failure after 2 hours throws an exception with the reason</exception>
-        private string DownloadSkylineTester(string skylineTesterZipName)
+        private string DownloadSkylineTester(string localZipFileName)
         {
-            // Verify the TeamCity token is present up front, so a misconfigured machine
-            // doesn't get silently retried for the two hours of the loop below.
-            TeamCityNightlyAuth.GetRequiredToken();
+            // Fetch the token once up front: fails fast on a misconfigured machine (rather
+            // than getting silently retried for the two hours of the loop below) and pins
+            // the token value for the whole run, so behavior is consistent even if the
+            // env var were to change mid-run.
+            var token = TeamCityNightlyAuth.GetRequiredToken();
 
             // Download most recent build of SkylineTester.
-            var skylineTesterZip = Path.Combine(_skylineTesterDir, skylineTesterZipName);
+            var skylineTesterZip = Path.Combine(_skylineTesterDir, localZipFileName);
             int attempts = CalcAllowedRetries(120); // Retry for up to two hours
             var useLastSuccessfulInsteadOfLastFinished = false;
             string failedReason = "Unable to download SkylineTester";
@@ -460,7 +462,7 @@ namespace SkylineNightly
             {
                 try
                 {
-                    DownloadSkylineTester(skylineTesterZip, _runMode, useLastSuccessfulInsteadOfLastFinished);
+                    DownloadSkylineTester(skylineTesterZip, _runMode, useLastSuccessfulInsteadOfLastFinished, token);
                 }
                 catch (Exception ex)
                 {
@@ -528,10 +530,10 @@ namespace SkylineNightly
             throw new IOException(failedReason);
         }
 
-        private void DownloadSkylineTester(string skylineTesterZip, RunMode mode, bool desperate)
+        private void DownloadSkylineTester(string skylineTesterZip, RunMode mode, bool desperate, string token)
         {
             using var client = new WebClient();
-            TeamCityNightlyAuth.ConfigureClient(client, TeamCityNightlyAuth.GetRequiredToken());
+            TeamCityNightlyAuth.ConfigureClient(client, token);
 
             var isRelease = ((mode == RunMode.release) || (mode == RunMode.release_perf));
             var isIntegration = mode == RunMode.integration || mode == RunMode.integration_perf;

--- a/pwiz_tools/Skyline/SkylineNightly/Nightly.cs
+++ b/pwiz_tools/Skyline/SkylineNightly/Nightly.cs
@@ -442,10 +442,10 @@ namespace SkylineNightly
         /// <summary>
         /// Downloads and extracts SkylineTester ZIP file and determines the branch name.
         /// </summary>
-        /// <param name="localZipFileName">Local destination filename for the downloaded zip (relative to the SkylineTester directory). The remote artifact name is fixed by SKYLINETESTER_ZIP_NAME.</param>
+        /// <param name="skylineTesterZipPath">Full local destination path for the downloaded zip. The remote artifact name is fixed by SKYLINETESTER_ZIP_NAME.</param>
         /// <returns>Branch URL</returns>
         /// <exception cref="IOException">Failure after 2 hours throws an exception with the reason</exception>
-        private string DownloadSkylineTester(string localZipFileName)
+        private string DownloadSkylineTester(string skylineTesterZipPath)
         {
             // Fetch the token once up front: fails fast on a misconfigured machine (rather
             // than getting silently retried for the two hours of the loop below) and pins
@@ -454,7 +454,6 @@ namespace SkylineNightly
             var token = TeamCityNightlyAuth.GetRequiredToken();
 
             // Download most recent build of SkylineTester.
-            var skylineTesterZip = Path.Combine(_skylineTesterDir, localZipFileName);
             int attempts = CalcAllowedRetries(120); // Retry for up to two hours
             var useLastSuccessfulInsteadOfLastFinished = false;
             string failedReason = "Unable to download SkylineTester";
@@ -462,7 +461,7 @@ namespace SkylineNightly
             {
                 try
                 {
-                    DownloadSkylineTester(skylineTesterZip, _runMode, useLastSuccessfulInsteadOfLastFinished, token);
+                    DownloadSkylineTester(skylineTesterZipPath, _runMode, useLastSuccessfulInsteadOfLastFinished, token);
                 }
                 catch (Exception ex)
                 {
@@ -486,7 +485,7 @@ namespace SkylineNightly
                 }
 
                 // Install SkylineTester.
-                if (!InstallSkylineTester(skylineTesterZip, _skylineTesterDir))
+                if (!InstallSkylineTester(skylineTesterZipPath, _skylineTesterDir))
                 {
                     throw new IOException("SkylineTester installation failed.");
                 }
@@ -494,8 +493,8 @@ namespace SkylineNightly
                 try
                 {
                     // Delete zip file.
-                    Log("Delete zip file " + skylineTesterZip);
-                    File.Delete(skylineTesterZip);
+                    Log("Delete zip file " + skylineTesterZipPath);
+                    File.Delete(skylineTesterZipPath);
 
                     // Figure out which branch we're working in - there's a file in the downloaded SkylineTester zip that tells us.
                     var branchLine = File.ReadAllLines(Path.Combine(_skylineTesterDir, "SkylineTester Files", "Version.cpp"))

--- a/pwiz_tools/Skyline/SkylineNightly/Nightly.cs
+++ b/pwiz_tools/Skyline/SkylineNightly/Nightly.cs
@@ -46,16 +46,13 @@ namespace SkylineNightly
 
         private const string NIGHTLY_TASK_NAME = "Skyline nightly build";
 
-        private const string TEAM_CITY_ZIP_URL = "https://teamcity.labkey.org/guestAuth/repository/download/{0}/.lastFinished/SkylineTester.zip{1}";
+        private const string SKYLINETESTER_ZIP_NAME = "SkylineTester.zip";
         private const string TEAM_CITY_BUILD_TYPE_64_MASTER = "bt209";
 
         // N.B. choice of "release" and "integration" branches is made in TeamCity VCS Roots "pwiz Github Skyline_Integration_Only" and "pwiz Github Skyline_Release_Only"
         // Thus TC admins can easily change the "release" and "integration" git branches at http://teamcity.labkey.org/admin/editProject.html?projectId=ProteoWizard&tab=projectVcsRoots
         private const string TEAM_CITY_BUILD_TYPE_64_RELEASE = "ProteoWizard_WindowsX8664SkylineReleaseBranchMsvcProfessional";
         private const string TEAM_CITY_BUILD_TYPE_64_INTEGRATION = "ProteoWizard_SkylineIntegrationBranchX8664";
-
-        private const string TEAM_CITY_USER_NAME = "guest";
-        private const string TEAM_CITY_USER_PASSWORD = "guest";
         private const string LABKEY_PROTOCOL = "https";
         private const string LABKEY_SERVER_ROOT = "skyline.ms";
         private const string LABKEY_MODULE = "testresults";
@@ -450,6 +447,10 @@ namespace SkylineNightly
         /// <exception cref="IOException">Failure after 2 hours throws an exception with the reason</exception>
         private string DownloadSkylineTester(string skylineTesterZipName)
         {
+            // Verify the TeamCity token is present up front, so a misconfigured machine
+            // doesn't get silently retried for the two hours of the loop below.
+            TeamCityNightlyAuth.GetRequiredToken();
+
             // Download most recent build of SkylineTester.
             var skylineTesterZip = Path.Combine(_skylineTesterDir, skylineTesterZipName);
             int attempts = CalcAllowedRetries(120); // Retry for up to two hours
@@ -529,30 +530,17 @@ namespace SkylineNightly
 
         private void DownloadSkylineTester(string skylineTesterZip, RunMode mode, bool desperate)
         {
-            // The current recommendation from MSFT for future-proofing HTTPS https://docs.microsoft.com/en-us/dotnet/framework/network-programming/tls
-            // is don't specify TLS levels at all, let the OS decide. But we worry that this will mess up Win7 and Win8 installs, so we continue to specify explicitly
-            try
-            {
-                var Tls13 = (SecurityProtocolType)12288; // From decompiled SecurityProtocolType - compiler has no definition for some reason
-                ServicePointManager.SecurityProtocol |= SecurityProtocolType.Tls | SecurityProtocolType.Tls11 | SecurityProtocolType.Tls12 | Tls13;
-            }
-            catch (NotSupportedException)
-            {
-                ServicePointManager.SecurityProtocol |= SecurityProtocolType.Tls | SecurityProtocolType.Tls11 | SecurityProtocolType.Tls12; // Probably an older Windows Server
-            }
-
             using var client = new WebClient();
+            TeamCityNightlyAuth.ConfigureClient(client, TeamCityNightlyAuth.GetRequiredToken());
 
-            client.Credentials = new NetworkCredential(TEAM_CITY_USER_NAME, TEAM_CITY_USER_PASSWORD);
             var isRelease = ((mode == RunMode.release) || (mode == RunMode.release_perf));
             var isIntegration = mode == RunMode.integration || mode == RunMode.integration_perf;
             var branchType = (isRelease || isIntegration) ? "" : "?branch=master"; // TC has a config just for release branch, and another for integration branch, but main config builds pull requests, other branches etc
             var buildType = isIntegration ? TEAM_CITY_BUILD_TYPE_64_INTEGRATION : isRelease ? TEAM_CITY_BUILD_TYPE_64_RELEASE : TEAM_CITY_BUILD_TYPE_64_MASTER;
 
-            string zipFileLink = string.Format(TEAM_CITY_ZIP_URL, buildType, branchType);
+            string zipFileLink = TeamCityNightlyAuth.GetArtifactUrl(buildType, SKYLINETESTER_ZIP_NAME, branchType, desperate);
             if (desperate)
             {
-                zipFileLink = zipFileLink.Replace(".lastFinished", ".lastSuccessful");
                 Log("In retry, download possibly stale (\".lastSuccessful\" rather than \".lastFinished\") SkylineTester zip file as " + zipFileLink);
             }
             else

--- a/pwiz_tools/Skyline/SkylineNightly/SkylineNightly.csproj
+++ b/pwiz_tools/Skyline/SkylineNightly/SkylineNightly.csproj
@@ -93,6 +93,7 @@
   <ItemGroup>
     <Compile Include="LogFileMonitor.cs" />
     <Compile Include="Nightly.cs" />
+    <Compile Include="TeamCityNightlyAuth.cs" />
     <Compile Include="SkylineNightly.cs">
       <SubType>Form</SubType>
     </Compile>

--- a/pwiz_tools/Skyline/SkylineNightly/TeamCityNightlyAuth.cs
+++ b/pwiz_tools/Skyline/SkylineNightly/TeamCityNightlyAuth.cs
@@ -41,14 +41,16 @@ namespace SkylineNightly
         // env var named by TokenEnvVar.
         public static string GetRequiredToken()
         {
+            // Trim because setx and copy/paste commonly introduce a trailing newline or stray whitespace;
+            // a value of " " or "abc\r\n" should fail fast (or be cleaned), not be sent as the Bearer credential.
             var token = Environment.GetEnvironmentVariable(TokenEnvVar);
-            if (string.IsNullOrEmpty(token))
+            if (string.IsNullOrWhiteSpace(token))
             {
                 throw new IOException("Environment variable " + TokenEnvVar + " is not set. " +
                     "A read-only TeamCity token is required to download nightly build artifacts. " +
                     "See https://skyline.ms/home/development/project-begin.view for test machine setup instructions.");
             }
-            return token;
+            return token.Trim();
         }
 
         // branchQuery is e.g. "?branch=master", or "" for build configs whose VCS root pins the branch.

--- a/pwiz_tools/Skyline/SkylineNightly/TeamCityNightlyAuth.cs
+++ b/pwiz_tools/Skyline/SkylineNightly/TeamCityNightlyAuth.cs
@@ -1,0 +1,80 @@
+/*
+ * Original author: Brian Pratt <bspratt .at. proteinms dot net>,
+ *                  MacCoss Lab, Department of Genome Sciences, UW
+ *
+ * Copyright 2026 University of Washington - Seattle, WA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Shared TeamCity artifact-download helpers used by both SkylineNightly
+// (downloads SkylineTester.zip) and SkylineNightlyShim (downloads
+// SkylineNightly.zip). This file is linked into SkylineNightlyShim via
+// <Compile Include="..\SkylineNightly\TeamCityNightlyAuth.cs" Link="..." />
+// so the auth scheme lives in one place.
+
+using System;
+using System.IO;
+using System.Net;
+
+namespace SkylineNightly
+{
+    internal static class TeamCityNightlyAuth
+    {
+        public const string TokenEnvVar = "TEAMCITY_NIGHTLY_TEST_AUTH_TOKEN";
+
+        private const string ARTIFACT_URL_TEMPLATE =
+            "https://teamcity.labkey.org/repository/download/{0}/{1}/{2}{3}";
+
+        // The historic /guestAuth/ path with hardcoded guest/guest creds is no
+        // longer accepted by the server; each nightly test machine must set the
+        // env var named by TokenEnvVar.
+        public static string GetRequiredToken()
+        {
+            var token = Environment.GetEnvironmentVariable(TokenEnvVar);
+            if (string.IsNullOrEmpty(token))
+            {
+                throw new IOException("Environment variable " + TokenEnvVar + " is not set. " +
+                    "A read-only TeamCity token is required to download nightly build artifacts. " +
+                    "See https://skyline.ms/home/development/project-begin.view for test machine setup instructions.");
+            }
+            return token;
+        }
+
+        // branchQuery is e.g. "?branch=master", or "" for build configs whose VCS root pins the branch.
+        // useLastSuccessful selects the most recent successful build instead of the most recent finished
+        // build; SkylineNightly switches to that during prolonged TC outages.
+        public static string GetArtifactUrl(string buildType, string zipName, string branchQuery, bool useLastSuccessful)
+        {
+            var status = useLastSuccessful ? ".lastSuccessful" : ".lastFinished";
+            return string.Format(ARTIFACT_URL_TEMPLATE, buildType, status, zipName, branchQuery);
+        }
+
+        public static void ConfigureClient(WebClient client, string token)
+        {
+            // The current recommendation from MSFT for future-proofing HTTPS https://docs.microsoft.com/en-us/dotnet/framework/network-programming/tls
+            // is don't specify TLS levels at all, let the OS decide. But we worry that this will mess up Win7 and Win8 installs, so we continue to specify explicitly.
+            try
+            {
+                var Tls13 = (SecurityProtocolType)12288; // From decompiled SecurityProtocolType - compiler has no definition for some reason
+                ServicePointManager.SecurityProtocol |= SecurityProtocolType.Tls | SecurityProtocolType.Tls11 | SecurityProtocolType.Tls12 | Tls13;
+            }
+            catch (NotSupportedException)
+            {
+                ServicePointManager.SecurityProtocol |= SecurityProtocolType.Tls | SecurityProtocolType.Tls11 | SecurityProtocolType.Tls12; // Probably an older Windows Server
+            }
+
+            client.Headers[HttpRequestHeader.Authorization] = "Bearer " + token;
+        }
+    }
+}

--- a/pwiz_tools/Skyline/SkylineNightlyShim/Program.cs
+++ b/pwiz_tools/Skyline/SkylineNightlyShim/Program.cs
@@ -31,17 +31,13 @@ using System.IO;
 using System.Linq;
 using System.Net;
 using Ionic.Zip;
+using SkylineNightly;
 
 namespace SkylineNightlyShim
 {
     static class Program
     {
-        private const string TEAM_CITY_ZIP_URL =
-            "https://teamcity.labkey.org/guestAuth/repository/download/{0}/.lastFinished/SkylineNightly.zip{1}";
-
         private const string TEAM_CITY_BUILD_TYPE_64_MASTER = "bt209";
-        private const string TEAM_CITY_USER_NAME = "guest";
-        private const string TEAM_CITY_USER_PASSWORD = "guest";
         private const string SKYLINENIGHTLY_ZIP = "SkylineNightly.zip";
 
         static void Log(string what)
@@ -112,16 +108,18 @@ namespace SkylineNightlyShim
         static void Main(string[] args)
         {
 
-            // The current recommendation from MSFT for future-proofing HTTPS https://docs.microsoft.com/en-us/dotnet/framework/network-programming/tls
-            // is don't specify TLS levels at all, let the OS decide. But we worry that this will mess up Win7 and Win8 installs, so we continue to specify explicitly
+            // Refuse to launch SkylineNightly if the test machine isn't configured with
+            // a TeamCity token — without one, the nightly run can't fetch SkylineTester
+            // either, and a clear message from the shim beats an obscure failure later.
+            string teamCityToken;
             try
             {
-                var Tls13 = (SecurityProtocolType)12288; // From decompiled SecurityProtocolType - compiler has no definition for some reason
-                ServicePointManager.SecurityProtocol |= SecurityProtocolType.Tls | SecurityProtocolType.Tls11 | SecurityProtocolType.Tls12 | Tls13;
+                teamCityToken = TeamCityNightlyAuth.GetRequiredToken();
             }
-            catch (NotSupportedException)
+            catch (IOException e)
             {
-                ServicePointManager.SecurityProtocol |= SecurityProtocolType.Tls | SecurityProtocolType.Tls11 | SecurityProtocolType.Tls12; // Probably an older Windows Server
+                Log(e.Message);
+                return;
             }
 
             // Do our work in the SkylineNightly directory
@@ -143,8 +141,8 @@ namespace SkylineNightlyShim
                 using (var client = new WebClient())
                 {
                     // Attempt to update SkylineNightly.exe
-                    client.Credentials = new NetworkCredential(TEAM_CITY_USER_NAME, TEAM_CITY_USER_PASSWORD);
-                    string zipFileLink = string.Format(TEAM_CITY_ZIP_URL, TEAM_CITY_BUILD_TYPE_64_MASTER, "?branch=master");
+                    TeamCityNightlyAuth.ConfigureClient(client, teamCityToken);
+                    string zipFileLink = TeamCityNightlyAuth.GetArtifactUrl(TEAM_CITY_BUILD_TYPE_64_MASTER, SKYLINENIGHTLY_ZIP, "?branch=master", false);
                     var fileName = Path.Combine(nightlyDirectory ?? throw new InvalidOperationException(), SKYLINENIGHTLY_ZIP);
                     Log("Update " + nightlyDirectory + " with " + zipFileLink);
                     client.DownloadFile(zipFileLink, fileName);

--- a/pwiz_tools/Skyline/SkylineNightlyShim/SkylineNightlyShim.csproj
+++ b/pwiz_tools/Skyline/SkylineNightlyShim/SkylineNightlyShim.csproj
@@ -77,6 +77,9 @@
   <ItemGroup>
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="..\SkylineNightly\TeamCityNightlyAuth.cs">
+      <Link>TeamCityNightlyAuth.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <None Include="App.config" />


### PR DESCRIPTION
## Summary

* Replaces TeamCity `guestAuth` (hardcoded `guest`/`guest`) with a read-only bearer token from env var `TEAMCITY_NIGHTLY_TEST_AUTH_TOKEN`. Affects both `SkylineNightlyShim/Program.cs` (downloads `SkylineNightly.zip`) and `SkylineNightly/Nightly.cs` (downloads `SkylineTester.zip`).
* Extracts a shared `TeamCityNightlyAuth` helper linked into both projects from a single source file, so the token name, URL composition, TLS setup, and `Authorization: Bearer` header live in one place.
* Missing or empty env var fails fast with a clear pointer to https://skyline.ms/home/development/project-begin.view, instead of silently retrying for the two hours of the existing outage-tolerance loop.

## Why now

TC is disabling anonymous artifact downloads, which would break every nightly test machine that currently uses the `/guestAuth/` URL with `guest`/`guest`.

## Rollout (handled outside this PR)

Existing installed shims still call `guestAuth` and therefore can't self-update from TC once guest is disabled. A one-time admin batch file (kept private) sets the env var and replaces the five files the shim normally updates, using the install dir discovered from Windows Task Scheduler. From then on, the shim updates itself nightly via the new path.

## Test plan

- [x] SkylineNightly Release|x64 builds clean.
- [x] SkylineNightlyShim Release|x64 builds clean.
- [x] Manual probe: `GET https://teamcity.labkey.org/repository/download/bt209/.lastFinished/SkylineNightly.zip?branch=master` with `Authorization: Bearer <token>` returns HTTP 200 (~655 KB zip containing the expected five files plus two extras).

See ai/todos/active/TODO-20260512_tc_readonly_token.md

Co-Authored-By: Claude <noreply@anthropic.com>