### PR TITLE
Made the OspreySharp task dataflow explicit, lazy-rehydrate, and driver-owned

### DIFF
--- a/pwiz_tools/OspreySharp/OspreySharp.Tasks/OspreyTask.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Tasks/OspreyTask.cs
@@ -101,6 +101,20 @@ namespace pwiz.OspreySharp.Tasks
         public virtual bool Rehydrate(PipelineContext ctx) => Run(ctx);
 
         /// <summary>
+        /// Whether this task participates in the pipeline for the current
+        /// configuration. Driver-owned membership predicate: the orchestrator
+        /// iterates only the included tasks and runs those whose outputs are
+        /// not already on disk, while excluded tasks lazy-rehydrate their state
+        /// through <see cref="PipelineContext.Demand{T}"/> when an included task
+        /// reaches for it. Replaces the <c>DeriveStartAtTask</c> /
+        /// <c>DeriveStopAfterTask</c> range gating (the membership becomes a
+        /// per-task fact rather than a contiguous [start..stop] window).
+        /// Default <c>true</c>; tasks that run only in some HPC modes override
+        /// to gate on the relevant <see cref="OspreyConfig"/> flags.
+        /// </summary>
+        public virtual bool IsIncluded(PipelineContext ctx) => true;
+
+        /// <summary>
         /// File paths this task reads as inputs. Reported in the
         /// <c>.osprey.task</c> sidecar so a human inspecting a
         /// completed-output sidecar can see what the task consumed.

--- a/pwiz_tools/OspreySharp/OspreySharp.Tasks/OspreyTask.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Tasks/OspreyTask.cs
@@ -85,20 +85,16 @@ namespace pwiz.OspreySharp.Tasks
         /// Lazily bring this task's outputs into memory from its on-disk
         /// artifacts, without recomputing them — the disk-load counterpart to
         /// the compute-only <see cref="Run"/>. Invoked at most once per run by
-        /// <see cref="PipelineContext.Demand{T}"/> when a downstream consumer
-        /// first reaches for this producer's state and the producer's own
+        /// <see cref="PipelineContext.Demand{T}"/> when a consumer first
+        /// reaches for this producer's state and the producer's own
         /// <see cref="Run"/> was never called (e.g. a worker-mode invocation
-        /// that starts mid-pipeline). Returns the same <c>bool</c> contract as
-        /// <see cref="Run"/>.
-        ///
-        /// Transitional default: forwards to <see cref="Run"/>, preserving the
-        /// legacy "an upstream getter hydrates-or-runs on first touch"
-        /// behavior byte-for-byte. The per-task Run/Rehydrate split (Phase B2)
-        /// overrides this with the producer's actual rehydrate path and moves
-        /// compute-only work into <see cref="Run"/>; once that split and the
-        /// driver-loop flip land, this default is removed.
+        /// that starts mid-pipeline). A producer whose <see cref="Run"/> did
+        /// already execute returns early via its own one-shot guard, so this is
+        /// a no-op there. Returns the same <c>bool</c> contract as
+        /// <see cref="Run"/>. A purely-aggregating terminal task that nothing
+        /// consumes implements this as a no-op returning <c>true</c>.
         /// </summary>
-        public virtual bool Rehydrate(PipelineContext ctx) => Run(ctx);
+        public abstract bool Rehydrate(PipelineContext ctx);
 
         /// <summary>
         /// Whether this task participates in the pipeline for the current

--- a/pwiz_tools/OspreySharp/OspreySharp.Tasks/OspreyTask.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Tasks/OspreyTask.cs
@@ -82,6 +82,25 @@ namespace pwiz.OspreySharp.Tasks
         public abstract bool Run(PipelineContext ctx);
 
         /// <summary>
+        /// Lazily bring this task's outputs into memory from its on-disk
+        /// artifacts, without recomputing them — the disk-load counterpart to
+        /// the compute-only <see cref="Run"/>. Invoked at most once per run by
+        /// <see cref="PipelineContext.Demand{T}"/> when a downstream consumer
+        /// first reaches for this producer's state and the producer's own
+        /// <see cref="Run"/> was never called (e.g. a worker-mode invocation
+        /// that starts mid-pipeline). Returns the same <c>bool</c> contract as
+        /// <see cref="Run"/>.
+        ///
+        /// Transitional default: forwards to <see cref="Run"/>, preserving the
+        /// legacy "an upstream getter hydrates-or-runs on first touch"
+        /// behavior byte-for-byte. The per-task Run/Rehydrate split (Phase B2)
+        /// overrides this with the producer's actual rehydrate path and moves
+        /// compute-only work into <see cref="Run"/>; once that split and the
+        /// driver-loop flip land, this default is removed.
+        /// </summary>
+        public virtual bool Rehydrate(PipelineContext ctx) => Run(ctx);
+
+        /// <summary>
         /// File paths this task reads as inputs. Reported in the
         /// <c>.osprey.task</c> sidecar so a human inspecting a
         /// completed-output sidecar can see what the task consumed.

--- a/pwiz_tools/OspreySharp/OspreySharp.Tasks/PipelineContext.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Tasks/PipelineContext.cs
@@ -101,47 +101,18 @@ namespace pwiz.OspreySharp.Tasks
 
         /// <summary>
         /// The tasks participating in this pipeline, in execution order.
-        /// The driver walks this list; tasks that need state from an
-        /// upstream sibling look it up by type via <see cref="GetTask{T}"/>.
+        /// The driver walks this list (running each that is
+        /// <see cref="OspreyTask.IsIncluded"/> and not already valid on disk);
+        /// tasks that need state from an upstream sibling reach it through
+        /// <see cref="Demand{T}"/>.
         /// </summary>
         public IReadOnlyList<OspreyTask> Tasks { get; }
-
-        /// <summary>
-        /// First task in <see cref="Tasks"/> whose <see cref="OspreyTask.Run"/>
-        /// will be invoked. Tasks before this one are present in the registry
-        /// (so consumers can still <see cref="GetTask{T}"/> them and pull
-        /// state through their lazy-rehydrate accessors) but their
-        /// <c>Run</c> is never called. Defaults to the first entry in
-        /// <see cref="Tasks"/>. Set once by the pipeline entry point from
-        /// CLI-derived <see cref="OspreyConfig"/> flags; immutable thereafter.
-        /// </summary>
-        public Type StartAtTask { get; }
-
-        /// <summary>
-        /// Last task in <see cref="Tasks"/> whose <see cref="OspreyTask.Run"/>
-        /// will be invoked. Tasks after this one are not reached. Defaults
-        /// to the last entry in <see cref="Tasks"/>. Set once by the
-        /// pipeline entry point from CLI-derived <see cref="OspreyConfig"/>
-        /// flags; immutable thereafter.
-        /// </summary>
-        public Type StopAfterTask { get; }
 
         public PipelineContext(OspreyConfig config,
             IEnumerable<OspreyTask> tasks,
             Action<string> logInfo,
             Action<string> logWarning,
             Action<string> logError)
-            : this(config, tasks, logInfo, logWarning, logError, null, null)
-        {
-        }
-
-        public PipelineContext(OspreyConfig config,
-            IEnumerable<OspreyTask> tasks,
-            Action<string> logInfo,
-            Action<string> logWarning,
-            Action<string> logError,
-            Type startAtTask,
-            Type stopAfterTask)
         {
             Config = config ?? throw new ArgumentNullException(nameof(config));
             if (tasks == null) throw new ArgumentNullException(nameof(tasks));
@@ -158,25 +129,6 @@ namespace pwiz.OspreySharp.Tasks
                 _tasksByType.Add(task.GetType(), task);
             }
             Tasks = list;
-
-            if (list.Count == 0)
-            {
-                StartAtTask = startAtTask;
-                StopAfterTask = stopAfterTask;
-            }
-            else
-            {
-                StartAtTask = startAtTask ?? list[0].GetType();
-                StopAfterTask = stopAfterTask ?? list[list.Count - 1].GetType();
-                if (!_tasksByType.ContainsKey(StartAtTask))
-                    throw new ArgumentException(
-                        string.Format(@"StartAtTask '{0}' is not in the pipeline task list.",
-                            StartAtTask.FullName), nameof(startAtTask));
-                if (!_tasksByType.ContainsKey(StopAfterTask))
-                    throw new ArgumentException(
-                        string.Format(@"StopAfterTask '{0}' is not in the pipeline task list.",
-                            StopAfterTask.FullName), nameof(stopAfterTask));
-            }
         }
 
         public void LogInfo(string message) { _logInfo(message); }
@@ -184,16 +136,15 @@ namespace pwiz.OspreySharp.Tasks
         public void LogError(string message) { _logError(message); }
 
         /// <summary>
-        /// Look up a task by its concrete type. Used by a task's
-        /// <see cref="OspreyTask.Run"/> implementation to reach the
-        /// typed accessor methods on an upstream producer
-        /// (e.g. <c>ctx.GetTask&lt;FirstJoinTask&gt;().GetReconciliationActions()</c>).
-        /// Throws <see cref="UnknownTaskException"/> if the requested
-        /// type is not in the pipeline; treat that as a programming
-        /// defect at pipeline-construction time rather than a runtime
-        /// condition to handle.
+        /// Look up a registered task by its concrete type. Internal lookup
+        /// backing <see cref="Demand{T}"/>; consumers reach producers through
+        /// <see cref="Demand{T}"/> (which materializes on first touch), not
+        /// this raw accessor. Throws <see cref="UnknownTaskException"/> if the
+        /// requested type is not in the pipeline; treat that as a
+        /// programming defect at pipeline-construction time rather than a
+        /// runtime condition to handle.
         /// </summary>
-        public T GetTask<T>() where T : OspreyTask
+        private T GetTask<T>() where T : OspreyTask
         {
             if (_tasksByType.TryGetValue(typeof(T), out var task))
                 return (T)task;

--- a/pwiz_tools/OspreySharp/OspreySharp.Tasks/PipelineContext.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Tasks/PipelineContext.cs
@@ -23,6 +23,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using pwiz.OspreySharp.Core;
 
 namespace pwiz.OspreySharp.Tasks
@@ -50,6 +51,15 @@ namespace pwiz.OspreySharp.Tasks
         private readonly Action<string> _logWarning;
         private readonly Action<string> _logError;
         private readonly Dictionary<Type, OspreyTask> _tasksByType;
+
+        /// <summary>
+        /// Producer types whose <see cref="OspreyTask.Rehydrate"/> has already
+        /// been driven by a <see cref="Demand{T}"/> first-touch this run.
+        /// Reproduces the one-shot semantics of each task's former
+        /// <c>_runOrHydrated</c> guard: a producer is materialized at most
+        /// once, no matter how many consumers demand it.
+        /// </summary>
+        private readonly HashSet<Type> _materialized = new HashSet<Type>();
 
         /// <summary>
         /// The configuration parsed from CLI args and the input library.
@@ -188,6 +198,58 @@ namespace pwiz.OspreySharp.Tasks
             if (_tasksByType.TryGetValue(typeof(T), out var task))
                 return (T)task;
             throw new UnknownTaskException(typeof(T));
+        }
+
+        /// <summary>
+        /// Resolve an upstream producer and ensure its state is materialized
+        /// before returning it. The first consumer to demand a given producer
+        /// triggers its <see cref="OspreyTask.Rehydrate"/> (lazy disk-load of
+        /// the producer's outputs); subsequent demands return the same
+        /// instance without re-materializing, via the <see cref="_materialized"/>
+        /// one-shot guard. This is the lazy-rehydrate replacement for the
+        /// <c>EnsureHydrated</c>-inside-getter pattern: callers ask the context
+        /// for what they need and the context owns when the producer's state
+        /// comes into being, rather than each accessor side-effecting a
+        /// hydrate/run on read.
+        ///
+        /// (Transitional note: until the per-task Run/Rehydrate split lands,
+        /// <see cref="OspreyTask.Rehydrate"/> defaults to <see cref="OspreyTask.Run"/>,
+        /// so a first-touch Demand reproduces today's "getter ran the upstream
+        /// task" behavior exactly.)
+        /// </summary>
+        public T Demand<T>() where T : OspreyTask
+        {
+            var task = GetTask<T>();
+            if (_materialized.Add(typeof(T)))
+                task.Rehydrate(this);
+            return task;
+        }
+
+        /// <summary>
+        /// Driver-owned skip predicate: <c>true</c> when every file
+        /// <paramref name="task"/> declares in <see cref="OspreyTask.Outputs"/>
+        /// already exists on disk with a matching
+        /// <see cref="OspreyTask.ValidityKey"/> sidecar — i.e. the task's work
+        /// is durably present and need not be recomputed. A task that declares
+        /// no outputs can never be skipped (returns <c>false</c>), matching the
+        /// "purely-in-memory transformation" posture documented on
+        /// <see cref="OspreyTask.Outputs"/>.
+        ///
+        /// Lifted verbatim from <c>AnalysisPipeline.IsTaskAlreadyDone</c> so the
+        /// driver loop can ask the context "can this rehydrate instead of run?"
+        /// rather than re-running the same outputs-valid check itself.
+        /// </summary>
+        public bool CanRehydrate(OspreyTask task)
+        {
+            var outputs = new List<string>(task.Outputs(this));
+            if (outputs.Count == 0) return false;
+            string key = task.ValidityKey(this);
+            foreach (var output in outputs)
+            {
+                if (!File.Exists(output)) return false;
+                if (!TaskValiditySidecar.IsValid(output, task.Name, key)) return false;
+            }
+            return true;
         }
     }
 

--- a/pwiz_tools/OspreySharp/OspreySharp.Tasks/PipelineContext.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Tasks/PipelineContext.cs
@@ -154,19 +154,20 @@ namespace pwiz.OspreySharp.Tasks
         /// <summary>
         /// Resolve an upstream producer and ensure its state is materialized
         /// before returning it. The first consumer to demand a given producer
-        /// triggers its <see cref="OspreyTask.Rehydrate"/> (lazy disk-load of
-        /// the producer's outputs); subsequent demands return the same
-        /// instance without re-materializing, via the <see cref="_materialized"/>
-        /// one-shot guard. This is the lazy-rehydrate replacement for the
-        /// <c>EnsureHydrated</c>-inside-getter pattern: callers ask the context
-        /// for what they need and the context owns when the producer's state
-        /// comes into being, rather than each accessor side-effecting a
-        /// hydrate/run on read.
+        /// triggers its <see cref="OspreyTask.Rehydrate"/>; subsequent demands
+        /// return the same instance without re-materializing, via the
+        /// <see cref="_materialized"/> one-shot guard. This is the
+        /// lazy-rehydrate replacement for the <c>EnsureHydrated</c>-inside-getter
+        /// pattern: callers ask the context for what they need and the context
+        /// owns when the producer's state comes into being, rather than each
+        /// accessor side-effecting a hydrate/run on read.
         ///
-        /// (Transitional note: until the per-task Run/Rehydrate split lands,
-        /// <see cref="OspreyTask.Rehydrate"/> defaults to <see cref="OspreyTask.Run"/>,
-        /// so a first-touch Demand reproduces today's "getter ran the upstream
-        /// task" behavior exactly.)
+        /// A producer whose <see cref="OspreyTask.Run"/> already executed
+        /// (driver ran it this pass) no-ops via its own one-shot guard. Each
+        /// producer's <see cref="OspreyTask.Rehydrate"/> dispatches on its mode:
+        /// it disk-loads worker-supplied state when present, else defers to
+        /// <see cref="OspreyTask.Run"/> (whose per-file load picks up already-valid
+        /// outputs on a straight-through resume).
         /// </summary>
         public T Demand<T>() where T : OspreyTask
         {

--- a/pwiz_tools/OspreySharp/OspreySharp.Test/PipelineMembershipTest.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Test/PipelineMembershipTest.cs
@@ -30,93 +30,64 @@ using pwiz.OspreySharp.Tasks;
 namespace pwiz.OspreySharp.Test
 {
     /// <summary>
-    /// Oracle for the Phase B5 driver-loop flip: proves the per-task
-    /// <see cref="OspreyTask.IsIncluded"/> membership predicate reproduces the
-    /// pipeline run-set that the legacy <c>DeriveStartAtTask</c> /
-    /// <c>DeriveStopAfterTask</c> range gating produces, across every HPC mode.
-    /// IsIncluded is not yet wired into the driver (B4); this test pins the
-    /// equivalence so B5 can replace the range walk with
-    /// <c>CanonicalPipeline().Where(t =&gt; t.IsIncluded(ctx))</c> without
-    /// changing which tasks run.
+    /// Pins the per-task <see cref="OspreyTask.IsIncluded"/> membership
+    /// predicate -- the driver-owned dataflow's source of truth for which
+    /// tasks run in each HPC mode -- against an explicit expected truth table.
     ///
-    /// One cell diverges by design: under the --input-scores full-pipeline mode
-    /// (--join-at-pass=1 --input-scores, no other join modifier) the old range
-    /// starts at PerFileScoring and so includes it, but PerFileScoring should
-    /// NOT compute there -- it must lazy-rehydrate the supplied scores. The old
-    /// range only "worked" because the pre-split monolithic Run dispatched to
-    /// the join-only load internally; after the Run/Rehydrate split the range
-    /// made the driver re-score from absent mzMLs (the mode-6 regression).
-    /// IsIncluded corrects this, so the test asserts the divergence explicitly.
+    /// The table is the run-set the legacy
+    /// <c>DeriveStartAtTask</c>/<c>DeriveStopAfterTask</c> range produced and
+    /// that this test proved IsIncluded reproduced before the range gating was
+    /// flipped (B4 oracle) and then removed (B6). It is kept as a permanent
+    /// regression guard so a future edit to an IsIncluded override that breaks
+    /// the membership of any mode fails here rather than silently mis-routing
+    /// the pipeline.
     /// </summary>
     [TestClass]
     public class PipelineMembershipTest
     {
-        private static OspreyConfig Inputs()
+        private static OspreyConfig WithInputScores(Action<OspreyConfig> set)
         {
-            return new OspreyConfig { InputScores = new List<string> { @"a.scores.parquet" } };
-        }
-
-        /// <summary>The six distinct (StartAt, StopAfter) pipeline modes.</summary>
-        private static IEnumerable<(string Name, OspreyConfig Config)> Modes()
-        {
-            yield return (@"straight-through", new OspreyConfig());
-            yield return (@"--no-join", new OspreyConfig { NoJoin = true });
-
-            var joinOnly = Inputs(); joinOnly.StopAfterStage5 = true;
-            yield return (@"--join-only", joinOnly);
-
-            var rescore = Inputs(); rescore.NoJoin = true;
-            yield return (@"rescore-worker", rescore);
-
-            var merge = Inputs(); merge.ExpectReconciledInput = true;
-            yield return (@"merge", merge);
-
-            yield return (@"input-scores-full", Inputs());
-        }
-
-        private static int IndexOfType(OspreyTask[] tasks, Type type)
-        {
-            for (int i = 0; i < tasks.Length; i++)
-                if (tasks[i].GetType() == type) return i;
-            return -1;
+            var config = new OspreyConfig { InputScores = new List<string> { @"a.scores.parquet" } };
+            set(config);
+            return config;
         }
 
         [TestMethod]
-        public void TestIsIncludedMatchesDeriveRange()
+        public void TestIsIncludedMembershipTable()
         {
-            foreach (var mode in Modes())
+            // Expected membership per mode, in CanonicalPipeline order
+            // [PerFileScoring, FirstJoin, PerFileRescore, MergeNode].
+            var cases = new (string Name, OspreyConfig Config, bool[] Expected)[]
+            {
+                (@"straight-through",  new OspreyConfig(),
+                    new[] { true,  true,  true,  true  }),
+                (@"--no-join",         new OspreyConfig { NoJoin = true },
+                    new[] { true,  false, false, false }),
+                (@"--join-only",       WithInputScores(c => c.StopAfterStage5 = true),
+                    new[] { false, true,  false, false }),
+                (@"rescore-worker",    WithInputScores(c => c.NoJoin = true),
+                    new[] { false, false, true,  false }),
+                (@"merge",             WithInputScores(c => c.ExpectReconciledInput = true),
+                    new[] { false, false, false, true  }),
+                // --join-at-pass=1 --input-scores (no other join modifier): the
+                // single-node full pipeline. PerFileScoring lazy-rehydrates the
+                // supplied scores rather than computing them, so it is excluded;
+                // FirstJoin..MergeNode compute Stages 5-8.
+                (@"input-scores-full", WithInputScores(_ => { }),
+                    new[] { false, true,  true,  true  }),
+            };
+
+            foreach (var c in cases)
             {
                 var tasks = AnalysisPipeline.CanonicalPipeline();
-                var ctx = new PipelineContext(mode.Config, tasks, null, null, null);
-
-                int startIdx = IndexOfType(tasks, AnalysisPipeline.DeriveStartAtTask(mode.Config));
-                int stopIdx = IndexOfType(tasks, AnalysisPipeline.DeriveStopAfterTask(mode.Config));
-                Assert.IsTrue(startIdx >= 0 && stopIdx >= 0,
-                    string.Format(@"{0}: DeriveStartAt/StopAfter not in CanonicalPipeline", mode.Name));
+                var ctx = new PipelineContext(c.Config, tasks, null, null, null);
+                Assert.AreEqual(tasks.Length, c.Expected.Length,
+                    string.Format(@"{0}: expected-row length must match task count", c.Name));
 
                 for (int i = 0; i < tasks.Length; i++)
                 {
-                    var task = tasks[i];
-                    bool inRange = startIdx <= i && i <= stopIdx;
-                    bool included = task.IsIncluded(ctx);
-
-                    bool knownDivergence = mode.Name == @"input-scores-full"
-                                           && task is PerFileScoringTask;
-                    if (knownDivergence)
-                    {
-                        Assert.IsFalse(included, string.Format(
-                            @"{0}/{1}: PerFileScoring must be excluded (lazy-rehydrate the supplied scores)",
-                            mode.Name, task.Name));
-                        Assert.IsTrue(inRange, string.Format(
-                            @"{0}/{1}: expected the legacy range to (wrongly) include it -- documents the corrected divergence",
-                            mode.Name, task.Name));
-                    }
-                    else
-                    {
-                        Assert.AreEqual(inRange, included, string.Format(
-                            @"{0}/{1}: IsIncluded ({2}) must match the DeriveStartAt..StopAfter range membership ({3})",
-                            mode.Name, task.Name, included, inRange));
-                    }
+                    Assert.AreEqual(c.Expected[i], tasks[i].IsIncluded(ctx), string.Format(
+                        @"{0}/{1}: IsIncluded must be {2}", c.Name, tasks[i].Name, c.Expected[i]));
                 }
             }
         }

--- a/pwiz_tools/OspreySharp/OspreySharp.Test/PipelineMembershipTest.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Test/PipelineMembershipTest.cs
@@ -1,0 +1,124 @@
+/*
+ * Original author: Brendan MacLean <brendanx .at. uw.edu>,
+ *                  MacCoss Lab, Department of Genome Sciences, UW
+ * AI assistance: Claude Code (Claude Opus 4.8) <noreply .at. anthropic.com>
+ *
+ * Based on osprey (https://github.com/MacCossLab/osprey)
+ *   by Michael J. MacCoss, MacCoss Lab, Department of Genome Sciences, UW
+ *
+ * Copyright 2026 University of Washington - Seattle, WA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
+using System.Collections.Generic;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using pwiz.OspreySharp.Core;
+using pwiz.OspreySharp.Tasks;
+
+namespace pwiz.OspreySharp.Test
+{
+    /// <summary>
+    /// Oracle for the Phase B5 driver-loop flip: proves the per-task
+    /// <see cref="OspreyTask.IsIncluded"/> membership predicate reproduces the
+    /// pipeline run-set that the legacy <c>DeriveStartAtTask</c> /
+    /// <c>DeriveStopAfterTask</c> range gating produces, across every HPC mode.
+    /// IsIncluded is not yet wired into the driver (B4); this test pins the
+    /// equivalence so B5 can replace the range walk with
+    /// <c>CanonicalPipeline().Where(t =&gt; t.IsIncluded(ctx))</c> without
+    /// changing which tasks run.
+    ///
+    /// One cell diverges by design: under the --input-scores full-pipeline mode
+    /// (--join-at-pass=1 --input-scores, no other join modifier) the old range
+    /// starts at PerFileScoring and so includes it, but PerFileScoring should
+    /// NOT compute there -- it must lazy-rehydrate the supplied scores. The old
+    /// range only "worked" because the pre-split monolithic Run dispatched to
+    /// the join-only load internally; after the Run/Rehydrate split the range
+    /// made the driver re-score from absent mzMLs (the mode-6 regression).
+    /// IsIncluded corrects this, so the test asserts the divergence explicitly.
+    /// </summary>
+    [TestClass]
+    public class PipelineMembershipTest
+    {
+        private static OspreyConfig Inputs()
+        {
+            return new OspreyConfig { InputScores = new List<string> { @"a.scores.parquet" } };
+        }
+
+        /// <summary>The six distinct (StartAt, StopAfter) pipeline modes.</summary>
+        private static IEnumerable<(string Name, OspreyConfig Config)> Modes()
+        {
+            yield return (@"straight-through", new OspreyConfig());
+            yield return (@"--no-join", new OspreyConfig { NoJoin = true });
+
+            var joinOnly = Inputs(); joinOnly.StopAfterStage5 = true;
+            yield return (@"--join-only", joinOnly);
+
+            var rescore = Inputs(); rescore.NoJoin = true;
+            yield return (@"rescore-worker", rescore);
+
+            var merge = Inputs(); merge.ExpectReconciledInput = true;
+            yield return (@"merge", merge);
+
+            yield return (@"input-scores-full", Inputs());
+        }
+
+        private static int IndexOfType(OspreyTask[] tasks, Type type)
+        {
+            for (int i = 0; i < tasks.Length; i++)
+                if (tasks[i].GetType() == type) return i;
+            return -1;
+        }
+
+        [TestMethod]
+        public void TestIsIncludedMatchesDeriveRange()
+        {
+            foreach (var mode in Modes())
+            {
+                var tasks = AnalysisPipeline.CanonicalPipeline();
+                var ctx = new PipelineContext(mode.Config, tasks, null, null, null);
+
+                int startIdx = IndexOfType(tasks, AnalysisPipeline.DeriveStartAtTask(mode.Config));
+                int stopIdx = IndexOfType(tasks, AnalysisPipeline.DeriveStopAfterTask(mode.Config));
+                Assert.IsTrue(startIdx >= 0 && stopIdx >= 0,
+                    string.Format(@"{0}: DeriveStartAt/StopAfter not in CanonicalPipeline", mode.Name));
+
+                for (int i = 0; i < tasks.Length; i++)
+                {
+                    var task = tasks[i];
+                    bool inRange = startIdx <= i && i <= stopIdx;
+                    bool included = task.IsIncluded(ctx);
+
+                    bool knownDivergence = mode.Name == @"input-scores-full"
+                                           && task is PerFileScoringTask;
+                    if (knownDivergence)
+                    {
+                        Assert.IsFalse(included, string.Format(
+                            @"{0}/{1}: PerFileScoring must be excluded (lazy-rehydrate the supplied scores)",
+                            mode.Name, task.Name));
+                        Assert.IsTrue(inRange, string.Format(
+                            @"{0}/{1}: expected the legacy range to (wrongly) include it -- documents the corrected divergence",
+                            mode.Name, task.Name));
+                    }
+                    else
+                    {
+                        Assert.AreEqual(inRange, included, string.Format(
+                            @"{0}/{1}: IsIncluded ({2}) must match the DeriveStartAt..StopAfter range membership ({3})",
+                            mode.Name, task.Name, included, inRange));
+                    }
+                }
+            }
+        }
+    }
+}

--- a/pwiz_tools/OspreySharp/OspreySharp/AnalysisPipeline.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/AnalysisPipeline.cs
@@ -76,10 +76,8 @@ namespace pwiz.OspreySharp
                 }
 
                 var pipelineTasks = CanonicalPipeline();
-                var startAt = DeriveStartAtTask(config);
-                var stopAfter = DeriveStopAfterTask(config);
                 var ctx = new PipelineContext(config, pipelineTasks,
-                    LogInfo, LogWarning, LogError, startAt, stopAfter);
+                    LogInfo, LogWarning, LogError);
 
                 // Phase B5 driver-owned dataflow: walk the canonical pipeline
                 // and run each INCLUDED task whose outputs are not already
@@ -125,12 +123,11 @@ namespace pwiz.OspreySharp
         /// The canonical four-task pipeline in execution order:
         /// PerFileScoring -> FirstJoin -> PerFileRescore -> MergeNode.
         /// Single source of truth for the task list. Tasks read upstream
-        /// state through ctx.GetTask&lt;T&gt;().GetX() rather than
-        /// constructor args; each task short-circuits its own work when
-        /// there is nothing to do (e.g. PerFileRescoreTask checks
-        /// FirstJoinTask.DidPlan internally and returns true as a no-op
-        /// when planning was skipped). Returning false from any task is
-        /// the signal to stop and propagate ctx.ExitCode.
+        /// state through ctx.Demand&lt;T&gt;().GetX() rather than constructor
+        /// args; the driver runs each task that is
+        /// <see cref="OspreyTask.IsIncluded"/> for the current config and whose
+        /// outputs are not already valid on disk. Returning false from any task
+        /// is the signal to stop and propagate ctx.ExitCode.
         /// </summary>
         internal static OspreyTask[] CanonicalPipeline()
         {
@@ -141,56 +138,6 @@ namespace pwiz.OspreySharp
                 new PerFileRescoreTask(),
                 new MergeNodeTask(),
             };
-        }
-
-        /// <summary>
-        /// Derives the StartAt task for <paramref name="config"/> from the
-        /// HPC CLI flags it carries. The four mass-spec pipeline tasks
-        /// (PerFileScoring -> FirstJoin -> PerFileRescore -> MergeNode) are
-        /// always present in the registry; this picks which one
-        /// <see cref="AnalysisPipeline.Run"/> starts at, leaving any
-        /// earlier tasks unrun (their lazy-rehydrate accessors fetch state
-        /// from disk if a downstream task needs it).
-        /// </summary>
-        internal static Type DeriveStartAtTask(OspreyConfig config)
-        {
-            bool hasInputScores = config.InputScores != null && config.InputScores.Count > 0;
-            if (hasInputScores)
-            {
-                // --join-at-pass=2 --input-scores ...
-                if (config.ExpectReconciledInput)
-                    return typeof(MergeNodeTask);
-                // --join-at-pass=1 --no-join --input-scores ... (rescore worker)
-                if (config.NoJoin)
-                    return typeof(PerFileRescoreTask);
-                // --join-at-pass=1 --join-only --input-scores ...
-                if (config.StopAfterStage5)
-                    return typeof(FirstJoinTask);
-            }
-            return typeof(PerFileScoringTask);
-        }
-
-        /// <summary>
-        /// Derives the StopAfter task for <paramref name="config"/> from the
-        /// HPC CLI flags it carries. See <see cref="DeriveStartAtTask"/>
-        /// for the parallel start-point derivation.
-        /// </summary>
-        internal static Type DeriveStopAfterTask(OspreyConfig config)
-        {
-            bool hasInputScores = config.InputScores != null && config.InputScores.Count > 0;
-            // --no-join (no --input-scores): only Stages 1-4
-            if (config.NoJoin && !hasInputScores)
-                return typeof(PerFileScoringTask);
-            // --join-at-pass=1 --no-join --input-scores ... (rescore worker)
-            if (config.NoJoin && hasInputScores)
-                return typeof(PerFileRescoreTask);
-            // --join-at-pass=1 --join-only (with or without --input-scores)
-            if (config.StopAfterStage5)
-                return typeof(FirstJoinTask);
-            // --join-at-pass=2 --input-scores ... (post-reconciled merge only)
-            if (config.ExpectReconciledInput && hasInputScores)
-                return typeof(MergeNodeTask);
-            return typeof(MergeNodeTask);
         }
 
         #region Utility Methods

--- a/pwiz_tools/OspreySharp/OspreySharp/AnalysisPipeline.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/AnalysisPipeline.cs
@@ -81,26 +81,29 @@ namespace pwiz.OspreySharp
                 var ctx = new PipelineContext(config, pipelineTasks,
                     LogInfo, LogWarning, LogError, startAt, stopAfter);
 
-                // Phase B range-gating: tasks before StartAt are skipped
-                // silently (their state lazy-rehydrates from disk via the
-                // producer-task accessors when a downstream task queries
-                // it); tasks at-or-after StartAt run normally through
-                // RunTask's sidecar dance; iteration stops after StopAfter.
-                bool inRange = false;
-                foreach (var task in ctx.Tasks)
+                // Phase B5 driver-owned dataflow: walk the canonical pipeline
+                // and run each INCLUDED task whose outputs are not already
+                // valid on disk. Membership is a per-task fact
+                // (OspreyTask.IsIncluded) rather than a contiguous
+                // [StartAt..StopAfter] window. Excluded tasks -- and included
+                // tasks whose outputs already exist (ctx.CanRehydrate) -- are
+                // not run here; their state lazy-rehydrates through ctx.Demand
+                // when a running task reaches for it. A task returning false is
+                // still the signal to stop and propagate ctx.ExitCode (e.g. an
+                // empty score set or a sidecar-write failure).
+                foreach (var task in pipelineTasks)
                 {
-                    if (!inRange)
+                    if (!task.IsIncluded(ctx))
+                        continue;
+
+                    if (ctx.CanRehydrate(task))
                     {
-                        if (task.GetType() != ctx.StartAtTask)
-                            continue;
-                        inRange = true;
+                        LogInfo(string.Format(@"[task] {0}: skipping (outputs valid)", task.Name));
+                        continue;
                     }
 
                     if (!RunTask(task, ctx))
                         return ctx.ExitCode;
-
-                    if (task.GetType() == ctx.StopAfterTask)
-                        break;
                 }
 
                 stopwatch.Stop();
@@ -199,24 +202,14 @@ namespace pwiz.OspreySharp
         /// short-circuit on <c>false</c> and propagate
         /// <see cref="PipelineContext.ExitCode"/>.
         ///
-        /// Phase B skip-if-outputs-valid: before invoking
-        /// <see cref="OspreyTask.Run"/>, check whether every output declared
-        /// by <see cref="OspreyTask.Outputs"/> exists with a matching
-        /// <c>.osprey.task</c> sidecar (validity-key check against
-        /// <see cref="OspreyTask.ValidityKey"/>). If so, the task's work is
-        /// already on disk -- log and return true without executing.
-        /// Otherwise, stale sidecars are cleared (so a mid-Run crash leaves
-        /// no false-positive sidecar), the task is run, and fresh sidecars
-        /// are written next to each declared output on success.
+        /// The skip-if-outputs-valid decision now lives in the driver loop
+        /// (<see cref="PipelineContext.CanRehydrate"/>): this is only called
+        /// for a task that is included and whose outputs are not already on
+        /// disk. The task is run and fresh <c>.osprey.task</c> sidecars are
+        /// written next to each declared output on success.
         /// </summary>
         private static bool RunTask(OspreyTask task, PipelineContext ctx)
         {
-            if (IsTaskAlreadyDone(task, ctx))
-            {
-                ctx.LogInfo(string.Format(@"[task] {0}: skipping (outputs valid)", task.Name));
-                return true;
-            }
-
             // Note: stale-sidecar cleanup is the responsibility of each
             // task body. A task-level pre-Run delete here would wipe the
             // per-file sidecars that <see cref="PerFileScoringTask"/>
@@ -261,19 +254,6 @@ namespace pwiz.OspreySharp
                 WriteTaskSidecars(task, ctx);
 
             return keepGoing;
-        }
-
-        private static bool IsTaskAlreadyDone(OspreyTask task, PipelineContext ctx)
-        {
-            var outputs = new List<string>(task.Outputs(ctx));
-            if (outputs.Count == 0) return false;
-            string key = task.ValidityKey(ctx);
-            foreach (var output in outputs)
-            {
-                if (!File.Exists(output)) return false;
-                if (!TaskValiditySidecar.IsValid(output, task.Name, key)) return false;
-            }
-            return true;
         }
 
         private static void WriteTaskSidecars(OspreyTask task, PipelineContext ctx)

--- a/pwiz_tools/OspreySharp/OspreySharp/AnalysisPipeline.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/AnalysisPipeline.cs
@@ -54,6 +54,27 @@ namespace pwiz.OspreySharp
 
             try
             {
+                // Worker-mode entry normalization: in --input-scores modes
+                // without explicit -i, synthesize InputFiles from the parquet
+                // stems ONCE here, at pipeline entry, so the driver's
+                // Outputs/IsTaskAlreadyDone skip checks and every per-task
+                // accessor see a populated InputFiles regardless of which task
+                // the run starts at. (Mutation-contract: InputFiles is a
+                // pipeline-populated field that does NOT feed any identity
+                // hash, so it may be written once at entry -- see
+                // PipelineContext.Config. Previously this lived inside
+                // PerFileScoringTask's join-only load, which the driver never
+                // reached when PerFileScoring was the StartAt task, e.g.
+                // `--join-at-pass=1 --input-scores`.)
+                if (config.InputScores != null && config.InputScores.Count > 0
+                    && (config.InputFiles == null || config.InputFiles.Count == 0))
+                {
+                    var synthetic = new List<string>(config.InputScores.Count);
+                    foreach (var p in config.InputScores)
+                        synthetic.Add(RescoreHydration.SyntheticInputFromParquet(p));
+                    config.InputFiles = synthetic;
+                }
+
                 var pipelineTasks = CanonicalPipeline();
                 var startAt = DeriveStartAtTask(config);
                 var stopAfter = DeriveStopAfterTask(config);

--- a/pwiz_tools/OspreySharp/OspreySharp/Program.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/Program.cs
@@ -183,11 +183,10 @@ namespace pwiz.OspreySharp
                 LogInfo("");
 
                 // Single entry point. Stage 6 worker mode
-                // (--join-at-pass=1 --no-join --input-scores) is routed
-                // by AnalysisPipeline.DeriveStartAtTask / DeriveStopAfterTask
-                // to start and stop on PerFileRescoreTask; PerFileScoring's
-                // lazy-rehydrate populates the upstream state from the
-                // boundary files on disk.
+                // (--join-at-pass=1 --no-join --input-scores) includes only
+                // PerFileRescoreTask (OspreyTask.IsIncluded); PerFileScoring's
+                // lazy-rehydrate (via ctx.Demand) populates the upstream state
+                // from the boundary files on disk.
                 var pipeline = new AnalysisPipeline();
                 return pipeline.Run(config);
             }

--- a/pwiz_tools/OspreySharp/OspreySharp/RescoreWorker.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/RescoreWorker.cs
@@ -80,11 +80,11 @@ namespace pwiz.OspreySharp
         public static int Run(OspreyConfig config)
         {
             // Phase C: the worker is now an alias for the canonical
-            // pipeline entry. AnalysisPipeline.DeriveStartAtTask /
-            // DeriveStopAfterTask route NoJoin+InputScores configs to
-            // start and stop on PerFileRescoreTask; PerFileScoringTask's
-            // probe-the-disk joinOnly path hydrates the upstream state
-            // (stubs, 1st-pass overlay, reconciliation actions, refined
+            // pipeline entry. The driver runs only the included tasks
+            // (OspreyTask.IsIncluded): a NoJoin+InputScores config includes
+            // PerFileRescoreTask, while PerFileScoringTask's probe-the-disk
+            // joinOnly Rehydrate (reached via ctx.Demand) hydrates the upstream
+            // state (stubs, 1st-pass overlay, reconciliation actions, refined
             // calibrations, gap-fill targets) from the boundary files,
             // matching what the deleted RunWorker assembled by hand.
             return new AnalysisPipeline().Run(config);

--- a/pwiz_tools/OspreySharp/OspreySharp/Tasks/FirstJoinTask.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/Tasks/FirstJoinTask.cs
@@ -147,7 +147,7 @@ namespace pwiz.OspreySharp.Tasks
         private void EnsureHydrated(PipelineContext ctx)
         {
             if (_runOrHydrated) return;
-            Run(ctx);
+            RunOrHydrate(ctx);
         }
 
         // Phase B resume surface. Reads each file's .scores.parquet,
@@ -181,99 +181,78 @@ namespace pwiz.OspreySharp.Tasks
                 + @";reconciliation=" + ctx.Config.Identity.ReconciliationParameterHash();
         }
 
+        /// <summary>
+        /// Dispatch the first materialization of this task to the compute
+        /// path (<see cref="Run"/>, the full Stage 5+6 work) or the disk-load
+        /// path (<see cref="Rehydrate"/>) based on whether the upstream
+        /// PerFileScoring task hydrated a rescore bundle from sibling sidecars
+        /// on disk. When it did, Stage 5 work (Percolator first-pass FDR,
+        /// first-pass protein FDR, 1st-pass sidecar write) and Stage 6
+        /// planning are already encoded in that bundle's q-values and
+        /// reconciliation state, so only compaction remains. The driver loop
+        /// calls <see cref="Run"/> directly (it only reaches this task in the
+        /// straight-through / --join-only modes where the bundle is absent and
+        /// the full path is correct); the accessor/<see cref="EnsureHydrated"/>
+        /// path comes through here so a worker-mode consumer triggers
+        /// <see cref="Rehydrate"/>. Transitional: removed at the Phase B5
+        /// driver-loop flip.
+        /// </summary>
+        private void RunOrHydrate(PipelineContext ctx)
+        {
+            var bundle = ctx.GetTask<PerFileScoringTask>().GetRescoreInputs(ctx);
+            if (bundle != null)
+                Rehydrate(ctx);
+            else
+                Run(ctx);
+        }
+
         public override bool Run(PipelineContext ctx)
         {
+            // Compute path (Stage 5 first-pass FDR + Stage 6 planning): the
+            // upstream PerFileScoring task did NOT hydrate a rescore bundle, so
+            // this run owns the full first-join work. The bundle-present
+            // disk-load counterpart lives in Rehydrate; until the Phase B5
+            // driver flip every entry funnels through RunOrHydrate, so this
+            // task is only ever reached here in the bundle-absent modes
+            // (straight-through, --join-only).
             if (_runOrHydrated) return true;
             _runOrHydrated = true;
             _ctx = ctx;
             var config = ctx.Config;
             var perFileScoring = ctx.GetTask<PerFileScoringTask>();
-            // Probe-the-disk dispatch: when the upstream PerFileScoring
-            // task hydrated a rescore bundle from sibling sidecars on
-            // disk, Stage 5 work (Percolator first-pass FDR, first-pass
-            // protein FDR, 1st-pass sidecar write) and Stage 6 planning
-            // are already encoded in that bundle's q-values and
-            // reconciliation state. Run the bundle path in those cases;
-            // run the original full Stage 5+6 path otherwise. Single
-            // dispatch covers both stage7 (--join-at-pass=2) and the
-            // collapsed stage6 worker path, replacing the prior
-            // ExpectReconciledInput-only gate.
-            var bundle = perFileScoring.GetRescoreInputs(ctx);
+
             // Mid-Run crash safety: clear stale sidecars for the outputs
             // this task is about to produce. A crash before the matching
             // post-Run sidecar write leaves no false-positive sidecar
-            // claiming the partially-written output is valid. Skipped on
-            // the bundle path because that path only overlays existing
-            // 1st/2nd-pass sidecars onto in-memory stubs; it doesn't write
-            // Pass1Path or reconciliation.json, so the sidecar delete
-            // would invalidate valid outputs from an upstream
-            // straight-through run -- and crucially, breaks resume on a
-            // lazy-hydrate path from a downstream task.
-            if (bundle == null)
-            {
-                foreach (var output in Outputs(ctx))
-                    TaskValiditySidecar.Delete(output, Name);
-            }
+            // claiming the partially-written output is valid.
+            foreach (var output in Outputs(ctx))
+                TaskValiditySidecar.Delete(output, Name);
+
             var perFileEntries = perFileScoring.GetPerFileEntries(ctx);
             var perFileCalibrations = perFileScoring.GetPerFileCalibrations(ctx);
             var perFileParquetPaths = perFileScoring.GetPerFileParquetPaths(ctx);
             var fullLibrary = perFileScoring.GetFullLibrary(ctx);
 
-            // Stage 5: First-pass FDR
-            // Skipped under the bundle path: the 1st-pass sidecar
-            // hydrated by PerFileScoringTask already carries the SVM
-            // scores + q-values from the straight-through pipeline run
-            // that produced the per-file boundary files. Re-running
-            // Percolator here would re-train SVMs on the same data and
-            // drift vs the sidecar. Mirrors Rust's compute_fdr_from_stubs
-            // skip (pipeline.rs:3916).
-            if (bundle == null)
-            {
-                ctx.LogInfo(string.Empty);
-                ctx.LogInfo(string.Format(@"Running {0} FDR control on coelution results...",
-                    config.FdrMethod));
+            // Stage 5: First-pass FDR.
+            ctx.LogInfo(string.Empty);
+            ctx.LogInfo(string.Format(@"Running {0} FDR control on coelution results...",
+                config.FdrMethod));
 
-                var swFdr = Stopwatch.StartNew();
-                RunFdr(perFileEntries, fullLibrary, config);
-                swFdr.Stop();
-                ctx.LogInfo(string.Format(@"[TIMING] Percolator/Simple FDR: {0:F1}s",
-                    swFdr.Elapsed.TotalSeconds));
-            }
-            else
-            {
-                ctx.LogInfo(@"Bundle hydration: skipping first-pass Percolator (sidecar provides q-values).");
-            }
+            var swFdr = Stopwatch.StartNew();
+            RunFdr(perFileEntries, fullLibrary, config);
+            swFdr.Stop();
+            ctx.LogInfo(string.Format(@"[TIMING] Percolator/Simple FDR: {0:F1}s",
+                swFdr.Elapsed.TotalSeconds));
 
-            // Log first-pass results
-            LogFirstPassResults(perFileEntries, config);
-
-            // Stage 5 diagnostic dump. Gated by OSPREY_DUMP_PERCOLATOR=1;
-            // exits when OSPREY_PERCOLATOR_ONLY=1 is also set. Writes all
-            // four q-values plus SVM score and PEP for every FdrEntry,
-            // before compaction drops any rows, so the cross-impl diff
-            // sees both targets and decoys.
-            if (OspreyDiagnostics.DumpPercolator)
-                OspreyDiagnostics.WriteStage5PercolatorDump(perFileEntries);
-            // OSPREY_PERCOLATOR_ONLY exits after Stage 5 work completes,
-            // independently of whether the dump ran. Lets us measure
-            // production stage5 wall without paying the dump cost.
-            if (OspreyDiagnostics.PercolatorOnly)
-                OspreyDiagnostics.ExitAfterDump(@"OSPREY_PERCOLATOR_ONLY");
+            LogFirstPassResultsAndDump(perFileEntries, config);
 
             // First-pass protein FDR: runs on the full pre-compaction
             // peptide pool so target and decoy proteins compete on a
             // symmetric set. Sets RunProteinQvalue on every FdrEntry,
             // which Stage 6 reconciliation reads via the protein-rescue
             // gate in ConsensusRts.Compute. Mirrors Rust pipeline.rs:3029
-            // ("First-pass protein FDR"). Skipped on the bundle path:
-            // the 1st-pass FDR sidecar already carries RunProteinQvalue
-            // from the original straight-through pipeline. Re-running
-            // the deterministic protein-FDR computation on identical
-            // inputs would just overwrite the loaded values with the
-            // same numbers (~17s on Astral 1-file; saves duplicate work
-            // on every post-Stage-6 rehydration entry).
-            if (config.ProteinFdr.HasValue && perFileEntries.Count > 0
-                && bundle == null)
+            // ("First-pass protein FDR").
+            if (config.ProteinFdr.HasValue && perFileEntries.Count > 0)
             {
                 ctx.LogInfo(string.Empty);
                 ctx.LogInfo(@"First-pass protein FDR");
@@ -282,6 +261,25 @@ namespace pwiz.OspreySharp.Tasks
                 swFirstPassProtein.Stop();
                 ctx.LogInfo(string.Format(@"[TIMING] First-pass protein FDR: {0:F1}s",
                     swFirstPassProtein.Elapsed.TotalSeconds));
+            }
+
+            // Persist the per-file `.1st-pass.fdr_scores.bin` sidecars
+            // BEFORE compaction so every stub (passing or not) carries
+            // its q-values into the file. Mirrors osprey/src/pipeline.rs
+            // around persist_fdr_scores at line ~3180. Stage 6 workers
+            // re-derive the post-compaction set by applying the q-value
+            // threshold themselves, so they need every entry's q-values
+            // -- not just the survivors.
+            int fdrSidecarFailures = WriteFdrScoresSidecars(
+                perFileEntries, perFileParquetPaths, config);
+            if (fdrSidecarFailures > 0 && config.StopAfterStage5)
+            {
+                ctx.LogError(string.Format(
+                    @"--join-at-pass=1 --join-only: {0}/{1} 1st-pass fdr_scores.bin sidecar " +
+                    @"writes failed; boundary file pair is incomplete. See warnings above.",
+                    fdrSidecarFailures, perFileEntries.Count));
+                ctx.ExitCode = 1;
+                return false;
             }
 
             // Compaction: drop entries whose base_id (entry_id with the
@@ -293,34 +291,7 @@ namespace pwiz.OspreySharp.Tasks
             // includes non-passing charge states that Rust has already
             // dropped, producing different rescore-target sets and
             // different per-file Vec positions.
-            // Persist the per-file `.1st-pass.fdr_scores.bin` sidecars
-            // BEFORE compaction so every stub (passing or not) carries
-            // its q-values into the file. Mirrors osprey/src/pipeline.rs
-            // around persist_fdr_scores at line ~3180. Stage 6 workers
-            // re-derive the post-compaction set by applying the q-value
-            // threshold themselves, so they need every entry's q-values
-            // -- not just the survivors. Skipped on the bundle path:
-            // the 1st-pass sidecar is what we just LOADED from to seed
-            // entries, so re-writing produces the same bytes (any
-            // divergence would be a sidecar-load bug, not a write
-            // requirement). Saves ~6s I/O per bundle-hydrated invocation.
-            int fdrSidecarFailures = 0;
-            if (bundle == null)
-            {
-                fdrSidecarFailures = WriteFdrScoresSidecars(
-                    perFileEntries, perFileParquetPaths, config);
-                if (fdrSidecarFailures > 0 && config.StopAfterStage5)
-                {
-                    ctx.LogError(string.Format(
-                        @"--join-at-pass=1 --join-only: {0}/{1} 1st-pass fdr_scores.bin sidecar " +
-                        @"writes failed; boundary file pair is incomplete. See warnings above.",
-                        fdrSidecarFailures, perFileEntries.Count));
-                    ctx.ExitCode = 1;
-                    return false;
-                }
-            }
-
-            CompactFirstPass(perFileEntries, bundle, config);
+            CompactFirstPass(perFileEntries, null, config);
 
             // NOTE: no 2nd-pass FDR sidecar overlay here. Stage 7
             // (MergeNodeTask) owns its own 2nd-pass rehydrate -- it reloads (or
@@ -335,14 +306,10 @@ namespace pwiz.OspreySharp.Tasks
             // Stage 6: planning checkpoint -- multi-charge consensus +
             // consensus RTs + per-file calibration refit + reconciliation
             // planning. Produces the inputs PerFileRescoreTask consumes.
-            // Skipped on the bundle path (the Stage 6 planner output is
-            // already encoded upstream by the straight-through run that
-            // wrote the boundary files; re-planning would drift). Runs
-            // even single-file -- multi-charge consensus + the planning
+            // Runs even single-file -- multi-charge consensus + the planning
             // checkpoint must still execute to match Rust; cross-run
             // reconciliation degenerates to zero actions there.
-            if (bundle == null
-                && perFileEntries.Count >= 1 && config.Reconciliation.Enabled)
+            if (perFileEntries.Count >= 1 && config.Reconciliation.Enabled)
             {
                 if (!PlanStage6(perFileEntries, perFileCalibrations,
                         perFileParquetPaths, fullLibrary, config))
@@ -350,6 +317,59 @@ namespace pwiz.OspreySharp.Tasks
             }
 
             return true;
+        }
+
+        public override bool Rehydrate(PipelineContext ctx)
+        {
+            // Disk-load path: the upstream PerFileScoring task hydrated a
+            // rescore bundle from sibling sidecars on disk, so the Stage 5
+            // SVM scores + q-values, first-pass protein FDR, and Stage 6
+            // planning state are already encoded in that bundle from the
+            // straight-through run that wrote the boundary files. Re-running
+            // any of them here would re-train SVMs / re-plan on identical
+            // inputs and drift vs the sidecars (mirrors Rust's
+            // compute_fdr_from_stubs skip, pipeline.rs:3916). All that remains
+            // is to adopt the bundle and compact. The compute counterpart is
+            // Run.
+            if (_runOrHydrated) return true;
+            _runOrHydrated = true;
+            _ctx = ctx;
+            var config = ctx.Config;
+            var perFileScoring = ctx.GetTask<PerFileScoringTask>();
+            var bundle = perFileScoring.GetRescoreInputs(ctx);
+            var perFileEntries = perFileScoring.GetPerFileEntries(ctx);
+
+            ctx.LogInfo(@"Bundle hydration: skipping first-pass Percolator (sidecar provides q-values).");
+
+            LogFirstPassResultsAndDump(perFileEntries, config);
+
+            // Compaction delegates to RescoreCompaction.Apply on the bundle
+            // path so the pre-compaction (file, vec_idx) keys in
+            // bundle.ReconciliationActions get rebuilt to post-compaction
+            // indices for PerFileRescoreTask.
+            CompactFirstPass(perFileEntries, bundle, config);
+
+            return true;
+        }
+
+        /// <summary>
+        /// Shared Stage 5 reporting for <see cref="Run"/> and
+        /// <see cref="Rehydrate"/>: log per-file first-pass passing counts,
+        /// then the diagnostic Percolator dump (gated by
+        /// OSPREY_DUMP_PERCOLATOR; written before compaction drops rows so the
+        /// cross-impl diff sees both targets and decoys) and the
+        /// OSPREY_PERCOLATOR_ONLY measurement exit.
+        /// </summary>
+        private void LogFirstPassResultsAndDump(
+            List<KeyValuePair<string, List<FdrEntry>>> perFileEntries,
+            OspreyConfig config)
+        {
+            LogFirstPassResults(perFileEntries, config);
+
+            if (OspreyDiagnostics.DumpPercolator)
+                OspreyDiagnostics.WriteStage5PercolatorDump(perFileEntries);
+            if (OspreyDiagnostics.PercolatorOnly)
+                OspreyDiagnostics.ExitAfterDump(@"OSPREY_PERCOLATOR_ONLY");
         }
 
         /// <summary>

--- a/pwiz_tools/OspreySharp/OspreySharp/Tasks/FirstJoinTask.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/Tasks/FirstJoinTask.cs
@@ -743,8 +743,12 @@ namespace pwiz.OspreySharp.Tasks
                     @"complete; wrote {0} reconciliation.json + matching fdr_scores.bin " +
                     @"sidecar pair(s). Exiting before Stage 6 rescore.",
                     perFileEntries.Count));
+                // Success: return true (not false). The stop after Stage 5 is now
+                // a membership fact -- PerFileRescore and MergeNode are excluded
+                // by IsIncluded under --join-only, so the driver loop iterates no
+                // further. The failure path above keeps ExitCode=1; return false.
                 _ctx.ExitCode = 0;
-                return false;
+                return true;
             }
 
             // Surface outputs for the next task.

--- a/pwiz_tools/OspreySharp/OspreySharp/Tasks/FirstJoinTask.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/Tasks/FirstJoinTask.cs
@@ -313,11 +313,23 @@ namespace pwiz.OspreySharp.Tasks
             // is to adopt the bundle and compact. The compute counterpart is
             // Run.
             if (_runOrHydrated) return true;
+            var perFileScoring = ctx.Demand<PerFileScoringTask>();
+            var bundle = perFileScoring.GetRescoreInputs(ctx);
+
+            // No rescore bundle (straight-through resume, or any non-worker
+            // entry that reaches this task via Demand): the full Stage 5 work
+            // is required, so defer to the compute path. Reached when the
+            // driver skipped this task's Run because its 1st-pass sidecars
+            // were already valid on disk and a downstream task is the first to
+            // touch its state -- recomputing is deterministic and matches
+            // those sidecars. The bundle-adopt disk-load below applies only
+            // when PerFileScoring hydrated a bundle from sibling sidecars.
+            if (bundle == null)
+                return Run(ctx);
+
             _runOrHydrated = true;
             _ctx = ctx;
             var config = ctx.Config;
-            var perFileScoring = ctx.Demand<PerFileScoringTask>();
-            var bundle = perFileScoring.GetRescoreInputs(ctx);
             var perFileEntries = perFileScoring.GetPerFileEntries(ctx);
 
             ctx.LogInfo(@"Bundle hydration: skipping first-pass Percolator (sidecar provides q-values).");

--- a/pwiz_tools/OspreySharp/OspreySharp/Tasks/FirstJoinTask.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/Tasks/FirstJoinTask.cs
@@ -68,7 +68,7 @@ namespace pwiz.OspreySharp.Tasks
     {
         public override string Name => @"FirstJoin";
 
-        // Outputs reached by downstream tasks through ctx.GetTask<FirstJoinTask>().
+        // Outputs reached by downstream tasks through ctx.Demand<FirstJoinTask>().
         // DidPlan is the gate downstream consumers (PerFileRescoreTask)
         // check to decide whether the Stage 6 planning state below is
         // meaningful or whether planning was skipped. Defaults are
@@ -88,36 +88,32 @@ namespace pwiz.OspreySharp.Tasks
         // mechanism; FirstJoinTask uses the same idempotent Run pattern.
         private bool _runOrHydrated;
 
-        public bool DidPlan(PipelineContext ctx) { EnsureHydrated(ctx); return _didPlan; }
+        public bool DidPlan(PipelineContext ctx) { return _didPlan; }
 
         public IReadOnlyDictionary<string, IReadOnlyList<(int Index, double Apex, double Start, double End)>> GetPerFileConsensusTargets(PipelineContext ctx)
         {
-            EnsureHydrated(ctx);
             if (_didPlan) return _perFileConsensusTargets;
             return ConsensusTargetsFromBundleOrEmpty(ctx);
         }
 
         public IReadOnlyDictionary<(string FileName, int Index), ReconcileAction> GetReconciliationActions(PipelineContext ctx)
         {
-            EnsureHydrated(ctx);
             if (_didPlan) return _reconciliationActions;
-            var bundle = ctx.GetTask<PerFileScoringTask>().GetRescoreInputs(ctx);
+            var bundle = ctx.Demand<PerFileScoringTask>().GetRescoreInputs(ctx);
             return bundle != null ? bundle.ReconciliationActions : _reconciliationActions;
         }
 
         public IReadOnlyDictionary<string, RTCalibration> GetRefinedCalibrations(PipelineContext ctx)
         {
-            EnsureHydrated(ctx);
             if (_didPlan) return _refinedCalibrations;
-            var bundle = ctx.GetTask<PerFileScoringTask>().GetRescoreInputs(ctx);
+            var bundle = ctx.Demand<PerFileScoringTask>().GetRescoreInputs(ctx);
             return bundle != null ? bundle.RefinedCalibrations : _refinedCalibrations;
         }
 
         public IReadOnlyDictionary<string, List<GapFillTarget>> GetPerFileGapFillForRescore(PipelineContext ctx)
         {
-            EnsureHydrated(ctx);
             if (_didPlan) return _perFileGapFillForRescore;
-            var bundle = ctx.GetTask<PerFileScoringTask>().GetRescoreInputs(ctx);
+            var bundle = ctx.Demand<PerFileScoringTask>().GetRescoreInputs(ctx);
             return bundle != null ? bundle.PerFileGapFill : _perFileGapFillForRescore;
         }
 
@@ -130,7 +126,7 @@ namespace pwiz.OspreySharp.Tasks
         private IReadOnlyDictionary<string, IReadOnlyList<(int Index, double Apex, double Start, double End)>>
             ConsensusTargetsFromBundleOrEmpty(PipelineContext ctx)
         {
-            var bundle = ctx.GetTask<PerFileScoringTask>().GetRescoreInputs(ctx);
+            var bundle = ctx.Demand<PerFileScoringTask>().GetRescoreInputs(ctx);
             if (bundle == null) return _perFileConsensusTargets;
             if (bundle.PerFileConsensusTargets != null) return bundle.PerFileConsensusTargets;
             var computed = new Dictionary<string,
@@ -142,12 +138,6 @@ namespace pwiz.OspreySharp.Tasks
             }
             bundle.PerFileConsensusTargets = computed;
             return computed;
-        }
-
-        private void EnsureHydrated(PipelineContext ctx)
-        {
-            if (_runOrHydrated) return;
-            RunOrHydrate(ctx);
         }
 
         // Phase B resume surface. Reads each file's .scores.parquet,
@@ -181,45 +171,20 @@ namespace pwiz.OspreySharp.Tasks
                 + @";reconciliation=" + ctx.Config.Identity.ReconciliationParameterHash();
         }
 
-        /// <summary>
-        /// Dispatch the first materialization of this task to the compute
-        /// path (<see cref="Run"/>, the full Stage 5+6 work) or the disk-load
-        /// path (<see cref="Rehydrate"/>) based on whether the upstream
-        /// PerFileScoring task hydrated a rescore bundle from sibling sidecars
-        /// on disk. When it did, Stage 5 work (Percolator first-pass FDR,
-        /// first-pass protein FDR, 1st-pass sidecar write) and Stage 6
-        /// planning are already encoded in that bundle's q-values and
-        /// reconciliation state, so only compaction remains. The driver loop
-        /// calls <see cref="Run"/> directly (it only reaches this task in the
-        /// straight-through / --join-only modes where the bundle is absent and
-        /// the full path is correct); the accessor/<see cref="EnsureHydrated"/>
-        /// path comes through here so a worker-mode consumer triggers
-        /// <see cref="Rehydrate"/>. Transitional: removed at the Phase B5
-        /// driver-loop flip.
-        /// </summary>
-        private void RunOrHydrate(PipelineContext ctx)
-        {
-            var bundle = ctx.GetTask<PerFileScoringTask>().GetRescoreInputs(ctx);
-            if (bundle != null)
-                Rehydrate(ctx);
-            else
-                Run(ctx);
-        }
-
         public override bool Run(PipelineContext ctx)
         {
             // Compute path (Stage 5 first-pass FDR + Stage 6 planning): the
             // upstream PerFileScoring task did NOT hydrate a rescore bundle, so
             // this run owns the full first-join work. The bundle-present
-            // disk-load counterpart lives in Rehydrate; until the Phase B5
-            // driver flip every entry funnels through RunOrHydrate, so this
-            // task is only ever reached here in the bundle-absent modes
-            // (straight-through, --join-only).
+            // disk-load counterpart lives in Rehydrate. The driver reaches this
+            // task here only in the bundle-absent modes (straight-through,
+            // --join-only); a worker-mode consumer materializes it via
+            // ctx.Demand which routes to Rehydrate.
             if (_runOrHydrated) return true;
             _runOrHydrated = true;
             _ctx = ctx;
             var config = ctx.Config;
-            var perFileScoring = ctx.GetTask<PerFileScoringTask>();
+            var perFileScoring = ctx.Demand<PerFileScoringTask>();
 
             // Mid-Run crash safety: clear stale sidecars for the outputs
             // this task is about to produce. A crash before the matching
@@ -335,7 +300,7 @@ namespace pwiz.OspreySharp.Tasks
             _runOrHydrated = true;
             _ctx = ctx;
             var config = ctx.Config;
-            var perFileScoring = ctx.GetTask<PerFileScoringTask>();
+            var perFileScoring = ctx.Demand<PerFileScoringTask>();
             var bundle = perFileScoring.GetRescoreInputs(ctx);
             var perFileEntries = perFileScoring.GetPerFileEntries(ctx);
 

--- a/pwiz_tools/OspreySharp/OspreySharp/Tasks/FirstJoinTask.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/Tasks/FirstJoinTask.cs
@@ -68,6 +68,22 @@ namespace pwiz.OspreySharp.Tasks
     {
         public override string Name => @"FirstJoin";
 
+        /// <summary>
+        /// Computes the Stage 5 first-join (Percolator first-pass FDR + Stage 6
+        /// planning) in straight-through, --join-only (StopAfterStage5), and
+        /// the --input-scores full-pipeline. Excluded in --no-join (stops at
+        /// Stage 1-4), the rescore worker, and the --join-at-pass=2 merge
+        /// (where it rehydrates the bundle rather than recomputing).
+        /// </summary>
+        public override bool IsIncluded(PipelineContext ctx)
+        {
+            var c = ctx.Config;
+            bool inputs = c.InputScores != null && c.InputScores.Count > 0;
+            return (!inputs && !c.NoJoin)
+                || (inputs && c.StopAfterStage5)
+                || (inputs && !c.NoJoin && !c.ExpectReconciledInput);
+        }
+
         // Outputs reached by downstream tasks through ctx.Demand<FirstJoinTask>().
         // DidPlan is the gate downstream consumers (PerFileRescoreTask)
         // check to decide whether the Stage 6 planning state below is

--- a/pwiz_tools/OspreySharp/OspreySharp/Tasks/MergeNodeTask.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/Tasks/MergeNodeTask.cs
@@ -88,6 +88,18 @@ namespace pwiz.OspreySharp.Tasks
                 + @";reconciliation=" + ctx.Config.Identity.ReconciliationParameterHash();
         }
 
+        /// <summary>
+        /// No-op disk-load: MergeNode is the terminal aggregator. Its output
+        /// (the .blib + 2nd-pass FDR sidecars) is an external artifact that no
+        /// other task consumes in-memory, so there is no cross-task state to
+        /// rehydrate and nothing ever <see cref="PipelineContext.Demand{T}"/>s
+        /// this task. The driver runs <see cref="Run"/> directly when the
+        /// output is absent and skips it (resume) when the output is already
+        /// valid; this override exists only to keep the contract satisfied once
+        /// the transitional base Rehydrate=Run shim is removed (Phase B6).
+        /// </summary>
+        public override bool Rehydrate(PipelineContext ctx) => true;
+
         public override bool Run(PipelineContext ctx)
         {
             _ctx = ctx;

--- a/pwiz_tools/OspreySharp/OspreySharp/Tasks/MergeNodeTask.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/Tasks/MergeNodeTask.cs
@@ -54,6 +54,21 @@ namespace pwiz.OspreySharp.Tasks
 
         public override string Name => @"MergeNode";
 
+        /// <summary>
+        /// Computes Stage 7-8 (2nd-pass FDR + protein FDR + blib) in
+        /// straight-through, the --join-at-pass=2 merge, and the --input-scores
+        /// full-pipeline. Excluded in --no-join, --join-only, and the rescore
+        /// worker (all of which stop before the merge node).
+        /// </summary>
+        public override bool IsIncluded(PipelineContext ctx)
+        {
+            var c = ctx.Config;
+            bool inputs = c.InputScores != null && c.InputScores.Count > 0;
+            return (!inputs && !c.NoJoin)
+                || (inputs && c.ExpectReconciledInput)
+                || (inputs && !c.NoJoin && !c.StopAfterStage5 && !c.ExpectReconciledInput);
+        }
+
         // Phase B resume surface. Reads each file's reconciled
         // .scores.parquet, writes the .2nd-pass.fdr_scores.bin
         // sidecars (only when protein-FDR is enabled) and the

--- a/pwiz_tools/OspreySharp/OspreySharp/Tasks/MergeNodeTask.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/Tasks/MergeNodeTask.cs
@@ -110,8 +110,8 @@ namespace pwiz.OspreySharp.Tasks
             // perFileEntries comes from PerFileRescoreTask -- it owns
             // the post-rescore version (mutated in place; or the
             // unchanged upstream reference when planning was skipped).
-            var perFileEntries = ctx.GetTask<PerFileRescoreTask>().GetPerFileEntries(ctx);
-            var perFileScoring = ctx.GetTask<PerFileScoringTask>();
+            var perFileEntries = ctx.Demand<PerFileRescoreTask>().GetPerFileEntries(ctx);
+            var perFileScoring = ctx.Demand<PerFileScoringTask>();
             var fullLibrary = perFileScoring.GetFullLibrary(ctx);
             var libraryById = perFileScoring.GetLibraryById(ctx);
             var perFileParquetPaths = perFileScoring.GetPerFileParquetPaths(ctx);

--- a/pwiz_tools/OspreySharp/OspreySharp/Tasks/PerFileRescoreTask.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/Tasks/PerFileRescoreTask.cs
@@ -334,6 +334,17 @@ namespace pwiz.OspreySharp.Tasks
             // each entry from the .1st-pass.fdr_scores.bin sidecar by
             // PerFileScoringTask's bundle hydration; no fresh FDR computation.
             if (_runOrHydrated) return true;
+
+            // Only the --join-at-pass=2 merge entry rehydrates here (reconciled
+            // parquets on disk, no mzMLs to rescore). Any other entry that
+            // reaches this task via Demand -- straight-through resume where the
+            // reconciled parquets are already valid on disk and a downstream
+            // task is the first to touch its state -- must take the compute
+            // path, whose per-file ScoreOrLoadForFile loads the valid
+            // reconciled parquets rather than re-scoring.
+            if (!ctx.Config.ExpectReconciledInput)
+                return Run(ctx);
+
             _runOrHydrated = true;
             _ctx = ctx;
             var perFileScoring = ctx.Demand<PerFileScoringTask>();

--- a/pwiz_tools/OspreySharp/OspreySharp/Tasks/PerFileRescoreTask.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/Tasks/PerFileRescoreTask.cs
@@ -113,14 +113,15 @@ namespace pwiz.OspreySharp.Tasks
         /// The post-rescore per-file entries. Mutated in place by
         /// <see cref="ExecuteRescore"/>; when this task short-circuits
         /// (no FirstJoinTask plan) the list is the unchanged upstream
-        /// reference. Lazy-rehydrates by invoking <see cref="Run"/> on
-        /// the first call when this task was skipped by the driver
-        /// (i.e. <see cref="PipelineContext.StartAtTask"/> is downstream),
-        /// so consumers always see populated state.
+        /// reference. Materializes on the first call when this task was
+        /// skipped by the driver (i.e. <see cref="PipelineContext.StartAtTask"/>
+        /// is downstream): <see cref="RunOrHydrate"/> picks the compute
+        /// path (<see cref="Run"/>) or the --join-at-pass=2 disk-load path
+        /// (<see cref="Rehydrate"/>), so consumers always see populated state.
         /// </summary>
         public List<KeyValuePair<string, List<FdrEntry>>> GetPerFileEntries(PipelineContext ctx)
         {
-            if (!_runOrHydrated) Run(ctx);
+            if (!_runOrHydrated) RunOrHydrate(ctx);
             if (_perFileEntries == null)
                 throw new InvalidOperationException(
                     @"PerFileRescoreTask.GetPerFileEntries called before Run populated the field.");
@@ -168,83 +169,42 @@ namespace pwiz.OspreySharp.Tasks
                 + @";reconciliation=" + ctx.Config.Identity.ReconciliationParameterHash();
         }
 
+        /// <summary>
+        /// Dispatch the first materialization of this task to the disk-load
+        /// path (<see cref="Rehydrate"/>) under --join-at-pass=2, where every
+        /// input parquet is already reconciled and the merge node has no mzMLs
+        /// to rescore from, or to the compute path (<see cref="Run"/>) for
+        /// every other mode (straight-through and the stage6 rescore worker,
+        /// which both actually re-score). The driver loop calls
+        /// <see cref="Run"/> directly (it only reaches this task in the
+        /// non--join-at-pass=2 modes); the accessor path
+        /// (<see cref="GetPerFileEntries"/>) comes through here so a
+        /// --join-at-pass=2 merge consumer triggers <see cref="Rehydrate"/>.
+        /// Transitional: removed at the Phase B5 driver-loop flip.
+        /// </summary>
+        private void RunOrHydrate(PipelineContext ctx)
+        {
+            if (ctx.Config.ExpectReconciledInput)
+                Rehydrate(ctx);
+            else
+                Run(ctx);
+        }
+
         public override bool Run(PipelineContext ctx)
         {
+            // Compute path (Stage 6 rescore): re-score each file's entries
+            // against the consensus + reconciliation boundaries and write the
+            // reconciled parquets. Used by the straight-through pipeline and
+            // the stage6 rescore worker. The --join-at-pass=2 merge node,
+            // which has only reconciled parquets + sidecars (no mzMLs to
+            // rescore from), takes Rehydrate instead; until the Phase B5
+            // driver flip every entry funnels through RunOrHydrate, so this
+            // task is only ever reached here in the rescore-capable modes.
             if (_runOrHydrated) return true;
             _runOrHydrated = true;
             _ctx = ctx;
             var perFileScoring = ctx.GetTask<PerFileScoringTask>();
             _perFileEntries = perFileScoring.GetPerFileEntries(ctx);
-
-            // Hard short-circuit for --join-at-pass=2: every input parquet
-            // already has osprey.reconciled = "true" (asserted by
-            // ParquetScoreCache.CheckParquetMetadata when ExpectReconciledInput
-            // is set), so Stage 5 first-pass Percolator AND Stage 6
-            // planning / rescore have ALREADY been performed upstream by
-            // the worker nodes that wrote those parquets. We must NOT
-            // touch FirstJoinTask here -- doing so transitively triggers
-            // FirstJoinTask.Run via EnsureHydrated, which re-runs Stage 5
-            // first-pass Percolator from scratch on the reconciled parquets
-            // (producing wildly different action counts than the planner
-            // saw on the raw Stage 4 inputs) and then attempts a Stage 6
-            // rescore that needs mzML files the merge node does not have
-            // (in production HPC, the merge node ships only sidecars +
-            // reconciled parquets, no mzMLs). MergeNodeTask is responsible
-            // for 2nd-pass Percolator (Bug C) and protein FDR + blib
-            // output starting from this hydrated, reconciled state.
-            // Mirrors Rust pipeline.rs:3313-3344 which gates the entire
-            // Stage 5+6 block on `!config.expect_reconciled_input`.
-            //
-            // Compaction still needs to run though: PerFileScoringTask's
-            // bundle-hydration path loads ALL entries from the parquet,
-            // including ones that failed first-pass FDR. FirstJoinTask's
-            // normal flow would run this compaction inline after first-pass
-            // Percolator (and we're skipping FirstJoinTask entirely here).
-            // Without it, MergeNodeTask's 2nd-pass Percolator would train
-            // on ~3x too many entries -- specifically the non-passing
-            // first-pass entries whose 1st-pass q-values are 1.0 -- and
-            // the SVM would learn a much worse decision boundary than the
-            // in-memory pipeline's, producing different per-precursor
-            // scores and different protein-FDR results. The compaction
-            // reads first-pass q-values that are already overlaid onto
-            // each entry from the .1st-pass.fdr_scores.bin sidecar by
-            // PerFileScoringTask's bundle hydration; no fresh FDR
-            // computation needed.
-            if (ctx.Config.ExpectReconciledInput)
-            {
-                var bundle = perFileScoring.GetRescoreInputs(ctx);
-                if (bundle != null)
-                {
-                    // First-pass protein FDR BEFORE compaction. The 1st-pass FDR
-                    // sidecar v3 already carries RunProteinQvalue from the original
-                    // straight-through pipeline, but Rust pipeline.rs:4292 (gated by
-                    // `!can_skip_fdr || config.expect_reconciled_input`) recomputes
-                    // it inline in the --join-at-pass=2 path. The recompute uses the
-                    // post-rehydration detected_peptides set + best_peptide_scores
-                    // (which differ from the original write-time inputs whenever any
-                    // upstream rebuild has nudged peptide q-values or score values
-                    // even at the ULP level). Without this matching recompute on the
-                    // C# side, the protein-rescue branch of compaction below sees
-                    // slightly stale RunProteinQvalue values and the post-compaction
-                    // detected_peptides set diverges from Rust by ~19 peptides on
-                    // Stellar Single (1 protein delta at Stage 7). Only runs when
-                    // protein FDR is enabled — the recompute is the protein-rescue
-                    // input and is meaningless otherwise. Mirrors Rust pipeline.rs:
-                    // 4292-4358.
-                    if (ctx.Config.ProteinFdr.HasValue && bundle.PerFileEntries.Count > 0)
-                    {
-                        var fullLibrary = perFileScoring.GetFullLibrary(ctx);
-                        ProteinFdr.RunFirstPassProteinFdr(
-                            bundle.PerFileEntries, fullLibrary, ctx.Config);
-                    }
-                    var stats = RescoreCompaction.Apply(bundle, ctx.Config);
-                    ctx.LogInfo(string.Format(
-                        @"--join-at-pass=2 compaction: {0} -> {1} entries ({2} passing base_ids; {3} action(s) dropped)",
-                        stats.EntriesBefore, stats.EntriesAfter,
-                        stats.FirstPassBaseIds, stats.DroppedActions));
-                }
-                return true;
-            }
 
             // Self-gate: rescore + reconciliation only run when there is
             // planning state to act on AND the rescore hasn't already been
@@ -344,6 +304,76 @@ namespace pwiz.OspreySharp.Tasks
             OspreyDiagnostics.CloseMpInputsDump();
             OspreyDiagnostics.ClosePredictRtDump();
             OspreyDiagnostics.CloseCwtPathDump();
+            return true;
+        }
+
+        public override bool Rehydrate(PipelineContext ctx)
+        {
+            // Disk-load path for --join-at-pass=2: every input parquet already
+            // has osprey.reconciled = "true" (asserted by
+            // ParquetScoreCache.CheckParquetMetadata when ExpectReconciledInput
+            // is set), so Stage 5 first-pass Percolator AND Stage 6 planning /
+            // rescore have ALREADY been performed upstream by the worker nodes
+            // that wrote those parquets. We must NOT touch FirstJoinTask here --
+            // demanding it would re-run Stage 5 first-pass Percolator from
+            // scratch on the reconciled parquets (producing wildly different
+            // action counts than the planner saw on the raw Stage 4 inputs) and
+            // then attempt a Stage 6 rescore that needs mzML files the merge
+            // node does not have (in production HPC the merge node ships only
+            // sidecars + reconciled parquets, no mzMLs). MergeNodeTask is
+            // responsible for 2nd-pass Percolator (Bug C) and protein FDR + blib
+            // output starting from this hydrated, reconciled state. Mirrors Rust
+            // pipeline.rs:3313-3344 which gates the entire Stage 5+6 block on
+            // `!config.expect_reconciled_input`.
+            //
+            // Compaction still needs to run though: PerFileScoringTask's
+            // bundle-hydration path loads ALL entries from the parquet,
+            // including ones that failed first-pass FDR. FirstJoinTask's normal
+            // flow would run this compaction inline after first-pass Percolator
+            // (and we skip FirstJoinTask entirely here). Without it,
+            // MergeNodeTask's 2nd-pass Percolator would train on ~3x too many
+            // entries -- specifically the non-passing first-pass entries whose
+            // 1st-pass q-values are 1.0 -- and the SVM would learn a much worse
+            // decision boundary than the in-memory pipeline's, producing
+            // different per-precursor scores and different protein-FDR results.
+            // The compaction reads first-pass q-values already overlaid onto
+            // each entry from the .1st-pass.fdr_scores.bin sidecar by
+            // PerFileScoringTask's bundle hydration; no fresh FDR computation.
+            if (_runOrHydrated) return true;
+            _runOrHydrated = true;
+            _ctx = ctx;
+            var perFileScoring = ctx.GetTask<PerFileScoringTask>();
+            _perFileEntries = perFileScoring.GetPerFileEntries(ctx);
+
+            var bundle = perFileScoring.GetRescoreInputs(ctx);
+            if (bundle != null)
+            {
+                // First-pass protein FDR BEFORE compaction. The 1st-pass FDR
+                // sidecar v3 already carries RunProteinQvalue from the original
+                // straight-through pipeline, but Rust pipeline.rs:4292 (gated by
+                // `!can_skip_fdr || config.expect_reconciled_input`) recomputes
+                // it inline in the --join-at-pass=2 path. The recompute uses the
+                // post-rehydration detected_peptides set + best_peptide_scores
+                // (which differ from the original write-time inputs whenever any
+                // upstream rebuild has nudged peptide q-values or score values
+                // even at the ULP level). Without this matching recompute on the
+                // C# side, the protein-rescue branch of compaction below sees
+                // slightly stale RunProteinQvalue values and the post-compaction
+                // detected_peptides set diverges from Rust by ~19 peptides on
+                // Stellar Single (1 protein delta at Stage 7). Only runs when
+                // protein FDR is enabled. Mirrors Rust pipeline.rs:4292-4358.
+                if (ctx.Config.ProteinFdr.HasValue && bundle.PerFileEntries.Count > 0)
+                {
+                    var fullLibrary = perFileScoring.GetFullLibrary(ctx);
+                    ProteinFdr.RunFirstPassProteinFdr(
+                        bundle.PerFileEntries, fullLibrary, ctx.Config);
+                }
+                var stats = RescoreCompaction.Apply(bundle, ctx.Config);
+                ctx.LogInfo(string.Format(
+                    @"--join-at-pass=2 compaction: {0} -> {1} entries ({2} passing base_ids; {3} action(s) dropped)",
+                    stats.EntriesBefore, stats.EntriesAfter,
+                    stats.FirstPassBaseIds, stats.DroppedActions));
+            }
             return true;
         }
 

--- a/pwiz_tools/OspreySharp/OspreySharp/Tasks/PerFileRescoreTask.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/Tasks/PerFileRescoreTask.cs
@@ -110,6 +110,22 @@ namespace pwiz.OspreySharp.Tasks
         public override string Name => @"PerFileRescore";
 
         /// <summary>
+        /// Computes the Stage 6 rescore in straight-through, the rescore worker
+        /// (--join-at-pass=1 --no-join --input-scores), and the --input-scores
+        /// full-pipeline. Excluded in --no-join, --join-only (stops at Stage 5),
+        /// and the --join-at-pass=2 merge (where it rehydrates rather than
+        /// re-scoring, the merge node having no mzMLs).
+        /// </summary>
+        public override bool IsIncluded(PipelineContext ctx)
+        {
+            var c = ctx.Config;
+            bool inputs = c.InputScores != null && c.InputScores.Count > 0;
+            return (!inputs && !c.NoJoin)
+                || (inputs && c.NoJoin)
+                || (inputs && !c.NoJoin && !c.StopAfterStage5 && !c.ExpectReconciledInput);
+        }
+
+        /// <summary>
         /// The post-rescore per-file entries. Mutated in place by
         /// <see cref="ExecuteRescore"/>; when this task short-circuits
         /// (no FirstJoinTask plan) the list is the unchanged upstream

--- a/pwiz_tools/OspreySharp/OspreySharp/Tasks/PerFileRescoreTask.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/Tasks/PerFileRescoreTask.cs
@@ -113,15 +113,14 @@ namespace pwiz.OspreySharp.Tasks
         /// The post-rescore per-file entries. Mutated in place by
         /// <see cref="ExecuteRescore"/>; when this task short-circuits
         /// (no FirstJoinTask plan) the list is the unchanged upstream
-        /// reference. Materializes on the first call when this task was
-        /// skipped by the driver (i.e. <see cref="PipelineContext.StartAtTask"/>
-        /// is downstream): <see cref="RunOrHydrate"/> picks the compute
-        /// path (<see cref="Run"/>) or the --join-at-pass=2 disk-load path
-        /// (<see cref="Rehydrate"/>), so consumers always see populated state.
+        /// reference. Pure read: the caller materializes this task first via
+        /// <see cref="PipelineContext.Demand{T}"/> (compute <see cref="Run"/>
+        /// for the rescore-capable modes, or the --join-at-pass=2
+        /// <see cref="Rehydrate"/> disk-load), so the field is populated by the
+        /// time any consumer reads it.
         /// </summary>
         public List<KeyValuePair<string, List<FdrEntry>>> GetPerFileEntries(PipelineContext ctx)
         {
-            if (!_runOrHydrated) RunOrHydrate(ctx);
             if (_perFileEntries == null)
                 throw new InvalidOperationException(
                     @"PerFileRescoreTask.GetPerFileEntries called before Run populated the field.");
@@ -169,27 +168,6 @@ namespace pwiz.OspreySharp.Tasks
                 + @";reconciliation=" + ctx.Config.Identity.ReconciliationParameterHash();
         }
 
-        /// <summary>
-        /// Dispatch the first materialization of this task to the disk-load
-        /// path (<see cref="Rehydrate"/>) under --join-at-pass=2, where every
-        /// input parquet is already reconciled and the merge node has no mzMLs
-        /// to rescore from, or to the compute path (<see cref="Run"/>) for
-        /// every other mode (straight-through and the stage6 rescore worker,
-        /// which both actually re-score). The driver loop calls
-        /// <see cref="Run"/> directly (it only reaches this task in the
-        /// non--join-at-pass=2 modes); the accessor path
-        /// (<see cref="GetPerFileEntries"/>) comes through here so a
-        /// --join-at-pass=2 merge consumer triggers <see cref="Rehydrate"/>.
-        /// Transitional: removed at the Phase B5 driver-loop flip.
-        /// </summary>
-        private void RunOrHydrate(PipelineContext ctx)
-        {
-            if (ctx.Config.ExpectReconciledInput)
-                Rehydrate(ctx);
-            else
-                Run(ctx);
-        }
-
         public override bool Run(PipelineContext ctx)
         {
             // Compute path (Stage 6 rescore): re-score each file's entries
@@ -197,13 +175,13 @@ namespace pwiz.OspreySharp.Tasks
             // reconciled parquets. Used by the straight-through pipeline and
             // the stage6 rescore worker. The --join-at-pass=2 merge node,
             // which has only reconciled parquets + sidecars (no mzMLs to
-            // rescore from), takes Rehydrate instead; until the Phase B5
-            // driver flip every entry funnels through RunOrHydrate, so this
-            // task is only ever reached here in the rescore-capable modes.
+            // rescore from), takes Rehydrate instead: the driver reaches this
+            // task here only in the rescore-capable modes, and a merge-node
+            // consumer materializes it via ctx.Demand, which routes to Rehydrate.
             if (_runOrHydrated) return true;
             _runOrHydrated = true;
             _ctx = ctx;
-            var perFileScoring = ctx.GetTask<PerFileScoringTask>();
+            var perFileScoring = ctx.Demand<PerFileScoringTask>();
             _perFileEntries = perFileScoring.GetPerFileEntries(ctx);
 
             // Self-gate: rescore + reconciliation only run when there is
@@ -224,7 +202,7 @@ namespace pwiz.OspreySharp.Tasks
             // the strict --join-at-pass=2 merge path. Downstream
             // MergeNodeTask still gets _perFileEntries via our accessor
             // (falls through to the upstream reference).
-            var firstJoin = ctx.GetTask<FirstJoinTask>();
+            var firstJoin = ctx.Demand<FirstJoinTask>();
             bool didPlan = firstJoin.DidPlan(ctx);
             var rescoreBundle = perFileScoring.GetRescoreInputs(ctx);
             bool anyPass2Present = false;
@@ -342,7 +320,7 @@ namespace pwiz.OspreySharp.Tasks
             if (_runOrHydrated) return true;
             _runOrHydrated = true;
             _ctx = ctx;
-            var perFileScoring = ctx.GetTask<PerFileScoringTask>();
+            var perFileScoring = ctx.Demand<PerFileScoringTask>();
             _perFileEntries = perFileScoring.GetPerFileEntries(ctx);
 
             var bundle = perFileScoring.GetRescoreInputs(ctx);

--- a/pwiz_tools/OspreySharp/OspreySharp/Tasks/PerFileScoringTask.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/Tasks/PerFileScoringTask.cs
@@ -119,10 +119,11 @@ namespace pwiz.OspreySharp.Tasks
         // a separate code path.
         private RescoreInputs _rescoreInputs;
 
-        // Phase B lazy-rehydrate gate. Set to true at the start of Run
-        // and by EnsureHydrated. Once set, neither path re-executes the
-        // body (multiple accessors querying state from a single skipped
-        // task all hit a fast no-op after the first hydration).
+        // Phase B lazy-rehydrate gate. Set to true at the start of both
+        // Run (compute) and Rehydrate (disk-load). Once set, neither path
+        // re-executes the body (multiple accessors querying state from a
+        // single skipped task all hit a fast no-op after the first
+        // materialization).
         private bool _runOrHydrated;
 
         // Producer accessors. The backing fields are built and mutated ONLY
@@ -161,17 +162,20 @@ namespace pwiz.OspreySharp.Tasks
         public RescoreInputs GetRescoreInputs(PipelineContext ctx) { EnsureHydrated(ctx); return _rescoreInputs; }
 
         /// <summary>
-        /// Lazy-rehydrate seam: when a downstream task queries one of
-        /// this task's outputs and <see cref="Run"/> has not executed
-        /// (i.e. this task is before <see cref="PipelineContext.StartAtTask"/>),
-        /// invoke Run so the same code path that populates state on a
-        /// straight-through run also populates state here. Idempotent;
+        /// Lazy-rehydrate seam: when a downstream task queries one of this
+        /// task's outputs and neither <see cref="Run"/> nor <see cref="Rehydrate"/>
+        /// has executed (i.e. this task is before
+        /// <see cref="PipelineContext.StartAtTask"/>), materialize its state
+        /// now. <see cref="RunOrHydrate"/> picks the compute path
+        /// (<see cref="Run"/>) or the disk-load path (<see cref="Rehydrate"/>)
+        /// from the same <c>--input-scores</c> signal the straight-through run
+        /// would, so the populated state is identical either way. Idempotent;
         /// subsequent calls are no-ops.
         /// </summary>
         private void EnsureHydrated(PipelineContext ctx)
         {
             if (_runOrHydrated) return;
-            Run(ctx);
+            RunOrHydrate(ctx);
         }
 
         // Phase B resume surface: the library and every input mzML are
@@ -198,11 +202,41 @@ namespace pwiz.OspreySharp.Tasks
             }
         }
 
+        /// <summary>
+        /// Dispatch the first materialization of this task to the compute
+        /// path (<see cref="Run"/>) or the disk-load path
+        /// (<see cref="Rehydrate"/>) based on the same <c>--input-scores</c>
+        /// signal a straight-through invocation reads. The driver loop calls
+        /// <see cref="Run"/> directly (it only reaches this task in the
+        /// non-<c>--input-scores</c> modes where compute is correct); the
+        /// accessor/<see cref="EnsureHydrated"/> path comes through here so a
+        /// worker-mode consumer triggers <see cref="Rehydrate"/> instead.
+        /// Transitional: removed with the driver-loop flip in Phase B5.
+        /// </summary>
+        private void RunOrHydrate(PipelineContext ctx)
+        {
+            bool joinOnly = ctx.Config.InputScores != null && ctx.Config.InputScores.Count > 0;
+            // The success/stop bool is meaningful only to the driver loop,
+            // which calls Run directly; the accessor hydration that comes
+            // through here just needs the producer's state populated.
+            if (joinOnly)
+                Rehydrate(ctx);
+            else
+                Run(ctx);
+        }
+
         public override bool Run(PipelineContext ctx)
         {
-            // Idempotent re-entry guard: a lazy-rehydrate via an
-            // accessor may have already executed this task body; the
-            // driver loop's call here is then a no-op.
+            // Compute path (Stages 1-4): load the library and score every
+            // input mzML from spectra. The worker-mode disk-load counterpart
+            // (--input-scores) lives in Rehydrate; until the Phase B5 driver
+            // flip every entry funnels through RunOrHydrate, so this task is
+            // only ever reached here in the non---input-scores modes where
+            // computing from spectra is the right thing.
+            //
+            // Idempotent re-entry guard: a lazy-rehydrate via an accessor may
+            // have already executed this task body; the driver loop's call
+            // here is then a no-op.
             if (_runOrHydrated) return true;
             _runOrHydrated = true;
             _ctx = ctx;
@@ -219,48 +253,30 @@ namespace pwiz.OspreySharp.Tasks
             // Per-file RT calibration handles harvested by ProcessFile so
             // Stage 6 reconciliation has the live RTCalibration objects.
             var perFileCalibrations = new ConcurrentDictionary<string, RTCalibration>();
-            // fileName -> .scores.parquet path. Populated by --join-only
-            // (which already knows the paths) so Stage 6 reconciliation
-            // can lazily load CWT candidates per file via
+            // fileName -> .scores.parquet path, populated below so Stage 6
+            // reconciliation can lazily load CWT candidates per file via
             // ParquetScoreCache.LoadCwtCandidatesFromParquet.
             var perFileParquetPaths = new Dictionary<string, string>();
 
-            bool joinOnly = config.InputScores != null && config.InputScores.Count > 0;
-            int nFiles = joinOnly ? config.InputScores.Count : config.InputFiles.Count;
-
-            // In --input-scores mode without explicit -i, synthesize
-            // InputFiles from the parquet stems so downstream code
-            // (Stage 6 rescore's fileNameToIdx in particular) can map
-            // each file_name back to a real (synthetic) input path.
-            if (joinOnly && (config.InputFiles == null || config.InputFiles.Count == 0))
-            {
-                var synthetic = new List<string>(config.InputScores.Count);
-                foreach (var p in config.InputScores)
-                    synthetic.Add(RescoreHydration.SyntheticInputFromParquet(p));
-                config.InputFiles = synthetic;
-            }
+            int nFiles = config.InputFiles.Count;
 
             // Pre-compute the parquet footer metadata ONCE, against the
             // unmutated outer config. ProcessFile clones the config per
             // file and mutates FragmentTolerance during MS2 calibration,
             // so reading config.Identity.SearchParameterHash() inside ProcessFile
             // would produce a hash that the join-only validator would
-            // not recognize. Built unconditionally (in any non-joinOnly
-            // mode) because Stage 6 reconciliation needs the per-file
-            // .scores.parquet on disk to lazily load CWT candidates --
-            // matches Rust's end-to-end behavior, which always writes
-            // the parquet sidecar regardless of --no-join.
-            Dictionary<string, string> parquetFooterMetadata = null;
-            if (!joinOnly)
+            // not recognize. Built unconditionally because Stage 6
+            // reconciliation needs the per-file .scores.parquet on disk to
+            // lazily load CWT candidates -- matches Rust's end-to-end
+            // behavior, which always writes the parquet sidecar regardless
+            // of --no-join.
+            var parquetFooterMetadata = new Dictionary<string, string>
             {
-                parquetFooterMetadata = new Dictionary<string, string>
-                {
-                    { @"osprey.version", Program.VERSION },
-                    { @"osprey.search_hash", config.Identity.SearchParameterHash() },
-                    { @"osprey.library_hash", config.Identity.LibraryIdentityHash() },
-                    { @"osprey.reconciled", @"false" },
-                };
-            }
+                { @"osprey.version", Program.VERSION },
+                { @"osprey.search_hash", config.Identity.SearchParameterHash() },
+                { @"osprey.library_hash", config.Identity.LibraryIdentityHash() },
+                { @"osprey.reconciled", @"false" },
+            };
 
             // File-level parallelism is configurable via
             // OSPREY_MAX_PARALLEL_FILES. See AnalysisPipeline (and
@@ -279,11 +295,7 @@ namespace pwiz.OspreySharp.Tasks
                 ctx.RunPlan.EffectiveFileParallelism = Math.Min(nFiles, Environment.ProcessorCount);
 
             var swAllFiles = Stopwatch.StartNew();
-            if (joinOnly)
-            {
-                LoadJoinOnlyScores(config, perFileEntries, perFileParquetPaths, perFileCalibrations);
-            }
-            else if (config.InputFiles.Count == 1)
+            if (config.InputFiles.Count == 1)
             {
                 // Single file: process directly (no parallel overhead)
                 string inputFile = config.InputFiles[0];
@@ -354,19 +366,84 @@ namespace pwiz.OspreySharp.Tasks
             ctx.LogInfo(string.Format(@"[TIMING] All files processed: {0:F1}s",
                 swAllFiles.Elapsed.TotalSeconds));
 
-            // End-to-end (non-joinOnly) modes: populate perFileParquetPaths
-            // from config.InputFiles so Stage 6 reconciliation can locate
-            // each file's freshly-written .scores.parquet to lazy-load CWT
-            // candidates from. ProcessFile writes the parquet whenever
-            // parquetFooterMetadata != null (now always set in non-joinOnly mode).
-            if (!joinOnly)
+            // Populate perFileParquetPaths from config.InputFiles so Stage 6
+            // reconciliation can locate each file's freshly-written
+            // .scores.parquet to lazy-load CWT candidates from. ProcessFile
+            // always writes the parquet (parquetFooterMetadata is non-null).
+            foreach (string inputFile in config.InputFiles)
             {
-                foreach (string inputFile in config.InputFiles)
-                {
-                    string fileName = Path.GetFileNameWithoutExtension(inputFile);
-                    perFileParquetPaths[fileName] = ParquetScoreCache.GetScoresPath(inputFile);
-                }
+                string fileName = Path.GetFileNameWithoutExtension(inputFile);
+                perFileParquetPaths[fileName] = ParquetScoreCache.GetScoresPath(inputFile);
             }
+
+            int totalScored = 0;
+            foreach (var kvp in perFileEntries)
+                totalScored += kvp.Value.Count;
+
+            ctx.LogInfo(string.Empty);
+            ctx.LogInfo(string.Format(
+                @"Coelution analysis complete. {0} total scored entries across {1} files",
+                totalScored, nFiles));
+
+            return FinalizeAndCheck(ctx, perFileEntries, perFileCalibrations,
+                perFileParquetPaths, nFiles, totalScored);
+        }
+
+        public override bool Rehydrate(PipelineContext ctx)
+        {
+            // Disk-load path for worker-mode entry (--input-scores): the
+            // per-file Stage 2-4 scores already exist on disk, so load the
+            // FdrEntry stubs + PIN features straight from the parquets
+            // (Stage 1 library still loads -- Stage 5+ needs it) instead of
+            // recomputing them from spectra, then adopt any reconciliation
+            // bundle that the merge node will read. The compute-from-spectra
+            // counterpart is Run.
+            if (_runOrHydrated) return true;
+            _runOrHydrated = true;
+            _ctx = ctx;
+            var config = ctx.Config;
+
+            // Stage 1: library + decoys (needed by Stage 5+ even though the
+            // per-file scores are loaded rather than computed).
+            if (!LoadLibraryAndDecoys(config, out _))
+                return false;
+
+            var perFileEntries = new List<KeyValuePair<string, List<FdrEntry>>>();
+            var perFileCalibrations = new ConcurrentDictionary<string, RTCalibration>();
+            // fileName -> .scores.parquet path; LoadJoinOnlyScores already
+            // knows each input parquet path and fills this in.
+            var perFileParquetPaths = new Dictionary<string, string>();
+
+            int nFiles = config.InputScores.Count;
+
+            // In --input-scores mode without explicit -i, synthesize
+            // InputFiles from the parquet stems so downstream code
+            // (Stage 6 rescore's fileNameToIdx in particular) can map
+            // each file_name back to a real (synthetic) input path.
+            if (config.InputFiles == null || config.InputFiles.Count == 0)
+            {
+                var synthetic = new List<string>(config.InputScores.Count);
+                foreach (var p in config.InputScores)
+                    synthetic.Add(RescoreHydration.SyntheticInputFromParquet(p));
+                config.InputFiles = synthetic;
+            }
+
+            // Mirror Run's EffectiveFileParallelism bookkeeping (unused by the
+            // disk-load path, which never calls ProcessFile, but kept so the
+            // RunPlan reflects the same per-run state either way).
+            int maxParallelFiles = OspreyEnvironment.MaxParallelFiles;
+            if (nFiles == 1 || maxParallelFiles == 1)
+                ctx.RunPlan.EffectiveFileParallelism = 1;
+            else if (maxParallelFiles > 1)
+                ctx.RunPlan.EffectiveFileParallelism = Math.Min(maxParallelFiles, nFiles);
+            else
+                ctx.RunPlan.EffectiveFileParallelism = Math.Min(nFiles, Environment.ProcessorCount);
+
+            var swAllFiles = Stopwatch.StartNew();
+            LoadJoinOnlyScores(config, perFileEntries, perFileParquetPaths, perFileCalibrations);
+            swAllFiles.Stop();
+            ctx.LogInfo(string.Format(@"[TIMING] All files processed: {0:F1}s",
+                swAllFiles.Elapsed.TotalSeconds));
 
             int totalScored = 0;
             foreach (var kvp in perFileEntries)
@@ -389,18 +466,31 @@ namespace pwiz.OspreySharp.Tasks
             // sidecars present yet) skips this block and _rescoreInputs
             // stays null.
             //
-            // Replaces the prior --join-at-pass=2-gated 1st-pass overlay:
-            // the disk state determines the hydration shape, not the CLI
+            // The disk state determines the hydration shape, not the CLI
             // flag (Phase C principle: mechanism-driven, not flag-driven).
-            if (joinOnly)
-            {
-                if (!HydrateRescoreBundleIfPresent(config, perFileEntries))
-                    return false;
-            }
+            if (!HydrateRescoreBundleIfPresent(config, perFileEntries))
+                return false;
 
-            // Surface per-file outputs for downstream tasks before any
-            // early-exit so a partial-success caller still sees the
-            // populated collections.
+            return FinalizeAndCheck(ctx, perFileEntries, perFileCalibrations,
+                perFileParquetPaths, nFiles, totalScored);
+        }
+
+        /// <summary>
+        /// Shared tail for <see cref="Run"/> and <see cref="Rehydrate"/>:
+        /// surface the per-file outputs for downstream tasks (before any
+        /// early-exit, so a partial-success caller still sees the populated
+        /// collections), then apply the two success-but-stop boundaries --
+        /// an empty score set (cannot run FDR) and <c>--no-join</c> (Stage
+        /// 1-4 only). Returns <c>true</c> to continue the pipeline, or
+        /// <c>false</c> with <see cref="PipelineContext.ExitCode"/> = 0 at
+        /// either boundary.
+        /// </summary>
+        private bool FinalizeAndCheck(PipelineContext ctx,
+            List<KeyValuePair<string, List<FdrEntry>>> perFileEntries,
+            ConcurrentDictionary<string, RTCalibration> perFileCalibrations,
+            Dictionary<string, string> perFileParquetPaths,
+            int nFiles, int totalScored)
+        {
             _perFileEntries = perFileEntries;
             _perFileCalibrations = perFileCalibrations;
             _perFileParquetPaths = perFileParquetPaths;
@@ -415,7 +505,7 @@ namespace pwiz.OspreySharp.Tasks
             // --no-join: stop here. Per-file `.scores.parquet` files are
             // now on disk; a separate `--join-only` invocation (typically
             // on a merge node) will pick them up and run Stage 5+.
-            if (config.NoJoin)
+            if (ctx.Config.NoJoin)
             {
                 ctx.LogInfo(string.Format(
                     @"--no-join: Stage 1-4 complete. {0} entries scored across {1} file(s). " +

--- a/pwiz_tools/OspreySharp/OspreySharp/Tasks/PerFileScoringTask.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/Tasks/PerFileScoringTask.cs
@@ -99,7 +99,7 @@ namespace pwiz.OspreySharp.Tasks
 
         public override string Name => @"PerFileScoring";
 
-        // Outputs reached by downstream tasks through ctx.GetTask<PerFileScoringTask>().
+        // Outputs reached by downstream tasks through ctx.Demand<PerFileScoringTask>().
         // Defaults are non-null empty collections so callers querying
         // outputs from a not-yet-run task never NPE on the accessor.
         private List<LibraryEntry> _fullLibrary = new List<LibraryEntry>();
@@ -137,8 +137,8 @@ namespace pwiz.OspreySharp.Tasks
         // IReadOnlyList would cascade through scoring-engine + FDR-project
         // signatures (RunCoelutionScoring, RunFdr, ProteinFdr, ...), out of
         // proportion to the value. Deferred to a future cross-project sweep.
-        public List<LibraryEntry> GetFullLibrary(PipelineContext ctx) { EnsureHydrated(ctx); return _fullLibrary; }
-        public IReadOnlyDictionary<uint, LibraryEntry> GetLibraryById(PipelineContext ctx) { EnsureHydrated(ctx); return _libraryById; }
+        public List<LibraryEntry> GetFullLibrary(PipelineContext ctx) { return _fullLibrary; }
+        public IReadOnlyDictionary<uint, LibraryEntry> GetLibraryById(PipelineContext ctx) { return _libraryById; }
         // GetPerFileEntries is DELIBERATELY a live, mutable, shared buffer --
         // NOT a read-only view, by design. The same
         // List<KeyValuePair<string, List<FdrEntry>>> reference is the
@@ -147,9 +147,9 @@ namespace pwiz.OspreySharp.Tasks
         // place -- all on this one instance. The no-copy cross-task hand-off
         // is load-bearing (copying it is a measured perf regression at
         // Astral scale). Do NOT "fix" this to IReadOnly or to return a copy.
-        public List<KeyValuePair<string, List<FdrEntry>>> GetPerFileEntries(PipelineContext ctx) { EnsureHydrated(ctx); return _perFileEntries; }
-        public IReadOnlyDictionary<string, RTCalibration> GetPerFileCalibrations(PipelineContext ctx) { EnsureHydrated(ctx); return _perFileCalibrations; }
-        public IReadOnlyDictionary<string, string> GetPerFileParquetPaths(PipelineContext ctx) { EnsureHydrated(ctx); return _perFileParquetPaths; }
+        public List<KeyValuePair<string, List<FdrEntry>>> GetPerFileEntries(PipelineContext ctx) { return _perFileEntries; }
+        public IReadOnlyDictionary<string, RTCalibration> GetPerFileCalibrations(PipelineContext ctx) { return _perFileCalibrations; }
+        public IReadOnlyDictionary<string, string> GetPerFileParquetPaths(PipelineContext ctx) { return _perFileParquetPaths; }
 
         /// <summary>
         /// The probe-the-disk reconciliation bundle, or <c>null</c> when
@@ -159,24 +159,7 @@ namespace pwiz.OspreySharp.Tasks
         /// this bundle so the worker hydration path and the in-pipeline
         /// path produce identical post-Stage-5 state.
         /// </summary>
-        public RescoreInputs GetRescoreInputs(PipelineContext ctx) { EnsureHydrated(ctx); return _rescoreInputs; }
-
-        /// <summary>
-        /// Lazy-rehydrate seam: when a downstream task queries one of this
-        /// task's outputs and neither <see cref="Run"/> nor <see cref="Rehydrate"/>
-        /// has executed (i.e. this task is before
-        /// <see cref="PipelineContext.StartAtTask"/>), materialize its state
-        /// now. <see cref="RunOrHydrate"/> picks the compute path
-        /// (<see cref="Run"/>) or the disk-load path (<see cref="Rehydrate"/>)
-        /// from the same <c>--input-scores</c> signal the straight-through run
-        /// would, so the populated state is identical either way. Idempotent;
-        /// subsequent calls are no-ops.
-        /// </summary>
-        private void EnsureHydrated(PipelineContext ctx)
-        {
-            if (_runOrHydrated) return;
-            RunOrHydrate(ctx);
-        }
+        public RescoreInputs GetRescoreInputs(PipelineContext ctx) { return _rescoreInputs; }
 
         // Phase B resume surface: the library and every input mzML are
         // read; per-file .scores.parquet + .calibration.json are written.
@@ -202,37 +185,14 @@ namespace pwiz.OspreySharp.Tasks
             }
         }
 
-        /// <summary>
-        /// Dispatch the first materialization of this task to the compute
-        /// path (<see cref="Run"/>) or the disk-load path
-        /// (<see cref="Rehydrate"/>) based on the same <c>--input-scores</c>
-        /// signal a straight-through invocation reads. The driver loop calls
-        /// <see cref="Run"/> directly (it only reaches this task in the
-        /// non-<c>--input-scores</c> modes where compute is correct); the
-        /// accessor/<see cref="EnsureHydrated"/> path comes through here so a
-        /// worker-mode consumer triggers <see cref="Rehydrate"/> instead.
-        /// Transitional: removed with the driver-loop flip in Phase B5.
-        /// </summary>
-        private void RunOrHydrate(PipelineContext ctx)
-        {
-            bool joinOnly = ctx.Config.InputScores != null && ctx.Config.InputScores.Count > 0;
-            // The success/stop bool is meaningful only to the driver loop,
-            // which calls Run directly; the accessor hydration that comes
-            // through here just needs the producer's state populated.
-            if (joinOnly)
-                Rehydrate(ctx);
-            else
-                Run(ctx);
-        }
-
         public override bool Run(PipelineContext ctx)
         {
             // Compute path (Stages 1-4): load the library and score every
             // input mzML from spectra. The worker-mode disk-load counterpart
-            // (--input-scores) lives in Rehydrate; until the Phase B5 driver
-            // flip every entry funnels through RunOrHydrate, so this task is
-            // only ever reached here in the non---input-scores modes where
-            // computing from spectra is the right thing.
+            // (--input-scores) lives in Rehydrate; the driver reaches this task
+            // here only in the non---input-scores modes (where computing from
+            // spectra is right), and a worker-mode consumer materializes it via
+            // ctx.Demand, which routes to Rehydrate.
             //
             // Idempotent re-entry guard: a lazy-rehydrate via an accessor may
             // have already executed this task body; the driver loop's call

--- a/pwiz_tools/OspreySharp/OspreySharp/Tasks/PerFileScoringTask.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/Tasks/PerFileScoringTask.cs
@@ -363,6 +363,21 @@ namespace pwiz.OspreySharp.Tasks
 
         public override bool Rehydrate(PipelineContext ctx)
         {
+            if (_runOrHydrated) return true;
+
+            // Without --input-scores there are no worker-supplied per-file
+            // scores to load. A Demand still reaches this task here on a
+            // straight-through resume: the driver skipped its Run because its
+            // own .scores.parquet outputs were already valid on disk
+            // (CanRehydrate), and a downstream task is the first to touch its
+            // state. The right re-materialization there is the compute path,
+            // whose per-file ScoreOrLoadForFile loads those valid parquets
+            // (rather than re-scoring) -- so defer to Run. The worker-mode
+            // join-only disk-load below applies only when --input-scores
+            // actually supplied the per-file scores.
+            if (ctx.Config.InputScores == null || ctx.Config.InputScores.Count == 0)
+                return Run(ctx);
+
             // Disk-load path for worker-mode entry (--input-scores): the
             // per-file Stage 2-4 scores already exist on disk, so load the
             // FdrEntry stubs + PIN features straight from the parquets
@@ -370,7 +385,6 @@ namespace pwiz.OspreySharp.Tasks
             // recomputing them from spectra, then adopt any reconciliation
             // bundle that the merge node will read. The compute-from-spectra
             // counterpart is Run.
-            if (_runOrHydrated) return true;
             _runOrHydrated = true;
             _ctx = ctx;
             var config = ctx.Config;

--- a/pwiz_tools/OspreySharp/OspreySharp/Tasks/PerFileScoringTask.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/Tasks/PerFileScoringTask.cs
@@ -99,6 +99,18 @@ namespace pwiz.OspreySharp.Tasks
 
         public override string Name => @"PerFileScoring";
 
+        /// <summary>
+        /// Computes per-file scores from spectra only when no per-file scores
+        /// were supplied via --input-scores. Under --input-scores it is
+        /// excluded: a downstream task lazy-rehydrates the supplied scores
+        /// through <c>ctx.Demand&lt;PerFileScoringTask&gt;()</c>.
+        /// </summary>
+        public override bool IsIncluded(PipelineContext ctx)
+        {
+            bool inputs = ctx.Config.InputScores != null && ctx.Config.InputScores.Count > 0;
+            return !inputs;
+        }
+
         // Outputs reached by downstream tasks through ctx.Demand<PerFileScoringTask>().
         // Defaults are non-null empty collections so callers querying
         // outputs from a not-yet-run task never NPE on the accessor.
@@ -376,17 +388,10 @@ namespace pwiz.OspreySharp.Tasks
 
             int nFiles = config.InputScores.Count;
 
-            // In --input-scores mode without explicit -i, synthesize
-            // InputFiles from the parquet stems so downstream code
-            // (Stage 6 rescore's fileNameToIdx in particular) can map
-            // each file_name back to a real (synthetic) input path.
-            if (config.InputFiles == null || config.InputFiles.Count == 0)
-            {
-                var synthetic = new List<string>(config.InputScores.Count);
-                foreach (var p in config.InputScores)
-                    synthetic.Add(RescoreHydration.SyntheticInputFromParquet(p));
-                config.InputFiles = synthetic;
-            }
+            // InputFiles is synthesized from the --input-scores parquet stems
+            // once at pipeline entry (AnalysisPipeline.Run), so downstream code
+            // (Stage 6 rescore's fileNameToIdx in particular) already has the
+            // synthetic input paths by the time this load runs.
 
             // Mirror Run's EffectiveFileParallelism bookkeeping (unused by the
             // disk-load path, which never calls ProcessFile, but kept so the


### PR DESCRIPTION
The headline change of the declarative-dataflow program (PR-B, after PR-A1 #4264). Replaces the implicit, side-effecting inter-task dataflow with an explicit, driver-owned, lazy-rehydrate one. Behavior-preserving: every sub-step verified byte-identical to master.

* **Per-task `Run` / `Rehydrate` split.** Each task's `Run` is now compute-only; a new `Rehydrate(ctx)` is the disk-load counterpart (PerFileScoring join-only load; FirstJoin bundle-adopt; PerFileRescore `--join-at-pass=2` compaction; MergeNode no-op). `OspreyTask.Rehydrate` is abstract.
* **`ctx.Demand<T>()` replaces `ctx.GetTask<T>()`.** Consumers demand a producer; the context materializes it on first touch (its `Rehydrate`, guarded one-shot) and producer getters become pure field reads. The 15 cross-task service-locator sites are gone; `GetTask` is now a private lookup backing `Demand`.
* **`OspreyTask.IsIncluded(ctx)` is the driver-owned membership predicate.** The driver walks `CanonicalPipeline().Where(t => t.IsIncluded(ctx))` and runs each whose outputs aren't already valid (`ctx.CanRehydrate`). The 5-branch `DeriveStartAt/StopAfterTask` range loop (+ `StartAt/StopAfter` context state and the 2nd ctor) is deleted; FirstJoin's `--join-only` success now `return true` (the stop is a membership fact).
* A new oracle test pins `IsIncluded` against an explicit per-mode truth table (it caught two bugs in the original design pseudocode during development).
* **Fresh-context self-review (pre-PR) fix:** straight-through *resume* (skip-then-`Demand` a producer) NPE'd on null `InputScores`; each `Rehydrate` now defers to `Run` off its worker-mode path (byte-for-byte the old `EnsureHydrated→Run`). Reproduced on the pre-fix build; byte-neutral for tested modes. A separate **pre-existing** resume bug it surfaced (1st-pass RTs via `ExecuteRescore`'s per-file skip, present on master) is filed in the backlog, not addressed here.
* Net deletion (~400 lines): `Run` reads top-to-bottom, the service locator and range ladder are gone. Follow-on PR-C (retire `_runOrHydrated` guard via mark-materialized; `PeakScoringContext`-style typed byproduct context) is scoped in the TODO.

## Test plan

- [x] `Build-OspreySharp.ps1 -RunTests -RunInspection` — 353 tests pass (incl. the new `IsIncluded` membership oracle), ReSharper inspection clean (0 warnings)
- [x] Worker-mode strict-rehydration gate (in-memory vs HPC chain, SHA byte-equality at every stage boundary) — OVERALL PASS on **Stellar AND Astral** 3-file (net8.0); Stage-5 hashes unchanged from master at every B-step
- [x] `Compare-EndToEnd-Crossimpl.ps1 -Files All -SkipRust` (Stellar 3-file) — OVERALL PASS, cross-impl bit-parity at 1e-9 (precursors 59768)
- [x] Mode-6 (`--join-at-pass=1 --input-scores` single-node full pipeline, regressed earlier in-branch then fixed by `IsIncluded`) — blib byte-size-identical to straight-through
- [x] Straight-through resume — NPE reproduced on pre-fix build, completes after the fix

See ai/todos/active/TODO-20260601_ospreysharp_declarative_pipeline_dataflow.md

Co-Authored-By: Claude <noreply@anthropic.com>