### PR TITLE
Fixed DiaUmpire vendor-format test tripping the persistent-dir change check

### DIFF
--- a/pwiz_tools/Skyline/TestPerf/DiaUmpireVendorFormatTest.cs
+++ b/pwiz_tools/Skyline/TestPerf/DiaUmpireVendorFormatTest.cs
@@ -139,12 +139,14 @@ namespace TestPerf
 
         protected override void DoTest()
         {
-            // DiaUmpire writes <name>-diaumpire.mz5 and <name>-diaumpire.mzid.gz next to each input
-            // in the persistent directory (and the test deletes+regenerates them below). Note them so
-            // the persistent-dir change detection doesn't flag them as unexpected new files when the
-            // area starts pristine -- e.g. on the shared CI download area, which is restored between
-            // runs (a developer box masks this because the files linger and end up in the baseline).
-            TestFilesDirs[0].PotentialAdditionalPersistentFileSet = new HashSet<string>(
+            // DiaUmpire writes <name>-diaumpire.mz5 and <name>-diaumpire.mzid.gz next to each input in
+            // the persistent (shared, downloaded) directory. These are transient: the test deletes them
+            // before the run to force fresh regeneration, and deletes them again at the end (below) so
+            // the persistent dir is left as it was found. Declare them as potentially-missing so the
+            // change check tolerates that removal on a box whose baseline already had them (e.g. left by
+            // an earlier or failed run); on a pristine area there is simply nothing to exempt. (Contrast
+            // PotentialAdditionalPersistentFileSet, which is for files intentionally KEPT for reuse.)
+            TestFilesDirs[0].PotentialMissingPersistentFileSet = new HashSet<string>(
                 DiaFiles.SelectMany(f =>
                 {
                     var dir = Path.GetDirectoryName(f) ?? string.Empty;
@@ -155,6 +157,8 @@ namespace TestPerf
                         Path.Combine(dir, baseName + "-diaumpire.mzid.gz")
                     };
                 }));
+
+            string[] searchFiles = DiaFiles.Select(GetVendorFileTestPath).ToArray();
 
             // Clean-up before running the test
             RunUI(() => SkylineWindow.ModifyDocument("Set default settings",
@@ -168,15 +172,8 @@ namespace TestPerf
             // Launch the wizard
             var importPeptideSearchDlg = ShowDialog<ImportPeptideSearchDlg>(SkylineWindow.ShowRunPeptideSearchDlg);
 
-            string[] searchFiles = DiaFiles.Select(p => GetVendorFileTestPath(p)).ToArray();
-            foreach (var searchFile in searchFiles)
-            {
-                // delete -diaumpire files so they get regenerated instead of reused
-                var searchFileDir = Path.GetDirectoryName(searchFile) ?? string.Empty;
-                foreach (var diaumpireFile in Directory.GetFiles(searchFileDir, "*-diaumpire.*"))
-                    FileEx.SafeDelete(diaumpireFile);
-                Assert.IsTrue(File.Exists(searchFile), string.Format("File {0} does not exist.", searchFile));
-            }
+            // delete -diaumpire files so they get regenerated instead of reused
+            RemoveDiaUmpireFiles();
 
             string fastaPathForImport = GetFastaTestPath(_instrumentValues.FastaPath);
             Assert.IsTrue(File.Exists(fastaPathForImport));
@@ -332,6 +329,24 @@ namespace TestPerf
             Assert.IsTrue(searchSucceeded.Value);
 
             RunUI(() => importPeptideSearchDlg.ClickCancelButton());
+
+            // Remove the regenerated DiaUmpire outputs so this test leaves the persistent (shared,
+            // downloaded) source directory exactly as it found it. These are transient, not cached for
+            // reuse -- we delete them at the start precisely to force regeneration.
+            RemoveDiaUmpireFiles();
+
+            void RemoveDiaUmpireFiles()
+            {
+                // Delete the generated -diaumpire outputs (full paths, found by globbing each input's
+                // directory) so they get regenerated instead of reused, and don't linger in the
+                // persistent (shared, downloaded) source directory.
+                foreach (var searchFile in searchFiles)
+                {
+                    var searchFileDir = Path.GetDirectoryName(searchFile) ?? string.Empty;
+                    foreach (var diaumpireFile in Directory.GetFiles(searchFileDir, "*-diaumpire.*"))
+                        FileEx.SafeDelete(diaumpireFile);
+                }
+            }
         }
     }
 }

--- a/pwiz_tools/Skyline/TestPerf/DiaUmpireVendorFormatTest.cs
+++ b/pwiz_tools/Skyline/TestPerf/DiaUmpireVendorFormatTest.cs
@@ -139,25 +139,6 @@ namespace TestPerf
 
         protected override void DoTest()
         {
-            // DiaUmpire writes <name>-diaumpire.mz5 and <name>-diaumpire.mzid.gz next to each input in
-            // the persistent (shared, downloaded) directory. These are transient: the test deletes them
-            // before the run to force fresh regeneration, and deletes them again at the end (below) so
-            // they don't linger in this shared source directory. Declare them as potentially-missing so the
-            // change check tolerates that removal on a box whose baseline already had them (e.g. left by
-            // an earlier or failed run); on a pristine area there is simply nothing to exempt. (Contrast
-            // PotentialAdditionalPersistentFileSet, which is for files intentionally KEPT for reuse.)
-            TestFilesDirs[0].PotentialMissingPersistentFileSet = new HashSet<string>(
-                DiaFiles.SelectMany(f =>
-                {
-                    var dir = Path.GetDirectoryName(f) ?? string.Empty;
-                    var baseName = Path.GetFileNameWithoutExtension(f);
-                    return new[]
-                    {
-                        Path.Combine(dir, baseName + "-diaumpire.mz5"),
-                        Path.Combine(dir, baseName + "-diaumpire.mzid.gz")
-                    };
-                }));
-
             string[] searchFiles = DiaFiles.Select(GetVendorFileTestPath).ToArray();
             foreach (var searchFile in searchFiles)
                 Assert.IsTrue(File.Exists(searchFile), string.Format("File {0} does not exist.", searchFile));
@@ -318,35 +299,47 @@ namespace TestPerf
                 Assert.AreEqual(0.05, importPeptideSearchDlg.SearchSettingsControl.CutoffScore);
             });
 
-            RunUI(() =>
+            // The search runs DiaUmpire, which (re)writes the -diaumpire outputs. Wrap it in try/finally
+            // so they are cleaned from the persistent (shared) source dir even if the search assertion
+            // below fails. (Nothing is generated before this point, so earlier failures leave nothing.)
+            try
             {
-                // Run the search
-                Assert.IsTrue(importPeptideSearchDlg.ClickNextButton());
+                RunUI(() =>
+                {
+                    // Run the search
+                    Assert.IsTrue(importPeptideSearchDlg.ClickNextButton());
 
-                importPeptideSearchDlg.SearchControl.SearchFinished += (success) => searchSucceeded = success;
-                importPeptideSearchDlg.BuildPepSearchLibControl.IncludeAmbiguousMatches = true;
-            });
+                    importPeptideSearchDlg.SearchControl.SearchFinished += (success) => searchSucceeded = success;
+                    importPeptideSearchDlg.BuildPepSearchLibControl.IncludeAmbiguousMatches = true;
+                });
 
-            WaitForConditionUI(120 * 600000, () => searchSucceeded.HasValue);
-            Assert.IsTrue(searchSucceeded.Value);
+                WaitForConditionUI(120 * 600000, () => searchSucceeded.HasValue);
+                Assert.IsTrue(searchSucceeded.Value);
 
-            RunUI(() => importPeptideSearchDlg.ClickCancelButton());
-
-            // Remove the regenerated DiaUmpire outputs so they don't linger in the persistent (shared,
-            // downloaded) source directory. These are transient, not cached for reuse -- we delete them
-            // at the start precisely to force regeneration.
-            RemoveDiaUmpireFiles();
+                RunUI(() => importPeptideSearchDlg.ClickCancelButton());
+            }
+            finally
+            {
+                RemoveDiaUmpireFiles();
+            }
 
             void RemoveDiaUmpireFiles()
             {
-                // Delete the generated -diaumpire outputs (full paths, found by globbing each input's
-                // directory) so they get regenerated instead of reused, and don't linger in the
-                // persistent (shared, downloaded) source directory.
+                // Delete the generated -diaumpire outputs (found by globbing each input's directory), and
+                // register each one we delete in its persistent dir's PotentialMissingPersistentFileSet so
+                // the persistent-dir modification check tolerates the deletion and stays in sync with the
+                // glob (same pattern as DeleteFilesForScreenshots in DiaSwathTutorialTest).
+                var testFilesDir = TestFilesDirs[0];
                 foreach (var searchFile in searchFiles)
                 {
                     var searchFileDir = Path.GetDirectoryName(searchFile) ?? string.Empty;
                     foreach (var diaumpireFile in Directory.GetFiles(searchFileDir, "*-diaumpire.*"))
+                    {
+                        testFilesDir.PotentialMissingPersistentFileSet ??= new HashSet<string>();
+                        testFilesDir.PotentialMissingPersistentFileSet.Add(
+                            PathEx.GetRelativePath(testFilesDir.PersistentFilesDir, diaumpireFile));
                         FileEx.SafeDelete(diaumpireFile);
+                    }
                 }
             }
         }

--- a/pwiz_tools/Skyline/TestPerf/DiaUmpireVendorFormatTest.cs
+++ b/pwiz_tools/Skyline/TestPerf/DiaUmpireVendorFormatTest.cs
@@ -139,6 +139,23 @@ namespace TestPerf
 
         protected override void DoTest()
         {
+            // DiaUmpire writes <name>-diaumpire.mz5 and <name>-diaumpire.mzid.gz next to each input
+            // in the persistent directory (and the test deletes+regenerates them below). Note them so
+            // the persistent-dir change detection doesn't flag them as unexpected new files when the
+            // area starts pristine -- e.g. on the shared CI download area, which is restored between
+            // runs (a developer box masks this because the files linger and end up in the baseline).
+            TestFilesDirs[0].PotentialAdditionalPersistentFileSet = new HashSet<string>(
+                DiaFiles.SelectMany(f =>
+                {
+                    var dir = Path.GetDirectoryName(f) ?? string.Empty;
+                    var baseName = Path.GetFileNameWithoutExtension(f);
+                    return new[]
+                    {
+                        Path.Combine(dir, baseName + "-diaumpire.mz5"),
+                        Path.Combine(dir, baseName + "-diaumpire.mzid.gz")
+                    };
+                }));
+
             // Clean-up before running the test
             RunUI(() => SkylineWindow.ModifyDocument("Set default settings",
                 d => d.ChangeSettings(SrmSettingsList.GetDefault())));

--- a/pwiz_tools/Skyline/TestPerf/DiaUmpireVendorFormatTest.cs
+++ b/pwiz_tools/Skyline/TestPerf/DiaUmpireVendorFormatTest.cs
@@ -142,7 +142,7 @@ namespace TestPerf
             // DiaUmpire writes <name>-diaumpire.mz5 and <name>-diaumpire.mzid.gz next to each input in
             // the persistent (shared, downloaded) directory. These are transient: the test deletes them
             // before the run to force fresh regeneration, and deletes them again at the end (below) so
-            // the persistent dir is left as it was found. Declare them as potentially-missing so the
+            // they don't linger in this shared source directory. Declare them as potentially-missing so the
             // change check tolerates that removal on a box whose baseline already had them (e.g. left by
             // an earlier or failed run); on a pristine area there is simply nothing to exempt. (Contrast
             // PotentialAdditionalPersistentFileSet, which is for files intentionally KEPT for reuse.)
@@ -159,6 +159,8 @@ namespace TestPerf
                 }));
 
             string[] searchFiles = DiaFiles.Select(GetVendorFileTestPath).ToArray();
+            foreach (var searchFile in searchFiles)
+                Assert.IsTrue(File.Exists(searchFile), string.Format("File {0} does not exist.", searchFile));
 
             // Clean-up before running the test
             RunUI(() => SkylineWindow.ModifyDocument("Set default settings",
@@ -330,9 +332,9 @@ namespace TestPerf
 
             RunUI(() => importPeptideSearchDlg.ClickCancelButton());
 
-            // Remove the regenerated DiaUmpire outputs so this test leaves the persistent (shared,
-            // downloaded) source directory exactly as it found it. These are transient, not cached for
-            // reuse -- we delete them at the start precisely to force regeneration.
+            // Remove the regenerated DiaUmpire outputs so they don't linger in the persistent (shared,
+            // downloaded) source directory. These are transient, not cached for reuse -- we delete them
+            // at the start precisely to force regeneration.
             RemoveDiaUmpireFiles();
 
             void RemoveDiaUmpireFiles()


### PR DESCRIPTION
## Summary

* `DiaUmpireVendorFormatTest` (`TestDiaUmpireWiffFile`) runs DiaUmpire on a `.wiff`, which writes `<name>-diaumpire.mz5` and `<name>-diaumpire.mzid.gz` next to the input -- i.e. into the persistent (shared, downloaded) source directory. The test deletes them at the start to force fresh regeneration but left the regenerated copies behind, so `TestFilesDir.CheckForModifiedPersistentFilesDir` flagged them as unexpected "New files" and failed the test.
* This only manifests when the persistent area starts **pristine** -- e.g. the shared CI download area, which is restored between runs. A developer box masks it: the files linger from a prior run and end up in the baseline snapshot, so they read as "not new" (the first run after a clean fails, then it self-heals).
* Fix: treat the outputs as the transient artifacts they are -- delete them again at the **end** of the test (a `RemoveDiaUmpireFiles()` helper used at start and end) so nothing lingers in the shared source dir, and declare them in `PotentialMissingPersistentFileSet` so the change check tolerates that removal when a prior run had already left them in the baseline.
* (An earlier revision used `PotentialAdditionalPersistentFileSet`, but that mechanism is for files intentionally KEPT for reuse -- which these are not, since the test deletes them to force regeneration.)
* Scope note: the test stays on `scripts/misc/tc-perftests-skiplist.txt` (skipped for disk-space reasons, unrelated to this check). This fix makes manual runs -- and any future re-enable -- behave correctly, and stops the outputs accumulating in the shared area.

## Test plan

Verified locally on Windows by forcing each baseline (manipulating the persistent `-diaumpire.*` first):

- [x] Pristine baseline (cache deleted) -> passes, persistent dir left clean
- [x] Pre-seeded baseline (files planted so the baseline already has them) -> passes via the `PotentialMissingPersistentFileSet` exemption, persistent dir left clean

Co-Authored-By: Claude <noreply@anthropic.com>
