### PR TITLE
Extracted SHA identity hashing into SearchIdentity and a driver-owned RunPlan

### DIFF
--- a/pwiz_tools/OspreySharp/OspreySharp.Core/OspreyConfig.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Core/OspreyConfig.cs
@@ -23,9 +23,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.IO;
-using System.Security.Cryptography;
-using System.Text;
 
 namespace pwiz.OspreySharp.Core
 {
@@ -208,267 +205,44 @@ namespace pwiz.OspreySharp.Core
         }
 
         /// <summary>
-        /// Compute SHA-256 hash of parameters that affect first-pass scoring.
-        /// If this hash changes, cached .scores.parquet files are invalid.
+        /// The bit-parity-critical identity hashing for this run. Split out
+        /// of <see cref="OspreyConfig"/> into <see cref="Core.SearchIdentity"/>
+        /// so this type is only the configuration bag and the SHA hashing is
+        /// its own single-responsibility unit. A fresh instance is returned
+        /// per access; it reads this config's hash-affecting fields at call
+        /// time, preserving the historical behavior of the former instance
+        /// methods. The hash recipes live on <see cref="Core.SearchIdentity"/>
+        /// and MUST stay byte-identical with Rust.
         /// </summary>
-        public string SearchParameterHash()
-        {
-            // Cross-impl bit-equivalence with Rust requires:
-            //  - Booleans: Rust prints "true"/"false" (lowercase). C# default
-            //    bool.ToString() is "True"/"False". Use lowercase explicitly.
-            //  - Numbers: invariant culture (no locale-dependent separators).
-            using (var sha256 = SHA256.Create())
-            {
-                var ic = System.Globalization.CultureInfo.InvariantCulture;
-                Func<bool, string> b = v => v ? "true" : "false";
-                var sb = new StringBuilder();
-                sb.AppendFormat(ic, "resolution_mode:{0}\n", ResolutionMode);
-                sb.AppendFormat(ic, "fragment_tolerance:{0},{1}\n", FragmentTolerance.Tolerance, FragmentTolerance.Unit);
-                sb.AppendFormat(ic, "precursor_tolerance:{0},{1}\n", PrecursorTolerance.Tolerance, PrecursorTolerance.Unit);
-                sb.AppendFormat(ic, "prefilter_enabled:{0}\n", b(PrefilterEnabled));
-                sb.AppendFormat(ic, "decoy_method:{0}\n", DecoyMethod);
-                sb.AppendFormat(ic, "decoys_in_library:{0}\n", b(DecoysInLibrary));
-                // Sort prefixes so ordering changes don't churn the hash.
-                // Lower-case to make case-only edits no-ops (matching the
-                // runtime comparison). Mirrors Rust's
-                // format!("decoy_prefixes:{:?}\n", prefixes) where {:?} on
-                // Vec<String> yields ["a", "b"] (double-quoted, comma-
-                // space-separated).
-                var prefixes = new List<string>(DecoyPrefixes != null ? DecoyPrefixes.Count : 0);
-                if (DecoyPrefixes != null)
-                {
-                    foreach (var p in DecoyPrefixes)
-                        prefixes.Add(p == null ? string.Empty : p.ToLowerInvariant());
-                }
-                prefixes.Sort(StringComparer.Ordinal);
-                var prefixList = new StringBuilder("[");
-                for (int i = 0; i < prefixes.Count; i++)
-                {
-                    if (i > 0) prefixList.Append(", ");
-                    prefixList.Append('"').Append(prefixes[i]).Append('"');
-                }
-                prefixList.Append(']');
-                sb.AppendFormat(ic, "decoy_prefixes:{0}\n", prefixList.ToString());
-                // Mirror Rust's `format!("decoy_pairing_manifest:{:?}\n", ...)`
-                // where the value is `Some("path")` or `None`. Rust's {:?}
-                // on String escapes \, ", \n, \r, \t, \0, and other control
-                // chars (< 0x20) -- critical for Windows paths whose `\`
-                // separators must become `\\` to match Rust's output. The
-                // path is not normalised; the user's choice (relative or
-                // absolute) is part of the hash so a moved manifest
-                // invalidates the cache.
-                sb.AppendFormat(ic, "decoy_pairing_manifest:{0}\n",
-                    string.IsNullOrEmpty(DecoyPairingManifestPath)
-                        ? "None"
-                        : "Some(\"" + EscapeForRustDebug(DecoyPairingManifestPath) + "\")");
-                sb.AppendFormat(ic, "decoy_pair_min_fraction:{0}\n", DecoyPairMinFraction);
-                sb.AppendFormat(ic, "rt_cal.enabled:{0}\n", b(RtCalibration.Enabled));
-                sb.AppendFormat(ic, "rt_cal.fallback_rt_tolerance:{0}\n", RtCalibration.FallbackRtTolerance);
-                sb.AppendFormat(ic, "rt_cal.rt_tolerance_factor:{0}\n", RtCalibration.RtToleranceFactor);
-                sb.AppendFormat(ic, "rt_cal.min_rt_tolerance:{0}\n", RtCalibration.MinRtTolerance);
-                sb.AppendFormat(ic, "rt_cal.max_rt_tolerance:{0}\n", RtCalibration.MaxRtTolerance);
-                sb.AppendFormat(ic, "rt_cal.loess_bandwidth:{0}\n", RtCalibration.LoessBandwidth);
-                sb.AppendFormat(ic, "rt_cal.min_calibration_points:{0}\n", RtCalibration.MinCalibrationPoints);
-                sb.AppendFormat(ic, "rt_cal.calibration_sample_size:{0}\n", RtCalibration.CalibrationSampleSize);
-                sb.AppendFormat(ic, "rt_cal.calibration_retry_factor:{0}\n", RtCalibration.CalibrationRetryFactor);
-                sb.AppendFormat(ic, "reconciliation.top_n_peaks:{0}\n", Reconciliation.TopNPeaks);
-
-                byte[] hashBytes = sha256.ComputeHash(Encoding.UTF8.GetBytes(sb.ToString()));
-                var result = new StringBuilder(64);
-                for (int i = 0; i < hashBytes.Length; i++)
-                {
-                    result.Append(hashBytes[i].ToString("x2"));
-                }
-                return result.ToString();
-            }
-        }
+        public SearchIdentity Identity => new SearchIdentity(this);
 
         /// <summary>
-        /// Compute a fast identity hash for the library file (file name + size
-        /// + mtime). Filesystem metadata only -- no content hashing. The
-        /// directory portion is deliberately NOT in the hash so the same
-        /// library identifies identically across Rust / .NET / OS variations
-        /// (drive letter case, forward vs back slash, relative vs absolute,
-        /// HPC node-local vs shared paths). Mirrors the
-        /// <c>reconciliation_parameter_hash</c> precedent that hashes only
-        /// sorted file stems for the input set. Same recipe as Rust's
-        /// <c>library_identity_hash</c>.
+        /// Convenience delegator to <see cref="Core.SearchIdentity.SearchParameterHash"/>.
         /// </summary>
-        public string LibraryIdentityHash()
-        {
-            string libPath = LibrarySource != null ? LibrarySource.Path : string.Empty;
-            using (var sha256 = SHA256.Create())
-            {
-                var sb = new StringBuilder();
-                string fileName = string.IsNullOrEmpty(libPath)
-                    ? string.Empty
-                    : Path.GetFileName(libPath);
-                sb.AppendFormat("file_name:{0}\n", fileName);
-                if (!string.IsNullOrEmpty(libPath) && File.Exists(libPath))
-                {
-                    var info = new FileInfo(libPath);
-                    sb.AppendFormat(System.Globalization.CultureInfo.InvariantCulture,
-                        "size:{0}\n", info.Length);
-                    // Unix seconds matching Rust's library_identity_hash
-                    // (SystemTime::duration_since(UNIX_EPOCH).as_secs()).
-                    long mtimeSecs = (long)(info.LastWriteTimeUtc
-                        - new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc)).TotalSeconds;
-                    sb.AppendFormat(System.Globalization.CultureInfo.InvariantCulture,
-                        "mtime:{0}\n", mtimeSecs);
-                }
-                byte[] hashBytes = sha256.ComputeHash(Encoding.UTF8.GetBytes(sb.ToString()));
-                var result = new StringBuilder(64);
-                for (int i = 0; i < hashBytes.Length; i++)
-                    result.Append(hashBytes[i].ToString("x2"));
-                return result.ToString();
-            }
-        }
+        public string SearchParameterHash() => Identity.SearchParameterHash();
 
         /// <summary>
-        /// Escape a string to match Rust's <c>{:?}</c> Debug formatter
-        /// output for <c>&amp;str</c> / <c>String</c>. Handles the cases
-        /// that actually appear in config values folded into the search
-        /// hash: backslashes, double quotes, common C escapes
-        /// (<c>\n</c>, <c>\r</c>, <c>\t</c>, <c>\0</c>), and other
-        /// sub-0x20 control characters via the <c>\u{...}</c> form.
-        /// Printable ASCII and non-ASCII bytes pass through unchanged --
-        /// matching Rust's default Debug output as of the language
-        /// versions in use by maccoss/osprey (1.75+). Used so cross-impl
-        /// hashes agree on Windows paths whose <c>\</c> separators must
-        /// render as <c>\\</c>.
+        /// Convenience delegator to <see cref="Core.SearchIdentity.LibraryIdentityHash"/>.
         /// </summary>
-        internal static string EscapeForRustDebug(string s)
-        {
-            if (string.IsNullOrEmpty(s))
-                return s ?? string.Empty;
-            var sb = new StringBuilder(s.Length + 8);
-            foreach (char c in s)
-            {
-                switch (c)
-                {
-                    case '\\': sb.Append(@"\\"); break;
-                    case '"':  sb.Append("\\\""); break;
-                    case '\n': sb.Append(@"\n"); break;
-                    case '\r': sb.Append(@"\r"); break;
-                    case '\t': sb.Append(@"\t"); break;
-                    case '\0': sb.Append(@"\0"); break;
-                    default:
-                        if (c < 0x20 || c == 0x7F)
-                        {
-                            // Rust's {:?} uses `\u{HEX}` with lowercase hex,
-                            // no padding. AppendFormat's `{0:x}` works on
-                            // net8.0 but produces `{x}` literally on net472
-                            // under the double-brace escape sequence; use
-                            // explicit ToString to avoid the regression.
-                            sb.Append(@"\u{");
-                            sb.Append(((int)c).ToString(@"x",
-                                System.Globalization.CultureInfo.InvariantCulture));
-                            sb.Append('}');
-                        }
-                        else
-                        {
-                            sb.Append(c);
-                        }
-                        break;
-                }
-            }
-            return sb.ToString();
-        }
+        public string LibraryIdentityHash() => Identity.LibraryIdentityHash();
 
         /// <summary>
-        /// SHA-256 of (search hash + reconciliation parameters + run FDR
-        /// + sorted file stems). Mirrors Rust
-        /// <c>OspreyConfig::reconciliation_parameter_hash</c> in
-        /// <c>crates/osprey-core/src/config.rs</c> and is written into
-        /// reconciled <c>.scores.parquet</c> footer metadata under
-        /// <c>osprey.reconciliation_hash</c>. The hash invalidates the
-        /// cache on any reconciliation parameter change OR on any change
-        /// to the multi-file set (file_stems are sorted to make the
-        /// hash invariant to invocation order).
+        /// Convenience delegator to <see cref="Core.SearchIdentity.ReconciliationParameterHash"/>.
         /// </summary>
-        public string ReconciliationParameterHash()
-        {
-            var stems = new List<string>(InputFiles?.Count ?? 0);
-            if (InputFiles != null)
-            {
-                foreach (var path in InputFiles)
-                {
-                    string stem = Path.GetFileNameWithoutExtension(path);
-                    if (!string.IsNullOrEmpty(stem))
-                        stems.Add(stem);
-                }
-            }
-            return ReconciliationParameterHashForStems(stems);
-        }
+        public string ReconciliationParameterHash() => Identity.ReconciliationParameterHash();
 
         /// <summary>
-        /// Compute the reconciliation parameter hash for an explicit set of
-        /// file stems. Used by per-file Stage 6 rescore workers, whose
-        /// <see cref="InputFiles"/> only carries this worker's single
-        /// parquet — the hash that the downstream <c>--join-at-pass=2</c>
-        /// merge node expects is computed over ALL files in the join, so
-        /// the worker must read the full set from the planner's
-        /// <c>reconciliation.json</c> envelope and pass it in here. The
-        /// stems are sorted + deduped internally so the hash is invariant
-        /// to caller ordering. Mirrors Rust
-        /// <c>OspreyConfig::reconciliation_parameter_hash_for_stems</c>.
+        /// Convenience delegator to <see cref="Core.SearchIdentity.ReconciliationParameterHashForStems"/>.
         /// </summary>
         public string ReconciliationParameterHashForStems(IReadOnlyList<string> fileStems)
-        {
-            using (var sha256 = SHA256.Create())
-            {
-                var ic = System.Globalization.CultureInfo.InvariantCulture;
-                var sb = new StringBuilder();
-                sb.Append(SearchParameterHash());
-                sb.AppendFormat(ic, "reconciliation.enabled:{0}\n",
-                    Reconciliation.Enabled ? "true" : "false");
-                sb.AppendFormat(ic, "reconciliation.consensus_fdr:{0}\n",
-                    Reconciliation.ConsensusFdr);
-                sb.AppendFormat(ic, "run_fdr:{0}\n", RunFdr);
-                // Mirror Rust's `format!("file_stems:{:?}\n", stems)` output
-                // exactly. {:?} on Vec<String> yields ["a", "b"] with the
-                // brackets and double-quoted, comma-space-separated values.
-                // Stems are sorted + deduped here so the hash matches the
-                // Rust side, which also sorts + dedups before hashing.
-                var stems = new List<string>(fileStems?.Count ?? 0);
-                if (fileStems != null)
-                {
-                    foreach (var stem in fileStems)
-                    {
-                        if (!string.IsNullOrEmpty(stem))
-                            stems.Add(stem);
-                    }
-                }
-                stems.Sort(StringComparer.Ordinal);
-                // Dedup in place (stems is sorted, so duplicates are
-                // adjacent). Rust does `dedup()` on a sorted Vec; same here.
-                int write = 0;
-                for (int read = 0; read < stems.Count; read++)
-                {
-                    if (read == 0 || !string.Equals(stems[read], stems[read - 1], StringComparison.Ordinal))
-                    {
-                        stems[write++] = stems[read];
-                    }
-                }
-                if (write < stems.Count)
-                    stems.RemoveRange(write, stems.Count - write);
+            => Identity.ReconciliationParameterHashForStems(fileStems);
 
-                var stemsList = new StringBuilder("[");
-                for (int i = 0; i < stems.Count; i++)
-                {
-                    if (i > 0) stemsList.Append(", ");
-                    stemsList.Append('"').Append(stems[i]).Append('"');
-                }
-                stemsList.Append(']');
-                sb.AppendFormat(ic, "file_stems:{0}\n", stemsList.ToString());
-
-                byte[] hashBytes = sha256.ComputeHash(Encoding.UTF8.GetBytes(sb.ToString()));
-                var result = new StringBuilder(64);
-                for (int i = 0; i < hashBytes.Length; i++)
-                    result.Append(hashBytes[i].ToString("x2"));
-                return result.ToString();
-            }
-        }
+        /// <summary>
+        /// Convenience delegator to <see cref="Core.SearchIdentity.EscapeForRustDebug"/>,
+        /// retained so existing callers / tests that referenced
+        /// <c>OspreyConfig.EscapeForRustDebug</c> keep compiling.
+        /// </summary>
+        internal static string EscapeForRustDebug(string s) => SearchIdentity.EscapeForRustDebug(s);
     }
 
     /// <summary>

--- a/pwiz_tools/OspreySharp/OspreySharp.Core/OspreyConfig.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Core/OspreyConfig.cs
@@ -183,15 +183,6 @@ namespace pwiz.OspreySharp.Core
         public bool ExpectReconciledInput { get; set; }
 
         /// <summary>
-        /// How many files will actually run concurrently in the current
-        /// invocation. Set by the pipeline before per-file ProcessFile()
-        /// calls; used to divide the inner main-search thread budget so
-        /// total thread demand stays near core count. Defaults to 1
-        /// (no scaling).
-        /// </summary>
-        public int EffectiveFileParallelism { get; set; } = 1;
-
-        /// <summary>
         /// Shallow clone for per-file ProcessFile() calls. The pipeline
         /// mutates a few fields (notably <see cref="FragmentTolerance"/>
         /// after MS2 calibration); cloning at the top of ProcessFile

--- a/pwiz_tools/OspreySharp/OspreySharp.Core/OspreyConfig.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Core/OspreyConfig.cs
@@ -215,34 +215,6 @@ namespace pwiz.OspreySharp.Core
         /// and MUST stay byte-identical with Rust.
         /// </summary>
         public SearchIdentity Identity => new SearchIdentity(this);
-
-        /// <summary>
-        /// Convenience delegator to <see cref="Core.SearchIdentity.SearchParameterHash"/>.
-        /// </summary>
-        public string SearchParameterHash() => Identity.SearchParameterHash();
-
-        /// <summary>
-        /// Convenience delegator to <see cref="Core.SearchIdentity.LibraryIdentityHash"/>.
-        /// </summary>
-        public string LibraryIdentityHash() => Identity.LibraryIdentityHash();
-
-        /// <summary>
-        /// Convenience delegator to <see cref="Core.SearchIdentity.ReconciliationParameterHash"/>.
-        /// </summary>
-        public string ReconciliationParameterHash() => Identity.ReconciliationParameterHash();
-
-        /// <summary>
-        /// Convenience delegator to <see cref="Core.SearchIdentity.ReconciliationParameterHashForStems"/>.
-        /// </summary>
-        public string ReconciliationParameterHashForStems(IReadOnlyList<string> fileStems)
-            => Identity.ReconciliationParameterHashForStems(fileStems);
-
-        /// <summary>
-        /// Convenience delegator to <see cref="Core.SearchIdentity.EscapeForRustDebug"/>,
-        /// retained so existing callers / tests that referenced
-        /// <c>OspreyConfig.EscapeForRustDebug</c> keep compiling.
-        /// </summary>
-        internal static string EscapeForRustDebug(string s) => SearchIdentity.EscapeForRustDebug(s);
     }
 
     /// <summary>

--- a/pwiz_tools/OspreySharp/OspreySharp.Core/OspreyConfig.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Core/OspreyConfig.cs
@@ -197,12 +197,12 @@ namespace pwiz.OspreySharp.Core
 
         /// <summary>
         /// The bit-parity-critical identity hashing for this run. Split out
-        /// of <see cref="OspreyConfig"/> into <see cref="Core.SearchIdentity"/>
+        /// of <see cref="OspreyConfig"/> into <see cref="SearchIdentity"/>
         /// so this type is only the configuration bag and the SHA hashing is
         /// its own single-responsibility unit. A fresh instance is returned
         /// per access; it reads this config's hash-affecting fields at call
         /// time, preserving the historical behavior of the former instance
-        /// methods. The hash recipes live on <see cref="Core.SearchIdentity"/>
+        /// methods. The hash recipes live on <see cref="SearchIdentity"/>
         /// and MUST stay byte-identical with Rust.
         /// </summary>
         public SearchIdentity Identity => new SearchIdentity(this);

--- a/pwiz_tools/OspreySharp/OspreySharp.Core/SearchIdentity.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Core/SearchIdentity.cs
@@ -1,0 +1,319 @@
+/*
+ * Original author: Brendan MacLean <brendanx .at. uw.edu>,
+ *                  MacCoss Lab, Department of Genome Sciences, UW
+ * AI assistance: Claude Code (Claude Opus 4.8) <noreply .at. anthropic.com>
+ *
+ * Based on osprey (https://github.com/MacCossLab/osprey)
+ *   by Michael J. MacCoss, MacCoss Lab, Department of Genome Sciences, UW
+ *
+ * Copyright 2026 University of Washington - Seattle, WA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace pwiz.OspreySharp.Core
+{
+    /// <summary>
+    /// Computes the bit-parity-critical identity hashes for an Osprey run —
+    /// the SHA-256 keys that gate cached-artifact reuse and cross-impl
+    /// (Rust) byte-equivalence. Split out of <see cref="OspreyConfig"/>,
+    /// which previously owned both the mutable configuration bag AND this
+    /// hashing — two responsibilities. The hash recipes are unchanged and
+    /// MUST stay byte-identical with Rust's <c>osprey-core/src/config.rs</c>
+    /// (invariant culture, Rust <c>{:?}</c> escaping, lowercase booleans);
+    /// see the per-method comments.
+    ///
+    /// Reads its inputs from the supplied <see cref="OspreyConfig"/> at call
+    /// time, so it reflects the config's hash-affecting fields as of each
+    /// call (matching the historical behavior when these methods lived on
+    /// <see cref="OspreyConfig"/>). Obtain one via <see cref="OspreyConfig.Identity"/>.
+    /// </summary>
+    public sealed class SearchIdentity
+    {
+        private readonly OspreyConfig _config;
+
+        public SearchIdentity(OspreyConfig config)
+        {
+            _config = config ?? throw new ArgumentNullException(nameof(config));
+        }
+
+        /// <summary>
+        /// Compute SHA-256 hash of parameters that affect first-pass scoring.
+        /// If this hash changes, cached .scores.parquet files are invalid.
+        /// </summary>
+        public string SearchParameterHash()
+        {
+            // Cross-impl bit-equivalence with Rust requires:
+            //  - Booleans: Rust prints "true"/"false" (lowercase). C# default
+            //    bool.ToString() is "True"/"False". Use lowercase explicitly.
+            //  - Numbers: invariant culture (no locale-dependent separators).
+            using (var sha256 = SHA256.Create())
+            {
+                var ic = System.Globalization.CultureInfo.InvariantCulture;
+                Func<bool, string> b = v => v ? "true" : "false";
+                var sb = new StringBuilder();
+                sb.AppendFormat(ic, "resolution_mode:{0}\n", _config.ResolutionMode);
+                sb.AppendFormat(ic, "fragment_tolerance:{0},{1}\n", _config.FragmentTolerance.Tolerance, _config.FragmentTolerance.Unit);
+                sb.AppendFormat(ic, "precursor_tolerance:{0},{1}\n", _config.PrecursorTolerance.Tolerance, _config.PrecursorTolerance.Unit);
+                sb.AppendFormat(ic, "prefilter_enabled:{0}\n", b(_config.PrefilterEnabled));
+                sb.AppendFormat(ic, "decoy_method:{0}\n", _config.DecoyMethod);
+                sb.AppendFormat(ic, "decoys_in_library:{0}\n", b(_config.DecoysInLibrary));
+                // Sort prefixes so ordering changes don't churn the hash.
+                // Lower-case to make case-only edits no-ops (matching the
+                // runtime comparison). Mirrors Rust's
+                // format!("decoy_prefixes:{:?}\n", prefixes) where {:?} on
+                // Vec<String> yields ["a", "b"] (double-quoted, comma-
+                // space-separated).
+                var prefixes = new List<string>(_config.DecoyPrefixes != null ? _config.DecoyPrefixes.Count : 0);
+                if (_config.DecoyPrefixes != null)
+                {
+                    foreach (var p in _config.DecoyPrefixes)
+                        prefixes.Add(p == null ? string.Empty : p.ToLowerInvariant());
+                }
+                prefixes.Sort(StringComparer.Ordinal);
+                var prefixList = new StringBuilder("[");
+                for (int i = 0; i < prefixes.Count; i++)
+                {
+                    if (i > 0) prefixList.Append(", ");
+                    prefixList.Append('"').Append(prefixes[i]).Append('"');
+                }
+                prefixList.Append(']');
+                sb.AppendFormat(ic, "decoy_prefixes:{0}\n", prefixList.ToString());
+                // Mirror Rust's `format!("decoy_pairing_manifest:{:?}\n", ...)`
+                // where the value is `Some("path")` or `None`. Rust's {:?}
+                // on String escapes \, ", \n, \r, \t, \0, and other control
+                // chars (< 0x20) -- critical for Windows paths whose `\`
+                // separators must become `\\` to match Rust's output. The
+                // path is not normalised; the user's choice (relative or
+                // absolute) is part of the hash so a moved manifest
+                // invalidates the cache.
+                sb.AppendFormat(ic, "decoy_pairing_manifest:{0}\n",
+                    string.IsNullOrEmpty(_config.DecoyPairingManifestPath)
+                        ? "None"
+                        : "Some(\"" + EscapeForRustDebug(_config.DecoyPairingManifestPath) + "\")");
+                sb.AppendFormat(ic, "decoy_pair_min_fraction:{0}\n", _config.DecoyPairMinFraction);
+                sb.AppendFormat(ic, "rt_cal.enabled:{0}\n", b(_config.RtCalibration.Enabled));
+                sb.AppendFormat(ic, "rt_cal.fallback_rt_tolerance:{0}\n", _config.RtCalibration.FallbackRtTolerance);
+                sb.AppendFormat(ic, "rt_cal.rt_tolerance_factor:{0}\n", _config.RtCalibration.RtToleranceFactor);
+                sb.AppendFormat(ic, "rt_cal.min_rt_tolerance:{0}\n", _config.RtCalibration.MinRtTolerance);
+                sb.AppendFormat(ic, "rt_cal.max_rt_tolerance:{0}\n", _config.RtCalibration.MaxRtTolerance);
+                sb.AppendFormat(ic, "rt_cal.loess_bandwidth:{0}\n", _config.RtCalibration.LoessBandwidth);
+                sb.AppendFormat(ic, "rt_cal.min_calibration_points:{0}\n", _config.RtCalibration.MinCalibrationPoints);
+                sb.AppendFormat(ic, "rt_cal.calibration_sample_size:{0}\n", _config.RtCalibration.CalibrationSampleSize);
+                sb.AppendFormat(ic, "rt_cal.calibration_retry_factor:{0}\n", _config.RtCalibration.CalibrationRetryFactor);
+                sb.AppendFormat(ic, "reconciliation.top_n_peaks:{0}\n", _config.Reconciliation.TopNPeaks);
+
+                byte[] hashBytes = sha256.ComputeHash(Encoding.UTF8.GetBytes(sb.ToString()));
+                var result = new StringBuilder(64);
+                for (int i = 0; i < hashBytes.Length; i++)
+                {
+                    result.Append(hashBytes[i].ToString("x2"));
+                }
+                return result.ToString();
+            }
+        }
+
+        /// <summary>
+        /// Compute a fast identity hash for the library file (file name + size
+        /// + mtime). Filesystem metadata only -- no content hashing. The
+        /// directory portion is deliberately NOT in the hash so the same
+        /// library identifies identically across Rust / .NET / OS variations
+        /// (drive letter case, forward vs back slash, relative vs absolute,
+        /// HPC node-local vs shared paths). Mirrors the
+        /// <c>reconciliation_parameter_hash</c> precedent that hashes only
+        /// sorted file stems for the input set. Same recipe as Rust's
+        /// <c>library_identity_hash</c>.
+        /// </summary>
+        public string LibraryIdentityHash()
+        {
+            string libPath = _config.LibrarySource != null ? _config.LibrarySource.Path : string.Empty;
+            using (var sha256 = SHA256.Create())
+            {
+                var sb = new StringBuilder();
+                string fileName = string.IsNullOrEmpty(libPath)
+                    ? string.Empty
+                    : Path.GetFileName(libPath);
+                sb.AppendFormat("file_name:{0}\n", fileName);
+                if (!string.IsNullOrEmpty(libPath) && File.Exists(libPath))
+                {
+                    var info = new FileInfo(libPath);
+                    sb.AppendFormat(System.Globalization.CultureInfo.InvariantCulture,
+                        "size:{0}\n", info.Length);
+                    // Unix seconds matching Rust's library_identity_hash
+                    // (SystemTime::duration_since(UNIX_EPOCH).as_secs()).
+                    long mtimeSecs = (long)(info.LastWriteTimeUtc
+                        - new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc)).TotalSeconds;
+                    sb.AppendFormat(System.Globalization.CultureInfo.InvariantCulture,
+                        "mtime:{0}\n", mtimeSecs);
+                }
+                byte[] hashBytes = sha256.ComputeHash(Encoding.UTF8.GetBytes(sb.ToString()));
+                var result = new StringBuilder(64);
+                for (int i = 0; i < hashBytes.Length; i++)
+                    result.Append(hashBytes[i].ToString("x2"));
+                return result.ToString();
+            }
+        }
+
+        /// <summary>
+        /// Escape a string to match Rust's <c>{:?}</c> Debug formatter
+        /// output for <c>&amp;str</c> / <c>String</c>. Handles the cases
+        /// that actually appear in config values folded into the search
+        /// hash: backslashes, double quotes, common C escapes
+        /// (<c>\n</c>, <c>\r</c>, <c>\t</c>, <c>\0</c>), and other
+        /// sub-0x20 control characters via the <c>\u{...}</c> form.
+        /// Printable ASCII and non-ASCII bytes pass through unchanged --
+        /// matching Rust's default Debug output as of the language
+        /// versions in use by maccoss/osprey (1.75+). Used so cross-impl
+        /// hashes agree on Windows paths whose <c>\</c> separators must
+        /// render as <c>\\</c>.
+        /// </summary>
+        internal static string EscapeForRustDebug(string s)
+        {
+            if (string.IsNullOrEmpty(s))
+                return s ?? string.Empty;
+            var sb = new StringBuilder(s.Length + 8);
+            foreach (char c in s)
+            {
+                switch (c)
+                {
+                    case '\\': sb.Append(@"\\"); break;
+                    case '"':  sb.Append("\\\""); break;
+                    case '\n': sb.Append(@"\n"); break;
+                    case '\r': sb.Append(@"\r"); break;
+                    case '\t': sb.Append(@"\t"); break;
+                    case '\0': sb.Append(@"\0"); break;
+                    default:
+                        if (c < 0x20 || c == 0x7F)
+                        {
+                            // Rust's {:?} uses `\u{HEX}` with lowercase hex,
+                            // no padding. AppendFormat's `{0:x}` works on
+                            // net8.0 but produces `{x}` literally on net472
+                            // under the double-brace escape sequence; use
+                            // explicit ToString to avoid the regression.
+                            sb.Append(@"\u{");
+                            sb.Append(((int)c).ToString(@"x",
+                                System.Globalization.CultureInfo.InvariantCulture));
+                            sb.Append('}');
+                        }
+                        else
+                        {
+                            sb.Append(c);
+                        }
+                        break;
+                }
+            }
+            return sb.ToString();
+        }
+
+        /// <summary>
+        /// SHA-256 of (search hash + reconciliation parameters + run FDR
+        /// + sorted file stems). Mirrors Rust
+        /// <c>OspreyConfig::reconciliation_parameter_hash</c> in
+        /// <c>crates/osprey-core/src/config.rs</c> and is written into
+        /// reconciled <c>.scores.parquet</c> footer metadata under
+        /// <c>osprey.reconciliation_hash</c>. The hash invalidates the
+        /// cache on any reconciliation parameter change OR on any change
+        /// to the multi-file set (file_stems are sorted to make the
+        /// hash invariant to invocation order).
+        /// </summary>
+        public string ReconciliationParameterHash()
+        {
+            var stems = new List<string>(_config.InputFiles?.Count ?? 0);
+            if (_config.InputFiles != null)
+            {
+                foreach (var path in _config.InputFiles)
+                {
+                    string stem = Path.GetFileNameWithoutExtension(path);
+                    if (!string.IsNullOrEmpty(stem))
+                        stems.Add(stem);
+                }
+            }
+            return ReconciliationParameterHashForStems(stems);
+        }
+
+        /// <summary>
+        /// Compute the reconciliation parameter hash for an explicit set of
+        /// file stems. Used by per-file Stage 6 rescore workers, whose
+        /// <see cref="OspreyConfig.InputFiles"/> only carries this worker's single
+        /// parquet — the hash that the downstream <c>--join-at-pass=2</c>
+        /// merge node expects is computed over ALL files in the join, so
+        /// the worker must read the full set from the planner's
+        /// <c>reconciliation.json</c> envelope and pass it in here. The
+        /// stems are sorted + deduped internally so the hash is invariant
+        /// to caller ordering. Mirrors Rust
+        /// <c>OspreyConfig::reconciliation_parameter_hash_for_stems</c>.
+        /// </summary>
+        public string ReconciliationParameterHashForStems(IReadOnlyList<string> fileStems)
+        {
+            using (var sha256 = SHA256.Create())
+            {
+                var ic = System.Globalization.CultureInfo.InvariantCulture;
+                var sb = new StringBuilder();
+                sb.Append(SearchParameterHash());
+                sb.AppendFormat(ic, "reconciliation.enabled:{0}\n",
+                    _config.Reconciliation.Enabled ? "true" : "false");
+                sb.AppendFormat(ic, "reconciliation.consensus_fdr:{0}\n",
+                    _config.Reconciliation.ConsensusFdr);
+                sb.AppendFormat(ic, "run_fdr:{0}\n", _config.RunFdr);
+                // Mirror Rust's `format!("file_stems:{:?}\n", stems)` output
+                // exactly. {:?} on Vec<String> yields ["a", "b"] with the
+                // brackets and double-quoted, comma-space-separated values.
+                // Stems are sorted + deduped here so the hash matches the
+                // Rust side, which also sorts + dedups before hashing.
+                var stems = new List<string>(fileStems?.Count ?? 0);
+                if (fileStems != null)
+                {
+                    foreach (var stem in fileStems)
+                    {
+                        if (!string.IsNullOrEmpty(stem))
+                            stems.Add(stem);
+                    }
+                }
+                stems.Sort(StringComparer.Ordinal);
+                // Dedup in place (stems is sorted, so duplicates are
+                // adjacent). Rust does `dedup()` on a sorted Vec; same here.
+                int write = 0;
+                for (int read = 0; read < stems.Count; read++)
+                {
+                    if (read == 0 || !string.Equals(stems[read], stems[read - 1], StringComparison.Ordinal))
+                    {
+                        stems[write++] = stems[read];
+                    }
+                }
+                if (write < stems.Count)
+                    stems.RemoveRange(write, stems.Count - write);
+
+                var stemsList = new StringBuilder("[");
+                for (int i = 0; i < stems.Count; i++)
+                {
+                    if (i > 0) stemsList.Append(", ");
+                    stemsList.Append('"').Append(stems[i]).Append('"');
+                }
+                stemsList.Append(']');
+                sb.AppendFormat(ic, "file_stems:{0}\n", stemsList.ToString());
+
+                byte[] hashBytes = sha256.ComputeHash(Encoding.UTF8.GetBytes(sb.ToString()));
+                var result = new StringBuilder(64);
+                for (int i = 0; i < hashBytes.Length; i++)
+                    result.Append(hashBytes[i].ToString("x2"));
+                return result.ToString();
+            }
+        }
+    }
+}

--- a/pwiz_tools/OspreySharp/OspreySharp.IO/ParquetScoreCache.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.IO/ParquetScoreCache.cs
@@ -1161,8 +1161,8 @@ namespace pwiz.OspreySharp.IO
             string currentVersion,
             Action<string> logWarning)
         {
-            string expectedSearch = config.SearchParameterHash();
-            string expectedLibrary = config.LibraryIdentityHash();
+            string expectedSearch = config.Identity.SearchParameterHash();
+            string expectedLibrary = config.Identity.LibraryIdentityHash();
 
             foreach (string path in paths)
             {

--- a/pwiz_tools/OspreySharp/OspreySharp.Tasks/OspreyTask.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Tasks/OspreyTask.cs
@@ -118,16 +118,16 @@ namespace pwiz.OspreySharp.Tasks
         /// output's <c>.osprey.task</c> sidecar after Run; checked on
         /// the next invocation before deciding whether to skip Run.
         ///
-        /// Default includes <see cref="OspreyConfig.SearchParameterHash"/>
-        /// and <see cref="OspreyConfig.LibraryIdentityHash"/> — the
+        /// Default includes <see cref="SearchIdentity.SearchParameterHash"/>
+        /// and <see cref="SearchIdentity.LibraryIdentityHash"/> — the
         /// two hashes that already participate in the parquet-metadata
         /// integrity check downstream. Tasks with extra per-task state
-        /// that affects their output (e.g. <see cref="OspreyConfig.ReconciliationParameterHash"/>
+        /// that affects their output (e.g. <see cref="SearchIdentity.ReconciliationParameterHash"/>
         /// for the rescore task) override and append.
         /// </summary>
         public virtual string ValidityKey(PipelineContext ctx) => string.Format(
             @"search={0};library={1}",
-            ctx.Config.SearchParameterHash(),
-            ctx.Config.LibraryIdentityHash());
+            ctx.Config.Identity.SearchParameterHash(),
+            ctx.Config.Identity.LibraryIdentityHash());
     }
 }

--- a/pwiz_tools/OspreySharp/OspreySharp.Tasks/PipelineContext.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Tasks/PipelineContext.cs
@@ -55,9 +55,9 @@ namespace pwiz.OspreySharp.Tasks
         /// The configuration parsed from CLI args and the input library.
         ///
         /// Mutation contract: fields that feed
-        /// <see cref="OspreyConfig.SearchParameterHash"/> /
-        /// <see cref="OspreyConfig.LibraryIdentityHash"/> /
-        /// <see cref="OspreyConfig.ReconciliationParameterHash"/> must
+        /// <see cref="SearchIdentity.SearchParameterHash"/> /
+        /// <see cref="SearchIdentity.LibraryIdentityHash"/> /
+        /// <see cref="SearchIdentity.ReconciliationParameterHash"/> must
         /// remain stable for the life of the run, so a worker can
         /// reproduce the same hash a straight-through invocation would
         /// stamp into its parquet footers. Pipeline-populated fields

--- a/pwiz_tools/OspreySharp/OspreySharp.Tasks/PipelineContext.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Tasks/PipelineContext.cs
@@ -62,15 +62,22 @@ namespace pwiz.OspreySharp.Tasks
         /// reproduce the same hash a straight-through invocation would
         /// stamp into its parquet footers. Pipeline-populated fields
         /// that do NOT feed those hashes (e.g. the worker-mode
-        /// synthesis of <c>InputFiles</c> from <c>InputScores</c>, the
-        /// pipeline's choice of <c>EffectiveFileParallelism</c>) may be
-        /// written once at pipeline entry. For per-file scratch that
+        /// synthesis of <c>InputFiles</c> from <c>InputScores</c>) may be
+        /// written once at pipeline entry. Run-time state that is not parsed
+        /// config (e.g. file parallelism) lives on <see cref="RunPlan"/>
+        /// instead. For per-file scratch that
         /// mutates hash-affecting fields (e.g. the MS2-calibrated
         /// FragmentTolerance), tasks must use
         /// <c>OspreyConfig.ShallowClone</c> so the mutation stays
         /// scoped to one file.
         /// </summary>
         public OspreyConfig Config { get; }
+
+        /// <summary>
+        /// Per-run, driver-owned pipeline state (not parsed config, not part
+        /// of any cache / identity hash). See <see cref="RunPlan"/>.
+        /// </summary>
+        public RunPlan RunPlan { get; } = new RunPlan();
 
         /// <summary>
         /// Process exit code requested by a task that has returned

--- a/pwiz_tools/OspreySharp/OspreySharp.Tasks/RunPlan.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Tasks/RunPlan.cs
@@ -1,0 +1,49 @@
+/*
+ * Original author: Brendan MacLean <brendanx .at. uw.edu>,
+ *                  MacCoss Lab, Department of Genome Sciences, UW
+ * AI assistance: Claude Code (Claude Opus 4.8) <noreply .at. anthropic.com>
+ *
+ * Based on osprey (https://github.com/MacCossLab/osprey)
+ *   by Michael J. MacCoss, MacCoss Lab, Department of Genome Sciences, UW
+ *
+ * Copyright 2026 University of Washington - Seattle, WA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace pwiz.OspreySharp.Tasks
+{
+    /// <summary>
+    /// Per-run, driver-owned pipeline state — distinct from the parsed
+    /// <c>OspreyConfig</c> (the configuration). Holds values the pipeline
+    /// computes at run time that are NOT configuration and are NOT part of
+    /// any cache / identity hash. Lives on <see cref="PipelineContext.RunPlan"/>.
+    ///
+    /// Splitting run-time state out of <c>OspreyConfig</c> lets the config
+    /// be the immutable, hash-affecting parsed inputs while this carries the
+    /// mutable per-run decisions. (First field moved: file parallelism;
+    /// more run-time state migrates here as the config is frozen.)
+    /// </summary>
+    public sealed class RunPlan
+    {
+        /// <summary>
+        /// How many files will actually run concurrently in the current
+        /// invocation. Computed once by <c>PerFileScoringTask</c> before the
+        /// per-file <c>ProcessFile()</c> calls and read to divide the inner
+        /// main-search thread budget so total thread demand stays near core
+        /// count. Defaults to 1 (no scaling). Does NOT feed any
+        /// <c>SearchIdentity</c> hash.
+        /// </summary>
+        public int EffectiveFileParallelism { get; set; } = 1;
+    }
+}

--- a/pwiz_tools/OspreySharp/OspreySharp.Test/CoreTypesTest.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Test/CoreTypesTest.cs
@@ -435,8 +435,8 @@ namespace pwiz.OspreySharp.Test
         public void TestSearchHashDeterministic()
         {
             var config = new OspreyConfig();
-            string hash1 = config.SearchParameterHash();
-            string hash2 = config.SearchParameterHash();
+            string hash1 = config.Identity.SearchParameterHash();
+            string hash2 = config.Identity.SearchParameterHash();
 
             Assert.AreEqual(hash1, hash2);
             Assert.AreEqual(64, hash1.Length); // SHA-256 hex is 64 chars
@@ -446,9 +446,9 @@ namespace pwiz.OspreySharp.Test
         public void TestSearchHashChangesWithTolerance()
         {
             var config = new OspreyConfig();
-            string hash1 = config.SearchParameterHash();
+            string hash1 = config.Identity.SearchParameterHash();
             config.FragmentTolerance.Tolerance = 20.0;
-            string hash2 = config.SearchParameterHash();
+            string hash2 = config.Identity.SearchParameterHash();
 
             Assert.AreNotEqual(hash1, hash2);
         }
@@ -466,25 +466,25 @@ namespace pwiz.OspreySharp.Test
             // Expected outputs below pin the exact char sequence Rust's
             // {:?} would produce on the same input.
             Assert.AreEqual(@"T:\\test\\manifest.tsv",
-                OspreyConfig.EscapeForRustDebug(@"T:\test\manifest.tsv"));
+                SearchIdentity.EscapeForRustDebug(@"T:\test\manifest.tsv"));
             Assert.AreEqual(@"/srv/data/manifest.tsv",
-                OspreyConfig.EscapeForRustDebug(@"/srv/data/manifest.tsv"));
+                SearchIdentity.EscapeForRustDebug(@"/srv/data/manifest.tsv"));
             Assert.AreEqual(@"line1\nline2",
-                OspreyConfig.EscapeForRustDebug("line1\nline2"));
+                SearchIdentity.EscapeForRustDebug("line1\nline2"));
             Assert.AreEqual(@"with \""quotes\""",
-                OspreyConfig.EscapeForRustDebug("with \"quotes\""));
+                SearchIdentity.EscapeForRustDebug("with \"quotes\""));
             Assert.AreEqual(@"\t\r\n\0",
-                OspreyConfig.EscapeForRustDebug("\t\r\n\0"));
+                SearchIdentity.EscapeForRustDebug("\t\r\n\0"));
             // DEL (0x7F) and sub-0x20 control chars render as Rust's
             // `\u{HEX}` form.
             Assert.AreEqual(@"a\u{7f}b",
-                OspreyConfig.EscapeForRustDebug("ab"));
+                SearchIdentity.EscapeForRustDebug("ab"));
             Assert.AreEqual(@"\u{1}\u{1f}",
-                OspreyConfig.EscapeForRustDebug(""));
+                SearchIdentity.EscapeForRustDebug(""));
             Assert.AreEqual(@"plain-ascii-7",
-                OspreyConfig.EscapeForRustDebug(@"plain-ascii-7"));
+                SearchIdentity.EscapeForRustDebug(@"plain-ascii-7"));
             Assert.AreEqual(string.Empty,
-                OspreyConfig.EscapeForRustDebug(string.Empty));
+                SearchIdentity.EscapeForRustDebug(string.Empty));
         }
 
         [TestMethod]
@@ -507,23 +507,23 @@ namespace pwiz.OspreySharp.Test
 
             // Pin the exact pre-hash escape that goes into Some("...").
             Assert.AreEqual(@"T:\\test\\manifest.tsv",
-                OspreyConfig.EscapeForRustDebug(winPath));
+                SearchIdentity.EscapeForRustDebug(winPath));
             Assert.AreEqual(linuxPath,
-                OspreyConfig.EscapeForRustDebug(linuxPath));
+                SearchIdentity.EscapeForRustDebug(linuxPath));
 
             var configEmpty = new OspreyConfig();
-            string hashEmpty = configEmpty.SearchParameterHash();
+            string hashEmpty = configEmpty.Identity.SearchParameterHash();
 
             var configWin = new OspreyConfig { DecoyPairingManifestPath = winPath };
-            string hashWin = configWin.SearchParameterHash();
+            string hashWin = configWin.Identity.SearchParameterHash();
             // Hash determinism: identical config -> identical hash.
-            Assert.AreEqual(hashWin, configWin.SearchParameterHash());
+            Assert.AreEqual(hashWin, configWin.Identity.SearchParameterHash());
             // Sensitivity: setting a manifest path changes the hash.
             Assert.AreNotEqual(hashEmpty, hashWin);
 
             var configLinux = new OspreyConfig { DecoyPairingManifestPath = linuxPath };
-            string hashLinux = configLinux.SearchParameterHash();
-            Assert.AreEqual(hashLinux, configLinux.SearchParameterHash());
+            string hashLinux = configLinux.Identity.SearchParameterHash();
+            Assert.AreEqual(hashLinux, configLinux.Identity.SearchParameterHash());
             // Distinct path shapes (different escape semantics) produce
             // distinct hashes.
             Assert.AreNotEqual(hashWin, hashLinux);
@@ -532,7 +532,7 @@ namespace pwiz.OspreySharp.Test
             // distinct hashes (catches accidental aliasing in the escape
             // path).
             var configWinAlt = new OspreyConfig { DecoyPairingManifestPath = winPathAlt };
-            Assert.AreNotEqual(hashWin, configWinAlt.SearchParameterHash());
+            Assert.AreNotEqual(hashWin, configWinAlt.Identity.SearchParameterHash());
         }
 
         [TestMethod]
@@ -551,19 +551,19 @@ namespace pwiz.OspreySharp.Test
             var configA = new OspreyConfig { DecoyPairMinFraction = 1.0 / 3.0 };
             var configB = new OspreyConfig { DecoyPairMinFraction = 1.0 / 3.0 };
             // Deterministic across two constructions of the same config.
-            Assert.AreEqual(configA.SearchParameterHash(),
-                configB.SearchParameterHash());
+            Assert.AreEqual(configA.Identity.SearchParameterHash(),
+                configB.Identity.SearchParameterHash());
             // Sensitive to a tiny perturbation of the threshold.
             var configC = new OspreyConfig { DecoyPairMinFraction = (1.0 / 3.0) + 1e-12 };
-            Assert.AreNotEqual(configA.SearchParameterHash(),
-                configC.SearchParameterHash());
+            Assert.AreNotEqual(configA.Identity.SearchParameterHash(),
+                configC.Identity.SearchParameterHash());
             // Sensitive to the default vs an explicit set to the same
             // value (catches a regression where the default would not be
             // hashed identically to an explicit-set).
             var configDefault = new OspreyConfig();
             var configExplicit80 = new OspreyConfig { DecoyPairMinFraction = 0.80 };
-            Assert.AreEqual(configDefault.SearchParameterHash(),
-                configExplicit80.SearchParameterHash());
+            Assert.AreEqual(configDefault.Identity.SearchParameterHash(),
+                configExplicit80.Identity.SearchParameterHash());
         }
 
         [TestMethod]

--- a/pwiz_tools/OspreySharp/OspreySharp/Tasks/FirstJoinTask.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/Tasks/FirstJoinTask.cs
@@ -178,7 +178,7 @@ namespace pwiz.OspreySharp.Tasks
         public override string ValidityKey(PipelineContext ctx)
         {
             return base.ValidityKey(ctx)
-                + @";reconciliation=" + ctx.Config.ReconciliationParameterHash();
+                + @";reconciliation=" + ctx.Config.Identity.ReconciliationParameterHash();
         }
 
         public override bool Run(PipelineContext ctx)
@@ -835,8 +835,8 @@ namespace pwiz.OspreySharp.Tasks
             OspreyConfig config,
             out Dictionary<string, List<GapFillTarget>> gapFillByFileOut)
         {
-            string searchHash = config.SearchParameterHash();
-            string libraryHash = config.LibraryIdentityHash();
+            string searchHash = config.Identity.SearchParameterHash();
+            string libraryHash = config.Identity.LibraryIdentityHash();
             var actions = reconciliationActions
                 ?? new Dictionary<(string File, int Index), ReconcileAction>();
 

--- a/pwiz_tools/OspreySharp/OspreySharp/Tasks/MergeNodeTask.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/Tasks/MergeNodeTask.cs
@@ -85,7 +85,7 @@ namespace pwiz.OspreySharp.Tasks
         public override string ValidityKey(PipelineContext ctx)
         {
             return base.ValidityKey(ctx)
-                + @";reconciliation=" + ctx.Config.ReconciliationParameterHash();
+                + @";reconciliation=" + ctx.Config.Identity.ReconciliationParameterHash();
         }
 
         public override bool Run(PipelineContext ctx)

--- a/pwiz_tools/OspreySharp/OspreySharp/Tasks/PerFileRescoreTask.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/Tasks/PerFileRescoreTask.cs
@@ -165,7 +165,7 @@ namespace pwiz.OspreySharp.Tasks
         public override string ValidityKey(PipelineContext ctx)
         {
             return base.ValidityKey(ctx)
-                + @";reconciliation=" + ctx.Config.ReconciliationParameterHash();
+                + @";reconciliation=" + ctx.Config.Identity.ReconciliationParameterHash();
         }
 
         public override bool Run(PipelineContext ctx)
@@ -465,13 +465,13 @@ namespace pwiz.OspreySharp.Tasks
             //    pipeline where config.InputFiles already has all files,
             //    or v1 backward compat).
             string reconciliationHash = (joinFileStems != null && joinFileStems.Count > 0)
-                ? config.ReconciliationParameterHashForStems(joinFileStems)
-                : config.ReconciliationParameterHash();
+                ? config.Identity.ReconciliationParameterHashForStems(joinFileStems)
+                : config.Identity.ReconciliationParameterHash();
             var metadata = new Dictionary<string, string>
             {
                 { @"osprey.version", Program.VERSION },
-                { @"osprey.search_hash", config.SearchParameterHash() },
-                { @"osprey.library_hash", config.LibraryIdentityHash() },
+                { @"osprey.search_hash", config.Identity.SearchParameterHash() },
+                { @"osprey.library_hash", config.Identity.LibraryIdentityHash() },
                 { @"osprey.reconciled", @"true" },
                 { @"osprey.reconciliation_hash", reconciliationHash },
             };

--- a/pwiz_tools/OspreySharp/OspreySharp/Tasks/PerFileRescoreTask.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/Tasks/PerFileRescoreTask.cs
@@ -373,7 +373,7 @@ namespace pwiz.OspreySharp.Tasks
         /// <see cref="ParquetScoreCache.WriteScoresParquet(string, List{FdrEntry}, Dictionary{string, string}, Dictionary{uint, LibraryEntry}, string)"/>
         /// with reconciliation metadata
         /// (<c>osprey.reconciled = "true"</c> +
-        /// <c>osprey.reconciliation_hash = config.ReconciliationParameterHash()</c>).
+        /// <c>osprey.reconciliation_hash = config.Identity.ReconciliationParameterHash()</c>).
         /// The original parquet is read-only here -- it is never overwritten,
         /// so it survives intact for files whose reconciliation is a no-op and
         /// as a crash-safe Stage 4 record. Mirrors Rust pipeline.rs:3050-3110.
@@ -627,7 +627,7 @@ namespace pwiz.OspreySharp.Tasks
                 // the MS2-calibrated tolerance (AnalysisPipeline.cs ~line 3552);
                 // without a per-file clone the mutation persists on the outer
                 // config, leaks into subsequent files, AND poisons the
-                // WriteReconciledParquet hash stamp (config.SearchParameterHash()
+                // WriteReconciledParquet hash stamp (config.Identity.SearchParameterHash()
                 // would then reflect the calibrated tolerance, not the value
                 // a fresh --join-at-pass=2 invocation recomputes from CLI
                 // defaults -- causing search_hash mismatch errors). Mirrors

--- a/pwiz_tools/OspreySharp/OspreySharp/Tasks/PerFileScoringTask.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/Tasks/PerFileScoringTask.cs
@@ -256,8 +256,8 @@ namespace pwiz.OspreySharp.Tasks
                 parquetFooterMetadata = new Dictionary<string, string>
                 {
                     { @"osprey.version", Program.VERSION },
-                    { @"osprey.search_hash", config.SearchParameterHash() },
-                    { @"osprey.library_hash", config.LibraryIdentityHash() },
+                    { @"osprey.search_hash", config.Identity.SearchParameterHash() },
+                    { @"osprey.library_hash", config.Identity.LibraryIdentityHash() },
                     { @"osprey.reconciled", @"false" },
                 };
             }

--- a/pwiz_tools/OspreySharp/OspreySharp/Tasks/PerFileScoringTask.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/Tasks/PerFileScoringTask.cs
@@ -269,14 +269,14 @@ namespace pwiz.OspreySharp.Tasks
 
             // Determine how many files will actually run concurrently so
             // ProcessFile can divide the inner main-search thread budget
-            // and avoid oversubscription. Stored on the config so the
-            // per-file clones inherit it.
+            // and avoid oversubscription. Stored on the per-run RunPlan
+            // (driver-owned run state), not on the parsed OspreyConfig.
             if (nFiles == 1 || maxParallelFiles == 1)
-                config.EffectiveFileParallelism = 1;
+                ctx.RunPlan.EffectiveFileParallelism = 1;
             else if (maxParallelFiles > 1)
-                config.EffectiveFileParallelism = Math.Min(maxParallelFiles, nFiles);
+                ctx.RunPlan.EffectiveFileParallelism = Math.Min(maxParallelFiles, nFiles);
             else
-                config.EffectiveFileParallelism = Math.Min(nFiles, Environment.ProcessorCount);
+                ctx.RunPlan.EffectiveFileParallelism = Math.Min(nFiles, Environment.ProcessorCount);
 
             var swAllFiles = Stopwatch.StartNew();
             if (joinOnly)
@@ -1005,12 +1005,12 @@ namespace pwiz.OspreySharp.Tasks
             // 32 threads on a 32-core box, the prior 96-way oversubscription
             // produced 45-95s wall-time variance on Stellar; a fair share
             // (10 threads each) holds the run near steady-state.
-            if (config.EffectiveFileParallelism > 1)
+            if (_ctx.RunPlan.EffectiveFileParallelism > 1)
             {
-                int perFileThreads = Math.Max(1, config.NThreads / config.EffectiveFileParallelism);
+                int perFileThreads = Math.Max(1, config.NThreads / _ctx.RunPlan.EffectiveFileParallelism);
                 _ctx.LogInfo(string.Format(
                     "[BENCH] Per-file thread cap: {0} ({1} total / {2} files in parallel)",
-                    perFileThreads, config.NThreads, config.EffectiveFileParallelism));
+                    perFileThreads, config.NThreads, _ctx.RunPlan.EffectiveFileParallelism));
                 config.NThreads = perFileThreads;
             }
 
@@ -1020,7 +1020,7 @@ namespace pwiz.OspreySharp.Tasks
             List<Spectrum> spectra;
             List<MS1Spectrum> ms1Spectra;
             var swParse = Stopwatch.StartNew();
-            LoadSpectra(inputFile, config.EffectiveFileParallelism > 1,
+            LoadSpectra(inputFile, _ctx.RunPlan.EffectiveFileParallelism > 1,
                 out spectra, out ms1Spectra);
             swParse.Stop();
 

--- a/pwiz_tools/OspreySharp/OspreySharp/Tasks/PerFileScoringTask.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/Tasks/PerFileScoringTask.cs
@@ -243,7 +243,7 @@ namespace pwiz.OspreySharp.Tasks
             // Pre-compute the parquet footer metadata ONCE, against the
             // unmutated outer config. ProcessFile clones the config per
             // file and mutates FragmentTolerance during MS2 calibration,
-            // so reading config.SearchParameterHash() inside ProcessFile
+            // so reading config.Identity.SearchParameterHash() inside ProcessFile
             // would produce a hash that the join-only validator would
             // not recognize. Built unconditionally (in any non-joinOnly
             // mode) because Stage 6 reconciliation needs the per-file


### PR DESCRIPTION
## Summary

* Split the bit-parity SHA identity hashing (`SearchParameterHash` / `LibraryIdentityHash` / `ReconciliationParameterHash[ForStems]` + `EscapeForRustDebug`) out of the mutable `OspreyConfig` bag into a single-responsibility `SearchIdentity` (`OspreySharp.Core`); `OspreyConfig` now exposes it via an `Identity` property. The hash recipes are moved verbatim and stay byte-identical with Rust.
* Repointed all ~10 hash callers to `config.Identity` / `SearchIdentity` and removed the `OspreyConfig` delegators (+ fixed the `<see cref>` docs).
* Moved `EffectiveFileParallelism` off `OspreyConfig` onto a new driver-owned `RunPlan` (`OspreySharp.Tasks`, exposed as `PipelineContext.RunPlan`) — separating per-run pipeline state from parsed configuration.
* This is the first slice (PR-A1) of the declarative-dataflow program's "freeze config" partner refactor. Full `OspreyConfig` init-only immutability is **deliberately deferred**: the remaining per-file `FragmentTolerance`/`NThreads` scratch uses a load-bearing in-place propagation pattern (the MS2-calibrated tolerance is written back to the config clone and read by ~15 downstream scoring sites), structurally like the deliberately-kept `_perFileEntries` buffer. See the TODO for the rationale.

## Test plan

- [x] `Build-OspreySharp.ps1 -RunTests -RunInspection` — 352 tests pass (incl. the SHA hash-oracle tests in `CoreTypesTest`), ReSharper inspection clean (0 warnings)
- [x] `Compare-EndToEnd-Crossimpl.ps1 -Files All -SkipRust` (Stellar 3-file) — OVERALL PASS, cross-impl bit-parity at 1e-9 (Stage 7 protein FDR + blib SQL content)
- [x] C#-vs-C# byte check (branch vs master) — Stage 7 dump byte-identical; blib identical apart from the non-deterministic BiblioSpec LSID/timestamp header

See ai/todos/active/TODO-20260601_ospreysharp_declarative_pipeline_dataflow.md

Co-Authored-By: Claude <noreply@anthropic.com>
