### PR TITLE
Replaced OspreySharp's producer-getter dataflow with a typed byproduct cache (PR-C)

### DIFF
--- a/pwiz_tools/OspreySharp/OspreySharp.Tasks/OspreyTask.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Tasks/OspreyTask.cs
@@ -111,6 +111,22 @@ namespace pwiz.OspreySharp.Tasks
         public virtual bool IsIncluded(PipelineContext ctx) => true;
 
         /// <summary>
+        /// The byproduct purpose types this task publishes for downstream tasks
+        /// to consume by type through <see cref="PipelineContext.Get{TInfo}"/>.
+        /// The pipeline context inverts these at construction into the
+        /// byproduct -> producer registry, so a consumer's cache miss can
+        /// lazily materialize this task. Each declared type must be published
+        /// (via <see cref="PipelineContext.Publish{TInfo}"/>) on every path this
+        /// task can run -- both <see cref="Run"/> and <see cref="Rehydrate"/> --
+        /// so a consumer sees the same value regardless of how the producer was
+        /// materialized. Default empty: a task that produces no by-type
+        /// consumable state (a terminal aggregator, or one whose only shared
+        /// output is an in-place-mutated buffer demanded directly) overrides
+        /// nothing.
+        /// </summary>
+        public virtual IEnumerable<Type> Publishes => Array.Empty<Type>();
+
+        /// <summary>
         /// File paths this task reads as inputs. Reported in the
         /// <c>.osprey.task</c> sidecar so a human inspecting a
         /// completed-output sidecar can see what the task consumed.

--- a/pwiz_tools/OspreySharp/OspreySharp.Tasks/PipelineContext.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Tasks/PipelineContext.cs
@@ -53,11 +53,13 @@ namespace pwiz.OspreySharp.Tasks
         private readonly Dictionary<Type, OspreyTask> _tasksByType;
 
         /// <summary>
-        /// Producer types whose <see cref="OspreyTask.Rehydrate"/> has already
-        /// been driven by a <see cref="Demand{T}"/> first-touch this run.
-        /// Reproduces the one-shot semantics of each task's former
-        /// <c>_runOrHydrated</c> guard: a producer is materialized at most
-        /// once, no matter how many consumers demand it.
+        /// Task types whose state is already in memory this run -- either the
+        /// driver ran them (it calls <see cref="MarkMaterialized"/> after
+        /// <see cref="OspreyTask.Run"/>) or a <see cref="Demand{T}"/> /
+        /// <see cref="Get{TInfo}"/> first-touch drove their
+        /// <see cref="OspreyTask.Rehydrate"/>. A task is materialized at most
+        /// once, no matter how many consumers reach it; this single guard
+        /// replaces the per-task <c>_runOrHydrated</c> field.
         /// </summary>
         private readonly HashSet<Type> _materialized = new HashSet<Type>();
 
@@ -198,6 +200,22 @@ namespace pwiz.OspreySharp.Tasks
             if (materialize && _materialized.Add(taskType))
                 task.Rehydrate(this);
             return task;
+        }
+
+        /// <summary>
+        /// Record that the driver has run <paramref name="task"/>, so a later
+        /// <see cref="Demand{T}"/> / <see cref="Get{TInfo}"/> for it returns the
+        /// already-computed state instead of driving <see cref="OspreyTask.Rehydrate"/>.
+        /// Called by <c>AnalysisPipeline.RunTask</c> after each
+        /// <see cref="OspreyTask.Run"/>. This is what lets tasks drop their former
+        /// per-instance <c>_runOrHydrated</c> guard: the context's
+        /// <see cref="_materialized"/> set now coordinates the driver-Run path and
+        /// the lazy-Rehydrate path with a single source of truth.
+        /// </summary>
+        public void MarkMaterialized(OspreyTask task)
+        {
+            if (task == null) throw new ArgumentNullException(nameof(task));
+            _materialized.Add(task.GetType());
         }
 
         /// <summary>

--- a/pwiz_tools/OspreySharp/OspreySharp.Tasks/PipelineContext.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Tasks/PipelineContext.cs
@@ -84,11 +84,14 @@ namespace pwiz.OspreySharp.Tasks
         /// <see cref="OspreyTask.Publishes"/>. This is the single registration
         /// point that lets <see cref="Get{TInfo}"/> lazily materialize a skipped
         /// producer on a cache miss, replacing the former pattern of every
-        /// consumer naming the producer task at its call site. A byproduct that
-        /// is a shared mutable buffer (in-place mutated by several tasks rather
-        /// than published once and read) is deliberately NOT registered here: its
-        /// materialization is a task-ordering dependency the consumer expresses
-        /// by demanding the correct mutator directly, not a value-presence miss.
+        /// consumer naming the producer task at its call site. Every registered
+        /// byproduct has exactly one producer (the constructor throws on a
+        /// duplicate). The one shared mutable buffer is registered like the rest:
+        /// it is modeled as three single-producer milestone types over the same
+        /// backing list (ScoredEntries -> PerFileScoring, CompactedEntries ->
+        /// FirstJoin, RescoredEntries -> PerFileRescore), so a consumer demanding
+        /// a given milestone resolves through this registry to the task that
+        /// brings the buffer to that state. See PipelineByproducts.cs.
         /// </summary>
         private readonly Dictionary<Type, Type> _producerByByproduct = new Dictionary<Type, Type>();
 

--- a/pwiz_tools/OspreySharp/OspreySharp.Tasks/PipelineContext.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Tasks/PipelineContext.cs
@@ -62,6 +62,35 @@ namespace pwiz.OspreySharp.Tasks
         private readonly HashSet<Type> _materialized = new HashSet<Type>();
 
         /// <summary>
+        /// Typed byproduct cache: state that one task computes and one or more
+        /// downstream tasks read, keyed by the byproduct's purpose type. Modeled
+        /// directly on Skyline's
+        /// <c>pwiz_tools/Skyline/Model/Results/Scoring/IPeakScoringModel.cs</c>
+        /// <c>PeakScoringContext</c> (its <c>AddInfo&lt;TInfo&gt;</c> /
+        /// <c>TryGetInfo&lt;TInfo&gt;</c> pair): a producer publishes a value once
+        /// and consumers retrieve it by type without naming the producer. Publish
+        /// is once-only (a second publish of the same type is a programming
+        /// defect). A consumer reaching for a byproduct whose producer has not yet
+        /// run materializes it lazily through <see cref="Get{TInfo}"/>, which
+        /// demands the registered producer (see <see cref="_producerByByproduct"/>).
+        /// </summary>
+        private readonly Dictionary<Type, object> _byproducts = new Dictionary<Type, object>();
+
+        /// <summary>
+        /// Maps each byproduct purpose type to the concrete task that publishes
+        /// it, built once at construction from each task's
+        /// <see cref="OspreyTask.Publishes"/>. This is the single registration
+        /// point that lets <see cref="Get{TInfo}"/> lazily materialize a skipped
+        /// producer on a cache miss, replacing the former pattern of every
+        /// consumer naming the producer task at its call site. A byproduct that
+        /// is a shared mutable buffer (in-place mutated by several tasks rather
+        /// than published once and read) is deliberately NOT registered here: its
+        /// materialization is a task-ordering dependency the consumer expresses
+        /// by demanding the correct mutator directly, not a value-presence miss.
+        /// </summary>
+        private readonly Dictionary<Type, Type> _producerByByproduct = new Dictionary<Type, Type>();
+
+        /// <summary>
         /// The configuration parsed from CLI args and the input library.
         ///
         /// Mutation contract: fields that feed
@@ -128,6 +157,23 @@ namespace pwiz.OspreySharp.Tasks
                     throw new ArgumentException(@"Pipeline task list contains a null entry.", nameof(tasks));
                 _tasksByType.Add(task.GetType(), task);
             }
+
+            // Invert each producer's declared byproducts into the
+            // byproduct -> producer registry that Get{TInfo} resolves a cache
+            // miss through. A byproduct with two producers is a definition
+            // defect (the registry could not pick which task to materialize),
+            // so fail fast at construction rather than silently lose one.
+            foreach (var task in list)
+            {
+                foreach (var byproductType in task.Publishes)
+                {
+                    if (_producerByByproduct.ContainsKey(byproductType))
+                        throw new ArgumentException(string.Format(
+                            @"Byproduct type '{0}' is published by more than one task; each registered byproduct must have a single producer.",
+                            byproductType.FullName), nameof(tasks));
+                    _producerByByproduct.Add(byproductType, task.GetType());
+                }
+            }
             Tasks = list;
         }
 
@@ -146,9 +192,26 @@ namespace pwiz.OspreySharp.Tasks
         /// </summary>
         private T GetTask<T>() where T : OspreyTask
         {
-            if (_tasksByType.TryGetValue(typeof(T), out var task))
-                return (T)task;
-            throw new UnknownTaskException(typeof(T));
+            return (T)DemandByType(typeof(T), materialize: false);
+        }
+
+        /// <summary>
+        /// Resolve a registered task by its runtime <see cref="Type"/>, optionally
+        /// materializing it. Shared core behind the generic <see cref="Demand{T}"/>
+        /// and the registry-driven lazy materialization in
+        /// <see cref="Get{TInfo}"/> (which knows the producer only as a
+        /// <see cref="Type"/> from <see cref="_producerByByproduct"/>, so it cannot
+        /// use the generic overload). When <paramref name="materialize"/> is true,
+        /// the producer's <see cref="OspreyTask.Rehydrate"/> is driven at most once
+        /// via the <see cref="_materialized"/> one-shot guard.
+        /// </summary>
+        private OspreyTask DemandByType(Type taskType, bool materialize)
+        {
+            if (!_tasksByType.TryGetValue(taskType, out var task))
+                throw new UnknownTaskException(taskType);
+            if (materialize && _materialized.Add(taskType))
+                task.Rehydrate(this);
+            return task;
         }
 
         /// <summary>
@@ -171,10 +234,66 @@ namespace pwiz.OspreySharp.Tasks
         /// </summary>
         public T Demand<T>() where T : OspreyTask
         {
-            var task = GetTask<T>();
-            if (_materialized.Add(typeof(T)))
-                task.Rehydrate(this);
-            return task;
+            return (T)DemandByType(typeof(T), materialize: true);
+        }
+
+        /// <summary>
+        /// Publish a byproduct value for downstream tasks, keyed by its purpose
+        /// type <typeparamref name="TInfo"/>. Once-only: publishing the same type
+        /// twice in a run is a programming defect (two producers, or a producer
+        /// running twice) and throws. The <c>AddInfo&lt;TInfo&gt;</c> counterpart
+        /// of Skyline's <c>PeakScoringContext</c>.
+        /// </summary>
+        public void Publish<TInfo>(TInfo info)
+        {
+            _byproducts.Add(typeof(TInfo), info);
+        }
+
+        /// <summary>
+        /// Read a byproduct value if it has been published, without triggering
+        /// any producer. Pure cache lookup -- the <c>TryGetInfo&lt;TInfo&gt;</c>
+        /// counterpart of Skyline's <c>PeakScoringContext</c>. Use
+        /// <see cref="Get{TInfo}"/> when a miss should lazily materialize the
+        /// registered producer instead of returning <c>false</c>.
+        /// </summary>
+        public bool TryGet<TInfo>(out TInfo info)
+        {
+            if (_byproducts.TryGetValue(typeof(TInfo), out var obj))
+            {
+                info = (TInfo)obj;
+                return true;
+            }
+            info = default;
+            return false;
+        }
+
+        /// <summary>
+        /// Retrieve a published byproduct, lazily materializing its producer on a
+        /// miss. If <typeparamref name="TInfo"/> is not yet in the cache, the
+        /// registered producer (<see cref="_producerByByproduct"/>) is demanded --
+        /// its <see cref="OspreyTask.Rehydrate"/> runs and publishes the value --
+        /// and the cache is read again. This is the public dataflow surface that
+        /// replaces consumers reaching through a named producer task's getter:
+        /// the consumer asks the context for the value by type and the context
+        /// owns when (and by which task) it comes into being.
+        ///
+        /// Throws <see cref="UnknownByproductException"/> if the type has no
+        /// registered producer, or if the producer ran but did not publish it --
+        /// both programming defects (a missing <see cref="OspreyTask.Publishes"/>
+        /// registration, or a producer path that forgot to publish), surfaced
+        /// loudly rather than returning a silent default.
+        /// </summary>
+        public TInfo Get<TInfo>()
+        {
+            if (TryGet(out TInfo info))
+                return info;
+            if (_producerByByproduct.TryGetValue(typeof(TInfo), out var producerType))
+            {
+                DemandByType(producerType, materialize: true);
+                if (TryGet(out info))
+                    return info;
+            }
+            throw new UnknownByproductException(typeof(TInfo));
         }
 
         /// <summary>
@@ -206,11 +325,12 @@ namespace pwiz.OspreySharp.Tasks
     }
 
     /// <summary>
-    /// Thrown by <see cref="PipelineContext.GetTask{T}"/> when a task
-    /// asks for an upstream producer that was not added to the pipeline
-    /// at construction time. This is always a programming defect (the
-    /// pipeline definition is missing the producer); fail fast and hard
-    /// so it surfaces in testing rather than at runtime.
+    /// Thrown by <see cref="PipelineContext.Demand{T}"/> (and the
+    /// registry-driven materialization in <see cref="PipelineContext.Get{TInfo}"/>)
+    /// when a task asks for an upstream producer that was not added to the
+    /// pipeline at construction time. This is always a programming defect (the
+    /// pipeline definition is missing the producer); fail fast and hard so it
+    /// surfaces in testing rather than at runtime.
     /// </summary>
     public sealed class UnknownTaskException : Exception
     {
@@ -218,6 +338,26 @@ namespace pwiz.OspreySharp.Tasks
 
         public UnknownTaskException(Type requestedType)
             : base(string.Format(@"Task type '{0}' is not registered in the current pipeline.",
+                requestedType?.FullName))
+        {
+            RequestedType = requestedType;
+        }
+    }
+
+    /// <summary>
+    /// Thrown by <see cref="PipelineContext.Get{TInfo}"/> when a byproduct type
+    /// has no registered producer, or when its producer ran but did not publish
+    /// the value. Both are programming defects -- a missing
+    /// <see cref="OspreyTask.Publishes"/> registration, or a producer code path
+    /// that neglected to <see cref="PipelineContext.Publish{TInfo}"/> -- and are
+    /// surfaced loudly rather than degrading to a silent default value.
+    /// </summary>
+    public sealed class UnknownByproductException : Exception
+    {
+        public Type RequestedType { get; }
+
+        public UnknownByproductException(Type requestedType)
+            : base(string.Format(@"Byproduct type '{0}' has no registered producer, or its producer did not publish it.",
                 requestedType?.FullName))
         {
             RequestedType = requestedType;

--- a/pwiz_tools/OspreySharp/OspreySharp.Tasks/PipelineContext.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Tasks/PipelineContext.cs
@@ -33,13 +33,13 @@ namespace pwiz.OspreySharp.Tasks
     ///
     /// Carries the <see cref="OspreyConfig"/>, logging callbacks, and
     /// the registry of <see cref="OspreyTask"/> instances participating
-    /// in the current pipeline. Downstream tasks query upstream tasks
-    /// through <see cref="GetTask{T}"/> and read their typed accessor
-    /// methods rather than receiving constructor parameters. Each
-    /// producer task owns the state it computes; consumers reach it
-    /// through the producer, which lets producers transparently
-    /// rehydrate their outputs from sibling artifacts (e.g. the worker
-    /// entry path) when their <see cref="OspreyTask.Run"/> never ran.
+    /// in the current pipeline. Downstream tasks read upstream state as
+    /// typed byproducts through <see cref="Get{TInfo}"/> rather than
+    /// receiving constructor parameters; a <see cref="Get{TInfo}"/> miss
+    /// lazily materializes the producing task (via <see cref="Demand{T}"/>),
+    /// which lets producers transparently rehydrate their outputs from
+    /// sibling artifacts (e.g. the worker entry path) when their
+    /// <see cref="OspreyTask.Run"/> never ran.
     ///
     /// The context is constructed once at the top of
     /// <c>AnalysisPipeline.Run</c> (or <c>RescoreWorker.Run</c>) and
@@ -180,20 +180,6 @@ namespace pwiz.OspreySharp.Tasks
         public void LogInfo(string message) { _logInfo(message); }
         public void LogWarning(string message) { _logWarning(message); }
         public void LogError(string message) { _logError(message); }
-
-        /// <summary>
-        /// Look up a registered task by its concrete type. Internal lookup
-        /// backing <see cref="Demand{T}"/>; consumers reach producers through
-        /// <see cref="Demand{T}"/> (which materializes on first touch), not
-        /// this raw accessor. Throws <see cref="UnknownTaskException"/> if the
-        /// requested type is not in the pipeline; treat that as a
-        /// programming defect at pipeline-construction time rather than a
-        /// runtime condition to handle.
-        /// </summary>
-        private T GetTask<T>() where T : OspreyTask
-        {
-            return (T)DemandByType(typeof(T), materialize: false);
-        }
 
         /// <summary>
         /// Resolve a registered task by its runtime <see cref="Type"/>, optionally

--- a/pwiz_tools/OspreySharp/OspreySharp.Tasks/PipelineContext.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Tasks/PipelineContext.cs
@@ -198,7 +198,20 @@ namespace pwiz.OspreySharp.Tasks
             if (!_tasksByType.TryGetValue(taskType, out var task))
                 throw new UnknownTaskException(taskType);
             if (materialize && _materialized.Add(taskType))
-                task.Rehydrate(this);
+            {
+                // Lazily drive the producer. Unlike the driver loop -- which
+                // inspects Run's bool and stops the pipeline on false -- a
+                // consumer's lazy Demand/Get has no return channel, so a failed
+                // Rehydrate would otherwise be swallowed and the consumer would
+                // proceed with default (empty) state. Surface a genuine failure
+                // (one that set a non-zero ExitCode -- e.g. a library load or
+                // empty-scores error) as a throw so the run fails loudly. A
+                // success-stop that returns false with ExitCode == 0 (e.g. the
+                // --no-join boundary, whose byproducts were already published
+                // before the stop) is intentionally left benign.
+                if (!task.Rehydrate(this) && ExitCode != 0)
+                    throw new RehydrateFailedException(taskType, ExitCode);
+            }
             return task;
         }
 
@@ -365,6 +378,30 @@ namespace pwiz.OspreySharp.Tasks
                 requestedType?.FullName))
         {
             RequestedType = requestedType;
+        }
+    }
+
+    /// <summary>
+    /// Thrown by <see cref="PipelineContext.Get{TInfo}"/> /
+    /// <see cref="PipelineContext.Demand{T}"/> when a lazily-driven
+    /// <see cref="OspreyTask.Rehydrate"/> reports failure (returns <c>false</c>)
+    /// and has set a non-zero <see cref="PipelineContext.ExitCode"/>. The driver
+    /// loop stops the pipeline on a false Run return, but a consumer's lazy
+    /// materialization has no such return channel, so this surfaces the failure
+    /// rather than letting the consumer proceed with default state. Carries the
+    /// task type and the exit code the failing task requested.
+    /// </summary>
+    public sealed class RehydrateFailedException : Exception
+    {
+        public Type TaskType { get; }
+        public int ExitCode { get; }
+
+        public RehydrateFailedException(Type taskType, int exitCode)
+            : base(string.Format(@"Task '{0}' failed to rehydrate its state (exit code {1}).",
+                taskType?.FullName, exitCode))
+        {
+            TaskType = taskType;
+            ExitCode = exitCode;
         }
     }
 }

--- a/pwiz_tools/OspreySharp/OspreySharp.Test/ByproductContextTest.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Test/ByproductContextTest.cs
@@ -1,0 +1,134 @@
+/*
+ * Original author: Brendan MacLean <brendanx .at. uw.edu>,
+ *                  MacCoss Lab, Department of Genome Sciences, UW
+ * AI assistance: Claude Code (Claude Opus 4.8) <noreply .at. anthropic.com>
+ *
+ * Based on osprey (https://github.com/MacCossLab/osprey)
+ *   by Michael J. MacCoss, MacCoss Lab, Department of Genome Sciences, UW
+ *
+ * Copyright 2026 University of Washington - Seattle, WA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
+using System.Collections.Generic;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using pwiz.OspreySharp.Core;
+using pwiz.OspreySharp.Tasks;
+
+namespace pwiz.OspreySharp.Test
+{
+    /// <summary>
+    /// Pins <see cref="PipelineContext"/>'s byproduct cache + registry-driven
+    /// lazy materialization. Focuses on the failure-surfacing contract: a
+    /// consumer's <see cref="PipelineContext.Get{TInfo}"/> drives the registered
+    /// producer's <see cref="OspreyTask.Rehydrate"/>, and -- unlike the driver
+    /// loop, which inspects Run's bool -- must not silently swallow a failed
+    /// rehydrate. The discriminator is the requested exit code: a genuine
+    /// failure (ExitCode != 0) throws; a success-but-stop (ExitCode == 0, whose
+    /// byproducts were published before the stop) is benign.
+    /// </summary>
+    [TestClass]
+    public class ByproductContextTest
+    {
+        private sealed class StubByproduct
+        {
+            public int Value { get; set; }
+        }
+
+        /// <summary>
+        /// Stub producer whose Rehydrate stops the pipeline (returns false). It
+        /// optionally publishes its byproduct first and sets a configurable exit
+        /// code, so a test can drive either the failure or the benign-stop path.
+        /// </summary>
+        private sealed class StubProducerTask : OspreyTask
+        {
+            private readonly bool _publishBeforeStop;
+            private readonly int _exitCode;
+
+            public StubProducerTask(bool publishBeforeStop, int exitCode)
+            {
+                _publishBeforeStop = publishBeforeStop;
+                _exitCode = exitCode;
+            }
+
+            public override string Name => @"StubProducer";
+            public override IEnumerable<Type> Publishes => new[] { typeof(StubByproduct) };
+            public override bool Run(PipelineContext ctx) => true;
+
+            public override bool Rehydrate(PipelineContext ctx)
+            {
+                if (_publishBeforeStop)
+                    ctx.Publish(new StubByproduct { Value = 42 });
+                ctx.ExitCode = _exitCode;
+                return false;
+            }
+        }
+
+        private static PipelineContext ContextFor(OspreyTask task)
+        {
+            return new PipelineContext(new OspreyConfig(), new[] { task }, null, null, null);
+        }
+
+        [TestMethod]
+        public void TestGetThrowsWhenRehydrateFailsWithExitCode()
+        {
+            // Rehydrate fails (returns false) and requests a non-zero exit code,
+            // never publishing the byproduct: Get must surface the failure rather
+            // than fall through to a default value.
+            var ctx = ContextFor(new StubProducerTask(publishBeforeStop: false, exitCode: 7));
+            try
+            {
+                ctx.Get<StubByproduct>();
+                Assert.Fail(@"Expected RehydrateFailedException");
+            }
+            catch (RehydrateFailedException ex)
+            {
+                Assert.AreEqual(typeof(StubProducerTask), ex.TaskType);
+                Assert.AreEqual(7, ex.ExitCode);
+            }
+        }
+
+        [TestMethod]
+        public void TestGetSucceedsWhenRehydrateStopsWithExitCodeZero()
+        {
+            // Rehydrate returns false but keeps ExitCode == 0 (a success-but-stop,
+            // e.g. the --no-join boundary) AFTER publishing its byproduct: Get
+            // must return the published value without throwing.
+            var ctx = ContextFor(new StubProducerTask(publishBeforeStop: true, exitCode: 0));
+            var info = ctx.Get<StubByproduct>();
+            Assert.IsNotNull(info);
+            Assert.AreEqual(42, info.Value);
+        }
+
+        [TestMethod]
+        public void TestPublishOnceThenTryGetReads()
+        {
+            var ctx = ContextFor(new StubProducerTask(publishBeforeStop: false, exitCode: 0));
+            ctx.Publish(new StubByproduct { Value = 5 });
+            Assert.IsTrue(ctx.TryGet<StubByproduct>(out var info));
+            Assert.AreEqual(5, info.Value);
+            // Publishing the same type twice is a programming defect.
+            try
+            {
+                ctx.Publish(new StubByproduct { Value = 6 });
+                Assert.Fail(@"Expected publish-once violation to throw");
+            }
+            catch (ArgumentException)
+            {
+                // expected: Dictionary.Add rejects the duplicate key
+            }
+        }
+    }
+}

--- a/pwiz_tools/OspreySharp/OspreySharp/AnalysisPipeline.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/AnalysisPipeline.cs
@@ -169,6 +169,11 @@ namespace pwiz.OspreySharp
             var sw = Stopwatch.StartNew();
             ctx.LogInfo(string.Format(@"[task] {0}: starting", task.Name));
             bool keepGoing = task.Run(ctx);
+            // The driver has now run this task, so its state is in memory: mark it
+            // materialized so a later Demand/Get by a downstream task returns the
+            // computed state instead of driving Rehydrate. Replaces the per-task
+            // _runOrHydrated guard that formerly bridged the Run and Rehydrate paths.
+            ctx.MarkMaterialized(task);
             sw.Stop();
             ctx.LogInfo(string.Format(@"[task] {0}: done ({1:F1}s)",
                 task.Name, sw.Elapsed.TotalSeconds));

--- a/pwiz_tools/OspreySharp/OspreySharp/Tasks/FirstJoinTask.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/Tasks/FirstJoinTask.cs
@@ -97,12 +97,13 @@ namespace pwiz.OspreySharp.Tasks
             typeof(CompactedEntries)
         };
 
-        // Outputs reached by downstream tasks through ctx.Demand<FirstJoinTask>().
-        // DidPlan is the gate downstream consumers (PerFileRescoreTask)
-        // check to decide whether the Stage 6 planning state below is
-        // meaningful or whether planning was skipped. Defaults are
-        // non-null empty collections so an accessor on a not-yet-run
-        // (or no-op) task never NPEs.
+        // Stage 6 planning state. Set by PlanStage6 (Run) and published into the
+        // typed byproduct slots that downstream consumers pull via ctx.Get<T>();
+        // the bundle-adopt Rehydrate path publishes the same slots from the
+        // worker bundle instead. DidPlan remains the gate PerFileRescore's
+        // self-gate checks to tell "planning ran" from "planning was skipped."
+        // Defaults are non-null empty collections so a published slot from a
+        // no-op / stopped-after-Stage-5 run is never null.
         private bool _didPlan;
         private IReadOnlyDictionary<string, IReadOnlyList<(int Index, double Apex, double Start, double End)>> _perFileConsensusTargets
             = new Dictionary<string, IReadOnlyList<(int, double, double, double)>>();
@@ -119,33 +120,6 @@ namespace pwiz.OspreySharp.Tasks
 
         public bool DidPlan(PipelineContext ctx) { return _didPlan; }
 
-        public IReadOnlyDictionary<string, IReadOnlyList<(int Index, double Apex, double Start, double End)>> GetPerFileConsensusTargets(PipelineContext ctx)
-        {
-            if (_didPlan) return _perFileConsensusTargets;
-            return ConsensusTargetsFromBundleOrEmpty(ctx);
-        }
-
-        public IReadOnlyDictionary<(string FileName, int Index), ReconcileAction> GetReconciliationActions(PipelineContext ctx)
-        {
-            if (_didPlan) return _reconciliationActions;
-            var bundle = ctx.Demand<PerFileScoringTask>().GetRescoreInputs(ctx);
-            return bundle != null ? bundle.ReconciliationActions : _reconciliationActions;
-        }
-
-        public IReadOnlyDictionary<string, RTCalibration> GetRefinedCalibrations(PipelineContext ctx)
-        {
-            if (_didPlan) return _refinedCalibrations;
-            var bundle = ctx.Demand<PerFileScoringTask>().GetRescoreInputs(ctx);
-            return bundle != null ? bundle.RefinedCalibrations : _refinedCalibrations;
-        }
-
-        public IReadOnlyDictionary<string, List<GapFillTarget>> GetPerFileGapFillForRescore(PipelineContext ctx)
-        {
-            if (_didPlan) return _perFileGapFillForRescore;
-            var bundle = ctx.Demand<PerFileScoringTask>().GetRescoreInputs(ctx);
-            return bundle != null ? bundle.PerFileGapFill : _perFileGapFillForRescore;
-        }
-
         // Bundle.PerFileConsensusTargets is null at hydration time (consensus
         // is meaningful only post-compaction); compute on demand from the
         // post-compaction stub list. Matches the worker's RunWorker-side
@@ -155,7 +129,7 @@ namespace pwiz.OspreySharp.Tasks
         private IReadOnlyDictionary<string, IReadOnlyList<(int Index, double Apex, double Start, double End)>>
             ConsensusTargetsFromBundleOrEmpty(PipelineContext ctx)
         {
-            var bundle = ctx.Demand<PerFileScoringTask>().GetRescoreInputs(ctx);
+            var bundle = ctx.Get<RescoreBundle>().Value;
             if (bundle == null) return _perFileConsensusTargets;
             if (bundle.PerFileConsensusTargets != null) return bundle.PerFileConsensusTargets;
             var computed = new Dictionary<string,
@@ -213,7 +187,6 @@ namespace pwiz.OspreySharp.Tasks
             _runOrHydrated = true;
             _ctx = ctx;
             var config = ctx.Config;
-            var perFileScoring = ctx.Demand<PerFileScoringTask>();
 
             // Mid-Run crash safety: clear stale sidecars for the outputs
             // this task is about to produce. A crash before the matching
@@ -222,10 +195,12 @@ namespace pwiz.OspreySharp.Tasks
             foreach (var output in Outputs(ctx))
                 TaskValiditySidecar.Delete(output, Name);
 
-            var perFileEntries = perFileScoring.GetPerFileEntries(ctx);
-            var perFileCalibrations = perFileScoring.GetPerFileCalibrations(ctx);
-            var perFileParquetPaths = perFileScoring.GetPerFileParquetPaths(ctx);
-            var fullLibrary = perFileScoring.GetFullLibrary(ctx);
+            // ScoredEntries (pre-compaction) -- this task is the one that
+            // compacts the shared buffer below, so it reads it before that.
+            var perFileEntries = ctx.Get<ScoredEntries>().Value;
+            var perFileCalibrations = ctx.Get<PerFileCalibrations>().Value;
+            var perFileParquetPaths = ctx.Get<PerFileParquetPaths>().Value;
+            var fullLibrary = ctx.Get<FullLibrary>().Value;
 
             // Stage 5: First-pass FDR.
             ctx.LogInfo(string.Empty);
@@ -336,8 +311,7 @@ namespace pwiz.OspreySharp.Tasks
             // is to adopt the bundle and compact. The compute counterpart is
             // Run.
             if (_runOrHydrated) return true;
-            var perFileScoring = ctx.Demand<PerFileScoringTask>();
-            var bundle = perFileScoring.GetRescoreInputs(ctx);
+            var bundle = ctx.Get<RescoreBundle>().Value;
 
             // No rescore bundle (straight-through resume, or any non-worker
             // entry that reaches this task via Demand): the full Stage 5 work
@@ -353,7 +327,7 @@ namespace pwiz.OspreySharp.Tasks
             _runOrHydrated = true;
             _ctx = ctx;
             var config = ctx.Config;
-            var perFileEntries = perFileScoring.GetPerFileEntries(ctx);
+            var perFileEntries = ctx.Get<ScoredEntries>().Value;
 
             ctx.LogInfo(@"Bundle hydration: skipping first-pass Percolator (sidecar provides q-values).");
 

--- a/pwiz_tools/OspreySharp/OspreySharp/Tasks/FirstJoinTask.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/Tasks/FirstJoinTask.cs
@@ -84,6 +84,19 @@ namespace pwiz.OspreySharp.Tasks
                 || (inputs && !c.NoJoin && !c.ExpectReconciledInput);
         }
 
+        // Stage 5/6 planning byproducts this task publishes. The same four types
+        // are published from Run (Stage-5 computed values) and from the
+        // bundle-adopt Rehydrate path -- publishing into one typed slot from
+        // both producers is what dissolves the former dual-source getters
+        // (_didPlan ? computed : bundle.X), since a consumer reads the slot
+        // without caring which path filled it.
+        public override IEnumerable<Type> Publishes => new[]
+        {
+            typeof(PerFileConsensusTargets), typeof(ReconciliationActions),
+            typeof(RefinedCalibrations), typeof(PerFileGapFillForRescore),
+            typeof(CompactedEntries)
+        };
+
         // Outputs reached by downstream tasks through ctx.Demand<FirstJoinTask>().
         // DidPlan is the gate downstream consumers (PerFileRescoreTask)
         // check to decide whether the Stage 6 planning state below is
@@ -297,6 +310,16 @@ namespace pwiz.OspreySharp.Tasks
                     return false;
             }
 
+            // Publish the Stage 6 planning byproducts (computed values, or the
+            // empty defaults when PlanStage6 was skipped / stopped after Stage
+            // 5), plus the CompactedEntries milestone of the shared buffer that
+            // CompactFirstPass produced above. Getters still serve existing
+            // consumers in this commit.
+            ctx.Publish(new PerFileConsensusTargets(_perFileConsensusTargets));
+            ctx.Publish(new ReconciliationActions(_reconciliationActions));
+            ctx.Publish(new RefinedCalibrations(_refinedCalibrations));
+            ctx.Publish(new PerFileGapFillForRescore(_perFileGapFillForRescore));
+            ctx.Publish(new CompactedEntries(perFileEntries));
             return true;
         }
 
@@ -342,6 +365,16 @@ namespace pwiz.OspreySharp.Tasks
             // indices for PerFileRescoreTask.
             CompactFirstPass(perFileEntries, bundle, config);
 
+            // Publish the SAME four planning byproducts as Run, but sourced from
+            // the adopted bundle (post-compaction). A consumer pulls
+            // ctx.Get<ReconciliationActions>() etc. without knowing whether this
+            // task computed them (Run) or adopted them from the worker bundle
+            // (here) -- the dual-source getter fallback collapses into one slot.
+            ctx.Publish(new ReconciliationActions(bundle.ReconciliationActions));
+            ctx.Publish(new RefinedCalibrations(bundle.RefinedCalibrations));
+            ctx.Publish(new PerFileGapFillForRescore(bundle.PerFileGapFill));
+            ctx.Publish(new PerFileConsensusTargets(ConsensusTargetsFromBundleOrEmpty(ctx)));
+            ctx.Publish(new CompactedEntries(perFileEntries));
             return true;
         }
 

--- a/pwiz_tools/OspreySharp/OspreySharp/Tasks/FirstJoinTask.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/Tasks/FirstJoinTask.cs
@@ -79,6 +79,14 @@ namespace pwiz.OspreySharp.Tasks
         {
             var c = ctx.Config;
             bool inputs = c.InputScores != null && c.InputScores.Count > 0;
+            // The (inputs && StopAfterStage5) clause leans on a CLI-enforced
+            // invariant: StopAfterStage5 (--join-only) is a modifier of
+            // --join-at-pass=<N>, and --join-at-pass=1 requires --input-scores,
+            // so StopAfterStage5 implies inputs at parse time -- a --join-only
+            // run can never reach here without InputScores.
+            // ProgramTests.TestValidateJoinOnlyRequiresInputScores pins that
+            // rejection, since the membership truth table (PipelineMembershipTest)
+            // does not encode the cross-flag dependency on its own.
             return (!inputs && !c.NoJoin)
                 || (inputs && c.StopAfterStage5)
                 || (inputs && !c.NoJoin && !c.ExpectReconciledInput);

--- a/pwiz_tools/OspreySharp/OspreySharp/Tasks/FirstJoinTask.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/Tasks/FirstJoinTask.cs
@@ -114,10 +114,6 @@ namespace pwiz.OspreySharp.Tasks
         private IReadOnlyDictionary<string, List<GapFillTarget>> _perFileGapFillForRescore
             = new Dictionary<string, List<GapFillTarget>>();
 
-        // Phase B lazy-rehydrate gate. See PerFileScoringTask for the
-        // mechanism; FirstJoinTask uses the same idempotent Run pattern.
-        private bool _runOrHydrated;
-
         public bool DidPlan(PipelineContext ctx) { return _didPlan; }
 
         // Bundle.PerFileConsensusTargets is null at hydration time (consensus
@@ -183,8 +179,6 @@ namespace pwiz.OspreySharp.Tasks
             // task here only in the bundle-absent modes (straight-through,
             // --join-only); a worker-mode consumer materializes it via
             // ctx.Demand which routes to Rehydrate.
-            if (_runOrHydrated) return true;
-            _runOrHydrated = true;
             _ctx = ctx;
             var config = ctx.Config;
 
@@ -310,7 +304,6 @@ namespace pwiz.OspreySharp.Tasks
             // compute_fdr_from_stubs skip, pipeline.rs:3916). All that remains
             // is to adopt the bundle and compact. The compute counterpart is
             // Run.
-            if (_runOrHydrated) return true;
             var bundle = ctx.Get<RescoreBundle>().Value;
 
             // No rescore bundle (straight-through resume, or any non-worker
@@ -324,7 +317,6 @@ namespace pwiz.OspreySharp.Tasks
             if (bundle == null)
                 return Run(ctx);
 
-            _runOrHydrated = true;
             _ctx = ctx;
             var config = ctx.Config;
             var perFileEntries = ctx.Get<ScoredEntries>().Value;

--- a/pwiz_tools/OspreySharp/OspreySharp/Tasks/MergeNodeTask.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/Tasks/MergeNodeTask.cs
@@ -122,14 +122,14 @@ namespace pwiz.OspreySharp.Tasks
             foreach (var output in Outputs(ctx))
                 TaskValiditySidecar.Delete(output, Name);
             var config = ctx.Config;
-            // perFileEntries comes from PerFileRescoreTask -- it owns
-            // the post-rescore version (mutated in place; or the
-            // unchanged upstream reference when planning was skipped).
-            var perFileEntries = ctx.Demand<PerFileRescoreTask>().GetPerFileEntries(ctx);
-            var perFileScoring = ctx.Demand<PerFileScoringTask>();
-            var fullLibrary = perFileScoring.GetFullLibrary(ctx);
-            var libraryById = perFileScoring.GetLibraryById(ctx);
-            var perFileParquetPaths = perFileScoring.GetPerFileParquetPaths(ctx);
+            // RescoredEntries is the final milestone of the shared buffer:
+            // demanding it materializes PerFileRescore (running its rescore /
+            // merge-mode compaction when the driver skipped it), which is what
+            // produces the post-rescore version this stage reads.
+            var perFileEntries = ctx.Get<RescoredEntries>().Value;
+            var fullLibrary = ctx.Get<FullLibrary>().Value;
+            var libraryById = ctx.Get<LibraryById>().Value;
+            var perFileParquetPaths = ctx.Get<PerFileParquetPaths>().Value;
 
             // Stage 8: Protein FDR (optional)
             if (config.ProteinFdr.HasValue)

--- a/pwiz_tools/OspreySharp/OspreySharp/Tasks/PerFileRescoreTask.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/Tasks/PerFileRescoreTask.cs
@@ -125,6 +125,14 @@ namespace pwiz.OspreySharp.Tasks
                 || (inputs && !c.NoJoin && !c.StopAfterStage5 && !c.ExpectReconciledInput);
         }
 
+        // The final milestone of the shared mutable entry buffer: this task
+        // overlays the Stage 6 rescore (or, in the --join-at-pass=2 merge path,
+        // applies its own compaction) onto the same backing list. MergeNode
+        // pulls RescoredEntries, so a cache miss lazily materializes this task --
+        // which is exactly what triggers the rescore/compaction in merge mode
+        // where the driver does not run this task.
+        public override IEnumerable<Type> Publishes => new[] { typeof(RescoredEntries) };
+
         /// <summary>
         /// The post-rescore per-file entries. Mutated in place by
         /// <see cref="ExecuteRescore"/>; when this task short-circuits
@@ -199,6 +207,13 @@ namespace pwiz.OspreySharp.Tasks
             _ctx = ctx;
             var perFileScoring = ctx.Demand<PerFileScoringTask>();
             _perFileEntries = perFileScoring.GetPerFileEntries(ctx);
+
+            // Publish the RescoredEntries milestone over the shared backing list
+            // now, while we hold its reference. ExecuteRescore (below) overlays
+            // it in place, and the self-gate may leave it unchanged; either way a
+            // consumer reading RescoredEntries.Value later sees the final buffer
+            // (milestone token over a shared store -- see PipelineByproducts.cs).
+            ctx.Publish(new RescoredEntries(_perFileEntries));
 
             // Self-gate: rescore + reconciliation only run when there is
             // planning state to act on AND the rescore hasn't already been
@@ -349,6 +364,10 @@ namespace pwiz.OspreySharp.Tasks
             _ctx = ctx;
             var perFileScoring = ctx.Demand<PerFileScoringTask>();
             _perFileEntries = perFileScoring.GetPerFileEntries(ctx);
+
+            // Publish the RescoredEntries milestone over the shared backing list
+            // (the merge path applies its own compaction below, in place).
+            ctx.Publish(new RescoredEntries(_perFileEntries));
 
             var bundle = perFileScoring.GetRescoreInputs(ctx);
             if (bundle != null)

--- a/pwiz_tools/OspreySharp/OspreySharp/Tasks/PerFileRescoreTask.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/Tasks/PerFileRescoreTask.cs
@@ -81,11 +81,11 @@ namespace pwiz.OspreySharp.Tasks
     /// (<c>--join-at-pass=1 --no-join --input-scores</c>). The worker
     /// mode previously had a separate <c>RunWorker</c> entry that
     /// hand-assembled the upstream hydration; Phase C collapsed that
-    /// path so the canonical pipeline's StartAt/StopAfter + the
-    /// upstream tasks' lazy-rehydrate accessors handle it. Run reads
-    /// upstream state from sibling tasks through
-    /// <c>ctx.GetTask&lt;PerFileScoringTask&gt;()</c> and
-    /// <c>ctx.GetTask&lt;FirstJoinTask&gt;()</c>, dispatches into
+    /// path so the canonical pipeline's IsIncluded membership + the
+    /// upstream tasks' lazy-rehydrate handle it. Run reads upstream state
+    /// as typed byproducts through <c>ctx.Get&lt;CompactedEntries&gt;()</c>,
+    /// <c>ctx.Get&lt;ReconciliationActions&gt;()</c>, etc. (a cache miss
+    /// materializes the producing task), dispatches into
     /// <see cref="ExecuteRescore"/>, then runs the per-process
     /// diagnostic-writer close + cross-impl bisection dump. Inherits
     /// the scoring engine (RunCoelutionScoring, LoadLibrary,
@@ -133,23 +133,9 @@ namespace pwiz.OspreySharp.Tasks
         // where the driver does not run this task.
         public override IEnumerable<Type> Publishes => new[] { typeof(RescoredEntries) };
 
-        /// <summary>
-        /// The post-rescore per-file entries. Mutated in place by
-        /// <see cref="ExecuteRescore"/>; when this task short-circuits
-        /// (no FirstJoinTask plan) the list is the unchanged upstream
-        /// reference. Pure read: the caller materializes this task first via
-        /// <see cref="PipelineContext.Demand{T}"/> (compute <see cref="Run"/>
-        /// for the rescore-capable modes, or the --join-at-pass=2
-        /// <see cref="Rehydrate"/> disk-load), so the field is populated by the
-        /// time any consumer reads it.
-        /// </summary>
-        public List<KeyValuePair<string, List<FdrEntry>>> GetPerFileEntries(PipelineContext ctx)
-        {
-            if (_perFileEntries == null)
-                throw new InvalidOperationException(
-                    @"PerFileRescoreTask.GetPerFileEntries called before Run populated the field.");
-            return _perFileEntries;
-        }
+        // _perFileEntries is the shared buffer this task overlays in place; it is
+        // published as the RescoredEntries milestone (in Run and the merge-mode
+        // Rehydrate) for MergeNode to pull via ctx.Get<RescoredEntries>().
 
         // Phase B resume surface. The reconciled parquet is written to a
         // SEPARATE <stem>.scores-reconciled.parquet sibling, leaving the
@@ -205,8 +191,12 @@ namespace pwiz.OspreySharp.Tasks
             if (_runOrHydrated) return true;
             _runOrHydrated = true;
             _ctx = ctx;
-            var perFileScoring = ctx.Demand<PerFileScoringTask>();
-            _perFileEntries = perFileScoring.GetPerFileEntries(ctx);
+            // CompactedEntries: the post-first-join buffer. Demanding it
+            // materializes FirstJoin (running its compaction + Stage 6 planning
+            // when the driver skipped it in worker-rescore mode), which is also
+            // what makes the planning byproducts read by ExecuteRescore below
+            // available -- one Get expresses the whole dependency.
+            _perFileEntries = ctx.Get<CompactedEntries>().Value;
 
             // Publish the RescoredEntries milestone over the shared backing list
             // now, while we hold its reference. ExecuteRescore (below) overlays
@@ -230,12 +220,11 @@ namespace pwiz.OspreySharp.Tasks
             // ExpectReconciledInput gate (Phase C: mechanism-driven, not
             // flag-driven) for the worker self-gate cases below;
             // ExpectReconciledInput keeps the hard short-circuit above for
-            // the strict --join-at-pass=2 merge path. Downstream
-            // MergeNodeTask still gets _perFileEntries via our accessor
-            // (falls through to the upstream reference).
+            // the strict --join-at-pass=2 merge path. Downstream MergeNodeTask
+            // reads the RescoredEntries milestone of this same backing list.
             var firstJoin = ctx.Demand<FirstJoinTask>();
             bool didPlan = firstJoin.DidPlan(ctx);
-            var rescoreBundle = perFileScoring.GetRescoreInputs(ctx);
+            var rescoreBundle = ctx.Get<RescoreBundle>().Value;
             bool anyPass2Present = false;
             if (ctx.Config.InputFiles != null)
             {
@@ -282,13 +271,13 @@ namespace pwiz.OspreySharp.Tasks
 
             var rescoreStats = ExecuteRescore(
                 _perFileEntries,
-                firstJoin.GetPerFileConsensusTargets(ctx),
-                firstJoin.GetReconciliationActions(ctx),
-                firstJoin.GetRefinedCalibrations(ctx),
-                perFileScoring.GetPerFileCalibrations(ctx),
-                firstJoin.GetPerFileGapFillForRescore(ctx),
-                perFileScoring.GetPerFileParquetPaths(ctx),
-                perFileScoring.GetFullLibrary(ctx),
+                ctx.Get<PerFileConsensusTargets>().Value,
+                ctx.Get<ReconciliationActions>().Value,
+                ctx.Get<RefinedCalibrations>().Value,
+                ctx.Get<PerFileCalibrations>().Value,
+                ctx.Get<PerFileGapFillForRescore>().Value,
+                ctx.Get<PerFileParquetPaths>().Value,
+                ctx.Get<FullLibrary>().Value,
                 ctx.Config,
                 joinFileStems);
             ctx.LogInfo(string.Format(
@@ -362,14 +351,18 @@ namespace pwiz.OspreySharp.Tasks
 
             _runOrHydrated = true;
             _ctx = ctx;
-            var perFileScoring = ctx.Demand<PerFileScoringTask>();
-            _perFileEntries = perFileScoring.GetPerFileEntries(ctx);
+            // ScoredEntries, NOT CompactedEntries: the merge path must NOT
+            // materialize FirstJoin (that would re-run Stage 5 Percolator on the
+            // reconciled parquets); it applies its own compaction below. Reading
+            // the pre-compaction milestone keeps the dependency on PerFileScoring
+            // alone, mirroring the old explicit Demand<PerFileScoringTask>.
+            _perFileEntries = ctx.Get<ScoredEntries>().Value;
 
             // Publish the RescoredEntries milestone over the shared backing list
             // (the merge path applies its own compaction below, in place).
             ctx.Publish(new RescoredEntries(_perFileEntries));
 
-            var bundle = perFileScoring.GetRescoreInputs(ctx);
+            var bundle = ctx.Get<RescoreBundle>().Value;
             if (bundle != null)
             {
                 // First-pass protein FDR BEFORE compaction. The 1st-pass FDR
@@ -388,7 +381,7 @@ namespace pwiz.OspreySharp.Tasks
                 // protein FDR is enabled. Mirrors Rust pipeline.rs:4292-4358.
                 if (ctx.Config.ProteinFdr.HasValue && bundle.PerFileEntries.Count > 0)
                 {
-                    var fullLibrary = perFileScoring.GetFullLibrary(ctx);
+                    var fullLibrary = ctx.Get<FullLibrary>().Value;
                     ProteinFdr.RunFirstPassProteinFdr(
                         bundle.PerFileEntries, fullLibrary, ctx.Config);
                 }

--- a/pwiz_tools/OspreySharp/OspreySharp/Tasks/PerFileRescoreTask.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/Tasks/PerFileRescoreTask.cs
@@ -103,10 +103,6 @@ namespace pwiz.OspreySharp.Tasks
         // PerFileScoringTask.
         private List<KeyValuePair<string, List<FdrEntry>>> _perFileEntries;
 
-        // Phase B lazy-rehydrate gate. See PerFileScoringTask for the
-        // mechanism.
-        private bool _runOrHydrated;
-
         public override string Name => @"PerFileRescore";
 
         /// <summary>
@@ -188,8 +184,6 @@ namespace pwiz.OspreySharp.Tasks
             // rescore from), takes Rehydrate instead: the driver reaches this
             // task here only in the rescore-capable modes, and a merge-node
             // consumer materializes it via ctx.Demand, which routes to Rehydrate.
-            if (_runOrHydrated) return true;
-            _runOrHydrated = true;
             _ctx = ctx;
             // CompactedEntries: the post-first-join buffer. Demanding it
             // materializes FirstJoin (running its compaction + Stage 6 planning
@@ -337,8 +331,7 @@ namespace pwiz.OspreySharp.Tasks
             // The compaction reads first-pass q-values already overlaid onto
             // each entry from the .1st-pass.fdr_scores.bin sidecar by
             // PerFileScoringTask's bundle hydration; no fresh FDR computation.
-            if (_runOrHydrated) return true;
-
+            //
             // Only the --join-at-pass=2 merge entry rehydrates here (reconciled
             // parquets on disk, no mzMLs to rescore). Any other entry that
             // reaches this task via Demand -- straight-through resume where the
@@ -349,7 +342,6 @@ namespace pwiz.OspreySharp.Tasks
             if (!ctx.Config.ExpectReconciledInput)
                 return Run(ctx);
 
-            _runOrHydrated = true;
             _ctx = ctx;
             // ScoredEntries, NOT CompactedEntries: the merge path must NOT
             // materialize FirstJoin (that would re-run Stage 5 Percolator on the

--- a/pwiz_tools/OspreySharp/OspreySharp/Tasks/PerFileScoringTask.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/Tasks/PerFileScoringTask.cs
@@ -142,13 +142,6 @@ namespace pwiz.OspreySharp.Tasks
         // a separate code path.
         private RescoreInputs _rescoreInputs;
 
-        // Phase B lazy-rehydrate gate. Set to true at the start of both
-        // Run (compute) and Rehydrate (disk-load). Once set, neither path
-        // re-executes the body (multiple accessors querying state from a
-        // single skipped task all hit a fast no-op after the first
-        // materialization).
-        private bool _runOrHydrated;
-
         // The backing fields above are built and mutated ONLY inside this task
         // (during Run / hydration) and published once in FinalizeAndCheck as the
         // FullLibrary / LibraryById / PerFileCalibrations / PerFileParquetPaths /
@@ -200,12 +193,6 @@ namespace pwiz.OspreySharp.Tasks
             // here only in the non---input-scores modes (where computing from
             // spectra is right), and a worker-mode consumer materializes it via
             // ctx.Demand, which routes to Rehydrate.
-            //
-            // Idempotent re-entry guard: a lazy-rehydrate via an accessor may
-            // have already executed this task body; the driver loop's call
-            // here is then a no-op.
-            if (_runOrHydrated) return true;
-            _runOrHydrated = true;
             _ctx = ctx;
             var config = ctx.Config;
 
@@ -358,8 +345,6 @@ namespace pwiz.OspreySharp.Tasks
 
         public override bool Rehydrate(PipelineContext ctx)
         {
-            if (_runOrHydrated) return true;
-
             // Without --input-scores there are no worker-supplied per-file
             // scores to load. A Demand still reaches this task here on a
             // straight-through resume: the driver skipped its Run because its
@@ -380,7 +365,6 @@ namespace pwiz.OspreySharp.Tasks
             // recomputing them from spectra, then adopt any reconciliation
             // bundle that the merge node will read. The compute-from-spectra
             // counterpart is Run.
-            _runOrHydrated = true;
             _ctx = ctx;
             var config = ctx.Config;
 

--- a/pwiz_tools/OspreySharp/OspreySharp/Tasks/PerFileScoringTask.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/Tasks/PerFileScoringTask.cs
@@ -149,40 +149,24 @@ namespace pwiz.OspreySharp.Tasks
         // materialization).
         private bool _runOrHydrated;
 
-        // Producer accessors. The backing fields are built and mutated ONLY
-        // inside this task (during Run / hydration); consumers in other tasks
-        // only read them. The dictionary accessors return IReadOnly* views to
-        // make the "Scoring owns this state; downstream only reads" contract
-        // explicit (the compiler now enforces no external mutation).
+        // The backing fields above are built and mutated ONLY inside this task
+        // (during Run / hydration) and published once in FinalizeAndCheck as the
+        // FullLibrary / LibraryById / PerFileCalibrations / PerFileParquetPaths /
+        // ScoredEntries / RescoreBundle byproducts; downstream tasks pull them by
+        // type via ctx.Get<T>() rather than through producer-typed getters.
         //
-        // GetFullLibrary is read-only by the same contract, but its return
-        // type stays List<LibraryEntry> for now: tightening it to
-        // IReadOnlyList would cascade through scoring-engine + FDR-project
-        // signatures (RunCoelutionScoring, RunFdr, ProteinFdr, ...), out of
-        // proportion to the value. Deferred to a future cross-project sweep.
-        public List<LibraryEntry> GetFullLibrary(PipelineContext ctx) { return _fullLibrary; }
-        public IReadOnlyDictionary<uint, LibraryEntry> GetLibraryById(PipelineContext ctx) { return _libraryById; }
-        // GetPerFileEntries is DELIBERATELY a live, mutable, shared buffer --
-        // NOT a read-only view, by design. The same
-        // List<KeyValuePair<string, List<FdrEntry>>> reference is the
-        // pipeline's working set: PerFileScoring produces it, FirstJoin
-        // compacts it in place, PerFileRescore overlays rescored entries in
-        // place -- all on this one instance. The no-copy cross-task hand-off
-        // is load-bearing (copying it is a measured perf regression at
-        // Astral scale). Do NOT "fix" this to IReadOnly or to return a copy.
-        public List<KeyValuePair<string, List<FdrEntry>>> GetPerFileEntries(PipelineContext ctx) { return _perFileEntries; }
-        public IReadOnlyDictionary<string, RTCalibration> GetPerFileCalibrations(PipelineContext ctx) { return _perFileCalibrations; }
-        public IReadOnlyDictionary<string, string> GetPerFileParquetPaths(PipelineContext ctx) { return _perFileParquetPaths; }
-
-        /// <summary>
-        /// The probe-the-disk reconciliation bundle, or <c>null</c> when
-        /// no per-file 1st-pass sidecar was found at joinOnly hydration
-        /// time (Stage 5 entry, or any non-joinOnly run). When non-null,
-        /// FirstJoinTask's reconciliation-state accessors fall back to
-        /// this bundle so the worker hydration path and the in-pipeline
-        /// path produce identical post-Stage-5 state.
-        /// </summary>
-        public RescoreInputs GetRescoreInputs(PipelineContext ctx) { return _rescoreInputs; }
+        // _perFileEntries stays a live, mutable, shared
+        // List<KeyValuePair<string, List<FdrEntry>>>: FirstJoin compacts it and
+        // PerFileRescore overlays it in place on this one instance (the no-copy
+        // hand-off is load-bearing at Astral scale). Its three in-place
+        // milestones are the ScoredEntries / CompactedEntries / RescoredEntries
+        // byproduct types -- see PipelineByproducts.cs.
+        //
+        // The FullLibrary byproduct wraps List<LibraryEntry> rather than
+        // IReadOnlyList: tightening it would cascade through RunCoelutionScoring /
+        // RunFdr / ProteinFdr signatures, out of proportion to the value.
+        // _rescoreInputs is the probe-the-disk reconciliation bundle (null at a
+        // Stage-5 entry / any non-joinOnly run), published wrapped in RescoreBundle.
 
         // Phase B resume surface: the library and every input mzML are
         // read; per-file .scores.parquet + .calibration.json are written.

--- a/pwiz_tools/OspreySharp/OspreySharp/Tasks/PerFileScoringTask.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/Tasks/PerFileScoringTask.cs
@@ -454,12 +454,15 @@ namespace pwiz.OspreySharp.Tasks
             _perFileParquetPaths = perFileParquetPaths;
 
             // Publish the Stage 1-4 byproducts once, in the shared Run/Rehydrate
-            // tail, before any success-but-stop early exit -- so a downstream
-            // consumer pulling them by type (ctx.Get<T>) sees the same values
-            // regardless of which path materialized this task. The getters still
-            // back the existing consumers in this commit; the cache is populated
-            // but not yet read (additive, byte-neutral). RescoreBundle wraps the
-            // nullable bundle (null at a Stage-5 entry / straight-through run).
+            // tail, BEFORE the success-but-stop early exits below -- so a
+            // downstream consumer pulling them by type (ctx.Get<T>) sees the
+            // same values regardless of which path materialized this task, even
+            // when this task then stops the pipeline. Because those stops keep
+            // ExitCode == 0, a lazy Demand that drove this Rehydrate still gets
+            // the published state and PipelineContext.DemandByType's
+            // failure-throw (which fires only on a false return WITH ExitCode != 0)
+            // correctly treats them as benign. RescoreBundle wraps the nullable
+            // bundle (null at a Stage-5 entry / straight-through run).
             ctx.Publish(new FullLibrary(_fullLibrary));
             ctx.Publish(new LibraryById(_libraryById));
             ctx.Publish(new PerFileCalibrations(_perFileCalibrations));

--- a/pwiz_tools/OspreySharp/OspreySharp/Tasks/PerFileScoringTask.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/Tasks/PerFileScoringTask.cs
@@ -111,6 +111,17 @@ namespace pwiz.OspreySharp.Tasks
             return !inputs;
         }
 
+        // Stage 1-4 byproducts this task publishes for downstream consumers to
+        // pull by type. ScoredEntries is the first milestone of the shared
+        // mutable entry buffer (FirstJoin and PerFileRescore publish the later
+        // CompactedEntries / RescoredEntries milestones of the same backing
+        // list); see PipelineByproducts.cs.
+        public override IEnumerable<Type> Publishes => new[]
+        {
+            typeof(FullLibrary), typeof(LibraryById), typeof(PerFileCalibrations),
+            typeof(PerFileParquetPaths), typeof(RescoreBundle), typeof(ScoredEntries)
+        };
+
         // Outputs reached by downstream tasks through ctx.Demand<PerFileScoringTask>().
         // Defaults are non-null empty collections so callers querying
         // outputs from a not-yet-run task never NPE on the accessor.
@@ -473,6 +484,20 @@ namespace pwiz.OspreySharp.Tasks
             _perFileEntries = perFileEntries;
             _perFileCalibrations = perFileCalibrations;
             _perFileParquetPaths = perFileParquetPaths;
+
+            // Publish the Stage 1-4 byproducts once, in the shared Run/Rehydrate
+            // tail, before any success-but-stop early exit -- so a downstream
+            // consumer pulling them by type (ctx.Get<T>) sees the same values
+            // regardless of which path materialized this task. The getters still
+            // back the existing consumers in this commit; the cache is populated
+            // but not yet read (additive, byte-neutral). RescoreBundle wraps the
+            // nullable bundle (null at a Stage-5 entry / straight-through run).
+            ctx.Publish(new FullLibrary(_fullLibrary));
+            ctx.Publish(new LibraryById(_libraryById));
+            ctx.Publish(new PerFileCalibrations(_perFileCalibrations));
+            ctx.Publish(new PerFileParquetPaths(_perFileParquetPaths));
+            ctx.Publish(new ScoredEntries(_perFileEntries));
+            ctx.Publish(new RescoreBundle(_rescoreInputs));
 
             if (perFileEntries.Count == 0 || totalScored == 0)
             {

--- a/pwiz_tools/OspreySharp/OspreySharp/Tasks/PipelineByproducts.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/Tasks/PipelineByproducts.cs
@@ -1,0 +1,169 @@
+/*
+ * Original author: Brendan MacLean <brendanx .at. uw.edu>,
+ *                  MacCoss Lab, Department of Genome Sciences, UW
+ * AI assistance: Claude Code (Claude Opus 4.8) <noreply .at. anthropic.com>
+ *
+ * Based on osprey (https://github.com/MacCossLab/osprey)
+ *   by Michael J. MacCoss, MacCoss Lab, Department of Genome Sciences, UW
+ *
+ * Copyright 2026 University of Washington - Seattle, WA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System.Collections.Generic;
+using pwiz.OspreySharp.Chromatography;
+using pwiz.OspreySharp.Core;
+using pwiz.OspreySharp.FDR.Reconciliation;
+
+namespace pwiz.OspreySharp.Tasks
+{
+    // Each type below names a single pipeline byproduct so PipelineContext's
+    // typed cache (Publish/TryGet/Get) can key on the value's PURPOSE rather
+    // than its raw CLR type. Several byproducts share a raw type -- e.g.
+    // IReadOnlyDictionary<string, RTCalibration> is BOTH the per-file
+    // calibrations and the refined calibrations -- which a typeof()-keyed cache
+    // could not tell apart. This mirrors how Skyline's PeakScoringContext keys
+    // on purpose types (e.g. MQuestAnalyteCrossCorrelations) instead of a bare
+    // collection type. The wrappers are thin and publish-once: the producer
+    // wraps its value, consumers read .Value. They carry no behavior -- the
+    // type identity is the whole point. The one mutable shared buffer is
+    // modeled as a small state hierarchy (see PerFileEntries below) so that it,
+    // too, resolves through the byproduct->producer registry uniformly.
+
+    /// <summary>The spectral library (with decoys) produced by Stage 1.</summary>
+    internal sealed class FullLibrary
+    {
+        public List<LibraryEntry> Value { get; }
+        public FullLibrary(List<LibraryEntry> value) { Value = value; }
+    }
+
+    /// <summary>Stage 1 library indexed by entry id, for Stage 7/8 lookups.</summary>
+    internal sealed class LibraryById
+    {
+        public IReadOnlyDictionary<uint, LibraryEntry> Value { get; }
+        public LibraryById(IReadOnlyDictionary<uint, LibraryEntry> value) { Value = value; }
+    }
+
+    /// <summary>Per-file first-pass RT calibrations from Stages 2-4.</summary>
+    internal sealed class PerFileCalibrations
+    {
+        public IReadOnlyDictionary<string, RTCalibration> Value { get; }
+        public PerFileCalibrations(IReadOnlyDictionary<string, RTCalibration> value) { Value = value; }
+    }
+
+    /// <summary>Map of file name to its on-disk <c>.scores.parquet</c> path.</summary>
+    internal sealed class PerFileParquetPaths
+    {
+        public IReadOnlyDictionary<string, string> Value { get; }
+        public PerFileParquetPaths(IReadOnlyDictionary<string, string> value) { Value = value; }
+    }
+
+    /// <summary>
+    /// The probe-the-disk reconciliation bundle PerFileScoring hydrates from
+    /// sibling sidecars in worker mode, or <c>null</c> at a Stage-5 entry / any
+    /// straight-through run that wrote no bundle. The wrapper is always
+    /// published once (presence == "PerFileScoring has been materialized"); its
+    /// <see cref="Value"/> is the nullable bundle, so a consumer distinguishes
+    /// "no bundle" (Value == null) from "producer not yet run" (cache miss).
+    /// </summary>
+    internal sealed class RescoreBundle
+    {
+        public RescoreInputs Value { get; }
+        public RescoreBundle(RescoreInputs value) { Value = value; }
+    }
+
+    /// <summary>
+    /// Stage 6 multi-charge consensus rescore targets per file (post-compaction
+    /// apex/start/end by stub index), produced by FirstJoin's planning step.
+    /// </summary>
+    internal sealed class PerFileConsensusTargets
+    {
+        public IReadOnlyDictionary<string, IReadOnlyList<(int Index, double Apex, double Start, double End)>> Value { get; }
+        public PerFileConsensusTargets(
+            IReadOnlyDictionary<string, IReadOnlyList<(int Index, double Apex, double Start, double End)>> value)
+        {
+            Value = value;
+        }
+    }
+
+    /// <summary>Stage 6 reconciliation actions keyed by (file, post-compaction index).</summary>
+    internal sealed class ReconciliationActions
+    {
+        public IReadOnlyDictionary<(string FileName, int Index), ReconcileAction> Value { get; }
+        public ReconciliationActions(IReadOnlyDictionary<(string FileName, int Index), ReconcileAction> value) { Value = value; }
+    }
+
+    /// <summary>Per-file refined RT calibrations from the Stage 6 calibration refit.</summary>
+    internal sealed class RefinedCalibrations
+    {
+        public IReadOnlyDictionary<string, RTCalibration> Value { get; }
+        public RefinedCalibrations(IReadOnlyDictionary<string, RTCalibration> value) { Value = value; }
+    }
+
+    /// <summary>Per-file gap-fill targets for the Stage 6 rescore.</summary>
+    internal sealed class PerFileGapFillForRescore
+    {
+        public IReadOnlyDictionary<string, List<GapFillTarget>> Value { get; }
+        public PerFileGapFillForRescore(IReadOnlyDictionary<string, List<GapFillTarget>> value) { Value = value; }
+    }
+
+    /// <summary>
+    /// The pipeline's working per-file FDR entry buffer. UNLIKE every other
+    /// byproduct here, this is a deliberately MUTABLE shared buffer: the same
+    /// inner <see cref="Value"/> list reference is created once by PerFileScoring,
+    /// compacted in place by FirstJoin, then overlaid in place by PerFileRescore
+    /// (the no-copy hand-off is load-bearing at Astral scale).
+    ///
+    /// The three in-place mutation milestones are modeled as the distinct
+    /// subtypes below (<see cref="ScoredEntries"/> -> <see cref="CompactedEntries"/>
+    /// -> <see cref="RescoredEntries"/>), each published once by its single
+    /// producing task, so the buffer resolves through the byproduct->producer
+    /// registry like every other byproduct: a consumer asks for the milestone it
+    /// needs (e.g. MergeNode wants <see cref="RescoredEntries"/>) and a cache
+    /// miss lazily materializes the producer that reaches that state.
+    ///
+    /// IMPORTANT: these subtypes are MILESTONE TOKENS over a shared backing
+    /// store, NOT immutable snapshots. Because all three wrap the SAME list (no
+    /// copy), reading <see cref="ScoredEntries"/> after PerFileRescore has run
+    /// returns the now-rescored list -- the type asserts "the buffer reached at
+    /// least this state," not "the buffer as it was at this state." In the
+    /// pipeline DAG each milestone is consumed before the next in-place mutation,
+    /// so a stale read is never observable. Registry keys are the concrete
+    /// subtypes (each single-producer); this base is only for shared accessor
+    /// code -- never publish or Get the base type itself.
+    /// </summary>
+    internal abstract class PerFileEntries
+    {
+        public List<KeyValuePair<string, List<FdrEntry>>> Value { get; }
+        protected PerFileEntries(List<KeyValuePair<string, List<FdrEntry>>> value) { Value = value; }
+    }
+
+    /// <summary>The buffer as produced by PerFileScoring (per-file scored stubs).</summary>
+    internal sealed class ScoredEntries : PerFileEntries
+    {
+        public ScoredEntries(List<KeyValuePair<string, List<FdrEntry>>> value) : base(value) { }
+    }
+
+    /// <summary>The buffer after FirstJoin's first-pass FDR + compaction.</summary>
+    internal sealed class CompactedEntries : PerFileEntries
+    {
+        public CompactedEntries(List<KeyValuePair<string, List<FdrEntry>>> value) : base(value) { }
+    }
+
+    /// <summary>The buffer after PerFileRescore's Stage 6 rescore / reconciliation overlay.</summary>
+    internal sealed class RescoredEntries : PerFileEntries
+    {
+        public RescoredEntries(List<KeyValuePair<string, List<FdrEntry>>> value) : base(value) { }
+    }
+}


### PR DESCRIPTION
## Summary

Replaces OspreySharp's implicit producer-getter dataflow (`ctx.Demand<ProducerTask>().GetX(ctx)`) with a typed **byproduct cache** on `PipelineContext`, modeled on Skyline's `PeakScoringContext.AddInfo`/`TryGetInfo`.

* **Byproduct cache + producer registry.** `Publish<T>` / `TryGet<T>` / `Get<T>` on `PipelineContext`, plus a byproduct→producer registry built from a new `OspreyTask.Publishes`. A `Get<T>` miss lazily materializes the registered producer (its `Rehydrate` publishes), so a consumer asks the context for a value *by type* rather than reaching through a named producer task. This is the half `PeakScoringContext` never needed — OspreySharp workers start mid-pipeline, so the registry answers "by-byproduct lookup → which task do I rehydrate?".
* **~13 named byproduct types.** Required because two byproducts share a raw type (`IReadOnlyDictionary<string, RTCalibration>` is both per-file and refined calibrations), exactly as Skyline keys on purpose-types like `MQuestAnalyteCrossCorrelations`.
* **The load-bearing mutable buffer as a state hierarchy.** The no-copy `_perFileEntries` buffer becomes `ScoredEntries → CompactedEntries → RescoredEntries`, each published once by its single producing task over the *same backing list*. This dissolves the registry "exception" entirely: the milestone type a consumer requests *selects the producer* — `MergeNode` reads `RescoredEntries` (materializing PerFileRescore), and PerFileRescore's merge-mode rehydrate reads `ScoredEntries` so it does **not** re-run Stage 5. The "merge mode must not re-run Stage 5" invariant is now enforced by the type, not a comment.
* **Dissolved the dual-source getters.** FirstJoin's four `_didPlan ? computed : bundle.X` accessors collapse into one published slot each (Run publishes computed; Rehydrate publishes from the adopted bundle). Removed all producer getters, `PipelineContext.GetTask<T>`, and the two `GetPerFileEntries` overloads.
* **Retired per-task `_runOrHydrated`.** The driver marks a task materialized after `Run`, so `_materialized` is the single guard coordinating the driver-Run and lazy-Rehydrate paths.
* **Surfaced lazy-rehydrate failures.** `Get`/`Demand` now throw `RehydrateFailedException` when a lazily-driven `Rehydrate` fails *with* a non-zero `ExitCode` (previously swallowed); success-stops (ExitCode 0) stay benign.

This is iteration N+1 of the recurring OspreySharp OOP-review program; successor to #4264 (PR-A) and #4266 (PR-B).

## Test plan

Every behavioral step gated green (bit-parity discipline — no tolerance loosening):

* Build + 356 tests + ReSharper inspection.
* **Worker-mode strict** (Stellar + Astral, net8.0): C# in-memory vs C# HPC chain bit-identical at every stage boundary (Stage-5 truth hash `0C353A72CBCC` held across all commits).
* **Compare-EndToEnd** (Rust vs C#, 1e-9): 59768 precursors, delta 0.
* `PipelineMembershipTest` (IsIncluded truth table) + new `ByproductContextTest` (cache throw/benign-stop + publish-once) green throughout.
* **Performance** (single-run side-by-side, Astral straight-through, C#, same machine): PR-C **1057.9s** vs master HEAD **1064.8s** — no regression (PR-C marginally faster, including `stage6`, the no-copy buffer hand-off). A Rust anchor (unchanged code) confirmed the machine state matched the published baseline (1464.7s vs published 1466s), so the comparison is environment-controlled. (A separate, pre-existing ~9% C# `stage1to4` regression from the earlier PR-A/B sprint — *not* PR-C — is filed at `ai/todos/backlog/TODO-ospreysharp_sprint_stage1to4_perf_regression.md`.)

See ai/todos/active/TODO-20260604_ospreysharp_byproduct_context_prc.md for the full C0–C7 engineering log.

A pre-existing, rare intermittent heap-corruption symptom in the Percolator→protein-FDR path (code unchanged by this PR) was observed once and filed separately as `ai/todos/backlog/TODO-ospreysharp_percolator_proteinfdr_rare_heap_corruption.md`; clean PR-C was 0/20 on the exact path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
