### PR TITLE
Fix BiblioSpec failing on blank 1/K0 cells in MaxQuant evidence.txt

### DIFF
--- a/pwiz_tools/BiblioSpec/src/MaxQuantReader.cpp
+++ b/pwiz_tools/BiblioSpec/src/MaxQuantReader.cpp
@@ -402,7 +402,14 @@ void MaxQuantReader::initEvidence()
                 break;
             boost::split(columns, line, boost::is_any_of("\t"));
             if (colInvK0 >= 0)
-                inverseK0_.push_back(boost::lexical_cast<double>(columns[colInvK0]));
+            {
+                // Blank 1/K0 values appear in evidence.txt for some runs; treat as "no IM" (0)
+                // rather than throwing, so a single blank row doesn't strip IM from the whole file.
+                // Must preserve row alignment because inverseK0_ is indexed by evidenceID.
+                string val = (colInvK0 < (int)columns.size()) ? columns[colInvK0] : string();
+                boost::trim(val);
+                inverseK0_.push_back(val.empty() ? 0.0 : boost::lexical_cast<double>(val));
+            }
             /* Some versions of MaxQuant are known to emit incorrect CCS values. Until we figure out how to tell them apart, best to just ignore. (bspratt July 2019)
             if (colCCS >= 0)
                 CCS_.push_back(boost::lexical_cast<double>(columns[colCCS]));


### PR DESCRIPTION
## Summary

* Treats blank (or whitespace-only) `1/K0` cells in MaxQuant `evidence.txt` as "no IM" (0.0) instead of letting `boost::lexical_cast` throw
* Preserves row alignment because `inverseK0_` is indexed by `evidenceID`; the consumer at `MaxQuantReader.cpp:760` already treats `ionMobility == 0` as "no IM" (no `ionMobilityType` set)
* Adds a bounds check for malformed (short) rows
* Reported by Ani via skyline.ms support thread #74557

## Test plan

- [x] Manual verification with the reporter's evidence.txt — bspratt 2026-05-13

Co-Authored-By: Claude <noreply@anthropic.com>