### PR TITLE
OspreySharp: library-decoy CLI flags + manifest proteins-override

### DIFF
--- a/pwiz_tools/OspreySharp/OspreySharp.IO/DecoyPairingManifest.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.IO/DecoyPairingManifest.cs
@@ -149,13 +149,18 @@ namespace pwiz.OspreySharp.IO
                 // `proteins` is optional -- older manifests without it still
                 // parse fine; ApplyToLibrary simply won't replace
                 // protein_ids when this column is absent.
-                // minRequiredCols deliberately covers only the REQUIRED
-                // columns (sequence, peptide_type, peptide_pair_index).
-                // Rows with fewer fields than the optional proteins
-                // column should still parse -- the iProteins<fields.Length
-                // guard below treats a missing trailing column as "no
-                // override," matching the Rust manifest reader's intent.
-                int minRequiredCols = Math.Max(iSeq, Math.Max(iType, iPair)) + 1;
+                // When the proteins column IS present in the header, rows
+                // truncated to drop it are treated as malformed (skipped
+                // and counted in nSkipped). This matches Rust 0c3a73e
+                // `max_needed = i_proteins.unwrap_or(0).max(...)`:
+                // strict for cross-impl byte parity. The body's
+                // `iProteins < fields.Length` guard is belt-and-suspenders
+                // against the early skip, not a design intent for lenient
+                // parsing of short rows.
+                int maxNeeded = Math.Max(iSeq, Math.Max(iType, iPair));
+                if (iProteins >= 0 && iProteins > maxNeeded)
+                    maxNeeded = iProteins;
+                int minRequiredCols = maxNeeded + 1;
                 var map = new Dictionary<string, ManifestEntryInfo>(StringComparer.Ordinal);
                 int nSkipped = 0;
                 string line;

--- a/pwiz_tools/OspreySharp/OspreySharp.IO/DecoyPairingManifest.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.IO/DecoyPairingManifest.cs
@@ -50,6 +50,19 @@ namespace pwiz.OspreySharp.IO
         /// authoritative.
         /// </summary>
         public int NNewlyMarkedDecoy { get; set; }
+
+        /// <summary>
+        /// Library entries whose <see cref="LibraryEntry.ProteinIds"/>
+        /// were replaced from the manifest's <c>proteins</c> column.
+        /// Carafe and similar library predictors may stamp a
+        /// per-peptide suffix into ProteinID (e.g.
+        /// <c>sp|P12345_pep00001|GENE_A</c>) which breaks protein
+        /// parsimony / picked-protein FDR -- the manifest carries the
+        /// clean, un-suffixed source accessions in its
+        /// semicolon-separated <c>proteins</c> column and is the
+        /// authoritative source of protein info when present.
+        /// </summary>
+        public int NProteinsReplaced { get; set; }
     }
 
     /// <summary>
@@ -80,9 +93,9 @@ namespace pwiz.OspreySharp.IO
     /// </summary>
     public class DecoyPairingManifest
     {
-        private readonly Dictionary<string, KindPairIndex> _seqToInfo;
+        private readonly Dictionary<string, ManifestEntryInfo> _seqToInfo;
 
-        private DecoyPairingManifest(Dictionary<string, KindPairIndex> seqToInfo)
+        private DecoyPairingManifest(Dictionary<string, ManifestEntryInfo> seqToInfo)
         {
             _seqToInfo = seqToInfo;
         }
@@ -114,12 +127,13 @@ namespace pwiz.OspreySharp.IO
                 if (header == null)
                     throw new InvalidDataException(@"FDRBench manifest is empty");
                 var cols = header.Split('\t');
-                int iSeq = -1, iType = -1, iPair = -1;
+                int iSeq = -1, iType = -1, iPair = -1, iProteins = -1;
                 for (int i = 0; i < cols.Length; i++)
                 {
                     if (cols[i] == @"sequence") iSeq = i;
                     else if (cols[i] == @"peptide_type") iType = i;
                     else if (cols[i] == @"peptide_pair_index") iPair = i;
+                    else if (cols[i] == @"proteins") iProteins = i;
                 }
                 if (iSeq < 0 || iType < 0 || iPair < 0)
                 {
@@ -128,9 +142,12 @@ namespace pwiz.OspreySharp.IO
                         @"(need sequence, peptide_type, peptide_pair_index). Got: {0}",
                         header));
                 }
+                // `proteins` is optional -- older manifests without it still
+                // parse fine; ApplyToLibrary simply won't replace
+                // protein_ids when this column is absent.
 
-                int minRequiredCols = Math.Max(iSeq, Math.Max(iType, iPair)) + 1;
-                var map = new Dictionary<string, KindPairIndex>(StringComparer.Ordinal);
+                int minRequiredCols = Math.Max(iSeq, Math.Max(iType, Math.Max(iPair, iProteins))) + 1;
+                var map = new Dictionary<string, ManifestEntryInfo>(StringComparer.Ordinal);
                 int nSkipped = 0;
                 string line;
                 while ((line = reader.ReadLine()) != null)
@@ -156,7 +173,24 @@ namespace pwiz.OspreySharp.IO
                         nSkipped++;
                         continue;
                     }
-                    map[fields[iSeq]] = new KindPairIndex(kind, pairIndex);
+                    // Parse the optional semicolon-separated proteins
+                    // column. Empty / "-" / single-dash -> empty list,
+                    // signalling "don't override library protein_ids."
+                    var proteins = new List<string>();
+                    if (iProteins >= 0 && iProteins < fields.Length)
+                    {
+                        string raw = fields[iProteins].Trim();
+                        if (raw.Length > 0 && raw != @"-")
+                        {
+                            foreach (var p in raw.Split(';'))
+                            {
+                                string pt = p.Trim();
+                                if (pt.Length > 0)
+                                    proteins.Add(pt);
+                            }
+                        }
+                    }
+                    map[fields[iSeq]] = new ManifestEntryInfo(kind, pairIndex, proteins);
                 }
                 return new DecoyPairingManifest(map);
             }
@@ -201,6 +235,14 @@ namespace pwiz.OspreySharp.IO
             var buckets = new Dictionary<BucketKey, List<int>>(
                 BucketKeyComparer.Instance);
             var decoySideIndices = new List<int>();
+            // Library indices whose ProteinIds should be replaced with
+            // the manifest's clean accessions (collected during the
+            // read-only scan; applied below). Carafe-style libraries
+            // stamp a per-peptide suffix into ProteinID that breaks
+            // protein parsimony; the manifest's `proteins` column
+            // carries the clean, un-suffixed source accessions and is
+            // the authoritative source of protein info when present.
+            var proteinOverride = new List<KeyValuePair<int, List<string>>>();
             for (int idx = 0; idx < library.Count; idx++)
             {
                 var entry = library[idx];
@@ -223,6 +265,16 @@ namespace pwiz.OspreySharp.IO
                 list.Add(idx);
                 if (!isTargetSide)
                     decoySideIndices.Add(idx);
+                // Manifest has clean source accessions for this sequence,
+                // and the library's stored ProteinIds differ -> queue the
+                // override. Empty Proteins (column absent / value was
+                // "-") is a no-op: the library wins.
+                if (info.Proteins != null && info.Proteins.Count > 0 &&
+                    !ProteinListsEqual(entry.ProteinIds, info.Proteins))
+                {
+                    proteinOverride.Add(
+                        new KeyValuePair<int, List<string>>(idx, info.Proteins));
+                }
             }
 
             // Mark manifest-identified decoys BEFORE pairing. Idempotent:
@@ -239,6 +291,15 @@ namespace pwiz.OspreySharp.IO
                 }
                 if ((library[idx].Id & LibraryEntry.DECOY_ID_BIT) == 0u)
                     library[idx].Id |= LibraryEntry.DECOY_ID_BIT;
+            }
+
+            // Replace library ProteinIds with the manifest's clean
+            // accessions for every sequence the manifest covers and
+            // whose stored ProteinIds disagree.
+            stats.NProteinsReplaced = proteinOverride.Count;
+            foreach (var kv in proteinOverride)
+            {
+                library[kv.Key].ProteinIds = new List<string>(kv.Value);
             }
 
             // Walk every target-side bucket; pair with the matching
@@ -322,15 +383,39 @@ namespace pwiz.OspreySharp.IO
             return (byte)(k == PeptideKind.Target || k == PeptideKind.Decoy ? 0 : 1);
         }
 
-        private struct KindPairIndex
+        // Cheap ordinal equality on two protein-ID lists. Used to decide
+        // whether the manifest's clean accessions would actually change
+        // the library entry (skip the rewrite when they match).
+        private static bool ProteinListsEqual(IList<string> a, IList<string> b)
+        {
+            if (a == null) return b == null || b.Count == 0;
+            if (b == null) return a.Count == 0;
+            if (a.Count != b.Count) return false;
+            for (int i = 0; i < a.Count; i++)
+            {
+                if (!string.Equals(a[i], b[i], StringComparison.Ordinal))
+                    return false;
+            }
+            return true;
+        }
+
+        // Per-sequence manifest metadata: peptide kind, pair index, and
+        // (optionally) the clean source proteins from the `proteins`
+        // column. When Proteins is non-empty, ApplyToLibrary replaces the
+        // matching library entry's ProteinIds; this is the authoritative
+        // protein source for Carafe-built libraries that stamped a
+        // per-peptide suffix into ProteinID.
+        private class ManifestEntryInfo
         {
             public readonly PeptideKind Kind;
             public readonly uint PairIndex;
+            public readonly List<string> Proteins;
 
-            public KindPairIndex(PeptideKind kind, uint pairIndex)
+            public ManifestEntryInfo(PeptideKind kind, uint pairIndex, List<string> proteins)
             {
                 Kind = kind;
                 PairIndex = pairIndex;
+                Proteins = proteins ?? new List<string>();
             }
         }
 

--- a/pwiz_tools/OspreySharp/OspreySharp.IO/DecoyPairingManifest.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.IO/DecoyPairingManifest.cs
@@ -130,10 +130,14 @@ namespace pwiz.OspreySharp.IO
                 int iSeq = -1, iType = -1, iPair = -1, iProteins = -1;
                 for (int i = 0; i < cols.Length; i++)
                 {
-                    if (cols[i] == @"sequence") iSeq = i;
-                    else if (cols[i] == @"peptide_type") iType = i;
-                    else if (cols[i] == @"peptide_pair_index") iPair = i;
-                    else if (cols[i] == @"proteins") iProteins = i;
+                    if (cols[i] == @"sequence")
+                        iSeq = i;
+                    else if (cols[i] == @"peptide_type")
+                        iType = i;
+                    else if (cols[i] == @"peptide_pair_index")
+                        iPair = i;
+                    else if (cols[i] == @"proteins")
+                        iProteins = i;
                 }
                 if (iSeq < 0 || iType < 0 || iPair < 0)
                 {
@@ -145,8 +149,13 @@ namespace pwiz.OspreySharp.IO
                 // `proteins` is optional -- older manifests without it still
                 // parse fine; ApplyToLibrary simply won't replace
                 // protein_ids when this column is absent.
-
-                int minRequiredCols = Math.Max(iSeq, Math.Max(iType, Math.Max(iPair, iProteins))) + 1;
+                // minRequiredCols deliberately covers only the REQUIRED
+                // columns (sequence, peptide_type, peptide_pair_index).
+                // Rows with fewer fields than the optional proteins
+                // column should still parse -- the iProteins<fields.Length
+                // guard below treats a missing trailing column as "no
+                // override," matching the Rust manifest reader's intent.
+                int minRequiredCols = Math.Max(iSeq, Math.Max(iType, iPair)) + 1;
                 var map = new Dictionary<string, ManifestEntryInfo>(StringComparer.Ordinal);
                 int nSkipped = 0;
                 string line;
@@ -324,13 +333,15 @@ namespace pwiz.OspreySharp.IO
                 tSorted.Sort((a, b) =>
                 {
                     int c = string.CompareOrdinal(library[a].Sequence, library[b].Sequence);
-                    if (c != 0) return c;
+                    if (c != 0)
+                        return c;
                     return library[a].Id.CompareTo(library[b].Id);
                 });
                 dSorted.Sort((a, b) =>
                 {
                     int c = string.CompareOrdinal(library[a].Sequence, library[b].Sequence);
-                    if (c != 0) return c;
+                    if (c != 0)
+                        return c;
                     return library[a].Id.CompareTo(library[b].Id);
                 });
                 int n = Math.Min(tSorted.Count, dSorted.Count);
@@ -388,9 +399,12 @@ namespace pwiz.OspreySharp.IO
         // the library entry (skip the rewrite when they match).
         private static bool ProteinListsEqual(IList<string> a, IList<string> b)
         {
-            if (a == null) return b == null || b.Count == 0;
-            if (b == null) return a.Count == 0;
-            if (a.Count != b.Count) return false;
+            if (a == null)
+                return b == null || b.Count == 0;
+            if (b == null)
+                return a.Count == 0;
+            if (a.Count != b.Count)
+                return false;
             for (int i = 0; i < a.Count; i++)
             {
                 if (!string.Equals(a[i], b[i], StringComparison.Ordinal))
@@ -477,11 +491,14 @@ namespace pwiz.OspreySharp.IO
             public int Compare(BucketKey x, BucketKey y)
             {
                 int c = x.PairIndex.CompareTo(y.PairIndex);
-                if (c != 0) return c;
+                if (c != 0)
+                    return c;
                 c = x.Partition.CompareTo(y.Partition);
-                if (c != 0) return c;
+                if (c != 0)
+                    return c;
                 c = x.Charge.CompareTo(y.Charge);
-                if (c != 0) return c;
+                if (c != 0)
+                    return c;
                 return x.IsTargetSide.CompareTo(y.IsTargetSide);
             }
         }

--- a/pwiz_tools/OspreySharp/OspreySharp.Test/DecoyPairingManifestTest.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Test/DecoyPairingManifestTest.cs
@@ -378,6 +378,13 @@ namespace pwiz.OspreySharp.Test
                     new[] { @"sp|original|FROM_LIB" }, libEntry1.ProteinIds);
                 CollectionAssert.AreEqual(
                     new[] { @"sp|orig_decoy|FROM_LIB" }, libEntry2.ProteinIds);
+                // The second manifest row classifies AEPTPID as `decoy`
+                // and the library entry is loaded as a target, so the
+                // manifest's sequence-based classification flips IsDecoy
+                // on it. Pin that side-effect so a future change to the
+                // marking-before-pairing ordering doesn't silently slip.
+                Assert.IsTrue(libEntry2.IsDecoy);
+                Assert.AreEqual(1, stats.NNewlyMarkedDecoy);
             }
             finally
             {

--- a/pwiz_tools/OspreySharp/OspreySharp.Test/DecoyPairingManifestTest.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Test/DecoyPairingManifestTest.cs
@@ -313,6 +313,79 @@ namespace pwiz.OspreySharp.Test
         }
 
         [TestMethod]
+        public void ManifestReplacesProteinIdsWithCleanAccessions()
+        {
+            // Cross-impl port of Rust `manifest_replaces_protein_ids_with_clean_accessions`
+            // (commit 0c3a73e). The manifest's `proteins` column is the
+            // authoritative source of protein info: a Carafe-built library
+            // can stamp a per-peptide suffix into ProteinID (e.g.
+            // `sp|P12345_pep00001|GENE_A`) that breaks protein parsimony
+            // unless we substitute the clean source accessions.
+            string path = WriteManifest(new[]
+            {
+                @"PEPTIDE	No	sp|P12345|GENE_A;sp|Q67890|GENE_B	target	0",
+                @"AEPTPID	Yes	decoy_sp|P12345|GENE_A;decoy_sp|Q67890|GENE_B	decoy	0",
+            });
+            try
+            {
+                var m = DecoyPairingManifest.FromTsv(path);
+                var libEntry1 = MakeEntry(1, @"PEPTIDE", 2, false);
+                libEntry1.ProteinIds.Add(@"sp|P12345_pep00001|GENE_A");
+                var libEntry2 = MakeEntry(2, @"AEPTPID", 2, false);
+                libEntry2.ProteinIds.Add(@"decoy_sp|P12345_pep00001|GENE_A");
+                var lib = new List<LibraryEntry> { libEntry1, libEntry2 };
+
+                var state = new PairingState();
+                var stats = m.ApplyToLibrary(lib, state);
+
+                Assert.AreEqual(1, stats.NPaired);
+                Assert.AreEqual(2, stats.NProteinsReplaced);
+                CollectionAssert.AreEqual(
+                    new[] { @"sp|P12345|GENE_A", @"sp|Q67890|GENE_B" },
+                    libEntry1.ProteinIds);
+                CollectionAssert.AreEqual(
+                    new[] { @"decoy_sp|P12345|GENE_A", @"decoy_sp|Q67890|GENE_B" },
+                    libEntry2.ProteinIds);
+            }
+            finally
+            {
+                File.Delete(path);
+            }
+        }
+
+        [TestMethod]
+        public void ManifestSkipsReplacementWhenProteinsColumnEmpty()
+        {
+            // Cross-impl port of Rust `manifest_skips_replacement_when_proteins_column_empty`.
+            // Empty or "-" `proteins` field is a no-op; library wins.
+            string path = WriteManifest(new[]
+            {
+                @"PEPTIDE	No	-	target	0",
+                @"AEPTPID	Yes		decoy	0",
+            });
+            try
+            {
+                var m = DecoyPairingManifest.FromTsv(path);
+                var libEntry1 = MakeEntry(1, @"PEPTIDE", 2, false);
+                libEntry1.ProteinIds.Add(@"sp|original|FROM_LIB");
+                var libEntry2 = MakeEntry(2, @"AEPTPID", 2, false);
+                libEntry2.ProteinIds.Add(@"sp|orig_decoy|FROM_LIB");
+                var lib = new List<LibraryEntry> { libEntry1, libEntry2 };
+                var state = new PairingState();
+                var stats = m.ApplyToLibrary(lib, state);
+                Assert.AreEqual(0, stats.NProteinsReplaced);
+                CollectionAssert.AreEqual(
+                    new[] { @"sp|original|FROM_LIB" }, libEntry1.ProteinIds);
+                CollectionAssert.AreEqual(
+                    new[] { @"sp|orig_decoy|FROM_LIB" }, libEntry2.ProteinIds);
+            }
+            finally
+            {
+                File.Delete(path);
+            }
+        }
+
+        [TestMethod]
         public void ManifestSkipsUnknownPeptideTypeRows()
         {
             string path = WriteManifest(new[]

--- a/pwiz_tools/OspreySharp/OspreySharp.Test/ProgramTests.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Test/ProgramTests.cs
@@ -634,6 +634,64 @@ namespace pwiz.OspreySharp.Test
             StringAssert.Contains(warn, "could not parse");
         }
 
+        // --- Library-decoy CLI flags ---------------------------------------
+
+        [TestMethod]
+        public void TestParseArgsDecoysInLibraryFlag()
+        {
+            // --decoys-in-library is a flat boolean; flips DecoysInLibrary
+            // to true without consuming a value. Mirrors Rust osprey's
+            // --decoys-in-library semantics.
+            var args = new[]
+            {
+                @"-i", @"x.mzML",
+                @"-l", @"lib.tsv",
+                @"-o", @"out.blib",
+                @"--decoys-in-library",
+            };
+            var config = Program.ParseArgs(args);
+            Assert.IsTrue(config.DecoysInLibrary);
+            Assert.IsTrue(string.IsNullOrEmpty(config.DecoyPairingManifestPath));
+        }
+
+        [TestMethod]
+        public void TestParseArgsDecoyPairingManifestFlag()
+        {
+            // --decoy-pairing-manifest <PATH> sets the path on the config
+            // without flipping DecoysInLibrary. The pipeline only consults
+            // the manifest when DecoysInLibrary is true; pairing this with
+            // --decoys-in-library is the typical invocation.
+            var args = new[]
+            {
+                @"-i", @"x.mzML",
+                @"-l", @"lib.tsv",
+                @"-o", @"out.blib",
+                @"--decoy-pairing-manifest", @"T:\test\manifest.tsv",
+                @"--decoys-in-library",
+            };
+            var config = Program.ParseArgs(args);
+            Assert.IsTrue(config.DecoysInLibrary);
+            Assert.AreEqual(@"T:\test\manifest.tsv", config.DecoyPairingManifestPath);
+        }
+
+        [TestMethod]
+        public void TestParseArgsDecoysInLibraryDefaultsFalse()
+        {
+            // Without the flag, DecoysInLibrary stays at its config default
+            // (false) and DecoyPairingManifestPath stays null. Pipeline runs
+            // the existing reverse-decoy path. Pins the "library-decoy mode
+            // is fully opt-in" contract.
+            var args = new[]
+            {
+                @"-i", @"x.mzML",
+                @"-l", @"lib.tsv",
+                @"-o", @"out.blib",
+            };
+            var config = Program.ParseArgs(args);
+            Assert.IsFalse(config.DecoysInLibrary);
+            Assert.IsTrue(string.IsNullOrEmpty(config.DecoyPairingManifestPath));
+        }
+
         // --- helpers -------------------------------------------------------
 
         private static string NewTempDir()

--- a/pwiz_tools/OspreySharp/OspreySharp.Test/ProgramTests.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Test/ProgramTests.cs
@@ -658,20 +658,61 @@ namespace pwiz.OspreySharp.Test
         public void TestParseArgsDecoyPairingManifestFlag()
         {
             // --decoy-pairing-manifest <PATH> sets the path on the config
-            // without flipping DecoysInLibrary. The pipeline only consults
-            // the manifest when DecoysInLibrary is true; pairing this with
-            // --decoys-in-library is the typical invocation.
+            // WITHOUT flipping DecoysInLibrary. Pin the contract here in
+            // isolation (no companion --decoys-in-library) so a regression
+            // where the flag accidentally enables library-decoy mode on
+            // its own would actually fail the test.
             var args = new[]
             {
                 @"-i", @"x.mzML",
                 @"-l", @"lib.tsv",
                 @"-o", @"out.blib",
                 @"--decoy-pairing-manifest", @"T:\test\manifest.tsv",
-                @"--decoys-in-library",
             };
             var config = Program.ParseArgs(args);
-            Assert.IsTrue(config.DecoysInLibrary);
+            Assert.IsFalse(config.DecoysInLibrary);
             Assert.AreEqual(@"T:\test\manifest.tsv", config.DecoyPairingManifestPath);
+        }
+
+        [TestMethod]
+        public void TestParseArgsDecoyPairingManifestRequiresValue()
+        {
+            // A bare --decoy-pairing-manifest with no value, or a value
+            // that's itself an option (--decoys-in-library), must throw
+            // rather than silently consume the next token as the path.
+            var argsNoValue = new[]
+            {
+                @"-i", @"x.mzML",
+                @"-l", @"lib.tsv",
+                @"-o", @"out.blib",
+                @"--decoy-pairing-manifest",
+            };
+            try
+            {
+                Program.ParseArgs(argsNoValue);
+                Assert.Fail(@"Expected ArgumentException for bare --decoy-pairing-manifest.");
+            }
+            catch (ArgumentException)
+            {
+                // expected
+            }
+
+            var argsFlagAsValue = new[]
+            {
+                @"-i", @"x.mzML",
+                @"-l", @"lib.tsv",
+                @"-o", @"out.blib",
+                @"--decoy-pairing-manifest", @"--decoys-in-library",
+            };
+            try
+            {
+                Program.ParseArgs(argsFlagAsValue);
+                Assert.Fail(@"Expected ArgumentException for next-flag-as-value.");
+            }
+            catch (ArgumentException)
+            {
+                // expected
+            }
         }
 
         [TestMethod]

--- a/pwiz_tools/OspreySharp/OspreySharp/Program.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/Program.cs
@@ -190,7 +190,7 @@ namespace pwiz.OspreySharp
         /// Parse command-line arguments into an OspreyConfig.
         /// Handles the same flags as the Rust CLI.
         /// </summary>
-        private static OspreyConfig ParseArgs(string[] args)
+        internal static OspreyConfig ParseArgs(string[] args)
         {
             var config = new OspreyConfig();
             var inputFiles = new List<string>();
@@ -322,6 +322,28 @@ namespace pwiz.OspreySharp
                     case "--no-prefilter":
                         config.PrefilterEnabled = false;
                         i++;
+                        break;
+
+                    case "--decoys-in-library":
+                        // Flat boolean override matching Rust osprey's
+                        // --decoys-in-library: flips true, never overrides
+                        // a YAML `true` back to false. When set together
+                        // with --decoy-pairing-manifest, the pipeline runs
+                        // the FDRBench manifest pass first; composition-
+                        // based pairing fills whatever the manifest didn't
+                        // cover. Hard error if no library entries match
+                        // any of DecoyPrefixes / Decoy column / manifest.
+                        config.DecoysInLibrary = true;
+                        i++;
+                        break;
+
+                    case "--decoy-pairing-manifest":
+                        i++;
+                        if (i < args.Length)
+                        {
+                            config.DecoyPairingManifestPath = args[i];
+                            i++;
+                        }
                         break;
 
                     case "--write-pin":

--- a/pwiz_tools/OspreySharp/OspreySharp/Program.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/Program.cs
@@ -339,11 +339,19 @@ namespace pwiz.OspreySharp
 
                     case "--decoy-pairing-manifest":
                         i++;
-                        if (i < args.Length)
+                        // Reject a missing value (end of args) AND reject
+                        // the next token starting with `--` (i.e. the next
+                        // option), which would otherwise silently consume
+                        // a sibling flag like --decoys-in-library as the
+                        // manifest path. Both produce the same usage
+                        // error so the user knows the option needs a path.
+                        if (i >= args.Length || args[i].StartsWith(@"--", StringComparison.Ordinal))
                         {
-                            config.DecoyPairingManifestPath = args[i];
-                            i++;
+                            throw new ArgumentException(
+                                @"--decoy-pairing-manifest requires a path argument.");
                         }
+                        config.DecoyPairingManifestPath = args[i];
+                        i++;
                         break;
 
                     case "--write-pin":
@@ -795,6 +803,15 @@ namespace pwiz.OspreySharp
             Console.Error.WriteLine("    --report <file>               Write TSV report to file");
             Console.Error.WriteLine("    --no-prefilter                Disable coelution signal pre-filter");
             Console.Error.WriteLine("    --write-pin                   Write PIN files for external tools");
+            Console.Error.WriteLine("    --decoys-in-library           Trust decoys already in the spectral library");
+            Console.Error.WriteLine("                                    (DIA-NN Decoy column / decoy_/rev_/DECOY_ protein");
+            Console.Error.WriteLine("                                    prefix / manifest) instead of generating reverse");
+            Console.Error.WriteLine("                                    decoys. Hard error if no decoys are recognised.");
+            Console.Error.WriteLine("    --decoy-pairing-manifest <PATH>");
+            Console.Error.WriteLine("                                  FDRBench 5-column pairing manifest (TSV) used");
+            Console.Error.WriteLine("                                    with --decoys-in-library. Manifest is the");
+            Console.Error.WriteLine("                                    authoritative source for peptide_type and");
+            Console.Error.WriteLine("                                    (optional) clean protein accessions.");
             Console.Error.WriteLine("    --join-at-pass=<N>            HPC: enter the pipeline at a join checkpoint.");
             Console.Error.WriteLine("                                    1 = consume Stage 4 outputs, run Stages 5-8.");
             Console.Error.WriteLine("                                    2 = consume Stage 6 outputs, run Stages 7-8.");

--- a/pwiz_tools/OspreySharp/OspreySharp/Program.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/Program.cs
@@ -556,6 +556,25 @@ namespace pwiz.OspreySharp
                 }
             }
 
+            // Warn on the silent no-op combination `--decoy-pairing-manifest`
+            // without `--decoys-in-library`. The manifest path is folded
+            // into SearchParameterHash, so it busts the .scores.parquet
+            // cache, but the pipeline only consults it inside the
+            // library-supplies-decoys branch. Mirrors Rust v26.6.0 (which
+            // is also silent here) -- the warning is a C#-only courtesy
+            // and does not change the hash or the run behaviour, so it
+            // preserves cross-impl byte parity.
+            if (!config.DecoysInLibrary &&
+                !string.IsNullOrEmpty(config.DecoyPairingManifestPath))
+            {
+                LogWarning(
+                    @"--decoy-pairing-manifest is set without --decoys-in-library; " +
+                    @"the manifest will NOT be consulted by the pipeline, but it " +
+                    @"still contributes to the search-parameter hash and will " +
+                    @"invalidate cached .scores.parquet files. Pass " +
+                    @"--decoys-in-library to actually enable library-decoy mode.");
+            }
+
             return config;
         }
 

--- a/pwiz_tools/OspreySharp/OspreySharp/Tasks/PerFileScoringTask.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/Tasks/PerFileScoringTask.cs
@@ -305,6 +305,14 @@ namespace pwiz.OspreySharp.Tasks
                     }
                     var manifestStats = manifest.ApplyToLibrary(library, pairingState);
                     pairingStats.NPairedViaManifest = manifestStats.NPaired;
+                    if (manifestStats.NProteinsReplaced > 0)
+                    {
+                        ctx.LogInfo(string.Format(
+                            @"Library-decoy mode: manifest replaced protein_ids on {0} library " +
+                            @"entries (clean source-protein accessions from the manifest's " +
+                            @"`proteins` column)",
+                            manifestStats.NProteinsReplaced));
+                    }
                     if (manifestStats.NNewlyMarkedDecoy > 0)
                     {
                         // Manifest classified entries as decoy that were


### PR DESCRIPTION
## Summary

Follow-up to PR #4214. Two tracks toward OspreySharp going primary
next week:

* **Track 1 -- library-decoy harness preparation.** Wires
  `--decoys-in-library` and `--decoy-pairing-manifest <PATH>` CLI
  flags into OspreySharp (was YAML-only) and extends the
  `Dataset-Config.ps1` / `Run-Osprey.ps1` / `Test-*.ps1` harness so
  the cross-impl Test-Regression byte-parity gate can drive the
  library-decoy code path end-to-end. New `AstralLibraryDecoy`
  dataset entry with placeholder library / manifest paths; ready
  to run as soon as Mike stages the Carafe-built library + FDRBench
  manifest.
* **Track 2 -- Mike's mid-May Rust catch-up.** Ports the
  manifest-proteins-override piece from `maccoss/osprey` commit
  `0c3a73e`. The FDRBench manifest's optional `proteins` column is
  now the authoritative source of protein info; OspreySharp
  substitutes its clean accessions onto every covered library
  entry whose stored `ProteinIds` came from a Carafe-stamped
  predictor (e.g. `sp|P12345_pep00001|GENE_A` -> `sp|P12345|GENE_A`).
  Without this the per-peptide suffix destroys the source-protein
  linkage protein parsimony / picked-protein FDR rely on.

Companion upstream PR landed at
[maccoss/osprey#35](https://github.com/maccoss/osprey/pull/35) --
defers the matching "no library decoys detected" hard error until
after the manifest pass on the Rust side, removing the deliberate
divergence noted in #4214's review.

## What's in this PR

| Commit | Purpose |
|---|---|
| `3222155146` | CLI flags: `--decoys-in-library` + `--decoy-pairing-manifest <PATH>` on OspreySharp; matches Rust osprey semantics; 3 ParseArgs tests pin the contract |
| `b1c3a81e1e` | Manifest proteins-override port from Rust `0c3a73e`: `ManifestApplyStats.NProteinsReplaced`, `ManifestEntryInfo.Proteins`, override loop in `DecoyPairingManifest.ApplyToLibrary`, pipeline log line. Two cross-impl tests match the Rust unit tests of the same names |

Sibling harness changes on `ai/master`:
[pwiz-ai@4bb8c7c](https://github.com/ProteoWizard/pwiz-ai/commit/4bb8c7c)
adds the dataset-config fields, the `AstralLibraryDecoy` entry, and
the `Run-Osprey.ps1` forwarding logic.

## Test plan

- [x] Build clean (net472 + net8.0), 0 errors
- [x] All 345 OspreySharp tests pass (340 + 3 CLI-flag tests + 2
      proteins-override tests)
- [x] ResSharper inspection: 4 pre-existing baseline warnings in
      untouched files (`RescoreWorker.cs`, `FileSaver.cs`,
      `PerFileRescoreTask.cs`); no new warnings from this branch
- [x] Stellar same-impl `Test-Snapshot.ps1 -Files All -CreateSnapshot`
      captured at v26.6.0 (PR #4214's baseline was at the merged
      commit `0e3c3cb5` from before the version bump; a recapture
      was needed); all 5 stages now PASS
- [ ] Stellar cross-impl `Test-Regression.ps1 -Force` -- pending,
      will run before merge
- [ ] Astral cross-impl `Test-Regression.ps1 -Force` -- pending,
      will run before merge
- [ ] Library-decoy end-to-end run: gated on Mike's files. Harness
      is ready; the `AstralLibraryDecoy` dataset entry will error
      cleanly with "file not found" until the Carafe-built library
      + FDRBench manifest land at
      `D:\test\osprey-runs\astral-libdecoy\`.

## Deferred

The two remaining functional Rust commits between PR #4214's
catch-up arc and `bcd7249`:

* `5da4a46`: `--fdrbench` native export. ~527 lines of Rust
  source; substantial new feature. Better as its own PR with
  fresh test scaffolding.
* `1fd7552`: 4000-byte protein column cap on `--fdrbench` output.
  Depends on `5da4a46` being landed first.

Both stay in scope for the broader OspreySharp-going-primary
transition. Scoped out of this PR per the user's "quick PR"
framing.

## Notes

* No changes to `OspreyConfig.SearchParameterHash` -- the
  proteins-override is a pipeline runtime behavior, not a config
  field. Existing `.scores.parquet` caches stay valid; Stellar and
  Astral cross-impl Test-Regression should not need re-capture.
* The proteins-override is a no-op for `Stellar` and `Astral` in
  reverse-decoy mode (no manifest, `proteins` column unused). The
  test plan is correct on those datasets without changing them.