### PR TITLE
Guarded Thermo analyzer lookup against empty analyzer list

### DIFF
--- a/pwiz.sln
+++ b/pwiz.sln
@@ -11,7 +11,8 @@ Global
 		BrowseOnly|x64 = BrowseOnly|x64
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{69BD51D3-2BBA-4462-A5A4-FC8EF88A52FD}.BrowseOnly|Win32.ActiveCfg = BrowseOnly|x64
+		{69BD51D3-2BBA-4462-A5A4-FC8EF88A52FD}.BrowseOnly|Win32.ActiveCfg = BrowseOnly|Win32
+		{69BD51D3-2BBA-4462-A5A4-FC8EF88A52FD}.BrowseOnly|Win32.Build.0 = BrowseOnly|Win32
 		{69BD51D3-2BBA-4462-A5A4-FC8EF88A52FD}.BrowseOnly|x64.ActiveCfg = BrowseOnly|x64
 		{69BD51D3-2BBA-4462-A5A4-FC8EF88A52FD}.BrowseOnly|x64.Build.0 = BrowseOnly|x64
 	EndGlobalSection

--- a/pwiz.sln
+++ b/pwiz.sln
@@ -11,8 +11,7 @@ Global
 		BrowseOnly|x64 = BrowseOnly|x64
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{69BD51D3-2BBA-4462-A5A4-FC8EF88A52FD}.BrowseOnly|Win32.ActiveCfg = BrowseOnly|Win32
-		{69BD51D3-2BBA-4462-A5A4-FC8EF88A52FD}.BrowseOnly|Win32.Build.0 = BrowseOnly|Win32
+		{69BD51D3-2BBA-4462-A5A4-FC8EF88A52FD}.BrowseOnly|Win32.ActiveCfg = BrowseOnly|x64
 		{69BD51D3-2BBA-4462-A5A4-FC8EF88A52FD}.BrowseOnly|x64.ActiveCfg = BrowseOnly|x64
 		{69BD51D3-2BBA-4462-A5A4-FC8EF88A52FD}.BrowseOnly|x64.Build.0 = BrowseOnly|x64
 	EndGlobalSection

--- a/pwiz/data/vendor_readers/Thermo/SpectrumList_Thermo.cpp
+++ b/pwiz/data/vendor_readers/Thermo/SpectrumList_Thermo.cpp
@@ -131,7 +131,7 @@ InstrumentConfigurationPtr SpectrumList_Thermo::findInstrumentConfiguration(cons
 
         try
         {
-            if (icPtr->componentList.analyzer(analyzerCount - 1).hasCVParam(massAnalyzerType))
+            if (analyzerCount > 0 && icPtr->componentList.analyzer(analyzerCount - 1).hasCVParam(massAnalyzerType))
                 return icPtr;
         }
         catch (out_of_range&)


### PR DESCRIPTION
## Summary

* Guard the Thermo analyzer lookup in `findInstrumentConfiguration` with `analyzerCount > 0` before accessing `analyzer(analyzerCount - 1)`. When an instrument configuration has no analyzer components, `analyzerCount - 1` underflows (size_t) and throws `out_of_range`; the guard avoids the exception path entirely.
* Map `BrowseOnly|Win32` to the `BrowseOnly|x64` build config in `pwiz.sln` and drop the Win32 build entry, so pressing F5 (run/debug) does not trigger a Win32 build that cannot succeed.

## Test plan

- [x] Built and tested locally by the author.

Co-Authored-By: Claude <noreply@anthropic.com>
