### PR TITLE
Fixed spurious GC-LEAK reports by opting the test host into the latest accessibility level

### DIFF
--- a/pwiz_tools/Skyline/TestRunner/Program.cs
+++ b/pwiz_tools/Skyline/TestRunner/Program.cs
@@ -272,6 +272,22 @@ namespace TestRunner
         static int Main(string[] args)
         {
             Console.OutputEncoding = Encoding.UTF8;
+
+            // EXPERIMENT: force a deterministic WinForms accessibility level before any control is
+            // created, overriding config/framework-quirk defaults, so the UseLegacyAccessibilityFeatures
+            // (#2) test isn't confounded by an unknown switch state. SetSwitch wins over config when it
+            // runs before the level is first read. Flag A below logs the resulting state.
+            //   SKYLINE_LEGACY_ACCESSIBILITY=1 -> full legacy (Level0); =0 -> latest (Level4); unset -> defaults.
+            var legacyAccessibility = Environment.GetEnvironmentVariable("SKYLINE_LEGACY_ACCESSIBILITY");
+            if (legacyAccessibility == "1" || legacyAccessibility == "0")
+            {
+                var useLegacy = legacyAccessibility == "1";
+                AppContext.SetSwitch("Switch.UseLegacyAccessibilityFeatures", useLegacy);
+                AppContext.SetSwitch("Switch.UseLegacyAccessibilityFeatures.2", useLegacy);
+                AppContext.SetSwitch("Switch.UseLegacyAccessibilityFeatures.3", useLegacy);
+                AppContext.SetSwitch("Switch.UseLegacyAccessibilityFeatures.4", useLegacy);
+            }
+
             Application.SetUnhandledExceptionMode(UnhandledExceptionMode.CatchException);
             Application.ThreadException += ThreadExceptionEventHandler;
 

--- a/pwiz_tools/Skyline/TestRunner/Program.cs
+++ b/pwiz_tools/Skyline/TestRunner/Program.cs
@@ -332,6 +332,32 @@ namespace TestRunner
                 Console.WriteLine("AppContext {0} = {1}", accessibilitySwitch, isOn);
             }
 
+            // DIAGNOSTIC (debug-only, not for merge): the AppContext switches above can read the
+            // same via TryGetSwitch whether unset or explicitly false, yet behave differently. Read
+            // the EFFECTIVE WinForms AccessibilityImprovements level (internal) to see the real state.
+            try
+            {
+                var aiType = typeof(System.Windows.Forms.Control).Assembly
+                    .GetType("System.Windows.Forms.AccessibilityImprovements");
+                if (aiType != null)
+                {
+                    foreach (var prop in aiType.GetProperties(System.Reflection.BindingFlags.Static
+                                 | System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Public))
+                    {
+                        if (prop.Name.StartsWith("Level") && prop.PropertyType == typeof(bool))
+                            Console.WriteLine("AccessibilityImprovements.{0} = {1}", prop.Name, prop.GetValue(null));
+                    }
+                }
+                else
+                {
+                    Console.WriteLine("AccessibilityImprovements type not found for level readout");
+                }
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine("AccessibilityImprovements level readout failed: {0}", ex.Message);
+            }
+
             if (commandLineArgs.HasArg("debug"))
             {
                 Console.WriteLine("*** Launching debugger ***\n\n");

--- a/pwiz_tools/Skyline/TestRunner/Program.cs
+++ b/pwiz_tools/Skyline/TestRunner/Program.cs
@@ -301,6 +301,21 @@ namespace TestRunner
                 Console.WriteLine("Process: {0}\n", Process.GetCurrentProcess().Id);
             }
 
+            // DIAGNOSTIC (GC-leak UIA exploration): confirm whether the legacy-accessibility
+            // AppContext switches are actually live in this process (config-applied vs silently
+            // dropped). Lets us trust/discard the UseLegacyAccessibilityFeatures experiment.
+            foreach (var accessibilitySwitch in new[]
+            {
+                "Switch.UseLegacyAccessibilityFeatures",
+                "Switch.UseLegacyAccessibilityFeatures.2",
+                "Switch.UseLegacyAccessibilityFeatures.3",
+                "Switch.UseLegacyAccessibilityFeatures.4"
+            })
+            {
+                AppContext.TryGetSwitch(accessibilitySwitch, out var isOn);
+                Console.WriteLine("AppContext {0} = {1}", accessibilitySwitch, isOn);
+            }
+
             if (commandLineArgs.HasArg("debug"))
             {
                 Console.WriteLine("*** Launching debugger ***\n\n");

--- a/pwiz_tools/Skyline/TestRunner/Program.cs
+++ b/pwiz_tools/Skyline/TestRunner/Program.cs
@@ -273,20 +273,26 @@ namespace TestRunner
         {
             Console.OutputEncoding = Encoding.UTF8;
 
-            // EXPERIMENT: force a deterministic WinForms accessibility level before any control is
-            // created, overriding config/framework-quirk defaults, so the UseLegacyAccessibilityFeatures
-            // (#2) test isn't confounded by an unknown switch state. SetSwitch wins over config when it
-            // runs before the level is first read. Flag A below logs the resulting state.
-            //   SKYLINE_LEGACY_ACCESSIBILITY=1 -> full legacy (Level0); =0 -> latest (Level4); unset -> defaults.
-            var legacyAccessibility = Environment.GetEnvironmentVariable("SKYLINE_LEGACY_ACCESSIBILITY");
-            if (legacyAccessibility == "1" || legacyAccessibility == "0")
-            {
-                var useLegacy = legacyAccessibility == "1";
-                AppContext.SetSwitch("Switch.UseLegacyAccessibilityFeatures", useLegacy);
-                AppContext.SetSwitch("Switch.UseLegacyAccessibilityFeatures.2", useLegacy);
-                AppContext.SetSwitch("Switch.UseLegacyAccessibilityFeatures.3", useLegacy);
-                AppContext.SetSwitch("Switch.UseLegacyAccessibilityFeatures.4", useLegacy);
-            }
+            // Opt the test runner into the latest WinForms accessibility level by explicitly setting
+            // all four UseLegacyAccessibilityFeatures switches to false BEFORE any control is created.
+            // This is test-host only -- it does not change shipping Skyline behavior.
+            //
+            // Why: at this exe's framework-default accessibility level (it targets .NET 4.7.2), closing
+            // a window does not release some UI Automation accessible-object provider handles, so the
+            // post-test GC check reports SkylineWindow/SrmDocument as not collected. Opting into the
+            // latest level (which carries the accessible-object lifetime fix) clears it. Subtlety:
+            // AppContext.TryGetSwitch reads the same whether a switch is unset or explicitly false, but
+            // the *effective* WinForms accessibility level differs -- so these must be set explicitly
+            // here, not merely left unset (the framework default is what leaks).
+            //
+            // Alternative: setting all four to TRUE (legacy accessibility) also stops the leak, by
+            // disabling the modern UI Automation provider path entirely. That is a larger behavioral
+            // change, but worth keeping in mind if a future framework regresses the lifetime fix at the
+            // latest level, or if we ever want to fully sidestep UIA providers in the test host.
+            AppContext.SetSwitch("Switch.UseLegacyAccessibilityFeatures", false);
+            AppContext.SetSwitch("Switch.UseLegacyAccessibilityFeatures.2", false);
+            AppContext.SetSwitch("Switch.UseLegacyAccessibilityFeatures.3", false);
+            AppContext.SetSwitch("Switch.UseLegacyAccessibilityFeatures.4", false);
 
             Application.SetUnhandledExceptionMode(UnhandledExceptionMode.CatchException);
             Application.ThreadException += ThreadExceptionEventHandler;
@@ -315,47 +321,6 @@ namespace TestRunner
             {
                 Console.WriteLine("TestRunner " + string.Join(" ", args) + "\n");
                 Console.WriteLine("Process: {0}\n", Process.GetCurrentProcess().Id);
-            }
-
-            // DIAGNOSTIC (GC-leak UIA exploration): confirm whether the legacy-accessibility
-            // AppContext switches are actually live in this process (config-applied vs silently
-            // dropped). Lets us trust/discard the UseLegacyAccessibilityFeatures experiment.
-            foreach (var accessibilitySwitch in new[]
-            {
-                "Switch.UseLegacyAccessibilityFeatures",
-                "Switch.UseLegacyAccessibilityFeatures.2",
-                "Switch.UseLegacyAccessibilityFeatures.3",
-                "Switch.UseLegacyAccessibilityFeatures.4"
-            })
-            {
-                AppContext.TryGetSwitch(accessibilitySwitch, out var isOn);
-                Console.WriteLine("AppContext {0} = {1}", accessibilitySwitch, isOn);
-            }
-
-            // DIAGNOSTIC (debug-only, not for merge): the AppContext switches above can read the
-            // same via TryGetSwitch whether unset or explicitly false, yet behave differently. Read
-            // the EFFECTIVE WinForms AccessibilityImprovements level (internal) to see the real state.
-            try
-            {
-                var aiType = typeof(System.Windows.Forms.Control).Assembly
-                    .GetType("System.Windows.Forms.AccessibilityImprovements");
-                if (aiType != null)
-                {
-                    foreach (var prop in aiType.GetProperties(System.Reflection.BindingFlags.Static
-                                 | System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Public))
-                    {
-                        if (prop.Name.StartsWith("Level") && prop.PropertyType == typeof(bool))
-                            Console.WriteLine("AccessibilityImprovements.{0} = {1}", prop.Name, prop.GetValue(null));
-                    }
-                }
-                else
-                {
-                    Console.WriteLine("AccessibilityImprovements type not found for level readout");
-                }
-            }
-            catch (Exception ex)
-            {
-                Console.WriteLine("AccessibilityImprovements level readout failed: {0}", ex.Message);
             }
 
             if (commandLineArgs.HasArg("debug"))

--- a/pwiz_tools/Skyline/TestRunner/Program.cs
+++ b/pwiz_tools/Skyline/TestRunner/Program.cs
@@ -277,18 +277,24 @@ namespace TestRunner
             // all four UseLegacyAccessibilityFeatures switches to false BEFORE any control is created.
             // This is test-host only -- it does not change shipping Skyline behavior.
             //
-            // Why: at this exe's framework-default accessibility level (it targets .NET 4.7.2), closing
-            // a window does not release some UI Automation accessible-object provider handles, so the
-            // post-test GC check reports SkylineWindow/SrmDocument as not collected. Opting into the
-            // latest level (which carries the accessible-object lifetime fix) clears it. Subtlety:
-            // AppContext.TryGetSwitch reads the same whether a switch is unset or explicitly false, but
-            // the *effective* WinForms accessibility level differs -- so these must be set explicitly
-            // here, not merely left unset (the framework default is what leaks).
+            // Why: at this exe's framework-default accessibility behavior (it targets .NET 4.7.2),
+            // closing a window does not release some UI Automation accessible-object provider handles,
+            // so the post-test GC check reports SkylineWindow/SrmDocument as not collected. Determined
+            // empirically on the affected Windows Server 2022 agent by toggling these switches: the
+            // framework default leaks, all-false (latest level) is clean, and all-true (full legacy) is
+            // also clean -- i.e. it is the intermediate default level that leaks, not either extreme.
             //
-            // Alternative: setting all four to TRUE (legacy accessibility) also stops the leak, by
-            // disabling the modern UI Automation provider path entirely. That is a larger behavioral
-            // change, but worth keeping in mind if a future framework regresses the lifetime fix at the
-            // latest level, or if we ever want to fully sidestep UIA providers in the test host.
+            // These must be set EXPLICITLY: WinForms resolves the effective accessibility level from the
+            // four switches, applying target-framework defaults to any left unset, so leaving them unset
+            // is NOT the same as setting them false. (AppContext.TryGetSwitch also reports false for an
+            // unset switch, so the difference is not visible by reading the switch values back -- only by
+            // behavior.) Setting all four is intentional: it lands on the latest level regardless of where
+            // the framework default sits, and is harmless.
+            //
+            // Alternative: setting all four to TRUE (full legacy accessibility) was also observed to stop
+            // the leak, by disabling the modern UI Automation provider path entirely. That is a larger
+            // behavioral change, kept as a note in case the latest-level behavior regresses in a future
+            // framework.
             AppContext.SetSwitch("Switch.UseLegacyAccessibilityFeatures", false);
             AppContext.SetSwitch("Switch.UseLegacyAccessibilityFeatures.2", false);
             AppContext.SetSwitch("Switch.UseLegacyAccessibilityFeatures.3", false);

--- a/pwiz_tools/Skyline/TestRunnerLib/RunTests.cs
+++ b/pwiz_tools/Skyline/TestRunnerLib/RunTests.cs
@@ -829,16 +829,6 @@ namespace TestRunnerLib
             private static extern int SetProcessWorkingSetSize(IntPtr process, int minimumWorkingSetSize, int
                 maximumWorkingSetSize);
 
-            // Windows UI Automation pins WinForms controls via RefCounted handles
-            // on their AccessibleObjects. Once any UIA client (Narrator, RDP, a
-            // screen reader, automation tooling) queries an accessible control,
-            // the runtime keeps a strong ref to that control's AccessibleObject
-            // until the process exits -- transitively rooting SkylineWindow and
-            // its undo stack through every dialog's back-pointer. This call
-            // releases all such roots so the next GC can reclaim normally.
-            [DllImport("UIAutomationCore.dll")]
-            private static extern int UiaDisconnectAllProviders();
-
             [DllImport("kernel32.dll", SetLastError = true)]
             public static extern UInt32 GetProcessHeaps(
                 UInt32 NumberOfHeaps,
@@ -1110,30 +1100,6 @@ namespace TestRunnerLib
 
             public static void FlushMemory()
             {
-                // Release UI Automation accessibility roots before GC so
-                // accessibility-pinned dialogs can be reclaimed normally.
-                // Non-fatal -- but log unexpected failures so the diagnostic is
-                // visible in test output (UIAutomationCore.dll should always be
-                // present on supported Windows versions).
-                if (Environment.OSVersion.Platform == PlatformID.Win32NT)
-                {
-                    try
-                    {
-                        UiaDisconnectAllProviders();
-                    }
-                    catch (Exception ex)
-                    {
-                        // Should never happen on supported Windows targets -- if it does,
-                        // accessibility-rooted Controls (and any SkylineWindow they
-                        // transitively pin) may still be reachable through Windows UI
-                        // Automation refs and appear as GC-LEAK survivors in this run.
-                        Console.WriteLine(
-                            @"UiaDisconnectAllProviders (UIAutomationCore.dll) failed: {0}. " +
-                            @"Accessibility-pinned controls may be reported as GC-LEAK survivors.",
-                            ex);
-                    }
-                }
-
                 GCSettings.LargeObjectHeapCompactionMode = GCLargeObjectHeapCompactionMode.CompactOnce;
                 GC.Collect();
                 GC.WaitForPendingFinalizers();

--- a/pwiz_tools/Skyline/TestUtil/TestFunctional.cs
+++ b/pwiz_tools/Skyline/TestUtil/TestFunctional.cs
@@ -2759,14 +2759,6 @@ namespace pwiz.SkylineTestUtil
             }
         }
 
-        // EXPERIMENT: when env SKYLINE_PRECLOSE_UIA_DISCONNECT=1, disconnect UI Automation
-        // providers while the window's controls still have live HWNDs (see GC-LEAK investigation).
-        private static readonly bool PreCloseUiaDisconnect =
-            "1".Equals(Environment.GetEnvironmentVariable("SKYLINE_PRECLOSE_UIA_DISCONNECT"));
-
-        [System.Runtime.InteropServices.DllImport("UIAutomationCore.dll")]
-        private static extern int UiaDisconnectAllProviders();
-
         private void EndTest()
         {
             if (_pauseAndContinueForm is { IsDisposed: false })
@@ -2775,19 +2767,6 @@ namespace pwiz.SkylineTestUtil
             }
 
             var skylineWindow = Program.MainWindow;
-
-            // EXPERIMENT (SKYLINE_PRECLOSE_UIA_DISCONNECT=1): disconnect UI Automation providers
-            // while the window's controls still have live HWNDs, to test whether #4248's post-close
-            // disconnect in MemoryManagement.FlushMemory runs too late to reclaim these accessibility
-            // RefCounted handles that pin SkylineWindow/SrmDocument as GC-LEAK survivors.
-            if (PreCloseUiaDisconnect && skylineWindow is { IsDisposed: false } && IsFormOpen(skylineWindow))
-            {
-                RunUI(() =>
-                {
-                    try { UiaDisconnectAllProviders(); }
-                    catch (Exception ex) { Console.WriteLine(@"pre-close UiaDisconnectAllProviders failed: {0}", ex); }
-                });
-            }
             if (skylineWindow == null || skylineWindow.IsDisposed || !IsFormOpen(skylineWindow))
             {
                 var startWindow = Program.StartWindow;

--- a/pwiz_tools/Skyline/TestUtil/TestFunctional.cs
+++ b/pwiz_tools/Skyline/TestUtil/TestFunctional.cs
@@ -2759,6 +2759,14 @@ namespace pwiz.SkylineTestUtil
             }
         }
 
+        // EXPERIMENT: when env SKYLINE_PRECLOSE_UIA_DISCONNECT=1, disconnect UI Automation
+        // providers while the window's controls still have live HWNDs (see GC-LEAK investigation).
+        private static readonly bool PreCloseUiaDisconnect =
+            "1".Equals(Environment.GetEnvironmentVariable("SKYLINE_PRECLOSE_UIA_DISCONNECT"));
+
+        [System.Runtime.InteropServices.DllImport("UIAutomationCore.dll")]
+        private static extern int UiaDisconnectAllProviders();
+
         private void EndTest()
         {
             if (_pauseAndContinueForm is { IsDisposed: false })
@@ -2767,6 +2775,19 @@ namespace pwiz.SkylineTestUtil
             }
 
             var skylineWindow = Program.MainWindow;
+
+            // EXPERIMENT (SKYLINE_PRECLOSE_UIA_DISCONNECT=1): disconnect UI Automation providers
+            // while the window's controls still have live HWNDs, to test whether #4248's post-close
+            // disconnect in MemoryManagement.FlushMemory runs too late to reclaim these accessibility
+            // RefCounted handles that pin SkylineWindow/SrmDocument as GC-LEAK survivors.
+            if (PreCloseUiaDisconnect && skylineWindow is { IsDisposed: false } && IsFormOpen(skylineWindow))
+            {
+                RunUI(() =>
+                {
+                    try { UiaDisconnectAllProviders(); }
+                    catch (Exception ex) { Console.WriteLine(@"pre-close UiaDisconnectAllProviders failed: {0}", ex); }
+                });
+            }
             if (skylineWindow == null || skylineWindow.IsDisposed || !IsFormOpen(skylineWindow))
             {
                 var startWindow = Program.StartWindow;


### PR DESCRIPTION
## Summary

* The post-test `GarbageCollectionTracker` intermittently reported `SkylineWindow, SrmDocument xN` for 100+ functional tests, but only on the Windows Server 2022 agent (TCA1). Root cause: at the framework-default WinForms accessibility level (TestRunner targets .NET 4.7.2), closing a window does not release the UI Automation accessible-object provider handles, which transitively pin `SkylineWindow`/`SrmDocument` through each dialog's back-pointer.
* `TestRunner.Main` now explicitly sets all four `Switch.UseLegacyAccessibilityFeatures*` to `false` before any control is created, opting the test host into the latest accessibility level. Empirically, at that level the providers are released on window close and the leak does not occur.
* Test-host only -- this lives in `TestRunner`, so shipping Skyline accessibility behavior is unchanged. It is OS-independent and harmless on agents that were already clean.
* Removes the ineffective `UiaDisconnectAllProviders` call (and its P/Invoke) added by #4248 -- see below.

## Why the previous fix (#4248) didn't take

#4248 had the right diagnosis -- the same dotMemory retention path we re-confirmed:

    RefCounted handle (Windows accessibility) -> ControlAccessibleObject -> Control
      -> events (EventHandlerList) -> EventHandler -> dialog -> SkylineWindow

...but the wrong mechanism:

* It called `UiaDisconnectAllProviders()` to release the providers at runtime. On this OS / framework patch level that call is inert. This was actually raised in review -- "I was hopeful that `UiaDisconnectAllProviders` would fix things, but ... this API call does not do anything" -- but it was attributed to a possibly-different cause, and the test-plan item "TC nightly leak count should drop to 0" was never confirmed before merge. The next nightly still showed the leaks.
* The #4248 repro was a debug build under dotMemory, and dotMemory's own hooks activate UIA (noted in #4248 itself). Under the profiler the leak is always present and a disconnect cannot be seen to "turn it off"; without the profiler (CI) the result was never confirmed. So the local repro could not validate the CI fix.

The real lever is not a runtime cleanup call -- it is the accessibility level, set once at startup, which governs whether the framework retains these handles at all. Forcing the switches is a deterministic on/off (default -> leaks; all-`false` -> clean; all-`true` -> clean); `UiaDisconnectAllProviders` never was.

## Why explicit `false`, not "leave it at the default"

`AppContext.TryGetSwitch` reads the same (all `false`) whether a switch is unset or explicitly set to `false`, yet the two behave oppositely: the framework default for a 4.7.2 target leaks, while explicitly opting into the latest level is clean. So the switches must be set explicitly; leaving them unset does nothing. (Setting all four to `true` -- full legacy -- also stops the leak by disabling the modern UIA provider path entirely; that is a larger change, kept in a code comment as a fallback if a future framework regresses the lifetime behavior at the latest level.)

## Test plan

Validated on the Windows Server 2022 agent (TCA1) that produced the failures -- debug build, no profiler attached:

- [x] Default level (switches unset) -- reproduces the leak (`TestManagingSearchTools x2`, `TestEncyclopeDiaPeptidesWithNoSignal x3`)
- [x] Forced all-`false` (this fix) -- both offenders clean
- [x] Forced all-`true` (legacy) -- also clean, confirming the accessibility level is the lever
- [x] Full Pass2 with the fix in place -- the agent's GC-LEAK false positives are gone and the accessibility-level change introduced no collateral failures (one unrelated failure, `TestDiaUmpireWiffFile`, is a pre-existing persistent-data-dir hygiene issue where DiaUmpire writes `-diaumpire.mz5`/`.mzid.gz` into a persistent dir -- independent of this change)

Co-Authored-By: Claude <noreply@anthropic.com>
