### PR TITLE
OspreySharp Stage 5 perf: SIMD SVM + parallel LOESS + parallel KDE

### DIFF
--- a/pwiz_tools/OspreySharp/Osprey-workflow.html
+++ b/pwiz_tools/OspreySharp/Osprey-workflow.html
@@ -504,13 +504,16 @@
   <p>
     <strong>End-to-end performance (3-file regression, Windows
     native, C: SSD source data, AV-scan excluded; all 8 cells
-    median-of-3 refreshed 2026-05-24):</strong>
-    Measured on the <code>test/integration-bucket3</code> branch
-    (PRs #38-#45 stacked, including the decoy gap-fill exclusion fix
-    AND the Welford → sum/n revert that recovered ~21 s on Stellar
-    Rust stage1to4) immediately after 3-file Astral straight-through
-    cross-impl bit-equality landed at 1e-9. Variance is &lt;5 s on
-    Stellar and &lt;90 s on Astral across the three repeats.
+    median-of-3 refreshed 2026-05-28 — round 3):</strong>
+    Measured on the <code>Skyline/work/20260527_svm_stage5_perf</code>
+    branch with Fix #1 landed (SIMD inner loops in
+    <code>LinearSvmClassifier.Train</code>). Round 3 walls run
+    ~20% slower than round 2 (2026-05-26 night) for both impls
+    uniformly — environmental drift, not a runtime change.  The
+    C#/Rust ratios are the load-bearing comparison; absolute walls
+    should be interpreted relative to the round-3 column on its own.
+    Variance is &lt;10 s on Stellar and &lt;90 s on Astral across
+    the three repeats.
   </p>
   <table style="margin: 8px 0; font-family: ui-monospace, SFMono-Regular, monospace; font-size: 11px; border-collapse: collapse;">
     <thead>
@@ -525,12 +528,12 @@
       </tr>
     </thead>
     <tbody>
-      <tr><td style="padding: 1px 12px 1px 0;">stage1to4</td><td style="text-align: right; padding: 1px 12px;">1:42</td><td style="text-align: right; padding: 1px 12px;">1:13</td><td style="text-align: right; padding: 1px 12px; color: #1a7f37;">0.72x (C# faster)</td><td style="text-align: right; padding: 1px 12px;">7:54</td><td style="text-align: right; padding: 1px 12px;">6:24</td><td style="text-align: right; padding: 1px 12px; color: #1a7f37;">0.81x (C# faster)</td></tr>
-      <tr><td style="padding: 1px 12px 1px 0;">stage5 (1st-pass FDR + plan)</td><td style="text-align: right; padding: 1px 12px;">1:14</td><td style="text-align: right; padding: 1px 12px;">2:04</td><td style="text-align: right; padding: 1px 12px; color: #b54708;">1.68x</td><td style="text-align: right; padding: 1px 12px;">1:27</td><td style="text-align: right; padding: 1px 12px;">5:12</td><td style="text-align: right; padding: 1px 12px; color: #b54708;">3.59x</td></tr>
-      <tr><td style="padding: 1px 12px 1px 0;">stage6 (rescore + gap-fill)</td><td style="text-align: right; padding: 1px 12px;">0:34</td><td style="text-align: right; padding: 1px 12px;">0:27</td><td style="text-align: right; padding: 1px 12px; color: #1a7f37;">0.81x (C# faster)</td><td style="text-align: right; padding: 1px 12px;">7:10</td><td style="text-align: right; padding: 1px 12px;">3:49</td><td style="text-align: right; padding: 1px 12px; color: #1a7f37;">0.53x (C# faster)</td></tr>
-      <tr><td style="padding: 1px 12px 1px 0;">stage7 (2nd-pass FDR + protein)</td><td style="text-align: right; padding: 1px 12px;">0:43</td><td style="text-align: right; padding: 1px 12px;">0:50</td><td style="text-align: right; padding: 1px 12px; color: #b54708;">1.17x</td><td style="text-align: right; padding: 1px 12px;">2:54</td><td style="text-align: right; padding: 1px 12px;">3:07</td><td style="text-align: right; padding: 1px 12px; color: #b54708;">1.07x</td></tr>
-      <tr><td style="padding: 1px 12px 1px 0;">blib write</td><td style="text-align: right; padding: 1px 12px;">0:19</td><td style="text-align: right; padding: 1px 12px;">0:02</td><td style="text-align: right; padding: 1px 12px; color: #1a7f37;">0.14x (C# faster)</td><td style="text-align: right; padding: 1px 12px;">2:02</td><td style="text-align: right; padding: 1px 12px;">0:07</td><td style="text-align: right; padding: 1px 12px; color: #1a7f37;">0.06x (C# faster)</td></tr>
-      <tr style="border-top: 1px solid #888;"><td style="padding: 1px 12px 1px 0;"><strong>Total</strong></td><td style="text-align: right; padding: 1px 12px;"><strong>4:33</strong></td><td style="text-align: right; padding: 1px 12px;"><strong>4:38</strong></td><td style="text-align: right; padding: 1px 12px;"><strong>1.02x (~tied)</strong></td><td style="text-align: right; padding: 1px 12px;"><strong>21:29</strong></td><td style="text-align: right; padding: 1px 12px;"><strong>18:41</strong></td><td style="text-align: right; padding: 1px 12px; color: #1a7f37;"><strong>0.87x (C# faster)</strong></td></tr>
+      <tr><td style="padding: 1px 12px 1px 0;">stage1to4</td><td style="text-align: right; padding: 1px 12px;">1:55</td><td style="text-align: right; padding: 1px 12px;">1:22</td><td style="text-align: right; padding: 1px 12px; color: #1a7f37;">0.72x (C# faster)</td><td style="text-align: right; padding: 1px 12px;">9:11</td><td style="text-align: right; padding: 1px 12px;">7:25</td><td style="text-align: right; padding: 1px 12px; color: #1a7f37;">0.81x (C# faster)</td></tr>
+      <tr><td style="padding: 1px 12px 1px 0;">stage5 (1st-pass FDR + plan)</td><td style="text-align: right; padding: 1px 12px;">1:21</td><td style="text-align: right; padding: 1px 12px;">1:58</td><td style="text-align: right; padding: 1px 12px; color: #b54708;">1.45x</td><td style="text-align: right; padding: 1px 12px;">1:43</td><td style="text-align: right; padding: 1px 12px;">6:20</td><td style="text-align: right; padding: 1px 12px; color: #b54708;">3.67x</td></tr>
+      <tr><td style="padding: 1px 12px 1px 0;">stage6 (rescore + gap-fill)</td><td style="text-align: right; padding: 1px 12px;">0:40</td><td style="text-align: right; padding: 1px 12px;">0:32</td><td style="text-align: right; padding: 1px 12px; color: #1a7f37;">0.80x (C# faster)</td><td style="text-align: right; padding: 1px 12px;">9:39</td><td style="text-align: right; padding: 1px 12px;">4:21</td><td style="text-align: right; padding: 1px 12px; color: #1a7f37;">0.45x (C# faster)</td></tr>
+      <tr><td style="padding: 1px 12px 1px 0;">stage7 (2nd-pass FDR + protein)</td><td style="text-align: right; padding: 1px 12px;">0:47</td><td style="text-align: right; padding: 1px 12px;">0:42</td><td style="text-align: right; padding: 1px 12px; color: #1a7f37;">0.89x (C# faster)</td><td style="text-align: right; padding: 1px 12px;">3:13</td><td style="text-align: right; padding: 1px 12px;">2:30</td><td style="text-align: right; padding: 1px 12px; color: #1a7f37;">0.78x (C# faster)</td></tr>
+      <tr><td style="padding: 1px 12px 1px 0;">blib write</td><td style="text-align: right; padding: 1px 12px;">0:22</td><td style="text-align: right; padding: 1px 12px;">0:03</td><td style="text-align: right; padding: 1px 12px; color: #1a7f37;">0.15x (C# faster)</td><td style="text-align: right; padding: 1px 12px;">1:41</td><td style="text-align: right; padding: 1px 12px;">0:09</td><td style="text-align: right; padding: 1px 12px; color: #1a7f37;">0.08x (C# faster)</td></tr>
+      <tr style="border-top: 1px solid #888;"><td style="padding: 1px 12px 1px 0;"><strong>Total</strong></td><td style="text-align: right; padding: 1px 12px;"><strong>5:05</strong></td><td style="text-align: right; padding: 1px 12px;"><strong>4:39</strong></td><td style="text-align: right; padding: 1px 12px; color: #1a7f37;"><strong>0.92x (C# faster)</strong></td><td style="text-align: right; padding: 1px 12px;"><strong>25:32</strong></td><td style="text-align: right; padding: 1px 12px;"><strong>21:00</strong></td><td style="text-align: right; padding: 1px 12px; color: #1a7f37;"><strong>0.82x (C# faster)</strong></td></tr>
     </tbody>
   </table>
   <p>
@@ -549,12 +552,17 @@
     </li>
     <li>
       <strong>stage5</strong> (first-pass FDR + reconciliation planning):
-      Rust faster on both datasets (the headline 1.67&times; / 3.62&times;
-      C#/Rust ratios in the Windows table are this stage). Percolator SVM
-      training runs the three folds in parallel on the C# side
-      (<code>ParallelEx</code>); per-fold wall is around 92s on a
-      16-thread Stellar 3-file run, but the inner SVM loop overhead in
-      managed code still trails the Rust <code>par_iter</code> path.
+      Rust still faster (1.45&times; Stellar / 3.67&times; Astral in the
+      Windows table). Fix #1 (SIMD inner loops via
+      <code>System.Numerics.Vector&lt;double&gt;</code> in
+      <code>LinearSvmClassifier.Train</code>) closed the SVM-Train CPU
+      gap at the 1-file scale (-31% Stellar Stage 5 wall isolated), but
+      at Astral 3-file scale Stage 5 wall is no longer SVM-dominated —
+      the 300K-sample training subsampling cap means Train CPU is
+      similar at 1-file and 3-file, and reconciliation planning across
+      3 large Astral files now dwarfs Train. Closing the residual Astral
+      Stage 5 gap requires a separate fix in the reconciliation path,
+      which is the next sprint target after Fix #1 lands.
     </li>
     <li>
       <strong>stage6</strong> (per-file rescore + gap-fill + reconciled
@@ -564,18 +572,23 @@
     </li>
     <li>
       <strong>stage7</strong> (second-pass Percolator + protein FDR):
-      Rust slightly faster (1.07&ndash;1.33&times; depending on
-      config), driven by Rust's <code>par_iter</code> SVM training in
-      the second-pass Percolator. Protein parsimony's
-      subset-elimination uses <code>HashSet&lt;string&gt;</code> on
-      the C# side; the 2nd-pass FDR sidecar overlay
-      (<code>FdrScoresSidecar.TryReadOverlay</code>) reads only the
-      sidecar and overlays scores by entry_id without re-reading the
-      source parquet. (Note: OspreySharp emits the 2nd-pass
-      Percolator work under a separate <code>[STAGE-WALL]
-      second-pass-fdr</code> marker; the totals above combine that
-      with the <code>stage7</code> marker so the column compares
-      like-for-like with Rust's single <code>stage7</code> marker.)
+      C# now faster than Rust on Stage 7 across every storage
+      configuration after Fix #1 (Windows 0.89&times; Stellar /
+      0.78&times; Astral; <code>/mnt/c</code> 0.75&times; / 0.74&times;;
+      <code>/home</code> 0.94&times; / 0.79&times;). Stage 7 is heavily
+      SVM-dominated — the 2nd-pass FDR re-runs Percolator on the
+      reconciled feature pool, and the same SIMD-vectorized
+      <code>LinearSvmClassifier.Train</code> that Fix #1 sped up
+      runs here too. Protein parsimony's subset-elimination uses
+      <code>HashSet&lt;string&gt;</code> on the C# side; the 2nd-pass
+      FDR sidecar overlay (<code>FdrScoresSidecar.TryReadOverlay</code>)
+      reads only the sidecar and overlays scores by entry_id without
+      re-reading the source parquet. (Note: OspreySharp emits the
+      2nd-pass Percolator work under a separate
+      <code>[STAGE-WALL] second-pass-fdr</code> marker; the totals
+      above combine that with the <code>stage7</code> marker so the
+      column compares like-for-like with Rust's single
+      <code>stage7</code> marker.)
     </li>
     <li>
       <strong>blib write</strong>: C# faster on both datasets.
@@ -588,21 +601,21 @@
   </ul>
   <p>
     <strong>WSL Linux end-to-end performance &mdash; ext4 inside
-    <code>/home</code> (median-of-3 2026-05-24)</strong>:
+    <code>/home</code> (median-of-3 2026-05-28 round 3 post
+    Fix #1)</strong>:
     Same workstation as the Windows benchmark above, WSL2 Ubuntu
     22.04, .NET 8.0.421, Rust 1.95.0. The WSL <code>ext4.vhdx</code>
-    is on the C: SSD (relocated this session via
-    <code>wsl --export</code>/<code>--import</code> from a D: HDD
-    location, where it had drifted at some point between the prior
-    2026-05-18 measurement and now). Test data is staged inside
-    the VHDX at <code>/home/brendanx/test/osprey-runs</code>, so
-    every read and write goes through Linux ext4 with no 9P drvfs
-    crossing. This is the &ldquo;Linux-native&rdquo; configuration:
-    Rust is 23-25% faster than C# in this regime (Stellar 3:56 vs
-    4:52; Astral 15:38 vs 19:31), matching the historical pattern
-    of native Linux ext4 favouring the Rust toolchain. Cross-OS
-    output parity is gated separately
-    by <code>Test-Snapshot.ps1</code> at 1e-6
+    is on the C: SSD; test data is staged inside the VHDX at
+    <code>/home/brendanx/test/osprey-runs</code>, so every read and
+    write goes through Linux ext4 with no 9P drvfs crossing. This
+    is the &ldquo;Linux-native&rdquo; configuration. With Fix #1
+    (SIMD inner loops in <code>LinearSvmClassifier.Train</code>) the
+    cross-impl gap closes considerably here: Rust beats C# by only
+    4% on Stellar (3:58 vs 4:09, was 23%) and 15% on Astral (16:06
+    vs 18:31, was 25%). Stage 7 ratio dropped from 1.33&times;
+    Stellar / 1.17&times; Astral to 0.94&times; / 0.79&times; — same
+    SVM kernel ran in 2nd-pass FDR. Cross-OS output parity is
+    gated separately by <code>Test-Snapshot.ps1</code> at 1e-6
     tolerance on four median-polish columns
     (<code>median_polish_cosine</code>, <code>_residual_ratio</code>,
     <code>_min_fragment_r2</code>, <code>_residual_correlation</code>)
@@ -626,17 +639,18 @@
       </tr>
     </thead>
     <tbody>
-      <tr><td style="padding: 1px 12px 1px 0;">stage1to4</td><td style="text-align: right; padding: 1px 12px;">1:44</td><td style="text-align: right; padding: 1px 12px;">1:19</td><td style="text-align: right; padding: 1px 12px; color: #1a7f37;">0.76x (C# faster)</td><td style="text-align: right; padding: 1px 12px;">6:40</td><td style="text-align: right; padding: 1px 12px;">6:47</td><td style="text-align: right; padding: 1px 12px;">1.02x (~tied)</td></tr>
-      <tr><td style="padding: 1px 12px 1px 0;">stage5 (1st-pass FDR + plan)</td><td style="text-align: right; padding: 1px 12px;">1:05</td><td style="text-align: right; padding: 1px 12px;">2:09</td><td style="text-align: right; padding: 1px 12px; color: #b54708;">1.98x</td><td style="text-align: right; padding: 1px 12px;">1:14</td><td style="text-align: right; padding: 1px 12px;">5:17</td><td style="text-align: right; padding: 1px 12px; color: #b54708;">4.25x</td></tr>
-      <tr><td style="padding: 1px 12px 1px 0;">stage6 (rescore + gap-fill)</td><td style="text-align: right; padding: 1px 12px;">0:21</td><td style="text-align: right; padding: 1px 12px;">0:27</td><td style="text-align: right; padding: 1px 12px; color: #b54708;">1.27x</td><td style="text-align: right; padding: 1px 12px;">3:54</td><td style="text-align: right; padding: 1px 12px;">3:53</td><td style="text-align: right; padding: 1px 12px;">0.99x (~tied)</td></tr>
-      <tr><td style="padding: 1px 12px 1px 0;">stage7 (2nd-pass FDR + protein)</td><td style="text-align: right; padding: 1px 12px;">0:39</td><td style="text-align: right; padding: 1px 12px;">0:52</td><td style="text-align: right; padding: 1px 12px; color: #b54708;">1.33x</td><td style="text-align: right; padding: 1px 12px;">2:55</td><td style="text-align: right; padding: 1px 12px;">3:24</td><td style="text-align: right; padding: 1px 12px; color: #b54708;">1.17x</td></tr>
-      <tr><td style="padding: 1px 12px 1px 0;">blib write</td><td style="text-align: right; padding: 1px 12px;">0:06</td><td style="text-align: right; padding: 1px 12px;">0:03</td><td style="text-align: right; padding: 1px 12px; color: #1a7f37;">0.54x (C# faster)</td><td style="text-align: right; padding: 1px 12px;">0:53</td><td style="text-align: right; padding: 1px 12px;">0:09</td><td style="text-align: right; padding: 1px 12px; color: #1a7f37;">0.18x (C# faster)</td></tr>
-      <tr style="border-top: 1px solid #888;"><td style="padding: 1px 12px 1px 0;"><strong>Total</strong></td><td style="text-align: right; padding: 1px 12px;"><strong>3:56</strong></td><td style="text-align: right; padding: 1px 12px;"><strong>4:52</strong></td><td style="text-align: right; padding: 1px 12px; color: #b54708;"><strong>1.23x (Rust faster)</strong></td><td style="text-align: right; padding: 1px 12px;"><strong>15:38</strong></td><td style="text-align: right; padding: 1px 12px;"><strong>19:31</strong></td><td style="text-align: right; padding: 1px 12px; color: #b54708;"><strong>1.25x (Rust faster)</strong></td></tr>
+      <tr><td style="padding: 1px 12px 1px 0;">stage1to4</td><td style="text-align: right; padding: 1px 12px;">1:46</td><td style="text-align: right; padding: 1px 12px;">1:20</td><td style="text-align: right; padding: 1px 12px; color: #1a7f37;">0.76x (C# faster)</td><td style="text-align: right; padding: 1px 12px;">7:08</td><td style="text-align: right; padding: 1px 12px;">7:13</td><td style="text-align: right; padding: 1px 12px;">1.01x (~tied)</td></tr>
+      <tr><td style="padding: 1px 12px 1px 0;">stage5 (1st-pass FDR + plan)</td><td style="text-align: right; padding: 1px 12px;">1:06</td><td style="text-align: right; padding: 1px 12px;">1:40</td><td style="text-align: right; padding: 1px 12px; color: #b54708;">1.51x</td><td style="text-align: right; padding: 1px 12px;">1:14</td><td style="text-align: right; padding: 1px 12px;">5:01</td><td style="text-align: right; padding: 1px 12px; color: #b54708;">4.07x</td></tr>
+      <tr><td style="padding: 1px 12px 1px 0;">stage6 (rescore + gap-fill)</td><td style="text-align: right; padding: 1px 12px;">0:21</td><td style="text-align: right; padding: 1px 12px;">0:27</td><td style="text-align: right; padding: 1px 12px; color: #b54708;">1.28x</td><td style="text-align: right; padding: 1px 12px;">3:59</td><td style="text-align: right; padding: 1px 12px;">3:52</td><td style="text-align: right; padding: 1px 12px;">0.97x (~tied)</td></tr>
+      <tr><td style="padding: 1px 12px 1px 0;">stage7 (2nd-pass FDR + protein)</td><td style="text-align: right; padding: 1px 12px;">0:39</td><td style="text-align: right; padding: 1px 12px;">0:36</td><td style="text-align: right; padding: 1px 12px; color: #1a7f37;">0.94x (C# faster)</td><td style="text-align: right; padding: 1px 12px;">2:50</td><td style="text-align: right; padding: 1px 12px;">2:14</td><td style="text-align: right; padding: 1px 12px; color: #1a7f37;">0.79x (C# faster)</td></tr>
+      <tr><td style="padding: 1px 12px 1px 0;">blib write</td><td style="text-align: right; padding: 1px 12px;">0:06</td><td style="text-align: right; padding: 1px 12px;">0:03</td><td style="text-align: right; padding: 1px 12px; color: #1a7f37;">0.52x (C# faster)</td><td style="text-align: right; padding: 1px 12px;">0:54</td><td style="text-align: right; padding: 1px 12px;">0:10</td><td style="text-align: right; padding: 1px 12px; color: #1a7f37;">0.18x (C# faster)</td></tr>
+      <tr style="border-top: 1px solid #888;"><td style="padding: 1px 12px 1px 0;"><strong>Total</strong></td><td style="text-align: right; padding: 1px 12px;"><strong>3:58</strong></td><td style="text-align: right; padding: 1px 12px;"><strong>4:09</strong></td><td style="text-align: right; padding: 1px 12px; color: #b54708;"><strong>1.04x (Rust faster)</strong></td><td style="text-align: right; padding: 1px 12px;"><strong>16:06</strong></td><td style="text-align: right; padding: 1px 12px;"><strong>18:31</strong></td><td style="text-align: right; padding: 1px 12px; color: #b54708;"><strong>1.15x (Rust faster)</strong></td></tr>
     </tbody>
   </table>
   <p>
     <strong>WSL Linux end-to-end performance &mdash; 9P drvfs to
-    Windows <code>/mnt/c</code> (median-of-3 2026-05-24)</strong>:
+    Windows <code>/mnt/c</code> (median-of-3 2026-05-28 round 3
+    post Fix #1)</strong>:
     Same WSL distro and binaries, but with test data living on the
     Windows side at <code>C:\test\osprey-runs</code> (accessed as
     <code>/mnt/c/test/osprey-runs</code> from inside WSL). Every
@@ -645,13 +659,15 @@
     default when they keep their data on the Windows filesystem and
     just run the pipeline from a WSL shell. 9P adds substantial
     per-syscall overhead (240 vs 14 files/s for fsync'd metadata
-    writes; raw I/O bench below) but the absolute totals are still
-    workable, and the C#/Rust ratio collapses to near 1.0&times; on
-    both datasets &mdash; C# and Rust are essentially tied here, and
-    on Stellar C# is marginally faster. The 9P penalty applies to
-    both implementations equally, so the cross-impl story is
-    unchanged: C# is not a performance sacrifice on the storage path
-    most users have.
+    writes; raw I/O bench below). With Fix #1 (SIMD inner loops in
+    <code>LinearSvmClassifier.Train</code>) C# now beats Rust by 14%
+    on Stellar and 5% on Astral at the total wall on this storage
+    path, despite the 9P penalty applying equally to both impls.
+    Stage 7 ratio dropped from 1.07&times; (Stellar) and 1.11&times;
+    (Astral) to 0.75&times; / 0.74&times; — the same SVM kernel that
+    Fix #1 vectorized runs in 2nd-pass FDR too, and the SVM is a
+    much larger fraction of Stage 7 wall than of Stage 5 at 3-file
+    scale (where reconciliation planning dominates).
   </p>
   <table style="margin: 8px 0; font-family: ui-monospace, SFMono-Regular, monospace; font-size: 11px; border-collapse: collapse;">
     <thead>
@@ -666,12 +682,12 @@
       </tr>
     </thead>
     <tbody>
-      <tr><td style="padding: 1px 12px 1px 0;">stage1to4</td><td style="text-align: right; padding: 1px 12px;">3:11</td><td style="text-align: right; padding: 1px 12px;">2:03</td><td style="text-align: right; padding: 1px 12px; color: #1a7f37;">0.65x (C# faster)</td><td style="text-align: right; padding: 1px 12px;">12:51</td><td style="text-align: right; padding: 1px 12px;">9:49</td><td style="text-align: right; padding: 1px 12px; color: #1a7f37;">0.76x (C# faster)</td></tr>
-      <tr><td style="padding: 1px 12px 1px 0;">stage5 (1st-pass FDR + plan)</td><td style="text-align: right; padding: 1px 12px;">1:06</td><td style="text-align: right; padding: 1px 12px;">2:12</td><td style="text-align: right; padding: 1px 12px; color: #b54708;">2.00x</td><td style="text-align: right; padding: 1px 12px;">1:17</td><td style="text-align: right; padding: 1px 12px;">5:23</td><td style="text-align: right; padding: 1px 12px; color: #b54708;">4.20x</td></tr>
-      <tr><td style="padding: 1px 12px 1px 0;">stage6 (rescore + gap-fill)</td><td style="text-align: right; padding: 1px 12px;">0:53</td><td style="text-align: right; padding: 1px 12px;">0:39</td><td style="text-align: right; padding: 1px 12px; color: #1a7f37;">0.75x (C# faster)</td><td style="text-align: right; padding: 1px 12px;">5:41</td><td style="text-align: right; padding: 1px 12px;">5:02</td><td style="text-align: right; padding: 1px 12px; color: #1a7f37;">0.88x (C# faster)</td></tr>
-      <tr><td style="padding: 1px 12px 1px 0;">stage7 (2nd-pass FDR + protein)</td><td style="text-align: right; padding: 1px 12px;">0:48</td><td style="text-align: right; padding: 1px 12px;">0:51</td><td style="text-align: right; padding: 1px 12px;">1.07x (~tied)</td><td style="text-align: right; padding: 1px 12px;">3:08</td><td style="text-align: right; padding: 1px 12px;">3:30</td><td style="text-align: right; padding: 1px 12px; color: #b54708;">1.11x</td></tr>
-      <tr><td style="padding: 1px 12px 1px 0;">blib write</td><td style="text-align: right; padding: 1px 12px;">0:06</td><td style="text-align: right; padding: 1px 12px;">0:09</td><td style="text-align: right; padding: 1px 12px; color: #b54708;">1.40x</td><td style="text-align: right; padding: 1px 12px;">0:56</td><td style="text-align: right; padding: 1px 12px;">0:24</td><td style="text-align: right; padding: 1px 12px; color: #1a7f37;">0.43x (C# faster)</td></tr>
-      <tr style="border-top: 1px solid #888;"><td style="padding: 1px 12px 1px 0;"><strong>Total</strong></td><td style="text-align: right; padding: 1px 12px;"><strong>6:05</strong></td><td style="text-align: right; padding: 1px 12px;"><strong>5:56</strong></td><td style="text-align: right; padding: 1px 12px;"><strong>0.97x (~tied)</strong></td><td style="text-align: right; padding: 1px 12px;"><strong>23:54</strong></td><td style="text-align: right; padding: 1px 12px;"><strong>24:09</strong></td><td style="text-align: right; padding: 1px 12px;"><strong>1.01x (~tied)</strong></td></tr>
+      <tr><td style="padding: 1px 12px 1px 0;">stage1to4</td><td style="text-align: right; padding: 1px 12px;">3:13</td><td style="text-align: right; padding: 1px 12px;">2:04</td><td style="text-align: right; padding: 1px 12px; color: #1a7f37;">0.64x (C# faster)</td><td style="text-align: right; padding: 1px 12px;">13:06</td><td style="text-align: right; padding: 1px 12px;">9:51</td><td style="text-align: right; padding: 1px 12px; color: #1a7f37;">0.75x (C# faster)</td></tr>
+      <tr><td style="padding: 1px 12px 1px 0;">stage5 (1st-pass FDR + plan)</td><td style="text-align: right; padding: 1px 12px;">1:06</td><td style="text-align: right; padding: 1px 12px;">1:43</td><td style="text-align: right; padding: 1px 12px; color: #b54708;">1.56x</td><td style="text-align: right; padding: 1px 12px;">1:16</td><td style="text-align: right; padding: 1px 12px;">5:10</td><td style="text-align: right; padding: 1px 12px; color: #b54708;">4.07x</td></tr>
+      <tr><td style="padding: 1px 12px 1px 0;">stage6 (rescore + gap-fill)</td><td style="text-align: right; padding: 1px 12px;">0:56</td><td style="text-align: right; padding: 1px 12px;">0:41</td><td style="text-align: right; padding: 1px 12px; color: #1a7f37;">0.74x (C# faster)</td><td style="text-align: right; padding: 1px 12px;">5:55</td><td style="text-align: right; padding: 1px 12px;">4:57</td><td style="text-align: right; padding: 1px 12px; color: #1a7f37;">0.84x (C# faster)</td></tr>
+      <tr><td style="padding: 1px 12px 1px 0;">stage7 (2nd-pass FDR + protein)</td><td style="text-align: right; padding: 1px 12px;">0:48</td><td style="text-align: right; padding: 1px 12px;">0:36</td><td style="text-align: right; padding: 1px 12px; color: #1a7f37;">0.75x (C# faster)</td><td style="text-align: right; padding: 1px 12px;">3:07</td><td style="text-align: right; padding: 1px 12px;">2:18</td><td style="text-align: right; padding: 1px 12px; color: #1a7f37;">0.74x (C# faster)</td></tr>
+      <tr><td style="padding: 1px 12px 1px 0;">blib write</td><td style="text-align: right; padding: 1px 12px;">0:06</td><td style="text-align: right; padding: 1px 12px;">0:10</td><td style="text-align: right; padding: 1px 12px; color: #b54708;">1.52x</td><td style="text-align: right; padding: 1px 12px;">0:53</td><td style="text-align: right; padding: 1px 12px;">0:27</td><td style="text-align: right; padding: 1px 12px; color: #1a7f37;">0.50x (C# faster)</td></tr>
+      <tr style="border-top: 1px solid #888;"><td style="padding: 1px 12px 1px 0;"><strong>Total</strong></td><td style="text-align: right; padding: 1px 12px;"><strong>6:10</strong></td><td style="text-align: right; padding: 1px 12px;"><strong>5:17</strong></td><td style="text-align: right; padding: 1px 12px; color: #1a7f37;"><strong>0.86x (C# faster)</strong></td><td style="text-align: right; padding: 1px 12px;"><strong>24:20</strong></td><td style="text-align: right; padding: 1px 12px;"><strong>23:08</strong></td><td style="text-align: right; padding: 1px 12px; color: #1a7f37;"><strong>0.95x (C# faster)</strong></td></tr>
     </tbody>
   </table>
   <p>

--- a/pwiz_tools/OspreySharp/Osprey-workflow.html
+++ b/pwiz_tools/OspreySharp/Osprey-workflow.html
@@ -504,16 +504,20 @@
   <p>
     <strong>End-to-end performance (3-file regression, Windows
     native, C: SSD source data, AV-scan excluded; all 8 cells
-    median-of-3 refreshed 2026-05-28 — round 3):</strong>
+    median-of-3 refreshed 2026-05-29 — round 4):</strong>
     Measured on the <code>Skyline/work/20260527_svm_stage5_perf</code>
-    branch with Fix #1 landed (SIMD inner loops in
-    <code>LinearSvmClassifier.Train</code>). Round 3 walls run
-    ~20% slower than round 2 (2026-05-26 night) for both impls
-    uniformly — environmental drift, not a runtime change.  The
-    C#/Rust ratios are the load-bearing comparison; absolute walls
-    should be interpreted relative to the round-3 column on its own.
-    Variance is &lt;10 s on Stellar and &lt;90 s on Astral across
-    the three repeats.
+    branch with Fix #1 + Fix #5b + Fix #6 landed (SIMD inner loops
+    in <code>LinearSvmClassifier.Train</code>, parallel LOESS outer
+    loop, parallel KDE Pdf binning in <code>PepEstimator.Fit</code>).
+    Stage 5/6 boundaries now aligned cross-impl: Rust labels stage5 =
+    percolator + protein FDR, stage6 = reconciliation + rescore +
+    gap-fill; C# previously folded reconciliation into stage5, which
+    is the artifact that created the historical &ldquo;Astral stage5
+    4&times;&rdquo; figure.  Measure-Pipeline.ps1 now derives the
+    reconciliation portion from the <code>[TIMING]</code> markers on
+    the C# side and shifts it into stage6, so the per-stage cells
+    here compare like-for-like.  Variance is &lt;7s on Stellar and
+    &lt;25s on Astral across the three repeats.
   </p>
   <table style="margin: 8px 0; font-family: ui-monospace, SFMono-Regular, monospace; font-size: 11px; border-collapse: collapse;">
     <thead>
@@ -528,12 +532,12 @@
       </tr>
     </thead>
     <tbody>
-      <tr><td style="padding: 1px 12px 1px 0;">stage1to4</td><td style="text-align: right; padding: 1px 12px;">1:55</td><td style="text-align: right; padding: 1px 12px;">1:22</td><td style="text-align: right; padding: 1px 12px; color: #1a7f37;">0.72x (C# faster)</td><td style="text-align: right; padding: 1px 12px;">9:11</td><td style="text-align: right; padding: 1px 12px;">7:25</td><td style="text-align: right; padding: 1px 12px; color: #1a7f37;">0.81x (C# faster)</td></tr>
-      <tr><td style="padding: 1px 12px 1px 0;">stage5 (1st-pass FDR + plan)</td><td style="text-align: right; padding: 1px 12px;">1:21</td><td style="text-align: right; padding: 1px 12px;">1:58</td><td style="text-align: right; padding: 1px 12px; color: #b54708;">1.45x</td><td style="text-align: right; padding: 1px 12px;">1:43</td><td style="text-align: right; padding: 1px 12px;">6:20</td><td style="text-align: right; padding: 1px 12px; color: #b54708;">3.67x</td></tr>
-      <tr><td style="padding: 1px 12px 1px 0;">stage6 (rescore + gap-fill)</td><td style="text-align: right; padding: 1px 12px;">0:40</td><td style="text-align: right; padding: 1px 12px;">0:32</td><td style="text-align: right; padding: 1px 12px; color: #1a7f37;">0.80x (C# faster)</td><td style="text-align: right; padding: 1px 12px;">9:39</td><td style="text-align: right; padding: 1px 12px;">4:21</td><td style="text-align: right; padding: 1px 12px; color: #1a7f37;">0.45x (C# faster)</td></tr>
-      <tr><td style="padding: 1px 12px 1px 0;">stage7 (2nd-pass FDR + protein)</td><td style="text-align: right; padding: 1px 12px;">0:47</td><td style="text-align: right; padding: 1px 12px;">0:42</td><td style="text-align: right; padding: 1px 12px; color: #1a7f37;">0.89x (C# faster)</td><td style="text-align: right; padding: 1px 12px;">3:13</td><td style="text-align: right; padding: 1px 12px;">2:30</td><td style="text-align: right; padding: 1px 12px; color: #1a7f37;">0.78x (C# faster)</td></tr>
-      <tr><td style="padding: 1px 12px 1px 0;">blib write</td><td style="text-align: right; padding: 1px 12px;">0:22</td><td style="text-align: right; padding: 1px 12px;">0:03</td><td style="text-align: right; padding: 1px 12px; color: #1a7f37;">0.15x (C# faster)</td><td style="text-align: right; padding: 1px 12px;">1:41</td><td style="text-align: right; padding: 1px 12px;">0:09</td><td style="text-align: right; padding: 1px 12px; color: #1a7f37;">0.08x (C# faster)</td></tr>
-      <tr style="border-top: 1px solid #888;"><td style="padding: 1px 12px 1px 0;"><strong>Total</strong></td><td style="text-align: right; padding: 1px 12px;"><strong>5:05</strong></td><td style="text-align: right; padding: 1px 12px;"><strong>4:39</strong></td><td style="text-align: right; padding: 1px 12px; color: #1a7f37;"><strong>0.92x (C# faster)</strong></td><td style="text-align: right; padding: 1px 12px;"><strong>25:32</strong></td><td style="text-align: right; padding: 1px 12px;"><strong>21:00</strong></td><td style="text-align: right; padding: 1px 12px; color: #1a7f37;"><strong>0.82x (C# faster)</strong></td></tr>
+      <tr><td style="padding: 1px 12px 1px 0;">stage1to4</td><td style="text-align: right; padding: 1px 12px;">1:54</td><td style="text-align: right; padding: 1px 12px;">1:19</td><td style="text-align: right; padding: 1px 12px; color: #1a7f37;">0.70x (C# faster)</td><td style="text-align: right; padding: 1px 12px;">9:09</td><td style="text-align: right; padding: 1px 12px;">7:17</td><td style="text-align: right; padding: 1px 12px; color: #1a7f37;">0.80x (C# faster)</td></tr>
+      <tr><td style="padding: 1px 12px 1px 0;">stage5 (1st-pass FDR, aligned)</td><td style="text-align: right; padding: 1px 12px;">1:21</td><td style="text-align: right; padding: 1px 12px;">1:14</td><td style="text-align: right; padding: 1px 12px; color: #1a7f37;">0.92x (C# faster)</td><td style="text-align: right; padding: 1px 12px;">1:42</td><td style="text-align: right; padding: 1px 12px;">1:14</td><td style="text-align: right; padding: 1px 12px; color: #1a7f37;">0.73x (C# faster)</td></tr>
+      <tr><td style="padding: 1px 12px 1px 0;">stage6 (reconciliation + rescore, aligned)</td><td style="text-align: right; padding: 1px 12px;">0:40</td><td style="text-align: right; padding: 1px 12px;">0:42</td><td style="text-align: right; padding: 1px 12px;">1.06x (~tied)</td><td style="text-align: right; padding: 1px 12px;">7:58</td><td style="text-align: right; padding: 1px 12px;">4:55</td><td style="text-align: right; padding: 1px 12px; color: #1a7f37;">0.62x (C# faster)</td></tr>
+      <tr><td style="padding: 1px 12px 1px 0;">stage7 (2nd-pass FDR + protein)</td><td style="text-align: right; padding: 1px 12px;">0:47</td><td style="text-align: right; padding: 1px 12px;">0:42</td><td style="text-align: right; padding: 1px 12px; color: #1a7f37;">0.91x (C# faster)</td><td style="text-align: right; padding: 1px 12px;">3:14</td><td style="text-align: right; padding: 1px 12px;">2:30</td><td style="text-align: right; padding: 1px 12px; color: #1a7f37;">0.78x (C# faster)</td></tr>
+      <tr><td style="padding: 1px 12px 1px 0;">blib write</td><td style="text-align: right; padding: 1px 12px;">0:19</td><td style="text-align: right; padding: 1px 12px;">0:03</td><td style="text-align: right; padding: 1px 12px; color: #1a7f37;">0.17x (C# faster)</td><td style="text-align: right; padding: 1px 12px;">1:53</td><td style="text-align: right; padding: 1px 12px;">0:09</td><td style="text-align: right; padding: 1px 12px; color: #1a7f37;">0.08x (C# faster)</td></tr>
+      <tr style="border-top: 1px solid #888;"><td style="padding: 1px 12px 1px 0;"><strong>Total</strong></td><td style="text-align: right; padding: 1px 12px;"><strong>5:03</strong></td><td style="text-align: right; padding: 1px 12px;"><strong>4:01</strong></td><td style="text-align: right; padding: 1px 12px; color: #1a7f37;"><strong>0.79x (C# faster)</strong></td><td style="text-align: right; padding: 1px 12px;"><strong>24:26</strong></td><td style="text-align: right; padding: 1px 12px;"><strong>16:10</strong></td><td style="text-align: right; padding: 1px 12px; color: #1a7f37;"><strong>0.66x (C# faster)</strong></td></tr>
     </tbody>
   </table>
   <p>
@@ -551,35 +555,46 @@
       <code>ProcessFile</code> calls.
     </li>
     <li>
-      <strong>stage5</strong> (first-pass FDR + reconciliation planning):
-      Rust still faster (1.45&times; Stellar / 3.67&times; Astral in the
-      Windows table). Fix #1 (SIMD inner loops via
-      <code>System.Numerics.Vector&lt;double&gt;</code> in
-      <code>LinearSvmClassifier.Train</code>) closed the SVM-Train CPU
-      gap at the 1-file scale (-31% Stellar Stage 5 wall isolated), but
-      at Astral 3-file scale Stage 5 wall is no longer SVM-dominated —
-      the 300K-sample training subsampling cap means Train CPU is
-      similar at 1-file and 3-file, and reconciliation planning across
-      3 large Astral files now dwarfs Train. Closing the residual Astral
-      Stage 5 gap requires a separate fix in the reconciliation path,
-      which is the next sprint target after Fix #1 lands.
+      <strong>stage5</strong> (first-pass FDR — percolator + protein
+      FDR; reconciliation planning is now in stage6 per the alignment
+      noted above): C# is 8% faster on Stellar (1:14 vs 1:21) and
+      27% faster on Astral (1:14 vs 1:42).  Three fixes drove this:
+      Fix #1 SIMD-vectorized the SVM dual-coordinate-descent inner
+      loops via <code>System.Numerics.Vector&lt;double&gt;</code>;
+      Fix #6 parallelized <code>PepEstimator.Fit</code>'s KDE binning
+      loop (the same kernel-density work Rust ran under
+      <code>par_iter</code>); the SVM grid search + folds run under
+      <code>OspreyParallel.For</code> with a per-worker
+      <code>SvmTrainScratch</code> pool that holds the per-fold
+      buffers in gen-2 across the run.  At Astral 3-file scale the
+      stage5 wall is dominated by the percolator FDR loop itself.
     </li>
     <li>
-      <strong>stage6</strong> (per-file rescore + gap-fill + reconciled
-      parquet write-back): C# faster on both datasets (0.81&times;
-      Stellar, 0.53&times; Astral on Windows native). The Astral ratio
-      reflects the pooled-scratch XCorr fix landed 2026-05-19.
+      <strong>stage6</strong> (reconciliation planning + per-file
+      rescore + gap-fill + reconciled parquet write-back, aligned to
+      include the reconciliation portion that C# previously logged
+      under stage5): essentially tied on Stellar (1.06&times;, 0:42
+      vs 0:40); C# 38% faster on Astral (4:55 vs 7:58 on Windows
+      native).  Two fixes drove the Astral win: Fix #5b wrapped
+      <code>LoessRegression.LoessFitInternal</code>'s outer loop in
+      <code>Parallel.For</code> (the per-x-point local regressions
+      are independent; serial form burned ~130s of single-core CPU
+      across the 9 LOESS fits per pipeline run); the existing
+      pooled-scratch XCorr fix (2026-05-19) handles the rescore
+      portion. The Astral stage6 fold-in revealed that
+      reconciliation planning, not SVM training, was the dominant
+      pre-fix bottleneck.
     </li>
     <li>
       <strong>stage7</strong> (second-pass Percolator + protein FDR):
-      C# now faster than Rust on Stage 7 across every storage
-      configuration after Fix #1 (Windows 0.89&times; Stellar /
-      0.78&times; Astral; <code>/mnt/c</code> 0.75&times; / 0.74&times;;
-      <code>/home</code> 0.94&times; / 0.79&times;). Stage 7 is heavily
-      SVM-dominated — the 2nd-pass FDR re-runs Percolator on the
-      reconciled feature pool, and the same SIMD-vectorized
-      <code>LinearSvmClassifier.Train</code> that Fix #1 sped up
-      runs here too. Protein parsimony's subset-elimination uses
+      C# faster than Rust everywhere after Fix #1 + #6 (Windows
+      0.91&times; Stellar / 0.78&times; Astral; <code>/mnt/c</code>
+      0.75&times; / 0.72&times;). Stage 7 is heavily SVM-dominated
+      — the 2nd-pass FDR re-runs Percolator on the reconciled feature
+      pool, and the same SIMD-vectorized
+      <code>LinearSvmClassifier.Train</code> + parallel KDE
+      <code>PepEstimator.Fit</code> that lifted stage5 lift stage7
+      too. Protein parsimony's subset-elimination uses
       <code>HashSet&lt;string&gt;</code> on the C# side; the 2nd-pass
       FDR sidecar overlay (<code>FdrScoresSidecar.TryReadOverlay</code>)
       reads only the sidecar and overlays scores by entry_id without
@@ -601,30 +616,39 @@
   </ul>
   <p>
     <strong>WSL Linux end-to-end performance &mdash; ext4 inside
-    <code>/home</code> (median-of-3 2026-05-28 round 3 post
-    Fix #1)</strong>:
+    <code>/home</code> (median-of-3 2026-05-29 round 4 post
+    Fix #1 + #5b + #6)</strong>:
     Same workstation as the Windows benchmark above, WSL2 Ubuntu
-    22.04, .NET 8.0.421, Rust 1.95.0. The WSL <code>ext4.vhdx</code>
-    is on the C: SSD; test data is staged inside the VHDX at
-    <code>/home/brendanx/test/osprey-runs</code>, so every read and
-    write goes through Linux ext4 with no 9P drvfs crossing. This
-    is the &ldquo;Linux-native&rdquo; configuration. With Fix #1
-    (SIMD inner loops in <code>LinearSvmClassifier.Train</code>) the
-    cross-impl gap closes considerably here: Rust beats C# by only
-    4% on Stellar (3:58 vs 4:09, was 23%) and 15% on Astral (16:06
-    vs 18:31, was 25%). Stage 7 ratio dropped from 1.33&times;
-    Stellar / 1.17&times; Astral to 0.94&times; / 0.79&times; — same
-    SVM kernel ran in 2nd-pass FDR. Cross-OS output parity is
-    gated separately by <code>Test-Snapshot.ps1</code> at 1e-6
-    tolerance on four median-polish columns
-    (<code>median_polish_cosine</code>, <code>_residual_ratio</code>,
-    <code>_min_fragment_r2</code>, <code>_residual_correlation</code>)
-    because both runtimes delegate <code>Math.Log</code> and
-    <code>Math.Exp</code> to the host libm (Linux glibc vs Windows ucrt),
-    which differ at f64 ULP level. All other Stage 1-4 columns are
-    bit-equal cross-OS, and the cross-OS divergence in stage5 percolator
-    TSV output is bounded to a handful of formatted-float characters
-    per ~200 MB file.
+    22.04, .NET 8.0.421, Rust 1.95.0.  The WSL
+    <code>ext4.vhdx</code> is on the C: SSD; test data is staged
+    inside the VHDX at <code>/home/brendanx/test/osprey-runs</code>,
+    so every read and write goes through Linux ext4 with no 9P
+    drvfs crossing.  This is the &ldquo;Linux-native&rdquo;
+    configuration, historically the cell where Rust&apos;s lead was
+    largest (round 2 had Rust 23&ndash;25% faster).  Round 4 has C#
+    ahead by 7% on Stellar (3:41 vs 3:58) and 4% on Astral (15:57
+    vs 16:38) at the total wall.  The gap is tighter than the
+    Windows-native or <code>/mnt/c</code> cells because of an
+    asymmetric benefit at stage6 on native Linux ext4: Rust stage6
+    drops from 5:57 (<code>/mnt/c</code>) to 4:05
+    (<code>/home</code>) &ndash;32%; C# stage6 drops from 5:36 to
+    4:39 &ndash;17%.  After Fix #5b parallelized the LOESS planner,
+    C#&apos;s stage6 is largely CPU-bound; Rust&apos;s remaining
+    stage6 work is more I/O-heavy and benefits more from the
+    native filesystem.  Stage 5 (aligned) is tied on both datasets
+    (0.97&times; Stellar / 0.91&times; Astral); stage7 is
+    decisively C#-faster (0.93&times; / 0.78&times;).  Cross-OS
+    output parity is gated separately by
+    <code>Test-Snapshot.ps1</code> at 1e-6 tolerance on four
+    median-polish columns (<code>median_polish_cosine</code>,
+    <code>_residual_ratio</code>, <code>_min_fragment_r2</code>,
+    <code>_residual_correlation</code>) because both runtimes
+    delegate <code>Math.Log</code> and <code>Math.Exp</code> to the
+    host libm (Linux glibc vs Windows ucrt), which differ at f64
+    ULP level.  All other Stage 1-4 columns are bit-equal cross-OS,
+    and the cross-OS divergence in stage5 percolator TSV output is
+    bounded to a handful of formatted-float characters per ~200 MB
+    file.
   </p>
   <table style="margin: 8px 0; font-family: ui-monospace, SFMono-Regular, monospace; font-size: 11px; border-collapse: collapse;">
     <thead>
@@ -639,35 +663,39 @@
       </tr>
     </thead>
     <tbody>
-      <tr><td style="padding: 1px 12px 1px 0;">stage1to4</td><td style="text-align: right; padding: 1px 12px;">1:46</td><td style="text-align: right; padding: 1px 12px;">1:20</td><td style="text-align: right; padding: 1px 12px; color: #1a7f37;">0.76x (C# faster)</td><td style="text-align: right; padding: 1px 12px;">7:08</td><td style="text-align: right; padding: 1px 12px;">7:13</td><td style="text-align: right; padding: 1px 12px;">1.01x (~tied)</td></tr>
-      <tr><td style="padding: 1px 12px 1px 0;">stage5 (1st-pass FDR + plan)</td><td style="text-align: right; padding: 1px 12px;">1:06</td><td style="text-align: right; padding: 1px 12px;">1:40</td><td style="text-align: right; padding: 1px 12px; color: #b54708;">1.51x</td><td style="text-align: right; padding: 1px 12px;">1:14</td><td style="text-align: right; padding: 1px 12px;">5:01</td><td style="text-align: right; padding: 1px 12px; color: #b54708;">4.07x</td></tr>
-      <tr><td style="padding: 1px 12px 1px 0;">stage6 (rescore + gap-fill)</td><td style="text-align: right; padding: 1px 12px;">0:21</td><td style="text-align: right; padding: 1px 12px;">0:27</td><td style="text-align: right; padding: 1px 12px; color: #b54708;">1.28x</td><td style="text-align: right; padding: 1px 12px;">3:59</td><td style="text-align: right; padding: 1px 12px;">3:52</td><td style="text-align: right; padding: 1px 12px;">0.97x (~tied)</td></tr>
-      <tr><td style="padding: 1px 12px 1px 0;">stage7 (2nd-pass FDR + protein)</td><td style="text-align: right; padding: 1px 12px;">0:39</td><td style="text-align: right; padding: 1px 12px;">0:36</td><td style="text-align: right; padding: 1px 12px; color: #1a7f37;">0.94x (C# faster)</td><td style="text-align: right; padding: 1px 12px;">2:50</td><td style="text-align: right; padding: 1px 12px;">2:14</td><td style="text-align: right; padding: 1px 12px; color: #1a7f37;">0.79x (C# faster)</td></tr>
-      <tr><td style="padding: 1px 12px 1px 0;">blib write</td><td style="text-align: right; padding: 1px 12px;">0:06</td><td style="text-align: right; padding: 1px 12px;">0:03</td><td style="text-align: right; padding: 1px 12px; color: #1a7f37;">0.52x (C# faster)</td><td style="text-align: right; padding: 1px 12px;">0:54</td><td style="text-align: right; padding: 1px 12px;">0:10</td><td style="text-align: right; padding: 1px 12px; color: #1a7f37;">0.18x (C# faster)</td></tr>
-      <tr style="border-top: 1px solid #888;"><td style="padding: 1px 12px 1px 0;"><strong>Total</strong></td><td style="text-align: right; padding: 1px 12px;"><strong>3:58</strong></td><td style="text-align: right; padding: 1px 12px;"><strong>4:09</strong></td><td style="text-align: right; padding: 1px 12px; color: #b54708;"><strong>1.04x (Rust faster)</strong></td><td style="text-align: right; padding: 1px 12px;"><strong>16:06</strong></td><td style="text-align: right; padding: 1px 12px;"><strong>18:31</strong></td><td style="text-align: right; padding: 1px 12px; color: #b54708;"><strong>1.15x (Rust faster)</strong></td></tr>
+      <tr><td style="padding: 1px 12px 1px 0;">stage1to4</td><td style="text-align: right; padding: 1px 12px;">1:44</td><td style="text-align: right; padding: 1px 12px;">1:20</td><td style="text-align: right; padding: 1px 12px; color: #1a7f37;">0.77x (C# faster)</td><td style="text-align: right; padding: 1px 12px;">7:27</td><td style="text-align: right; padding: 1px 12px;">7:32</td><td style="text-align: right; padding: 1px 12px;">1.01x (~tied)</td></tr>
+      <tr><td style="padding: 1px 12px 1px 0;">stage5 (1st-pass FDR, aligned)</td><td style="text-align: right; padding: 1px 12px;">1:07</td><td style="text-align: right; padding: 1px 12px;">1:05</td><td style="text-align: right; padding: 1px 12px;">0.97x (~tied)</td><td style="text-align: right; padding: 1px 12px;">1:15</td><td style="text-align: right; padding: 1px 12px;">1:09</td><td style="text-align: right; padding: 1px 12px; color: #1a7f37;">0.91x (C# faster)</td></tr>
+      <tr><td style="padding: 1px 12px 1px 0;">stage6 (reconciliation + rescore, aligned)</td><td style="text-align: right; padding: 1px 12px;">0:22</td><td style="text-align: right; padding: 1px 12px;">0:35</td><td style="text-align: right; padding: 1px 12px; color: #b54708;">1.61x</td><td style="text-align: right; padding: 1px 12px;">4:05</td><td style="text-align: right; padding: 1px 12px;">4:39</td><td style="text-align: right; padding: 1px 12px; color: #b54708;">1.14x</td></tr>
+      <tr><td style="padding: 1px 12px 1px 0;">stage7 (2nd-pass FDR + protein)</td><td style="text-align: right; padding: 1px 12px;">0:39</td><td style="text-align: right; padding: 1px 12px;">0:36</td><td style="text-align: right; padding: 1px 12px; color: #1a7f37;">0.93x (C# faster)</td><td style="text-align: right; padding: 1px 12px;">2:52</td><td style="text-align: right; padding: 1px 12px;">2:14</td><td style="text-align: right; padding: 1px 12px; color: #1a7f37;">0.78x (C# faster)</td></tr>
+      <tr><td style="padding: 1px 12px 1px 0;">blib write</td><td style="text-align: right; padding: 1px 12px;">0:06</td><td style="text-align: right; padding: 1px 12px;">0:03</td><td style="text-align: right; padding: 1px 12px; color: #1a7f37;">0.51x (C# faster)</td><td style="text-align: right; padding: 1px 12px;">0:55</td><td style="text-align: right; padding: 1px 12px;">0:11</td><td style="text-align: right; padding: 1px 12px; color: #1a7f37;">0.20x (C# faster)</td></tr>
+      <tr style="border-top: 1px solid #888;"><td style="padding: 1px 12px 1px 0;"><strong>Total</strong></td><td style="text-align: right; padding: 1px 12px;"><strong>3:58</strong></td><td style="text-align: right; padding: 1px 12px;"><strong>3:41</strong></td><td style="text-align: right; padding: 1px 12px; color: #1a7f37;"><strong>0.93x (C# faster)</strong></td><td style="text-align: right; padding: 1px 12px;"><strong>16:38</strong></td><td style="text-align: right; padding: 1px 12px;"><strong>15:57</strong></td><td style="text-align: right; padding: 1px 12px; color: #1a7f37;"><strong>0.96x (C# faster)</strong></td></tr>
     </tbody>
   </table>
   <p>
     <strong>WSL Linux end-to-end performance &mdash; 9P drvfs to
-    Windows <code>/mnt/c</code> (median-of-3 2026-05-28 round 3
-    post Fix #1)</strong>:
+    Windows <code>/mnt/c</code> (median-of-3 2026-05-29 round 4
+    post Fix #1 + #5b + #6)</strong>:
     Same WSL distro and binaries, but with test data living on the
     Windows side at <code>C:\test\osprey-runs</code> (accessed as
     <code>/mnt/c/test/osprey-runs</code> from inside WSL). Every
     read and write crosses the 9P protocol bridge between Linux and
-    Windows NTFS — this is the configuration developers get by
-    default when they keep their data on the Windows filesystem and
-    just run the pipeline from a WSL shell. 9P adds substantial
-    per-syscall overhead (240 vs 14 files/s for fsync'd metadata
-    writes; raw I/O bench below). With Fix #1 (SIMD inner loops in
-    <code>LinearSvmClassifier.Train</code>) C# now beats Rust by 14%
-    on Stellar and 5% on Astral at the total wall on this storage
-    path, despite the 9P penalty applying equally to both impls.
-    Stage 7 ratio dropped from 1.07&times; (Stellar) and 1.11&times;
-    (Astral) to 0.75&times; / 0.74&times; — the same SVM kernel that
-    Fix #1 vectorized runs in 2nd-pass FDR too, and the SVM is a
-    much larger fraction of Stage 7 wall than of Stage 5 at 3-file
-    scale (where reconciliation planning dominates).
+    Windows NTFS &mdash; this is the configuration developers get
+    by default when they keep their data on the Windows filesystem
+    and just run the pipeline from a WSL shell.  9P adds substantial
+    per-syscall overhead but the absolute totals are still
+    workable.  C# beats Rust by 23% on Stellar (4:48 vs 6:13) and
+    21% on Astral (19:24 vs 24:31) at the total wall, despite
+    the 9P penalty applying equally to both impls.  Aligned-stage5
+    is essentially tied (0.98&times; Stellar / 0.93&times; Astral)
+    after Fix #6 closed the KDE Pdf parallelism gap; aligned-stage6
+    is also tied to slightly C#-faster (0.94&times; both datasets)
+    after Fix #5b parallelized the LOESS planner; stage7 is
+    decisively C#-faster (0.75&times; Stellar / 0.72&times;
+    Astral).  The historical &ldquo;Astral stage5 4&times; C#/Rust&rdquo;
+    figure was a combination of two effects that the round-4 numbers
+    isolate cleanly: the underlying LOESS parallelism gap (Fix #5b
+    closed it) and a stage-label boundary mismatch (the alignment
+    above moved reconciliation into stage6 where Rust labels it).
   </p>
   <table style="margin: 8px 0; font-family: ui-monospace, SFMono-Regular, monospace; font-size: 11px; border-collapse: collapse;">
     <thead>
@@ -682,12 +710,12 @@
       </tr>
     </thead>
     <tbody>
-      <tr><td style="padding: 1px 12px 1px 0;">stage1to4</td><td style="text-align: right; padding: 1px 12px;">3:13</td><td style="text-align: right; padding: 1px 12px;">2:04</td><td style="text-align: right; padding: 1px 12px; color: #1a7f37;">0.64x (C# faster)</td><td style="text-align: right; padding: 1px 12px;">13:06</td><td style="text-align: right; padding: 1px 12px;">9:51</td><td style="text-align: right; padding: 1px 12px; color: #1a7f37;">0.75x (C# faster)</td></tr>
-      <tr><td style="padding: 1px 12px 1px 0;">stage5 (1st-pass FDR + plan)</td><td style="text-align: right; padding: 1px 12px;">1:06</td><td style="text-align: right; padding: 1px 12px;">1:43</td><td style="text-align: right; padding: 1px 12px; color: #b54708;">1.56x</td><td style="text-align: right; padding: 1px 12px;">1:16</td><td style="text-align: right; padding: 1px 12px;">5:10</td><td style="text-align: right; padding: 1px 12px; color: #b54708;">4.07x</td></tr>
-      <tr><td style="padding: 1px 12px 1px 0;">stage6 (rescore + gap-fill)</td><td style="text-align: right; padding: 1px 12px;">0:56</td><td style="text-align: right; padding: 1px 12px;">0:41</td><td style="text-align: right; padding: 1px 12px; color: #1a7f37;">0.74x (C# faster)</td><td style="text-align: right; padding: 1px 12px;">5:55</td><td style="text-align: right; padding: 1px 12px;">4:57</td><td style="text-align: right; padding: 1px 12px; color: #1a7f37;">0.84x (C# faster)</td></tr>
-      <tr><td style="padding: 1px 12px 1px 0;">stage7 (2nd-pass FDR + protein)</td><td style="text-align: right; padding: 1px 12px;">0:48</td><td style="text-align: right; padding: 1px 12px;">0:36</td><td style="text-align: right; padding: 1px 12px; color: #1a7f37;">0.75x (C# faster)</td><td style="text-align: right; padding: 1px 12px;">3:07</td><td style="text-align: right; padding: 1px 12px;">2:18</td><td style="text-align: right; padding: 1px 12px; color: #1a7f37;">0.74x (C# faster)</td></tr>
-      <tr><td style="padding: 1px 12px 1px 0;">blib write</td><td style="text-align: right; padding: 1px 12px;">0:06</td><td style="text-align: right; padding: 1px 12px;">0:10</td><td style="text-align: right; padding: 1px 12px; color: #b54708;">1.52x</td><td style="text-align: right; padding: 1px 12px;">0:53</td><td style="text-align: right; padding: 1px 12px;">0:27</td><td style="text-align: right; padding: 1px 12px; color: #1a7f37;">0.50x (C# faster)</td></tr>
-      <tr style="border-top: 1px solid #888;"><td style="padding: 1px 12px 1px 0;"><strong>Total</strong></td><td style="text-align: right; padding: 1px 12px;"><strong>6:10</strong></td><td style="text-align: right; padding: 1px 12px;"><strong>5:17</strong></td><td style="text-align: right; padding: 1px 12px; color: #1a7f37;"><strong>0.86x (C# faster)</strong></td><td style="text-align: right; padding: 1px 12px;"><strong>24:20</strong></td><td style="text-align: right; padding: 1px 12px;"><strong>23:08</strong></td><td style="text-align: right; padding: 1px 12px; color: #1a7f37;"><strong>0.95x (C# faster)</strong></td></tr>
+      <tr><td style="padding: 1px 12px 1px 0;">stage1to4</td><td style="text-align: right; padding: 1px 12px;">3:16</td><td style="text-align: right; padding: 1px 12px;">2:03</td><td style="text-align: right; padding: 1px 12px; color: #1a7f37;">0.63x (C# faster)</td><td style="text-align: right; padding: 1px 12px;">13:09</td><td style="text-align: right; padding: 1px 12px;">9:51</td><td style="text-align: right; padding: 1px 12px; color: #1a7f37;">0.75x (C# faster)</td></tr>
+      <tr><td style="padding: 1px 12px 1px 0;">stage5 (1st-pass FDR, aligned)</td><td style="text-align: right; padding: 1px 12px;">1:07</td><td style="text-align: right; padding: 1px 12px;">1:05</td><td style="text-align: right; padding: 1px 12px;">0.98x (~tied)</td><td style="text-align: right; padding: 1px 12px;">1:16</td><td style="text-align: right; padding: 1px 12px;">1:10</td><td style="text-align: right; padding: 1px 12px; color: #1a7f37;">0.93x (C# faster)</td></tr>
+      <tr><td style="padding: 1px 12px 1px 0;">stage6 (reconciliation + rescore, aligned)</td><td style="text-align: right; padding: 1px 12px;">0:56</td><td style="text-align: right; padding: 1px 12px;">0:53</td><td style="text-align: right; padding: 1px 12px; color: #1a7f37;">0.94x (C# faster)</td><td style="text-align: right; padding: 1px 12px;">5:57</td><td style="text-align: right; padding: 1px 12px;">5:36</td><td style="text-align: right; padding: 1px 12px; color: #1a7f37;">0.94x (C# faster)</td></tr>
+      <tr><td style="padding: 1px 12px 1px 0;">stage7 (2nd-pass FDR + protein)</td><td style="text-align: right; padding: 1px 12px;">0:48</td><td style="text-align: right; padding: 1px 12px;">0:36</td><td style="text-align: right; padding: 1px 12px; color: #1a7f37;">0.75x (C# faster)</td><td style="text-align: right; padding: 1px 12px;">3:08</td><td style="text-align: right; padding: 1px 12px;">2:16</td><td style="text-align: right; padding: 1px 12px; color: #1a7f37;">0.72x (C# faster)</td></tr>
+      <tr><td style="padding: 1px 12px 1px 0;">blib write</td><td style="text-align: right; padding: 1px 12px;">0:06</td><td style="text-align: right; padding: 1px 12px;">0:09</td><td style="text-align: right; padding: 1px 12px; color: #b54708;">1.54x</td><td style="text-align: right; padding: 1px 12px;">0:54</td><td style="text-align: right; padding: 1px 12px;">0:25</td><td style="text-align: right; padding: 1px 12px; color: #1a7f37;">0.47x (C# faster)</td></tr>
+      <tr style="border-top: 1px solid #888;"><td style="padding: 1px 12px 1px 0;"><strong>Total</strong></td><td style="text-align: right; padding: 1px 12px;"><strong>6:13</strong></td><td style="text-align: right; padding: 1px 12px;"><strong>4:48</strong></td><td style="text-align: right; padding: 1px 12px; color: #1a7f37;"><strong>0.77x (C# faster)</strong></td><td style="text-align: right; padding: 1px 12px;"><strong>24:31</strong></td><td style="text-align: right; padding: 1px 12px;"><strong>19:24</strong></td><td style="text-align: right; padding: 1px 12px; color: #1a7f37;"><strong>0.79x (C# faster)</strong></td></tr>
     </tbody>
   </table>
   <p>

--- a/pwiz_tools/OspreySharp/OspreySharp.Chromatography/LoessRegression.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Chromatography/LoessRegression.cs
@@ -23,6 +23,7 @@
 
 using System;
 using System.Linq;
+using System.Threading.Tasks;
 
 namespace pwiz.OspreySharp.Chromatography
 {
@@ -407,7 +408,16 @@ namespace pwiz.OspreySharp.Chromatography
 
             double[] fitted = new double[n];
 
-            for (int i = 0; i < n; i++)
+            // Each output index i is independent: it reads x/y/weights only
+            // (read-only across the loop) and writes fitted[i] only. The
+            // outer loop is embarrassingly parallel. At Astral 3-file scale
+            // ~96K x-points per LOESS fit x 9 fits per Fit() call (3 files x
+            // (1 initial + 2 robust)) the serial form burned 130s of CPU on
+            // a single core; parallelizing across 16 cores collapses that
+            // wall to a few seconds. Rust's loess_fit is also serial per
+            // call but auto-vectorized to be ~50x faster per iteration; we
+            // close most of the gap with parallelism alone.
+            Parallel.For(0, n, i =>
             {
                 double xi = x[i];
 
@@ -454,7 +464,7 @@ namespace pwiz.OspreySharp.Chromatography
                         fitted[i] = b0 + b1 * xi;
                     }
                 }
-            }
+            });
 
             return fitted;
         }

--- a/pwiz_tools/OspreySharp/OspreySharp.ML/LinearSvmClassifier.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.ML/LinearSvmClassifier.cs
@@ -527,6 +527,22 @@ namespace pwiz.OspreySharp.ML
                     // indexed loop. For p=21 features the AVX2 path is 5
                     // vector iters + 1 scalar tail, ~3.5x fewer instructions
                     // than the scalar form.
+                    //
+                    // f64 reduction order vs Rust: Rust does a strict
+                    // left-fold scalar sum over the row.  This path
+                    // accumulates per-lane partial sums (lane stride =
+                    // Vector<double>.Count, which is 4 on AVX2, 8 on
+                    // AVX-512, 2 on ARM NEON) then horizontal-sums via
+                    // Vector.Dot.  Per-op drift is sub-ULP; cumulative
+                    // drift on the n*iter dot products stays inside the
+                    // 1e-9 cross-impl parity gate at p=21.  Note that
+                    // the gate's headroom now implicitly assumes a
+                    // lane-stride-stable runtime -- a future CPU/runtime
+                    // swap (e.g. AVX2 -> AVX-512 in production) shifts
+                    // the lane stride and therefore the divergence
+                    // pattern.  If parity ever drifts past 1e-9 after
+                    // such a swap, bisect by forcing the scalar tail
+                    // (set vecSize to a value > cols) to confirm.
                     double wx;
                     int k = 0;
                     if (cols >= vecSize)

--- a/pwiz_tools/OspreySharp/OspreySharp.ML/LinearSvmClassifier.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.ML/LinearSvmClassifier.cs
@@ -35,6 +35,7 @@
 
 using System;
 using System.Collections.Concurrent;
+using System.Numerics;
 using System.Threading;
 
 namespace pwiz.OspreySharp.ML
@@ -512,14 +513,41 @@ namespace pwiz.OspreySharp.ML
 
                 double maxPgViolation = 0.0;
 
+                int vecSize = Vector<double>.Count;
                 for (int idx = 0; idx < n; idx++)
                 {
                     int i = indices[idx];
                     int rowStart = cols * i;
 
-                    // w . x_i (augmented: includes bias w[p] * 1.0)
-                    double wx = 0.0;
-                    for (int k = 0; k < cols; k++)
+                    // w . x_i (augmented: includes bias w[p] * 1.0).
+                    // Hand-vectorized via System.Numerics.Vector<double>: the
+                    // canonical Rust pattern w[..p].iter().zip(row).map(...).sum()
+                    // gets auto-vectorized by LLVM into AVX2/AVX-512 FMA, but
+                    // RyuJIT does not auto-vectorize the equivalent scalar
+                    // indexed loop. For p=21 features the AVX2 path is 5
+                    // vector iters + 1 scalar tail, ~3.5x fewer instructions
+                    // than the scalar form.
+                    double wx;
+                    int k = 0;
+                    if (cols >= vecSize)
+                    {
+                        Vector<double> sumVec = Vector<double>.Zero;
+                        for (; k + vecSize <= cols; k += vecSize)
+                        {
+                            var wv = new Vector<double>(w, k);
+                            var xv = new Vector<double>(data, rowStart + k);
+                            sumVec += wv * xv;
+                        }
+                        // Vector.Sum is .NET 7+; Vector.Dot with the ones
+                        // vector gives the same horizontal sum and is
+                        // available on the net472 target as well.
+                        wx = Vector.Dot(sumVec, Vector<double>.One);
+                    }
+                    else
+                    {
+                        wx = 0.0;
+                    }
+                    for (; k < cols; k++)
                         wx += w[k] * data[rowStart + k];
                     wx += w[p];
 
@@ -539,9 +567,22 @@ namespace pwiz.OspreySharp.ML
                         alpha[i] = Math.Max(alpha[i] - g / diag[i], 0.0);
                         double d = (alpha[i] - alphaOld) * y[i];
 
-                        // Update w += d * x_i (augmented)
-                        for (int k = 0; k < cols; k++)
-                            w[k] += d * data[rowStart + k];
+                        // Update w += d * x_i (augmented). Same SIMD pattern
+                        // as the dot product above; LLVM vectorizes the Rust
+                        // iter_mut().zip() form natively.
+                        int k2 = 0;
+                        if (cols >= vecSize)
+                        {
+                            var dVec = new Vector<double>(d);
+                            for (; k2 + vecSize <= cols; k2 += vecSize)
+                            {
+                                var wv = new Vector<double>(w, k2);
+                                var xv = new Vector<double>(data, rowStart + k2);
+                                (wv + dVec * xv).CopyTo(w, k2);
+                            }
+                        }
+                        for (; k2 < cols; k2++)
+                            w[k2] += d * data[rowStart + k2];
                         w[p] += d; // bias feature = 1.0
                     }
                 }

--- a/pwiz_tools/OspreySharp/OspreySharp.ML/PepEstimator.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.ML/PepEstimator.cs
@@ -115,15 +115,18 @@ namespace pwiz.OspreySharp.ML
 
             // Compute raw PEP at each bin. Each bin's Pdf evaluation is
             // independent and writes to its own bins[i] slot, so this
-            // outer loop parallelizes cleanly. Inside Pdf the sum over
-            // the sample stays serial -- that preserves bit-for-bit
-            // PDF values relative to the prior serial implementation
-            // (no reduction-order perturbation), so the cross-impl
-            // 1e-9 parity gate (which already tolerates Rust's
-            // par_iter reduction in its kde::pdf) stays comfortably
-            // wide.  Default nBins is 1000, so 16 cores get ~62
-            // iterations each -- well above the Parallel.For overhead
-            // floor.
+            // outer loop parallelizes cleanly.  Inside Pdf the sum over
+            // the sample stays serial: PDF values remain bit-for-bit
+            // identical to the prior serial implementation here on the
+            // C# side.  The Rust counterpart at osprey-ml/src/kde.rs
+            // uses rayon par_iter inside pdf, so its PDF values are
+            // already non-deterministic at sub-ULP; cross-impl 1e-9
+            // parity tolerates that Rust-side variation.  This PR
+            // doesn't change either side's reduction order; it only
+            // parallelizes the outer binning loop, leaving the
+            // cross-impl bit-equality budget untouched.  Default
+            // nBins is 1000, so 16 cores get ~62 iterations each --
+            // well above the Parallel.For overhead floor.
             var bins = new double[nBins];
             Parallel.For(0, nBins, i =>
             {

--- a/pwiz_tools/OspreySharp/OspreySharp.ML/PepEstimator.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.ML/PepEstimator.cs
@@ -34,6 +34,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 
 namespace pwiz.OspreySharp.ML
 {
@@ -112,9 +113,19 @@ namespace pwiz.OspreySharp.ML
             }
             double scoreStep = nBins > 1 ? (maxScore - minScore) / (nBins - 1) : 1.0;
 
-            // Compute raw PEP at each bin
+            // Compute raw PEP at each bin. Each bin's Pdf evaluation is
+            // independent and writes to its own bins[i] slot, so this
+            // outer loop parallelizes cleanly. Inside Pdf the sum over
+            // the sample stays serial -- that preserves bit-for-bit
+            // PDF values relative to the prior serial implementation
+            // (no reduction-order perturbation), so the cross-impl
+            // 1e-9 parity gate (which already tolerates Rust's
+            // par_iter reduction in its kde::pdf) stays comfortably
+            // wide.  Default nBins is 1000, so 16 cores get ~62
+            // iterations each -- well above the Parallel.For overhead
+            // floor.
             var bins = new double[nBins];
-            for (int i = 0; i < nBins; i++)
+            Parallel.For(0, nBins, i =>
             {
                 double score = minScore + i * scoreStep;
                 double fDecoy = decoyKde.Pdf(score) * pi0;
@@ -124,7 +135,7 @@ namespace pwiz.OspreySharp.ML
                     bins[i] = Math.Max(0.0, Math.Min(1.0, fDecoy / denom));
                 else
                     bins[i] = 1.0;
-            }
+            });
 
             // Enforce monotonicity: PEP must be non-increasing as score increases
             IsotonicRegressionDecreasing(bins);

--- a/pwiz_tools/OspreySharp/OspreySharp.Test/MLTest.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Test/MLTest.cs
@@ -305,6 +305,65 @@ namespace pwiz.OspreySharp.Test
             Assert.AreEqual(0.0, score, 1e-10);
         }
 
+        /// <summary>
+        /// Exercises the SIMD path in <see cref="LinearSvmClassifier.Train"/>
+        /// at the feature dimension Osprey actually uses (21 PIN features).
+        /// On AVX2 (Vector&lt;double&gt;.Count = 4) the inner dot product is
+        /// 5 vector iters + 1 scalar tail; on AVX-512 (Count = 8) it is
+        /// 2 vector iters + 5 scalar tail.  The Stellar/Astral end-to-end
+        /// cross-impl gate exercises the same shape but is too slow for
+        /// the unit test suite; this test locks in a fast regression
+        /// signal that the vec/scalar split itself is wired correctly.
+        /// </summary>
+        [TestMethod]
+        public void TestSvmHighDimensional()
+        {
+            const int p = 21;
+            const int nPos = 16;
+            const int nNeg = 16;
+            const int n = nPos + nNeg;
+            // Targets centered at +1 on feature 0, decoys at -1 on
+            // feature 0; remaining 20 features are deterministic noise
+            // from XorShift64 so the dot product mixes every lane on
+            // both AVX2 and AVX-512.
+            var data = new double[n * p];
+            var rng = new XorShift64(7u);
+            for (int row = 0; row < n; row++)
+            {
+                double center = row < nPos ? 1.0 : -1.0;
+                data[row * p] = center;
+                for (int col = 1; col < p; col++)
+                {
+                    // Map uint64 to [-0.5, 0.5] via the high 53 bits.
+                    ulong r = rng.Next();
+                    data[row * p + col] = ((double)(r >> 11) / (double)(1UL << 53)) - 0.5;
+                }
+            }
+            var features = new Matrix(data, n, p);
+            var labels = new bool[n];
+            for (int i = 0; i < nPos; i++)
+                labels[i] = false; // targets
+            for (int i = nPos; i < n; i++)
+                labels[i] = true; // decoys
+
+            var model = LinearSvmClassifier.Train(features, labels, 1.0, 42);
+            Assert.AreEqual(p, model.Weights.Length);
+            // Discriminating feature 0 should dominate the weight magnitude
+            // by a wide margin; noise features should be small.
+            double w0Abs = Math.Abs(model.Weights[0]);
+            for (int col = 1; col < p; col++)
+            {
+                Assert.IsTrue(w0Abs > Math.Abs(model.Weights[col]),
+                    string.Format("feature 0 weight {0} should dominate noise feature {1} weight {2}",
+                        model.Weights[0], col, model.Weights[col]));
+            }
+
+            // Determinism: same seed, same weights bit-for-bit.
+            var model2 = LinearSvmClassifier.Train(features, labels, 1.0, 42);
+            CollectionAssert.AreEqual(model.Weights, model2.Weights);
+            Assert.AreEqual(model.Bias, model2.Bias);
+        }
+
         #endregion
 
         #region FeatureStandardizer Tests


### PR DESCRIPTION
## Summary

* Fix #1 vectorized the `LinearSvmClassifier.Train` dual coordinate descent inner loops via `System.Numerics.Vector<double>`. AVX2/AVX-512 lowering of the dot product + weight update on the SVM hot path. Astral 3-file end-to-end C# wall: 22:02 → 19:48 (-10%).
* Fix #5b parallelized `LoessRegression.LoessFitInternal`'s outer per-x-point loop via `Parallel.For`. Each point's local regression is independent. At Astral 3-file scale, reconciliation planning runs 9 LOESS fits (3 files × initial + 2 robustness iters) that previously consumed ~130s of single-core CPU; the parallel form collapses to a few seconds wall. Astral 3-file end-to-end C# wall: 19:48 → 15:17 (-23% on top of Fix #1).
* Fix #6 parallelized `PepEstimator.Fit`'s outer KDE binning loop via `Parallel.For`. Each bin's two `Pdf` evaluations are independent and write to their own `bins[i]` slot; the inner `Pdf` sum stays serial so PDF values are bit-for-bit identical to the prior implementation. Astral 3-file end-to-end C# wall: 15:17 → 15:08.
* `Measure-Pipeline.ps1` aligns the stage5/stage6 boundary cross-impl by deriving the reconciliation portion of C# stage5 from the existing `[TIMING] Percolator/Simple FDR` and `[TIMING] First-pass protein FDR` lines and shifting it into stage6 (where Rust labels the same work). This resolves the historical "Astral stage5 4x C#/Rust" figure as a combination of the now-fixed LOESS gap and the now-fixed label mismatch.
* `Osprey-workflow.html` refreshed with round-4 medians (3-rep) across Windows native + WSL /mnt/c + WSL /home. C# beats Rust end-to-end on every cell: Windows native 0.79x Stellar / 0.66x Astral; WSL /mnt/c 0.77x / 0.79x; WSL /home 0.93x / 0.96x.

## Test plan

- [x] `Compare-EndToEnd-Crossimpl.ps1 -Dataset Stellar -Files Single` — PASS at 1e-9 (Stage 7 protein FDR + blib SQL row+col)
- [x] `Compare-EndToEnd-Crossimpl.ps1 -Dataset Astral -Files All` — PASS at 1e-9 (Stage 7 protein FDR + blib SQL row+col)
- [x] Round-4 perf table refresh: 3-rep median across Windows native + WSL /mnt/c + WSL /home; both impls, both datasets; variance under 7s on Stellar / 25s on Astral per cell
- [x] All `OspreySharp.Test` tests pass (build with -RunTests green)

Co-Authored-By: Claude <noreply@anthropic.com>