### PR TITLE
Relocated stateless fragment helpers out of AbstractScoringTask

### DIFF
--- a/pwiz_tools/OspreySharp/OspreySharp.Core/FragmentMath.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Core/FragmentMath.cs
@@ -1,0 +1,117 @@
+/*
+ * Original author: Brendan MacLean <brendanx .at. uw.edu>,
+ *                  MacCoss Lab, Department of Genome Sciences, UW
+ * AI assistance: Claude Code (Claude Opus 4.8) <noreply .at. anthropic.com>
+ *
+ * Based on osprey (https://github.com/MacCossLab/osprey)
+ *   by Michael J. MacCoss, MacCoss Lab, Department of Genome Sciences, UW
+ *
+ * Copyright 2026 University of Washington - Seattle, WA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
+using System.Collections.Concurrent;
+using System.Linq;
+
+namespace pwiz.OspreySharp.Core
+{
+    /// <summary>
+    /// Stateless library-fragment m/z utilities: top-6 fragment selection
+    /// (memoized per library entry) and the top-N spectrum-match prefilter.
+    ///
+    /// Relocated verbatim out of <c>AbstractScoringTask</c> (which had
+    /// accreted these alongside its I/O and orchestration). The arithmetic
+    /// is unchanged from the original so cross-impl parity is unaffected.
+    /// The fragment-overlap counter that paired with these lives in
+    /// <c>OspreySharp.Scoring.FragmentOverlap</c> instead, because it
+    /// depends on <c>ScoringMath</c> (the Core leaf cannot reference Scoring).
+    /// </summary>
+    public static class FragmentMath
+    {
+        /// <summary>
+        /// Cached top-6 fragment m/z values for an entry. Computed once,
+        /// reused across all prefilter calls for the same entry. Thread-safe
+        /// via ConcurrentDictionary.
+        /// </summary>
+        private static readonly ConcurrentDictionary<uint, double[]> _top6MzCache =
+            new ConcurrentDictionary<uint, double[]>();
+
+        private static double[] GetTop6FragmentMzs(LibraryEntry entry)
+        {
+            return _top6MzCache.GetOrAdd(entry.Id, _ =>
+            {
+                var frags = entry.Fragments;
+                if (frags == null || frags.Count == 0)
+                    return new double[0];
+
+                int nTop = Math.Min(frags.Count, 6);
+                if (frags.Count <= 6)
+                {
+                    var mzs = new double[frags.Count];
+                    for (int i = 0; i < frags.Count; i++)
+                        mzs[i] = frags[i].Mz;
+                    return mzs;
+                }
+
+                // Find top 6 by intensity, stable on ties to match
+                // Rust slice::sort_by. Array.Sort with Comparison<T>
+                // is introsort and unstable.
+                var result = Enumerable.Range(0, frags.Count)
+                    .OrderByDescending(i => frags[i].RelativeIntensity)
+                    .Take(nTop)
+                    .Select(i => frags[i].Mz)
+                    .ToArray();
+                return result;
+            });
+        }
+
+        /// <summary>
+        /// Check if at least 2 of the top 6 library fragments have matching peaks
+        /// in the spectrum. Uses cached top-6 m/z values (no allocation per call).
+        /// Port of has_topn_fragment_match in osprey-scoring/src/lib.rs:112.
+        /// </summary>
+        public static bool HasTopNFragmentMatch(
+            LibraryEntry entry, double[] spectrumMzs, FragmentToleranceConfig fragTol)
+        {
+            var frags = entry.Fragments;
+            if (frags == null || frags.Count == 0 || spectrumMzs == null || spectrumMzs.Length == 0)
+                return true;
+
+            double[] top6Mzs = GetTop6FragmentMzs(entry);
+            int nTop = top6Mzs.Length;
+            int requiredMatches = nTop <= 1 ? 1 : 2;
+            int matchCount = 0;
+
+            // Per-fragment tolerance: in ppm mode, each fragment's Da window
+            // depends on its own m/z. Matches Rust has_topn_fragment_match.
+            for (int t = 0; t < nTop; t++)
+            {
+                double mz = top6Mzs[t];
+                double tolDa = fragTol.ToleranceDa(mz);
+                double lower = mz - tolDa;
+                double upper = mz + tolDa;
+                int lo = 0, hi = spectrumMzs.Length;
+                while (lo < hi) { int mid = (lo + hi) / 2; if (spectrumMzs[mid] < lower) lo = mid + 1; else hi = mid; }
+                if (lo < spectrumMzs.Length && spectrumMzs[lo] <= upper)
+                {
+                    matchCount++;
+                    if (matchCount >= requiredMatches)
+                        return true;
+                }
+            }
+            return false;
+        }
+    }
+}

--- a/pwiz_tools/OspreySharp/OspreySharp.Scoring/FragmentOverlap.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Scoring/FragmentOverlap.cs
@@ -1,0 +1,89 @@
+/*
+ * Original author: Brendan MacLean <brendanx .at. uw.edu>,
+ *                  MacCoss Lab, Department of Genome Sciences, UW
+ * AI assistance: Claude Code (Claude Opus 4.8) <noreply .at. anthropic.com>
+ *
+ * Based on osprey (https://github.com/MacCossLab/osprey)
+ *   by Michael J. MacCoss, MacCoss Lab, Department of Genome Sciences, UW
+ *
+ * Copyright 2026 University of Washington - Seattle, WA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
+using System.Collections.Generic;
+using pwiz.OspreySharp.Core;
+
+namespace pwiz.OspreySharp.Scoring
+{
+    /// <summary>
+    /// Top-N fragment-overlap counting between two library fragment lists.
+    ///
+    /// Relocated verbatim out of <c>AbstractScoringTask</c>. Lives in
+    /// Scoring rather than Core (alongside its sibling fragment helpers in
+    /// <c>OspreySharp.Core.FragmentMath</c>) because it uses
+    /// <see cref="ScoringMath.LowerBoundDouble"/> for the m/z lower-bound
+    /// search, and the Core leaf cannot reference Scoring.
+    /// </summary>
+    public static class FragmentOverlap
+    {
+        /// <summary>
+        /// Count how many of the top-N (by intensity) m/z values from
+        /// <paramref name="fragsA"/> have a match within tolerance in
+        /// the top-N of <paramref name="fragsB"/>. Mirrors
+        /// osprey/crates/osprey/src/pipeline.rs::count_topn_fragment_overlap.
+        /// </summary>
+        public static int CountTopNFragmentOverlap(
+            IList<LibraryFragment> fragsA, IList<LibraryFragment> fragsB,
+            int n, double tolerance, ToleranceUnit unit)
+        {
+            double[] topA = TopNFragmentMzs(fragsA, n);
+            double[] topB = TopNFragmentMzs(fragsB, n);
+            Array.Sort(topB); // Array.Sort OK: single primitive array used only for binary-search of m/z; tie-ordering doesn't affect match-or-not
+            int matches = 0;
+            for (int i = 0; i < topA.Length; i++)
+            {
+                double mz = topA[i];
+                double tolDa = unit == ToleranceUnit.Ppm ? mz * tolerance / 1e6 : tolerance;
+                double lo = mz - tolDa;
+                double hi = mz + tolDa;
+                int idx = ScoringMath.LowerBoundDouble(topB, lo);
+                if (idx < topB.Length && topB[idx] <= hi) matches++;
+            }
+            return matches;
+        }
+
+        /// <summary>Get m/z values of top-N fragments by intensity (stable on ties).</summary>
+        private static double[] TopNFragmentMzs(IList<LibraryFragment> fragments, int n)
+        {
+            if (fragments.Count <= n)
+            {
+                var all = new double[fragments.Count];
+                for (int i = 0; i < fragments.Count; i++) all[i] = fragments[i].Mz;
+                return all;
+            }
+            // Stable sort by descending intensity (matches Rust slice::sort_by).
+            var idx = new int[fragments.Count];
+            for (int i = 0; i < idx.Length; i++) idx[i] = i;
+            Array.Sort(idx, (a, b) => // Array.Sort OK: comparator's secondary key is the unique fragment index, so no ties
+            {
+                int c = fragments[b].RelativeIntensity.CompareTo(fragments[a].RelativeIntensity);
+                return c != 0 ? c : a.CompareTo(b);
+            });
+            var top = new double[n];
+            for (int i = 0; i < n; i++) top[i] = fragments[idx[i]].Mz;
+            return top;
+        }
+    }
+}

--- a/pwiz_tools/OspreySharp/OspreySharp/Tasks/AbstractScoringTask.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/Tasks/AbstractScoringTask.cs
@@ -84,14 +84,6 @@ namespace pwiz.OspreySharp.Tasks
                 if (lb < 0) lb ^= 0x7FFFFFFFFFFFFFFFL;
                 return la.CompareTo(lb);
             });
-        /// <summary>
-        /// Get cached top-6 fragment m/z values for an entry. Computed once,
-        /// reused across all prefilter calls for the same entry. Thread-safe
-        /// via ConcurrentDictionary.
-        /// </summary>
-        internal static readonly ConcurrentDictionary<uint, double[]> _top6MzCache =
-            new ConcurrentDictionary<uint, double[]>();
-
         // Internal so FirstJoinTask (which now owns RunPercolatorFdr +
         // RunPercolatorStreaming + BuildBasicFeatures) can reuse the
         // same 21-feature width without redeclaring it.
@@ -1105,7 +1097,7 @@ namespace pwiz.OspreySharp.Tasks
 
                 for (int i = startScan; i <= endScan; i++)
                 {
-                    bool passes = HasTopNFragmentMatch(
+                    bool passes = FragmentMath.HasTopNFragmentMatch(
                         candidate, windowSpectra[i].Mzs, config.FragmentTolerance);
                     int slot = (i - startScan) % WIN;
                     if (window[slot])
@@ -1816,74 +1808,6 @@ namespace pwiz.OspreySharp.Tasks
         }
 
 
-        private static double[] GetTop6FragmentMzs(LibraryEntry entry)
-        {
-            return _top6MzCache.GetOrAdd(entry.Id, _ =>
-            {
-                var frags = entry.Fragments;
-                if (frags == null || frags.Count == 0)
-                    return new double[0];
-
-                int nTop = Math.Min(frags.Count, 6);
-                if (frags.Count <= 6)
-                {
-                    var mzs = new double[frags.Count];
-                    for (int i = 0; i < frags.Count; i++)
-                        mzs[i] = frags[i].Mz;
-                    return mzs;
-                }
-
-                // Find top 6 by intensity, stable on ties to match
-                // Rust slice::sort_by. Array.Sort with Comparison<T>
-                // is introsort and unstable.
-                var result = Enumerable.Range(0, frags.Count)
-                    .OrderByDescending(i => frags[i].RelativeIntensity)
-                    .Take(nTop)
-                    .Select(i => frags[i].Mz)
-                    .ToArray();
-                return result;
-            });
-        }
-
-
-        /// <summary>
-        /// Check if at least 2 of the top 6 library fragments have matching peaks
-        /// in the spectrum. Uses cached top-6 m/z values (no allocation per call).
-        /// Port of has_topn_fragment_match in osprey-scoring/src/lib.rs:112.
-        /// </summary>
-        protected static bool HasTopNFragmentMatch(
-            LibraryEntry entry, double[] spectrumMzs, FragmentToleranceConfig fragTol)
-        {
-            var frags = entry.Fragments;
-            if (frags == null || frags.Count == 0 || spectrumMzs == null || spectrumMzs.Length == 0)
-                return true;
-
-            double[] top6Mzs = GetTop6FragmentMzs(entry);
-            int nTop = top6Mzs.Length;
-            int requiredMatches = nTop <= 1 ? 1 : 2;
-            int matchCount = 0;
-
-            // Per-fragment tolerance: in ppm mode, each fragment's Da window
-            // depends on its own m/z. Matches Rust has_topn_fragment_match.
-            for (int t = 0; t < nTop; t++)
-            {
-                double mz = top6Mzs[t];
-                double tolDa = fragTol.ToleranceDa(mz);
-                double lower = mz - tolDa;
-                double upper = mz + tolDa;
-                int lo = 0, hi = spectrumMzs.Length;
-                while (lo < hi) { int mid = (lo + hi) / 2; if (spectrumMzs[mid] < lower) lo = mid + 1; else hi = mid; }
-                if (lo < spectrumMzs.Length && spectrumMzs[lo] <= upper)
-                {
-                    matchCount++;
-                    if (matchCount >= requiredMatches)
-                        return true;
-                }
-            }
-            return false;
-        }
-
-
         /// <summary>
         /// Extract fragment XICs for a candidate across the scan range.
         /// </summary>
@@ -2446,6 +2370,10 @@ namespace pwiz.OspreySharp.Tasks
         /// [M-1, M+0, M+1, M+2, M+3]. Uses a simple mass-dependent decay model -
         /// sufficient for cosine-similarity comparison with the observed envelope.
         /// </summary>
+        // Dead code: no callers tree-wide (found during the domain-helper
+        // relocation). Left in place, not relocated, pending the Tasks-layer
+        // dead-code pass tracked in TODO-ospreysharp_task_layer_decomposition
+        // (PR-C); do not delete without confirming it is still uncalled.
         private static double[] TheoreticalIsotopeEnvelope(double precursorMz, int charge)
         {
             // Approximate neutral mass (ignores proton mass precisely - good enough here).
@@ -2772,7 +2700,7 @@ namespace pwiz.OspreySharp.Tasks
 
                         var fragsA = library[libIdxA].Fragments;
                         var fragsB = library[libIdxB].Fragments;
-                        int overlap = CountTopNFragmentOverlap(fragsA, fragsB, 6,
+                        int overlap = FragmentOverlap.CountTopNFragmentOverlap(fragsA, fragsB, 6,
                             fragTolValue, fragTolUnit);
                         int minA = Math.Min(fragsA.Count, 6);
                         int minB = Math.Min(fragsB.Count, 6);
@@ -2814,56 +2742,6 @@ namespace pwiz.OspreySharp.Tasks
             for (int i = 0; i < n; i++)
                 if (!removed[i]) kept.Add(entries[i]);
             return kept;
-        }
-
-
-        /// <summary>
-        /// Count how many of the top-N (by intensity) m/z values from
-        /// <paramref name="fragsA"/> have a match within tolerance in
-        /// the top-N of <paramref name="fragsB"/>. Mirrors
-        /// osprey/crates/osprey/src/pipeline.rs::count_topn_fragment_overlap.
-        /// </summary>
-        private static int CountTopNFragmentOverlap(
-            IList<LibraryFragment> fragsA, IList<LibraryFragment> fragsB,
-            int n, double tolerance, ToleranceUnit unit)
-        {
-            double[] topA = TopNFragmentMzs(fragsA, n);
-            double[] topB = TopNFragmentMzs(fragsB, n);
-            Array.Sort(topB); // Array.Sort OK: single primitive array used only for binary-search of m/z; tie-ordering doesn't affect match-or-not
-            int matches = 0;
-            for (int i = 0; i < topA.Length; i++)
-            {
-                double mz = topA[i];
-                double tolDa = unit == ToleranceUnit.Ppm ? mz * tolerance / 1e6 : tolerance;
-                double lo = mz - tolDa;
-                double hi = mz + tolDa;
-                int idx = ScoringMath.LowerBoundDouble(topB, lo);
-                if (idx < topB.Length && topB[idx] <= hi) matches++;
-            }
-            return matches;
-        }
-
-
-        /// <summary>Get m/z values of top-N fragments by intensity (stable on ties).</summary>
-        private static double[] TopNFragmentMzs(IList<LibraryFragment> fragments, int n)
-        {
-            if (fragments.Count <= n)
-            {
-                var all = new double[fragments.Count];
-                for (int i = 0; i < fragments.Count; i++) all[i] = fragments[i].Mz;
-                return all;
-            }
-            // Stable sort by descending intensity (matches Rust slice::sort_by).
-            var idx = new int[fragments.Count];
-            for (int i = 0; i < idx.Length; i++) idx[i] = i;
-            Array.Sort(idx, (a, b) => // Array.Sort OK: comparator's secondary key is the unique fragment index, so no ties
-            {
-                int c = fragments[b].RelativeIntensity.CompareTo(fragments[a].RelativeIntensity);
-                return c != 0 ? c : a.CompareTo(b);
-            });
-            var top = new double[n];
-            for (int i = 0; i < n; i++) top[i] = fragments[idx[i]].Mz;
-            return top;
         }
 
 

--- a/pwiz_tools/OspreySharp/OspreySharp/Tasks/PerFileScoringTask.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/Tasks/PerFileScoringTask.cs
@@ -2156,7 +2156,7 @@ namespace pwiz.OspreySharp.Tasks
                 var spec = windowSpectra[si];
                 if (Math.Abs(spec.RetentionTime - expectedRt) > initialTolerance)
                     continue;
-                if (!HasTopNFragmentMatch(entry, spec.Mzs, config.FragmentTolerance))
+                if (!FragmentMath.HasTopNFragmentMatch(entry, spec.Mzs, config.FragmentTolerance))
                     continue;
                 candidateSpectra.Add(spec);
                 candidateWindowIndices.Add(si);


### PR DESCRIPTION
## Summary

* Relocated the stateless library-fragment helpers out of the `AbstractScoringTask` god class, verbatim (arithmetic byte-for-byte unchanged):
  * `HasTopNFragmentMatch` + `GetTop6FragmentMzs` (+ its `_top6MzCache`) → new `OspreySharp.Core/FragmentMath.cs`
  * `CountTopNFragmentOverlap` + `TopNFragmentMzs` → new `OspreySharp.Scoring/FragmentOverlap.cs`
* Homes split by actual dependency: the top-6 match prefilter is Core-typed → `Core`; the overlap counter calls `ScoringMath.LowerBoundDouble`, so it lives in `Scoring` (the `Core` leaf cannot reference `Scoring`).
* Second PR of the multi-PR Tasks-layer cleanup (follows #4249). Deferred by design: `LoadLibrary` → `IO` (needs logging-callback injection, not a verbatim move) and the correlation/binary-search dedup (parity-sensitive) — both tracked in the decomposition backlog.
* Flagged the dead `TheoreticalIsotopeEnvelope` in place (zero callers tree-wide; not relocated into new public surface), same call as PR #4249's `CosineSimilarity`.

## Test plan

- [x] Build clean (net472 + net8.0); OspreySharp suite 345/347 pass, 2 skip; ReSharper inspection 0/0
- [x] Cross-impl bit-parity, Stellar 1-file @ 1e-9 — PASS (precursor delta 0; Stage 7 protein FDR + blib content PASS)
- [x] Cross-impl bit-parity, Astral 3-file @ 1e-9 — PASS (precursor delta 0)
- [x] Performance A/B (Stellar, C#-only, 3 repeats, master vs branch) — no regression; stage1to4 median 89.4s branch vs 92.1s master (within run-to-run noise). The hot `HasTopNFragmentMatch` prefilter now resolves across the `exe → Core.dll` boundary at no measurable cost.

See ai/todos/active/TODO-20260530_ospreysharp_relocate_domain_helpers.md

Co-Authored-By: Claude <noreply@anthropic.com>
