### PR TITLE
Fixed MSConvertGUI debug build broken by install-native-dependencies location

### DIFF
--- a/pwiz_tools/MSConvertGUI/Jamfile.jam
+++ b/pwiz_tools/MSConvertGUI/Jamfile.jam
@@ -89,6 +89,24 @@ if [ modules.peek : NT ]
     }
 
 
+    # Single <location> for install-native-dependencies, matching the
+    # Debug/Release choice used by do_msconvert_build and build-location.
+    # Always returns exactly one <location> (never the incoming property list)
+    # so the stage target's <translate-path> is not re-injected into translate.
+    rule install-native-dependencies-location ( properties * )
+    {
+        if <variant>debug in $(properties) ||
+           <debug-symbols>on in $(properties)
+        {
+            return <location>$(PWIZ_BUILD_PATH)/MSConvertGUI/bin/$(PLATFORM)/Debug ;
+        }
+        else
+        {
+            return <location>$(PWIZ_BUILD_PATH)/MSConvertGUI/bin/$(PLATFORM)/Release ;
+        }
+    }
+
+
     # Shared rule for setting build properties on test targets (same as do_msconvert_build).
     rule build-properties ( targets + : sources * : properties * )
     {
@@ -101,8 +119,15 @@ if [ modules.peek : NT ]
             ../../pwiz_tools/commandline//msdiff
             ../../pwiz/utility/bindings/CLI//pwiz_bindings_cli
         : # requirements
-            <location>$(PWIZ_BUILD_PATH)/MSConvertGUI/bin/$(PLATFORM)/Release
-            <variant>debug:<location>$(PWIZ_BUILD_PATH)/MSConvertGUI/bin/$(PLATFORM)/Debug
+            # <location> is a free feature, so an unconditional value plus a
+            # conditional one accumulate (both appear) rather than override,
+            # which feeds a 2-element list to path.relative and breaks debug
+            # builds. Use a conditional rule that always returns a single
+            # <location> matching build-location's Debug/Release choice.
+            # (build-location itself can't be reused here: its else branch
+            # echoes back all properties, which re-injects the stage target's
+            # <translate-path> and crashes property.translate.)
+            <conditional>@install-native-dependencies-location
             <install-type>EXE
             <install-type>CONFIG
             <install-type>SHARED_LIB

--- a/pwiz_tools/MSConvertGUI/Jamfile.jam
+++ b/pwiz_tools/MSConvertGUI/Jamfile.jam
@@ -31,18 +31,27 @@ if [ modules.peek : NT ]
         : "MSConvertGUI" "A tool for converting mass spectrometry data formats." "Vanderbilt University" "MSConvertGUI" ;
 
 
-    rule do_msconvert_build ( targets + : sources * : properties * )
+    # Single source of truth for the MSConvertGUI MSBuild configuration. The
+    # build OutDir (build-location), the staged native-dependencies location
+    # (install-native-dependencies-location), and the MSBuild Configuration
+    # (do_msconvert_build) must all agree, or native deps get staged to a
+    # different folder than the exe. Keep that choice here so they can't drift.
+    rule msconvert-config ( properties * )
     {
-        local config ;
         if <variant>debug in $(properties) ||
            <debug-symbols>on in $(properties)
         {
-            config = "Debug" ;
+            return "Debug" ;
         }
         else
         {
-            config = "Release" ;
+            return "Release" ;
         }
+    }
+
+    rule do_msconvert_build ( targets + : sources * : properties * )
+    {
+        local config = [ msconvert-config $(properties) ] ;
         CONFIGURATION on $(<[1]) = $(config) ;
 
         local location = [ path.make [ feature.get-values location : $(properties) ] ] ;
@@ -67,20 +76,11 @@ if [ modules.peek : NT ]
 
     rule build-location ( properties * )
     {
-        local result ;
         # don't override the location when it's already set
         if ! <location> in $(properties:G)
         {
-            if <variant>debug in $(properties) ||
-               <debug-symbols>on in $(properties)
-            {
-                result = <location>$(PWIZ_BUILD_PATH)/MSConvertGUI/bin/$(PLATFORM)/Debug ;
-            }
-            else
-            {
-                result = <location>$(PWIZ_BUILD_PATH)/MSConvertGUI/bin/$(PLATFORM)/Release ;
-            }
-            return $(result) ;
+            local config = [ msconvert-config $(properties) ] ;
+            return <location>$(PWIZ_BUILD_PATH)/MSConvertGUI/bin/$(PLATFORM)/$(config) ;
         }
         else
         {
@@ -93,17 +93,13 @@ if [ modules.peek : NT ]
     # Debug/Release choice used by do_msconvert_build and build-location.
     # Always returns exactly one <location> (never the incoming property list)
     # so the stage target's <translate-path> is not re-injected into translate.
+    # Unlike build-location this intentionally ignores any externally-supplied
+    # <location>: this internal install target is never given one, and forcing
+    # the value keeps it locked to the exe's OutDir.
     rule install-native-dependencies-location ( properties * )
     {
-        if <variant>debug in $(properties) ||
-           <debug-symbols>on in $(properties)
-        {
-            return <location>$(PWIZ_BUILD_PATH)/MSConvertGUI/bin/$(PLATFORM)/Debug ;
-        }
-        else
-        {
-            return <location>$(PWIZ_BUILD_PATH)/MSConvertGUI/bin/$(PLATFORM)/Release ;
-        }
+        local config = [ msconvert-config $(properties) ] ;
+        return <location>$(PWIZ_BUILD_PATH)/MSConvertGUI/bin/$(PLATFORM)/$(config) ;
     }
 
 


### PR DESCRIPTION
## Summary

* Fixed a project-load failure when building MSConvertGUI in a debug configuration (regression from #4099's install-native-dependencies target)
* The install target set <location> with an unconditional Release value plus a conditional <variant>debug Debug value; because <location> is a free feature these accumulate rather than override, so path.relative got a 2-element list and aborted
* Replaced those two location properties with a conditional install-native-dependencies-location rule that always yields a single <location>, matching the Debug/Release choice in do_msconvert_build
* build-location was not reusable for the stage target: its else branch returns the full property list, which re-injects <translate-path>@stage-translate-path into property.translate and crashes with "unknown rule"

## Test plan

- [x] quickbuild debug build of MSConvertGUI (variant=debug debug-symbols=on iterator-debugging=on runtime-debugging=on) now passes project load and builds; previously failed at load

Co-Authored-By: Claude <noreply@anthropic.com>