### PR TITLE
Include ProteowizardWrapper in pwiz subset source tarball

### DIFF
--- a/Jamroot.jam
+++ b/Jamroot.jam
@@ -1749,7 +1749,7 @@ tar.create boost_$(BOOST_VERSION:J=_).tar.bz2
     "exclude:pwiz_tools/Shared/BiblioSpec"
     "exclude:pwiz_tools/Shared/Crawdad"
     "exclude:pwiz_tools/Shared/ProteomeDb"
-    "exclude:pwiz_tools/Shared/ProteowizardWrapper"
+    # ProteowizardWrapper is needed by MSConvertGUI.sln (shared remote dialog refactor)
     "exclude:pwiz_tools/Shared/Lib/Microsoft.Diagnostics.Runtime"
     "exclude:pwiz_tools/Shared/Lib/MSAmanda"
     "exclude:pwiz_tools/Shared/Lib/DotNetZip"


### PR DESCRIPTION
## Summary
- Removes `exclude:pwiz_tools/Shared/ProteowizardWrapper` from `.pwiz-src-exclusions` in `Jamroot.jam`.
- Unblocks the `Core Windows x86_64 subset` ([#3997618](https://teamcity.labkey.org/buildConfiguration/bt88/3997618)) and `Core Windows x86_64 subset (no vendor DLLs)` ([#3997621](https://teamcity.labkey.org/buildConfiguration/ProteoWizard_WindowsX86subsetNoVendorDll/3997621)) builds on master.

## Why
After [`959ea3dc3d`](https://github.com/ProteoWizard/pwiz/commit/959ea3dc3d) ("Moved BaseFileDialogNE to shared CommonFileDialogs project for MSConvertGUI reuse") landed, `MSConvertGUI.sln` references `..\Shared\ProteowizardWrapper\ProteowizardWrapper.csproj`. The pwiz subset source tarball still excluded that folder (historically Skyline-only), so the post-merge subset builds extracted a tarball missing the csproj and MSBuild failed with `MSB3202: The project file ... was not found`.

These builds only run on master, so the breakage didn't surface on the original PR.

## Test plan
- [ ] After merge, confirm the next `Core subset source tarball` build (bt642 / triggers bt88 and bt645) succeeds end-to-end.
- [ ] Spot-check that no Skyline-specific files leak into the subset tarball via the ProteowizardWrapper directory (it has its own csproj + a few .cs files; no Skyline references).

🤖 Generated with [Claude Code](https://claude.com/claude-code)