### PR TITLE
Pointed missing-token error at the SkylineNightly wiki page

### DIFF
--- a/pwiz_tools/Skyline/SkylineNightly/TeamCityNightlyAuth.cs
+++ b/pwiz_tools/Skyline/SkylineNightly/TeamCityNightlyAuth.cs
@@ -48,7 +48,7 @@ namespace SkylineNightly
             {
                 throw new IOException("Environment variable " + TokenEnvVar + " is not set. " +
                     "A read-only TeamCity token is required to download nightly build artifacts. " +
-                    "See https://skyline.ms/home/development/project-begin.view for test machine setup instructions.");
+                    "See https://skyline.ms/home/development/wiki-page.view?name=SkylineNightly to obtain the token and set this env var.");
             }
             return token.Trim();
         }


### PR DESCRIPTION
## Summary

* Follow-up to #4202. Updates the `TeamCityNightlyAuth.GetRequiredToken` error message so operators are sent to https://skyline.ms/home/development/wiki-page.view?name=SkylineNightly — the page that actually carries the token value and setup instructions — rather than the generic project-begin page.

## Test plan

- [x] SkylineNightly Release|x64 builds clean.
- [x] SkylineNightlyShim Release|x64 builds clean (linked file).

See ai/todos/active/TODO-20260512_tc_readonly_token.md

Co-Authored-By: Claude <noreply@anthropic.com>