### PR TITLE
Made OspreySharp's resume Rehydrate load from its own outputs, not Run

### DIFF
--- a/pwiz_tools/OspreySharp/OspreySharp.Test/ByproductContextTest.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Test/ByproductContextTest.cs
@@ -76,6 +76,46 @@ namespace pwiz.OspreySharp.Test
             }
         }
 
+        /// <summary>A second producer type that also publishes
+        /// <see cref="StubByproduct"/>, to drive the single-producer
+        /// registration check in <see cref="PipelineContext"/>'s constructor.</summary>
+        private sealed class SecondStubProducerTask : OspreyTask
+        {
+            public override string Name => @"SecondStubProducer";
+            public override IEnumerable<Type> Publishes => new[] { typeof(StubByproduct) };
+            public override bool Run(PipelineContext ctx) => true;
+            public override bool Rehydrate(PipelineContext ctx) => true;
+        }
+
+        /// <summary>Counts how many times its Rehydrate is driven, so a test can
+        /// assert the <see cref="PipelineContext"/> one-shot materialization guard
+        /// (driver-Run vs lazy-Demand) holds.</summary>
+        private sealed class CountingProducerTask : OspreyTask
+        {
+            public int RehydrateCount;
+            public override string Name => @"CountingProducer";
+            public override IEnumerable<Type> Publishes => new[] { typeof(StubByproduct) };
+            public override bool Run(PipelineContext ctx) => true;
+
+            public override bool Rehydrate(PipelineContext ctx)
+            {
+                RehydrateCount++;
+                ctx.Publish(new StubByproduct { Value = 99 });
+                return true;
+            }
+        }
+
+        /// <summary>A producer whose Rehydrate succeeds (returns true) but neglects
+        /// to publish its declared byproduct -- a programming defect that
+        /// <see cref="PipelineContext.Get{TInfo}"/> must surface loudly.</summary>
+        private sealed class ForgetfulProducerTask : OspreyTask
+        {
+            public override string Name => @"ForgetfulProducer";
+            public override IEnumerable<Type> Publishes => new[] { typeof(StubByproduct) };
+            public override bool Run(PipelineContext ctx) => true;
+            public override bool Rehydrate(PipelineContext ctx) => true;
+        }
+
         private static PipelineContext ContextFor(OspreyTask task)
         {
             return new PipelineContext(new OspreyConfig(), new[] { task }, null, null, null);
@@ -128,6 +168,72 @@ namespace pwiz.OspreySharp.Test
             catch (ArgumentException)
             {
                 // expected: Dictionary.Add rejects the duplicate key
+            }
+        }
+
+        [TestMethod]
+        public void TestDuplicateProducerThrowsAtConstruction()
+        {
+            // Two tasks declaring the same byproduct in Publishes is a definition
+            // defect: the registry could not pick which task to materialize on a
+            // cache miss, so the constructor must fail fast rather than silently
+            // drop one producer.
+            try
+            {
+                var unused = new PipelineContext(new OspreyConfig(),
+                    new OspreyTask[] { new StubProducerTask(publishBeforeStop: false, exitCode: 0), new SecondStubProducerTask() },
+                    null, null, null);
+                Assert.Fail(@"Expected duplicate-producer registration to throw");
+            }
+            catch (ArgumentException)
+            {
+                // expected: each registered byproduct must have a single producer
+            }
+        }
+
+        [TestMethod]
+        public void TestMarkMaterializedSuppressesRehydrate()
+        {
+            // The driver calls MarkMaterialized after Run; a later Demand/Get for
+            // that task must then NOT drive Rehydrate (its state is already in
+            // memory). This is the single guard coordinating the driver-Run path
+            // and the lazy-Rehydrate path.
+            var task = new CountingProducerTask();
+            var ctx = ContextFor(task);
+            ctx.MarkMaterialized(task);
+            var resolved = ctx.Demand<CountingProducerTask>();
+            Assert.AreSame(task, resolved);
+            Assert.AreEqual(0, task.RehydrateCount);
+        }
+
+        [TestMethod]
+        public void TestDemandRehydratesAtMostOnce()
+        {
+            // The first consumer's Demand drives Rehydrate; subsequent demands
+            // return the same instance without re-materializing (the _materialized
+            // one-shot guard that replaced the per-task _runOrHydrated field).
+            var task = new CountingProducerTask();
+            var ctx = ContextFor(task);
+            ctx.Demand<CountingProducerTask>();
+            ctx.Demand<CountingProducerTask>();
+            Assert.AreEqual(1, task.RehydrateCount);
+        }
+
+        [TestMethod]
+        public void TestGetThrowsWhenProducerRehydratesButDoesNotPublish()
+        {
+            // A producer whose Rehydrate succeeds but forgets to publish its
+            // declared byproduct is a programming defect; Get must surface it as
+            // UnknownByproductException rather than degrade to a silent default.
+            var ctx = ContextFor(new ForgetfulProducerTask());
+            try
+            {
+                ctx.Get<StubByproduct>();
+                Assert.Fail(@"Expected UnknownByproductException");
+            }
+            catch (UnknownByproductException ex)
+            {
+                Assert.AreEqual(typeof(StubByproduct), ex.RequestedType);
             }
         }
     }

--- a/pwiz_tools/OspreySharp/OspreySharp.Test/ByproductContextTest.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Test/ByproductContextTest.cs
@@ -93,9 +93,10 @@ namespace pwiz.OspreySharp.Test
         private sealed class CountingProducerTask : OspreyTask
         {
             public int RehydrateCount;
+            public int RunCount;
             public override string Name => @"CountingProducer";
             public override IEnumerable<Type> Publishes => new[] { typeof(StubByproduct) };
-            public override bool Run(PipelineContext ctx) => true;
+            public override bool Run(PipelineContext ctx) { RunCount++; return true; }
 
             public override bool Rehydrate(PipelineContext ctx)
             {
@@ -217,6 +218,22 @@ namespace pwiz.OspreySharp.Test
             ctx.Demand<CountingProducerTask>();
             ctx.Demand<CountingProducerTask>();
             Assert.AreEqual(1, task.RehydrateCount);
+        }
+
+        [TestMethod]
+        public void TestDemandDrivesRehydrateNeverRun()
+        {
+            // The decisive dataflow invariant at the machinery level: a lazy
+            // Demand materializes a producer through Rehydrate (load), NEVER Run
+            // (compute) -- Run is the driver loop's job alone. This is the
+            // unit-speed guard for the "Run is outer-loop-only" constraint that
+            // the per-task pure-load rehydrate paths uphold (their end-to-end
+            // coverage is the straight-through-resume smoke).
+            var task = new CountingProducerTask();
+            var ctx = ContextFor(task);
+            ctx.Demand<CountingProducerTask>();
+            Assert.AreEqual(1, task.RehydrateCount);
+            Assert.AreEqual(0, task.RunCount);
         }
 
         [TestMethod]

--- a/pwiz_tools/OspreySharp/OspreySharp/Tasks/FirstJoinTask.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/Tasks/FirstJoinTask.cs
@@ -129,11 +129,12 @@ namespace pwiz.OspreySharp.Tasks
         // post-compaction stub list. Matches the worker's RunWorker-side
         // multi-charge selection so the worker entry-path collapse keeps
         // identical consensus output regardless of which producer task
-        // owned the hydration.
+        // owned the hydration. Takes the already-resolved bundle so it serves
+        // both the worker-published bundle and the straight-through-resume
+        // bundle this task builds from its own sidecars.
         private IReadOnlyDictionary<string, IReadOnlyList<(int Index, double Apex, double Start, double End)>>
-            ConsensusTargetsFromBundleOrEmpty(PipelineContext ctx)
+            ConsensusTargetsFromBundle(PipelineContext ctx, RescoreInputs bundle)
         {
-            var bundle = ctx.Get<RescoreBundle>().Value;
             if (bundle == null) return _perFileConsensusTargets;
             if (bundle.PerFileConsensusTargets != null) return bundle.PerFileConsensusTargets;
             var computed = new Dictionary<string,
@@ -302,32 +303,35 @@ namespace pwiz.OspreySharp.Tasks
 
         public override bool Rehydrate(PipelineContext ctx)
         {
-            // Disk-load path: the upstream PerFileScoring task hydrated a
-            // rescore bundle from sibling sidecars on disk, so the Stage 5
-            // SVM scores + q-values, first-pass protein FDR, and Stage 6
-            // planning state are already encoded in that bundle from the
-            // straight-through run that wrote the boundary files. Re-running
-            // any of them here would re-train SVMs / re-plan on identical
-            // inputs and drift vs the sidecars (mirrors Rust's
+            // Disk-load path: the Stage 5 SVM scores + q-values, first-pass
+            // protein FDR, and Stage 6 planning state already exist on disk in
+            // the boundary sidecars (.1st-pass.fdr_scores.bin +
+            // .reconciliation.json) a prior straight-through run wrote.
+            // Re-running any of them here would re-train SVMs / re-plan on
+            // identical inputs and drift vs the sidecars (mirrors Rust's
             // compute_fdr_from_stubs skip, pipeline.rs:3916). All that remains
-            // is to adopt the bundle and compact. The compute counterpart is
-            // Run.
-            var bundle = ctx.Get<RescoreBundle>().Value;
-
-            // No rescore bundle (straight-through resume, or any non-worker
-            // entry that reaches this task via Demand): the full Stage 5 work
-            // is required, so defer to the compute path. Reached when the
-            // driver skipped this task's Run because its 1st-pass sidecars
-            // were already valid on disk and a downstream task is the first to
-            // touch its state -- recomputing is deterministic and matches
-            // those sidecars. The bundle-adopt disk-load below applies only
-            // when PerFileScoring hydrated a bundle from sibling sidecars.
-            if (bundle == null)
-                return Run(ctx);
-
+            // is to adopt a post-Stage-5 bundle and compact. The compute
+            // counterpart is Run.
             _ctx = ctx;
             var config = ctx.Config;
             var perFileEntries = ctx.Get<ScoredEntries>().Value;
+
+            // The bundle to adopt. In worker mode the upstream PerFileScoring
+            // task hydrated it from sibling sidecars and published it. On a
+            // straight-through resume it published null (no bundle): the driver
+            // skipped THIS task's Run because its own 1st-pass + reconciliation
+            // sidecars were already valid on disk (CanRehydrate) and a
+            // downstream task is the first to touch its state. Build the
+            // equivalent bundle here from those own outputs rather than
+            // deferring to Run -- so a lazy Demand loads, never computes, and
+            // Run stays outer-loop-only.
+            var bundle = ctx.Get<RescoreBundle>().Value;
+            if (bundle == null)
+            {
+                bundle = LoadOwnReconciliationBundle(ctx, perFileEntries);
+                if (bundle == null)
+                    return false;  // load failure; ExitCode already set
+            }
 
             ctx.LogInfo(@"Bundle hydration: skipping first-pass Percolator (sidecar provides q-values).");
 
@@ -342,14 +346,79 @@ namespace pwiz.OspreySharp.Tasks
             // Publish the SAME four planning byproducts as Run, but sourced from
             // the adopted bundle (post-compaction). A consumer pulls
             // ctx.Get<ReconciliationActions>() etc. without knowing whether this
-            // task computed them (Run) or adopted them from the worker bundle
-            // (here) -- the dual-source getter fallback collapses into one slot.
+            // task computed them (Run), adopted them from the worker bundle, or
+            // rebuilt them from its own sidecars (straight-through resume) --
+            // the dual-source getter fallback collapses into one slot.
             ctx.Publish(new ReconciliationActions(bundle.ReconciliationActions));
             ctx.Publish(new RefinedCalibrations(bundle.RefinedCalibrations));
             ctx.Publish(new PerFileGapFillForRescore(bundle.PerFileGapFill));
-            ctx.Publish(new PerFileConsensusTargets(ConsensusTargetsFromBundleOrEmpty(ctx)));
+            ctx.Publish(new PerFileConsensusTargets(ConsensusTargetsFromBundle(ctx, bundle)));
             ctx.Publish(new CompactedEntries(perFileEntries));
             return true;
+        }
+
+        /// <summary>
+        /// Build the post-Stage-5 rescore bundle from THIS task's own
+        /// <c>.1st-pass.fdr_scores.bin</c> + <c>.reconciliation.json</c> sidecars
+        /// for a straight-through resume, where the driver skipped
+        /// <see cref="Run"/> because those outputs were already valid on disk
+        /// (<see cref="PipelineContext.CanRehydrate"/>) and a downstream task is
+        /// the first to touch this task's state. Overlays the first-pass q-values
+        /// onto the shared stubs and parses the reconciliation envelopes -- the
+        /// same bundle PerFileScoring's worker-mode hydration produces, but owned
+        /// here against this task's own outputs. Returns <c>null</c> (with
+        /// <see cref="PipelineContext.ExitCode"/> set) on a load failure; because
+        /// CanRehydrate gated the sidecars as valid, that is a genuine fault, not
+        /// a "recompute instead" case. Clears PIN features on the overlaid stubs,
+        /// exactly as the worker hydration does, so PerFileRescore's "Features !=
+        /// null means rescored" parquet criterion and MergeNode's feature reload
+        /// stay correct.
+        /// </summary>
+        private RescoreInputs LoadOwnReconciliationBundle(
+            PipelineContext ctx,
+            List<KeyValuePair<string, List<FdrEntry>>> perFileEntries)
+        {
+            // Resolve each loaded file's own .scores.parquet path in
+            // perFileEntries order so HydrateReconciliationOverlay's
+            // index-correspondence contract (entries[i] <-> parquetPaths[i])
+            // holds; PerFileScoring published these paths as PerFileParquetPaths.
+            var perFileParquetPaths = ctx.Get<PerFileParquetPaths>().Value;
+            var parquetPaths = new List<string>(perFileEntries.Count);
+            foreach (var kvp in perFileEntries)
+            {
+                if (!perFileParquetPaths.TryGetValue(kvp.Key, out var path))
+                {
+                    ctx.LogError(string.Format(
+                        @"Resume rehydrate: no scores parquet path published for {0}", kvp.Key));
+                    ctx.ExitCode = 1;
+                    return null;
+                }
+                parquetPaths.Add(path);
+            }
+
+            RescoreInputs bundle;
+            try
+            {
+                bundle = RescoreHydration.HydrateReconciliationOverlay(perFileEntries, parquetPaths);
+            }
+            catch (InvalidDataException ex)
+            {
+                ctx.LogError(string.Format(
+                    @"Resume rehydrate: failed to hydrate reconciliation bundle from own sidecars: {0}",
+                    ex.Message));
+                ctx.ExitCode = 1;
+                return null;
+            }
+
+            // Clear PIN features on the overlaid stubs so PerFileRescore's
+            // "Features != null means this entry was rescored" parquet criterion
+            // stays correct and MergeNode reloads features from the reconciled
+            // parquet -- mirrors PerFileScoringTask.HydrateRescoreBundleIfPresent.
+            foreach (var kvp in perFileEntries)
+                foreach (var entry in kvp.Value)
+                    entry.Features = null;
+
+            return bundle;
         }
 
         /// <summary>

--- a/pwiz_tools/OspreySharp/OspreySharp/Tasks/PerFileRescoreTask.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/Tasks/PerFileRescoreTask.cs
@@ -332,15 +332,26 @@ namespace pwiz.OspreySharp.Tasks
             // each entry from the .1st-pass.fdr_scores.bin sidecar by
             // PerFileScoringTask's bundle hydration; no fresh FDR computation.
             //
-            // Only the --join-at-pass=2 merge entry rehydrates here (reconciled
-            // parquets on disk, no mzMLs to rescore). Any other entry that
-            // reaches this task via Demand -- straight-through resume where the
-            // reconciled parquets are already valid on disk and a downstream
-            // task is the first to touch its state -- must take the compute
-            // path, whose per-file ScoreOrLoadForFile loads the valid
-            // reconciled parquets rather than re-scoring.
+            // Straight-through resume: the driver skipped this task's Run
+            // because its reconciled parquets are already valid on disk
+            // (CanRehydrate) and a downstream task (MergeNode) is the first to
+            // touch its state. A resumed Run self-gates to a no-op here --
+            // FirstJoin rehydrates (so DidPlan is false) and there is no rescore
+            // bundle, so ExecuteRescore never runs and the shared buffer is left
+            // at its post-compaction (CompactedEntries) state; MergeNode reloads
+            // the rescored features from the valid reconciled parquets on disk.
+            // Reproduce exactly that end state by loading the CompactedEntries
+            // milestone (which materializes FirstJoin's own pure rehydrate) and
+            // publishing it as RescoredEntries -- never calling Run, so Rehydrate
+            // stays pure. The --join-at-pass=2 merge path (ExpectReconciledInput)
+            // below is a different rehydrate that must NOT materialize FirstJoin.
             if (!ctx.Config.ExpectReconciledInput)
-                return Run(ctx);
+            {
+                _ctx = ctx;
+                _perFileEntries = ctx.Get<CompactedEntries>().Value;
+                ctx.Publish(new RescoredEntries(_perFileEntries));
+                return true;
+            }
 
             _ctx = ctx;
             // ScoredEntries, NOT CompactedEntries: the merge path must NOT

--- a/pwiz_tools/OspreySharp/OspreySharp/Tasks/PerFileScoringTask.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/Tasks/PerFileScoringTask.cs
@@ -350,13 +350,12 @@ namespace pwiz.OspreySharp.Tasks
             // straight-through resume: the driver skipped its Run because its
             // own .scores.parquet outputs were already valid on disk
             // (CanRehydrate), and a downstream task is the first to touch its
-            // state. The right re-materialization there is the compute path,
-            // whose per-file ScoreOrLoadForFile loads those valid parquets
-            // (rather than re-scoring) -- so defer to Run. The worker-mode
-            // join-only disk-load below applies only when --input-scores
-            // actually supplied the per-file scores.
+            // state. Load those valid parquets straight from disk (never
+            // compute) so Rehydrate stays pure -- Run is outer-loop-only. The
+            // worker-mode join-only disk-load below applies only when
+            // --input-scores actually supplied the per-file scores.
             if (ctx.Config.InputScores == null || ctx.Config.InputScores.Count == 0)
-                return Run(ctx);
+                return RehydrateFromOwnOutputs(ctx);
 
             // Disk-load path for worker-mode entry (--input-scores): the
             // per-file Stage 2-4 scores already exist on disk, so load the
@@ -428,6 +427,89 @@ namespace pwiz.OspreySharp.Tasks
             // flag (Phase C principle: mechanism-driven, not flag-driven).
             if (!HydrateRescoreBundleIfPresent(config, perFileEntries))
                 return false;
+
+            return FinalizeAndCheck(ctx, perFileEntries, perFileCalibrations,
+                perFileParquetPaths, nFiles, totalScored);
+        }
+
+        /// <summary>
+        /// Pure load-from-own-outputs rehydrate for a straight-through resume:
+        /// the driver skipped this task's <see cref="Run"/> because its per-file
+        /// <c>.scores.parquet</c> outputs were already valid on disk
+        /// (<see cref="PipelineContext.CanRehydrate"/>), and a downstream task is
+        /// the first to touch its state. Load the library and each file's stubs +
+        /// PIN features + calibration straight from those valid parquets -- the
+        /// same disk-load <see cref="ScoreOrLoadForFile"/> takes on its fast-skip
+        /// arm, but with no <see cref="ProcessFile"/> compute fallback, so a lazy
+        /// Demand never triggers scoring (Run stays outer-loop-only). Produces
+        /// the identical post-Stage-4 state Run leaves on a resume:
+        /// <see cref="_rescoreInputs"/> stays null (a straight-through run wrote
+        /// no reconciliation bundle), and the same byproducts publish through the
+        /// shared <see cref="FinalizeAndCheck"/> tail. Because CanRehydrate gated
+        /// the outputs as valid, a load failure here is a genuine fault (not a
+        /// "fall back to rescore" case) and stops the pipeline.
+        /// </summary>
+        private bool RehydrateFromOwnOutputs(PipelineContext ctx)
+        {
+            _ctx = ctx;
+            var config = ctx.Config;
+
+            // Stage 1: library + decoys (needed by Stage 5+ even though the
+            // per-file scores are loaded rather than computed).
+            if (!LoadLibraryAndDecoys(config, out _))
+                return false;
+
+            var perFileEntries = new List<KeyValuePair<string, List<FdrEntry>>>();
+            var perFileCalibrations = new ConcurrentDictionary<string, RTCalibration>();
+            var perFileParquetPaths = new Dictionary<string, string>();
+
+            int nFiles = config.InputFiles?.Count ?? 0;
+
+            // Mirror Run's EffectiveFileParallelism bookkeeping (unused by the
+            // disk-load path, which never calls ProcessFile, but kept so the
+            // RunPlan reflects the same per-run state either way).
+            int maxParallelFiles = OspreyEnvironment.MaxParallelFiles;
+            if (nFiles == 1 || maxParallelFiles == 1)
+                ctx.RunPlan.EffectiveFileParallelism = 1;
+            else if (maxParallelFiles > 1)
+                ctx.RunPlan.EffectiveFileParallelism = Math.Min(maxParallelFiles, nFiles);
+            else
+                ctx.RunPlan.EffectiveFileParallelism = Math.Min(nFiles, Environment.ProcessorCount);
+
+            var swAllFiles = Stopwatch.StartNew();
+            if (config.InputFiles != null)
+            {
+                // Sequential in InputFiles order to match Run's "collect in
+                // original order" -- downstream FirstJoin iterates perFileEntries.
+                foreach (string inputFile in config.InputFiles)
+                {
+                    string fileName = Path.GetFileNameWithoutExtension(inputFile);
+                    string scoresPath = ParquetScoreCache.GetScoresPath(inputFile);
+                    var stubs = TryLoadStubsAndCalibration(scoresPath, fileName, perFileCalibrations, ctx);
+                    if (stubs == null)
+                    {
+                        ctx.LogError(string.Format(
+                            @"Resume rehydrate: failed to load valid-on-disk scores for {0} ({1})",
+                            fileName, scoresPath));
+                        ctx.ExitCode = 1;
+                        return false;
+                    }
+                    perFileEntries.Add(new KeyValuePair<string, List<FdrEntry>>(fileName, stubs));
+                    perFileParquetPaths[fileName] = scoresPath;
+                }
+            }
+            swAllFiles.Stop();
+            ctx.LogInfo(string.Format(@"[TIMING] All files processed: {0:F1}s",
+                swAllFiles.Elapsed.TotalSeconds));
+
+            int totalScored = 0;
+            foreach (var kvp in perFileEntries)
+                totalScored += kvp.Value.Count;
+
+            ctx.LogInfo(string.Empty);
+            ctx.LogInfo(string.Format(
+                @"Coelution analysis complete. {0} total scored entries across {1} files",
+                totalScored, nFiles));
 
             return FinalizeAndCheck(ctx, perFileEntries, perFileCalibrations,
                 perFileParquetPaths, nFiles, totalScored);

--- a/pwiz_tools/OspreySharp/OspreySharp/Tasks/PerFileScoringTask.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/Tasks/PerFileScoringTask.cs
@@ -485,12 +485,14 @@ namespace pwiz.OspreySharp.Tasks
                 {
                     string fileName = Path.GetFileNameWithoutExtension(inputFile);
                     string scoresPath = ParquetScoreCache.GetScoresPath(inputFile);
-                    var stubs = TryLoadStubsAndCalibration(scoresPath, fileName, perFileCalibrations, ctx);
+                    // Strict load: CanRehydrate already certified these outputs
+                    // valid, so a failure is a genuine fault, not a "fall back to
+                    // rescore" case -- TryLoadStubsAndCalibration logs it as an
+                    // error (no misleading "will rescore" warning). Fail loudly;
+                    // Rehydrate must not compute.
+                    var stubs = TryLoadStubsAndCalibration(scoresPath, fileName, perFileCalibrations, ctx, resumeStrict: true);
                     if (stubs == null)
                     {
-                        ctx.LogError(string.Format(
-                            @"Resume rehydrate: failed to load valid-on-disk scores for {0} ({1})",
-                            fileName, scoresPath));
                         ctx.ExitCode = 1;
                         return false;
                     }
@@ -1065,15 +1067,23 @@ namespace pwiz.OspreySharp.Tasks
         /// <summary>
         /// Best-effort load of one file's stubs + PIN features from a
         /// <c>.scores.parquet</c> plus the calibration sibling. Returns
-        /// the stub list on success or <c>null</c> on any read failure
-        /// (caller treats null as "fall back to rescore"). Mirrors the
-        /// load logic in the <c>--join-only</c> branch above.
+        /// the stub list on success or <c>null</c> on a stub/feature read
+        /// failure. With <paramref name="resumeStrict"/> = <c>false</c> (the
+        /// default, used by <see cref="ScoreOrLoadForFile"/>) the caller falls
+        /// back to rescoring, so a failure logs a "will rescore" warning. With
+        /// <paramref name="resumeStrict"/> = <c>true</c> (the pure-load resume
+        /// path, where <see cref="PipelineContext.CanRehydrate"/> already
+        /// certified the outputs valid and there is NO rescore fallback) a
+        /// failure is a genuine fault and logs an error instead -- no misleading
+        /// "will rescore" messaging. Mirrors the load logic in the
+        /// <c>--join-only</c> branch above.
         /// </summary>
         private static List<FdrEntry> TryLoadStubsAndCalibration(
             string scoresPath,
             string fileName,
             ConcurrentDictionary<string, RTCalibration> perFileCalibrations,
-            PipelineContext ctx)
+            PipelineContext ctx,
+            bool resumeStrict = false)
         {
             List<FdrEntry> stubs;
             try
@@ -1082,9 +1092,14 @@ namespace pwiz.OspreySharp.Tasks
                 var features = ParquetScoreCache.LoadPinFeaturesFromParquet(scoresPath);
                 if (features.Count != stubs.Count)
                 {
-                    ctx.LogWarning(string.Format(
-                        @"  Per-file resume: {0} has {1} stubs but {2} feature rows; will rescore.",
-                        scoresPath, stubs.Count, features.Count));
+                    if (resumeStrict)
+                        ctx.LogError(string.Format(
+                            @"  Resume rehydrate: {0} has {1} stubs but {2} feature rows; cannot load valid-on-disk scores.",
+                            scoresPath, stubs.Count, features.Count));
+                    else
+                        ctx.LogWarning(string.Format(
+                            @"  Per-file resume: {0} has {1} stubs but {2} feature rows; will rescore.",
+                            scoresPath, stubs.Count, features.Count));
                     return null;
                 }
                 for (int j = 0; j < stubs.Count; j++)
@@ -1092,9 +1107,14 @@ namespace pwiz.OspreySharp.Tasks
             }
             catch (Exception ex)
             {
-                ctx.LogWarning(string.Format(
-                    @"  Per-file resume: failed to load {0}: {1}; will rescore.",
-                    scoresPath, ex.Message));
+                if (resumeStrict)
+                    ctx.LogError(string.Format(
+                        @"  Resume rehydrate: failed to load valid-on-disk scores from {0}: {1}",
+                        scoresPath, ex.Message));
+                else
+                    ctx.LogWarning(string.Format(
+                        @"  Per-file resume: failed to load {0}: {1}; will rescore.",
+                        scoresPath, ex.Message));
                 return null;
             }
 


### PR DESCRIPTION
## Summary

* Eliminated the three remaining `Rehydrate -> return Run(ctx)` deferrals (PerFileScoring,
  FirstJoin, PerFileRescore) — the last violations of the declarative-dataflow constraint that
  **Run is outer-loop-only and Rehydrate only loads, never computes**. A lazy `Demand`/`Get` on a
  straight-through resume now loads each task's own valid-on-disk outputs instead of re-entering `Run`.
* PerFileScoring: new `RehydrateFromOwnOutputs` loads its own `.scores.parquet` stubs + PIN features
  + calibration via the existing `TryLoadStubsAndCalibration` (the same loader `Run`'s per-file
  fast-skip uses), then publishes through the shared `FinalizeAndCheck` tail. `_rescoreInputs` stays
  null (no bundle on a straight-through run), matching `Run`.
* FirstJoin: when the worker published no bundle (straight-through resume), new
  `LoadOwnReconciliationBundle` rebuilds the post-Stage-5 `RescoreInputs` from this task's own
  `.1st-pass.fdr_scores.bin` + `.reconciliation.json` (via `RescoreHydration.HydrateReconciliationOverlay`),
  nulls PIN features as the worker hydration does, then flows through the existing, gate-validated
  bundle-adopt compact/publish path. `ConsensusTargetsFromBundleOrEmpty(ctx)` ->
  `ConsensusTargetsFromBundle(ctx, bundle)` so it serves both the worker-published and the
  locally-rebuilt bundle.
* PerFileRescore: the straight-through branch reads `CompactedEntries` and publishes `RescoredEntries`
  inline, reproducing exactly what the old `Run` left on resume (its self-gate was a no-op there) —
  no `Run` call.
* Kept the `&& ExitCode != 0` discriminator in `PipelineContext.DemandByType`: PerFileScoring's
  Rehydrate still routes through `FinalizeAndCheck`'s legitimate success-but-stop returns
  (`--no-join` / empty scores), so a bare publish-or-throw would wrongly fail those benign stops.
* Added `ByproductContextTest` coverage for previously-untested cache invariants: single-producer
  ctor throw, `MarkMaterialized` suppression, the one-shot `Demand` guard, publish-or-throw on a
  forgetful producer, and a unit gate asserting a `Demand` drives `Rehydrate` and never `Run`.

See ai/todos/active/TODO-20260604_ospreysharp_rehydrate_purity_prd.md

## ⚠️ Reviewer note — a pre-existing bug this PR deliberately does NOT fix

Building the new straight-through-resume parity gate **surfaced (byte-exact) the known pre-existing
resume-RT bug** (tracked in `ai/todos/backlog/TODO-ospreysharp_straightthrough_resume_1stpass_rt.md`):
on resume the buffer is left at 1st-pass RTs, so MergeNode writes 1st-pass RTs to the blib
(~11K/59768 entries, ~1.3 min; warm blib 52,486,144 vs cold 52,514,816 on Stellar 3-file). This PR is
**behavior-preserving** — PerFileRescore's resume Rehydrate reproduces the old `Run` resume behavior
exactly — so it does NOT fix that bug; the new resume gate FAILS today, on purpose, as the standing
gate the fix must turn green. **Recommended follow-up (PR-E):** make PerFileRescore's resume Rehydrate
load its own `.scores-reconciled.parquet` (overlay reconciled RT/area/Features/ParquetIndex onto the
CompactedEntries rows + append gap-fill rows). Note the parity trap: a fresh `OverlayRescoredEntries`
PRESERVES the original ParquetIndex (PerFileRescoreTask.cs:1013) and gap-fill rows carry
`ParquetIndex = uint.MaxValue` — the load must reproduce that, not the reconciled-parquet row index.
Worth its own focused PR with careful gating, not bolted onto this structural refactor.

## Test plan

- [x] Build-OspreySharp -RunTests -RunInspection — 361 tests pass (359 + 2 skipped), ReSharper clean
- [x] Compare-Stage7-Rehydration-Strict-CSharp (worker-mode strict, net8.0) — **Stellar OVERALL PASS** (in-memory vs HPC chain bit-identical at every stage boundary)
- [x] Compare-Stage7-Rehydration-Strict-CSharp **Astral** — **OVERALL PASS** (bit-parity at every stage boundary)
- [x] Compare-StraightThroughResume-CSharp (Stellar) — resume fires pure-load (21.6x faster, 0 from-spectra scoring); blib byte-matches master's resume output 52,486,144 (behavior-preserving; exposes the separate resume-RT bug)
- [x] ByproductContextTest — 5 new methods pass, incl. the Rehydrate-never-Run unit gate

Co-Authored-By: Claude <noreply@anthropic.com>
