### PR TITLE
Stopped Stage 6 from overwriting the Stage 4 scores parquet

### DIFF
--- a/pwiz_tools/OspreySharp/OspreySharp.IO/ParquetScoreCache.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.IO/ParquetScoreCache.cs
@@ -932,9 +932,19 @@ namespace pwiz.OspreySharp.IO
             return Path.Combine(dir, stem + ".scores.parquet");
         }
 
+        // The reconciled-output marker is appended AFTER the ".scores" token
+        // (".scores-reconciled.parquet"), NOT inserted before it. Stage 4 always
+        // writes exactly "<stem>.scores.parquet" (GetScoresPath appends that
+        // literal), so a Stage 4 path can never end in ".scores-reconciled.parquet"
+        // even when the input stem itself ends in ".reconciled". That makes the
+        // suffix an UNAMBIGUOUS "this is a Stage 6 reconciled output" signal --
+        // no parquet-metadata read needed to tell the two apart.
+        public const string ScoresParquetSuffix = ".scores.parquet";
+        public const string ReconciledScoresParquetSuffix = ".scores-reconciled.parquet";
+
         /// <summary>
         /// Returns the reconciled scores Parquet path for a given mzML path:
-        /// {stem}.reconciled.scores.parquet in the same directory. Stage 6
+        /// {stem}.scores-reconciled.parquet in the same directory. Stage 6
         /// (<c>PerFileRescoreTask</c>) writes this file instead of overwriting
         /// the Stage 4 <see cref="GetScoresPath"/> output, so the original
         /// per-file scores survive a reconciliation pass (and a partial Stage 6
@@ -945,30 +955,35 @@ namespace pwiz.OspreySharp.IO
         {
             string dir = Path.GetDirectoryName(mzmlPath) ?? string.Empty;
             string stem = Path.GetFileNameWithoutExtension(mzmlPath);
-            return Path.Combine(dir, stem + ".reconciled.scores.parquet");
+            return Path.Combine(dir, stem + ReconciledScoresParquetSuffix);
         }
 
         /// <summary>
-        /// Map an original <c>.scores.parquet</c> path to its sibling
-        /// <c>.reconciled.scores.parquet</c> path. Uses a literal-suffix
-        /// replace rather than a stem rebuild because
-        /// <c>Path.GetFileNameWithoutExtension</c> of
-        /// <c>x.scores.parquet</c> is <c>x.scores</c> -- the <c>.reconciled</c>
-        /// marker has to be inserted BEFORE <c>.scores</c>, not appended to the
-        /// trailing-extension-stripped stem. Inputs that already end in
-        /// <c>.reconciled.scores.parquet</c> are returned unchanged.
+        /// True if <paramref name="path"/> is a Stage 6 reconciled-scores parquet
+        /// (ends in <c>.scores-reconciled.parquet</c>). Unambiguous: see the note
+        /// on <see cref="ReconciledScoresParquetSuffix"/>.
+        /// </summary>
+        public static bool IsReconciledScoresPath(string path)
+        {
+            return !string.IsNullOrEmpty(path)
+                && path.EndsWith(ReconciledScoresParquetSuffix, StringComparison.Ordinal);
+        }
+
+        /// <summary>
+        /// Map an original <c>.scores.parquet</c> path to its reconciled sibling
+        /// <c>.scores-reconciled.parquet</c> by swapping the trailing suffix. A
+        /// path that is already a reconciled output is returned unchanged (safe
+        /// and unambiguous, since the two suffixes never collide).
         /// </summary>
         public static string ReconciledPathFromScoresPath(string scoresPath)
         {
             if (string.IsNullOrEmpty(scoresPath))
                 return scoresPath;
-            const string reconciledSuffix = ".reconciled.scores.parquet";
-            const string scoresSuffix = ".scores.parquet";
-            if (scoresPath.EndsWith(reconciledSuffix, StringComparison.Ordinal))
+            if (scoresPath.EndsWith(ReconciledScoresParquetSuffix, StringComparison.Ordinal))
                 return scoresPath;
-            if (scoresPath.EndsWith(scoresSuffix, StringComparison.Ordinal))
-                return scoresPath.Substring(0, scoresPath.Length - scoresSuffix.Length)
-                    + reconciledSuffix;
+            if (scoresPath.EndsWith(ScoresParquetSuffix, StringComparison.Ordinal))
+                return scoresPath.Substring(0, scoresPath.Length - ScoresParquetSuffix.Length)
+                    + ReconciledScoresParquetSuffix;
             return scoresPath;
         }
 

--- a/pwiz_tools/OspreySharp/OspreySharp.IO/ParquetScoreCache.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.IO/ParquetScoreCache.cs
@@ -933,6 +933,64 @@ namespace pwiz.OspreySharp.IO
         }
 
         /// <summary>
+        /// Returns the reconciled scores Parquet path for a given mzML path:
+        /// {stem}.reconciled.scores.parquet in the same directory. Stage 6
+        /// (<c>PerFileRescoreTask</c>) writes this file instead of overwriting
+        /// the Stage 4 <see cref="GetScoresPath"/> output, so the original
+        /// per-file scores survive a reconciliation pass (and a partial Stage 6
+        /// crash can no longer leave the Stage 4 parquet in an indeterminate
+        /// half-rewritten state).
+        /// </summary>
+        public static string GetReconciledScoresPath(string mzmlPath)
+        {
+            string dir = Path.GetDirectoryName(mzmlPath) ?? string.Empty;
+            string stem = Path.GetFileNameWithoutExtension(mzmlPath);
+            return Path.Combine(dir, stem + ".reconciled.scores.parquet");
+        }
+
+        /// <summary>
+        /// Map an original <c>.scores.parquet</c> path to its sibling
+        /// <c>.reconciled.scores.parquet</c> path. Uses a literal-suffix
+        /// replace rather than a stem rebuild because
+        /// <c>Path.GetFileNameWithoutExtension</c> of
+        /// <c>x.scores.parquet</c> is <c>x.scores</c> -- the <c>.reconciled</c>
+        /// marker has to be inserted BEFORE <c>.scores</c>, not appended to the
+        /// trailing-extension-stripped stem. Inputs that already end in
+        /// <c>.reconciled.scores.parquet</c> are returned unchanged.
+        /// </summary>
+        public static string ReconciledPathFromScoresPath(string scoresPath)
+        {
+            if (string.IsNullOrEmpty(scoresPath))
+                return scoresPath;
+            const string reconciledSuffix = ".reconciled.scores.parquet";
+            const string scoresSuffix = ".scores.parquet";
+            if (scoresPath.EndsWith(reconciledSuffix, StringComparison.Ordinal))
+                return scoresPath;
+            if (scoresPath.EndsWith(scoresSuffix, StringComparison.Ordinal))
+                return scoresPath.Substring(0, scoresPath.Length - scoresSuffix.Length)
+                    + reconciledSuffix;
+            return scoresPath;
+        }
+
+        /// <summary>
+        /// The path a post-Stage-6 reader (Stage 7 feature reload, resume /
+        /// <c>--join-at-pass=2</c>) should consume for a given original
+        /// <c>.scores.parquet</c> path: the reconciled sibling when it exists
+        /// on disk, otherwise the original. This per-file selection is the
+        /// read-side contract that makes the separate-reconciled-file design
+        /// byte-equivalent to the former in-place overwrite: files that had
+        /// reconciliation work read the reconciled bytes (which used to be
+        /// written over the original), while files with no Stage 6 work -- which
+        /// <c>PerFileRescoreTask</c> deliberately skips, leaving no reconciled
+        /// file -- read the untouched original (which used to be left in place).
+        /// </summary>
+        public static string EffectiveScoresPathFromScoresPath(string scoresPath)
+        {
+            string reconciled = ReconciledPathFromScoresPath(scoresPath);
+            return File.Exists(reconciled) ? reconciled : scoresPath;
+        }
+
+        /// <summary>
         /// Check if an existing Parquet file's custom metadata matches the expected values.
         /// Returns true if all expected keys exist with matching values.
         /// </summary>

--- a/pwiz_tools/OspreySharp/OspreySharp.Tasks/OspreyTask.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Tasks/OspreyTask.cs
@@ -97,10 +97,12 @@ namespace pwiz.OspreySharp.Tasks
         /// <see cref="Run"/> is skipped. After a successful Run, the
         /// driver writes a <c>&lt;output&gt;.&lt;TaskName&gt;.osprey.task</c>
         /// sidecar next to each output file. The per-task naming lets
-        /// two tasks that produce the same output path (e.g. PerFileScoring
-        /// writes the initial <c>.scores.parquet</c>, PerFileRescore later
-        /// overwrites it in place with reconciled content) keep distinct
-        /// validity records.
+        /// two tasks that produce the same output path keep distinct
+        /// validity records. (Historically PerFileScoring wrote the initial
+        /// <c>.scores.parquet</c> and PerFileRescore overwrote it in place;
+        /// Stage 6 now writes a separate <c>.scores-reconciled.parquet</c>, so
+        /// they no longer share an output -- the per-task naming remains for any
+        /// future same-path producers.)
         ///
         /// A task that returns no Outputs cannot be skipped; the driver
         /// always invokes <see cref="Run"/> for it. Use that posture

--- a/pwiz_tools/OspreySharp/OspreySharp.Tasks/TaskValiditySidecar.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Tasks/TaskValiditySidecar.cs
@@ -34,13 +34,15 @@ namespace pwiz.OspreySharp.Tasks
     /// next to each task output at path
     /// <c>&lt;output&gt;.&lt;TaskName&gt;.osprey.task</c>.
     ///
-    /// Naming includes the task name so that two tasks which write
-    /// to the same output (e.g. PerFileScoringTask writes the
-    /// initial <c>.scores.parquet</c>, PerFileRescoreTask later
-    /// overwrites it in place with reconciled content) do not
-    /// trample each other's validity records. Each task checks its
-    /// own sidecar; downstream consumers don't need to know which
-    /// task wrote last.
+    /// Naming includes the task name so that two tasks writing to the
+    /// same output path do not trample each other's validity records.
+    /// (Historically PerFileScoringTask wrote <c>.scores.parquet</c> and
+    /// PerFileRescoreTask overwrote it in place; Stage 6 now writes a
+    /// separate <c>.reconciled.scores.parquet</c>, so the two tasks no
+    /// longer share an output -- but the task-name disambiguation remains
+    /// for any future same-path producers.) Each task checks its own
+    /// sidecar; downstream consumers don't need to know which task wrote
+    /// last.
     ///
     /// On the next pipeline invocation, the driver reads each
     /// output's sidecar before running the producing task; when

--- a/pwiz_tools/OspreySharp/OspreySharp.Tasks/TaskValiditySidecar.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Tasks/TaskValiditySidecar.cs
@@ -38,7 +38,7 @@ namespace pwiz.OspreySharp.Tasks
     /// same output path do not trample each other's validity records.
     /// (Historically PerFileScoringTask wrote <c>.scores.parquet</c> and
     /// PerFileRescoreTask overwrote it in place; Stage 6 now writes a
-    /// separate <c>.reconciled.scores.parquet</c>, so the two tasks no
+    /// separate <c>.scores-reconciled.parquet</c>, so the two tasks no
     /// longer share an output -- but the task-name disambiguation remains
     /// for any future same-path producers.) Each task checks its own
     /// sidecar; downstream consumers don't need to know which task wrote

--- a/pwiz_tools/OspreySharp/OspreySharp.Test/IOTest.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Test/IOTest.cs
@@ -1292,6 +1292,75 @@ namespace pwiz.OspreySharp.Test
         }
 
         /// <summary>
+        /// Verifies GetReconciledScoresPath returns the reconciled sibling path
+        /// (Stage 6's separate output, not an overwrite of Stage 4's).
+        /// </summary>
+        [TestMethod]
+        public void TestGetReconciledScoresPath()
+        {
+            Assert.AreEqual(@"C:\data\sample1.reconciled.scores.parquet",
+                ParquetScoreCache.GetReconciledScoresPath(@"C:\data\sample1.mzML"));
+            Assert.AreEqual(@"D:\runs\experiment.raw.reconciled.scores.parquet",
+                ParquetScoreCache.GetReconciledScoresPath(@"D:\runs\experiment.raw.mzML"));
+        }
+
+        /// <summary>
+        /// Verifies ReconciledPathFromScoresPath inserts ".reconciled" before
+        /// ".scores.parquet" and is idempotent on an already-reconciled path
+        /// (the --join-at-pass=2 case where the input IS the reconciled file).
+        /// </summary>
+        [TestMethod]
+        public void TestReconciledPathFromScoresPath()
+        {
+            Assert.AreEqual(@"C:\data\sample1.reconciled.scores.parquet",
+                ParquetScoreCache.ReconciledPathFromScoresPath(@"C:\data\sample1.scores.parquet"));
+            // Idempotent: an already-reconciled path is returned unchanged.
+            Assert.AreEqual(@"C:\data\sample1.reconciled.scores.parquet",
+                ParquetScoreCache.ReconciledPathFromScoresPath(@"C:\data\sample1.reconciled.scores.parquet"));
+            // Composes with GetScoresPath to equal GetReconciledScoresPath.
+            const string mzml = @"D:\runs\experiment.raw.mzML";
+            Assert.AreEqual(ParquetScoreCache.GetReconciledScoresPath(mzml),
+                ParquetScoreCache.ReconciledPathFromScoresPath(ParquetScoreCache.GetScoresPath(mzml)));
+        }
+
+        /// <summary>
+        /// Verifies EffectiveScoresPathFromScoresPath returns the reconciled
+        /// sibling when it exists on disk, else the original -- the per-file
+        /// read contract that makes the separate-reconciled-file design
+        /// byte-equivalent to the former in-place overwrite.
+        /// </summary>
+        [TestMethod]
+        public void TestEffectiveScoresPathFromScoresPath()
+        {
+            string dir = Path.Combine(Path.GetTempPath(),
+                "osprey_eff_" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(dir);
+            try
+            {
+                string original = Path.Combine(dir, "sample1.scores.parquet");
+                string reconciled = Path.Combine(dir, "sample1.reconciled.scores.parquet");
+                File.WriteAllText(original, "x");
+
+                // No reconciled sibling -> original (no-work file).
+                Assert.AreEqual(original,
+                    ParquetScoreCache.EffectiveScoresPathFromScoresPath(original));
+
+                // Reconciled sibling present -> reconciled (rescored file).
+                File.WriteAllText(reconciled, "y");
+                Assert.AreEqual(reconciled,
+                    ParquetScoreCache.EffectiveScoresPathFromScoresPath(original));
+
+                // An already-reconciled input that exists is returned as-is.
+                Assert.AreEqual(reconciled,
+                    ParquetScoreCache.EffectiveScoresPathFromScoresPath(reconciled));
+            }
+            finally
+            {
+                try { Directory.Delete(dir, true); } catch { /* best-effort */ }
+            }
+        }
+
+        /// <summary>
         /// Verifies that writing an empty list does not create a file.
         /// </summary>
         [TestMethod]

--- a/pwiz_tools/OspreySharp/OspreySharp.Test/IOTest.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Test/IOTest.cs
@@ -1298,29 +1298,52 @@ namespace pwiz.OspreySharp.Test
         [TestMethod]
         public void TestGetReconciledScoresPath()
         {
-            Assert.AreEqual(@"C:\data\sample1.reconciled.scores.parquet",
+            Assert.AreEqual(@"C:\data\sample1.scores-reconciled.parquet",
                 ParquetScoreCache.GetReconciledScoresPath(@"C:\data\sample1.mzML"));
-            Assert.AreEqual(@"D:\runs\experiment.raw.reconciled.scores.parquet",
+            Assert.AreEqual(@"D:\runs\experiment.raw.scores-reconciled.parquet",
                 ParquetScoreCache.GetReconciledScoresPath(@"D:\runs\experiment.raw.mzML"));
         }
 
         /// <summary>
-        /// Verifies ReconciledPathFromScoresPath inserts ".reconciled" before
-        /// ".scores.parquet" and is idempotent on an already-reconciled path
-        /// (the --join-at-pass=2 case where the input IS the reconciled file).
+        /// Verifies ReconciledPathFromScoresPath swaps the ".scores.parquet"
+        /// suffix for ".scores-reconciled.parquet" and is idempotent on an
+        /// already-reconciled path (the --join-at-pass=2 case where the input IS
+        /// the reconciled file).
         /// </summary>
         [TestMethod]
         public void TestReconciledPathFromScoresPath()
         {
-            Assert.AreEqual(@"C:\data\sample1.reconciled.scores.parquet",
+            Assert.AreEqual(@"C:\data\sample1.scores-reconciled.parquet",
                 ParquetScoreCache.ReconciledPathFromScoresPath(@"C:\data\sample1.scores.parquet"));
             // Idempotent: an already-reconciled path is returned unchanged.
-            Assert.AreEqual(@"C:\data\sample1.reconciled.scores.parquet",
-                ParquetScoreCache.ReconciledPathFromScoresPath(@"C:\data\sample1.reconciled.scores.parquet"));
+            Assert.AreEqual(@"C:\data\sample1.scores-reconciled.parquet",
+                ParquetScoreCache.ReconciledPathFromScoresPath(@"C:\data\sample1.scores-reconciled.parquet"));
             // Composes with GetScoresPath to equal GetReconciledScoresPath.
             const string mzml = @"D:\runs\experiment.raw.mzML";
             Assert.AreEqual(ParquetScoreCache.GetReconciledScoresPath(mzml),
                 ParquetScoreCache.ReconciledPathFromScoresPath(ParquetScoreCache.GetScoresPath(mzml)));
+        }
+
+        /// <summary>
+        /// Regression for the suffix-ambiguity Copilot flagged on PR #4261: an
+        /// input stem that itself ends in ".reconciled" must NOT be mistaken for
+        /// a Stage 6 reconciled output. Because the marker sits AFTER ".scores"
+        /// (".scores-reconciled.parquet"), the Stage 4 file is unambiguously an
+        /// original and maps to a distinct reconciled sibling (no overwrite).
+        /// </summary>
+        [TestMethod]
+        public void TestReconciledNamingUnambiguousForReconciledStem()
+        {
+            // Input "sample.reconciled.mzML" -> Stage 4 "sample.reconciled.scores.parquet".
+            string stage4 = ParquetScoreCache.GetScoresPath(@"C:\data\sample.reconciled.mzML");
+            Assert.AreEqual(@"C:\data\sample.reconciled.scores.parquet", stage4);
+            // It must be classified as an original, not a reconciled output...
+            Assert.IsFalse(ParquetScoreCache.IsReconciledScoresPath(stage4));
+            // ...and map to a DISTINCT reconciled sibling (not back onto itself).
+            string reconciled = ParquetScoreCache.ReconciledPathFromScoresPath(stage4);
+            Assert.AreEqual(@"C:\data\sample.reconciled.scores-reconciled.parquet", reconciled);
+            Assert.AreNotEqual(stage4, reconciled);
+            Assert.IsTrue(ParquetScoreCache.IsReconciledScoresPath(reconciled));
         }
 
         /// <summary>
@@ -1338,7 +1361,7 @@ namespace pwiz.OspreySharp.Test
             try
             {
                 string original = Path.Combine(dir, "sample1.scores.parquet");
-                string reconciled = Path.Combine(dir, "sample1.reconciled.scores.parquet");
+                string reconciled = Path.Combine(dir, "sample1.scores-reconciled.parquet");
                 File.WriteAllText(original, "x");
 
                 // No reconciled sibling -> original (no-work file).

--- a/pwiz_tools/OspreySharp/OspreySharp.Test/ProgramTests.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Test/ProgramTests.cs
@@ -445,6 +445,32 @@ namespace pwiz.OspreySharp.Test
         }
 
         [TestMethod]
+        public void TestResolveDirectoryPrefersReconciledPerStem()
+        {
+            // The *.scores.parquet glob also matches Stage 6's
+            // <stem>.reconciled.scores.parquet siblings. For any stem that has
+            // both, only the reconciled file is returned; never both.
+            string dir = NewTempDir();
+            try
+            {
+                File.WriteAllText(Path.Combine(dir, "a.scores.parquet"), string.Empty);
+                File.WriteAllText(Path.Combine(dir, "a.reconciled.scores.parquet"), string.Empty);
+                File.WriteAllText(Path.Combine(dir, "b.scores.parquet"), string.Empty); // no reconciled sibling
+                File.WriteAllText(Path.Combine(dir, "c.reconciled.scores.parquet"), string.Empty); // no original
+                var resolved = Program.ResolveInputScores(new List<string> { dir });
+                CollectionAssert.AreEqual(
+                    new[] { "a.reconciled.scores.parquet", "b.scores.parquet", "c.reconciled.scores.parquet" },
+                    resolved.ConvertAll(Path.GetFileName));
+                // The superseded original must not appear.
+                CollectionAssert.DoesNotContain(resolved.ConvertAll(Path.GetFileName), "a.scores.parquet");
+            }
+            finally
+            {
+                Directory.Delete(dir, true);
+            }
+        }
+
+        [TestMethod]
         public void TestResolveEmptyDirectoryErrors()
         {
             string dir = NewTempDir();

--- a/pwiz_tools/OspreySharp/OspreySharp.Test/ProgramTests.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Test/ProgramTests.cs
@@ -447,19 +447,24 @@ namespace pwiz.OspreySharp.Test
         [TestMethod]
         public void TestResolveDirectoryPrefersReconciledPerStem()
         {
-            // The *.scores.parquet glob also matches Stage 6's
-            // <stem>.reconciled.scores.parquet siblings. For any stem that has
-            // both, only the reconciled file is returned; never both.
+            // The directory holds both Stage 4 <stem>.scores.parquet and Stage 6
+            // <stem>.scores-reconciled.parquet files. For any stem that has both,
+            // only the reconciled file is returned; never both.
             string dir = NewTempDir();
             try
             {
                 File.WriteAllText(Path.Combine(dir, "a.scores.parquet"), string.Empty);
-                File.WriteAllText(Path.Combine(dir, "a.reconciled.scores.parquet"), string.Empty);
+                File.WriteAllText(Path.Combine(dir, "a.scores-reconciled.parquet"), string.Empty);
                 File.WriteAllText(Path.Combine(dir, "b.scores.parquet"), string.Empty); // no reconciled sibling
-                File.WriteAllText(Path.Combine(dir, "c.reconciled.scores.parquet"), string.Empty); // no original
+                File.WriteAllText(Path.Combine(dir, "c.scores-reconciled.parquet"), string.Empty); // no original
+                // An input stem ending in ".reconciled" stays an original (Copilot
+                // ambiguity regression guard) -- its Stage 4 file must be returned
+                // as an original, not misread as a reconciled output.
+                File.WriteAllText(Path.Combine(dir, "d.reconciled.scores.parquet"), string.Empty);
                 var resolved = Program.ResolveInputScores(new List<string> { dir });
                 CollectionAssert.AreEqual(
-                    new[] { "a.reconciled.scores.parquet", "b.scores.parquet", "c.reconciled.scores.parquet" },
+                    new[] { "a.scores-reconciled.parquet", "b.scores.parquet",
+                            "c.scores-reconciled.parquet", "d.reconciled.scores.parquet" },
                     resolved.ConvertAll(Path.GetFileName));
                 // The superseded original must not appear.
                 CollectionAssert.DoesNotContain(resolved.ConvertAll(Path.GetFileName), "a.scores.parquet");

--- a/pwiz_tools/OspreySharp/OspreySharp/Program.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/Program.cs
@@ -774,12 +774,14 @@ namespace pwiz.OspreySharp
         /// paths are passed through unchanged. Throws if the directory is
         /// empty or any explicit path doesn't exist.
         ///
-        /// Directory mode dedupes per stem: the glob <c>*.scores.parquet</c>
-        /// also matches Stage 6's <c>&lt;stem&gt;.reconciled.scores.parquet</c>
-        /// sibling, so for any stem that has both, only the reconciled file is
-        /// returned (the authoritative later pass; the <c>--join-at-pass=2</c>
-        /// reconciled-input gate expects reconciled parquets). A stem with only
-        /// an original is returned as-is.
+        /// Directory mode collects both the Stage 4 <c>*.scores.parquet</c> files
+        /// and the Stage 6 <c>*.scores-reconciled.parquet</c> siblings, then
+        /// dedupes per stem: for any stem that has both, only the reconciled file
+        /// is returned (the authoritative later pass; the <c>--join-at-pass=2</c>
+        /// reconciled-input gate expects reconciled parquets). A stem with only an
+        /// original is returned as-is. The two suffixes are unambiguous, so this
+        /// never returns both files for one stem (see
+        /// <see cref="ParquetScoreCache.ReconciledScoresParquetSuffix"/>).
         /// </summary>
         internal static List<string> ResolveInputScores(List<string> paths)
         {
@@ -789,24 +791,25 @@ namespace pwiz.OspreySharp
             if (paths.Count == 1 && Directory.Exists(paths[0]))
             {
                 string dir = paths[0];
-                string[] found = Directory.GetFiles(dir, "*.scores.parquet", SearchOption.TopDirectoryOnly);
-                if (found.Length == 0)
+                // Glob *.parquet and classify by suffix in code rather than
+                // relying on multi-dot search-pattern matching (which differs
+                // across platforms). Keep only the two known scores suffixes.
+                var originals = new List<string>();
+                var reconciledSet = new HashSet<string>(StringComparer.Ordinal);
+                foreach (string f in Directory.GetFiles(dir, "*.parquet", SearchOption.TopDirectoryOnly))
+                {
+                    if (ParquetScoreCache.IsReconciledScoresPath(f))
+                        reconciledSet.Add(f);
+                    else if (f.EndsWith(ParquetScoreCache.ScoresParquetSuffix, StringComparison.Ordinal))
+                        originals.Add(f);
+                }
+                if (originals.Count == 0 && reconciledSet.Count == 0)
                     throw new ArgumentException(string.Format(
                         "No *.scores.parquet files found in --input-scores directory: {0}", dir));
-                const string reconciledSuffix = ".reconciled.scores.parquet";
-                var reconciledSet = new HashSet<string>(StringComparer.Ordinal);
-                foreach (string f in found)
-                    if (f.EndsWith(reconciledSuffix, StringComparison.Ordinal))
-                        reconciledSet.Add(f);
-                var result = new List<string>(found.Length);
-                foreach (string f in found)
-                {
-                    if (f.EndsWith(reconciledSuffix, StringComparison.Ordinal))
-                        result.Add(f); // reconciled: always authoritative
-                    else if (!reconciledSet.Contains(ParquetScoreCache.ReconciledPathFromScoresPath(f)))
-                        result.Add(f); // original with no reconciled sibling
-                    // else: original superseded by its reconciled sibling -> drop
-                }
+                var result = new List<string>(reconciledSet);            // reconciled: authoritative
+                foreach (string f in originals)
+                    if (!reconciledSet.Contains(ParquetScoreCache.ReconciledPathFromScoresPath(f)))
+                        result.Add(f);                                   // original with no reconciled sibling
                 result.Sort(StringComparer.Ordinal); // unique filenames, no ties
                 return result;
             }

--- a/pwiz_tools/OspreySharp/OspreySharp/Program.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/Program.cs
@@ -25,6 +25,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using pwiz.OspreySharp.Core;
+using pwiz.OspreySharp.IO;
 
 namespace pwiz.OspreySharp
 {
@@ -772,6 +773,13 @@ namespace pwiz.OspreySharp
         /// non-recursive list of *.scores.parquet files in it; explicit file
         /// paths are passed through unchanged. Throws if the directory is
         /// empty or any explicit path doesn't exist.
+        ///
+        /// Directory mode dedupes per stem: the glob <c>*.scores.parquet</c>
+        /// also matches Stage 6's <c>&lt;stem&gt;.reconciled.scores.parquet</c>
+        /// sibling, so for any stem that has both, only the reconciled file is
+        /// returned (the authoritative later pass; the <c>--join-at-pass=2</c>
+        /// reconciled-input gate expects reconciled parquets). A stem with only
+        /// an original is returned as-is.
         /// </summary>
         internal static List<string> ResolveInputScores(List<string> paths)
         {
@@ -785,8 +793,22 @@ namespace pwiz.OspreySharp
                 if (found.Length == 0)
                     throw new ArgumentException(string.Format(
                         "No *.scores.parquet files found in --input-scores directory: {0}", dir));
-                Array.Sort(found, StringComparer.Ordinal); // Array.Sort OK: filenames are unique, no ties possible
-                return new List<string>(found);
+                const string reconciledSuffix = ".reconciled.scores.parquet";
+                var reconciledSet = new HashSet<string>(StringComparer.Ordinal);
+                foreach (string f in found)
+                    if (f.EndsWith(reconciledSuffix, StringComparison.Ordinal))
+                        reconciledSet.Add(f);
+                var result = new List<string>(found.Length);
+                foreach (string f in found)
+                {
+                    if (f.EndsWith(reconciledSuffix, StringComparison.Ordinal))
+                        result.Add(f); // reconciled: always authoritative
+                    else if (!reconciledSet.Contains(ParquetScoreCache.ReconciledPathFromScoresPath(f)))
+                        result.Add(f); // original with no reconciled sibling
+                    // else: original superseded by its reconciled sibling -> drop
+                }
+                result.Sort(StringComparer.Ordinal); // unique filenames, no ties
+                return result;
             }
 
             foreach (string p in paths)

--- a/pwiz_tools/OspreySharp/OspreySharp/RescoreHydration.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/RescoreHydration.cs
@@ -412,8 +412,9 @@ namespace pwiz.OspreySharp
 
         /// <summary>
         /// Inverse of <c>scores_path_for_input</c>: given
-        /// <c>/data/sample1.scores.parquet</c>, produce a synthetic input
-        /// path <c>/data/sample1.mzML</c> whose stem matches what the
+        /// <c>/data/sample1.scores.parquet</c> (or its reconciled sibling
+        /// <c>/data/sample1.reconciled.scores.parquet</c>), produce a synthetic
+        /// input path <c>/data/sample1.mzML</c> whose stem matches what the
         /// worker used. This lets the worker reuse the existing
         /// path-derivation helpers (FDR sidecars, calibration JSON,
         /// reconciliation JSON) without duplicating them. The synthetic
@@ -426,9 +427,16 @@ namespace pwiz.OspreySharp
             // GetFileNameWithoutExtension returns "" not null for valid paths
             // and throws on invalid input, so the result is never null here.
             string stem = Path.GetFileNameWithoutExtension(parquetPath);
-            // Strip a trailing ".scores" if present.
+            // Strip the trailing ".reconciled.scores" (Stage 6 reconciled
+            // output) or ".scores" (Stage 4 output). Check the longer suffix
+            // first: GetFileNameWithoutExtension of "x.reconciled.scores.parquet"
+            // is "x.reconciled.scores", and stripping only ".scores" would
+            // leave the bogus stem "x.reconciled".
+            const string ReconciledScoresSuffix = ".reconciled.scores";
             const string ScoresSuffix = ".scores";
-            if (stem.EndsWith(ScoresSuffix, StringComparison.Ordinal))
+            if (stem.EndsWith(ReconciledScoresSuffix, StringComparison.Ordinal))
+                stem = stem.Substring(0, stem.Length - ReconciledScoresSuffix.Length);
+            else if (stem.EndsWith(ScoresSuffix, StringComparison.Ordinal))
                 stem = stem.Substring(0, stem.Length - ScoresSuffix.Length);
             string parent = Path.GetDirectoryName(parquetPath);
             string filename = stem + ".mzML";

--- a/pwiz_tools/OspreySharp/OspreySharp/RescoreHydration.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/RescoreHydration.cs
@@ -413,7 +413,7 @@ namespace pwiz.OspreySharp
         /// <summary>
         /// Inverse of <c>scores_path_for_input</c>: given
         /// <c>/data/sample1.scores.parquet</c> (or its reconciled sibling
-        /// <c>/data/sample1.reconciled.scores.parquet</c>), produce a synthetic
+        /// <c>/data/sample1.scores-reconciled.parquet</c>), produce a synthetic
         /// input path <c>/data/sample1.mzML</c> whose stem matches what the
         /// worker used. This lets the worker reuse the existing
         /// path-derivation helpers (FDR sidecars, calibration JSON,
@@ -427,12 +427,13 @@ namespace pwiz.OspreySharp
             // GetFileNameWithoutExtension returns "" not null for valid paths
             // and throws on invalid input, so the result is never null here.
             string stem = Path.GetFileNameWithoutExtension(parquetPath);
-            // Strip the trailing ".reconciled.scores" (Stage 6 reconciled
-            // output) or ".scores" (Stage 4 output). Check the longer suffix
-            // first: GetFileNameWithoutExtension of "x.reconciled.scores.parquet"
-            // is "x.reconciled.scores", and stripping only ".scores" would
-            // leave the bogus stem "x.reconciled".
-            const string ReconciledScoresSuffix = ".reconciled.scores";
+            // Strip the trailing ".scores-reconciled" (Stage 6 reconciled output)
+            // or ".scores" (Stage 4 output). These two tokens never collide with
+            // an input stem because Stage 4 always appends exactly ".scores"
+            // (so the only way a name ends in ".scores-reconciled" is Stage 6).
+            // GetFileNameWithoutExtension of "x.scores-reconciled.parquet" is
+            // "x.scores-reconciled"; check the longer token first.
+            const string ReconciledScoresSuffix = ".scores-reconciled";
             const string ScoresSuffix = ".scores";
             if (stem.EndsWith(ReconciledScoresSuffix, StringComparison.Ordinal))
                 stem = stem.Substring(0, stem.Length - ReconciledScoresSuffix.Length);

--- a/pwiz_tools/OspreySharp/OspreySharp/Tasks/MergeNodeTask.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/Tasks/MergeNodeTask.cs
@@ -62,8 +62,13 @@ namespace pwiz.OspreySharp.Tasks
         public override IEnumerable<string> Inputs(PipelineContext ctx)
         {
             if (ctx.Config.InputFiles == null) yield break;
+            // Stage 7 reads the reconciled parquet when Stage 6 produced one,
+            // else the original Stage 4 parquet (no-work files). Recorded for
+            // provenance only -- the driver validates tasks by output sidecar
+            // key, never by re-checking Inputs() existence (TaskValiditySidecar).
             foreach (var input in ctx.Config.InputFiles)
-                yield return ParquetScoreCache.GetScoresPath(input);
+                yield return ParquetScoreCache.EffectiveScoresPathFromScoresPath(
+                    ParquetScoreCache.GetScoresPath(input));
         }
 
         public override IEnumerable<string> Outputs(PipelineContext ctx)
@@ -192,16 +197,23 @@ namespace pwiz.OspreySharp.Tasks
                                     kvp.Key, kvp.Value.Count));
                                 continue;
                             }
+                            // Read the RECONCILED parquet (Stage 6's rescored
+                            // features) when it exists; fall back to the original
+                            // Stage 4 parquet for files that had no reconciliation
+                            // work (no reconciled sibling was written). The
+                            // perFileParquetPaths map holds original paths.
+                            string effectiveParquetPath =
+                                ParquetScoreCache.EffectiveScoresPathFromScoresPath(parquetPath);
                             List<double[]> featRows;
                             try
                             {
-                                featRows = ParquetScoreCache.LoadPinFeaturesFromParquet(parquetPath);
+                                featRows = ParquetScoreCache.LoadPinFeaturesFromParquet(effectiveParquetPath);
                             }
                             catch (Exception ex)
                             {
                                 ctx.LogWarning(string.Format(
                                     "Second-pass FDR: failed to reload PIN features from {0}: {1}",
-                                    parquetPath, ex.Message));
+                                    effectiveParquetPath, ex.Message));
                                 continue;
                             }
                             int nMapped = 0;
@@ -355,7 +367,8 @@ namespace pwiz.OspreySharp.Tasks
                         {
                             TaskValiditySidecar.Write(pass2Path, Name, Program.VERSION,
                                 taskValidityKey,
-                                new[] { ParquetScoreCache.GetScoresPath(inputFile3) });
+                                new[] { ParquetScoreCache.EffectiveScoresPathFromScoresPath(
+                                    ParquetScoreCache.GetScoresPath(inputFile3)) });
                         }
                         catch (Exception ex)
                         {

--- a/pwiz_tools/OspreySharp/OspreySharp/Tasks/PerFileRescoreTask.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/Tasks/PerFileRescoreTask.cs
@@ -128,7 +128,7 @@ namespace pwiz.OspreySharp.Tasks
         }
 
         // Phase B resume surface. The reconciled parquet is written to a
-        // SEPARATE <stem>.reconciled.scores.parquet sibling, leaving the
+        // SEPARATE <stem>.scores-reconciled.parquet sibling, leaving the
         // upstream PerFileScoringTask <stem>.scores.parquet intact (so a
         // partial Stage 6 crash can no longer half-rewrite the Stage 4
         // output, and downstream readers can fall back to the original
@@ -350,7 +350,7 @@ namespace pwiz.OspreySharp.Tasks
 
         /// <summary>
         /// Phase 3 -- write the reconciled per-file
-        /// <c>.reconciled.scores.parquet</c>.
+        /// <c>.scores-reconciled.parquet</c>.
         ///
         /// Reload the original Stage 4 parquet's full per-row data
         /// (identity, boundaries, 21 PIN features, CWT candidate lists) from
@@ -368,8 +368,11 @@ namespace pwiz.OspreySharp.Tasks
         /// The original parquet is read-only here -- it is never overwritten,
         /// so it survives intact for files whose reconciliation is a no-op and
         /// as a crash-safe Stage 4 record. Mirrors Rust pipeline.rs:3050-3110.
+        /// Returns true when the reconciled parquet was written; false on a
+        /// reload/write failure (so the caller does not stamp a validity sidecar
+        /// over a stale or absent output).
         /// </summary>
-        private void WriteReconciledParquet(string originalPath, string reconciledPath,
+        private bool WriteReconciledParquet(string originalPath, string reconciledPath,
             List<FdrEntry> fdrEntries,
             string fileName, List<LibraryEntry> fullLibrary, OspreyConfig config,
             IReadOnlyList<string> joinFileStems)
@@ -385,7 +388,7 @@ namespace pwiz.OspreySharp.Tasks
                 _ctx.LogWarning(string.Format(
                     "Stage 6 write-back: failed to reload {0}: {1} (skipping)",
                     originalPath, ex.Message));
-                return;
+                return false;
             }
             int origRowCount = fullEntries.Count;
 
@@ -474,12 +477,13 @@ namespace pwiz.OspreySharp.Tasks
                 _ctx.LogWarning(string.Format(
                     "Stage 6 write-back: failed to write reconciled scores for {0}: {1}",
                     fileName, ex.Message));
-                return;
+                return false;
             }
 
             _ctx.LogInfo(string.Format(
                 "  Wrote reconciled parquet for {0}: {1} rows ({2} replaced + {3} appended; original {4} rows)",
                 fileName, fullEntries.Count, nReplaced, nAppended, origRowCount));
+            return true;
         }
 
         /// <summary>
@@ -548,7 +552,7 @@ namespace pwiz.OspreySharp.Tasks
                 // because the worker's StopAfter terminates the pipeline
                 // here -- no downstream consumer reads them.
                 // The rescore READS the original Stage 4 parquet and WRITES a
-                // separate <stem>.reconciled.scores.parquet. Resume validity is
+                // separate <stem>.scores-reconciled.parquet. Resume validity is
                 // keyed on the reconciled output (the task's declared Output),
                 // not on the original read source.
                 bool hasParquetPath = perFileParquetPaths.TryGetValue(fileName, out string perFileParquetPath);
@@ -724,37 +728,56 @@ namespace pwiz.OspreySharp.Tasks
                 }
 
                 // PHASE 3 -- reconciled parquet write-back. Read the original
-                // Stage 4 parquet, write a separate .reconciled.scores.parquet
+                // Stage 4 parquet, write a separate .scores-reconciled.parquet
                 // sibling (leaving the original intact).
                 if (perFileParquetPaths != null &&
                     perFileParquetPaths.TryGetValue(fileName, out string parquetPath) &&
                     File.Exists(parquetPath))
                 {
                     string reconciledOutPath = ParquetScoreCache.ReconciledPathFromScoresPath(parquetPath);
-                    WriteReconciledParquet(parquetPath, reconciledOutPath, fdrEntries, fileName,
+                    bool wrote = WriteReconciledParquet(parquetPath, reconciledOutPath, fdrEntries, fileName,
                         fullLibrary, config, joinFileStems);
 
-                    // Per-file resume sidecar: write next to the
-                    // reconciled parquet so a subsequent invocation with
-                    // the same validity key can skip this file. The
-                    // pre-write delete above guarantees the sidecar
-                    // appears only after WriteReconciledParquet finished.
-                    var perFileInputs = new List<string>
+                    // Only stamp the per-file resume sidecar when the reconciled
+                    // parquet was actually written. Stamping it after a failed
+                    // write could mark a STALE reconciled parquet (left from a
+                    // prior run with a different validity key) as valid, letting
+                    // Stage 7 / a future resume consume old rescored content. On
+                    // failure, clear any such stale output + sidecar so the next
+                    // run re-rescores this file from scratch.
+                    if (wrote)
                     {
-                        FdrScoresSidecar.Pass1Path(inputFile),
-                    };
-                    if (config.Reconciliation != null && config.Reconciliation.Enabled)
-                        perFileInputs.Add(ReconciliationFile.PathForInput(inputFile));
-                    try
-                    {
-                        TaskValiditySidecar.Write(reconciledOutPath, Name, Program.VERSION,
-                            taskValidityKey, perFileInputs);
+                        var perFileInputs = new List<string>
+                        {
+                            FdrScoresSidecar.Pass1Path(inputFile),
+                        };
+                        if (config.Reconciliation != null && config.Reconciliation.Enabled)
+                            perFileInputs.Add(ReconciliationFile.PathForInput(inputFile));
+                        try
+                        {
+                            TaskValiditySidecar.Write(reconciledOutPath, Name, Program.VERSION,
+                                taskValidityKey, perFileInputs);
+                        }
+                        catch (Exception ex)
+                        {
+                            _ctx.LogWarning(string.Format(
+                                @"  Failed to write {0} sidecar for {1}: {2}",
+                                Name, reconciledOutPath, ex.Message));
+                        }
                     }
-                    catch (Exception ex)
+                    else
                     {
-                        _ctx.LogWarning(string.Format(
-                            @"  Failed to write {0} sidecar for {1}: {2}",
-                            Name, reconciledOutPath, ex.Message));
+                        TaskValiditySidecar.Delete(reconciledOutPath, Name);
+                        try
+                        {
+                            if (File.Exists(reconciledOutPath)) File.Delete(reconciledOutPath);
+                        }
+                        catch (Exception ex)
+                        {
+                            _ctx.LogWarning(string.Format(
+                                @"  Failed to remove stale reconciled parquet {0} after a failed write: {1}",
+                                reconciledOutPath, ex.Message));
+                        }
                     }
                 }
             }

--- a/pwiz_tools/OspreySharp/OspreySharp/Tasks/PerFileRescoreTask.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/Tasks/PerFileRescoreTask.cs
@@ -149,6 +149,15 @@ namespace pwiz.OspreySharp.Tasks
         public override IEnumerable<string> Outputs(PipelineContext ctx)
         {
             if (ctx.Config.InputFiles == null) yield break;
+            // Declares a reconciled path per input, but ExecuteRescore skips
+            // files with no consensus/reconciliation/gap-fill work, so those get
+            // no reconciled output. When any no-work file is present the driver's
+            // task-level IsTaskAlreadyDone (which requires EVERY declared output
+            // to exist) therefore can't short-circuit the whole task on resume --
+            // it re-enters Run, which fast per-file-skips already-rescored files
+            // via their reconciled sidecars. Correctness is unaffected; this is a
+            // deliberate, inert coarse-skip. (We don't filter to work-files here
+            // because that set isn't known until the Stage 6 planner has run.)
             foreach (var input in ctx.Config.InputFiles)
                 yield return ParquetScoreCache.GetReconciledScoresPath(input);
         }

--- a/pwiz_tools/OspreySharp/OspreySharp/Tasks/PerFileRescoreTask.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/Tasks/PerFileRescoreTask.cs
@@ -127,11 +127,12 @@ namespace pwiz.OspreySharp.Tasks
             return _perFileEntries;
         }
 
-        // Phase B resume surface. The reconciled parquet overwrites the
-        // upstream PerFileScoringTask parquet at the same path, but
-        // the per-task sidecar naming
-        // (<output>.PerFileRescore.osprey.task) keeps the two tasks'
-        // validity records distinct. ValidityKey adds the
+        // Phase B resume surface. The reconciled parquet is written to a
+        // SEPARATE <stem>.reconciled.scores.parquet sibling, leaving the
+        // upstream PerFileScoringTask <stem>.scores.parquet intact (so a
+        // partial Stage 6 crash can no longer half-rewrite the Stage 4
+        // output, and downstream readers can fall back to the original
+        // for files that had no reconciliation work). ValidityKey adds the
         // reconciliation parameter hash because the rescored content
         // depends on it.
         public override IEnumerable<string> Inputs(PipelineContext ctx)
@@ -149,7 +150,7 @@ namespace pwiz.OspreySharp.Tasks
         {
             if (ctx.Config.InputFiles == null) yield break;
             foreach (var input in ctx.Config.InputFiles)
-                yield return ParquetScoreCache.GetScoresPath(input);
+                yield return ParquetScoreCache.GetReconciledScoresPath(input);
         }
 
         public override string ValidityKey(PipelineContext ctx)
@@ -348,37 +349,42 @@ namespace pwiz.OspreySharp.Tasks
         // accessors. Run() above is the only entry point.
 
         /// <summary>
-        /// Phase 3 -- write the reconciled per-file <c>.scores.parquet</c>.
+        /// Phase 3 -- write the reconciled per-file
+        /// <c>.reconciled.scores.parquet</c>.
         ///
         /// Reload the original Stage 4 parquet's full per-row data
-        /// (identity, boundaries, 21 PIN features, CWT candidate lists),
-        /// replace re-scored rows in place by <see cref="FdrEntry.ParquetIndex"/>
-        /// (NOT by post-compaction Vec position; the two diverge after
-        /// first-pass FDR drops non-passing entries), append gap-fill
-        /// rows at the end, reassign each gap-fill stub's
-        /// <see cref="FdrEntry.ParquetIndex"/> to the actual row it now
-        /// occupies, then write back via
+        /// (identity, boundaries, 21 PIN features, CWT candidate lists) from
+        /// <paramref name="originalPath"/>, replace re-scored rows in place by
+        /// <see cref="FdrEntry.ParquetIndex"/> (NOT by post-compaction Vec
+        /// position; the two diverge after first-pass FDR drops non-passing
+        /// entries), append gap-fill rows at the end, reassign each gap-fill
+        /// stub's <see cref="FdrEntry.ParquetIndex"/> to the actual row it now
+        /// occupies, then write to the SEPARATE
+        /// <paramref name="reconciledPath"/> via
         /// <see cref="ParquetScoreCache.WriteScoresParquet(string, List{FdrEntry}, Dictionary{string, string}, Dictionary{uint, LibraryEntry}, string)"/>
         /// with reconciliation metadata
         /// (<c>osprey.reconciled = "true"</c> +
         /// <c>osprey.reconciliation_hash = config.ReconciliationParameterHash()</c>).
-        /// Mirrors Rust pipeline.rs:3050-3110.
+        /// The original parquet is read-only here -- it is never overwritten,
+        /// so it survives intact for files whose reconciliation is a no-op and
+        /// as a crash-safe Stage 4 record. Mirrors Rust pipeline.rs:3050-3110.
         /// </summary>
-        private void WriteReconciledParquet(string parquetPath, List<FdrEntry> fdrEntries,
+        private void WriteReconciledParquet(string originalPath, string reconciledPath,
+            List<FdrEntry> fdrEntries,
             string fileName, List<LibraryEntry> fullLibrary, OspreyConfig config,
             IReadOnlyList<string> joinFileStems)
         {
-            // 1. Reload the original parquet's per-row state.
+            // 1. Reload the original parquet's per-row state (read-only).
             List<FdrEntry> fullEntries;
             try
             {
-                fullEntries = ParquetScoreCache.LoadFullFdrEntries(parquetPath);
+                fullEntries = ParquetScoreCache.LoadFullFdrEntries(originalPath);
             }
             catch (Exception ex)
             {
                 _ctx.LogWarning(string.Format(
                     "Stage 6 write-back: failed to reload {0}: {1} (skipping)",
-                    parquetPath, ex.Message));
+                    originalPath, ex.Message));
                 return;
             }
             int origRowCount = fullEntries.Count;
@@ -460,7 +466,7 @@ namespace pwiz.OspreySharp.Tasks
 
             try
             {
-                ParquetScoreCache.WriteScoresParquet(parquetPath, fullEntries,
+                ParquetScoreCache.WriteScoresParquet(reconciledPath, fullEntries,
                     metadata, libraryById, fileName);
             }
             catch (Exception ex)
@@ -541,10 +547,17 @@ namespace pwiz.OspreySharp.Tasks
                 // remain at the pre-rescore state (1st-pass overlay)
                 // because the worker's StopAfter terminates the pipeline
                 // here -- no downstream consumer reads them.
+                // The rescore READS the original Stage 4 parquet and WRITES a
+                // separate <stem>.reconciled.scores.parquet. Resume validity is
+                // keyed on the reconciled output (the task's declared Output),
+                // not on the original read source.
                 bool hasParquetPath = perFileParquetPaths.TryGetValue(fileName, out string perFileParquetPath);
+                string reconciledPath = hasParquetPath
+                    ? ParquetScoreCache.ReconciledPathFromScoresPath(perFileParquetPath)
+                    : null;
                 if (hasParquetPath
-                    && File.Exists(perFileParquetPath)
-                    && TaskValiditySidecar.IsValid(perFileParquetPath, Name, taskValidityKey))
+                    && File.Exists(reconciledPath)
+                    && TaskValiditySidecar.IsValid(reconciledPath, Name, taskValidityKey))
                 {
                     _ctx.LogInfo(string.Format(
                         @"[file] {0}/{1} {2}: skipping (outputs valid)",
@@ -553,9 +566,9 @@ namespace pwiz.OspreySharp.Tasks
                 }
                 // About to (re-)rescore this file: clear any stale sidecar
                 // so a mid-Run crash leaves no false-positive pointing at
-                // the partially-written parquet.
+                // the partially-written reconciled parquet.
                 if (hasParquetPath)
-                    TaskValiditySidecar.Delete(perFileParquetPath, Name);
+                    TaskValiditySidecar.Delete(reconciledPath, Name);
 
                 IReadOnlyList<(int Index, double Apex, double Start, double End)> consensusTargets;
                 if (!perFileConsensusTargets.TryGetValue(fileName, out consensusTargets))
@@ -710,12 +723,15 @@ namespace pwiz.OspreySharp.Tasks
                     totalRescored += nGapCwt + nGapForced;
                 }
 
-                // PHASE 3 -- reconciled parquet write-back.
+                // PHASE 3 -- reconciled parquet write-back. Read the original
+                // Stage 4 parquet, write a separate .reconciled.scores.parquet
+                // sibling (leaving the original intact).
                 if (perFileParquetPaths != null &&
                     perFileParquetPaths.TryGetValue(fileName, out string parquetPath) &&
                     File.Exists(parquetPath))
                 {
-                    WriteReconciledParquet(parquetPath, fdrEntries, fileName,
+                    string reconciledOutPath = ParquetScoreCache.ReconciledPathFromScoresPath(parquetPath);
+                    WriteReconciledParquet(parquetPath, reconciledOutPath, fdrEntries, fileName,
                         fullLibrary, config, joinFileStems);
 
                     // Per-file resume sidecar: write next to the
@@ -731,14 +747,14 @@ namespace pwiz.OspreySharp.Tasks
                         perFileInputs.Add(ReconciliationFile.PathForInput(inputFile));
                     try
                     {
-                        TaskValiditySidecar.Write(parquetPath, Name, Program.VERSION,
+                        TaskValiditySidecar.Write(reconciledOutPath, Name, Program.VERSION,
                             taskValidityKey, perFileInputs);
                     }
                     catch (Exception ex)
                     {
                         _ctx.LogWarning(string.Format(
                             @"  Failed to write {0} sidecar for {1}: {2}",
-                            Name, parquetPath, ex.Message));
+                            Name, reconciledOutPath, ex.Message));
                     }
                 }
             }

--- a/pwiz_tools/OspreySharp/OspreySharp/Tasks/PerFileScoringTask.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/Tasks/PerFileScoringTask.cs
@@ -714,9 +714,12 @@ namespace pwiz.OspreySharp.Tasks
             for (int fileIdx = 0; fileIdx < config.InputScores.Count; fileIdx++)
             {
                 string parquetPath = config.InputScores[fileIdx];
-                string fileName = Path.GetFileNameWithoutExtension(parquetPath);
-                if (fileName.EndsWith(@".scores", StringComparison.Ordinal))
-                    fileName = fileName.Substring(0, fileName.Length - @".scores".Length);
+                // Derive the bare input stem via the single shared suffix-strip
+                // helper so a .reconciled.scores.parquet input maps to the same
+                // fileName key as its .scores.parquet sibling (a naive trailing
+                // ".scores" strip would leave the bogus key "<stem>.reconciled").
+                string fileName = Path.GetFileNameWithoutExtension(
+                    RescoreHydration.SyntheticInputFromParquet(parquetPath)) ?? string.Empty;
                 _ctx.LogInfo(string.Format(@"===== Loading file {0}/{1}: {2} (from {3}) =====",
                     fileIdx + 1, config.InputScores.Count, fileName, parquetPath));
                 var stubs = ParquetScoreCache.LoadFdrStubsFromParquet(parquetPath);
@@ -743,9 +746,10 @@ namespace pwiz.OspreySharp.Tasks
                     string parquetDir = Path.GetDirectoryName(Path.GetFullPath(parquetPath));
                     if (parquetDir != null)
                     {
-                        // fileName is the bare input stem (the trailing
-                        // ".scores" was stripped above), so combining it
-                        // with parquetDir yields the same input-stem path
+                        // fileName is the bare input stem (the scores /
+                        // reconciled-scores suffix was stripped above via
+                        // SyntheticInputFromParquet), so combining it with
+                        // parquetDir yields the same input-stem path
                         // ProcessFile passes to CalibrationPathForInput.
                         string calStemPath = Path.Combine(parquetDir, fileName);
                         string calPath = CalibrationIO.CalibrationPathForInput(calStemPath, parquetDir);

--- a/pwiz_tools/OspreySharp/OspreySharp/Tasks/PerFileScoringTask.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/Tasks/PerFileScoringTask.cs
@@ -715,7 +715,7 @@ namespace pwiz.OspreySharp.Tasks
             {
                 string parquetPath = config.InputScores[fileIdx];
                 // Derive the bare input stem via the single shared suffix-strip
-                // helper so a .reconciled.scores.parquet input maps to the same
+                // helper so a .scores-reconciled.parquet input maps to the same
                 // fileName key as its .scores.parquet sibling (a naive trailing
                 // ".scores" strip would leave the bogus key "<stem>.reconciled").
                 string fileName = Path.GetFileNameWithoutExtension(


### PR DESCRIPTION
## Summary

* Stage 6 (`PerFileRescoreTask`) now writes a separate `<stem>.reconciled.scores.parquet` instead of overwriting the Stage 4 `<stem>.scores.parquet` in place. A partial Stage 6 crash can no longer leave the Stage 4 output in an indeterminate half-rewritten state (the original survives intact).
* Stage 7 (`MergeNodeTask`) and the resume / `--join-at-pass=2` paths read the reconciled file when it exists, else fall back to the original via `ParquetScoreCache.EffectiveScoresPathFromScoresPath` (per-file; provably byte-equivalent to the former overwrite, since no-work files were never reconciled).
* `--input-scores <dir>` dedupes per stem (the glob now also matches the reconciled sibling); `RescoreHydration.SyntheticInputFromParquet` strips the `.reconciled.scores` suffix.
* C#-only. Rust `osprey` is unchanged; the 1e-9 cross-impl gate compares Stage 7 + blib content, not intermediate parquet paths.
* Long-deferred fix flagged in the 2026-05-16 WSL-parity sprint (finding #7) and specced 2026-05-19; supersedes the planned "PR-D" forward-reach move.

## Test plan

- [x] Pre-commit gate: build OK, ReSharper inspection 0/0, 349 passed + 2 skipped (4 new path/glob unit tests)
- [x] Straight-through 1e-9 cross-impl (Astral 3-file): precursor delta 0, Stage 7 protein-FDR + blib content PASS
- [x] In-memory vs HPC sidecar+rehydrate parity (Stellar 3-file): bit-identical at every stage boundary (Stage 5 sidecars, Stage 6 reconciled parquet at `--tolerance 0`, Stage 7 dump + blib 1e-9); Stage 4 original confirmed surviving in both truth and worker dirs

Co-Authored-By: Claude <noreply@anthropic.com>