### PR TITLE
Extracted stateless scoring math out of AbstractScoringTask

### DIFF
--- a/pwiz_tools/OspreySharp/OspreySharp.Scoring/ScoringMath.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Scoring/ScoringMath.cs
@@ -1,0 +1,138 @@
+/*
+ * Original author: Brendan MacLean <brendanx .at. uw.edu>,
+ *                  MacCoss Lab, Department of Genome Sciences, UW
+ * AI assistance: Claude Code (Claude Opus 4.8) <noreply .at. anthropic.com>
+ *
+ * Based on osprey (https://github.com/MacCossLab/osprey)
+ *   by Michael J. MacCoss, MacCoss Lab, Department of Genome Sciences, UW
+ *
+ * Copyright 2026 University of Washington - Seattle, WA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
+
+namespace pwiz.OspreySharp.Scoring
+{
+    /// <summary>
+    /// Stateless numeric primitives used by the scoring pipeline:
+    /// range-windowed Pearson correlation and lower-bound binary search
+    /// over a sorted <c>double[]</c>.
+    ///
+    /// Relocated verbatim out of <c>AbstractScoringTask</c> (which had
+    /// accreted these pure helpers alongside its I/O and orchestration).
+    /// The arithmetic is byte-for-byte unchanged from the originals so
+    /// cross-impl parity is unaffected by the move.
+    ///
+    /// Known duplication, deliberately preserved here pending a
+    /// parity-gated consolidation (see backlog
+    /// <c>TODO-ospreysharp_task_layer_decomposition</c>, PR-C):
+    /// <list type="bullet">
+    ///   <item><see cref="PearsonOverRange"/> and
+    ///   <see cref="PearsonCorrelationInRange"/> are two independent
+    ///   range-Pearson ports with different no-variance guards
+    ///   (product &lt; 1e-30 vs sqrt &lt; 1e-10); they are NOT merged.</item>
+    ///   <item><see cref="PearsonCorrelation.Pearson"/> is a third,
+    ///   full-array variant.</item>
+    ///   <item><see cref="BinarySearchLowerBound"/> and
+    ///   <see cref="LowerBoundDouble"/> are functionally identical
+    ///   lower-bound searches with different midpoint arithmetic.</item>
+    /// </list>
+    /// </summary>
+    public static class ScoringMath
+    {
+        /// <summary>
+        /// Pearson correlation over an inclusive index range. Returns NaN if either
+        /// subrange has no variance or the range is too short.
+        /// </summary>
+        public static double PearsonOverRange(double[] x, double[] y, int start, int end)
+        {
+            int n = end - start + 1;
+            if (n < 3)
+                return double.NaN;
+
+            double sumX = 0, sumY = 0, sumXY = 0, sumX2 = 0, sumY2 = 0;
+            for (int i = start; i <= end; i++)
+            {
+                double xi = x[i];
+                double yi = y[i];
+                sumX += xi;
+                sumY += yi;
+                sumXY += xi * yi;
+                sumX2 += xi * xi;
+                sumY2 += yi * yi;
+            }
+
+            double dn = n;
+            double denom = (dn * sumX2 - sumX * sumX) * (dn * sumY2 - sumY * sumY);
+            if (denom < 1e-30)
+                return 0.0;
+
+            return (dn * sumXY - sumX * sumY) / Math.Sqrt(denom);
+        }
+
+        /// <summary>
+        /// Compute Pearson correlation between two intensity arrays over a range.
+        /// </summary>
+        public static double PearsonCorrelationInRange(double[] x, double[] y, int start, int end)
+        {
+            int n = end - start + 1;
+            if (n < 3)
+                return double.NaN;
+
+            double sumX = 0, sumY = 0, sumXY = 0, sumX2 = 0, sumY2 = 0;
+            for (int i = start; i <= end; i++)
+            {
+                sumX += x[i];
+                sumY += y[i];
+                sumXY += x[i] * y[i];
+                sumX2 += x[i] * x[i];
+                sumY2 += y[i] * y[i];
+            }
+
+            double denom = Math.Sqrt((n * sumX2 - sumX * sumX) * (n * sumY2 - sumY * sumY));
+            if (denom < 1e-10)
+                return 0.0;
+
+            return (n * sumXY - sumX * sumY) / denom;
+        }
+
+        /// <summary>Smallest index i where arr[i] >= v (sorted ascending).</summary>
+        public static int LowerBoundDouble(double[] arr, double v)
+        {
+            int lo = 0, hi = arr.Length;
+            while (lo < hi)
+            {
+                int m = (lo + hi) >> 1;
+                if (arr[m] < v) lo = m + 1; else hi = m;
+            }
+            return lo;
+        }
+
+        public static int BinarySearchLowerBound(double[] sortedArray, double value)
+        {
+            int lo = 0;
+            int hi = sortedArray.Length;
+            while (lo < hi)
+            {
+                int mid = lo + (hi - lo) / 2;
+                if (sortedArray[mid] < value)
+                    lo = mid + 1;
+                else
+                    hi = mid;
+            }
+            return lo;
+        }
+    }
+}

--- a/pwiz_tools/OspreySharp/OspreySharp.Scoring/ScoringMath.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Scoring/ScoringMath.cs
@@ -53,8 +53,9 @@ namespace pwiz.OspreySharp.Scoring
     public static class ScoringMath
     {
         /// <summary>
-        /// Pearson correlation over an inclusive index range. Returns NaN if either
-        /// subrange has no variance or the range is too short.
+        /// Pearson correlation over an inclusive index range. Returns NaN when the
+        /// range is too short (fewer than 3 points); returns 0.0 when either
+        /// subrange has no variance (denominator below 1e-30).
         /// </summary>
         public static double PearsonOverRange(double[] x, double[] y, int start, int end)
         {

--- a/pwiz_tools/OspreySharp/OspreySharp.Test/MLTest.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Test/MLTest.cs
@@ -306,7 +306,7 @@ namespace pwiz.OspreySharp.Test
         }
 
         /// <summary>
-        /// Exercises the SIMD path in <see cref="LinearSvmClassifier.Train"/>
+        /// Exercises the SIMD path in <see cref="LinearSvmClassifier.Train(Matrix, bool[], double, ulong)"/>
         /// at the feature dimension Osprey actually uses (21 PIN features).
         /// On AVX2 (Vector&lt;double&gt;.Count = 4) the inner dot product is
         /// 5 vector iters + 1 scalar tail; on AVX-512 (Count = 8) it is
@@ -336,7 +336,7 @@ namespace pwiz.OspreySharp.Test
                 {
                     // Map uint64 to [-0.5, 0.5] via the high 53 bits.
                     ulong r = rng.Next();
-                    data[row * p + col] = ((double)(r >> 11) / (double)(1UL << 53)) - 0.5;
+                    data[row * p + col] = ((double)(r >> 11) / (1UL << 53)) - 0.5;
                 }
             }
             var features = new Matrix(data, n, p);

--- a/pwiz_tools/OspreySharp/OspreySharp/Tasks/AbstractScoringTask.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/Tasks/AbstractScoringTask.cs
@@ -2471,6 +2471,10 @@ namespace pwiz.OspreySharp.Tasks
         /// <summary>
         /// Cosine similarity between two equal-length arrays (sqrt-intensity preprocessing).
         /// </summary>
+        // Dead code: no callers tree-wide. Left in place (not relocated with the
+        // other stateless math) pending the Tasks-layer dead-code pass tracked in
+        // TODO-ospreysharp_task_layer_decomposition (PR-C); do not delete without
+        // confirming it is still uncalled.
         private static double CosineSimilarity(double[] a, double[] b)
         {
             if (a == null || b == null || a.Length != b.Length || a.Length == 0)

--- a/pwiz_tools/OspreySharp/OspreySharp/Tasks/AbstractScoringTask.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/Tasks/AbstractScoringTask.cs
@@ -431,7 +431,7 @@ namespace pwiz.OspreySharp.Tasks
                     if (spectrum.Mzs == null || spectrum.Mzs.Length == 0)
                         continue;
 
-                    int lo = BinarySearchLowerBound(spectrum.Mzs, lower);
+                    int lo = ScoringMath.BinarySearchLowerBound(spectrum.Mzs, lower);
                     if (lo >= spectrum.Mzs.Length || spectrum.Mzs[lo] > upper)
                         continue;
 
@@ -457,37 +457,6 @@ namespace pwiz.OspreySharp.Tasks
             }
 
             return xics;
-        }
-
-
-        /// <summary>
-        /// Pearson correlation over an inclusive index range. Returns NaN if either
-        /// subrange has no variance or the range is too short.
-        /// </summary>
-        protected static double PearsonOverRange(double[] x, double[] y, int start, int end)
-        {
-            int n = end - start + 1;
-            if (n < 3)
-                return double.NaN;
-
-            double sumX = 0, sumY = 0, sumXY = 0, sumX2 = 0, sumY2 = 0;
-            for (int i = start; i <= end; i++)
-            {
-                double xi = x[i];
-                double yi = y[i];
-                sumX += xi;
-                sumY += yi;
-                sumXY += xi * yi;
-                sumX2 += xi * xi;
-                sumY2 += yi * yi;
-            }
-
-            double dn = n;
-            double denom = (dn * sumX2 - sumX * sumX) * (dn * sumY2 - sumY * sumY);
-            if (denom < 1e-30)
-                return 0.0;
-
-            return (dn * sumXY - sumX * sumY) / Math.Sqrt(denom);
         }
 
 
@@ -937,14 +906,14 @@ namespace pwiz.OspreySharp.Tasks
 
             // Map override RTs to indices via Rust partition_point semantics:
             // first index where rt >= target. start_index then saturating_sub(1).
-            int startIdx = BinarySearchLowerBound(rtArr, ob.Start);
+            int startIdx = ScoringMath.BinarySearchLowerBound(rtArr, ob.Start);
             if (startIdx > 0) startIdx--;
             if (startIdx > last) startIdx = last;
 
-            int endIdx = BinarySearchLowerBound(rtArr, ob.End);
+            int endIdx = ScoringMath.BinarySearchLowerBound(rtArr, ob.End);
             if (endIdx > last) endIdx = last;
 
-            int apexIdx = BinarySearchLowerBound(rtArr, ob.Apex);
+            int apexIdx = ScoringMath.BinarySearchLowerBound(rtArr, ob.Apex);
             if (apexIdx > last) apexIdx = last;
             if (apexIdx > 0 &&
                 Math.Abs(rtArr[apexIdx - 1] - ob.Apex) < Math.Abs(rtArr[apexIdx] - ob.Apex))
@@ -1360,7 +1329,7 @@ namespace pwiz.OspreySharp.Tasks
                 {
                     for (int jj = ii + 1; jj < xics.Count; jj++)
                     {
-                        double corr = PearsonCorrelation(
+                        double corr = ScoringMath.PearsonCorrelationInRange(
                             xics[ii].Intensities, xics[jj].Intensities,
                             p.StartIndex, p.EndIndex);
                         if (!double.IsNaN(corr))
@@ -1438,7 +1407,7 @@ namespace pwiz.OspreySharp.Tasks
                             for (int ii = 0; ii < xics.Count; ii++)
                                 for (int jj = ii + 1; jj < xics.Count; jj++)
                                 {
-                                    double c = PearsonCorrelation(xics[ii].Intensities, xics[jj].Intensities,
+                                    double c = ScoringMath.PearsonCorrelationInRange(xics[ii].Intensities, xics[jj].Intensities,
                                         p.StartIndex, p.EndIndex);
                                     if (!double.IsNaN(c)) { psum += c; pcnt++; }
                                 }
@@ -1983,7 +1952,7 @@ namespace pwiz.OspreySharp.Tasks
                     if (spectrum.Mzs == null || spectrum.Mzs.Length == 0)
                         continue;
 
-                    int lo = BinarySearchLowerBound(spectrum.Mzs, lower);
+                    int lo = ScoringMath.BinarySearchLowerBound(spectrum.Mzs, lower);
                     if (lo >= spectrum.Mzs.Length || spectrum.Mzs[lo] > upper)
                         continue;
 
@@ -2039,7 +2008,7 @@ namespace pwiz.OspreySharp.Tasks
             {
                 for (int j = i + 1; j < xics.Count; j++)
                 {
-                    double corr = PearsonCorrelation(
+                    double corr = ScoringMath.PearsonCorrelationInRange(
                         xics[i].Intensities, xics[j].Intensities,
                         peak.StartIndex, peak.EndIndex);
                     if (double.IsNaN(corr))
@@ -2202,7 +2171,7 @@ namespace pwiz.OspreySharp.Tasks
                 double lower = frag.Mz - tolDa;
                 double upper = frag.Mz + tolDa;
 
-                int lo = BinarySearchLowerBound(spectrum.Mzs, lower);
+                int lo = ScoringMath.BinarySearchLowerBound(spectrum.Mzs, lower);
                 double bestIntensity = 0.0;
                 double bestDiff = double.MaxValue;
 
@@ -2285,7 +2254,7 @@ namespace pwiz.OspreySharp.Tasks
                     double lower = frag.Mz - tolDa;
                     double upper = frag.Mz + tolDa;
 
-                    int lo = BinarySearchLowerBound(apexSpectrum.Mzs, lower);
+                    int lo = ScoringMath.BinarySearchLowerBound(apexSpectrum.Mzs, lower);
                     double bestError = double.MaxValue;
                     double bestIntensity = 0.0;
                     double bestMz = 0.0;
@@ -2408,7 +2377,7 @@ namespace pwiz.OspreySharp.Tasks
             {
                 double[] ms1Arr = ms1Intensities.ToArray();
                 double[] refArr = refValues.ToArray();
-                ms1PrecursorCoelution = PearsonCorrelation(ms1Arr, refArr, 0, ms1Arr.Length - 1);
+                ms1PrecursorCoelution = ScoringMath.PearsonCorrelationInRange(ms1Arr, refArr, 0, ms1Arr.Length - 1);
                 if (double.IsNaN(ms1PrecursorCoelution))
                     ms1PrecursorCoelution = 0.0;
             }
@@ -2522,33 +2491,6 @@ namespace pwiz.OspreySharp.Tasks
                 return 0.0;
 
             return Math.Max(0.0, Math.Min(1.0, dot / denom));
-        }
-
-
-        /// <summary>
-        /// Compute Pearson correlation between two intensity arrays over a range.
-        /// </summary>
-        private double PearsonCorrelation(double[] x, double[] y, int start, int end)
-        {
-            int n = end - start + 1;
-            if (n < 3)
-                return double.NaN;
-
-            double sumX = 0, sumY = 0, sumXY = 0, sumX2 = 0, sumY2 = 0;
-            for (int i = start; i <= end; i++)
-            {
-                sumX += x[i];
-                sumY += y[i];
-                sumXY += x[i] * y[i];
-                sumX2 += x[i] * x[i];
-                sumY2 += y[i] * y[i];
-            }
-
-            double denom = Math.Sqrt((n * sumX2 - sumX * sumX) * (n * sumY2 - sumY * sumY));
-            if (denom < 1e-10)
-                return 0.0;
-
-            return (n * sumXY - sumX * sumY) / denom;
         }
 
 
@@ -2891,7 +2833,7 @@ namespace pwiz.OspreySharp.Tasks
                 double tolDa = unit == ToleranceUnit.Ppm ? mz * tolerance / 1e6 : tolerance;
                 double lo = mz - tolDa;
                 double hi = mz + tolDa;
-                int idx = LowerBoundDouble(topB, lo);
+                int idx = ScoringMath.LowerBoundDouble(topB, lo);
                 if (idx < topB.Length && topB[idx] <= hi) matches++;
             }
             return matches;
@@ -2918,19 +2860,6 @@ namespace pwiz.OspreySharp.Tasks
             var top = new double[n];
             for (int i = 0; i < n; i++) top[i] = fragments[idx[i]].Mz;
             return top;
-        }
-
-
-        /// <summary>Smallest index i where arr[i] >= v (sorted ascending).</summary>
-        private static int LowerBoundDouble(double[] arr, double v)
-        {
-            int lo = 0, hi = arr.Length;
-            while (lo < hi)
-            {
-                int m = (lo + hi) >> 1;
-                if (arr[m] < v) lo = m + 1; else hi = m;
-            }
-            return lo;
         }
 
 
@@ -2995,22 +2924,6 @@ namespace pwiz.OspreySharp.Tasks
             }
 
             return deduped;
-        }
-
-
-        protected static int BinarySearchLowerBound(double[] sortedArray, double value)
-        {
-            int lo = 0;
-            int hi = sortedArray.Length;
-            while (lo < hi)
-            {
-                int mid = lo + (hi - lo) / 2;
-                if (sortedArray[mid] < value)
-                    lo = mid + 1;
-                else
-                    hi = mid;
-            }
-            return lo;
         }
     }
 }

--- a/pwiz_tools/OspreySharp/OspreySharp/Tasks/PerFileScoringTask.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/Tasks/PerFileScoringTask.cs
@@ -2246,7 +2246,7 @@ namespace pwiz.OspreySharp.Tasks
                     for (int j = i + 1; j < xics.Count; j++)
                     {
                         double[] intj = xics[j].Intensities;
-                        double corr = PearsonOverRange(inti, intj, si, ei);
+                        double corr = ScoringMath.PearsonOverRange(inti, intj, si, ei);
                         if (!double.IsNaN(corr))
                             corrSum += corr;
                     }
@@ -2378,7 +2378,7 @@ namespace pwiz.OspreySharp.Tasks
                     double lower = frag.Mz - tolDa;
                     double upper = frag.Mz + tolDa;
 
-                    int lo = BinarySearchLowerBound(apexSpectrum.Mzs, lower);
+                    int lo = ScoringMath.BinarySearchLowerBound(apexSpectrum.Mzs, lower);
                     if (lo < apexSpectrum.Mzs.Length && apexSpectrum.Mzs[lo] <= upper)
                     {
                         double bestMz = apexSpectrum.Mzs[lo];


### PR DESCRIPTION
## Summary

* Extracted four stateless numeric helpers (`PearsonOverRange`, `PearsonCorrelationInRange`, `BinarySearchLowerBound`, `LowerBoundDouble`) out of the 3,016-line `AbstractScoringTask` god class into a new `OspreySharp.Scoring/ScoringMath.cs`. Pure relocation — method bodies are byte-for-byte unchanged; only call sites gained the `ScoringMath.` qualifier. `AbstractScoringTask` shrinks 3,016 → 2,929 LOC.
* First of a multi-PR Tasks-layer architecture cleanup (mega-method decomposition, encapsulation, and the parity-sensitive correlation-dedup are deferred to backlog TODOs). The duplicate Pearson/cosine implementations are deliberately *not* merged here — that needs a dedicated parity measurement.
* The former instance `PearsonCorrelation` was renamed to `PearsonCorrelationInRange` on relocation (made `static`) to avoid a confusing name echo with the sibling `PearsonCorrelation` type; arithmetic unchanged.
* `CosineSimilarity` was found to be dead code (zero call sites) during extraction and left in place — flagged for a later dead-code pass rather than relocated into new public surface.
* Includes a small, separate commit fixing pre-existing ReSharper inspection warnings in `OspreySharp.Test/MLTest.cs` (ambiguous `Train` doc cref + a redundant cast), which were already red on `master` from #4246.

## Test plan

- [x] Build clean (net472 + net8.0)
- [x] OspreySharp unit suite — 345/347 pass, 2 skip (exact baseline)
- [x] ReSharper inspection — 0 errors / 0 warnings
- [x] Cross-impl bit-parity, Stellar 1-file @ 1e-9 — PASS (precursor delta 0; Stage 7 protein FDR + blib content PASS)
- [x] Cross-impl bit-parity, Astral 3-file @ 1e-9 — PASS (precursor delta 0; Stage 7 protein FDR + blib content PASS)
- [x] Performance A/B (Stellar, C#-only, 3 repeats, master vs branch) — no regression; stage1to4 median 88.7s branch vs 90.4s master (within noise)

See ai/todos/active/TODO-20260529_ospreysharp_extract_scoring_math.md

Co-Authored-By: Claude <noreply@anthropic.com>
