### PR TITLE
Fix MSConvertGUI silently re-enabling zlib compression when checkbox is unchecked

### DIFF
--- a/pwiz_tools/MSConvertGUI/MainForm.cs
+++ b/pwiz_tools/MSConvertGUI/MainForm.cs
@@ -650,8 +650,9 @@ namespace MSConvertGUI
             if (!WriteIndexBox.Checked)
                 commandLine.Append("--noindex|");
 
-            if (UseZlibBox.Checked)
-                commandLine.Append("--zlib|");
+            // msconvert.exe defaults --zlib to true, so we must emit --zlib=off explicitly when unchecked --
+            // otherwise this command line would silently re-enable compression when handed back to msconvert.exe.
+            commandLine.Append(UseZlibBox.Checked ? "--zlib|" : "--zlib=off|");
 
             if (GzipBox.Checked)
                 commandLine.Append("--gzip|");
@@ -697,7 +698,9 @@ namespace MSConvertGUI
             Precision32.Checked = (commandLine.IndexOf("--32") >= 0);
             Precision64.Checked = !Precision32.Checked;
             WriteIndexBox.Checked = !(commandLine.IndexOf("--noindex") >= 0);
-            UseZlibBox.Checked = (commandLine.IndexOf("--zlib") >= 0);
+            // Match the bare --zlib token (framed by | separators), so --zlib=off does not satisfy a
+            // substring check and incorrectly tick the box.
+            UseZlibBox.Checked = ("|" + commandLine + "|").IndexOf("|--zlib|") >= 0;
             GzipBox.Checked = (commandLine.IndexOf("--gzip") >= 0);
             NumpressLinearBox.Checked = (commandLine.IndexOf("--numpressLinear") >= 0);
             NumpressSlofBox.Checked = (commandLine.IndexOf("--numpressSlof") >= 0);
@@ -740,6 +743,7 @@ namespace MSConvertGUI
                     case "--32":
                     case "--noindex":
                     case "--zlib":
+                    case "--zlib=off":
                     case "--gzip":
                     case "--numpressLinear":
                     case "--numpressSlof":

--- a/pwiz_tools/MSConvertGUI/MainLogic.cs
+++ b/pwiz_tools/MSConvertGUI/MainLogic.cs
@@ -322,7 +322,16 @@ namespace MSConvertGUI
                             break;
                         case "--zlib":
                         case "-z":
-                            zlib = true;
+                            // This loop pre-replaces '=' with ' ', so --zlib=off arrives as two tokens
+                            // ["--zlib", "off"]; peek and consume an explicit off/false value.
+                            if (x + 1 < commandList.Length &&
+                                (commandList[x + 1] == "off" || commandList[x + 1] == "false"))
+                            {
+                                zlib = false;
+                                x++;
+                            }
+                            else
+                                zlib = true;
                             break;
                         case "--gzip":
                         case "-g":

--- a/pwiz_tools/MSConvertGUI/MainLogic.cs
+++ b/pwiz_tools/MSConvertGUI/MainLogic.cs
@@ -213,6 +213,9 @@ namespace MSConvertGUI
                     case "-z":
                         zlib = true;
                         break;
+                    case "--zlib=off":
+                        zlib = false;
+                        break;
                     case "--gzip":
                     case "-g":
                         gzip = true;

--- a/pwiz_tools/MSConvertGUI/Test/MainLogicTest.cs
+++ b/pwiz_tools/MSConvertGUI/Test/MainLogicTest.cs
@@ -460,4 +460,35 @@ namespace Test
             CompareFiles(extension);
         }
     }
+
+    /// <summary>
+    /// Parser-only tests for MainLogic.ParseCommandLine — no msconvert.exe / vendor data required,
+    /// so these can run in any environment where the MSConvertGUI assembly loads.
+    /// </summary>
+    [TestClass]
+    public class MainLogicParserTest
+    {
+        private static MainLogic CreateLogic()
+        {
+            return new MainLogic(new ProgressForm.JobInfo(), new Map<string, int>(), new object());
+        }
+
+        [TestMethod]
+        public void ZlibFlagRoundTrip()
+        {
+            // (argv, expectedCompression)
+            var cases = new (string argv, MSDataFile.Compression expected)[]
+            {
+                ("fake.mzML",                      MSDataFile.Compression.Compression_Zlib), // msconvert.exe default is on
+                ("--zlib|fake.mzML",               MSDataFile.Compression.Compression_Zlib),
+                ("--zlib=off|fake.mzML",           MSDataFile.Compression.Compression_None),
+            };
+
+            foreach (var (argv, expected) in cases)
+            {
+                var config = CreateLogic().ParseCommandLine("out", argv);
+                Assert.AreEqual(expected, config.WriteConfig.compression, "argv=" + argv);
+            }
+        }
+    }
 }


### PR DESCRIPTION
## Summary

When the user unchecks **Use zlib compression** in MSConvertGUI, the constructed command line omits `--zlib` entirely. `msconvert.exe`'s CLI defaults `--zlib` to `true`, and so does MSConvertGUI's own in-process parser (`MainLogic.cs:144` initializes `zlib = true` to match msconvert.exe). The result: unchecking the box had no effect on either path — the displayed/saved command line silently re-enabled compression when handed back to `msconvert.exe`, **and** the in-GUI conversion through `MainLogic` also kept compression on.

Fix:

* `ConstructCommandline()` now emits `--zlib=off` explicitly when the checkbox is unchecked (and `--zlib` when checked), so the GUI state actually reaches both consumers.
* `SetControlsFromCommandline()` round-tripping is tightened so a substring search for `--zlib` doesn't match `--zlib=off` and incorrectly tick the box.
* `--zlib=off` is recognized as a known token in the boolean-switch in `SetControlsFromCommandline` and in both `MainLogic` parsers — the pipe-separated argv parser and the `--config`-file parser (the latter pre-replaces `=` with whitespace, so the case there peeks the next token for `off`/`false`).
* Added a focused parser-only `[TestClass]` (`MainLogicParserTest`) in `MainLogicTest.cs` that asserts the resulting `WriteConfig.compression` for the no-flag, `--zlib`, and `--zlib=off` cases. This test runs without msconvert.exe or vendor data so it executes in any environment that can load the assembly.

Fixes #4243 

## Test plan

- [ ] `MainLogicParserTest.ZlibFlagRoundTrip` passes.
- [ ] Launch MSConvertGUI, uncheck **Use zlib compression**, click **Show command-line** — verify the line contains `--zlib=off`.
- [ ] Re-check the box, click again — verify the line contains `--zlib` (no `=off`).
- [ ] Save a preset with the box unchecked, reload it — verify the checkbox remains unchecked. Repeat with the box checked.
- [ ] Convert a file in MSConvertGUI with the box unchecked — verify the output `.mzML` has uncompressed binary arrays (i.e., the in-GUI conversion path also honors the unchecked state, not only the Show command-line output).