### PR TITLE
Added --start-page=true|false launch flag for scripted Skyline launches

### DIFF
--- a/pwiz_tools/Skyline/Program.cs
+++ b/pwiz_tools/Skyline/Program.cs
@@ -184,9 +184,11 @@ namespace pwiz.Skyline
             SkylineRemoteAccountServices.Initialize();
             SecurityProtocolInitializer.Initialize(); // Enable highest available security level for HTTPS connections
 
-            // For testing and debugging Skyline command-line interface
-            bool openDoc = args != null && args.Length > 0 &&
-                           (args[0] == OPEN_DOCUMENT_ARG || args[0].StartsWith(OPEN_DOCUMENT_ARG + @"="));
+            // For testing and debugging Skyline command-line interface.
+            // Scan every arg, not just args[0], so --opendoc composes order-independently
+            // with --start-page (and any future GUI-launch flag).
+            bool openDoc = args != null && args.Any(a =>
+                a == OPEN_DOCUMENT_ARG || a.StartsWith(OPEN_DOCUMENT_ARG + @"="));
             try
             {
                 var parsedStartPage = ParseStartPageArg(args);

--- a/pwiz_tools/Skyline/Program.cs
+++ b/pwiz_tools/Skyline/Program.cs
@@ -72,8 +72,8 @@ namespace pwiz.Skyline
 
         // Set by --start-page=true|false on the command line. Null when the flag
         // was not specified. When set, overrides Settings.Default.ShowStartupForm and
-        // (when true) can also surface the StartPage modally after --opendoc loads a file.
-        public static bool? StartPageOverride { get; set; }
+        // (when true) can also surface the StartPage modally after --opendoc.
+        public static bool? StartPageOverride { get; private set; }
 
         public static string MainToolServiceName { get; private set; }
         
@@ -191,9 +191,7 @@ namespace pwiz.Skyline
                 a == OPEN_DOCUMENT_ARG || a.StartsWith(OPEN_DOCUMENT_ARG + @"="));
             try
             {
-                var parsedStartPage = ParseStartPageArg(args);
-                if (parsedStartPage.HasValue)
-                    StartPageOverride = parsedStartPage;
+                StartPageOverride = ParseStartPageArg(args);
             }
             catch (ArgumentException ex)
             {

--- a/pwiz_tools/Skyline/Program.cs
+++ b/pwiz_tools/Skyline/Program.cs
@@ -68,6 +68,12 @@ namespace pwiz.Skyline
         public const int EXIT_CODE_FAILURE_TO_START = 1;
         public const int EXIT_CODE_RAN_WITH_ERRORS = 2;
         public const string OPEN_DOCUMENT_ARG = "--opendoc";
+        public const string START_PAGE_ARG = "--start-page";
+
+        // Set by --start-page=true|false on the command line. Null when the flag
+        // was not specified. When set, overrides Settings.Default.ShowStartupForm and
+        // (when true) can also surface the StartPage modally after --opendoc loads a file.
+        public static bool? StartPageOverride { get; set; }
 
         public static string MainToolServiceName { get; private set; }
         
@@ -181,7 +187,20 @@ namespace pwiz.Skyline
             // For testing and debugging Skyline command-line interface
             bool openDoc = args != null && args.Length > 0 &&
                            (args[0] == OPEN_DOCUMENT_ARG || args[0].StartsWith(OPEN_DOCUMENT_ARG + @"="));
-            if (args != null && args.Length > 0 && !openDoc) 
+            try
+            {
+                var parsedStartPage = ParseStartPageArg(args);
+                if (parsedStartPage.HasValue)
+                    StartPageOverride = parsedStartPage;
+            }
+            catch (ArgumentException ex)
+            {
+                Common.SystemUtil.PInvoke.Kernel32.AttachConsoleToParentProcess();
+                Console.Error.WriteLine(ex.Message);
+                return EXIT_CODE_FAILURE_TO_START;
+            }
+            bool isGuiLaunch = openDoc || StartPageOverride.HasValue;
+            if (args != null && args.Length > 0 && !isGuiLaunch)
             {
                 if (!CommandLineRunner.HasCommandPrefix(args[0]))
                 {
@@ -316,11 +335,15 @@ namespace pwiz.Skyline
                 try
                 {
                     var activationArgs = AppDomain.CurrentDomain.SetupInformation.ActivationArguments;
-                    if ((activationArgs != null &&
-                        activationArgs.ActivationData != null &&
-                        activationArgs.ActivationData.Length != 0) ||
-                        openDoc ||
-                        !Settings.Default.ShowStartupForm)
+                    bool activationDataPresent = activationArgs != null &&
+                                                 activationArgs.ActivationData != null &&
+                                                 activationArgs.ActivationData.Length != 0;
+                    // Activation data and --opendoc always go straight to MainWindow.
+                    // Otherwise, --start-page=true|false overrides the user preference,
+                    // and without the flag the existing ShowStartupForm setting wins.
+                    bool showStartPage = !activationDataPresent && !openDoc &&
+                                         (StartPageOverride ?? Settings.Default.ShowStartupForm);
+                    if (!showStartPage)
                     {
                         MainWindow = new SkylineWindow(args);
                     }
@@ -379,6 +402,33 @@ namespace pwiz.Skyline
             MainWindow = null;
             SystemEvents.DisplaySettingsChanged -= SystemEventsOnDisplaySettingsChanged;
             return EXIT_CODE_SUCCESS;
+        }
+
+        // Returns null when --start-page is absent, true/false for --start-page=true|false.
+        // Throws ArgumentException for --start-page with no value or an unparseable value.
+        internal static bool? ParseStartPageArg(string[] args)
+        {
+            if (args == null)
+                return null;
+            bool? result = null;
+            foreach (var a in args)
+            {
+                if (a.Equals(START_PAGE_ARG, StringComparison.OrdinalIgnoreCase) ||
+                    a.StartsWith(START_PAGE_ARG + @"=", StringComparison.OrdinalIgnoreCase))
+                {
+                    var eq = a.IndexOf('=');
+                    var val = eq >= 0 ? a.Substring(eq + 1) : string.Empty;
+                    if (val.Equals(@"true", StringComparison.OrdinalIgnoreCase))
+                        result = true;
+                    else if (val.Equals(@"false", StringComparison.OrdinalIgnoreCase))
+                        result = false;
+                    else
+                        throw new ArgumentException(string.Format(
+                            SkylineResources.Program_ParseStartPageArg_Invalid_argument__0___Use__start_page_true_or__start_page_false,
+                            a));
+                }
+            }
+            return result;
         }
 
         private static void SystemEventsOnDisplaySettingsChanged(object sender, EventArgs eventArgs)

--- a/pwiz_tools/Skyline/Skyline.cs
+++ b/pwiz_tools/Skyline/Skyline.cs
@@ -266,6 +266,9 @@ namespace pwiz.Skyline
             }
             if (args != null && args.Length != 0)
             {
+                _wasOpenDocLaunch = args.Any(a =>
+                    a.Equals(Program.OPEN_DOCUMENT_ARG) ||
+                    a.StartsWith(Program.OPEN_DOCUMENT_ARG + @"="));
                 // Support both --opendoc path/to/file and --opendoc=path/to/file
                 _fileToOpen = args.Select(a =>
                 {
@@ -309,9 +312,6 @@ namespace pwiz.Skyline
         {
             base.OnShown(e);
 
-            // Remember whether --opendoc was on the command line so that
-            // --start-page=true (below) only fires for the open-doc launch path.
-            bool wasOpenDocLaunch = _fileToOpen != null;
             if (HasFileToOpen())
             {
                 try
@@ -328,9 +328,11 @@ namespace pwiz.Skyline
             EnsureUIModeSet();
 
             // --start-page=true combined with --opendoc surfaces the StartPage as a
-            // modal dialog over the loaded document. The flag alone (no --opendoc)
-            // is handled by the startup-time StartPage route in Program.cs.
-            if (wasOpenDocLaunch && Program.StartPageOverride == true)
+            // modal dialog over the MainWindow (loaded with the document or empty if
+            // --opendoc had no path). The flag alone (no --opendoc) is handled by the
+            // startup-time StartPage route in Program.cs, where the SkylineWindow is
+            // constructed with no args and _wasOpenDocLaunch stays false.
+            if (_wasOpenDocLaunch && Program.StartPageOverride == true)
                 OpenStartPage();
         }
 
@@ -1367,6 +1369,7 @@ namespace pwiz.Skyline
 
         private Control _activeClipboardControl;
         private string _fileToOpen;
+        private bool _wasOpenDocLaunch;
 
         public void ClipboardControlGotFocus(Control clipboardControl)
         {

--- a/pwiz_tools/Skyline/Skyline.cs
+++ b/pwiz_tools/Skyline/Skyline.cs
@@ -272,7 +272,9 @@ namespace pwiz.Skyline
                     if (a.StartsWith(Program.OPEN_DOCUMENT_ARG + @"="))
                         return a.Substring(Program.OPEN_DOCUMENT_ARG.Length + 1);
                     return a;
-                }).Where(a => !a.Equals(Program.OPEN_DOCUMENT_ARG)).LastOrDefault();
+                }).Where(a => !a.Equals(Program.OPEN_DOCUMENT_ARG) &&
+                              !a.StartsWith(Program.START_PAGE_ARG + @"=", StringComparison.OrdinalIgnoreCase) &&
+                              !a.Equals(Program.START_PAGE_ARG, StringComparison.OrdinalIgnoreCase)).LastOrDefault();
             }
 
             var defaultUIMode = Settings.Default.UIMode;
@@ -307,6 +309,9 @@ namespace pwiz.Skyline
         {
             base.OnShown(e);
 
+            // Remember whether --opendoc was on the command line so that
+            // --start-page=true (below) only fires for the open-doc launch path.
+            bool wasOpenDocLaunch = _fileToOpen != null;
             if (HasFileToOpen())
             {
                 try
@@ -321,6 +326,12 @@ namespace pwiz.Skyline
             _fileToOpen = null;
 
             EnsureUIModeSet();
+
+            // --start-page=true combined with --opendoc surfaces the StartPage as a
+            // modal dialog over the loaded document. The flag alone (no --opendoc)
+            // is handled by the startup-time StartPage route in Program.cs.
+            if (wasOpenDocLaunch && Program.StartPageOverride == true)
+                OpenStartPage();
         }
 
         private bool HasFileToOpen()

--- a/pwiz_tools/Skyline/SkylineResources.designer.cs
+++ b/pwiz_tools/Skyline/SkylineResources.designer.cs
@@ -1725,7 +1725,17 @@ namespace pwiz.Skyline {
                         "ase_install_the_32_bit_version", resourceCulture);
             }
         }
-        
+
+        /// <summary>
+        ///   Looks up a localized string similar to Invalid argument &apos;{0}&apos;. Use --start-page=true or --start-page=false..
+        /// </summary>
+        public static string Program_ParseStartPageArg_Invalid_argument__0___Use__start_page_true_or__start_page_false {
+            get {
+                return ResourceManager.GetString("Program_ParseStartPageArg_Invalid_argument__0___Use__start_page_true_or__start_pa" +
+                        "ge_false", resourceCulture);
+            }
+        }
+
         /// <summary>
         ///   Looks up a localized string similar to Do you want to save your current settings before switching?.
         /// </summary>

--- a/pwiz_tools/Skyline/SkylineResources.ja.resx
+++ b/pwiz_tools/Skyline/SkylineResources.ja.resx
@@ -598,6 +598,9 @@
   <data name="Program_Main_You_are_attempting_to_run_a_64_bit_version_of__0__on_a_32_bit_OS_Please_install_the_32_bit_version" xml:space="preserve">
     <value>32ビットOSで{0}の64ビットバージョンを実行しようとしています。32ビットバージョンをインストールしてください。</value>
   </data>
+  <data name="Program_ParseStartPageArg_Invalid_argument__0___Use__start_page_true_or__start_page_false" xml:space="preserve">
+    <value>無効な引数 '{0}' です。--start-page=true または --start-page=false を指定してください。</value>
+  </data>
   <data name="SelectSettingsHandler_ToolStripMenuItemClick_Do_you_want_to_save_your_current_settings_before_switching" xml:space="preserve">
     <value>切り替える前に現在の設定を保存しますか？</value>
   </data>

--- a/pwiz_tools/Skyline/SkylineResources.resx
+++ b/pwiz_tools/Skyline/SkylineResources.resx
@@ -608,6 +608,9 @@ Try uninstalling and reinstalling Skyline, or contact your IT department if the 
   <data name="Program_Main_You_are_attempting_to_run_a_64_bit_version_of__0__on_a_32_bit_OS_Please_install_the_32_bit_version" xml:space="preserve">
     <value>You are attempting to run a 64-bit version of {0} on a 32-bit OS. Please install the 32-bit version.</value>
   </data>
+  <data name="Program_ParseStartPageArg_Invalid_argument__0___Use__start_page_true_or__start_page_false" xml:space="preserve">
+    <value>Invalid argument '{0}'. Use --start-page=true or --start-page=false.</value>
+  </data>
   <data name="SelectSettingsHandler_ToolStripMenuItemClick_Do_you_want_to_save_your_current_settings_before_switching" xml:space="preserve">
     <value>Do you want to save your current settings before switching?</value>
   </data>

--- a/pwiz_tools/Skyline/SkylineResources.zh-CHS.resx
+++ b/pwiz_tools/Skyline/SkylineResources.zh-CHS.resx
@@ -598,6 +598,9 @@
   <data name="Program_Main_You_are_attempting_to_run_a_64_bit_version_of__0__on_a_32_bit_OS_Please_install_the_32_bit_version" xml:space="preserve">
     <value>您正在尝试于 32 比特的操作系统上运行 64 比特的{0}版本。请安装 32 比特版本。</value>
   </data>
+  <data name="Program_ParseStartPageArg_Invalid_argument__0___Use__start_page_true_or__start_page_false" xml:space="preserve">
+    <value>无效参数 '{0}'。请使用 --start-page=true 或 --start-page=false。</value>
+  </data>
   <data name="SelectSettingsHandler_ToolStripMenuItemClick_Do_you_want_to_save_your_current_settings_before_switching" xml:space="preserve">
     <value>您是否想要在转换前保存您的当前设置？</value>
   </data>

--- a/pwiz_tools/Skyline/Test/StartPageArgTest.cs
+++ b/pwiz_tools/Skyline/Test/StartPageArgTest.cs
@@ -1,0 +1,82 @@
+/*
+ * Original author: Brendan MacLean <brendanx .at. u.washington.edu>,
+ *                  MacCoss Lab, Department of Genome Sciences, UW
+ * AI assistance: Claude Code (Claude Opus 4.7) <noreply .at. anthropic.com>
+ *
+ * Copyright 2026 University of Washington - Seattle, WA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using pwiz.Skyline;
+using pwiz.SkylineTestUtil;
+
+namespace pwiz.SkylineTest
+{
+    /// <summary>
+    /// Unit tests for <see cref="Program.ParseStartPageArg"/>, covering the
+    /// --start-page=true|false launch flag introduced for scripted Skyline launches.
+    /// </summary>
+    [TestClass]
+    public class StartPageArgTest : AbstractUnitTest
+    {
+        [TestMethod]
+        public void TestParseStartPageArg()
+        {
+            // Absent flag returns null.
+            Assert.IsNull(Program.ParseStartPageArg(null));
+            Assert.IsNull(Program.ParseStartPageArg(new string[0]));
+            Assert.IsNull(Program.ParseStartPageArg(new[] { @"--opendoc=foo.sky" }));
+
+            // Valid true/false values.
+            Assert.AreEqual(true, Program.ParseStartPageArg(new[] { @"--start-page=true" }));
+            Assert.AreEqual(false, Program.ParseStartPageArg(new[] { @"--start-page=false" }));
+
+            // Case-insensitive on both the key and the value.
+            Assert.AreEqual(true, Program.ParseStartPageArg(new[] { @"--Start-Page=TRUE" }));
+            Assert.AreEqual(false, Program.ParseStartPageArg(new[] { @"--START-PAGE=False" }));
+
+            // Composes with --opendoc in either order, value reflects the flag.
+            Assert.AreEqual(true, Program.ParseStartPageArg(new[] { @"--opendoc=foo.sky", @"--start-page=true" }));
+            Assert.AreEqual(false, Program.ParseStartPageArg(new[] { @"--start-page=false", @"--opendoc=foo.sky" }));
+
+            // Bare --start-page with no value is rejected.
+            AssertParseError(new[] { @"--start-page" }, @"--start-page");
+
+            // Unparseable values are rejected, message echoes the offending token.
+            AssertParseError(new[] { @"--start-page=foo" }, @"--start-page=foo");
+            AssertParseError(new[] { @"--start-page=" }, @"--start-page=");
+            AssertParseError(new[] { @"--start-page=1" }, @"--start-page=1");
+        }
+
+        private static void AssertParseError(string[] args, string expectedToken)
+        {
+            try
+            {
+                Program.ParseStartPageArg(args);
+                Assert.Fail();
+            }
+            catch (ArgumentException ex)
+            {
+                // Message is the formatted resource; verify both the resource string and
+                // that it surfaces the offending argument token to the user.
+                AssertEx.Contains(ex.Message, expectedToken);
+                AssertEx.Contains(ex.Message, string.Format(
+                    SkylineResources.Program_ParseStartPageArg_Invalid_argument__0___Use__start_page_true_or__start_page_false,
+                    expectedToken));
+            }
+        }
+    }
+}

--- a/pwiz_tools/Skyline/Test/Test.csproj
+++ b/pwiz_tools/Skyline/Test/Test.csproj
@@ -289,6 +289,7 @@
     <Compile Include="SrmSettingsChangeTest.cs" />
     <Compile Include="SrmSettingsTest.cs" />
     <Compile Include="SSRCalc3Test.cs" />
+    <Compile Include="StartPageArgTest.cs" />
     <Compile Include="StatisticsTest.cs" />
     <Compile Include="StringHelpersTest.cs" />
     <Compile Include="DiskSpaceTest.cs" />

--- a/pwiz_tools/Skyline/TestFunctional/StartPageOverrideFlagTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/StartPageOverrideFlagTest.cs
@@ -1,0 +1,110 @@
+/*
+ * Original author: Brendan MacLean <brendanx .at. u.washington.edu>,
+ *                  MacCoss Lab, Department of Genome Sciences, UW
+ * AI assistance: Claude Code (Claude Opus 4.7) <noreply .at. anthropic.com>
+ *
+ * Copyright 2026 University of Washington - Seattle, WA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using pwiz.Skyline;
+using pwiz.Skyline.Controls.Startup;
+using pwiz.Skyline.Properties;
+using pwiz.SkylineTestUtil;
+
+namespace pwiz.SkylineTestFunctional
+{
+    /// <summary>
+    /// Verifies that <see cref="Program.StartPageOverride"/> = true (from the
+    /// --start-page=true launch flag) forces the StartPage to appear even when
+    /// <see cref="Settings.Default"/>.ShowStartupForm would otherwise suppress it.
+    /// </summary>
+    [TestClass]
+    public class StartPageOverrideTrueTest : AbstractFunctionalTest
+    {
+        [TestMethod]
+        public void TestStartPageOverrideTrue()
+        {
+            RunFunctionalTest();
+        }
+
+        protected override bool ShowStartPage => true;
+
+        protected override void InitializeSkylineSettings()
+        {
+            base.InitializeSkylineSettings();
+            // ShowStartPage = true makes the test framework wait for StartPage,
+            // but we flip ShowStartupForm off so the only thing surfacing the
+            // StartPage is the override flag below.
+            Settings.Default.ShowStartupForm = false;
+            Program.StartPageOverride = true;
+        }
+
+        protected override void DoTest()
+        {
+            try
+            {
+                var startPage = WaitForOpenForm<StartPage>();
+                Assert.IsNotNull(startPage);
+                RunUI(() => startPage.DoAction(skylineWindow => true));
+                WaitForOpenForm<SkylineWindow>();
+            }
+            finally
+            {
+                Program.StartPageOverride = null;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="Program.StartPageOverride"/> = false (from the
+    /// --start-page=false launch flag) forces the MainWindow to open directly,
+    /// even when <see cref="Settings.Default"/>.ShowStartupForm would normally
+    /// route the launch through the StartPage.
+    /// </summary>
+    [TestClass]
+    public class StartPageOverrideFalseTest : AbstractFunctionalTest
+    {
+        [TestMethod]
+        public void TestStartPageOverrideFalse()
+        {
+            RunFunctionalTest();
+        }
+
+        protected override bool ShowStartPage => false;
+
+        protected override void InitializeSkylineSettings()
+        {
+            base.InitializeSkylineSettings();
+            // ShowStartupForm = true would normally show the StartPage; the override
+            // forces a direct MainWindow launch, bypassing the user preference.
+            Settings.Default.ShowStartupForm = true;
+            Program.StartPageOverride = false;
+        }
+
+        protected override void DoTest()
+        {
+            try
+            {
+                Assert.IsNull(FindOpenForm<StartPage>());
+                Assert.IsNotNull(SkylineWindow);
+            }
+            finally
+            {
+                Program.StartPageOverride = null;
+            }
+        }
+    }
+}

--- a/pwiz_tools/Skyline/TestFunctional/StartPageOverrideFlagTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/StartPageOverrideFlagTest.cs
@@ -52,19 +52,20 @@ namespace pwiz.SkylineTestFunctional
             Program.StartPageOverride = true;
         }
 
+        // The framework's [TestCleanup] always invokes Cleanup(), regardless of where the
+        // test failed -- robust against any path that bypasses DoTest's body.
+        protected override void Cleanup()
+        {
+            Program.StartPageOverride = null;
+            base.Cleanup();
+        }
+
         protected override void DoTest()
         {
-            try
-            {
-                var startPage = WaitForOpenForm<StartPage>();
-                Assert.IsNotNull(startPage);
-                RunUI(() => startPage.DoAction(skylineWindow => true));
-                WaitForOpenForm<SkylineWindow>();
-            }
-            finally
-            {
-                Program.StartPageOverride = null;
-            }
+            var startPage = WaitForOpenForm<StartPage>();
+            Assert.IsNotNull(startPage);
+            RunUI(() => startPage.DoAction(skylineWindow => true));
+            WaitForOpenForm<SkylineWindow>();
         }
     }
 
@@ -94,17 +95,16 @@ namespace pwiz.SkylineTestFunctional
             Program.StartPageOverride = false;
         }
 
+        protected override void Cleanup()
+        {
+            Program.StartPageOverride = null;
+            base.Cleanup();
+        }
+
         protected override void DoTest()
         {
-            try
-            {
-                Assert.IsNull(FindOpenForm<StartPage>());
-                Assert.IsNotNull(SkylineWindow);
-            }
-            finally
-            {
-                Program.StartPageOverride = null;
-            }
+            Assert.IsNull(FindOpenForm<StartPage>());
+            Assert.IsNotNull(SkylineWindow);
         }
     }
 }

--- a/pwiz_tools/Skyline/TestFunctional/StartPageOverrideFlagTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/StartPageOverrideFlagTest.cs
@@ -57,7 +57,6 @@ namespace pwiz.SkylineTestFunctional
         protected override void DoTest()
         {
             var startPage = WaitForOpenForm<StartPage>();
-            Assert.IsNotNull(startPage);
             RunUI(() => startPage.DoAction(skylineWindow => true));
             WaitForOpenForm<SkylineWindow>();
         }
@@ -92,7 +91,6 @@ namespace pwiz.SkylineTestFunctional
         protected override void DoTest()
         {
             Assert.IsNull(FindOpenForm<StartPage>());
-            Assert.IsNotNull(SkylineWindow);
         }
     }
 
@@ -117,7 +115,6 @@ namespace pwiz.SkylineTestFunctional
 
         protected override void DoTest()
         {
-            Assert.IsNotNull(SkylineWindow);
             // No --opendoc path -> empty new document, no file path.
             RunUI(() =>
             {
@@ -125,10 +122,8 @@ namespace pwiz.SkylineTestFunctional
                 Assert.AreEqual(0, SkylineWindow.Document.PeptideCount);
             });
             var startPage = WaitForOpenForm<StartPage>();
-            Assert.IsNotNull(startPage);
             // Closing the modal returns control to MainWindow; the framework cleans up.
-            RunUI(() => startPage.DialogResult = System.Windows.Forms.DialogResult.Cancel);
-            WaitForClosedForm<StartPage>();
+            OkDialog(startPage, startPage.Close);
         }
     }
 }

--- a/pwiz_tools/Skyline/TestFunctional/StartPageOverrideFlagTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/StartPageOverrideFlagTest.cs
@@ -27,9 +27,10 @@ using pwiz.SkylineTestUtil;
 namespace pwiz.SkylineTestFunctional
 {
     /// <summary>
-    /// Verifies that <see cref="Program.StartPageOverride"/> = true (from the
-    /// --start-page=true launch flag) forces the StartPage to appear even when
-    /// <see cref="Settings.Default"/>.ShowStartupForm would otherwise suppress it.
+    /// Verifies that --start-page=true on the command line forces the StartPage to
+    /// appear even when <see cref="Settings.Default"/>.ShowStartupForm would
+    /// otherwise suppress it. Exercises <see cref="Program.Main"/>'s argument
+    /// parsing end-to-end via the AbstractFunctionalTest LaunchArgs hook.
     /// </summary>
     [TestClass]
     public class StartPageOverrideTrueTest : AbstractFunctionalTest
@@ -42,22 +43,15 @@ namespace pwiz.SkylineTestFunctional
 
         protected override bool ShowStartPage => true;
 
+        protected override string[] LaunchArgs => new[] { @"--start-page=true" };
+
         protected override void InitializeSkylineSettings()
         {
             base.InitializeSkylineSettings();
-            // ShowStartPage = true makes the test framework wait for StartPage,
-            // but we flip ShowStartupForm off so the only thing surfacing the
-            // StartPage is the override flag below.
+            // ShowStartPage = true makes the framework wait for the StartPage, but we
+            // flip ShowStartupForm off so the only thing surfacing the StartPage is
+            // --start-page=true.
             Settings.Default.ShowStartupForm = false;
-            Program.StartPageOverride = true;
-        }
-
-        // The framework's [TestCleanup] always invokes Cleanup(), regardless of where the
-        // test failed -- robust against any path that bypasses DoTest's body.
-        protected override void Cleanup()
-        {
-            Program.StartPageOverride = null;
-            base.Cleanup();
         }
 
         protected override void DoTest()
@@ -70,10 +64,9 @@ namespace pwiz.SkylineTestFunctional
     }
 
     /// <summary>
-    /// Verifies that <see cref="Program.StartPageOverride"/> = false (from the
-    /// --start-page=false launch flag) forces the MainWindow to open directly,
-    /// even when <see cref="Settings.Default"/>.ShowStartupForm would normally
-    /// route the launch through the StartPage.
+    /// Verifies that --start-page=false on the command line forces the MainWindow
+    /// to open directly, even when <see cref="Settings.Default"/>.ShowStartupForm
+    /// would normally route the launch through the StartPage.
     /// </summary>
     [TestClass]
     public class StartPageOverrideFalseTest : AbstractFunctionalTest
@@ -86,25 +79,56 @@ namespace pwiz.SkylineTestFunctional
 
         protected override bool ShowStartPage => false;
 
+        protected override string[] LaunchArgs => new[] { @"--start-page=false" };
+
         protected override void InitializeSkylineSettings()
         {
             base.InitializeSkylineSettings();
-            // ShowStartupForm = true would normally show the StartPage; the override
+            // ShowStartupForm = true would normally show the StartPage; --start-page=false
             // forces a direct MainWindow launch, bypassing the user preference.
             Settings.Default.ShowStartupForm = true;
-            Program.StartPageOverride = false;
-        }
-
-        protected override void Cleanup()
-        {
-            Program.StartPageOverride = null;
-            base.Cleanup();
         }
 
         protected override void DoTest()
         {
             Assert.IsNull(FindOpenForm<StartPage>());
             Assert.IsNotNull(SkylineWindow);
+        }
+    }
+
+    /// <summary>
+    /// Verifies that --opendoc combined with --start-page=true opens the
+    /// MainWindow first and then surfaces the StartPage as a modal dialog on top.
+    /// With a bare --opendoc (no path), the MainWindow comes up with an empty
+    /// document and no file path; the StartPage is layered over it.
+    /// </summary>
+    [TestClass]
+    public class StartPageOpenDocOverrideTrueTest : AbstractFunctionalTest
+    {
+        [TestMethod]
+        public void TestStartPageOpenDocOverrideTrue()
+        {
+            RunFunctionalTest();
+        }
+
+        // The framework waits for MainWindow first (ShowStartPage = false / default);
+        // DoTest waits for the StartPage modal that OnShown surfaces afterward.
+        protected override string[] LaunchArgs => new[] { @"--opendoc", @"--start-page=true" };
+
+        protected override void DoTest()
+        {
+            Assert.IsNotNull(SkylineWindow);
+            // No --opendoc path -> empty new document, no file path.
+            RunUI(() =>
+            {
+                Assert.IsNull(SkylineWindow.DocumentFilePath);
+                Assert.AreEqual(0, SkylineWindow.Document.PeptideCount);
+            });
+            var startPage = WaitForOpenForm<StartPage>();
+            Assert.IsNotNull(startPage);
+            // Closing the modal returns control to MainWindow; the framework cleans up.
+            RunUI(() => startPage.DialogResult = System.Windows.Forms.DialogResult.Cancel);
+            WaitForClosedForm<StartPage>();
         }
     }
 }

--- a/pwiz_tools/Skyline/TestFunctional/TestFunctional.csproj
+++ b/pwiz_tools/Skyline/TestFunctional/TestFunctional.csproj
@@ -484,6 +484,7 @@
     <Compile Include="SrmCourseScenarioTest.cs" />
     <Compile Include="SrmSmMolChromTest.cs" />
     <Compile Include="StandardTypeTest.cs" />
+    <Compile Include="StartPageOverrideFlagTest.cs" />
     <Compile Include="StartPageTest.cs" />
     <Compile Include="SummaryGraphLinePlotsTest.cs" />
     <Compile Include="SummaryGraphVisibilityTest.cs" />

--- a/pwiz_tools/Skyline/TestUtil/TestFunctional.cs
+++ b/pwiz_tools/Skyline/TestUtil/TestFunctional.cs
@@ -379,6 +379,14 @@ namespace pwiz.SkylineTestUtil
         protected virtual bool ShowStartPage {get { return false; }}
         protected virtual List<string> SetMru { get { return new List<string>(); } }
 
+        /// <summary>
+        /// Command-line arguments passed to <see cref="Program.Main"/> for this test
+        /// run. Default null -- behave like an unargumented Skyline.exe launch.
+        /// Override to exercise the Program.Main argument-parsing path (e.g. --opendoc,
+        /// --start-page=true|false).
+        /// </summary>
+        protected virtual string[] LaunchArgs => null;
+
         private static void SkylineInvoke(Action act)
         {
             var form = (SkylineWindow as FormEx) ?? FindOpenForm<StartPage>();
@@ -2316,7 +2324,7 @@ namespace pwiz.SkylineTestUtil
             var threadTest = new Thread(WaitForSkyline) { Name = @"Functional test thread" };
             LocalizationHelper.InitThread(threadTest);
             threadTest.Start();
-            Program.Main();
+            Program.Main(LaunchArgs);
             threadTest.Join();
 
             // Were all windows disposed?


### PR DESCRIPTION
## Summary

* New `--start-page=true|false` launch flag controls whether the StartPage appears at launch, independent of `Settings.Default.ShowStartupForm` and `--opendoc`. Removes the semantic accident where bare `--opendoc` was the only way to skip the StartPage for scripted launches.
* `--start-page=true` combined with `--opendoc PATH` loads the document, then surfaces the StartPage as a modal dialog over the loaded MainWindow. Every combination of the two flags has a clear documented meaning (see `Program.cs` decision logic).
* Invalid values (`--start-page` with no value, `--start-page=foo`) exit cleanly with `EXIT_CODE_FAILURE_TO_START` and a localized stderr message; no GUI launch. Fully additive: existing AutoQC / SkylineBatch / SkylineRunner shim flows that do not pass the flag are unchanged.

Fixes #4216

## Test plan

- [x] `TestParseStartPageArg` - unit test of `Program.ParseStartPageArg` across absent / valid / case-insensitive / multi-arg / invalid cases.
- [x] `TestStartPageOverrideTrue` - functional test: override beats `ShowStartupForm=false` and surfaces the StartPage.
- [x] `TestStartPageOverrideFalse` - functional test: override beats `ShowStartupForm=true` and forces a direct MainWindow launch.
- [x] Existing `TestStartPageOpenFile / OpenRecent / CheckActionBoxes / NewDocument` still pass.
- [x] `CodeInspection` passes (no ReSharper warnings).
- [ ] Manual smoke check from a developer's `Bin\` folder before merge (the TestFunctional framework calls `Program.Main()` without arguments, so the arg-driven parse / GUI-detection path is not exercised end-to-end by automated tests):
  - `Skyline.exe --start-page=false` - empty MainWindow, no StartPage.
  - `Skyline.exe --start-page=true` with `ShowStartupForm=false` - StartPage shown.
  - `Skyline.exe --opendoc <path> --start-page=true` - document loads, then StartPage modal.
  - `Skyline.exe --opendoc <path> --start-page=false` - document loads, no StartPage.
  - `Skyline.exe --start-page` and `Skyline.exe --start-page=foo` - stderr error, exit 1, no UI.

Co-Authored-By: Claude <noreply@anthropic.com>