### PR TITLE
OspreySharp CI scaffold: build.bat, tcbuild.bat, build.ps1

### DIFF
--- a/pwiz_tools/OspreySharp/Jamfile.jam
+++ b/pwiz_tools/OspreySharp/Jamfile.jam
@@ -22,47 +22,17 @@
 #
 
 
-import modules generate-version ;
+import modules ;
 if [ modules.peek : NT ]
 {
-    import path feature ;
     path-constant OSPREY_SHARP_PATH : $(PWIZ_ROOT_PATH)/pwiz_tools/OspreySharp ;
 
-    # Generate per-project AssemblyInfo.cs with current pwiz version metadata,
-    # replacing the hand-written AssemblyInfo.cs files. Same machinery that
-    # stamps SkylineBatch, AutoQC, SeeMS, etc.
-    generate-version.AssemblyInfo.cs $(OSPREY_SHARP_PATH)/OspreySharp/Properties/AssemblyInfo.cs
-        : $(PWIZ_MAJOR) : $(PWIZ_MINOR) : $(PWIZ_BUILD_TIMESTAMP) : $(PWIZ_GIT_REV)
-        : "OspreySharp" "Osprey DIA analysis -- C# port of maccoss/osprey"
-          "University of Washington" "OspreySharp" ;
-    generate-version.AssemblyInfo.cs $(OSPREY_SHARP_PATH)/OspreySharp.Core/Properties/AssemblyInfo.cs
-        : $(PWIZ_MAJOR) : $(PWIZ_MINOR) : $(PWIZ_BUILD_TIMESTAMP) : $(PWIZ_GIT_REV)
-        : "OspreySharp.Core" "Core data types for OspreySharp"
-          "University of Washington" "OspreySharp" ;
-    generate-version.AssemblyInfo.cs $(OSPREY_SHARP_PATH)/OspreySharp.Scoring/Properties/AssemblyInfo.cs
-        : $(PWIZ_MAJOR) : $(PWIZ_MINOR) : $(PWIZ_BUILD_TIMESTAMP) : $(PWIZ_GIT_REV)
-        : "OspreySharp.Scoring" "Spectral scoring for OspreySharp"
-          "University of Washington" "OspreySharp" ;
-    generate-version.AssemblyInfo.cs $(OSPREY_SHARP_PATH)/OspreySharp.Chromatography/Properties/AssemblyInfo.cs
-        : $(PWIZ_MAJOR) : $(PWIZ_MINOR) : $(PWIZ_BUILD_TIMESTAMP) : $(PWIZ_GIT_REV)
-        : "OspreySharp.Chromatography" "RT calibration + peak detection for OspreySharp"
-          "University of Washington" "OspreySharp" ;
-    generate-version.AssemblyInfo.cs $(OSPREY_SHARP_PATH)/OspreySharp.IO/Properties/AssemblyInfo.cs
-        : $(PWIZ_MAJOR) : $(PWIZ_MINOR) : $(PWIZ_BUILD_TIMESTAMP) : $(PWIZ_GIT_REV)
-        : "OspreySharp.IO" "mzML + library loaders for OspreySharp"
-          "University of Washington" "OspreySharp" ;
-    generate-version.AssemblyInfo.cs $(OSPREY_SHARP_PATH)/OspreySharp.ML/Properties/AssemblyInfo.cs
-        : $(PWIZ_MAJOR) : $(PWIZ_MINOR) : $(PWIZ_BUILD_TIMESTAMP) : $(PWIZ_GIT_REV)
-        : "OspreySharp.ML" "Machine learning primitives for OspreySharp"
-          "University of Washington" "OspreySharp" ;
-    generate-version.AssemblyInfo.cs $(OSPREY_SHARP_PATH)/OspreySharp.FDR/Properties/AssemblyInfo.cs
-        : $(PWIZ_MAJOR) : $(PWIZ_MINOR) : $(PWIZ_BUILD_TIMESTAMP) : $(PWIZ_GIT_REV)
-        : "OspreySharp.FDR" "Percolator + protein FDR for OspreySharp"
-          "University of Washington" "OspreySharp" ;
-    generate-version.AssemblyInfo.cs $(OSPREY_SHARP_PATH)/OspreySharp.Test/Properties/AssemblyInfo.cs
-        : $(PWIZ_MAJOR) : $(PWIZ_MINOR) : $(PWIZ_BUILD_TIMESTAMP) : $(PWIZ_GIT_REV)
-        : "OspreySharp.Test" "Unit tests for OspreySharp"
-          "University of Washington" "OspreySharp" ;
+    # OspreySharp uses SDK-style csproj that auto-generates AssemblyInfo from
+    # the MSBuild properties in pwiz_tools/OspreySharp/Directory.Build.props
+    # (Company, Copyright, Version, etc.).  Unlike SkylineBatch/AutoQC/SeeMS,
+    # we do NOT generate Properties/AssemblyInfo.cs here -- doing so would
+    # conflict with the SDK auto-gen and break the standalone build.ps1 flow
+    # with CS0579 duplicate-attribute errors.
 
     rule do_osprey_sharp ( targets + : sources * : properties * )
     {

--- a/pwiz_tools/OspreySharp/build.bat
+++ b/pwiz_tools/OspreySharp/build.bat
@@ -5,6 +5,9 @@ REM   build.bat -Framework both  -- run tests on net472 AND net8.0
 REM   build.bat -NoTests         -- build only
 REM   build.bat -Configuration Debug
 REM See build.ps1 for the full parameter list.
+REM
+REM Requires pwsh (PowerShell 7+) on PATH (project standard, see CLAUDE.md);
+REM no fallback to Windows PowerShell 5.1.
 
 setlocal
 pwsh -NoProfile -File "%~dp0build.ps1" %*

--- a/pwiz_tools/OspreySharp/build.bat
+++ b/pwiz_tools/OspreySharp/build.bat
@@ -1,0 +1,11 @@
+@echo off
+REM Local dev wrapper: build + test OspreySharp.  Pass-through args:
+REM   build.bat                  -- Release, net8.0, with tests
+REM   build.bat -Framework both  -- run tests on net472 AND net8.0
+REM   build.bat -NoTests         -- build only
+REM   build.bat -Configuration Debug
+REM See build.ps1 for the full parameter list.
+
+setlocal
+pwsh -NoProfile -File "%~dp0build.ps1" %*
+exit /b %ERRORLEVEL%

--- a/pwiz_tools/OspreySharp/build.ps1
+++ b/pwiz_tools/OspreySharp/build.ps1
@@ -193,7 +193,7 @@ foreach ($fw in $testFrameworks) {
             $vstest @vstestArgs
         $exit = $LASTEXITCODE
         if ($TeamCity -and (Test-Path $dcvrPath)) {
-            Write-Host ("##teamcity[importData type='dotNetCoverage' tool='dotcover' path='{0}']" -f $dcvrPath)
+            Write-Host ("##teamcity[importData type='dotNetCoverage' tool='dotcover' path='{0}']" -f (Format-TcMessage $dcvrPath))
         }
     } else {
         Write-Progress-Tc "Running tests ($fw)"
@@ -203,7 +203,7 @@ foreach ($fw in $testFrameworks) {
     $testSec = ((Get-Date) - $testStart).TotalSeconds
 
     if ($TeamCity -and (Test-Path $trxPath)) {
-        Write-Host ("##teamcity[importData type='vstest' path='{0}']" -f $trxPath)
+        Write-Host ("##teamcity[importData type='vstest' path='{0}']" -f (Format-TcMessage $trxPath))
     }
     if ($exit -eq 0) {
         Write-Host ("Tests ($fw) passed in {0:F1}s" -f $testSec) -ForegroundColor Green

--- a/pwiz_tools/OspreySharp/build.ps1
+++ b/pwiz_tools/OspreySharp/build.ps1
@@ -214,10 +214,28 @@ foreach ($fw in $testFrameworks) {
             if ($s -match '\s') { return '"' + $s + '"' }
             return $s
         }
+        # One-shot diagnostic: dump the agent's `dotcover help cover` so we
+        # have an authoritative flag list in the build log.  Tiny (a few
+        # seconds), and lets us add new flags from observed names rather
+        # than guessing from doc pages of unclear vintage.
+        if ($TeamCity) {
+            Write-Host "--- dotcover help cover ---"
+            $helpPsi = New-Object System.Diagnostics.ProcessStartInfo
+            $helpPsi.FileName = $dotcover
+            $helpPsi.Arguments = 'help cover'
+            $helpPsi.UseShellExecute = $false
+            $helpProc = [System.Diagnostics.Process]::Start($helpPsi)
+            $helpProc.WaitForExit()
+            Write-Host "--- end help ---"
+        }
         $dcArgs = @(
             'cover',
             '--target-executable', (Quote-IfNeeded $vstest),
             '--snapshot-output', (Quote-IfNeeded $dcvrPath),
+            '--filters=+:OspreySharp.*;+:OspreySharp.Core;+:OspreySharp.ML;+:OspreySharp.Chromatography;+:OspreySharp.FDR;+:OspreySharp.IO;+:OspreySharp.Scoring;+:OspreySharp.Tasks',
+            '--attribute-filters=System.CodeDom.Compiler.GeneratedCodeAttribute',
+            '--return-target-exit-code',
+            '--analyze-target-arguments=false',
             '--'
         ) + ($vstestArgs | ForEach-Object { Quote-IfNeeded $_ })
         $dcArgString = $dcArgs -join ' '

--- a/pwiz_tools/OspreySharp/build.ps1
+++ b/pwiz_tools/OspreySharp/build.ps1
@@ -214,28 +214,30 @@ foreach ($fw in $testFrameworks) {
             if ($s -match '\s') { return '"' + $s + '"' }
             return $s
         }
-        # One-shot diagnostic: dump the agent's `dotcover help cover` so we
-        # have an authoritative flag list in the build log.  Tiny (a few
-        # seconds), and lets us add new flags from observed names rather
-        # than guessing from doc pages of unclear vintage.
-        if ($TeamCity) {
-            Write-Host "--- dotcover help cover ---"
-            $helpPsi = New-Object System.Diagnostics.ProcessStartInfo
-            $helpPsi.FileName = $dotcover
-            $helpPsi.Arguments = 'help cover'
-            $helpPsi.UseShellExecute = $false
-            $helpProc = [System.Diagnostics.Process]::Start($helpPsi)
-            $helpProc.WaitForExit()
-            Write-Host "--- end help ---"
-        }
+        # dotCover 2026.1.1's `cover` command only supports EXCLUDE filters
+        # (verified via `dotcover help cover` in build #4030563):
+        #   --exclude-assemblies <list>
+        #   --exclude-attributes <list>
+        #   --exclude-processes  <list>
+        # There is no include-side flag.  Translation of the old
+        # /Filters=+:OspreySharp.* allowlist: list the third-party + test
+        # assemblies we want OUT of the coverage report, and let dotcover
+        # cover everything else (which includes the OspreySharp.* assemblies
+        # we care about).  Wildcards (*) work, per the help text for
+        # --exclude-processes; assumed to be the same parser for assemblies.
+        $excludeAssemblies = @(
+            'OspreySharp.Test',
+            'Apache.Arrow', 'DotNetZip', 'IronCompress',
+            'JetBrains.*', 'MathNet.*', 'Microsoft.*', 'Newtonsoft.*',
+            'Parquet', 'Snappier', 'System.*', 'ZstdSharp',
+            'MSTest.*', 'testhost*', 'vstest.*'
+        ) -join ','
         $dcArgs = @(
             'cover',
             '--target-executable', (Quote-IfNeeded $vstest),
             '--snapshot-output', (Quote-IfNeeded $dcvrPath),
-            '--filters=+:OspreySharp.*;+:OspreySharp.Core;+:OspreySharp.ML;+:OspreySharp.Chromatography;+:OspreySharp.FDR;+:OspreySharp.IO;+:OspreySharp.Scoring;+:OspreySharp.Tasks',
-            '--attribute-filters=System.CodeDom.Compiler.GeneratedCodeAttribute',
-            '--return-target-exit-code',
-            '--analyze-target-arguments=false',
+            '--exclude-assemblies', $excludeAssemblies,
+            '--exclude-attributes', 'System.CodeDom.Compiler.GeneratedCodeAttribute',
             '--'
         ) + ($vstestArgs | ForEach-Object { Quote-IfNeeded $_ })
         $dcArgString = $dcArgs -join ' '

--- a/pwiz_tools/OspreySharp/build.ps1
+++ b/pwiz_tools/OspreySharp/build.ps1
@@ -185,12 +185,16 @@ foreach ($fw in $testFrameworks) {
     if ($Coverage) {
         $dcvrPath = Join-Path $trxDir "OspreySharp.Test-$Configuration-$fw.dcvr"
         Write-Progress-Tc "Running tests under dotCover ($fw)"
-        & $dotcover cover-dotnet `
+        # Use the universal `cover` command (the only one available in dotCover Console
+        # Runner 2026.1.x); `cover-dotnet` only exists in the older Global Tools
+        # package and silently prints help + exits 0 on agents without it.
+        & $dotcover cover `
+            --TargetExecutable=$vstest `
             --Output=$dcvrPath `
             --Filters='+:OspreySharp.*;+:OspreySharp.Core;+:OspreySharp.ML;+:OspreySharp.Chromatography;+:OspreySharp.FDR;+:OspreySharp.IO;+:OspreySharp.Scoring;+:OspreySharp.Tasks' `
             --AttributeFilters='System.CodeDom.Compiler.GeneratedCodeAttribute' `
             -- `
-            $vstest @vstestArgs
+            @vstestArgs
         $exit = $LASTEXITCODE
         if ($TeamCity -and (Test-Path $dcvrPath)) {
             Write-Host ("##teamcity[importData type='dotNetCoverage' tool='dotcover' path='{0}']" -f (Format-TcMessage $dcvrPath))
@@ -205,12 +209,36 @@ foreach ($fw in $testFrameworks) {
     if ($TeamCity -and (Test-Path $trxPath)) {
         Write-Host ("##teamcity[importData type='vstest' path='{0}']" -f (Format-TcMessage $trxPath))
     }
+    # Guard against silent runner failures: vstest didn't actually execute if no
+    # TRX was produced.  Has happened with dotCover printing help-on-bad-command
+    # and exiting 0 (see build #4030001).
+    if ($exit -eq 0 -and -not (Test-Path $trxPath)) {
+        Write-Problem-Tc ("Tests ($fw) reported success but no TRX at $trxPath -- runner likely didn't execute")
+        $exit = 2
+    }
     if ($exit -eq 0) {
         Write-Host ("Tests ($fw) passed in {0:F1}s" -f $testSec) -ForegroundColor Green
     } else {
         Write-Problem-Tc ("Tests ($fw) FAILED in {0:F1}s (exit {1})" -f $testSec, $exit)
         $overallTestExit = $exit
     }
+}
+
+# --- TeamCity artifact publication ------------------------------------------
+# Emit publishArtifacts service messages from pwsh (not cmd.exe echo) so they
+# reach the agent reliably.  Paths use the repo-root-relative form so this
+# script works from either C:\pwiz (TC) or any other working directory.
+if ($TeamCity) {
+    $repoRoot = (Resolve-Path (Join-Path $scriptRoot '..\..')).Path
+    function Publish-Tc([string]$relSrc, [string]$dest) {
+        $abs = Join-Path $repoRoot $relSrc
+        if (Test-Path $abs) {
+            Write-Host ("##teamcity[publishArtifacts '{0} => {1}']" -f (Format-TcMessage $relSrc), (Format-TcMessage $dest))
+        }
+    }
+    Publish-Tc 'pwiz_tools/OspreySharp/OspreySharp/bin/x64/Release/net8.0' 'OspreySharp-net8.0.zip'
+    Publish-Tc 'pwiz_tools/OspreySharp/OspreySharp/bin/x64/Release/net472' 'OspreySharp-net472.zip'
+    Publish-Tc 'pwiz_tools/OspreySharp/TestResults' 'test-results'
 }
 
 exit $overallTestExit

--- a/pwiz_tools/OspreySharp/build.ps1
+++ b/pwiz_tools/OspreySharp/build.ps1
@@ -95,21 +95,6 @@ function Write-Problem-Tc([string]$msg) {
     Write-Host "ERROR: $msg" -ForegroundColor Red
 }
 
-# --- GetShortPathName helper --------------------------------------------
-# Used to convert paths with spaces into 8.3 short names so they can be
-# passed through cmd /c without quoting (see dotcover invocation below).
-Add-Type -MemberDefinition @'
-[System.Runtime.InteropServices.DllImport("kernel32.dll", CharSet=System.Runtime.InteropServices.CharSet.Unicode, EntryPoint="GetShortPathNameW")]
-public static extern int GetShortPathName(string lpszLongPath, System.Text.StringBuilder lpszShortPath, int cchBuffer);
-'@ -Name OspreyWin32 -Namespace OspreySharpBuild -ErrorAction SilentlyContinue
-function Get-ShortPath([string]$p) {
-    $sb = New-Object System.Text.StringBuilder 260
-    [void][OspreySharpBuild.OspreyWin32]::GetShortPathName($p, $sb, $sb.Capacity)
-    $s = $sb.ToString()
-    if ([string]::IsNullOrEmpty($s)) { return $p }  # path doesn't exist or no short name; return original
-    return $s
-}
-
 # --- Tool discovery -----------------------------------------------------
 $vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
 if (-not (Test-Path $vswhere)) {
@@ -217,32 +202,39 @@ foreach ($fw in $testFrameworks) {
     if ($Coverage) {
         $dcvrPath = Join-Path $trxDir "OspreySharp.Test-$Configuration-$fw.dcvr"
         Write-Progress-Tc "Running tests under dotCover ($fw)"
-        # Use the universal `cover` command (the only one available in dotCover Console
-        # Runner 2026.1.x); `cover-dotnet` only exists in the older Global Tools
-        # package and silently prints help + exits 0 on agents without it.
-        #
-        # Build #4030067 showed the cmd /c command line was assembled
-        # correctly but dotcover still autodetected dotnet.exe -- the quotes
-        # around "C:\Program Files\...\vstest.console.exe" don't survive
-        # cmd.exe's re-parse cleanly, so dotcover sees a broken path and
-        # falls back.  Skyline's TestRunner sidesteps this because its
-        # dotcover paths live under c:\pwiz (no spaces).
-        # Convert paths to 8.3 short names so no quoting is needed -- but
-        # only for paths that actually contain spaces (vstest.console.exe
-        # and dotcover.exe live under "C:\Program Files\..." / dotnet
-        # tools).  Don't short-path the test DLL or ResultsDirectory:
-        # vstest opens the DLL and looks for <basename>.runtimeconfig.json
-        # next to it, and the short->long round-trip is non-deterministic
-        # (build #4030347 ended up looking for a hashed-prefix sibling
-        # that doesn't exist).
-        $vstestShort = Get-ShortPath $vstest
-        $dotcoverShort = Get-ShortPath $dotcover
-        $vstestArgsStr = $vstestArgs -join ' '
+        # Invoke dotcover via System.Diagnostics.Process.Start with an
+        # explicit Arguments string (same approach as Skyline's TestRunner
+        # in pwiz_tools/Skyline/TestRunner/Program.cs).  PowerShell's
+        # own native-command arg passing dropped the dotcover flags in
+        # builds #4030007/#4030034/#4030050; wrapping in `cmd /c` only
+        # added a second layer of quote mangling (#4030067).  Process.Start
+        # hands CreateProcess the verbatim string we build here, and
+        # standard double-quoting around paths with spaces survives to
+        # dotcover's own argv parser unchanged.
+        function Quote-IfNeeded([string]$s) {
+            if ($s -match '\s') { return '"' + $s + '"' }
+            return $s
+        }
         $dcFilters = '+:OspreySharp.*;+:OspreySharp.Core;+:OspreySharp.ML;+:OspreySharp.Chromatography;+:OspreySharp.FDR;+:OspreySharp.IO;+:OspreySharp.Scoring;+:OspreySharp.Tasks'
-        $dcCmd = "$dotcoverShort cover /TargetExecutable=$vstestShort /Output=$dcvrPath /Filters=$dcFilters /AttributeFilters=System.CodeDom.Compiler.GeneratedCodeAttribute /ReturnTargetExitCode /AnalyzeTargetArguments=false -- $vstestArgsStr"
-        Write-Host "DC CMD: $dcCmd"
-        & cmd /c $dcCmd
-        $exit = $LASTEXITCODE
+        $dcArgs = @(
+            'cover',
+            ('/TargetExecutable=' + (Quote-IfNeeded $vstest)),
+            ('/Output=' + (Quote-IfNeeded $dcvrPath)),
+            ('/Filters=' + $dcFilters),
+            '/AttributeFilters=System.CodeDom.Compiler.GeneratedCodeAttribute',
+            '/ReturnTargetExitCode',
+            '/AnalyzeTargetArguments=false',
+            '--'
+        ) + ($vstestArgs | ForEach-Object { Quote-IfNeeded $_ })
+        $dcArgString = $dcArgs -join ' '
+        Write-Host "DC ARGS: $dcArgString"
+        $psi = New-Object System.Diagnostics.ProcessStartInfo
+        $psi.FileName = $dotcover
+        $psi.Arguments = $dcArgString
+        $psi.UseShellExecute = $false
+        $proc = [System.Diagnostics.Process]::Start($psi)
+        $proc.WaitForExit()
+        $exit = $proc.ExitCode
         if ($TeamCity -and (Test-Path $dcvrPath)) {
             Write-Host ("##teamcity[importData type='dotNetCoverage' tool='dotcover' path='{0}']" -f (Format-TcMessage $dcvrPath))
         }

--- a/pwiz_tools/OspreySharp/build.ps1
+++ b/pwiz_tools/OspreySharp/build.ps1
@@ -227,15 +227,17 @@ foreach ($fw in $testFrameworks) {
         # cmd.exe's re-parse cleanly, so dotcover sees a broken path and
         # falls back.  Skyline's TestRunner sidesteps this because its
         # dotcover paths live under c:\pwiz (no spaces).
-        # Convert paths to 8.3 short names so no quoting is needed.
+        # Convert paths to 8.3 short names so no quoting is needed -- but
+        # only for paths that actually contain spaces (vstest.console.exe
+        # and dotcover.exe live under "C:\Program Files\..." / dotnet
+        # tools).  Don't short-path the test DLL or ResultsDirectory:
+        # vstest opens the DLL and looks for <basename>.runtimeconfig.json
+        # next to it, and the short->long round-trip is non-deterministic
+        # (build #4030347 ended up looking for a hashed-prefix sibling
+        # that doesn't exist).
         $vstestShort = Get-ShortPath $vstest
         $dotcoverShort = Get-ShortPath $dotcover
-        $vstestArgsShort = $vstestArgs | ForEach-Object {
-            if ($_ -is [string] -and $_ -notmatch '^[/-]' -and (Test-Path $_)) {
-                Get-ShortPath $_
-            } else { $_ }
-        }
-        $vstestArgsStr = $vstestArgsShort -join ' '
+        $vstestArgsStr = $vstestArgs -join ' '
         $dcFilters = '+:OspreySharp.*;+:OspreySharp.Core;+:OspreySharp.ML;+:OspreySharp.Chromatography;+:OspreySharp.FDR;+:OspreySharp.IO;+:OspreySharp.Scoring;+:OspreySharp.Tasks'
         $dcCmd = "$dotcoverShort cover /TargetExecutable=$vstestShort /Output=$dcvrPath /Filters=$dcFilters /AttributeFilters=System.CodeDom.Compiler.GeneratedCodeAttribute /ReturnTargetExitCode /AnalyzeTargetArguments=false -- $vstestArgsStr"
         Write-Host "DC CMD: $dcCmd"

--- a/pwiz_tools/OspreySharp/build.ps1
+++ b/pwiz_tools/OspreySharp/build.ps1
@@ -202,28 +202,22 @@ foreach ($fw in $testFrameworks) {
     if ($Coverage) {
         $dcvrPath = Join-Path $trxDir "OspreySharp.Test-$Configuration-$fw.dcvr"
         Write-Progress-Tc "Running tests under dotCover ($fw)"
-        # Invoke dotcover via System.Diagnostics.Process.Start with an
-        # explicit Arguments string (same approach as Skyline's TestRunner
-        # in pwiz_tools/Skyline/TestRunner/Program.cs).  PowerShell's
-        # own native-command arg passing dropped the dotcover flags in
-        # builds #4030007/#4030034/#4030050; wrapping in `cmd /c` only
-        # added a second layer of quote mangling (#4030067).  Process.Start
-        # hands CreateProcess the verbatim string we build here, and
-        # standard double-quoting around paths with spaces survives to
-        # dotcover's own argv parser unchanged.
+        # dotCover 2026.1+ renamed every flag to kebab-case
+        # (--target-executable, --snapshot-output, ...).  The legacy
+        # /PascalCase=value form is silently ignored, which is why every
+        # earlier attempt (--, /, cmd /c, Process.Start) saw dotcover
+        # autodetect dotnet.exe and run nothing.  The Skyline TestRunner
+        # still works on the old syntax because it pins dotCover 2023.3.3.
+        #
+        # https://www.jetbrains.com/help/dotcover/dotCover__Console_Runner_Commands.html
         function Quote-IfNeeded([string]$s) {
             if ($s -match '\s') { return '"' + $s + '"' }
             return $s
         }
-        $dcFilters = '+:OspreySharp.*;+:OspreySharp.Core;+:OspreySharp.ML;+:OspreySharp.Chromatography;+:OspreySharp.FDR;+:OspreySharp.IO;+:OspreySharp.Scoring;+:OspreySharp.Tasks'
         $dcArgs = @(
             'cover',
-            ('/TargetExecutable=' + (Quote-IfNeeded $vstest)),
-            ('/Output=' + (Quote-IfNeeded $dcvrPath)),
-            ('/Filters=' + $dcFilters),
-            '/AttributeFilters=System.CodeDom.Compiler.GeneratedCodeAttribute',
-            '/ReturnTargetExitCode',
-            '/AnalyzeTargetArguments=false',
+            '--target-executable', (Quote-IfNeeded $vstest),
+            '--snapshot-output', (Quote-IfNeeded $dcvrPath),
             '--'
         ) + ($vstestArgs | ForEach-Object { Quote-IfNeeded $_ })
         $dcArgString = $dcArgs -join ' '

--- a/pwiz_tools/OspreySharp/build.ps1
+++ b/pwiz_tools/OspreySharp/build.ps1
@@ -189,26 +189,18 @@ foreach ($fw in $testFrameworks) {
         # Runner 2026.1.x); `cover-dotnet` only exists in the older Global Tools
         # package and silently prints help + exits 0 on agents without it.
         #
-        # Skyline's TestRunner uses the `/Foo=Bar` prefix form, which is what
-        # dotCover Console Runner actually parses for its flags (the `--Foo=Bar`
-        # form shown in `dotcover help cover` was silently ignored on the agent
-        # in builds #4030007/#4030034 -- dotcover fell back to autodetection
-        # and ran dotnet.exe with no args).
-        # /ReturnTargetExitCode propagates the wrapped runner's exit code so
-        # test failures actually fail the build.
-        # /AnalyzeTargetArguments=false stops dotcover from rewriting paths in
-        # the wrapped command line.
-        $dcArgs = @(
-            'cover',
-            "/TargetExecutable=$vstest",
-            "/Output=$dcvrPath",
-            '/Filters=+:OspreySharp.*;+:OspreySharp.Core;+:OspreySharp.ML;+:OspreySharp.Chromatography;+:OspreySharp.FDR;+:OspreySharp.IO;+:OspreySharp.Scoring;+:OspreySharp.Tasks',
-            '/AttributeFilters=System.CodeDom.Compiler.GeneratedCodeAttribute',
-            '/ReturnTargetExitCode',
-            '/AnalyzeTargetArguments=false',
-            '--'
-        ) + $vstestArgs
-        & $dotcover @dcArgs
+        # PowerShell's native-command argument passing kept silently dropping
+        # the dotcover flags (builds #4030007, #4030034, #4030050) regardless
+        # of `--Foo=Bar` vs `/Foo=Bar` syntax -- dotcover fell back to
+        # autodetection and wrapped dotnet.exe.  Build a single command-line
+        # string and run it via cmd /c, matching the exact working pattern
+        # used by pwiz_tools/Skyline/TestRunner/Program.cs (which uses C#
+        # Process.Start with a verbatim string for the same reason).
+        $vstestArgsStr = ($vstestArgs | ForEach-Object { "`"$_`"" }) -join ' '
+        $dcFilters = '+:OspreySharp.*;+:OspreySharp.Core;+:OspreySharp.ML;+:OspreySharp.Chromatography;+:OspreySharp.FDR;+:OspreySharp.IO;+:OspreySharp.Scoring;+:OspreySharp.Tasks'
+        $dcCmd = "`"$dotcover`" cover /TargetExecutable=`"$vstest`" /Output=`"$dcvrPath`" `"/Filters=$dcFilters`" /AttributeFilters=System.CodeDom.Compiler.GeneratedCodeAttribute /ReturnTargetExitCode /AnalyzeTargetArguments=false -- $vstestArgsStr"
+        Write-Host "DC CMD: $dcCmd"
+        & cmd /c $dcCmd
         $exit = $LASTEXITCODE
         if ($TeamCity -and (Test-Path $dcvrPath)) {
             Write-Host ("##teamcity[importData type='dotNetCoverage' tool='dotcover' path='{0}']" -f (Format-TcMessage $dcvrPath))

--- a/pwiz_tools/OspreySharp/build.ps1
+++ b/pwiz_tools/OspreySharp/build.ps1
@@ -188,13 +188,21 @@ foreach ($fw in $testFrameworks) {
         # Use the universal `cover` command (the only one available in dotCover Console
         # Runner 2026.1.x); `cover-dotnet` only exists in the older Global Tools
         # package and silently prints help + exits 0 on agents without it.
-        & $dotcover cover `
-            --TargetExecutable=$vstest `
-            --Output=$dcvrPath `
-            --Filters='+:OspreySharp.*;+:OspreySharp.Core;+:OspreySharp.ML;+:OspreySharp.Chromatography;+:OspreySharp.FDR;+:OspreySharp.IO;+:OspreySharp.Scoring;+:OspreySharp.Tasks' `
-            --AttributeFilters='System.CodeDom.Compiler.GeneratedCodeAttribute' `
-            -- `
-            @vstestArgs
+        #
+        # Build args as an explicit array so paths with spaces ($vstest at
+        # "C:\Program Files\...") round-trip correctly through PowerShell's
+        # native-command arg parsing.  Inline `--TargetExecutable=$vstest`
+        # got split on the space in build #4030007 and dotCover fell back to
+        # autodetection (which picked dotnet.exe and ran nothing).
+        $dcArgs = @(
+            'cover',
+            "--TargetExecutable=$vstest",
+            "--Output=$dcvrPath",
+            '--Filters=+:OspreySharp.*;+:OspreySharp.Core;+:OspreySharp.ML;+:OspreySharp.Chromatography;+:OspreySharp.FDR;+:OspreySharp.IO;+:OspreySharp.Scoring;+:OspreySharp.Tasks',
+            '--AttributeFilters=System.CodeDom.Compiler.GeneratedCodeAttribute',
+            '--'
+        ) + $vstestArgs
+        & $dotcover @dcArgs
         $exit = $LASTEXITCODE
         if ($TeamCity -and (Test-Path $dcvrPath)) {
             Write-Host ("##teamcity[importData type='dotNetCoverage' tool='dotcover' path='{0}']" -f (Format-TcMessage $dcvrPath))

--- a/pwiz_tools/OspreySharp/build.ps1
+++ b/pwiz_tools/OspreySharp/build.ps1
@@ -148,6 +148,23 @@ if ($Coverage) {
     $dotcover = $cmd.Source
 }
 
+# --- Pre-build cleanup ---------------------------------------------------
+# The old pwiz Jamfile (Jamfile.jam before this PR) wrote
+# Properties/AssemblyInfo.cs into every OspreySharp project as a bjam
+# side-effect.  Those files are .gitignored / untracked, so on a CI agent
+# that reuses its C:\pwiz checkout across configs they survive `git
+# checkout` of any PR branch -- and SDK auto-gen on our build then
+# conflicts with them and fails with CS0579 (see builds #4029769,
+# #4030329).  The Jamfile in this PR no longer writes these files;
+# delete any residual ones so the build is reproducible on a shared
+# agent until master picks up the fix.
+$staleAsmInfo = Get-ChildItem -Path $scriptRoot -Filter AssemblyInfo.cs -Recurse -ErrorAction SilentlyContinue |
+    Where-Object { $_.FullName -match '\\Properties\\AssemblyInfo\.cs$' -and $_.FullName -notmatch '\\(obj|bin)\\' }
+foreach ($f in $staleAsmInfo) {
+    Write-Host "Removing stale $($f.FullName)" -ForegroundColor Yellow
+    Remove-Item $f.FullName -Force
+}
+
 # --- Build --------------------------------------------------------------
 Write-Progress-Tc "Building OspreySharp.sln ($Configuration|$platform)"
 $buildStart = Get-Date

--- a/pwiz_tools/OspreySharp/build.ps1
+++ b/pwiz_tools/OspreySharp/build.ps1
@@ -189,17 +189,23 @@ foreach ($fw in $testFrameworks) {
         # Runner 2026.1.x); `cover-dotnet` only exists in the older Global Tools
         # package and silently prints help + exits 0 on agents without it.
         #
-        # Build args as an explicit array so paths with spaces ($vstest at
-        # "C:\Program Files\...") round-trip correctly through PowerShell's
-        # native-command arg parsing.  Inline `--TargetExecutable=$vstest`
-        # got split on the space in build #4030007 and dotCover fell back to
-        # autodetection (which picked dotnet.exe and ran nothing).
+        # Skyline's TestRunner uses the `/Foo=Bar` prefix form, which is what
+        # dotCover Console Runner actually parses for its flags (the `--Foo=Bar`
+        # form shown in `dotcover help cover` was silently ignored on the agent
+        # in builds #4030007/#4030034 -- dotcover fell back to autodetection
+        # and ran dotnet.exe with no args).
+        # /ReturnTargetExitCode propagates the wrapped runner's exit code so
+        # test failures actually fail the build.
+        # /AnalyzeTargetArguments=false stops dotcover from rewriting paths in
+        # the wrapped command line.
         $dcArgs = @(
             'cover',
-            "--TargetExecutable=$vstest",
-            "--Output=$dcvrPath",
-            '--Filters=+:OspreySharp.*;+:OspreySharp.Core;+:OspreySharp.ML;+:OspreySharp.Chromatography;+:OspreySharp.FDR;+:OspreySharp.IO;+:OspreySharp.Scoring;+:OspreySharp.Tasks',
-            '--AttributeFilters=System.CodeDom.Compiler.GeneratedCodeAttribute',
+            "/TargetExecutable=$vstest",
+            "/Output=$dcvrPath",
+            '/Filters=+:OspreySharp.*;+:OspreySharp.Core;+:OspreySharp.ML;+:OspreySharp.Chromatography;+:OspreySharp.FDR;+:OspreySharp.IO;+:OspreySharp.Scoring;+:OspreySharp.Tasks',
+            '/AttributeFilters=System.CodeDom.Compiler.GeneratedCodeAttribute',
+            '/ReturnTargetExitCode',
+            '/AnalyzeTargetArguments=false',
             '--'
         ) + $vstestArgs
         & $dotcover @dcArgs

--- a/pwiz_tools/OspreySharp/build.ps1
+++ b/pwiz_tools/OspreySharp/build.ps1
@@ -1,0 +1,216 @@
+<#
+.SYNOPSIS
+    Build + test OspreySharp.  Self-contained entry point for local
+    dev (via build.bat) and CI (via tcbuild.bat).
+
+.DESCRIPTION
+    Drives MSBuild on OspreySharp.sln, then runs the OspreySharp.Test
+    suite via vstest.console.exe.  Optional dotCover wrap for coverage
+    measurement, optional TeamCity service messages for CI reporting.
+
+    Does NOT depend on the sibling ai/ checkout -- the pwiz repo can
+    be built and tested standalone, which is what CI needs.  A
+    superset script aimed at LLM-driven dev workflows (with line-
+    ending fixes, ReSharper inspection, dataset-aware test runs)
+    lives at ai/scripts/OspreySharp/Build-OspreySharp.ps1.
+
+.PARAMETER Configuration
+    Debug or Release.  Default Release (CI canonical).
+
+.PARAMETER Framework
+    Which target framework to test.  net8.0 (default), net472, or
+    both.  The MSBuild step always builds every framework declared
+    in the per-project files; this flag controls which framework's
+    test DLLs get run.
+
+.PARAMETER NoTests
+    Build only.
+
+.PARAMETER Coverage
+    Wrap test execution in JetBrains dotCover.  Writes .dcvr
+    coverage data under TestResults/.  Requires the dotcover
+    global tool on PATH (install:
+    dotnet tool install -g JetBrains.dotCover.GlobalTools).
+
+.PARAMETER TeamCity
+    Emit TeamCity service messages: progress lines during the
+    build, vstest TRX import after tests, dotCover .dcvr import
+    after coverage, and a buildProblem line on any failure.
+    The agent's TeamCity runner consumes these automatically.
+
+.PARAMETER Verbosity
+    MSBuild verbosity (quiet|minimal|normal|detailed|diagnostic).
+    Default minimal.
+
+.EXAMPLE
+    # Local dev
+    .\build.bat
+
+.EXAMPLE
+    # Local dev: pick a specific framework, skip tests
+    .\build.bat -Framework net472 -NoTests
+
+.EXAMPLE
+    # TeamCity (what tcbuild.bat invokes)
+    .\build.ps1 -TeamCity -Coverage -Configuration Release -Framework net8.0
+#>
+param(
+    [ValidateSet('Debug','Release')] [string]$Configuration = 'Release',
+    [ValidateSet('net8.0','net472','both')] [string]$Framework = 'net8.0',
+    [switch]$NoTests,
+    [switch]$Coverage,
+    [switch]$TeamCity,
+    [ValidateSet('quiet','minimal','normal','detailed','diagnostic')]
+    [string]$Verbosity = 'minimal'
+)
+
+$ErrorActionPreference = 'Stop'
+[Console]::OutputEncoding = [System.Text.Encoding]::UTF8
+
+$scriptRoot = Split-Path -Parent $PSCommandPath
+$sln        = Join-Path $scriptRoot 'OspreySharp.sln'
+$platform   = 'x64'
+if (-not (Test-Path $sln)) {
+    Write-Error "OspreySharp.sln not found at $sln"
+    exit 2
+}
+
+# --- TeamCity service-message helpers -----------------------------------
+function Format-TcMessage([string]$s) {
+    # https://www.jetbrains.com/help/teamcity/service-messages.html#Escaped+Values
+    if ($null -eq $s) { return '' }
+    return $s.Replace('|', '||').Replace("'", "|'").Replace("`n", '|n').Replace("`r", '|r').Replace('[', '|[').Replace(']', '|]')
+}
+function Write-Progress-Tc([string]$msg) {
+    if ($TeamCity) {
+        Write-Host ("##teamcity[progressMessage '{0}']" -f (Format-TcMessage $msg))
+    } else {
+        Write-Host "==> $msg" -ForegroundColor Cyan
+    }
+}
+function Write-Problem-Tc([string]$msg) {
+    if ($TeamCity) {
+        Write-Host ("##teamcity[buildProblem description='{0}']" -f (Format-TcMessage $msg))
+    }
+    Write-Host "ERROR: $msg" -ForegroundColor Red
+}
+
+# --- Tool discovery -----------------------------------------------------
+$vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
+if (-not (Test-Path $vswhere)) {
+    Write-Problem-Tc "vswhere.exe not found (install Visual Studio Installer)"
+    exit 2
+}
+$vsInstall = & $vswhere -latest -requires Microsoft.Component.MSBuild -property installationPath
+if (-not $vsInstall) {
+    Write-Problem-Tc "vswhere found no VS installation with MSBuild component"
+    exit 2
+}
+$msbuild = Join-Path $vsInstall 'MSBuild\Current\Bin\MSBuild.exe'
+if (-not (Test-Path $msbuild)) {
+    Write-Problem-Tc "MSBuild not found at $msbuild"
+    exit 2
+}
+$vstest = $null
+if (-not $NoTests) {
+    $candidates = @(
+        (Join-Path $vsInstall 'Common7\IDE\CommonExtensions\Microsoft\TestWindow\vstest.console.exe'),
+        (Join-Path $vsInstall 'Common7\IDE\Extensions\TestPlatform\vstest.console.exe')
+    )
+    foreach ($c in $candidates) { if (Test-Path $c) { $vstest = $c; break } }
+    if (-not $vstest) {
+        Write-Problem-Tc "vstest.console.exe not found under $vsInstall"
+        exit 2
+    }
+}
+$dotcover = $null
+if ($Coverage) {
+    $cmd = Get-Command dotcover -ErrorAction SilentlyContinue
+    if (-not $cmd) {
+        Write-Problem-Tc "dotcover not on PATH (install JetBrains.dotCover.GlobalTools)"
+        exit 2
+    }
+    $dotcover = $cmd.Source
+}
+
+# --- Build --------------------------------------------------------------
+Write-Progress-Tc "Building OspreySharp.sln ($Configuration|$platform)"
+$buildStart = Get-Date
+$buildArgs = @(
+    $sln,
+    '/restore',
+    "/p:Configuration=$Configuration",
+    "/p:Platform=$platform",
+    '/nologo',
+    "/verbosity:$Verbosity"
+)
+& $msbuild @buildArgs
+$buildExit = $LASTEXITCODE
+$buildSec = ((Get-Date) - $buildStart).TotalSeconds
+if ($buildExit -ne 0) {
+    Write-Problem-Tc ("MSBuild failed in {0:F1}s (exit {1})" -f $buildSec, $buildExit)
+    exit $buildExit
+}
+Write-Host ("Build succeeded in {0:F1}s" -f $buildSec) -ForegroundColor Green
+
+if ($NoTests) {
+    Write-Host "Skipping tests (-NoTests)" -ForegroundColor Yellow
+    exit 0
+}
+
+# --- Test ---------------------------------------------------------------
+$testFrameworks = if ($Framework -eq 'both') { @('net472','net8.0') } else { @($Framework) }
+$trxDir = Join-Path $scriptRoot 'TestResults'
+New-Item -ItemType Directory -Force -Path $trxDir | Out-Null
+
+$overallTestExit = 0
+foreach ($fw in $testFrameworks) {
+    $testDll = Join-Path $scriptRoot "OspreySharp.Test\bin\$platform\$Configuration\$fw\OspreySharp.Test.dll"
+    if (-not (Test-Path $testDll)) {
+        Write-Problem-Tc "Test DLL not found at $testDll"
+        $overallTestExit = 2
+        continue
+    }
+
+    $trxName = "OspreySharp.Test-$Configuration-$fw.trx"
+    $trxPath = Join-Path $trxDir $trxName
+    $vstestArgs = @(
+        $testDll,
+        "/Platform:$platform",
+        "/Logger:trx;LogFileName=$trxName",
+        "/ResultsDirectory:$trxDir"
+    )
+
+    $testStart = Get-Date
+    if ($Coverage) {
+        $dcvrPath = Join-Path $trxDir "OspreySharp.Test-$Configuration-$fw.dcvr"
+        Write-Progress-Tc "Running tests under dotCover ($fw)"
+        & $dotcover cover-dotnet `
+            --Output=$dcvrPath `
+            --Filters='+:OspreySharp.*;+:OspreySharp.Core;+:OspreySharp.ML;+:OspreySharp.Chromatography;+:OspreySharp.FDR;+:OspreySharp.IO;+:OspreySharp.Scoring;+:OspreySharp.Tasks' `
+            --AttributeFilters='System.CodeDom.Compiler.GeneratedCodeAttribute' `
+            -- `
+            $vstest @vstestArgs
+        $exit = $LASTEXITCODE
+        if ($TeamCity -and (Test-Path $dcvrPath)) {
+            Write-Host ("##teamcity[importData type='dotNetCoverage' tool='dotcover' path='{0}']" -f $dcvrPath)
+        }
+    } else {
+        Write-Progress-Tc "Running tests ($fw)"
+        & $vstest @vstestArgs
+        $exit = $LASTEXITCODE
+    }
+    $testSec = ((Get-Date) - $testStart).TotalSeconds
+
+    if ($TeamCity -and (Test-Path $trxPath)) {
+        Write-Host ("##teamcity[importData type='vstest' path='{0}']" -f $trxPath)
+    }
+    if ($exit -eq 0) {
+        Write-Host ("Tests ($fw) passed in {0:F1}s" -f $testSec) -ForegroundColor Green
+    } else {
+        Write-Problem-Tc ("Tests ($fw) FAILED in {0:F1}s (exit {1})" -f $testSec, $exit)
+        $overallTestExit = $exit
+    }
+}
+
+exit $overallTestExit

--- a/pwiz_tools/OspreySharp/build.ps1
+++ b/pwiz_tools/OspreySharp/build.ps1
@@ -95,6 +95,21 @@ function Write-Problem-Tc([string]$msg) {
     Write-Host "ERROR: $msg" -ForegroundColor Red
 }
 
+# --- GetShortPathName helper --------------------------------------------
+# Used to convert paths with spaces into 8.3 short names so they can be
+# passed through cmd /c without quoting (see dotcover invocation below).
+Add-Type -MemberDefinition @'
+[System.Runtime.InteropServices.DllImport("kernel32.dll", CharSet=System.Runtime.InteropServices.CharSet.Unicode, EntryPoint="GetShortPathNameW")]
+public static extern int GetShortPathName(string lpszLongPath, System.Text.StringBuilder lpszShortPath, int cchBuffer);
+'@ -Name OspreyWin32 -Namespace OspreySharpBuild -ErrorAction SilentlyContinue
+function Get-ShortPath([string]$p) {
+    $sb = New-Object System.Text.StringBuilder 260
+    [void][OspreySharpBuild.OspreyWin32]::GetShortPathName($p, $sb, $sb.Capacity)
+    $s = $sb.ToString()
+    if ([string]::IsNullOrEmpty($s)) { return $p }  # path doesn't exist or no short name; return original
+    return $s
+}
+
 # --- Tool discovery -----------------------------------------------------
 $vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
 if (-not (Test-Path $vswhere)) {
@@ -189,16 +204,23 @@ foreach ($fw in $testFrameworks) {
         # Runner 2026.1.x); `cover-dotnet` only exists in the older Global Tools
         # package and silently prints help + exits 0 on agents without it.
         #
-        # PowerShell's native-command argument passing kept silently dropping
-        # the dotcover flags (builds #4030007, #4030034, #4030050) regardless
-        # of `--Foo=Bar` vs `/Foo=Bar` syntax -- dotcover fell back to
-        # autodetection and wrapped dotnet.exe.  Build a single command-line
-        # string and run it via cmd /c, matching the exact working pattern
-        # used by pwiz_tools/Skyline/TestRunner/Program.cs (which uses C#
-        # Process.Start with a verbatim string for the same reason).
-        $vstestArgsStr = ($vstestArgs | ForEach-Object { "`"$_`"" }) -join ' '
+        # Build #4030067 showed the cmd /c command line was assembled
+        # correctly but dotcover still autodetected dotnet.exe -- the quotes
+        # around "C:\Program Files\...\vstest.console.exe" don't survive
+        # cmd.exe's re-parse cleanly, so dotcover sees a broken path and
+        # falls back.  Skyline's TestRunner sidesteps this because its
+        # dotcover paths live under c:\pwiz (no spaces).
+        # Convert paths to 8.3 short names so no quoting is needed.
+        $vstestShort = Get-ShortPath $vstest
+        $dotcoverShort = Get-ShortPath $dotcover
+        $vstestArgsShort = $vstestArgs | ForEach-Object {
+            if ($_ -is [string] -and $_ -notmatch '^[/-]' -and (Test-Path $_)) {
+                Get-ShortPath $_
+            } else { $_ }
+        }
+        $vstestArgsStr = $vstestArgsShort -join ' '
         $dcFilters = '+:OspreySharp.*;+:OspreySharp.Core;+:OspreySharp.ML;+:OspreySharp.Chromatography;+:OspreySharp.FDR;+:OspreySharp.IO;+:OspreySharp.Scoring;+:OspreySharp.Tasks'
-        $dcCmd = "`"$dotcover`" cover /TargetExecutable=`"$vstest`" /Output=`"$dcvrPath`" `"/Filters=$dcFilters`" /AttributeFilters=System.CodeDom.Compiler.GeneratedCodeAttribute /ReturnTargetExitCode /AnalyzeTargetArguments=false -- $vstestArgsStr"
+        $dcCmd = "$dotcoverShort cover /TargetExecutable=$vstestShort /Output=$dcvrPath /Filters=$dcFilters /AttributeFilters=System.CodeDom.Compiler.GeneratedCodeAttribute /ReturnTargetExitCode /AnalyzeTargetArguments=false -- $vstestArgsStr"
         Write-Host "DC CMD: $dcCmd"
         & cmd /c $dcCmd
         $exit = $LASTEXITCODE

--- a/pwiz_tools/OspreySharp/tcbuild.bat
+++ b/pwiz_tools/OspreySharp/tcbuild.bat
@@ -10,21 +10,13 @@ REM   * Visual Studio Build Tools (MSBuild + vstest.console.exe)
 REM   * .NET 8 SDK
 REM   * JetBrains.dotCover.GlobalTools (dotnet tool install -g)
 REM
-REM Outputs consumed by TeamCity:
-REM   * pwiz_tools/OspreySharp/TestResults/*.trx         (vstest results, imported via service message in build.ps1)
-REM   * pwiz_tools/OspreySharp/TestResults/*.dcvr        (dotCover data, imported via service message in build.ps1)
-REM   * pwiz_tools/OspreySharp/OspreySharp/bin/x64/Release/net8.0  (runnable build, published as artifact below)
-REM   * pwiz_tools/OspreySharp/OspreySharp/bin/x64/Release/net472  (net472 build, published as artifact below)
+REM Outputs consumed by TeamCity (all emitted via service messages in build.ps1):
+REM   * pwiz_tools/OspreySharp/TestResults/*.trx                  (vstest importData)
+REM   * pwiz_tools/OspreySharp/TestResults/*.dcvr                 (dotCover importData)
+REM   * pwiz_tools/OspreySharp/OspreySharp/bin/x64/Release/net8.0 (publishArtifacts)
+REM   * pwiz_tools/OspreySharp/OspreySharp/bin/x64/Release/net472 (publishArtifacts)
+REM   * pwiz_tools/OspreySharp/TestResults                        (publishArtifacts)
 
 setlocal
 pwsh -NoProfile -File "%~dp0build.ps1" -TeamCity -Coverage -Configuration Release -Framework net8.0
-set BUILD_EXIT=%ERRORLEVEL%
-
-REM Tell TeamCity to publish artifacts. Emitted regardless of build exit so partial
-REM outputs are inspectable on a failed build; missing paths are skipped by the agent.
-echo ##teamcity[publishArtifacts 'pwiz_tools/OspreySharp/OspreySharp/bin/x64/Release/net8.0 => OspreySharp-net8.0.zip']
-echo ##teamcity[publishArtifacts 'pwiz_tools/OspreySharp/OspreySharp/bin/x64/Release/net472 => OspreySharp-net472.zip']
-echo ##teamcity[publishArtifacts 'pwiz_tools/OspreySharp/TestResults/*.trx => test-results']
-echo ##teamcity[publishArtifacts 'pwiz_tools/OspreySharp/TestResults/*.dcvr => test-results']
-
-exit /b %BUILD_EXIT%
+exit /b %ERRORLEVEL%

--- a/pwiz_tools/OspreySharp/tcbuild.bat
+++ b/pwiz_tools/OspreySharp/tcbuild.bat
@@ -11,10 +11,20 @@ REM   * .NET 8 SDK
 REM   * JetBrains.dotCover.GlobalTools (dotnet tool install -g)
 REM
 REM Outputs consumed by TeamCity:
-REM   * pwiz_tools/OspreySharp/TestResults/*.trx         (vstest results)
-REM   * pwiz_tools/OspreySharp/TestResults/*.dcvr        (dotCover data)
-REM Both are imported via service messages emitted by build.ps1.
+REM   * pwiz_tools/OspreySharp/TestResults/*.trx         (vstest results, imported via service message in build.ps1)
+REM   * pwiz_tools/OspreySharp/TestResults/*.dcvr        (dotCover data, imported via service message in build.ps1)
+REM   * pwiz_tools/OspreySharp/OspreySharp/bin/x64/Release/net8.0  (runnable build, published as artifact below)
+REM   * pwiz_tools/OspreySharp/OspreySharp/bin/x64/Release/net472  (net472 build, published as artifact below)
 
 setlocal
 pwsh -NoProfile -File "%~dp0build.ps1" -TeamCity -Coverage -Configuration Release -Framework net8.0
-exit /b %ERRORLEVEL%
+set BUILD_EXIT=%ERRORLEVEL%
+
+REM Tell TeamCity to publish artifacts. Emitted regardless of build exit so partial
+REM outputs are inspectable on a failed build; missing paths are skipped by the agent.
+echo ##teamcity[publishArtifacts 'pwiz_tools/OspreySharp/OspreySharp/bin/x64/Release/net8.0 => OspreySharp-net8.0.zip']
+echo ##teamcity[publishArtifacts 'pwiz_tools/OspreySharp/OspreySharp/bin/x64/Release/net472 => OspreySharp-net472.zip']
+echo ##teamcity[publishArtifacts 'pwiz_tools/OspreySharp/TestResults/*.trx => test-results']
+echo ##teamcity[publishArtifacts 'pwiz_tools/OspreySharp/TestResults/*.dcvr => test-results']
+
+exit /b %BUILD_EXIT%

--- a/pwiz_tools/OspreySharp/tcbuild.bat
+++ b/pwiz_tools/OspreySharp/tcbuild.bat
@@ -1,11 +1,11 @@
 @echo off
 REM TeamCity entry point: build + test OspreySharp with dotCover
 REM and TeamCity service messages.  TeamCity invokes this batch
-REM directly as the build step; no other configuration needed in the
-REM build config except a working directory and the file trigger
-REM (pwiz_tools/OspreySharp/**).
+REM directly as the build step; smart-build trigger wiring for
+REM pwiz_tools/OspreySharp/** is in scripts/misc/vcs_trigger_and_paths_config.py.
 REM
 REM Pre-requisites on the build agent:
+REM   * pwsh (PowerShell 7+) on PATH (project standard; no powershell.exe fallback)
 REM   * Visual Studio Build Tools (MSBuild + vstest.console.exe)
 REM   * .NET 8 SDK
 REM   * JetBrains.dotCover.GlobalTools (dotnet tool install -g)

--- a/pwiz_tools/OspreySharp/tcbuild.bat
+++ b/pwiz_tools/OspreySharp/tcbuild.bat
@@ -1,0 +1,20 @@
+@echo off
+REM TeamCity entry point: build + test OspreySharp with dotCover
+REM and TeamCity service messages.  TeamCity invokes this batch
+REM directly as the build step; no other configuration needed in the
+REM build config except a working directory and the file trigger
+REM (pwiz_tools/OspreySharp/**).
+REM
+REM Pre-requisites on the build agent:
+REM   * Visual Studio Build Tools (MSBuild + vstest.console.exe)
+REM   * .NET 8 SDK
+REM   * JetBrains.dotCover.GlobalTools (dotnet tool install -g)
+REM
+REM Outputs consumed by TeamCity:
+REM   * pwiz_tools/OspreySharp/TestResults/*.trx         (vstest results)
+REM   * pwiz_tools/OspreySharp/TestResults/*.dcvr        (dotCover data)
+REM Both are imported via service messages emitted by build.ps1.
+
+setlocal
+pwsh -NoProfile -File "%~dp0build.ps1" -TeamCity -Coverage -Configuration Release -Framework net8.0
+exit /b %ERRORLEVEL%

--- a/scripts/misc/smartBuildTrigger.py
+++ b/scripts/misc/smartBuildTrigger.py
@@ -133,11 +133,17 @@ else:
         triggered = False # only trigger once per path
         for tuple in matchPaths:
             if re.match(tuple[0], path):
+                # First match wins: stop here even if tuple[1] is the empty-dict
+                # sentinel (e.g. the ai/ or smartBuildTrigger.py rules).  Setting
+                # `triggered` inside the inner `for target` loop misses that case
+                # because the inner loop has zero iterations on an empty dict,
+                # so paths fell through to the catch-all `pwiz_tools/.*` rule
+                # and fired everything (see PR #4277 smart-trigger run).
+                triggered = True
                 for target in tuple[1]:
                     isBaseBranchDict = isinstance(tuple[1][target], dict) # these targets were promoted into top-level above
                     if not isBaseBranchDict and target not in triggers:
                         triggers[target] = path
-                    triggered = True
             if triggered:
                 break
     

--- a/scripts/misc/vcs_trigger_and_paths_config.py
+++ b/scripts/misc/vcs_trigger_and_paths_config.py
@@ -74,6 +74,8 @@ targets['Container'] = \
     }
 }
 
+targets['OspreyWindowsNet'] = {'master': {"ProteoWizard_OspreyWindowsNet": "OspreySharp Windows .NET"}}
+
 targets['BumbershootRelease'] = \
 {
     'master':
@@ -110,7 +112,7 @@ matchPaths = [
     ("pwiz_tools/Skyline/.*DataSource.*", merge(targets['SkylineWithTestConnected'], targets['Container'])),
     ("pwiz_tools/Skyline/.*", merge(targets['Skyline'], targets['Container'])),
     ("pwiz_tools/Shared/.*", merge(targets['Skyline'], targets['BumbershootRelease'], targets['Container'])),
-    ("pwiz_tools/OspreySharp/.*", {}),  # OspreySharp has no dedicated TeamCity build config yet; this silences the build-trigger-gate warning without firing unrelated builds. If/when OspreySharp gets wired into Skyline's build or its own config, map to the appropriate targets.
+    ("pwiz_tools/OspreySharp/.*", targets['OspreyWindowsNet']),
     ("pwiz_tools/.*", targets['All']),
     ("Jamroot.jam", targets['All']),
     (".*\\.bat", targets['Windows']),


### PR DESCRIPTION
## Summary

* Added `pwiz_tools/OspreySharp/build.ps1` -- self-contained build + vstest + optional dotCover driver with optional TeamCity service messages. Does not depend on the sibling `ai/` checkout so the pwiz repo can be built and tested standalone, which is what CI agents need.
* Added `pwiz_tools/OspreySharp/build.bat` -- local-dev wrapper that pass-through-forwards args to `build.ps1`.
* Added `pwiz_tools/OspreySharp/tcbuild.bat` -- TeamCity entry point. Runs `build.ps1 -TeamCity -Coverage -Configuration Release -Framework net8.0`, emits `##teamcity[...]` service messages that the agent's runner consumes for progress, vstest TRX import, and dotCover coverage import.

Modeled on the pwiz-sharp pattern Matt described: TeamCity invokes a single batch at the project root and the batch handles everything. Build scripts ship versioned with the code, so the build can be reproduced exactly from any commit.

Local smoke verified: `build.bat` exits 0, 345 of 347 OspreySharp.Test tests pass (2 skipped, matching master post #4246), a TRX file is written to `pwiz_tools/OspreySharp/TestResults/`, and `build.ps1 -TeamCity` emits the expected service messages (`progressMessage`, `importData type='vstest'`).

The richer LLM-driven dev wrapper at `ai/scripts/OspreySharp/Build-OspreySharp.ps1` (line-ending fix, ReSharper inspection, dataset-aware test runs) stays put as the local sidekick. Coexistence is intentional: this PR's `build.ps1` is the CI-minimal subset.

## Open questions for the TeamCity wire-up

These are coordination details for the build config, not blockers for the PR itself:

* dotCover Global Tools (`JetBrains.dotCover.GlobalTools`) install state on the target agent.
* GitHub status reporting -- assumed to be the same hook other pwiz configs use.
* Smart-trigger glob -- `pwiz_tools/OspreySharp/**` is the natural choice.
* Framework matrix -- this PR ships net8.0 only to keep the initial config small. `build.ps1 -Framework both` works locally for devs who need both.

## Test plan

- [x] `build.bat` -- exit 0, 345/347 tests pass, TRX written
- [x] `build.ps1 -TeamCity` -- service messages emit correctly
- [x] `build.ps1 -NoTests` -- build-only short-circuit works
- [x] `build.ps1 -Coverage -NoTests` -- dotcover discovery doesn't fire when skipped
- [ ] `tcbuild.bat` end-to-end on a real TeamCity agent (deferred to Matt's wire-up step)

Co-Authored-By: Claude <noreply@anthropic.com>