### PR TITLE
Relocated LoadLibrary into OspreySharp.IO

### DIFF
--- a/pwiz_tools/OspreySharp/OspreySharp.IO/LibraryLoader.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.IO/LibraryLoader.cs
@@ -1,0 +1,123 @@
+/*
+ * Original author: Brendan MacLean <brendanx .at. uw.edu>,
+ *                  MacCoss Lab, Department of Genome Sciences, UW
+ * AI assistance: Claude Code (Claude Opus 4.8) <noreply .at. anthropic.com>
+ *
+ * Based on osprey (https://github.com/MacCossLab/osprey)
+ *   by Michael J. MacCoss, MacCoss Lab, Department of Genome Sciences, UW
+ *
+ * Copyright 2026 University of Washington - Seattle, WA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using pwiz.OspreySharp.Core;
+
+namespace pwiz.OspreySharp.IO
+{
+    /// <summary>
+    /// Loads a spectral library from its configured source, picking the
+    /// format-specific loader and using the binary <c>.libcache</c> for
+    /// fast reload. Relocated out of <c>AbstractScoringTask</c> — all of
+    /// its collaborators (<see cref="LibraryCache"/>, the format loaders,
+    /// <see cref="LibraryDeduplicator"/>) already live in this assembly.
+    ///
+    /// Logging is injected via callbacks rather than read from a pipeline
+    /// context, so this stays in the I/O layer with no dependency on the
+    /// task framework. The logic is otherwise unchanged from the original.
+    /// </summary>
+    public static class LibraryLoader
+    {
+        /// <summary>
+        /// Load spectral library from the configured source, using binary cache
+        /// when available. Matches Rust's .libcache mechanism for fast reload.
+        /// </summary>
+        public static List<LibraryEntry> Load(OspreyConfig config,
+            Action<string> logInfo, Action<string> logWarning)
+        {
+            string path = config.LibrarySource.Path;
+            string cachePath = path + ".libcache";
+
+            // Try loading from binary cache first
+            if (File.Exists(cachePath))
+            {
+                try
+                {
+                    var cached = LibraryCache.LoadCache(cachePath);
+                    if (cached != null && cached.Count > 0)
+                    {
+                        logInfo(string.Format(
+                            "Loaded {0} library entries from cache '{1}'",
+                            cached.Count, cachePath));
+                        return cached;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    logWarning(string.Format(
+                        "Failed to load library cache: {0}. Falling back to source.", ex.Message));
+                }
+            }
+
+            // Parse from source
+            logInfo(string.Format("Loading spectral library from {0}...", path));
+
+            List<LibraryEntry> entries;
+
+            switch (config.LibrarySource.Format)
+            {
+                case LibraryFormat.DiannTsv:
+                    var tsvLoader = new DiannTsvLoader();
+                    entries = tsvLoader.Load(path);
+                    break;
+
+                case LibraryFormat.Blib:
+                    var blibLoader = new BlibLoader();
+                    entries = blibLoader.Load(path);
+                    break;
+
+                case LibraryFormat.Elib:
+                    var elibLoader = new ElibLoader();
+                    entries = elibLoader.Load(path);
+                    break;
+
+                default:
+                    throw new NotSupportedException(string.Format(
+                        "Unsupported library format: {0}", config.LibrarySource.Format));
+            }
+
+            // Deduplicate library entries
+            entries = LibraryDeduplicator.DeduplicateLibrary(entries);
+
+            logInfo(string.Format("Loaded {0} library entries", entries.Count));
+
+            // Save binary cache for next run
+            try
+            {
+                LibraryCache.SaveCache(cachePath, entries);
+                logInfo(string.Format(
+                    "Saved library cache ({0} entries) to '{1}'",
+                    entries.Count, cachePath));
+            }
+            catch (Exception ex)
+            {
+                logWarning(string.Format("Failed to save library cache: {0}", ex.Message));
+            }
+
+            return entries;
+        }
+    }
+}

--- a/pwiz_tools/OspreySharp/OspreySharp.IO/LibraryLoader.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.IO/LibraryLoader.cs
@@ -48,6 +48,11 @@ namespace pwiz.OspreySharp.IO
         public static List<LibraryEntry> Load(OspreyConfig config,
             Action<string> logInfo, Action<string> logWarning)
         {
+            // Default the injected log callbacks to no-ops so a null delegate
+            // cannot NRE this public API (matches PipelineContext's pattern).
+            logInfo = logInfo ?? (_ => { });
+            logWarning = logWarning ?? (_ => { });
+
             string path = config.LibrarySource.Path;
             string cachePath = path + ".libcache";
 

--- a/pwiz_tools/OspreySharp/OspreySharp/Tasks/AbstractScoringTask.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/Tasks/AbstractScoringTask.cs
@@ -31,7 +31,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using pwiz.OspreySharp.Chromatography;
 using pwiz.OspreySharp.Core;
-using pwiz.OspreySharp.IO;
 using pwiz.OspreySharp.Scoring;
 
 namespace pwiz.OspreySharp.Tasks
@@ -139,85 +138,6 @@ namespace pwiz.OspreySharp.Tasks
         private static string F10(double v)
         {
             return OspreyDiagnostics.F10(v);
-        }
-
-
-        /// <summary>
-        /// Load spectral library from the configured source, using binary cache
-        /// when available. Matches Rust's .libcache mechanism for fast reload.
-        /// </summary>
-        protected List<LibraryEntry> LoadLibrary(OspreyConfig config)
-        {
-            string path = config.LibrarySource.Path;
-            string cachePath = path + ".libcache";
-
-            // Try loading from binary cache first
-            if (File.Exists(cachePath))
-            {
-                try
-                {
-                    var cached = LibraryCache.LoadCache(cachePath);
-                    if (cached != null && cached.Count > 0)
-                    {
-                        _ctx.LogInfo(string.Format(
-                            "Loaded {0} library entries from cache '{1}'",
-                            cached.Count, cachePath));
-                        return cached;
-                    }
-                }
-                catch (Exception ex)
-                {
-                    _ctx.LogWarning(string.Format(
-                        "Failed to load library cache: {0}. Falling back to source.", ex.Message));
-                }
-            }
-
-            // Parse from source
-            _ctx.LogInfo(string.Format("Loading spectral library from {0}...", path));
-
-            List<LibraryEntry> entries;
-
-            switch (config.LibrarySource.Format)
-            {
-                case LibraryFormat.DiannTsv:
-                    var tsvLoader = new DiannTsvLoader();
-                    entries = tsvLoader.Load(path);
-                    break;
-
-                case LibraryFormat.Blib:
-                    var blibLoader = new BlibLoader();
-                    entries = blibLoader.Load(path);
-                    break;
-
-                case LibraryFormat.Elib:
-                    var elibLoader = new ElibLoader();
-                    entries = elibLoader.Load(path);
-                    break;
-
-                default:
-                    throw new NotSupportedException(string.Format(
-                        "Unsupported library format: {0}", config.LibrarySource.Format));
-            }
-
-            // Deduplicate library entries
-            entries = LibraryDeduplicator.DeduplicateLibrary(entries);
-
-            _ctx.LogInfo(string.Format("Loaded {0} library entries", entries.Count));
-
-            // Save binary cache for next run
-            try
-            {
-                LibraryCache.SaveCache(cachePath, entries);
-                _ctx.LogInfo(string.Format(
-                    "Saved library cache ({0} entries) to '{1}'",
-                    entries.Count, cachePath));
-            }
-            catch (Exception ex)
-            {
-                _ctx.LogWarning(string.Format("Failed to save library cache: {0}", ex.Message));
-            }
-
-            return entries;
         }
 
 

--- a/pwiz_tools/OspreySharp/OspreySharp/Tasks/PerFileScoringTask.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/Tasks/PerFileScoringTask.cs
@@ -191,7 +191,7 @@ namespace pwiz.OspreySharp.Tasks
 
             // Stage 1: Load library + generate decoys
             var swLibrary = Stopwatch.StartNew();
-            var library = LoadLibrary(config);
+            var library = LibraryLoader.Load(config, ctx.LogInfo, ctx.LogWarning);
             if (library == null || library.Count == 0)
             {
                 ctx.LogError(@"Library is empty after loading");


### PR DESCRIPTION
## Summary

* Relocated `LoadLibrary` out of `AbstractScoringTask` into a new `OspreySharp.IO/LibraryLoader.cs`. All of its collaborators (`LibraryCache`, the format loaders, `LibraryDeduplicator`) already live in `OspreySharp.IO`, so this is where library loading belongs.
* Not a byte-verbatim move (unlike #4249/#4250): `LoadLibrary` logged through the instance `_ctx`, so logging is now injected via `Action<string> logInfo, logWarning` callbacks — keeping `LibraryLoader` free of any task-framework dependency. The logic and log messages are otherwise unchanged.
* Removed the now-redundant `using pwiz.OspreySharp.IO` from `AbstractScoringTask` (`LoadLibrary` was its only IO consumer). Net effect: `AbstractScoringTask` no longer references the I/O layer at all.
* Third PR of the multi-PR Tasks-layer cleanup (follows #4249, #4250); `AbstractScoringTask` is now a clean scoring engine, ready for the mega-method decomposition.

## Test plan

- [x] Build clean (net472 + net8.0); OspreySharp suite 345/347 pass, 2 skip; ReSharper inspection 0/0
- [x] Cross-impl bit-parity, Stellar 1-file @ 1e-9 — PASS (precursor delta 0; Stage 7 + blib content PASS; C# wall 02:05)
- [x] C#-only multi-file gate, Astral 3-file @ 1e-9 — PASS (precursor delta 0; Stage 7 + blib PASS). Ran `Compare-EndToEnd-Crossimpl -Files All -SkipRust` (reused cached Rust reference, C# straight-through only, wall 17:16) — exercises the multi-file reconciliation/consensus/gap-fill path without re-running Rust.
- [n/a] Perf A/B — `LoadLibrary` is a one-time Stage-1 call (cached via `.libcache`), not a hot loop, so the cross-assembly cost of a single call is unmeasurable. Parity-run C# walls (Stellar 02:05) are the sanity check; no regression.

See ai/todos/active/TODO-20260530_ospreysharp_loadlibrary_to_io.md

Co-Authored-By: Claude <noreply@anthropic.com>
