### PR TITLE
Clear up spurious GC-LEAK reports in TestRunner: disconnect UI Automation providers between tests to reclaim accessibility-pinned controls

### DIFF
--- a/pwiz_tools/Skyline/TestRunnerLib/RunTests.cs
+++ b/pwiz_tools/Skyline/TestRunnerLib/RunTests.cs
@@ -1112,13 +1112,26 @@ namespace TestRunnerLib
             {
                 // Release UI Automation accessibility roots before GC so
                 // accessibility-pinned dialogs can be reclaimed normally.
-                try
+                // Non-fatal -- but log unexpected failures so the diagnostic is
+                // visible in test output (UIAutomationCore.dll should always be
+                // present on supported Windows versions).
+                if (Environment.OSVersion.Platform == PlatformID.Win32NT)
                 {
-                    UiaDisconnectAllProviders();
-                }
-                catch
-                {
-                    // UIAutomationCore.dll unavailable -- non-fatal
+                    try
+                    {
+                        UiaDisconnectAllProviders();
+                    }
+                    catch (Exception ex)
+                    {
+                        // Should never happen on supported Windows targets -- if it does,
+                        // accessibility-rooted Controls (and any SkylineWindow they
+                        // transitively pin) may still be reachable through Windows UI
+                        // Automation refs and appear as GC-LEAK survivors in this run.
+                        Console.WriteLine(
+                            @"UiaDisconnectAllProviders (UIAutomationCore.dll) failed: {0}. " +
+                            @"Accessibility-pinned controls may be reported as GC-LEAK survivors.",
+                            ex);
+                    }
                 }
 
                 GCSettings.LargeObjectHeapCompactionMode = GCLargeObjectHeapCompactionMode.CompactOnce;

--- a/pwiz_tools/Skyline/TestRunnerLib/RunTests.cs
+++ b/pwiz_tools/Skyline/TestRunnerLib/RunTests.cs
@@ -829,6 +829,16 @@ namespace TestRunnerLib
             private static extern int SetProcessWorkingSetSize(IntPtr process, int minimumWorkingSetSize, int
                 maximumWorkingSetSize);
 
+            // Windows UI Automation pins WinForms controls via RefCounted handles
+            // on their AccessibleObjects. Once any UIA client (Narrator, RDP, a
+            // screen reader, automation tooling) queries an accessible control,
+            // the runtime keeps a strong ref to that control's AccessibleObject
+            // until the process exits -- transitively rooting SkylineWindow and
+            // its undo stack through every dialog's back-pointer. This call
+            // releases all such roots so the next GC can reclaim normally.
+            [DllImport("UIAutomationCore.dll")]
+            private static extern int UiaDisconnectAllProviders();
+
             [DllImport("kernel32.dll", SetLastError = true)]
             public static extern UInt32 GetProcessHeaps(
                 UInt32 NumberOfHeaps,
@@ -1100,6 +1110,17 @@ namespace TestRunnerLib
 
             public static void FlushMemory()
             {
+                // Release UI Automation accessibility roots before GC so
+                // accessibility-pinned dialogs can be reclaimed normally.
+                try
+                {
+                    UiaDisconnectAllProviders();
+                }
+                catch
+                {
+                    // UIAutomationCore.dll unavailable -- non-fatal
+                }
+
                 GCSettings.LargeObjectHeapCompactionMode = GCLargeObjectHeapCompactionMode.CompactOnce;
                 GC.Collect();
                 GC.WaitForPendingFinalizers();


### PR DESCRIPTION
## Summary

Adds a single call to `UiaDisconnectAllProviders()` at the start of
`TestRunnerLib.MemoryManagement.FlushMemory`. This releases all
Windows UI Automation provider references held by the test runner
process, so accessibility-rooted Controls can be garbage collected
between tests.

## Some background

The apparent GC leak was vexing - intermittent and seemingly random. Eventually I noticed that it only happens on our TCA1 machine - not on AWS agents, and noticed that one difference there is Windows Server 2022 (TCA1) vs Windows Server 2019 (AWS).

I got login access to the TCA1 machine and installed DotMemory. Working with that and Claude eventually leds us here.

The fix here is OS-independent: UiaDisconnectAllProviders is documented and stable back to Vista, so the disconnect call works the same way on both 2019 and 2022 agents -- and adding it costs nothing on machines that were already clean.

## What was broken

The post-test `GarbageCollectionTracker` was reporting `SkylineWindow,
SrmDocument xN` leaks for 100+ tests intermittently. Same code, same
TC agent (but only that one TCA1), days apart: zero leaks one day, 297 the next.

dotMemory analysis on a leaking run showed the SkylineWindow
retention path was always the same shape:

```
RefCounted handle (Windows accessibility, process root)
  -> ControlAccessibleObject (ownerControl)
  -> Control (a ComboBox, DataGridView, or any docked Control)
  -> Control.events (EventHandlerList)
  -> EventHandler delegate (_target points at a dialog)
  -> dialog (holds a back-pointer to SkylineWindow)
  -> SkylineWindow
```

The root is COM-style: once any UIA client queries an accessible
control, Windows takes a RefCounted handle on the AccessibleObject,
which back-references its owner Control, which holds event
subscriptions whose targets are dialogs that hold SkylineWindow
references. Everything from the Control down stays alive for the
process lifetime.

## What triggers UIA activation

We don't know exactly. The leak fires under TeamCity automation with
no interactive user, so it isn't being triggered by a logged-in user
or a screen reader. Plausible candidates include WinForms internals,
a background Windows service that probes accessibility periodically,
.NET Framework patch-level behavior, or some agent-side tool. What
matters is that *something* on the affected agent activates UIA
providers, and once activated the providers pin Controls until the
process exits.

The intermittency between runs is consistent with that picture --
whether a given run leaks depends on whether a UIA query happens to
occur during it.

## What this fix does

`UiaDisconnectAllProviders` is the Windows-documented API for
releasing all UIA provider refs held by the calling process. After
the call, the AccessibleObjects can be GC'd, and the next GC cycle
reclaims the Control + event-list + dialog + SkylineWindow chain.

Calling it from `FlushMemory` means it happens before every
per-test leak check, every dotMemory snapshot, and every end-of-run
final pass. One line of code; no source-tree-wide changes.

## What this fix does NOT do

- **It does not change production Skyline behavior.**
  `MemoryManagement.FlushMemory` is in `TestRunnerLib` and is only
  called by the test runner.

- **It does not change the underlying WinForms / Windows behavior.**
  Any UIA client that queries accessibility after the disconnect
  call will get fresh provider refs. This is by design -- we want
  accessibility to keep working when it's actively used.

- **It does not eliminate all dotMemory-observed leaks for local
  investigation.** dotMemory's profiling hooks themselves activate
  UIA, so a `_GC_LEAK` snapshot taken via dotMemory will still show
  residual accessibility-rooted SkylineWindow instances. CI runs
  (no profiler attached) come out clean.

- **It does not address real user memory pressure.** Real interactive
  users rarely churn dialogs aggressively enough for this leak to
  accumulate meaningfully in a single session.

## Test plan

- [ ] TC nightly -- leak count should drop to 0 on agents that had
      been showing 100+ false positives
- [ ] Manual sanity: open and close a few Skyline dialogs in normal
      operation, confirm no unexpected accessibility behavior