### PR TITLE
Diagnose vendor reader test file-lock failures: retry + RestartManager

### DIFF
--- a/pwiz/utility/misc/Filesystem.cpp
+++ b/pwiz/utility/misc/Filesystem.cpp
@@ -527,7 +527,12 @@ PWIZ_API_DECL void force_close_handles_to_filepath(const std::string& filepath, 
 
 PWIZ_API_DECL std::string find_locking_processes(const std::string& path)
 {
-#ifdef _MSC_VER
+    // Gate on PWIZ_HAS_RESTART_MANAGER (set by the Jamfile under
+    // <toolset>msvc:) rather than _MSC_VER -- clang-cl also defines
+    // _MSC_VER but the Jamfile does not link rstrtmgr.lib for non-msvc
+    // toolsets, so an _MSC_VER-only gate would compile the body but
+    // fail at link.
+#ifdef PWIZ_HAS_RESTART_MANAGER
     DWORD sessionHandle = 0;
     WCHAR sessionKey[CCH_RM_SESSION_KEY + 1] = {0};
     DWORD rcStart = RmStartSession(&sessionHandle, 0, sessionKey);

--- a/pwiz/utility/misc/Filesystem.cpp
+++ b/pwiz/utility/misc/Filesystem.cpp
@@ -38,6 +38,7 @@
     #include <wincrypt.h>
     #include <winternl.h>
     #include <Psapi.h>
+    #include <RestartManager.h>
     #include <boost/nowide/convert.hpp>
     #include <boost/noncopyable.hpp>
 #else
@@ -61,6 +62,7 @@
 #include <boost/spirit/include/karma.hpp>
 //#include <boost/xpressive/xpressive.hpp>
 #include <iostream>
+#include <sstream>
 #include <thread>
 #include <filesystem>
 
@@ -519,6 +521,73 @@ PWIZ_API_DECL void force_close_handles_to_filepath(const std::string& filepath, 
             //    fprintf(stderr, "[force_close_handles_to_filepath()] Closed section handle.\n");
         }
     }
+#endif
+}
+
+
+PWIZ_API_DECL std::string find_locking_processes(const std::string& path)
+{
+#ifdef WIN32
+    DWORD sessionHandle = 0;
+    WCHAR sessionKey[CCH_RM_SESSION_KEY + 1] = {0};
+    if (RmStartSession(&sessionHandle, 0, sessionKey) != ERROR_SUCCESS)
+        return "(RestartManager session unavailable)";
+
+    std::string result;
+    try
+    {
+        std::wstring widePath = boost::locale::conv::utf_to_utf<wchar_t>(path);
+        PCWSTR files[1] = { widePath.c_str() };
+        DWORD rcRegister = RmRegisterResources(sessionHandle, 1, files, 0, nullptr, 0, nullptr);
+        if (rcRegister != ERROR_SUCCESS)
+        {
+            std::ostringstream oss;
+            oss << "(RmRegisterResources failed, rc=" << rcRegister << ")";
+            result = oss.str();
+        }
+        else
+        {
+            UINT nProcInfoNeeded = 0;
+            UINT nProcInfo = 0;
+            DWORD lpdwRebootReasons = RmRebootReasonNone;
+            DWORD rc = RmGetList(sessionHandle, &nProcInfoNeeded, &nProcInfo, nullptr, &lpdwRebootReasons);
+            if (rc != ERROR_MORE_DATA && rc != ERROR_SUCCESS)
+            {
+                std::ostringstream oss;
+                oss << "(RmGetList failed, rc=" << rc << ")";
+                result = oss.str();
+            }
+            else if (nProcInfoNeeded > 0)
+            {
+                std::vector<RM_PROCESS_INFO> procs(nProcInfoNeeded);
+                nProcInfo = nProcInfoNeeded;
+                DWORD rc2 = RmGetList(sessionHandle, &nProcInfoNeeded, &nProcInfo, procs.data(), &lpdwRebootReasons);
+                if (rc2 == ERROR_SUCCESS)
+                {
+                    std::ostringstream oss;
+                    for (UINT i = 0; i < nProcInfo; ++i)
+                    {
+                        if (i > 0)
+                            oss << ", ";
+                        oss << boost::locale::conv::utf_to_utf<char>(procs[i].strAppName)
+                            << " (PID " << procs[i].Process.dwProcessId << ")";
+                    }
+                    result = oss.str();
+                }
+                else
+                {
+                    std::ostringstream oss;
+                    oss << "(RmGetList (second call) failed, rc=" << rc2 << ")";
+                    result = oss.str();
+                }
+            }
+        }
+    }
+    catch (...) {}
+    RmEndSession(sessionHandle);
+    return result.empty() ? "(no holders identified by RestartManager)" : result;
+#else
+    return "(RestartManager not available on this platform)";
 #endif
 }
 

--- a/pwiz/utility/misc/Filesystem.cpp
+++ b/pwiz/utility/misc/Filesystem.cpp
@@ -567,38 +567,49 @@ PWIZ_API_DECL std::string find_locking_processes(const std::string& path)
                 oss << "(RmGetList failed, rc=" << rc << ")";
                 result = oss.str();
             }
-            else if (nProcInfoNeeded > 0)
+            else
             {
-                // Retry the fetch a few times if the holder list grows
-                // between the sizing call and the fetch (RmGetList returns
-                // ERROR_MORE_DATA in that race); otherwise we would lose
-                // the diagnostic on exactly the contested cases this
-                // helper is meant to surface.
-                DWORD rc2 = ERROR_MORE_DATA;
-                std::vector<RM_PROCESS_INFO> procs;
-                for (int attempt = 0; attempt < 3 && rc2 == ERROR_MORE_DATA; ++attempt)
+                // Treat ERROR_MORE_DATA with nProcInfoNeeded==0 as a fuzzy
+                // degenerate case: RM indicated holders exist but didn't
+                // size the buffer. Floor at 16 so the second call has a
+                // chance to return them rather than silently reporting
+                // "no holders".
+                if (rc == ERROR_MORE_DATA && nProcInfoNeeded == 0)
+                    nProcInfoNeeded = 16;
+
+                if (nProcInfoNeeded > 0)
                 {
-                    procs.resize(nProcInfoNeeded);
-                    nProcInfo = nProcInfoNeeded;
-                    rc2 = RmGetList(sessionHandle, &nProcInfoNeeded, &nProcInfo, procs.data(), &lpdwRebootReasons);
-                }
-                if (rc2 == ERROR_SUCCESS)
-                {
-                    std::ostringstream oss;
-                    for (UINT i = 0; i < nProcInfo; ++i)
+                    // Retry the fetch a few times if the holder list grows
+                    // between the sizing call and the fetch (RmGetList returns
+                    // ERROR_MORE_DATA in that race); otherwise we would lose
+                    // the diagnostic on exactly the contested cases this
+                    // helper is meant to surface.
+                    DWORD rc2 = ERROR_MORE_DATA;
+                    std::vector<RM_PROCESS_INFO> procs;
+                    for (int attempt = 0; attempt < 3 && rc2 == ERROR_MORE_DATA; ++attempt)
                     {
-                        if (i > 0)
-                            oss << ", ";
-                        oss << boost::locale::conv::utf_to_utf<char>(procs[i].strAppName)
-                            << " (PID " << procs[i].Process.dwProcessId << ")";
+                        procs.resize(nProcInfoNeeded);
+                        nProcInfo = nProcInfoNeeded;
+                        rc2 = RmGetList(sessionHandle, &nProcInfoNeeded, &nProcInfo, procs.data(), &lpdwRebootReasons);
                     }
-                    result = oss.str();
-                }
-                else
-                {
-                    std::ostringstream oss;
-                    oss << "(RmGetList (second call) failed, rc=" << rc2 << ")";
-                    result = oss.str();
+                    if (rc2 == ERROR_SUCCESS)
+                    {
+                        std::ostringstream oss;
+                        for (UINT i = 0; i < nProcInfo; ++i)
+                        {
+                            if (i > 0)
+                                oss << ", ";
+                            oss << boost::locale::conv::utf_to_utf<char>(procs[i].strAppName)
+                                << " (PID " << procs[i].Process.dwProcessId << ")";
+                        }
+                        result = oss.str();
+                    }
+                    else
+                    {
+                        std::ostringstream oss;
+                        oss << "(RmGetList (second call) failed, rc=" << rc2 << ")";
+                        result = oss.str();
+                    }
                 }
             }
         }

--- a/pwiz/utility/misc/Filesystem.cpp
+++ b/pwiz/utility/misc/Filesystem.cpp
@@ -559,9 +559,19 @@ PWIZ_API_DECL std::string find_locking_processes(const std::string& path)
             }
             else if (nProcInfoNeeded > 0)
             {
-                std::vector<RM_PROCESS_INFO> procs(nProcInfoNeeded);
-                nProcInfo = nProcInfoNeeded;
-                DWORD rc2 = RmGetList(sessionHandle, &nProcInfoNeeded, &nProcInfo, procs.data(), &lpdwRebootReasons);
+                // Retry the fetch a few times if the holder list grows
+                // between the sizing call and the fetch (RmGetList returns
+                // ERROR_MORE_DATA in that race); otherwise we would lose
+                // the diagnostic on exactly the contested cases this
+                // helper is meant to surface.
+                DWORD rc2 = ERROR_MORE_DATA;
+                std::vector<RM_PROCESS_INFO> procs;
+                for (int attempt = 0; attempt < 3 && rc2 == ERROR_MORE_DATA; ++attempt)
+                {
+                    procs.resize(nProcInfoNeeded);
+                    nProcInfo = nProcInfoNeeded;
+                    rc2 = RmGetList(sessionHandle, &nProcInfoNeeded, &nProcInfo, procs.data(), &lpdwRebootReasons);
+                }
                 if (rc2 == ERROR_SUCCESS)
                 {
                     std::ostringstream oss;

--- a/pwiz/utility/misc/Filesystem.cpp
+++ b/pwiz/utility/misc/Filesystem.cpp
@@ -527,7 +527,7 @@ PWIZ_API_DECL void force_close_handles_to_filepath(const std::string& filepath, 
 
 PWIZ_API_DECL std::string find_locking_processes(const std::string& path)
 {
-#ifdef WIN32
+#ifdef _MSC_VER
     DWORD sessionHandle = 0;
     WCHAR sessionKey[CCH_RM_SESSION_KEY + 1] = {0};
     if (RmStartSession(&sessionHandle, 0, sessionKey) != ERROR_SUCCESS)

--- a/pwiz/utility/misc/Filesystem.cpp
+++ b/pwiz/utility/misc/Filesystem.cpp
@@ -530,8 +530,13 @@ PWIZ_API_DECL std::string find_locking_processes(const std::string& path)
 #ifdef _MSC_VER
     DWORD sessionHandle = 0;
     WCHAR sessionKey[CCH_RM_SESSION_KEY + 1] = {0};
-    if (RmStartSession(&sessionHandle, 0, sessionKey) != ERROR_SUCCESS)
-        return "(RestartManager session unavailable)";
+    DWORD rcStart = RmStartSession(&sessionHandle, 0, sessionKey);
+    if (rcStart != ERROR_SUCCESS)
+    {
+        std::ostringstream oss;
+        oss << "(RmStartSession failed, rc=" << rcStart << ")";
+        return oss.str();
+    }
 
     std::string result;
     try
@@ -593,7 +598,16 @@ PWIZ_API_DECL std::string find_locking_processes(const std::string& path)
             }
         }
     }
-    catch (...) {}
+    catch (const std::exception& e)
+    {
+        if (result.empty())
+            result = std::string("(internal exception: ") + e.what() + ")";
+    }
+    catch (...)
+    {
+        if (result.empty())
+            result = "(unknown internal exception)";
+    }
     RmEndSession(sessionHandle);
     return result.empty() ? "(no holders identified by RestartManager)" : result;
 #else

--- a/pwiz/utility/misc/Filesystem.hpp
+++ b/pwiz/utility/misc/Filesystem.hpp
@@ -104,10 +104,12 @@ PWIZ_API_DECL bool running_on_wine();
 PWIZ_API_DECL void force_close_handles_to_filepath(const std::string& filepath, bool closeMemoryMappedSections = false) noexcept(true);
 
 
-/// on Windows, uses the Restart Manager API to identify processes holding handles on the
-/// given path; returns a comma-separated "appname (PID N)" listing, or a sentinel string
-/// describing the failure mode (RestartManager session unavailable, RmRegisterResources
-/// or RmGetList failure with rc, etc.). On non-Windows builds, returns a stub string.
+/// on MSVC Windows builds, uses the Restart Manager API to identify processes holding
+/// handles on the given path; returns a comma-separated "appname (PID N)" listing, or a
+/// sentinel string describing the failure mode (RestartManager session unavailable,
+/// RmRegisterResources or RmGetList failure with rc, etc.). On non-MSVC builds
+/// (including non-MSVC Windows toolsets such as clang-cl or mingw, where the Restart
+/// Manager header/library are not linked) returns a stub string.
 PWIZ_API_DECL std::string find_locking_processes(const std::string& path);
 
 

--- a/pwiz/utility/misc/Filesystem.hpp
+++ b/pwiz/utility/misc/Filesystem.hpp
@@ -104,12 +104,12 @@ PWIZ_API_DECL bool running_on_wine();
 PWIZ_API_DECL void force_close_handles_to_filepath(const std::string& filepath, bool closeMemoryMappedSections = false) noexcept(true);
 
 
-/// on MSVC Windows builds, uses the Restart Manager API to identify processes holding
-/// handles on the given path; returns a comma-separated "appname (PID N)" listing, or a
-/// sentinel string describing the failure mode (RestartManager session unavailable,
-/// RmRegisterResources or RmGetList failure with rc, etc.). On non-MSVC builds
-/// (including non-MSVC Windows toolsets such as clang-cl or mingw, where the Restart
-/// Manager header/library are not linked) returns a stub string.
+/// when PWIZ_HAS_RESTART_MANAGER is defined (set by the Jamfile under the msvc toolset,
+/// where rstrtmgr.lib is linked), uses the Restart Manager API to identify processes
+/// holding handles on the given path; returns a comma-separated "appname (PID N)"
+/// listing, or a sentinel string describing the failure mode (RmStartSession /
+/// RmRegisterResources / RmGetList failure with rc, etc.). On any other build returns
+/// a stub string.
 PWIZ_API_DECL std::string find_locking_processes(const std::string& path);
 
 

--- a/pwiz/utility/misc/Filesystem.hpp
+++ b/pwiz/utility/misc/Filesystem.hpp
@@ -104,6 +104,13 @@ PWIZ_API_DECL bool running_on_wine();
 PWIZ_API_DECL void force_close_handles_to_filepath(const std::string& filepath, bool closeMemoryMappedSections = false) noexcept(true);
 
 
+/// on Windows, uses the Restart Manager API to identify processes holding handles on the
+/// given path; returns a comma-separated "appname (PID N)" listing, or a sentinel string
+/// describing the failure mode (RestartManager session unavailable, RmRegisterResources
+/// or RmGetList failure with rc, etc.). On non-Windows builds, returns a stub string.
+PWIZ_API_DECL std::string find_locking_processes(const std::string& path);
+
+
 /// adds utf8_codecvt_facet to boost::filesystem::path's default behavior so it works with UTF-8 std::strings;
 /// uses a singleton so the imbuement is only done once
 PWIZ_API_DECL void enable_utf8_path_operations();

--- a/pwiz/utility/misc/Filesystem.hpp
+++ b/pwiz/utility/misc/Filesystem.hpp
@@ -104,12 +104,13 @@ PWIZ_API_DECL bool running_on_wine();
 PWIZ_API_DECL void force_close_handles_to_filepath(const std::string& filepath, bool closeMemoryMappedSections = false) noexcept(true);
 
 
-/// when PWIZ_HAS_RESTART_MANAGER is defined (set by the Jamfile under the msvc toolset,
-/// where rstrtmgr.lib is linked), uses the Restart Manager API to identify processes
-/// holding handles on the given path; returns a comma-separated "appname (PID N)"
-/// listing, or a sentinel string describing the failure mode (RmStartSession /
-/// RmRegisterResources / RmGetList failure with rc, etc.). On any other build returns
-/// a stub string.
+/// Always exported. When PWIZ_HAS_RESTART_MANAGER is defined (set by the Jamfile
+/// under the msvc toolset, where rstrtmgr.lib is linked), the body uses the Restart
+/// Manager API to identify processes holding handles on the given path; returns a
+/// comma-separated "appname (PID N)" listing, or a sentinel string describing the
+/// failure mode (RmStartSession / RmRegisterResources / RmGetList failure with rc,
+/// etc.). On any other build the body returns a stub sentinel string -- the symbol
+/// itself is always linkable so callers do not need to conditionally compile.
 PWIZ_API_DECL std::string find_locking_processes(const std::string& path);
 
 

--- a/pwiz/utility/misc/Jamfile.jam
+++ b/pwiz/utility/misc/Jamfile.jam
@@ -60,6 +60,7 @@ lib pwiz_utility_misc
         <toolset>msvc:<library>oleaut32
         <toolset>msvc:<library>psapi
         <toolset>msvc:<library>rstrtmgr
+        <toolset>msvc:<define>PWIZ_HAS_RESTART_MANAGER
         <library>/ext/boost//thread
         <library>/ext/boost//iostreams
         <library>/ext/boost//filesystem

--- a/pwiz/utility/misc/Jamfile.jam
+++ b/pwiz/utility/misc/Jamfile.jam
@@ -31,6 +31,7 @@ project
 
 lib oleaut32 : : <name>oleaut32 ; # for Variant/SafeArray functions
 lib psapi : : <name>psapi ; # for GetMappedFileNameW
+lib rstrtmgr : : <name>rstrtmgr ; # for Restart Manager (findLockingProcesses diagnostic in VendorReaderTestHarness)
 lib SHA1 : SHA1.cpp : <link>static <library>/ext/boost//filesystem ;
 
 # testing with precompiled header support
@@ -102,11 +103,13 @@ lib pwiz_utility_vendor_reader_test_harness
         <library>pwiz_utility_misc
         <library>$(PWIZ_ROOT_PATH)/pwiz/data/msdata//pwiz_data_msdata
         <library>$(PWIZ_ROOT_PATH)/pwiz/analysis/spectrum_processing//pwiz_analysis_spectrum_processing
+        <toolset>msvc:<library>rstrtmgr
     : # default-build
     : # usage-requirements
         <library>pwiz_utility_misc
         <library>$(PWIZ_ROOT_PATH)/pwiz/data/msdata//pwiz_data_msdata
         <library>$(PWIZ_ROOT_PATH)/pwiz/analysis/spectrum_processing//pwiz_analysis_spectrum_processing
+        <toolset>msvc:<library>rstrtmgr
         #<testing.semaphore>io_semaphore
         #<testing.semaphore>mt_semaphore
     ;

--- a/pwiz/utility/misc/Jamfile.jam
+++ b/pwiz/utility/misc/Jamfile.jam
@@ -31,7 +31,7 @@ project
 
 lib oleaut32 : : <name>oleaut32 ; # for Variant/SafeArray functions
 lib psapi : : <name>psapi ; # for GetMappedFileNameW
-lib rstrtmgr : : <name>rstrtmgr ; # for Restart Manager (findLockingProcesses diagnostic in VendorReaderTestHarness)
+lib rstrtmgr : : <name>rstrtmgr ; # for Restart Manager (find_locking_processes diagnostic in Filesystem.cpp)
 lib SHA1 : SHA1.cpp : <link>static <library>/ext/boost//filesystem ;
 
 # testing with precompiled header support
@@ -59,6 +59,7 @@ lib pwiz_utility_misc
         <toolset>msvc:<source>automation_vector.cpp
         <toolset>msvc:<library>oleaut32
         <toolset>msvc:<library>psapi
+        <toolset>msvc:<library>rstrtmgr
         <library>/ext/boost//thread
         <library>/ext/boost//iostreams
         <library>/ext/boost//filesystem
@@ -77,6 +78,7 @@ lib pwiz_utility_misc
         <library>/ext/zstd//zstd
         <toolset>msvc:<library>oleaut32
         <toolset>msvc:<library>psapi
+        <toolset>msvc:<library>rstrtmgr
     ;
 
 
@@ -103,13 +105,11 @@ lib pwiz_utility_vendor_reader_test_harness
         <library>pwiz_utility_misc
         <library>$(PWIZ_ROOT_PATH)/pwiz/data/msdata//pwiz_data_msdata
         <library>$(PWIZ_ROOT_PATH)/pwiz/analysis/spectrum_processing//pwiz_analysis_spectrum_processing
-        <toolset>msvc:<library>rstrtmgr
     : # default-build
     : # usage-requirements
         <library>pwiz_utility_misc
         <library>$(PWIZ_ROOT_PATH)/pwiz/data/msdata//pwiz_data_msdata
         <library>$(PWIZ_ROOT_PATH)/pwiz/analysis/spectrum_processing//pwiz_analysis_spectrum_processing
-        <toolset>msvc:<library>rstrtmgr
         #<testing.semaphore>io_semaphore
         #<testing.semaphore>mt_semaphore
     ;

--- a/pwiz/utility/misc/VendorReaderTestHarness.cpp
+++ b/pwiz/utility/misc/VendorReaderTestHarness.cpp
@@ -22,15 +22,6 @@
 #define PWIZ_SOURCE
 
 
-// Windows headers must come before boost so that WIN32_LEAN_AND_MEAN and
-// NOMINMAX take effect before boost transitively includes <windows.h>.
-#ifdef _MSC_VER
-    #define WIN32_LEAN_AND_MEAN
-    #define NOMINMAX
-    #include <windows.h>
-    #include <RestartManager.h>
-#endif
-
 #include "VendorReaderTestHarness.hpp"
 #include "pwiz/data/msdata/TextWriter.hpp"
 #include "pwiz/data/msdata/MSDataFile.hpp"
@@ -72,80 +63,6 @@ namespace util {
 
 
 namespace {
-
-#ifdef _MSC_VER
-// Use Windows RestartManager to identify which processes hold a handle on
-// the given path. Used as a diagnostic when the rename-back round-trip
-// after a vendor reader test fails (typical culprits on TeamCity agents:
-// Windows Defender, Search indexer, recently-loaded reader DLLs).
-std::string findLockingProcesses(const std::string& path)
-{
-    DWORD sessionHandle = 0;
-    WCHAR sessionKey[CCH_RM_SESSION_KEY + 1] = {0};
-    if (RmStartSession(&sessionHandle, 0, sessionKey) != ERROR_SUCCESS)
-        return "(RestartManager session unavailable)";
-
-    std::string result;
-    try
-    {
-        std::wstring widePath = boost::locale::conv::utf_to_utf<wchar_t>(path);
-        PCWSTR files[1] = { widePath.c_str() };
-        DWORD rcRegister = RmRegisterResources(sessionHandle, 1, files, 0, nullptr, 0, nullptr);
-        if (rcRegister != ERROR_SUCCESS)
-        {
-            std::ostringstream oss;
-            oss << "(RmRegisterResources failed, rc=" << rcRegister << ")";
-            result = oss.str();
-        }
-        else
-        {
-            UINT nProcInfoNeeded = 0;
-            UINT nProcInfo = 0;
-            DWORD lpdwRebootReasons = RmRebootReasonNone;
-            DWORD rc = RmGetList(sessionHandle, &nProcInfoNeeded, &nProcInfo, nullptr, &lpdwRebootReasons);
-            if (rc != ERROR_MORE_DATA && rc != ERROR_SUCCESS)
-            {
-                std::ostringstream oss;
-                oss << "(RmGetList failed, rc=" << rc << ")";
-                result = oss.str();
-            }
-            else if (nProcInfoNeeded > 0)
-            {
-                std::vector<RM_PROCESS_INFO> procs(nProcInfoNeeded);
-                nProcInfo = nProcInfoNeeded;
-                DWORD rc2 = RmGetList(sessionHandle, &nProcInfoNeeded, &nProcInfo, procs.data(), &lpdwRebootReasons);
-                if (rc2 == ERROR_SUCCESS)
-                {
-                    std::ostringstream oss;
-                    for (UINT i = 0; i < nProcInfo; ++i)
-                    {
-                        if (i > 0)
-                            oss << ", ";
-                        oss << boost::locale::conv::utf_to_utf<char>(procs[i].strAppName)
-                            << " (PID " << procs[i].Process.dwProcessId << ")";
-                    }
-                    result = oss.str();
-                }
-                else
-                {
-                    std::ostringstream oss;
-                    oss << "(RmGetList (second call) failed, rc=" << rc2 << ")";
-                    result = oss.str();
-                }
-            }
-        }
-    }
-    catch (...) {}
-    RmEndSession(sessionHandle);
-    return result.empty() ? "(no holders identified by RestartManager)" : result;
-}
-#else
-std::string findLockingProcesses(const std::string& /*path*/)
-{
-    return "(RestartManager not available on this platform)";
-}
-#endif
-
 
 struct TestTimer : Timer
 {
@@ -1135,7 +1052,7 @@ TestResult testReader(const Reader& reader, const vector<string>& args, bool tes
                             cerr << "Cannot rename " << rawpath << ": there are unreleased file locks!" << endl;
                         else
                         {
-                            std::string holders = findLockingProcesses(currentPath);
+                            std::string holders = find_locking_processes(currentPath);
                             throw runtime_error("Cannot rename " + rawpath + ": there are unreleased file locks! "
                                                 "Last error: " + lastError + ". Lock holders: " + holders);
                         }

--- a/pwiz/utility/misc/VendorReaderTestHarness.cpp
+++ b/pwiz/utility/misc/VendorReaderTestHarness.cpp
@@ -90,7 +90,14 @@ std::string findLockingProcesses(const std::string& path)
     {
         std::wstring widePath = boost::locale::conv::utf_to_utf<wchar_t>(path);
         PCWSTR files[1] = { widePath.c_str() };
-        if (RmRegisterResources(sessionHandle, 1, files, 0, nullptr, 0, nullptr) == ERROR_SUCCESS)
+        DWORD rcRegister = RmRegisterResources(sessionHandle, 1, files, 0, nullptr, 0, nullptr);
+        if (rcRegister != ERROR_SUCCESS)
+        {
+            std::ostringstream oss;
+            oss << "(RmRegisterResources failed, rc=" << rcRegister << ")";
+            result = oss.str();
+        }
+        else
         {
             UINT nProcInfoNeeded = 0;
             UINT nProcInfo = 0;

--- a/pwiz/utility/misc/VendorReaderTestHarness.cpp
+++ b/pwiz/utility/misc/VendorReaderTestHarness.cpp
@@ -103,7 +103,8 @@ std::string findLockingProcesses(const std::string& path)
                     std::ostringstream oss;
                     for (UINT i = 0; i < nProcInfo; ++i)
                     {
-                        if (i > 0) oss << ", ";
+                        if (i > 0)
+                            oss << ", ";
                         oss << boost::locale::conv::utf_to_utf<char>(procs[i].strAppName)
                             << " (PID " << procs[i].Process.dwProcessId << ")";
                     }
@@ -1102,8 +1103,13 @@ TestResult testReader(const Reader& reader, const vector<string>& args, bool tes
                     if (!renameOk)
                     {
                         const std::string& currentPath = isRenamed ? renamedPath : rawpath;
-                        // HACK: bug in CompassXtract, used only for YEP/FID formats now, keeps directory locked after opening it but has no problem with re-opening the file
-                        if (bfs::exists(bfs::path(currentPath) / "Analysis.yep"))
+                        // HACK: bug in CompassXtract, used only for YEP/FID formats now,
+                        // keeps directory locked after opening it but has no problem with
+                        // re-opening the file. Only suppress when the fixture is still intact
+                        // (forward rename never happened); a failed rename-back leaves the
+                        // fixture at <rawpath>.renamed and must surface as an error so the
+                        // test run does not continue against a broken fixture.
+                        if (!isRenamed && bfs::exists(bfs::path(rawpath) / "Analysis.yep"))
                             cerr << "Cannot rename " << rawpath << ": there are unreleased file locks!" << endl;
                         else
                         {

--- a/pwiz/utility/misc/VendorReaderTestHarness.cpp
+++ b/pwiz/utility/misc/VendorReaderTestHarness.cpp
@@ -1069,7 +1069,15 @@ TestResult testReader(const Reader& reader, const vector<string>& args, bool tes
                     // retry briefly to absorb transient holds from AV scanners / indexers / OS
                     // file-handle release lag on CI agents -- a real reader-side handle leak
                     // remains pinned no matter how long we wait, so the final failure path
-                    // still surfaces those
+                    // still surfaces those.
+                    //
+                    // Track which side of the rename round-trip we are on so that if the
+                    // forward rename succeeds but the rename-back fails, the retry only
+                    // repeats the rename-back step (rather than failing with "path not
+                    // found" because the source has already moved) and the final
+                    // diagnostic queries the path that is actually still on disk.
+                    std::string renamedPath = rawpath + ".renamed";
+                    bool isRenamed = false;
                     bool renameOk = false;
                     std::string lastError = "(no exception captured)";
                     for (int attempt = 0; attempt < 5; ++attempt)
@@ -1078,8 +1086,13 @@ TestResult testReader(const Reader& reader, const vector<string>& args, bool tes
                             std::this_thread::sleep_for(std::chrono::milliseconds(250 * attempt));
                         try
                         {
-                            bfs::rename(rawpath, rawpath + ".renamed");
-                            bfs::rename(rawpath + ".renamed", rawpath);
+                            if (!isRenamed)
+                            {
+                                bfs::rename(rawpath, renamedPath);
+                                isRenamed = true;
+                            }
+                            bfs::rename(renamedPath, rawpath);
+                            isRenamed = false;
                             renameOk = true;
                             break;
                         }
@@ -1088,12 +1101,13 @@ TestResult testReader(const Reader& reader, const vector<string>& args, bool tes
                     }
                     if (!renameOk)
                     {
+                        const std::string& currentPath = isRenamed ? renamedPath : rawpath;
                         // HACK: bug in CompassXtract, used only for YEP/FID formats now, keeps directory locked after opening it but has no problem with re-opening the file
-                        if (bfs::exists(bfs::path(rawpath) / "Analysis.yep"))
+                        if (bfs::exists(bfs::path(currentPath) / "Analysis.yep"))
                             cerr << "Cannot rename " << rawpath << ": there are unreleased file locks!" << endl;
                         else
                         {
-                            std::string holders = findLockingProcesses(rawpath);
+                            std::string holders = findLockingProcesses(currentPath);
                             throw runtime_error("Cannot rename " + rawpath + ": there are unreleased file locks! "
                                                 "Last error: " + lastError + ". Lock holders: " + holders);
                         }

--- a/pwiz/utility/misc/VendorReaderTestHarness.cpp
+++ b/pwiz/utility/misc/VendorReaderTestHarness.cpp
@@ -46,6 +46,15 @@
 #include "boost/locale/encoding_utf.hpp"
 #include "pwiz/data/msdata/Serializer_mzML.hpp"
 #include "pwiz/utility/minimxml/XMLWriter.hpp"
+#include <thread>
+#include <chrono>
+
+#ifdef _MSC_VER
+    #define WIN32_LEAN_AND_MEAN
+    #define NOMINMAX
+    #include <windows.h>
+    #include <RestartManager.h>
+#endif
 
 
 using namespace pwiz::util;
@@ -61,6 +70,59 @@ namespace util {
 
 
 namespace {
+
+#ifdef _MSC_VER
+// Use Windows RestartManager to identify which processes hold a handle on
+// the given path. Used as a diagnostic when the rename-back round-trip
+// after a vendor reader test fails (typical culprits on TeamCity agents:
+// Windows Defender, Search indexer, recently-loaded reader DLLs).
+std::string findLockingProcesses(const std::string& path)
+{
+    DWORD sessionHandle = 0;
+    WCHAR sessionKey[CCH_RM_SESSION_KEY + 1] = {0};
+    if (RmStartSession(&sessionHandle, 0, sessionKey) != ERROR_SUCCESS)
+        return "(RestartManager session unavailable)";
+
+    std::string result;
+    try
+    {
+        std::wstring widePath = boost::locale::conv::utf_to_utf<wchar_t>(path);
+        PCWSTR files[1] = { widePath.c_str() };
+        if (RmRegisterResources(sessionHandle, 1, files, 0, nullptr, 0, nullptr) == ERROR_SUCCESS)
+        {
+            UINT nProcInfoNeeded = 0;
+            UINT nProcInfo = 0;
+            DWORD lpdwRebootReasons = RmRebootReasonNone;
+            DWORD rc = RmGetList(sessionHandle, &nProcInfoNeeded, &nProcInfo, nullptr, &lpdwRebootReasons);
+            if (nProcInfoNeeded > 0 && (rc == ERROR_MORE_DATA || rc == ERROR_SUCCESS))
+            {
+                std::vector<RM_PROCESS_INFO> procs(nProcInfoNeeded);
+                nProcInfo = nProcInfoNeeded;
+                if (RmGetList(sessionHandle, &nProcInfoNeeded, &nProcInfo, procs.data(), &lpdwRebootReasons) == ERROR_SUCCESS)
+                {
+                    std::ostringstream oss;
+                    for (UINT i = 0; i < nProcInfo; ++i)
+                    {
+                        if (i > 0) oss << ", ";
+                        oss << boost::locale::conv::utf_to_utf<char>(procs[i].strAppName)
+                            << " (PID " << procs[i].Process.dwProcessId << ")";
+                    }
+                    result = oss.str();
+                }
+            }
+        }
+    }
+    catch (...) {}
+    RmEndSession(sessionHandle);
+    return result.empty() ? "(no holders identified by RestartManager)" : result;
+}
+#else
+std::string findLockingProcesses(const std::string& /*path*/)
+{
+    return "(RestartManager not available on this platform)";
+}
+#endif
+
 
 struct TestTimer : Timer
 {
@@ -1004,18 +1066,37 @@ TestResult testReader(const Reader& reader, const vector<string>& args, bool tes
                 if (bfs::exists(rawpath))
                 {
                     // test that the reader releases any locks on the data so it can be moved/deleted
-                    try
+                    // retry briefly to absorb transient holds from AV scanners / indexers / OS
+                    // file-handle release lag on CI agents -- a real reader-side handle leak
+                    // remains pinned no matter how long we wait, so the final failure path
+                    // still surfaces those
+                    bool renameOk = false;
+                    std::string lastError = "(no exception captured)";
+                    for (int attempt = 0; attempt < 5; ++attempt)
                     {
-                        bfs::rename(rawpath, rawpath + ".renamed");
-                        bfs::rename(rawpath + ".renamed", rawpath);
+                        if (attempt > 0)
+                            std::this_thread::sleep_for(std::chrono::milliseconds(250 * attempt));
+                        try
+                        {
+                            bfs::rename(rawpath, rawpath + ".renamed");
+                            bfs::rename(rawpath + ".renamed", rawpath);
+                            renameOk = true;
+                            break;
+                        }
+                        catch (const std::exception& e) { lastError = e.what(); }
+                        catch (...) { lastError = "(unknown rename failure)"; }
                     }
-                    catch (...)
+                    if (!renameOk)
                     {
                         // HACK: bug in CompassXtract, used only for YEP/FID formats now, keeps directory locked after opening it but has no problem with re-opening the file
                         if (bfs::exists(bfs::path(rawpath) / "Analysis.yep"))
                             cerr << "Cannot rename " << rawpath << ": there are unreleased file locks!" << endl;
                         else
-                            throw runtime_error("Cannot rename " + rawpath + ": there are unreleased file locks!");
+                        {
+                            std::string holders = findLockingProcesses(rawpath);
+                            throw runtime_error("Cannot rename " + rawpath + ": there are unreleased file locks! "
+                                                "Last error: " + lastError + ". Lock holders: " + holders);
+                        }
                     }
                 }
             }

--- a/pwiz/utility/misc/VendorReaderTestHarness.cpp
+++ b/pwiz/utility/misc/VendorReaderTestHarness.cpp
@@ -1052,8 +1052,15 @@ TestResult testReader(const Reader& reader, const vector<string>& args, bool tes
                             cerr << "Cannot rename " << rawpath << ": there are unreleased file locks!" << endl;
                         else
                         {
+                            // Report the source -> target of the actual failing rename:
+                            // if isRenamed is true the forward rename succeeded and the
+                            // rename-back is the failing operation (renamedPath -> rawpath);
+                            // otherwise the forward rename itself failed (rawpath -> renamedPath).
+                            const std::string& sourcePath = isRenamed ? renamedPath : rawpath;
+                            const std::string& targetPath = isRenamed ? rawpath : renamedPath;
                             std::string holders = find_locking_processes(currentPath);
-                            throw runtime_error("Cannot rename " + rawpath + ": there are unreleased file locks! "
+                            throw runtime_error("Cannot rename " + sourcePath + " -> " + targetPath +
+                                                ": there are unreleased file locks! "
                                                 "Last error: " + lastError + ". Lock holders: " + holders);
                         }
                     }

--- a/pwiz/utility/misc/VendorReaderTestHarness.cpp
+++ b/pwiz/utility/misc/VendorReaderTestHarness.cpp
@@ -22,6 +22,15 @@
 #define PWIZ_SOURCE
 
 
+// Windows headers must come before boost so that WIN32_LEAN_AND_MEAN and
+// NOMINMAX take effect before boost transitively includes <windows.h>.
+#ifdef _MSC_VER
+    #define WIN32_LEAN_AND_MEAN
+    #define NOMINMAX
+    #include <windows.h>
+    #include <RestartManager.h>
+#endif
+
 #include "VendorReaderTestHarness.hpp"
 #include "pwiz/data/msdata/TextWriter.hpp"
 #include "pwiz/data/msdata/MSDataFile.hpp"
@@ -48,13 +57,6 @@
 #include "pwiz/utility/minimxml/XMLWriter.hpp"
 #include <thread>
 #include <chrono>
-
-#ifdef _MSC_VER
-    #define WIN32_LEAN_AND_MEAN
-    #define NOMINMAX
-    #include <windows.h>
-    #include <RestartManager.h>
-#endif
 
 
 using namespace pwiz::util;
@@ -94,11 +96,18 @@ std::string findLockingProcesses(const std::string& path)
             UINT nProcInfo = 0;
             DWORD lpdwRebootReasons = RmRebootReasonNone;
             DWORD rc = RmGetList(sessionHandle, &nProcInfoNeeded, &nProcInfo, nullptr, &lpdwRebootReasons);
-            if (nProcInfoNeeded > 0 && (rc == ERROR_MORE_DATA || rc == ERROR_SUCCESS))
+            if (rc != ERROR_MORE_DATA && rc != ERROR_SUCCESS)
+            {
+                std::ostringstream oss;
+                oss << "(RmGetList failed, rc=" << rc << ")";
+                result = oss.str();
+            }
+            else if (nProcInfoNeeded > 0)
             {
                 std::vector<RM_PROCESS_INFO> procs(nProcInfoNeeded);
                 nProcInfo = nProcInfoNeeded;
-                if (RmGetList(sessionHandle, &nProcInfoNeeded, &nProcInfo, procs.data(), &lpdwRebootReasons) == ERROR_SUCCESS)
+                DWORD rc2 = RmGetList(sessionHandle, &nProcInfoNeeded, &nProcInfo, procs.data(), &lpdwRebootReasons);
+                if (rc2 == ERROR_SUCCESS)
                 {
                     std::ostringstream oss;
                     for (UINT i = 0; i < nProcInfo; ++i)
@@ -108,6 +117,12 @@ std::string findLockingProcesses(const std::string& path)
                         oss << boost::locale::conv::utf_to_utf<char>(procs[i].strAppName)
                             << " (PID " << procs[i].Process.dwProcessId << ")";
                     }
+                    result = oss.str();
+                }
+                else
+                {
+                    std::ostringstream oss;
+                    oss << "(RmGetList (second call) failed, rc=" << rc2 << ")";
                     result = oss.str();
                 }
             }

--- a/pwiz/utility/misc/VendorReaderTestHarness.cpp
+++ b/pwiz/utility/misc/VendorReaderTestHarness.cpp
@@ -1058,10 +1058,32 @@ TestResult testReader(const Reader& reader, const vector<string>& args, bool tes
                             // otherwise the forward rename itself failed (rawpath -> renamedPath).
                             const std::string& sourcePath = isRenamed ? renamedPath : rawpath;
                             const std::string& targetPath = isRenamed ? rawpath : renamedPath;
-                            std::string holders = find_locking_processes(currentPath);
-                            throw runtime_error("Cannot rename " + sourcePath + " -> " + targetPath +
-                                                ": there are unreleased file locks! "
-                                                "Last error: " + lastError + ". Lock holders: " + holders);
+                            // Distinguish "path no longer exists" (e.g. AV quarantined it)
+                            // from "RestartManager found no holders" -- the former is a
+                            // useful diagnostic; the latter is the default sentinel.
+                            std::string holders = bfs::exists(currentPath)
+                                ? find_locking_processes(currentPath)
+                                : "(path no longer exists: " + currentPath + ")";
+                            // Best-effort restoration: if the forward rename succeeded but
+                            // the rename-back is what's failing, try one last non-throwing
+                            // rename-back so subsequent tests at least see the fixture at
+                            // its expected location (locked, but locatable) rather than
+                            // missing entirely.
+                            if (isRenamed)
+                            {
+                                boost::system::error_code ec;
+                                bfs::rename(renamedPath, rawpath, ec);
+                                // result intentionally ignored; we're about to throw
+                            }
+                            // Also log to cerr before throwing -- test harnesses sometimes
+                            // truncate or reformat exception what() strings, and the
+                            // lock-holder list is exactly the information we want preserved
+                            // verbatim in CI logs.
+                            std::string msg = "Cannot rename " + sourcePath + " -> " + targetPath +
+                                              ": there are unreleased file locks! "
+                                              "Last error: " + lastError + ". Lock holders: " + holders;
+                            cerr << msg << endl;
+                            throw runtime_error(msg);
                         }
                     }
                 }


### PR DESCRIPTION
## Summary

`VendorReaderTestHarness` does a rename round-trip on the test `.d`
directory after each vendor reader test to verify all handles were
released. On TeamCity it occasionally fails ("Cannot rename ...: there
are unreleased file locks!") even though the same test passes most
other runs -- consistent with a transient external holder (Windows
Defender, Search indexer, OS file-handle release lag) rather than a
reader-side handle leak (which would fail deterministically).

Two changes:

- **Retry the rename** up to 5 times with backoff (0/250/500/750/1000 ms,
  total 2.5s budget on failure paths only). Transient holders typically
  clear in well under a second; a real reader bug remains pinned no
  matter how long we wait, so the final failure path still surfaces
  those.

- **On final failure, use the Windows Restart Manager API**
  (`RmStartSession` / `RmRegisterResources` / `RmGetList`) to enumerate
  the processes holding handles on the path, and include the result
  plus the underlying OS error in the thrown message. Replaces the
  generic "unreleased file locks!" string with concrete diagnostic
  data, e.g. `Lock holders: MsMpEng.exe (PID 1234)`.

Restart Manager support is MSVC-only; on other toolsets the helper
returns a stub string. New library dependency: `rstrtmgr.lib` on MSVC.

## What this does NOT do

- It does not silence the failure in CI -- a real reader-side handle
  leak still fails the test, just with better diagnostics.
- It does not change reader behavior -- this is purely test-harness
  diagnostic code.

## Test plan

- [ ] TC nightly -- the intermittent ImsSynthCCS.d failure should
      either stop occurring (transient AV) or, if it still fires,
      now name the locking process in the failure message
- [ ] Linux/macOS CI -- builds with the stub helper, no Restart
      Manager linkage