### PR TITLE
Tightened read-only PerFileScoringTask accessors; documented state ownership

### DIFF
--- a/pwiz_tools/OspreySharp/OspreySharp/Tasks/FirstJoinTask.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/Tasks/FirstJoinTask.cs
@@ -587,7 +587,7 @@ namespace pwiz.OspreySharp.Tasks
         private bool PlanStage6(
             List<KeyValuePair<string, List<FdrEntry>>> perFileEntries,
             IReadOnlyDictionary<string, RTCalibration> perFileCalibrations,
-            Dictionary<string, string> perFileParquetPaths,
+            IReadOnlyDictionary<string, string> perFileParquetPaths,
             List<LibraryEntry> fullLibrary,
             OspreyConfig config)
         {
@@ -900,7 +900,7 @@ namespace pwiz.OspreySharp.Tasks
         /// </returns>
         private int WriteFdrScoresSidecars(
             List<KeyValuePair<string, List<FdrEntry>>> perFileEntries,
-            Dictionary<string, string> perFileParquetPaths,
+            IReadOnlyDictionary<string, string> perFileParquetPaths,
             OspreyConfig config)
         {
             int failures = 0;
@@ -955,7 +955,7 @@ namespace pwiz.OspreySharp.Tasks
             Dictionary<string, RTCalibration> refinedCalibrations,
             IReadOnlyDictionary<string, RTCalibration> perFileCalibrations,
             List<LibraryEntry> fullLibrary,
-            Dictionary<string, string> perFileParquetPaths,
+            IReadOnlyDictionary<string, string> perFileParquetPaths,
             OspreyConfig config,
             out Dictionary<string, List<GapFillTarget>> gapFillByFileOut)
         {
@@ -1106,7 +1106,7 @@ namespace pwiz.OspreySharp.Tasks
         /// </summary>
         private static string ResolveSidecarBasePath(
             string fileName,
-            Dictionary<string, string> perFileParquetPaths,
+            IReadOnlyDictionary<string, string> perFileParquetPaths,
             OspreyConfig config)
         {
             // Normal mode: prefer the actual input mzML path so sidecars

--- a/pwiz_tools/OspreySharp/OspreySharp/Tasks/MergeNodeTask.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/Tasks/MergeNodeTask.cs
@@ -554,7 +554,7 @@ namespace pwiz.OspreySharp.Tasks
         private void WriteBlibOutput(
             List<KeyValuePair<string, List<FdrEntry>>> perFileEntries,
             List<LibraryEntry> fullLibrary,
-            Dictionary<uint, LibraryEntry> libraryById,
+            IReadOnlyDictionary<uint, LibraryEntry> libraryById,
             OspreyConfig config)
         {
             // Two-stage blib output gate, mirroring Rust pipeline.rs:4596-4668.
@@ -892,7 +892,7 @@ namespace pwiz.OspreySharp.Tasks
         private static void WriteBlibFile(
             OspreyConfig config,
             List<KeyValuePair<string, List<FdrEntry>>> perFileEntries,
-            Dictionary<uint, LibraryEntry> libraryById,
+            IReadOnlyDictionary<uint, LibraryEntry> libraryById,
             Dictionary<(string, byte), KeyValuePair<string, FdrEntry>> bestByPrecursor,
             Dictionary<(string, byte), double> bestExpPrecursorQ,
             Dictionary<(string, string), double[]> sharedBounds,

--- a/pwiz_tools/OspreySharp/OspreySharp/Tasks/PerFileScoringTask.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/Tasks/PerFileScoringTask.cs
@@ -125,11 +125,30 @@ namespace pwiz.OspreySharp.Tasks
         // task all hit a fast no-op after the first hydration).
         private bool _runOrHydrated;
 
+        // Producer accessors. The backing fields are built and mutated ONLY
+        // inside this task (during Run / hydration); consumers in other tasks
+        // only read them. The dictionary accessors return IReadOnly* views to
+        // make the "Scoring owns this state; downstream only reads" contract
+        // explicit (the compiler now enforces no external mutation).
+        //
+        // GetFullLibrary is read-only by the same contract, but its return
+        // type stays List<LibraryEntry> for now: tightening it to
+        // IReadOnlyList would cascade through scoring-engine + FDR-project
+        // signatures (RunCoelutionScoring, RunFdr, ProteinFdr, ...), out of
+        // proportion to the value. Deferred to a future cross-project sweep.
         public List<LibraryEntry> GetFullLibrary(PipelineContext ctx) { EnsureHydrated(ctx); return _fullLibrary; }
-        public Dictionary<uint, LibraryEntry> GetLibraryById(PipelineContext ctx) { EnsureHydrated(ctx); return _libraryById; }
+        public IReadOnlyDictionary<uint, LibraryEntry> GetLibraryById(PipelineContext ctx) { EnsureHydrated(ctx); return _libraryById; }
+        // GetPerFileEntries is DELIBERATELY a live, mutable, shared buffer --
+        // NOT a read-only view, by design. The same
+        // List<KeyValuePair<string, List<FdrEntry>>> reference is the
+        // pipeline's working set: PerFileScoring produces it, FirstJoin
+        // compacts it in place, PerFileRescore overlays rescored entries in
+        // place -- all on this one instance. The no-copy cross-task hand-off
+        // is load-bearing (copying it is a measured perf regression at
+        // Astral scale). Do NOT "fix" this to IReadOnly or to return a copy.
         public List<KeyValuePair<string, List<FdrEntry>>> GetPerFileEntries(PipelineContext ctx) { EnsureHydrated(ctx); return _perFileEntries; }
-        public ConcurrentDictionary<string, RTCalibration> GetPerFileCalibrations(PipelineContext ctx) { EnsureHydrated(ctx); return _perFileCalibrations; }
-        public Dictionary<string, string> GetPerFileParquetPaths(PipelineContext ctx) { EnsureHydrated(ctx); return _perFileParquetPaths; }
+        public IReadOnlyDictionary<string, RTCalibration> GetPerFileCalibrations(PipelineContext ctx) { EnsureHydrated(ctx); return _perFileCalibrations; }
+        public IReadOnlyDictionary<string, string> GetPerFileParquetPaths(PipelineContext ctx) { EnsureHydrated(ctx); return _perFileParquetPaths; }
 
         /// <summary>
         /// The probe-the-disk reconciliation bundle, or <c>null</c> when


### PR DESCRIPTION
## Summary

* Tightened three genuinely read-only `PerFileScoringTask` producer accessors —
  `GetLibraryById`, `GetPerFileCalibrations`, `GetPerFileParquetPaths` — to return
  `IReadOnly*` views, so the compiler now enforces that downstream tasks only read
  this Scoring-owned state. Widened the consuming signatures to match
  (FirstJoinTask: `PlanStage6`, `WriteFdrScoresSidecars`, `WriteReconciliationFiles`,
  `ResolveSidecarBasePath`; MergeNodeTask: `WriteBlibOutput`, `WriteBlibFile`).
* Documented `GetPerFileEntries` / `_perFileEntries` as a **deliberately live,
  mutable, shared buffer** — the same `List<KeyValuePair<…>>` reference is produced
  by Scoring, compacted in place by FirstJoin, and overlaid in place by
  PerFileRescore. The no-copy cross-task hand-off is load-bearing (copying it is a
  measured perf regression at Astral scale), so it is explicitly NOT a read-only
  view and must not be "fixed" to one.
* Left `GetFullLibrary` as `List<LibraryEntry>` with a doc note: read-only by the
  same contract, but tightening to `IReadOnlyList` cascades through scoring-engine +
  FDR-project signatures (`RunCoelutionScoring`, `RunFdr`, `ProteinFdr`, …) — out of
  proportion to this PR; deferred to a future cross-project sweep.

This is the deflated PR-A from the OspreySharp Tasks-layer cleanup program (follows
#4254–#4258). The freeze-the-shared-buffer idea was deliberately walked back.

## Test plan

- [x] `Build-OspreySharp.ps1 -RunInspection -RunTests` — Build OK, 345/347 (2 skipped),
  inspection clean.

No cross-impl regression gate was run, by design: this change is pure
type-widening (`Dictionary` → the `IReadOnly*` interface the concrete types
already implement) plus comments. The same instances flow at runtime with
identical member dispatch, so there is no behavioral surface for the 1e-9 gate to
exercise — the build + unit tests are the complete proof. (Happy to run it if a
reviewer prefers belt-and-suspenders.)

See ai/todos/active/TODO-20260531_ospreysharp_readonly_accessors.md

Co-Authored-By: Claude <noreply@anthropic.com>
