### PR TITLE
Added a --task CLI for single-task HPC, replacing the mode flags

### DIFF
--- a/pwiz_tools/OspreySharp/Osprey-workflow.html
+++ b/pwiz_tools/OspreySharp/Osprey-workflow.html
@@ -345,7 +345,7 @@
 <!-- ================================================================= -->
 <g transform="translate(0, 1310)">
   <text x="600" y="14" text-anchor="middle" style="font-size: 10px; fill: #555;">
-    --no-join exits here (per-file .scores.parquet on disk); --join-at-pass=1 resumes here on a coordinator node
+    --task PerFileScoring exits here (per-file .scores.parquet on disk); --task FirstJoin resumes here on a coordinator node
   </text>
 </g>
 
@@ -406,7 +406,7 @@
 <!-- ================================================================= -->
 <g transform="translate(0, 1850)">
   <text x="600" y="14" text-anchor="middle" style="font-size: 10px; fill: #555;">
-    --join-at-pass=1 --join-only would stop here (future: plan files to disk for HPC fan-back-out); --join-at-pass=1 continues
+    --task FirstJoin stops here (writes the Stage 5 -> 6 boundary sidecars for HPC fan-back-out); the full pipeline continues
   </text>
 </g>
 
@@ -444,7 +444,7 @@
 <!-- ================================================================= -->
 <g transform="translate(0, 2150)">
   <text x="600" y="14" text-anchor="middle" style="font-size: 10px; fill: #555;">
-    --join-at-pass=2 --input-scores ... resumes here from reconciled per-file parquets (second join begins)
+    --task MergeNode --input-scores ... resumes here from reconciled per-file parquets (second join begins)
   </text>
 </g>
 

--- a/pwiz_tools/OspreySharp/Osprey-workflow.html
+++ b/pwiz_tools/OspreySharp/Osprey-workflow.html
@@ -504,20 +504,25 @@
   <p>
     <strong>End-to-end performance (3-file regression, Windows
     native, C: SSD source data, AV-scan excluded; all 8 cells
-    median-of-3 refreshed 2026-05-29 — round 4):</strong>
-    Measured on the <code>Skyline/work/20260527_svm_stage5_perf</code>
-    branch with Fix #1 + Fix #5b + Fix #6 landed (SIMD inner loops
-    in <code>LinearSvmClassifier.Train</code>, parallel LOESS outer
-    loop, parallel KDE Pdf binning in <code>PepEstimator.Fit</code>).
-    Stage 5/6 boundaries now aligned cross-impl: Rust labels stage5 =
+    median-of-3 refreshed 2026-06-06):</strong>
+    Re-measured on the post-PR-E codebase (the <code>--task</code> HPC
+    CLI branch) with the machine quiesced &mdash; no reboot, but every
+    other application shut down so nothing competed for CPU.  These are
+    the dependable reported figures: C# Astral total settles at
+    ~17:40 run-to-run and occasionally finishes ~10% faster (the
+    earlier 16:10 figure), but that lower time is not reproducible on
+    demand, so the table reports the stable upper figure to avoid false
+    &ldquo;regression&rdquo; flags; Rust does not show this variance.
+    Stage 5/6 boundaries are aligned cross-impl: Rust labels stage5 =
     percolator + protein FDR, stage6 = reconciliation + rescore +
     gap-fill; C# previously folded reconciliation into stage5, which
     is the artifact that created the historical &ldquo;Astral stage5
-    4&times;&rdquo; figure.  Measure-Pipeline.ps1 now derives the
+    4&times;&rdquo; figure.  Measure-Pipeline.ps1 derives the
     reconciliation portion from the <code>[TIMING]</code> markers on
     the C# side and shifts it into stage6, so the per-stage cells
-    here compare like-for-like.  Variance is &lt;7s on Stellar and
-    &lt;25s on Astral across the three repeats.
+    here compare like-for-like.  Variance across the three repeats is
+    tight on C# (Astral total 17:44..17:48, Stellar 3:32..3:46) and
+    wider on Rust, mostly in blib write (Astral total 25:01..26:19).
   </p>
   <table style="margin: 8px 0; font-family: ui-monospace, SFMono-Regular, monospace; font-size: 11px; border-collapse: collapse;">
     <thead>
@@ -532,12 +537,12 @@
       </tr>
     </thead>
     <tbody>
-      <tr><td style="padding: 1px 12px 1px 0;">stage1to4</td><td style="text-align: right; padding: 1px 12px;">1:54</td><td style="text-align: right; padding: 1px 12px;">1:19</td><td style="text-align: right; padding: 1px 12px; color: #1a7f37;">0.70x (C# faster)</td><td style="text-align: right; padding: 1px 12px;">9:09</td><td style="text-align: right; padding: 1px 12px;">7:17</td><td style="text-align: right; padding: 1px 12px; color: #1a7f37;">0.80x (C# faster)</td></tr>
-      <tr><td style="padding: 1px 12px 1px 0;">stage5 (1st-pass FDR, aligned)</td><td style="text-align: right; padding: 1px 12px;">1:21</td><td style="text-align: right; padding: 1px 12px;">1:14</td><td style="text-align: right; padding: 1px 12px; color: #1a7f37;">0.92x (C# faster)</td><td style="text-align: right; padding: 1px 12px;">1:42</td><td style="text-align: right; padding: 1px 12px;">1:14</td><td style="text-align: right; padding: 1px 12px; color: #1a7f37;">0.73x (C# faster)</td></tr>
-      <tr><td style="padding: 1px 12px 1px 0;">stage6 (reconciliation + rescore, aligned)</td><td style="text-align: right; padding: 1px 12px;">0:40</td><td style="text-align: right; padding: 1px 12px;">0:42</td><td style="text-align: right; padding: 1px 12px;">1.06x (~tied)</td><td style="text-align: right; padding: 1px 12px;">7:58</td><td style="text-align: right; padding: 1px 12px;">4:55</td><td style="text-align: right; padding: 1px 12px; color: #1a7f37;">0.62x (C# faster)</td></tr>
-      <tr><td style="padding: 1px 12px 1px 0;">stage7 (2nd-pass FDR + protein)</td><td style="text-align: right; padding: 1px 12px;">0:47</td><td style="text-align: right; padding: 1px 12px;">0:42</td><td style="text-align: right; padding: 1px 12px; color: #1a7f37;">0.91x (C# faster)</td><td style="text-align: right; padding: 1px 12px;">3:14</td><td style="text-align: right; padding: 1px 12px;">2:30</td><td style="text-align: right; padding: 1px 12px; color: #1a7f37;">0.78x (C# faster)</td></tr>
-      <tr><td style="padding: 1px 12px 1px 0;">blib write</td><td style="text-align: right; padding: 1px 12px;">0:19</td><td style="text-align: right; padding: 1px 12px;">0:03</td><td style="text-align: right; padding: 1px 12px; color: #1a7f37;">0.17x (C# faster)</td><td style="text-align: right; padding: 1px 12px;">1:53</td><td style="text-align: right; padding: 1px 12px;">0:09</td><td style="text-align: right; padding: 1px 12px; color: #1a7f37;">0.08x (C# faster)</td></tr>
-      <tr style="border-top: 1px solid #888;"><td style="padding: 1px 12px 1px 0;"><strong>Total</strong></td><td style="text-align: right; padding: 1px 12px;"><strong>5:03</strong></td><td style="text-align: right; padding: 1px 12px;"><strong>4:01</strong></td><td style="text-align: right; padding: 1px 12px; color: #1a7f37;"><strong>0.79x (C# faster)</strong></td><td style="text-align: right; padding: 1px 12px;"><strong>24:26</strong></td><td style="text-align: right; padding: 1px 12px;"><strong>16:10</strong></td><td style="text-align: right; padding: 1px 12px; color: #1a7f37;"><strong>0.66x (C# faster)</strong></td></tr>
+      <tr><td style="padding: 1px 12px 1px 0;">stage1to4</td><td style="text-align: right; padding: 1px 12px;">2:05</td><td style="text-align: right; padding: 1px 12px;">1:25</td><td style="text-align: right; padding: 1px 12px; color: #1a7f37;">0.68x (C# faster)</td><td style="text-align: right; padding: 1px 12px;">9:46</td><td style="text-align: right; padding: 1px 12px;">8:12</td><td style="text-align: right; padding: 1px 12px; color: #1a7f37;">0.84x (C# faster)</td></tr>
+      <tr><td style="padding: 1px 12px 1px 0;">stage5 (1st-pass FDR, aligned)</td><td style="text-align: right; padding: 1px 12px;">1:11</td><td style="text-align: right; padding: 1px 12px;">1:01</td><td style="text-align: right; padding: 1px 12px; color: #1a7f37;">0.87x (C# faster)</td><td style="text-align: right; padding: 1px 12px;">1:34</td><td style="text-align: right; padding: 1px 12px;">1:08</td><td style="text-align: right; padding: 1px 12px; color: #1a7f37;">0.72x (C# faster)</td></tr>
+      <tr><td style="padding: 1px 12px 1px 0;">stage6 (reconciliation + rescore, aligned)</td><td style="text-align: right; padding: 1px 12px;">0:38</td><td style="text-align: right; padding: 1px 12px;">0:37</td><td style="text-align: right; padding: 1px 12px;">0.99x (~tied)</td><td style="text-align: right; padding: 1px 12px;">8:59</td><td style="text-align: right; padding: 1px 12px;">5:59</td><td style="text-align: right; padding: 1px 12px; color: #1a7f37;">0.67x (C# faster)</td></tr>
+      <tr><td style="padding: 1px 12px 1px 0;">stage7 (2nd-pass FDR + protein)</td><td style="text-align: right; padding: 1px 12px;">0:42</td><td style="text-align: right; padding: 1px 12px;">0:34</td><td style="text-align: right; padding: 1px 12px; color: #1a7f37;">0.83x (C# faster)</td><td style="text-align: right; padding: 1px 12px;">2:58</td><td style="text-align: right; padding: 1px 12px;">2:08</td><td style="text-align: right; padding: 1px 12px; color: #1a7f37;">0.72x (C# faster)</td></tr>
+      <tr><td style="padding: 1px 12px 1px 0;">blib write</td><td style="text-align: right; padding: 1px 12px;">0:22</td><td style="text-align: right; padding: 1px 12px;">0:04</td><td style="text-align: right; padding: 1px 12px; color: #1a7f37;">0.18x (C# faster)</td><td style="text-align: right; padding: 1px 12px;">1:55</td><td style="text-align: right; padding: 1px 12px;">0:09</td><td style="text-align: right; padding: 1px 12px; color: #1a7f37;">0.08x (C# faster)</td></tr>
+      <tr style="border-top: 1px solid #888;"><td style="padding: 1px 12px 1px 0;"><strong>Total</strong></td><td style="text-align: right; padding: 1px 12px;"><strong>4:57</strong></td><td style="text-align: right; padding: 1px 12px;"><strong>3:42</strong></td><td style="text-align: right; padding: 1px 12px; color: #1a7f37;"><strong>0.75x (C# faster)</strong></td><td style="text-align: right; padding: 1px 12px;"><strong>25:13</strong></td><td style="text-align: right; padding: 1px 12px;"><strong>17:38</strong></td><td style="text-align: right; padding: 1px 12px; color: #1a7f37;"><strong>0.70x (C# faster)</strong></td></tr>
     </tbody>
   </table>
   <p>
@@ -546,8 +551,8 @@
   <ul>
     <li>
       <strong>stage1to4</strong> (per-file scoring): C# faster on
-      both datasets on Windows native (0.72&times; Stellar,
-      0.81&times; Astral). Foundations: <code>XcorrScratchPool</code>
+      both datasets on Windows native (0.68&times; Stellar,
+      0.84&times; Astral). Foundations: <code>XcorrScratchPool</code>
       (LOH-allocation-free ~100K-bin scratch), pre-preprocessed XCorr
       cache with f32 narrowing, pooled <code>visitedBins</code> for
       O(n_fragments) clear, per-file thread scaling, and a mzML read
@@ -557,8 +562,8 @@
     <li>
       <strong>stage5</strong> (first-pass FDR — percolator + protein
       FDR; reconciliation planning is now in stage6 per the alignment
-      noted above): C# is 8% faster on Stellar (1:14 vs 1:21) and
-      27% faster on Astral (1:14 vs 1:42).  Three fixes drove this:
+      noted above): C# is 14% faster on Stellar (1:01 vs 1:11) and
+      28% faster on Astral (1:08 vs 1:34).  Three fixes drove this:
       Fix #1 SIMD-vectorized the SVM dual-coordinate-descent inner
       loops via <code>System.Numerics.Vector&lt;double&gt;</code>;
       Fix #6 parallelized <code>PepEstimator.Fit</code>'s KDE binning
@@ -573,8 +578,8 @@
       <strong>stage6</strong> (reconciliation planning + per-file
       rescore + gap-fill + reconciled parquet write-back, aligned to
       include the reconciliation portion that C# previously logged
-      under stage5): essentially tied on Stellar (1.06&times;, 0:42
-      vs 0:40); C# 38% faster on Astral (4:55 vs 7:58 on Windows
+      under stage5): essentially tied on Stellar (0.99&times;, 0:37
+      vs 0:38); C# 33% faster on Astral (5:59 vs 8:59 on Windows
       native).  Two fixes drove the Astral win: Fix #5b wrapped
       <code>LoessRegression.LoessFitInternal</code>'s outer loop in
       <code>Parallel.For</code> (the per-x-point local regressions
@@ -588,7 +593,7 @@
     <li>
       <strong>stage7</strong> (second-pass Percolator + protein FDR):
       C# faster than Rust everywhere after Fix #1 + #6 (Windows
-      0.91&times; Stellar / 0.78&times; Astral; <code>/mnt/c</code>
+      0.83&times; Stellar / 0.72&times; Astral; <code>/mnt/c</code>
       0.75&times; / 0.72&times;). Stage 7 is heavily SVM-dominated
       — the 2nd-pass FDR re-runs Percolator on the reconciled feature
       pool, and the same SIMD-vectorized

--- a/pwiz_tools/OspreySharp/OspreySharp.Core/OspreyConfig.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Core/OspreyConfig.cs
@@ -144,11 +144,14 @@ namespace pwiz.OspreySharp.Core
         public int NThreads { get; set; } = Environment.ProcessorCount;
 
         /// <summary>
-        /// HPC scoring split: when true, run Stages 1-4 only and exit. Each
-        /// input mzML produces a {stem}.scores.parquet next to it; no FDR
-        /// is run and no blib is written. Set by <c>--task PerFileScoring</c>
-        /// (and <c>--task PerFileRescore</c>, which is the same membership with
-        /// <see cref="InputScores"/> instead of mzML input).
+        /// Pipeline-membership flag (read by each task's <c>IsIncluded</c>):
+        /// include only the per-file fan-out, not the join. Set by both
+        /// <c>--task PerFileScoring</c> and <c>--task PerFileRescore</c>; the
+        /// concrete behavior depends on the input type. With <c>-i</c> mzML it
+        /// is the Stage 1-4 worker — each input produces a
+        /// <c>{stem}.scores.parquet</c> next to it, no FDR, no blib. With
+        /// <see cref="InputScores"/> it is the Stage 6 rescore worker. The two
+        /// are told apart by input type (see <see cref="SelectedTask"/>).
         /// </summary>
         public bool NoJoin { get; set; }
 

--- a/pwiz_tools/OspreySharp/OspreySharp.Core/OspreyConfig.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Core/OspreyConfig.cs
@@ -146,15 +146,16 @@ namespace pwiz.OspreySharp.Core
         /// <summary>
         /// HPC scoring split: when true, run Stages 1-4 only and exit. Each
         /// input mzML produces a {stem}.scores.parquet next to it; no FDR
-        /// is run and no blib is written. Set by the --no-join CLI flag.
-        /// Mutually exclusive with <see cref="InputScores"/>.
+        /// is run and no blib is written. Set by <c>--task PerFileScoring</c>
+        /// (and <c>--task PerFileRescore</c>, which is the same membership with
+        /// <see cref="InputScores"/> instead of mzML input).
         /// </summary>
         public bool NoJoin { get; set; }
 
         /// <summary>
         /// HPC scoring split: when set (non-null, non-empty), skip Stages 1-4
         /// entirely and load these per-file scoring caches as the starting
-        /// point for Stage 5+. Set by --join-only + --input-scores. When set,
+        /// point for Stage 5+. Set by <c>--input-scores</c>. When set,
         /// <see cref="InputFiles"/> is ignored.
         /// </summary>
         public List<string> InputScores { get; set; }
@@ -164,23 +165,34 @@ namespace pwiz.OspreySharp.Core
         /// having written the boundary files
         /// (<c>&lt;stem&gt;.&lt;phase&gt;-pass.fdr_scores.bin</c> and
         /// <c>&lt;stem&gt;.reconciliation.json</c>) for each input file.
-        /// Skips Stage 6 + 7 + 8. Set by the
-        /// <c>--join-at-pass=1 --join-only</c> flag combination.
+        /// Skips Stage 6 + 7 + 8. Set by <c>--task FirstJoin</c>.
         /// </summary>
         public bool StopAfterStage5 { get; set; }
 
         /// <summary>
         /// HPC: when true, every <c>--input-scores</c> parquet must carry
         /// <c>osprey.reconciled = "true"</c> in its footer metadata. Set
-        /// by <c>--join-at-pass=2</c>; the post-Stage-6 (reconciled)
+        /// by <c>--task MergeNode</c>; the post-Stage-6 (reconciled)
         /// entry point. Stages 1-6 are skipped: the pipeline loads
         /// reconciled scores + the <c>.{1st,2nd}-pass.fdr_scores.bin</c>
         /// sidecars, then runs Stages 7-8 (second-pass FDR overlay,
         /// protein parsimony + picked-protein FDR, blib output). Mirrors
-        /// Rust's <c>config.expect_reconciled_input</c> wired from
-        /// <c>main.rs</c> at the same flag.
+        /// Rust's <c>config.expect_reconciled_input</c>.
         /// </summary>
         public bool ExpectReconciledInput { get; set; }
+
+        /// <summary>
+        /// The single pipeline task selected by <c>--task &lt;Name&gt;</c> on the
+        /// CLI, or null for the full pipeline (no <c>--task</c>). The three
+        /// membership flags above (<see cref="NoJoin"/>,
+        /// <see cref="StopAfterStage5"/>, <see cref="ExpectReconciledInput"/>)
+        /// are derived from this and drive each task's <c>IsIncluded</c>; this
+        /// property additionally lets argument validation enforce the
+        /// task&#8596;input-type contract (e.g. PerFileScoring takes mzML,
+        /// PerFileRescore takes <see cref="InputScores"/>) and name the task the
+        /// user actually typed in error messages.
+        /// </summary>
+        public HpcTask? SelectedTask { get; set; }
 
         /// <summary>
         /// Shallow clone for per-file ProcessFile() calls. The pipeline
@@ -206,6 +218,19 @@ namespace pwiz.OspreySharp.Core
         /// and MUST stay byte-identical with Rust.
         /// </summary>
         public SearchIdentity Identity => new SearchIdentity(this);
+    }
+
+    /// <summary>
+    /// A single HPC pipeline task selectable via <c>--task &lt;Name&gt;</c>
+    /// (one HPC node = one task). The names are the stable CLI contract and
+    /// match each task's <c>OspreyTask.Name</c>.
+    /// </summary>
+    public enum HpcTask
+    {
+        PerFileScoring,
+        FirstJoin,
+        PerFileRescore,
+        MergeNode
     }
 
     /// <summary>

--- a/pwiz_tools/OspreySharp/OspreySharp.Test/PipelineMembershipTest.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Test/PipelineMembershipTest.cs
@@ -61,18 +61,18 @@ namespace pwiz.OspreySharp.Test
             {
                 (@"straight-through",  new OspreyConfig(),
                     new[] { true,  true,  true,  true  }),
-                (@"--no-join",         new OspreyConfig { NoJoin = true },
+                (@"PerFileScoring",    new OspreyConfig { NoJoin = true },
                     new[] { true,  false, false, false }),
-                (@"--join-only",       WithInputScores(c => c.StopAfterStage5 = true),
+                (@"FirstJoin",         WithInputScores(c => c.StopAfterStage5 = true),
                     new[] { false, true,  false, false }),
-                (@"rescore-worker",    WithInputScores(c => c.NoJoin = true),
+                (@"PerFileRescore",    WithInputScores(c => c.NoJoin = true),
                     new[] { false, false, true,  false }),
-                (@"merge",             WithInputScores(c => c.ExpectReconciledInput = true),
+                (@"MergeNode",         WithInputScores(c => c.ExpectReconciledInput = true),
                     new[] { false, false, false, true  }),
-                // --join-at-pass=1 --input-scores (no other join modifier): the
-                // single-node full pipeline. PerFileScoring lazy-rehydrates the
-                // supplied scores rather than computing them, so it is excluded;
-                // FirstJoin..MergeNode compute Stages 5-8.
+                // --input-scores with no --task: the single-node full pipeline.
+                // PerFileScoring lazy-rehydrates the supplied scores rather than
+                // computing them, so it is excluded; FirstJoin..MergeNode compute
+                // Stages 5-8.
                 (@"input-scores-full", WithInputScores(_ => { }),
                     new[] { false, true,  true,  true  }),
             };

--- a/pwiz_tools/OspreySharp/OspreySharp.Test/ProgramTests.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Test/ProgramTests.cs
@@ -64,8 +64,8 @@ namespace pwiz.OspreySharp.Test
             };
             string err = Program.ValidateArgs(config, noJoinFlag: false, joinOnlyFlag: true, joinOnlyModifier: false);
             Assert.IsNotNull(err);
-            // Error refers to the canonical flag the user typed.
-            StringAssert.Contains(err, "--join-at-pass=1");
+            // Error refers to the task the user selected via --task.
+            StringAssert.Contains(err, "--task FirstJoin");
             StringAssert.Contains(err, "--input-scores");
         }
 
@@ -81,7 +81,7 @@ namespace pwiz.OspreySharp.Test
             };
             string err = Program.ValidateArgs(config, noJoinFlag: false, joinOnlyFlag: true, joinOnlyModifier: false);
             Assert.IsNotNull(err);
-            StringAssert.Contains(err, "--join-at-pass=1");
+            StringAssert.Contains(err, "--task FirstJoin");
             StringAssert.Contains(err, "cannot be combined with --input");
         }
 
@@ -94,7 +94,7 @@ namespace pwiz.OspreySharp.Test
             };
             string err = Program.ValidateArgs(config, noJoinFlag: false, joinOnlyFlag: true, joinOnlyModifier: false);
             Assert.IsNotNull(err);
-            StringAssert.Contains(err, "--join-at-pass=1");
+            StringAssert.Contains(err, "--task FirstJoin");
             StringAssert.Contains(err, "--library and --output");
         }
 
@@ -200,7 +200,7 @@ namespace pwiz.OspreySharp.Test
             string err = Program.ValidateArgs(config,
                 noJoinFlag: false, joinOnlyFlag: true, joinOnlyModifier: true);
             Assert.IsNotNull(err);
-            StringAssert.Contains(err, "--join-at-pass=1 --join-only");
+            StringAssert.Contains(err, "--task FirstJoin");
             StringAssert.Contains(err, "2+ parquet files");
         }
 
@@ -376,6 +376,118 @@ namespace pwiz.OspreySharp.Test
             Assert.IsNull(err);
             Assert.IsFalse(noJoin);
             Assert.IsFalse(joinOnly);
+        }
+
+        // --- ResolveTask (--task) -----------------------------------------
+
+        [TestMethod]
+        public void TestResolveTaskPerFileScoring()
+        {
+            // --task PerFileScoring == --no-join: noJoin only, no entry point.
+            string err = Program.ResolveTask("PerFileScoring",
+                out bool noJoin, out bool joinOnly, out int? joinAtPass);
+            Assert.IsNull(err);
+            Assert.IsTrue(noJoin);
+            Assert.IsFalse(joinOnly);
+            Assert.IsFalse(joinAtPass.HasValue);
+        }
+
+        [TestMethod]
+        public void TestResolveTaskFirstJoin()
+        {
+            // --task FirstJoin == --join-at-pass=1 --join-only.
+            string err = Program.ResolveTask("FirstJoin",
+                out bool noJoin, out bool joinOnly, out int? joinAtPass);
+            Assert.IsNull(err);
+            Assert.IsFalse(noJoin);
+            Assert.IsTrue(joinOnly);
+            Assert.AreEqual(1, joinAtPass);
+        }
+
+        [TestMethod]
+        public void TestResolveTaskPerFileRescore()
+        {
+            // --task PerFileRescore == --join-at-pass=1 --no-join.
+            string err = Program.ResolveTask("PerFileRescore",
+                out bool noJoin, out bool joinOnly, out int? joinAtPass);
+            Assert.IsNull(err);
+            Assert.IsTrue(noJoin);
+            Assert.IsFalse(joinOnly);
+            Assert.AreEqual(1, joinAtPass);
+        }
+
+        [TestMethod]
+        public void TestResolveTaskMergeNode()
+        {
+            // --task MergeNode == --join-at-pass=2.
+            string err = Program.ResolveTask("MergeNode",
+                out bool noJoin, out bool joinOnly, out int? joinAtPass);
+            Assert.IsNull(err);
+            Assert.IsFalse(noJoin);
+            Assert.IsFalse(joinOnly);
+            Assert.AreEqual(2, joinAtPass);
+        }
+
+        [TestMethod]
+        public void TestResolveTaskIsCaseInsensitive()
+        {
+            string err = Program.ResolveTask("perfilerescore",
+                out bool noJoin, out bool joinOnly, out int? joinAtPass);
+            Assert.IsNull(err);
+            Assert.IsTrue(noJoin);
+            Assert.IsFalse(joinOnly);
+            Assert.AreEqual(1, joinAtPass);
+        }
+
+        [TestMethod]
+        public void TestResolveTaskUnknownErrors()
+        {
+            string err = Program.ResolveTask("Bogus",
+                out _, out _, out _);
+            Assert.IsNotNull(err);
+            StringAssert.Contains(err, "unknown task");
+            StringAssert.Contains(err, "Bogus");
+        }
+
+        [TestMethod]
+        public void TestResolveTaskMapsToExpectedConfigFlags()
+        {
+            // End-to-end: each task name, run through ResolveTask ->
+            // NormalizeHpcArgs (the same wiring Main uses), must produce the
+            // (NoJoin, StopAfterStage5, ExpectReconciledInput) config tuple
+            // that the four tasks' IsIncluded methods read. Mirrors the
+            // membership rows in PipelineMembershipTest.
+            //   task             | NoJoin | StopAfterStage5 | ExpectReconciled
+            //   PerFileScoring   | true   | false           | false
+            //   FirstJoin        | false  | true            | false
+            //   PerFileRescore   | true   | false           | false
+            //   MergeNode        | false  | false           | true
+            var cases = new (string Task, bool NoJoin, bool StopAfterStage5, bool ExpectReconciled)[]
+            {
+                ("PerFileScoring", true,  false, false),
+                ("FirstJoin",      false, true,  false),
+                ("PerFileRescore", true,  false, false),
+                ("MergeNode",      false, false, true),
+            };
+            foreach (var c in cases)
+            {
+                string resolveErr = Program.ResolveTask(c.Task,
+                    out bool noJoin, out bool joinOnly, out int? joinAtPass);
+                Assert.IsNull(resolveErr, c.Task);
+                string normErr = Program.NormalizeHpcArgs(joinAtPass,
+                    ref noJoin, ref joinOnly, out bool joinOnlyModifier);
+                Assert.IsNull(normErr, c.Task);
+                // Main applies these same three assignments after ParseArgs.
+                bool cfgNoJoin = noJoin;
+                bool cfgStopAfterStage5 = joinOnlyModifier;
+                bool cfgExpectReconciled = joinAtPass.HasValue && joinAtPass.Value == 2;
+                Assert.AreEqual(c.NoJoin, cfgNoJoin,
+                    string.Format("{0}: NoJoin", c.Task));
+                Assert.AreEqual(c.StopAfterStage5, cfgStopAfterStage5,
+                    string.Format("{0}: StopAfterStage5", c.Task));
+                Assert.AreEqual(c.ExpectReconciled, cfgExpectReconciled,
+                    string.Format("{0}: ExpectReconciledInput", c.Task));
+            }
         }
 
         // --- ResolveInputScores -------------------------------------------

--- a/pwiz_tools/OspreySharp/OspreySharp.Test/ProgramTests.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Test/ProgramTests.cs
@@ -46,53 +46,46 @@ namespace pwiz.OspreySharp.Test
         // --- ValidateArgs --------------------------------------------------
 
         [TestMethod]
-        public void TestValidateNoJoinAndJoinOnlyIsMutex()
-        {
-            var config = new OspreyConfig();
-            string err = Program.ValidateArgs(config, noJoinFlag: true, joinOnlyFlag: true, joinOnlyModifier: false);
-            Assert.IsNotNull(err);
-            StringAssert.Contains(err, "mutually exclusive");
-        }
-
-        [TestMethod]
-        public void TestValidateJoinOnlyRequiresInputScores()
+        public void TestValidateFirstJoinRequiresInputScores()
         {
             var config = new OspreyConfig
             {
+                StopAfterStage5 = true,   // --task FirstJoin
                 LibrarySource = LibrarySource.FromPath("ref.blib"),
                 OutputBlib = "out.blib"
             };
-            string err = Program.ValidateArgs(config, noJoinFlag: false, joinOnlyFlag: true, joinOnlyModifier: false);
+            string err = Program.ValidateArgs(config);
             Assert.IsNotNull(err);
-            // Error refers to the task the user selected via --task.
             StringAssert.Contains(err, "--task FirstJoin");
             StringAssert.Contains(err, "--input-scores");
         }
 
         [TestMethod]
-        public void TestValidateJoinOnlyRejectsInputMzml()
+        public void TestValidateFirstJoinRejectsInputMzml()
         {
             var config = new OspreyConfig
             {
+                StopAfterStage5 = true,   // --task FirstJoin
                 InputFiles = new List<string> { "a.mzML" },
                 InputScores = new List<string> { "a.scores.parquet" },
                 LibrarySource = LibrarySource.FromPath("ref.blib"),
                 OutputBlib = "out.blib"
             };
-            string err = Program.ValidateArgs(config, noJoinFlag: false, joinOnlyFlag: true, joinOnlyModifier: false);
+            string err = Program.ValidateArgs(config);
             Assert.IsNotNull(err);
             StringAssert.Contains(err, "--task FirstJoin");
             StringAssert.Contains(err, "cannot be combined with --input");
         }
 
         [TestMethod]
-        public void TestValidateJoinOnlyRequiresLibraryAndOutput()
+        public void TestValidateFirstJoinRequiresLibraryAndOutput()
         {
             var config = new OspreyConfig
             {
+                StopAfterStage5 = true,   // --task FirstJoin
                 InputScores = new List<string> { "a.scores.parquet" }
             };
-            string err = Program.ValidateArgs(config, noJoinFlag: false, joinOnlyFlag: true, joinOnlyModifier: false);
+            string err = Program.ValidateArgs(config);
             Assert.IsNotNull(err);
             StringAssert.Contains(err, "--task FirstJoin");
             StringAssert.Contains(err, "--library and --output");
@@ -106,7 +99,7 @@ namespace pwiz.OspreySharp.Test
                 NoJoin = true,
                 LibrarySource = LibrarySource.FromPath("ref.blib")
             };
-            string err = Program.ValidateArgs(config, noJoinFlag: true, joinOnlyFlag: false, joinOnlyModifier: false);
+            string err = Program.ValidateArgs(config);
             Assert.IsNotNull(err);
             StringAssert.Contains(err, "--input <mzML");
         }
@@ -121,7 +114,7 @@ namespace pwiz.OspreySharp.Test
                 InputScores = new List<string> { "a.scores.parquet" },
                 LibrarySource = LibrarySource.FromPath("ref.blib")
             };
-            string err = Program.ValidateArgs(config, noJoinFlag: true, joinOnlyFlag: false, joinOnlyModifier: false);
+            string err = Program.ValidateArgs(config);
             Assert.IsNotNull(err);
             StringAssert.Contains(err, "--input-scores");
         }
@@ -140,7 +133,7 @@ namespace pwiz.OspreySharp.Test
                 OutputBlib = "out.blib",
             };
             Assert.IsNull(
-                Program.ValidateArgs(config, noJoinFlag: true, joinOnlyFlag: false, joinOnlyModifier: false));
+                Program.ValidateArgs(config));
         }
 
         [TestMethod]
@@ -155,7 +148,7 @@ namespace pwiz.OspreySharp.Test
                 InputScores = new List<string> { "a.scores.parquet" },
                 // missing LibrarySource and OutputBlib
             };
-            string err = Program.ValidateArgs(config, noJoinFlag: true, joinOnlyFlag: false, joinOnlyModifier: false);
+            string err = Program.ValidateArgs(config);
             Assert.IsNotNull(err);
             StringAssert.Contains(err, "--library and --output");
         }
@@ -169,71 +162,72 @@ namespace pwiz.OspreySharp.Test
                 InputFiles = new List<string> { "a.mzML" },
                 LibrarySource = LibrarySource.FromPath("ref.blib")
             };
-            Assert.IsNull(Program.ValidateArgs(config, noJoinFlag: true, joinOnlyFlag: false, joinOnlyModifier: false));
+            Assert.IsNull(Program.ValidateArgs(config));
         }
 
         [TestMethod]
-        public void TestValidateJoinOnlyHappyPath()
+        public void TestValidateFullFromScoresHappyPath()
         {
+            // Default full pipeline started from --input-scores (no --task):
+            // all membership flags false. Stages 5-8 run from the parquet
+            // entry point.
             var config = new OspreyConfig
             {
                 InputScores = new List<string> { "a.scores.parquet", "b.scores.parquet" },
                 LibrarySource = LibrarySource.FromPath("ref.blib"),
                 OutputBlib = "out.blib"
             };
-            Assert.IsNull(Program.ValidateArgs(config, noJoinFlag: false, joinOnlyFlag: true, joinOnlyModifier: false));
+            Assert.IsNull(Program.ValidateArgs(config));
         }
 
         [TestMethod]
-        public void TestValidateJoinOnlyModifierRejectsSingleFile()
+        public void TestValidateFirstJoinRejectsSingleFile()
         {
-            // --join-at-pass=1 --join-only writes the Stage 5 → Stage 6
-            // boundary file pair; that's only meaningful with siblings,
-            // so a single-file invocation should error fast rather than
-            // running Stages 1-5 and silently producing nothing useful.
+            // --task FirstJoin writes the Stage 5 → Stage 6 boundary file
+            // pair; that's only meaningful with siblings, so a single-file
+            // invocation should error fast rather than running Stages 1-5 and
+            // silently producing nothing useful.
             var config = new OspreyConfig
             {
+                StopAfterStage5 = true,   // --task FirstJoin
                 InputScores = new List<string> { "only.scores.parquet" },
                 LibrarySource = LibrarySource.FromPath("ref.blib"),
                 OutputBlib = "out.blib"
             };
-            string err = Program.ValidateArgs(config,
-                noJoinFlag: false, joinOnlyFlag: true, joinOnlyModifier: true);
+            string err = Program.ValidateArgs(config);
             Assert.IsNotNull(err);
             StringAssert.Contains(err, "--task FirstJoin");
             StringAssert.Contains(err, "2+ parquet files");
         }
 
         [TestMethod]
-        public void TestValidateJoinOnlyModifierRequiresReconciliationEnabled()
+        public void TestValidateFirstJoinRequiresReconciliationEnabled()
         {
             var config = new OspreyConfig
             {
+                StopAfterStage5 = true,   // --task FirstJoin
                 InputScores = new List<string> { "a.scores.parquet", "b.scores.parquet" },
                 LibrarySource = LibrarySource.FromPath("ref.blib"),
                 OutputBlib = "out.blib"
             };
             config.Reconciliation.Enabled = false;
-            string err = Program.ValidateArgs(config,
-                noJoinFlag: false, joinOnlyFlag: true, joinOnlyModifier: true);
+            string err = Program.ValidateArgs(config);
             Assert.IsNotNull(err);
             StringAssert.Contains(err, "Reconciliation.Enabled");
         }
 
         [TestMethod]
-        public void TestValidateJoinOnlyPlainAcceptsSingleFile()
+        public void TestValidateFullFromScoresAcceptsSingleFile()
         {
-            // Plain --join-at-pass=1 (no modifier) runs Stages 5-8 from
-            // the parquet entry point; a 1-file run is a degenerate but
-            // legal case and shouldn't be rejected here.
+            // Default full pipeline from a single --input-scores file (no
+            // --task): a degenerate but legal case, not rejected here.
             var config = new OspreyConfig
             {
                 InputScores = new List<string> { "only.scores.parquet" },
                 LibrarySource = LibrarySource.FromPath("ref.blib"),
                 OutputBlib = "out.blib"
             };
-            Assert.IsNull(Program.ValidateArgs(config,
-                noJoinFlag: false, joinOnlyFlag: true, joinOnlyModifier: false));
+            Assert.IsNull(Program.ValidateArgs(config));
         }
 
         [TestMethod]
@@ -245,7 +239,7 @@ namespace pwiz.OspreySharp.Test
                 LibrarySource = LibrarySource.FromPath("ref.blib"),
                 OutputBlib = "out.blib"
             };
-            Assert.IsNull(Program.ValidateArgs(config, noJoinFlag: false, joinOnlyFlag: false, joinOnlyModifier: false));
+            Assert.IsNull(Program.ValidateArgs(config));
         }
 
         [TestMethod]
@@ -256,126 +250,65 @@ namespace pwiz.OspreySharp.Test
                 LibrarySource = LibrarySource.FromPath("ref.blib"),
                 OutputBlib = "out.blib"
             };
-            string err = Program.ValidateArgs(config, noJoinFlag: false, joinOnlyFlag: false, joinOnlyModifier: false);
+            string err = Program.ValidateArgs(config);
             Assert.IsNotNull(err);
             StringAssert.Contains(err, "No input files");
         }
 
-        // --- NormalizeHpcArgs (--join-at-pass) ----------------------------
-
         [TestMethod]
-        public void TestNormalizeJoinAtPass1MapsToJoinOnly()
+        public void TestValidateMergeNodeRequiresLibraryAndOutput()
         {
-            bool noJoin = false, joinOnly = false;
-            string err = Program.NormalizeHpcArgs(joinAtPass: 1, noJoinFlag: ref noJoin, joinOnlyFlag: ref joinOnly, joinOnlyModifier: out _);
-            Assert.IsNull(err);
-            Assert.IsTrue(joinOnly, "joinOnly should be set to true so existing Stage 5+ path runs");
-            Assert.IsFalse(noJoin);
-        }
-
-        [TestMethod]
-        public void TestNormalizeJoinAtPass2InProcessSucceeds()
-        {
-            // `--join-at-pass=2` (without --no-join) is the post-Stage-6
-            // reconciled-parquet entry point. Routes through the existing
-            // joinOnly Stage 5+ path; the in-pipeline reconciled-input
-            // gate enforces the strict input contract.
-            bool noJoin = false, joinOnly = false;
-            string err = Program.NormalizeHpcArgs(joinAtPass: 2, noJoinFlag: ref noJoin, joinOnlyFlag: ref joinOnly, joinOnlyModifier: out _);
-            Assert.IsNull(err);
-            Assert.IsTrue(joinOnly, "joinOnly should be set so Stage 5+ input-scores path runs");
-            Assert.IsFalse(noJoin);
-        }
-
-        [TestMethod]
-        public void TestNormalizeJoinAtPass2NoJoinNotImplemented()
-        {
-            // `--join-at-pass=2 --no-join` is the per-file Stage 7 worker
-            // mode (not yet ported); should still error.
-            bool noJoin = true, joinOnly = false;
-            string err = Program.NormalizeHpcArgs(joinAtPass: 2, noJoinFlag: ref noJoin, joinOnlyFlag: ref joinOnly, joinOnlyModifier: out _);
+            // --task MergeNode (ExpectReconciledInput) enters the shared
+            // join-only branch via --input-scores. A missing --output must name
+            // MergeNode, not FirstJoin.
+            var config = new OspreyConfig
+            {
+                ExpectReconciledInput = true,
+                InputScores = new List<string> { "a.scores-reconciled.parquet", "b.scores-reconciled.parquet" },
+                LibrarySource = LibrarySource.FromPath("ref.blib"),
+                // missing OutputBlib
+            };
+            string err = Program.ValidateArgs(config);
             Assert.IsNotNull(err);
-            StringAssert.Contains(err, "not implemented");
+            StringAssert.Contains(err, "--task MergeNode");
+            StringAssert.Contains(err, "--library and --output");
         }
 
         [TestMethod]
-        public void TestNormalizeJoinAtPassInvalidValueErrors()
+        public void TestValidateMergeNodeRejectsInputMzml()
         {
-            bool noJoin = false, joinOnly = false;
-            string err = Program.NormalizeHpcArgs(joinAtPass: 3, noJoinFlag: ref noJoin, joinOnlyFlag: ref joinOnly, joinOnlyModifier: out _);
+            var config = new OspreyConfig
+            {
+                ExpectReconciledInput = true,
+                InputFiles = new List<string> { "a.mzML" },
+                InputScores = new List<string> { "a.scores-reconciled.parquet" },
+                LibrarySource = LibrarySource.FromPath("ref.blib"),
+                OutputBlib = "out.blib"
+            };
+            string err = Program.ValidateArgs(config);
             Assert.IsNotNull(err);
-            StringAssert.Contains(err, "must be 1 or 2");
+            StringAssert.Contains(err, "--task MergeNode");
+            StringAssert.Contains(err, "cannot be combined with --input");
         }
 
         [TestMethod]
-        public void TestNormalizeJoinAtPass1WithJoinOnlyModifierSetsStopFlag()
+        public void TestValidateFullPipelineFromScoresNamesInputScores()
         {
-            // `--join-at-pass=1 --join-only` means "run only Stage 5 + planning,
-            // write boundary files, exit." Both joinOnly (existing
-            // Stage 5+ entry path) and joinOnlyModifier (post-planning
-            // early exit signal) should be set.
-            bool noJoin = false, joinOnly = true;
-            string err = Program.NormalizeHpcArgs(
-                joinAtPass: 1, noJoinFlag: ref noJoin, joinOnlyFlag: ref joinOnly,
-                joinOnlyModifier: out bool joinOnlyModifier);
-            Assert.IsNull(err);
-            Assert.IsTrue(joinOnly);
-            Assert.IsTrue(joinOnlyModifier);
-        }
-
-        [TestMethod]
-        public void TestNormalizeJoinAtPass1WithNoJoinModifierKeepsBothFlags()
-        {
-            // --join-at-pass=1 --no-join is the per-file rescore worker
-            // mode. Normalize keeps noJoinFlag true and joinOnlyFlag false
-            // (they're not flipped); Main routes the combination to
-            // RescoreWorker.Run.
-            bool noJoin = true, joinOnly = false;
-            string err = Program.NormalizeHpcArgs(joinAtPass: 1, noJoinFlag: ref noJoin, joinOnlyFlag: ref joinOnly, joinOnlyModifier: out bool joinOnlyModifier);
-            Assert.IsNull(err, "got: {0}", err);
-            Assert.IsTrue(noJoin, "noJoinFlag should remain true");
-            Assert.IsFalse(joinOnly, "joinOnlyFlag should remain false");
-            Assert.IsFalse(joinOnlyModifier, "joinOnlyModifier should be false");
-        }
-
-        [TestMethod]
-        public void TestNormalizeJoinOnlyAloneErrorsNoEntryPoint()
-        {
-            bool noJoin = false, joinOnly = true;
-            string err = Program.NormalizeHpcArgs(joinAtPass: null, noJoinFlag: ref noJoin, joinOnlyFlag: ref joinOnly, joinOnlyModifier: out _);
+            // Default full pipeline started from --input-scores (no --task):
+            // neither joinOnlyFlag nor ExpectReconciledInput. The shared
+            // join-only branch should reference --input-scores, not a task name
+            // the user never selected.
+            var config = new OspreyConfig
+            {
+                InputScores = new List<string> { "a.scores.parquet", "b.scores.parquet" },
+                LibrarySource = LibrarySource.FromPath("ref.blib"),
+                // missing OutputBlib
+            };
+            string err = Program.ValidateArgs(config);
             Assert.IsNotNull(err);
-            StringAssert.Contains(err, "modifier");
-        }
-
-        [TestMethod]
-        public void TestNormalizeNoJoinAndJoinOnlyModifiersAreMutex()
-        {
-            bool noJoin = true, joinOnly = true;
-            string err = Program.NormalizeHpcArgs(joinAtPass: 1, noJoinFlag: ref noJoin, joinOnlyFlag: ref joinOnly, joinOnlyModifier: out _);
-            Assert.IsNotNull(err);
-            StringAssert.Contains(err, "mutually exclusive");
-        }
-
-        [TestMethod]
-        public void TestNormalizeNoJoinAloneUnchanged()
-        {
-            // Stage 1 entry path with `-i ...` + `--no-join` keeps its
-            // existing meaning: do per-file work only = Stages 1-4.
-            bool noJoin = true, joinOnly = false;
-            string err = Program.NormalizeHpcArgs(joinAtPass: null, noJoinFlag: ref noJoin, joinOnlyFlag: ref joinOnly, joinOnlyModifier: out _);
-            Assert.IsNull(err);
-            Assert.IsTrue(noJoin);
-            Assert.IsFalse(joinOnly);
-        }
-
-        [TestMethod]
-        public void TestNormalizeDefaultModeIsNoop()
-        {
-            bool noJoin = false, joinOnly = false;
-            string err = Program.NormalizeHpcArgs(joinAtPass: null, noJoinFlag: ref noJoin, joinOnlyFlag: ref joinOnly, joinOnlyModifier: out _);
-            Assert.IsNull(err);
-            Assert.IsFalse(noJoin);
-            Assert.IsFalse(joinOnly);
+            StringAssert.Contains(err, "--input-scores");
+            StringAssert.Contains(err, "--library and --output");
+            Assert.IsFalse(err.Contains("--task"), "full-from-scores error must not name a --task: " + err);
         }
 
         // --- ResolveTask (--task) -----------------------------------------
@@ -383,60 +316,56 @@ namespace pwiz.OspreySharp.Test
         [TestMethod]
         public void TestResolveTaskPerFileScoring()
         {
-            // --task PerFileScoring == --no-join: noJoin only, no entry point.
             string err = Program.ResolveTask("PerFileScoring",
-                out bool noJoin, out bool joinOnly, out int? joinAtPass);
+                out bool noJoin, out bool stopAfterStage5, out bool expectReconciled);
             Assert.IsNull(err);
             Assert.IsTrue(noJoin);
-            Assert.IsFalse(joinOnly);
-            Assert.IsFalse(joinAtPass.HasValue);
+            Assert.IsFalse(stopAfterStage5);
+            Assert.IsFalse(expectReconciled);
         }
 
         [TestMethod]
         public void TestResolveTaskFirstJoin()
         {
-            // --task FirstJoin == --join-at-pass=1 --join-only.
             string err = Program.ResolveTask("FirstJoin",
-                out bool noJoin, out bool joinOnly, out int? joinAtPass);
+                out bool noJoin, out bool stopAfterStage5, out bool expectReconciled);
             Assert.IsNull(err);
             Assert.IsFalse(noJoin);
-            Assert.IsTrue(joinOnly);
-            Assert.AreEqual(1, joinAtPass);
+            Assert.IsTrue(stopAfterStage5);
+            Assert.IsFalse(expectReconciled);
         }
 
         [TestMethod]
         public void TestResolveTaskPerFileRescore()
         {
-            // --task PerFileRescore == --join-at-pass=1 --no-join.
             string err = Program.ResolveTask("PerFileRescore",
-                out bool noJoin, out bool joinOnly, out int? joinAtPass);
+                out bool noJoin, out bool stopAfterStage5, out bool expectReconciled);
             Assert.IsNull(err);
             Assert.IsTrue(noJoin);
-            Assert.IsFalse(joinOnly);
-            Assert.AreEqual(1, joinAtPass);
+            Assert.IsFalse(stopAfterStage5);
+            Assert.IsFalse(expectReconciled);
         }
 
         [TestMethod]
         public void TestResolveTaskMergeNode()
         {
-            // --task MergeNode == --join-at-pass=2.
             string err = Program.ResolveTask("MergeNode",
-                out bool noJoin, out bool joinOnly, out int? joinAtPass);
+                out bool noJoin, out bool stopAfterStage5, out bool expectReconciled);
             Assert.IsNull(err);
             Assert.IsFalse(noJoin);
-            Assert.IsFalse(joinOnly);
-            Assert.AreEqual(2, joinAtPass);
+            Assert.IsFalse(stopAfterStage5);
+            Assert.IsTrue(expectReconciled);
         }
 
         [TestMethod]
         public void TestResolveTaskIsCaseInsensitive()
         {
             string err = Program.ResolveTask("perfilerescore",
-                out bool noJoin, out bool joinOnly, out int? joinAtPass);
+                out bool noJoin, out bool stopAfterStage5, out bool expectReconciled);
             Assert.IsNull(err);
             Assert.IsTrue(noJoin);
-            Assert.IsFalse(joinOnly);
-            Assert.AreEqual(1, joinAtPass);
+            Assert.IsFalse(stopAfterStage5);
+            Assert.IsFalse(expectReconciled);
         }
 
         [TestMethod]
@@ -452,11 +381,9 @@ namespace pwiz.OspreySharp.Test
         [TestMethod]
         public void TestResolveTaskMapsToExpectedConfigFlags()
         {
-            // End-to-end: each task name, run through ResolveTask ->
-            // NormalizeHpcArgs (the same wiring Main uses), must produce the
-            // (NoJoin, StopAfterStage5, ExpectReconciledInput) config tuple
-            // that the four tasks' IsIncluded methods read. Mirrors the
-            // membership rows in PipelineMembershipTest.
+            // Each task name must resolve to the (NoJoin, StopAfterStage5,
+            // ExpectReconciledInput) config tuple the four tasks' IsIncluded
+            // methods read. Mirrors the membership rows in PipelineMembershipTest.
             //   task             | NoJoin | StopAfterStage5 | ExpectReconciled
             //   PerFileScoring   | true   | false           | false
             //   FirstJoin        | false  | true            | false
@@ -472,22 +399,65 @@ namespace pwiz.OspreySharp.Test
             foreach (var c in cases)
             {
                 string resolveErr = Program.ResolveTask(c.Task,
-                    out bool noJoin, out bool joinOnly, out int? joinAtPass);
+                    out bool noJoin, out bool stopAfterStage5, out bool expectReconciled);
                 Assert.IsNull(resolveErr, c.Task);
-                string normErr = Program.NormalizeHpcArgs(joinAtPass,
-                    ref noJoin, ref joinOnly, out bool joinOnlyModifier);
-                Assert.IsNull(normErr, c.Task);
-                // Main applies these same three assignments after ParseArgs.
-                bool cfgNoJoin = noJoin;
-                bool cfgStopAfterStage5 = joinOnlyModifier;
-                bool cfgExpectReconciled = joinAtPass.HasValue && joinAtPass.Value == 2;
-                Assert.AreEqual(c.NoJoin, cfgNoJoin,
-                    string.Format("{0}: NoJoin", c.Task));
-                Assert.AreEqual(c.StopAfterStage5, cfgStopAfterStage5,
+                Assert.AreEqual(c.NoJoin, noJoin, string.Format("{0}: NoJoin", c.Task));
+                Assert.AreEqual(c.StopAfterStage5, stopAfterStage5,
                     string.Format("{0}: StopAfterStage5", c.Task));
-                Assert.AreEqual(c.ExpectReconciled, cfgExpectReconciled,
+                Assert.AreEqual(c.ExpectReconciled, expectReconciled,
                     string.Format("{0}: ExpectReconciledInput", c.Task));
             }
+        }
+
+        // --- ParseArgs: unknown / retired flags fail fast -----------------
+
+        [TestMethod]
+        public void TestParseArgsRejectsRetiredNoJoin()
+        {
+            // The retired HPC mode flags are now unknown options. ParseArgs
+            // must throw rather than silently dropping them (which would run
+            // the full pipeline in the wrong mode). Replaced by --task <Name>.
+            var ex = Assert.ThrowsException<ArgumentException>(
+                () => Program.ParseArgs(new[] { "--no-join", "-i", "a.mzML" }));
+            StringAssert.Contains(ex.Message, "--no-join");
+        }
+
+        [TestMethod]
+        public void TestParseArgsRejectsRetiredJoinOnly()
+        {
+            var ex = Assert.ThrowsException<ArgumentException>(
+                () => Program.ParseArgs(new[] { "--join-only" }));
+            StringAssert.Contains(ex.Message, "--join-only");
+        }
+
+        [TestMethod]
+        public void TestParseArgsRejectsRetiredJoinAtPass()
+        {
+            var ex = Assert.ThrowsException<ArgumentException>(
+                () => Program.ParseArgs(new[] { "--join-at-pass=2" }));
+            StringAssert.Contains(ex.Message, "--join-at-pass=2");
+
+            // Space-separated form too.
+            Assert.ThrowsException<ArgumentException>(
+                () => Program.ParseArgs(new[] { "--join-at-pass", "1" }));
+        }
+
+        [TestMethod]
+        public void TestParseArgsRejectsUnknownFlag()
+        {
+            // Any unrecognized option fails fast (e.g. a typo), not just the
+            // retired flags.
+            var ex = Assert.ThrowsException<ArgumentException>(
+                () => Program.ParseArgs(new[] { "--bogus-flag" }));
+            StringAssert.Contains(ex.Message, "--bogus-flag");
+        }
+
+        [TestMethod]
+        public void TestParseArgsAcceptsTaskAndValidArgs()
+        {
+            // --task and ordinary flags must NOT throw.
+            Program.ParseArgs(new[] { "--task", "FirstJoin", "-l", "ref.blib", "-o", "out.blib" });
+            Program.ParseArgs(new[] { "--task=MergeNode", "-l", "ref.blib", "-o", "out.blib" });
         }
 
         // --- ResolveInputScores -------------------------------------------

--- a/pwiz_tools/OspreySharp/OspreySharp.Test/ProgramTests.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Test/ProgramTests.cs
@@ -498,6 +498,19 @@ namespace pwiz.OspreySharp.Test
             Program.ParseArgs(new[] { "--task=MergeNode", "-l", "ref.blib", "-o", "out.blib" });
         }
 
+        [TestMethod]
+        public void TestParseArgsRejectsTaskWithoutValue()
+        {
+            // A bare --task (or --task followed by another flag) must throw,
+            // like the other required-value flags, so it can't be silently
+            // ignored when ParseArgs runs outside Main's pre-scan.
+            var ex = Assert.ThrowsException<ArgumentException>(
+                () => Program.ParseArgs(new[] { "--task" }));
+            StringAssert.Contains(ex.Message, "--task");
+            Assert.ThrowsException<ArgumentException>(
+                () => Program.ParseArgs(new[] { "--task", "-l", "ref.blib" }));
+        }
+
         // --- ResolveInputScores -------------------------------------------
 
         [TestMethod]

--- a/pwiz_tools/OspreySharp/OspreySharp.Test/ProgramTests.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Test/ProgramTests.cs
@@ -43,17 +43,136 @@ namespace pwiz.OspreySharp.Test
     [TestClass]
     public class ProgramTests
     {
-        // --- ValidateArgs --------------------------------------------------
+        // --- ValidateArgs: --task is authoritative over input type --------
+
+        private static OspreyConfig TaskConfig(HpcTask task)
+        {
+            // Mirror Main's wiring: ResolveTask -> SelectedTask + derived flags.
+            return new OspreyConfig
+            {
+                SelectedTask = task,
+                NoJoin = task == HpcTask.PerFileScoring || task == HpcTask.PerFileRescore,
+                StopAfterStage5 = task == HpcTask.FirstJoin,
+                ExpectReconciledInput = task == HpcTask.MergeNode,
+            };
+        }
+
+        // -- PerFileScoring (mzML in) --
+
+        [TestMethod]
+        public void TestValidatePerFileScoringHappyPath()
+        {
+            var config = TaskConfig(HpcTask.PerFileScoring);
+            config.InputFiles = new List<string> { "a.mzML" };
+            config.LibrarySource = LibrarySource.FromPath("ref.blib");
+            Assert.IsNull(Program.ValidateArgs(config));
+        }
+
+        [TestMethod]
+        public void TestValidatePerFileScoringRequiresInput()
+        {
+            var config = TaskConfig(HpcTask.PerFileScoring);
+            config.LibrarySource = LibrarySource.FromPath("ref.blib");
+            string err = Program.ValidateArgs(config);
+            Assert.IsNotNull(err);
+            StringAssert.Contains(err, "--task PerFileScoring");
+            StringAssert.Contains(err, "--input <mzML");
+        }
+
+        [TestMethod]
+        public void TestValidatePerFileScoringRequiresLibrary()
+        {
+            var config = TaskConfig(HpcTask.PerFileScoring);
+            config.InputFiles = new List<string> { "a.mzML" };
+            string err = Program.ValidateArgs(config);
+            Assert.IsNotNull(err);
+            StringAssert.Contains(err, "--task PerFileScoring");
+            StringAssert.Contains(err, "--library");
+        }
+
+        [TestMethod]
+        public void TestValidatePerFileScoringRejectsInputScores()
+        {
+            // --task is authoritative: PerFileScoring + --input-scores must
+            // error, not silently dispatch PerFileRescore.
+            var config = TaskConfig(HpcTask.PerFileScoring);
+            config.InputScores = new List<string> { "a.scores.parquet" };
+            config.LibrarySource = LibrarySource.FromPath("ref.blib");
+            config.OutputBlib = "out.blib";
+            string err = Program.ValidateArgs(config);
+            Assert.IsNotNull(err);
+            StringAssert.Contains(err, "--task PerFileScoring");
+            StringAssert.Contains(err, "not --input-scores");
+        }
+
+        // -- PerFileRescore (--input-scores in) --
+
+        [TestMethod]
+        public void TestValidatePerFileRescoreHappyPath()
+        {
+            var config = TaskConfig(HpcTask.PerFileRescore);
+            config.InputScores = new List<string> { "a.scores.parquet" };
+            config.LibrarySource = LibrarySource.FromPath("ref.blib");
+            config.OutputBlib = "out.blib";
+            Assert.IsNull(Program.ValidateArgs(config));
+        }
+
+        [TestMethod]
+        public void TestValidatePerFileRescoreRequiresInputScores()
+        {
+            var config = TaskConfig(HpcTask.PerFileRescore);
+            config.LibrarySource = LibrarySource.FromPath("ref.blib");
+            config.OutputBlib = "out.blib";
+            string err = Program.ValidateArgs(config);
+            Assert.IsNotNull(err);
+            StringAssert.Contains(err, "--task PerFileRescore");
+            StringAssert.Contains(err, "--input-scores");
+        }
+
+        [TestMethod]
+        public void TestValidatePerFileRescoreRequiresLibraryAndOutput()
+        {
+            var config = TaskConfig(HpcTask.PerFileRescore);
+            config.InputScores = new List<string> { "a.scores.parquet" };
+            string err = Program.ValidateArgs(config);
+            Assert.IsNotNull(err);
+            StringAssert.Contains(err, "--task PerFileRescore");
+            StringAssert.Contains(err, "--library and --output");
+        }
+
+        [TestMethod]
+        public void TestValidatePerFileRescoreRejectsInputMzml()
+        {
+            // Authoritative: PerFileRescore + -i mzML must error, not silently
+            // dispatch PerFileScoring. Error must name the task the user typed.
+            var config = TaskConfig(HpcTask.PerFileRescore);
+            config.InputFiles = new List<string> { "a.mzML" };
+            config.LibrarySource = LibrarySource.FromPath("ref.blib");
+            config.OutputBlib = "out.blib";
+            string err = Program.ValidateArgs(config);
+            Assert.IsNotNull(err);
+            StringAssert.Contains(err, "--task PerFileRescore");
+            StringAssert.Contains(err, "not -i <mzML>");
+        }
+
+        // -- FirstJoin (--input-scores in, 2+ files, reconciliation on) --
+
+        [TestMethod]
+        public void TestValidateFirstJoinHappyPath()
+        {
+            var config = TaskConfig(HpcTask.FirstJoin);
+            config.InputScores = new List<string> { "a.scores.parquet", "b.scores.parquet" };
+            config.LibrarySource = LibrarySource.FromPath("ref.blib");
+            config.OutputBlib = "out.blib";
+            Assert.IsNull(Program.ValidateArgs(config));
+        }
 
         [TestMethod]
         public void TestValidateFirstJoinRequiresInputScores()
         {
-            var config = new OspreyConfig
-            {
-                StopAfterStage5 = true,   // --task FirstJoin
-                LibrarySource = LibrarySource.FromPath("ref.blib"),
-                OutputBlib = "out.blib"
-            };
+            var config = TaskConfig(HpcTask.FirstJoin);
+            config.LibrarySource = LibrarySource.FromPath("ref.blib");
+            config.OutputBlib = "out.blib";
             string err = Program.ValidateArgs(config);
             Assert.IsNotNull(err);
             StringAssert.Contains(err, "--task FirstJoin");
@@ -63,14 +182,11 @@ namespace pwiz.OspreySharp.Test
         [TestMethod]
         public void TestValidateFirstJoinRejectsInputMzml()
         {
-            var config = new OspreyConfig
-            {
-                StopAfterStage5 = true,   // --task FirstJoin
-                InputFiles = new List<string> { "a.mzML" },
-                InputScores = new List<string> { "a.scores.parquet" },
-                LibrarySource = LibrarySource.FromPath("ref.blib"),
-                OutputBlib = "out.blib"
-            };
+            var config = TaskConfig(HpcTask.FirstJoin);
+            config.InputFiles = new List<string> { "a.mzML" };
+            config.InputScores = new List<string> { "a.scores.parquet", "b.scores.parquet" };
+            config.LibrarySource = LibrarySource.FromPath("ref.blib");
+            config.OutputBlib = "out.blib";
             string err = Program.ValidateArgs(config);
             Assert.IsNotNull(err);
             StringAssert.Contains(err, "--task FirstJoin");
@@ -80,11 +196,8 @@ namespace pwiz.OspreySharp.Test
         [TestMethod]
         public void TestValidateFirstJoinRequiresLibraryAndOutput()
         {
-            var config = new OspreyConfig
-            {
-                StopAfterStage5 = true,   // --task FirstJoin
-                InputScores = new List<string> { "a.scores.parquet" }
-            };
+            var config = TaskConfig(HpcTask.FirstJoin);
+            config.InputScores = new List<string> { "a.scores.parquet", "b.scores.parquet" };
             string err = Program.ValidateArgs(config);
             Assert.IsNotNull(err);
             StringAssert.Contains(err, "--task FirstJoin");
@@ -92,108 +205,14 @@ namespace pwiz.OspreySharp.Test
         }
 
         [TestMethod]
-        public void TestValidateNoJoinRequiresInput()
-        {
-            var config = new OspreyConfig
-            {
-                NoJoin = true,
-                LibrarySource = LibrarySource.FromPath("ref.blib")
-            };
-            string err = Program.ValidateArgs(config);
-            Assert.IsNotNull(err);
-            StringAssert.Contains(err, "--input <mzML");
-        }
-
-        [TestMethod]
-        public void TestValidateNoJoinRejectsInputScores()
-        {
-            var config = new OspreyConfig
-            {
-                NoJoin = true,
-                InputFiles = new List<string> { "a.mzML" },
-                InputScores = new List<string> { "a.scores.parquet" },
-                LibrarySource = LibrarySource.FromPath("ref.blib")
-            };
-            string err = Program.ValidateArgs(config);
-            Assert.IsNotNull(err);
-            StringAssert.Contains(err, "--input-scores");
-        }
-
-        [TestMethod]
-        public void TestValidateNoJoinWorkerHappyPath()
-        {
-            // --join-at-pass=1 --no-join (per-file rescore worker):
-            // requires --input-scores, --library, and --output. No
-            // --input mzML.
-            var config = new OspreyConfig
-            {
-                NoJoin = true,
-                InputScores = new List<string> { "a.scores.parquet" },
-                LibrarySource = LibrarySource.FromPath("ref.blib"),
-                OutputBlib = "out.blib",
-            };
-            Assert.IsNull(
-                Program.ValidateArgs(config));
-        }
-
-        [TestMethod]
-        public void TestValidateNoJoinWorkerRequiresLibraryAndOutput()
-        {
-            // Worker mode without --library or --output — like the in-process
-            // --join-at-pass=1 path, both are required so the per-file
-            // parquet write-back has somewhere to go.
-            var config = new OspreyConfig
-            {
-                NoJoin = true,
-                InputScores = new List<string> { "a.scores.parquet" },
-                // missing LibrarySource and OutputBlib
-            };
-            string err = Program.ValidateArgs(config);
-            Assert.IsNotNull(err);
-            StringAssert.Contains(err, "--library and --output");
-        }
-
-        [TestMethod]
-        public void TestValidateNoJoinHappyPath()
-        {
-            var config = new OspreyConfig
-            {
-                NoJoin = true,
-                InputFiles = new List<string> { "a.mzML" },
-                LibrarySource = LibrarySource.FromPath("ref.blib")
-            };
-            Assert.IsNull(Program.ValidateArgs(config));
-        }
-
-        [TestMethod]
-        public void TestValidateFullFromScoresHappyPath()
-        {
-            // Default full pipeline started from --input-scores (no --task):
-            // all membership flags false. Stages 5-8 run from the parquet
-            // entry point.
-            var config = new OspreyConfig
-            {
-                InputScores = new List<string> { "a.scores.parquet", "b.scores.parquet" },
-                LibrarySource = LibrarySource.FromPath("ref.blib"),
-                OutputBlib = "out.blib"
-            };
-            Assert.IsNull(Program.ValidateArgs(config));
-        }
-
-        [TestMethod]
         public void TestValidateFirstJoinRejectsSingleFile()
         {
-            // --task FirstJoin writes the Stage 5 → Stage 6 boundary file
-            // pair; that's only meaningful with siblings, so a single-file
-            // invocation should error fast rather than running Stages 1-5 and
-            // silently producing nothing useful.
-            var config = new OspreyConfig
-            {
-                StopAfterStage5 = true,   // --task FirstJoin
-                InputScores = new List<string> { "only.scores.parquet" },
-                LibrarySource = LibrarySource.FromPath("ref.blib"),
-                OutputBlib = "out.blib"
-            };
+            // FirstJoin writes the Stage 5 -> Stage 6 boundary pair, only
+            // meaningful with siblings; a single-file run errors fast.
+            var config = TaskConfig(HpcTask.FirstJoin);
+            config.InputScores = new List<string> { "only.scores.parquet" };
+            config.LibrarySource = LibrarySource.FromPath("ref.blib");
+            config.OutputBlib = "out.blib";
             string err = Program.ValidateArgs(config);
             Assert.IsNotNull(err);
             StringAssert.Contains(err, "--task FirstJoin");
@@ -203,35 +222,85 @@ namespace pwiz.OspreySharp.Test
         [TestMethod]
         public void TestValidateFirstJoinRequiresReconciliationEnabled()
         {
-            var config = new OspreyConfig
-            {
-                StopAfterStage5 = true,   // --task FirstJoin
-                InputScores = new List<string> { "a.scores.parquet", "b.scores.parquet" },
-                LibrarySource = LibrarySource.FromPath("ref.blib"),
-                OutputBlib = "out.blib"
-            };
+            var config = TaskConfig(HpcTask.FirstJoin);
+            config.InputScores = new List<string> { "a.scores.parquet", "b.scores.parquet" };
+            config.LibrarySource = LibrarySource.FromPath("ref.blib");
+            config.OutputBlib = "out.blib";
             config.Reconciliation.Enabled = false;
             string err = Program.ValidateArgs(config);
             Assert.IsNotNull(err);
             StringAssert.Contains(err, "Reconciliation.Enabled");
         }
 
+        // -- MergeNode (reconciled --input-scores in) --
+
         [TestMethod]
-        public void TestValidateFullFromScoresAcceptsSingleFile()
+        public void TestValidateMergeNodeHappyPath()
         {
-            // Default full pipeline from a single --input-scores file (no
-            // --task): a degenerate but legal case, not rejected here.
-            var config = new OspreyConfig
-            {
-                InputScores = new List<string> { "only.scores.parquet" },
-                LibrarySource = LibrarySource.FromPath("ref.blib"),
-                OutputBlib = "out.blib"
-            };
+            var config = TaskConfig(HpcTask.MergeNode);
+            config.InputScores = new List<string> { "a.scores-reconciled.parquet" };
+            config.LibrarySource = LibrarySource.FromPath("ref.blib");
+            config.OutputBlib = "out.blib";
             Assert.IsNull(Program.ValidateArgs(config));
         }
 
         [TestMethod]
-        public void TestValidateDefaultModeIsUnaffected()
+        public void TestValidateMergeNodeRequiresInputScores()
+        {
+            // Uncontested gap from ultrareview: --task MergeNode without
+            // --input-scores (even with -i mzML) used to pass validation and
+            // silently run the full pipeline. It must now fail fast.
+            var config = TaskConfig(HpcTask.MergeNode);
+            config.InputFiles = new List<string> { "a.mzML" };
+            config.LibrarySource = LibrarySource.FromPath("ref.blib");
+            config.OutputBlib = "out.blib";
+            string err = Program.ValidateArgs(config);
+            Assert.IsNotNull(err);
+            StringAssert.Contains(err, "--task MergeNode");
+            // -i present -> the cross is reported first; either way it must not pass.
+        }
+
+        [TestMethod]
+        public void TestValidateMergeNodeRequiresInputScoresNoMzml()
+        {
+            var config = TaskConfig(HpcTask.MergeNode);
+            config.LibrarySource = LibrarySource.FromPath("ref.blib");
+            config.OutputBlib = "out.blib";
+            string err = Program.ValidateArgs(config);
+            Assert.IsNotNull(err);
+            StringAssert.Contains(err, "--task MergeNode");
+            StringAssert.Contains(err, "--input-scores");
+        }
+
+        [TestMethod]
+        public void TestValidateMergeNodeRequiresLibraryAndOutput()
+        {
+            var config = TaskConfig(HpcTask.MergeNode);
+            config.InputScores = new List<string> { "a.scores-reconciled.parquet" };
+            string err = Program.ValidateArgs(config);
+            Assert.IsNotNull(err);
+            StringAssert.Contains(err, "--task MergeNode");
+            StringAssert.Contains(err, "--library and --output");
+        }
+
+        [TestMethod]
+        public void TestValidateMergeNodeRejectsInputMzml()
+        {
+            var config = TaskConfig(HpcTask.MergeNode);
+            config.InputFiles = new List<string> { "a.mzML" };
+            config.InputScores = new List<string> { "a.scores-reconciled.parquet" };
+            config.LibrarySource = LibrarySource.FromPath("ref.blib");
+            config.OutputBlib = "out.blib";
+            string err = Program.ValidateArgs(config);
+            Assert.IsNotNull(err);
+            StringAssert.Contains(err, "--task MergeNode");
+            StringAssert.Contains(err, "cannot be combined with --input");
+        }
+
+        // -- Default (no --task): full pipeline from -i mzML or --input-scores --
+
+        [TestMethod]
+        public void TestValidateDefaultFullHappyPath()
         {
             var config = new OspreyConfig
             {
@@ -256,48 +325,25 @@ namespace pwiz.OspreySharp.Test
         }
 
         [TestMethod]
-        public void TestValidateMergeNodeRequiresLibraryAndOutput()
+        public void TestValidateFullFromScoresHappyPath()
         {
-            // --task MergeNode (ExpectReconciledInput) enters the shared
-            // join-only branch via --input-scores. A missing --output must name
-            // MergeNode, not FirstJoin.
+            // No --task + --input-scores: the full pipeline started from scores
+            // (PerFileScoring lazy-rehydrates). A single file is a legal,
+            // degenerate case.
             var config = new OspreyConfig
             {
-                ExpectReconciledInput = true,
-                InputScores = new List<string> { "a.scores-reconciled.parquet", "b.scores-reconciled.parquet" },
-                LibrarySource = LibrarySource.FromPath("ref.blib"),
-                // missing OutputBlib
-            };
-            string err = Program.ValidateArgs(config);
-            Assert.IsNotNull(err);
-            StringAssert.Contains(err, "--task MergeNode");
-            StringAssert.Contains(err, "--library and --output");
-        }
-
-        [TestMethod]
-        public void TestValidateMergeNodeRejectsInputMzml()
-        {
-            var config = new OspreyConfig
-            {
-                ExpectReconciledInput = true,
-                InputFiles = new List<string> { "a.mzML" },
-                InputScores = new List<string> { "a.scores-reconciled.parquet" },
+                InputScores = new List<string> { "only.scores.parquet" },
                 LibrarySource = LibrarySource.FromPath("ref.blib"),
                 OutputBlib = "out.blib"
             };
-            string err = Program.ValidateArgs(config);
-            Assert.IsNotNull(err);
-            StringAssert.Contains(err, "--task MergeNode");
-            StringAssert.Contains(err, "cannot be combined with --input");
+            Assert.IsNull(Program.ValidateArgs(config));
         }
 
         [TestMethod]
-        public void TestValidateFullPipelineFromScoresNamesInputScores()
+        public void TestValidateFullFromScoresRequiresLibraryAndOutput()
         {
-            // Default full pipeline started from --input-scores (no --task):
-            // neither joinOnlyFlag nor ExpectReconciledInput. The shared
-            // join-only branch should reference --input-scores, not a task name
-            // the user never selected.
+            // No --task: the error references --input-scores, not a task the
+            // user never selected.
             var config = new OspreyConfig
             {
                 InputScores = new List<string> { "a.scores.parquet", "b.scores.parquet" },
@@ -311,100 +357,92 @@ namespace pwiz.OspreySharp.Test
             Assert.IsFalse(err.Contains("--task"), "full-from-scores error must not name a --task: " + err);
         }
 
+        [TestMethod]
+        public void TestValidateFullFromScoresRejectsInputMzml()
+        {
+            var config = new OspreyConfig
+            {
+                InputFiles = new List<string> { "a.mzML" },
+                InputScores = new List<string> { "a.scores.parquet" },
+                LibrarySource = LibrarySource.FromPath("ref.blib"),
+                OutputBlib = "out.blib"
+            };
+            string err = Program.ValidateArgs(config);
+            Assert.IsNotNull(err);
+            StringAssert.Contains(err, "cannot be combined with --input");
+        }
+
         // --- ResolveTask (--task) -----------------------------------------
 
         [TestMethod]
         public void TestResolveTaskPerFileScoring()
         {
-            string err = Program.ResolveTask("PerFileScoring",
-                out bool noJoin, out bool stopAfterStage5, out bool expectReconciled);
-            Assert.IsNull(err);
-            Assert.IsTrue(noJoin);
-            Assert.IsFalse(stopAfterStage5);
-            Assert.IsFalse(expectReconciled);
+            Assert.IsNull(Program.ResolveTask("PerFileScoring", out HpcTask task));
+            Assert.AreEqual(HpcTask.PerFileScoring, task);
         }
 
         [TestMethod]
         public void TestResolveTaskFirstJoin()
         {
-            string err = Program.ResolveTask("FirstJoin",
-                out bool noJoin, out bool stopAfterStage5, out bool expectReconciled);
-            Assert.IsNull(err);
-            Assert.IsFalse(noJoin);
-            Assert.IsTrue(stopAfterStage5);
-            Assert.IsFalse(expectReconciled);
+            Assert.IsNull(Program.ResolveTask("FirstJoin", out HpcTask task));
+            Assert.AreEqual(HpcTask.FirstJoin, task);
         }
 
         [TestMethod]
         public void TestResolveTaskPerFileRescore()
         {
-            string err = Program.ResolveTask("PerFileRescore",
-                out bool noJoin, out bool stopAfterStage5, out bool expectReconciled);
-            Assert.IsNull(err);
-            Assert.IsTrue(noJoin);
-            Assert.IsFalse(stopAfterStage5);
-            Assert.IsFalse(expectReconciled);
+            Assert.IsNull(Program.ResolveTask("PerFileRescore", out HpcTask task));
+            Assert.AreEqual(HpcTask.PerFileRescore, task);
         }
 
         [TestMethod]
         public void TestResolveTaskMergeNode()
         {
-            string err = Program.ResolveTask("MergeNode",
-                out bool noJoin, out bool stopAfterStage5, out bool expectReconciled);
-            Assert.IsNull(err);
-            Assert.IsFalse(noJoin);
-            Assert.IsFalse(stopAfterStage5);
-            Assert.IsTrue(expectReconciled);
+            Assert.IsNull(Program.ResolveTask("MergeNode", out HpcTask task));
+            Assert.AreEqual(HpcTask.MergeNode, task);
         }
 
         [TestMethod]
         public void TestResolveTaskIsCaseInsensitive()
         {
-            string err = Program.ResolveTask("perfilerescore",
-                out bool noJoin, out bool stopAfterStage5, out bool expectReconciled);
-            Assert.IsNull(err);
-            Assert.IsTrue(noJoin);
-            Assert.IsFalse(stopAfterStage5);
-            Assert.IsFalse(expectReconciled);
+            Assert.IsNull(Program.ResolveTask("perfilerescore", out HpcTask task));
+            Assert.AreEqual(HpcTask.PerFileRescore, task);
         }
 
         [TestMethod]
         public void TestResolveTaskUnknownErrors()
         {
-            string err = Program.ResolveTask("Bogus",
-                out _, out _, out _);
+            string err = Program.ResolveTask("Bogus", out _);
             Assert.IsNotNull(err);
             StringAssert.Contains(err, "unknown task");
             StringAssert.Contains(err, "Bogus");
         }
 
         [TestMethod]
-        public void TestResolveTaskMapsToExpectedConfigFlags()
+        public void TestResolveTaskMapsToExpectedMembershipFlags()
         {
-            // Each task name must resolve to the (NoJoin, StopAfterStage5,
-            // ExpectReconciledInput) config tuple the four tasks' IsIncluded
-            // methods read. Mirrors the membership rows in PipelineMembershipTest.
+            // Each task must derive (via Main's wiring, mirrored by TaskConfig)
+            // the (NoJoin, StopAfterStage5, ExpectReconciledInput) tuple the four
+            // tasks' IsIncluded methods read. Mirrors PipelineMembershipTest.
             //   task             | NoJoin | StopAfterStage5 | ExpectReconciled
             //   PerFileScoring   | true   | false           | false
             //   FirstJoin        | false  | true            | false
             //   PerFileRescore   | true   | false           | false
             //   MergeNode        | false  | false           | true
-            var cases = new (string Task, bool NoJoin, bool StopAfterStage5, bool ExpectReconciled)[]
+            var cases = new (HpcTask Task, bool NoJoin, bool StopAfterStage5, bool ExpectReconciled)[]
             {
-                ("PerFileScoring", true,  false, false),
-                ("FirstJoin",      false, true,  false),
-                ("PerFileRescore", true,  false, false),
-                ("MergeNode",      false, false, true),
+                (HpcTask.PerFileScoring, true,  false, false),
+                (HpcTask.FirstJoin,      false, true,  false),
+                (HpcTask.PerFileRescore, true,  false, false),
+                (HpcTask.MergeNode,      false, false, true),
             };
             foreach (var c in cases)
             {
-                string resolveErr = Program.ResolveTask(c.Task,
-                    out bool noJoin, out bool stopAfterStage5, out bool expectReconciled);
-                Assert.IsNull(resolveErr, c.Task);
-                Assert.AreEqual(c.NoJoin, noJoin, string.Format("{0}: NoJoin", c.Task));
-                Assert.AreEqual(c.StopAfterStage5, stopAfterStage5,
+                var config = TaskConfig(c.Task);
+                Assert.AreEqual(c.NoJoin, config.NoJoin, string.Format("{0}: NoJoin", c.Task));
+                Assert.AreEqual(c.StopAfterStage5, config.StopAfterStage5,
                     string.Format("{0}: StopAfterStage5", c.Task));
-                Assert.AreEqual(c.ExpectReconciled, expectReconciled,
+                Assert.AreEqual(c.ExpectReconciled, config.ExpectReconciledInput,
                     string.Format("{0}: ExpectReconciledInput", c.Task));
             }
         }

--- a/pwiz_tools/OspreySharp/OspreySharp/Program.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/Program.cs
@@ -371,13 +371,16 @@ namespace pwiz.OspreySharp
                         break;
 
                     case "--task":
-                        // The HPC task selector is resolved in Main's pre-scan
-                        // (ResolveTask -> config membership flags). Consume the
-                        // flag + its value here so ParseArgs doesn't reject it
-                        // as an unknown flag.
+                        // The HPC task selector is resolved + validated in Main's
+                        // pre-scan (ResolveTask). Consume the flag + its required
+                        // value here; throw on a missing value (mirrors the other
+                        // required-value flags) so a bare --task fails fast even
+                        // when ParseArgs is exercised directly, outside Main.
                         i++; // consume flag
-                        if (i < args.Length && !args[i].StartsWith("-"))
-                            i++; // consume value
+                        if (i >= args.Length || args[i].StartsWith("-"))
+                            throw new ArgumentException(
+                                "--task requires a task name (PerFileScoring, FirstJoin, PerFileRescore, or MergeNode).");
+                        i++; // consume value
                         break;
 
                     case "--input-scores":

--- a/pwiz_tools/OspreySharp/OspreySharp/Program.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/Program.cs
@@ -71,11 +71,12 @@ namespace pwiz.OspreySharp
                 // Scan args for the HPC task selector up front so error
                 // messages fire before --input-scores resolution. A single
                 // `--task <Name>` runs exactly one pipeline task (HPC: one
-                // node = one task); it maps to the internal
-                // (noJoinFlag, joinOnlyFlag, joinAtPass) tuple that the
-                // mode-routing wiring (NormalizeHpcArgs + the four tasks'
-                // IsIncluded) already reads. Default (no --task) runs the
-                // full straight-through pipeline.
+                // node = one task) by setting the (NoJoin, StopAfterStage5,
+                // ExpectReconciledInput) config flags the four tasks'
+                // IsIncluded methods read. Default (no --task) runs the full
+                // straight-through pipeline. Any unrecognized flag (including
+                // the retired --no-join / --join-only / --join-at-pass) fails
+                // fast in ParseArgs.
                 string taskName = null;
                 for (int i = 0; i < args.Length; i++)
                 {
@@ -96,12 +97,13 @@ namespace pwiz.OspreySharp
                     }
                 }
 
-                bool joinOnlyFlag = false;
-                bool noJoinFlag = false;
-                int? joinAtPass = null;
+                bool taskNoJoin = false;
+                bool taskStopAfterStage5 = false;
+                bool taskExpectReconciledInput = false;
                 if (taskName != null)
                 {
-                    string taskErr = ResolveTask(taskName, out noJoinFlag, out joinOnlyFlag, out joinAtPass);
+                    string taskErr = ResolveTask(taskName,
+                        out taskNoJoin, out taskStopAfterStage5, out taskExpectReconciledInput);
                     if (taskErr != null)
                     {
                         LogError(taskErr);
@@ -109,32 +111,25 @@ namespace pwiz.OspreySharp
                     }
                 }
 
-                string normErr = NormalizeHpcArgs(joinAtPass, ref noJoinFlag, ref joinOnlyFlag, out bool joinOnlyModifier);
-                if (normErr != null)
-                {
-                    LogError(normErr);
-                    return 1;
-                }
-
                 OspreyConfig config = ParseArgs(args);
-                // --task PerFileScoring / PerFileRescore set noJoinFlag; the
-                // old --no-join CLI flag used to set config.NoJoin directly in
-                // ParseArgs. Carry it across from the resolved tuple now.
-                config.NoJoin = noJoinFlag;
-                config.StopAfterStage5 = joinOnlyModifier;
-                // --join-at-pass=2 sets the strict-reconciled-input gate;
-                // the pipeline asserts every --input-scores parquet has
-                // osprey.reconciled = "true" via ParquetScoreCache
-                // validation. Mirrors Rust's main.rs:613 wiring.
-                config.ExpectReconciledInput = joinAtPass.HasValue && joinAtPass.Value == 2;
-                string err = ValidateArgs(config, noJoinFlag, joinOnlyFlag, joinOnlyModifier);
+                // --task sets the pipeline-membership flags the tasks' IsIncluded
+                // methods read. ExpectReconciledInput additionally arms the
+                // strict-reconciled-input gate (every --input-scores parquet must
+                // carry osprey.reconciled = "true"). Mirrors Rust's main.rs wiring.
+                config.NoJoin = taskNoJoin;
+                config.StopAfterStage5 = taskStopAfterStage5;
+                config.ExpectReconciledInput = taskExpectReconciledInput;
+                string err = ValidateArgs(config);
                 if (err != null)
                 {
                     LogError(err);
                     return 1;
                 }
-                bool joinOnly = joinOnlyFlag
-                                || (config.InputScores != null && config.InputScores.Count > 0);
+                // Runs that consume --input-scores (FirstJoin, PerFileRescore,
+                // MergeNode, or the default full pipeline started from scores)
+                // have no mzML inputs to validate and ignore --output handling
+                // differently from per-file scoring.
+                bool joinOnly = config.InputScores != null && config.InputScores.Count > 0;
 
                 // Non-fatal warning: --task PerFileScoring with --output
                 // supplied — that Stage 1-4 worker mode ignores --output. The
@@ -147,9 +142,9 @@ namespace pwiz.OspreySharp
                                "Per-file `.scores.parquet` files will be written next to each input mzML.");
                 }
 
-                // Validate input files exist on disk (skip in --join-only mode
-                // where there are no mzML inputs; --input-scores paths were
-                // already validated by ResolveInputScores during parsing).
+                // Validate input files exist on disk (skip when consuming
+                // --input-scores, where there are no mzML inputs; --input-scores
+                // paths were already validated by ResolveInputScores during parsing).
                 if (!joinOnly)
                 {
                     foreach (string inputFile in config.InputFiles)
@@ -376,9 +371,9 @@ namespace pwiz.OspreySharp
 
                     case "--task":
                         // The HPC task selector is resolved in Main's pre-scan
-                        // (ResolveTask -> the join tuple -> NormalizeHpcArgs).
-                        // Consume the flag + its value here so ParseArgs
-                        // doesn't fall through to the unknown-flag warning.
+                        // (ResolveTask -> config membership flags). Consume the
+                        // flag + its value here so ParseArgs doesn't reject it
+                        // as an unknown flag.
                         i++; // consume flag
                         if (i < args.Length && !args[i].StartsWith("-"))
                             i++; // consume value
@@ -487,15 +482,24 @@ namespace pwiz.OspreySharp
                         break;
 
                     default:
-                        // Unknown flag -- could be a positional input file
+                        // A non-flag token that exists on disk is a positional
+                        // input file. Anything else starting with '-' is an
+                        // unrecognized option — fail fast (caught by Main) rather
+                        // than silently ignoring it, which could run the wrong
+                        // pipeline (e.g. a retired --no-join would otherwise be
+                        // dropped and the full pipeline would run). The retired
+                        // HPC mode flags have no special-case: they are simply
+                        // unknown now, replaced by --task <Name>.
                         if (!arg.StartsWith("-") && File.Exists(arg))
                         {
                             inputFiles.Add(arg);
+                            i++;
+                            break;
                         }
-                        else
-                        {
-                            LogWarning(string.Format("Unknown argument: {0}", arg));
-                        }
+                        if (arg.StartsWith("-"))
+                            throw new ArgumentException(string.Format(
+                                "Unknown argument: {0}. Run with --help to see valid options.", arg));
+                        LogWarning(string.Format("Unknown argument: {0}", arg));
                         i++;
                         break;
                 }
@@ -584,50 +588,46 @@ namespace pwiz.OspreySharp
 
         /// <summary>
         /// Resolve a <c>--task &lt;Name&gt;</c> selector (case-insensitive,
-        /// matched against each task's stable <c>Name</c>) into the internal
-        /// (<paramref name="noJoinFlag"/>, <paramref name="joinOnlyFlag"/>,
-        /// <paramref name="joinAtPass"/>) tuple that <see cref="NormalizeHpcArgs"/>
-        /// and the four tasks' <c>IsIncluded</c> already read. One node = one
-        /// task on HPC. The mapping is the 1:1 collapse of the retired
-        /// <c>--no-join</c> / <c>--join-only</c> / <c>--join-at-pass</c> mode
-        /// flags:
-        ///   PerFileScoring -> --no-join            (Stages 1-4 per file)
-        ///   FirstJoin      -> --join-at-pass=1 --join-only (Stage 5)
-        ///   PerFileRescore -> --join-at-pass=1 --no-join   (Stage 6 rescore)
-        ///   MergeNode      -> --join-at-pass=2             (Stages 7-8)
-        /// <c>--input-scores</c> is an input specifier, not a mode flag, and
-        /// is validated separately by <see cref="ValidateArgs"/>.
+        /// matched against each task's stable <c>Name</c>) into the three
+        /// pipeline-membership config flags the four tasks' <c>IsIncluded</c>
+        /// methods read. One node = one task on HPC:
+        ///   PerFileScoring -> NoJoin                 (Stages 1-4 per file)
+        ///   FirstJoin      -> StopAfterStage5        (Stage 5 join)
+        ///   PerFileRescore -> NoJoin                 (Stage 6 rescore; with --input-scores)
+        ///   MergeNode      -> ExpectReconciledInput  (Stages 7-8)
+        /// PerFileScoring and PerFileRescore share <c>NoJoin</c>; the pipeline
+        /// distinguishes them by input type (mzML vs <c>--input-scores</c>).
+        /// <c>--input-scores</c> is an input specifier, not a mode flag, and is
+        /// validated separately by <see cref="ValidateArgs"/>.
         ///
         /// Returns null on success, or an error message string for an unknown
         /// task name. Internal so OspreySharp.Test can exercise it.
         /// </summary>
-        internal static string ResolveTask(string taskName, out bool noJoinFlag, out bool joinOnlyFlag,
-            out int? joinAtPass)
+        internal static string ResolveTask(string taskName, out bool noJoin, out bool stopAfterStage5,
+            out bool expectReconciledInput)
         {
-            noJoinFlag = false;
-            joinOnlyFlag = false;
-            joinAtPass = null;
+            noJoin = false;
+            stopAfterStage5 = false;
+            expectReconciledInput = false;
 
             if (string.Equals(taskName, "PerFileScoring", StringComparison.OrdinalIgnoreCase))
             {
-                noJoinFlag = true;
+                noJoin = true;
                 return null;
             }
             if (string.Equals(taskName, "FirstJoin", StringComparison.OrdinalIgnoreCase))
             {
-                joinOnlyFlag = true;
-                joinAtPass = 1;
+                stopAfterStage5 = true;
                 return null;
             }
             if (string.Equals(taskName, "PerFileRescore", StringComparison.OrdinalIgnoreCase))
             {
-                noJoinFlag = true;
-                joinAtPass = 1;
+                noJoin = true;
                 return null;
             }
             if (string.Equals(taskName, "MergeNode", StringComparison.OrdinalIgnoreCase))
             {
-                joinAtPass = 2;
+                expectReconciledInput = true;
                 return null;
             }
             return string.Format(
@@ -636,131 +636,32 @@ namespace pwiz.OspreySharp
         }
 
         /// <summary>
-        /// Normalize the HPC entry-point + modifier flags before
-        /// <see cref="ValidateArgs"/>. Resolves the
-        /// (<c>--join-at-pass=&lt;N&gt;</c>, <c>--join-only</c>,
-        /// <c>--no-join</c>) triple into the same
-        /// (<paramref name="noJoinFlag"/>, <paramref name="joinOnlyFlag"/>)
-        /// tuple downstream code already reads.
-        ///
-        /// Modifier semantics: <c>--join-only</c> runs only the next join
-        /// from the entry point; <c>--no-join</c> runs only the per-file
-        /// fan-out. <c>--join-at-pass=1</c> selects the post-Stage-4 entry
-        /// point; <c>--join-at-pass=2</c> the post-Stage-6 entry point.
-        ///
-        /// Status (post-PR-2): --join-at-pass=1 with --join-only is now
-        /// supported and writes the Stage 5 → Stage 6 boundary file pair
-        /// before exiting. Plain --join-at-pass=1 (no modifier) runs
-        /// Stages 5-8 from a Stage-4-parquet entry point. The remaining
-        /// "not yet implemented" combinations are --join-at-pass=1 with
-        /// --no-join (Stage 6 worker mode) and --join-at-pass=2. Mirrors
-        /// normalize_hpc_args() in osprey/src/main.rs.
-        ///
-        /// Returns null on success, or an error message string on failure.
-        /// Internal so OspreySharp.Test can exercise it.
+        /// Validate the parsed config against the selected <c>--task</c>
+        /// (whose three membership flags <see cref="ResolveTask"/> has already
+        /// set on the config: <see cref="OspreyConfig.NoJoin"/>,
+        /// <see cref="OspreyConfig.StopAfterStage5"/> = FirstJoin,
+        /// <see cref="OspreyConfig.ExpectReconciledInput"/> = MergeNode) and the
+        /// <c>--input-scores</c> input specifier. Returns null on success or an
+        /// error message string on failure. Does not log warnings (those stay
+        /// in <see cref="Main"/>). Internal so OspreySharp.Test can exercise it.
         /// </summary>
-        internal static string NormalizeHpcArgs(int? joinAtPass, ref bool noJoinFlag, ref bool joinOnlyFlag, out bool joinOnlyModifier)
+        internal static string ValidateArgs(OspreyConfig config)
         {
-            joinOnlyModifier = false;
-
-            // Modifiers are mutually exclusive: can't be both per-file-only
-            // and join-only simultaneously.
-            if (noJoinFlag && joinOnlyFlag)
-                return "--no-join and --join-only are mutually exclusive modifiers.";
-
-            // --join-only is a modifier of --join-at-pass=<N>; standalone
-            // use has no entry point to modify. The old standalone spelling
-            // that meant "run Stages 5-8 from Stage 4 parquets" is now
-            // --join-at-pass=1.
-            if (joinOnlyFlag && !joinAtPass.HasValue)
-            {
-                return "--join-only is a modifier and requires --join-at-pass=<N>. " +
-                       "To run Stages 5-8 from Stage 4 parquets, use --join-at-pass=1 --input-scores ...";
-            }
-
-            if (!joinAtPass.HasValue)
-            {
-                // Stage 1 entry point (with -i ...). --no-join keeps its
-                // existing meaning: do per-file work only = Stages 1-4.
-                return null;
-            }
-
-            switch (joinAtPass.Value)
-            {
-                case 1:
-                    if (noJoinFlag)
-                    {
-                        // `--join-at-pass=1 --no-join` is the per-file
-                        // rescore worker entry point. noJoinFlag stays
-                        // true; joinOnlyFlag stays false. Dispatch in
-                        // Main routes to RescoreWorker.Run instead of
-                        // the in-process AnalysisPipeline.Run.
-                        return null;
-                    }
-                    // `--join-at-pass=1 --join-only` (modifier present) means
-                    // "run only the Stage 5 join phase, write boundary
-                    // files, exit before Stage 6 rescore." Plain
-                    // `--join-at-pass=1` (no modifier) runs Stages 5-8.
-                    // In both cases joinOnlyFlag drives the existing Stage
-                    // 5+ entry path; the modifier-vs-plain distinction is
-                    // captured separately for the post-planning early
-                    // exit decision.
-                    joinOnlyModifier = joinOnlyFlag;
-                    joinOnlyFlag = true;
-                    return null;
-                case 2:
-                    if (noJoinFlag)
-                    {
-                        return "--join-at-pass=2 --no-join: per-file Stage 7 worker mode is not implemented (reconciled input + Stage 7-8 in-process is the supported path).";
-                    }
-                    // `--join-at-pass=2` is the post-Stage-6 entry point.
-                    // The pipeline reads reconciled .scores.parquet via
-                    // --input-scores plus the per-file
-                    // .{1st,2nd}-pass.fdr_scores.bin sidecars, skips
-                    // Stages 1-6, and runs Stages 7-8. ExpectReconciledInput
-                    // is set on the config after NormalizeHpcArgs by the
-                    // caller (Main needs the joinAtPass value to be visible
-                    // there). Routes through the same joinOnly path Stage 5+
-                    // input-scores uses; the in-pipeline reconciled-parquet
-                    // gate enforces the strict input contract.
-                    joinOnlyFlag = true;
-                    return null;
-                default:
-                    return string.Format("--join-at-pass must be 1 or 2 (got {0}).", joinAtPass.Value);
-            }
-        }
-
-        /// <summary>
-        /// Validate the resolved HPC task selection (<see cref="ResolveTask"/>
-        /// sets the noJoin/joinOnly/joinAtPass tuple; <c>--input-scores</c> is
-        /// the input specifier) against the parsed config. Returns null on
-        /// success or an error message string on failure. Does not log
-        /// warnings (those stay in <see cref="Main"/>). Internal so
-        /// OspreySharp.Test can exercise it.
-        /// </summary>
-        internal static string ValidateArgs(OspreyConfig config, bool noJoinFlag, bool joinOnlyFlag,
-            bool joinOnlyModifier)
-        {
-            if (noJoinFlag && joinOnlyFlag)
-                return "--task PerFileScoring and --task FirstJoin are mutually exclusive.";
-
             bool hasInputScores = config.InputScores != null && config.InputScores.Count > 0;
-            if (joinOnlyFlag && !hasInputScores)
-                return "--task FirstJoin requires --input-scores <path...>.";
 
-            bool joinOnly = joinOnlyFlag || hasInputScores;
+            // --task FirstJoin (StopAfterStage5) consumes score parquets.
+            if (config.StopAfterStage5 && !hasInputScores)
+                return "--task FirstJoin requires --input-scores <path...>.";
 
             if (config.NoJoin)
             {
-                // Two distinct --no-join task modes (mutually exclusive):
+                // PerFileScoring and PerFileRescore both set NoJoin; the input
+                // type tells them apart:
                 //   - --task PerFileScoring: Stage 1-4 worker (mzML in,
                 //     per-file .scores.parquet out).
-                //   - --task PerFileRescore: Stage 6 worker (Stage 4
-                //     parquets + boundary files in, reconciled per-file
-                //     parquets out).
-                // The rescore worker mode is identified by the presence of
-                // --input-scores; the Stage 1-4 worker mode is identified
-                // by --input. Reject the cross.
+                //   - --task PerFileRescore: Stage 6 worker (--input-scores in,
+                //     reconciled per-file parquets out).
+                // Reject the cross.
                 if (hasInputScores)
                 {
                     if (config.InputFiles.Count > 0)
@@ -776,20 +677,29 @@ namespace pwiz.OspreySharp
                     return "--task PerFileScoring requires --library.";
                 return null;
             }
-            if (joinOnly)
+
+            // Any non-NoJoin run that consumes --input-scores: --task FirstJoin
+            // (StopAfterStage5), --task MergeNode (ExpectReconciledInput), or the
+            // default full pipeline started from --input-scores (neither). These
+            // share the same input requirements; name the task the user actually
+            // selected so the guidance is correct, falling back to the
+            // --input-scores trigger when no --task was given.
+            if (hasInputScores)
             {
+                string selector = config.StopAfterStage5 ? "--task FirstJoin"
+                    : config.ExpectReconciledInput ? "--task MergeNode"
+                    : "--input-scores";
                 if (config.InputFiles.Count > 0)
-                    return "--task FirstJoin cannot be combined with --input. Use --input-scores instead.";
+                    return selector + " cannot be combined with --input. Use --input-scores instead.";
                 if (config.LibrarySource == null || string.IsNullOrEmpty(config.OutputBlib))
-                    return "--task FirstJoin requires --library and --output.";
-                // --task FirstJoin (joinOnlyModifier present) writes the
-                // Stage 5 → Stage 6 boundary file pair, which is only
-                // meaningful when (a) there are siblings to reconcile against
-                // and (b) reconciliation is enabled. Reject early — running
-                // Stages 1-5 only to silently produce nothing useful (or to
-                // fall through to Stage 8 in single-file misconfigurations)
-                // is worse than failing fast with a clear message.
-                if (joinOnlyModifier)
+                    return selector + " requires --library and --output.";
+                // --task FirstJoin writes the Stage 5 → Stage 6 boundary file
+                // pair, which is only meaningful when (a) there are siblings to
+                // reconcile against and (b) reconciliation is enabled. Reject
+                // early — running Stages 1-5 only to silently produce nothing
+                // useful (or to fall through to Stage 8 in single-file
+                // misconfigurations) is worse than failing fast.
+                if (config.StopAfterStage5)
                 {
                     if (config.InputScores.Count < 2)
                         return string.Format(
@@ -824,7 +734,7 @@ namespace pwiz.OspreySharp
         /// Directory mode collects both the Stage 4 <c>*.scores.parquet</c> files
         /// and the Stage 6 <c>*.scores-reconciled.parquet</c> siblings, then
         /// dedupes per stem: for any stem that has both, only the reconciled file
-        /// is returned (the authoritative later pass; the <c>--join-at-pass=2</c>
+        /// is returned (the authoritative later pass; the <c>--task MergeNode</c>
         /// reconciled-input gate expects reconciled parquets). A stem with only an
         /// original is returned as-is. The two suffixes are unambiguous, so this
         /// never returns both files for one stem (see

--- a/pwiz_tools/OspreySharp/OspreySharp/Program.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/Program.cs
@@ -97,28 +97,29 @@ namespace pwiz.OspreySharp
                     }
                 }
 
-                bool taskNoJoin = false;
-                bool taskStopAfterStage5 = false;
-                bool taskExpectReconciledInput = false;
+                HpcTask? selectedTask = null;
                 if (taskName != null)
                 {
-                    string taskErr = ResolveTask(taskName,
-                        out taskNoJoin, out taskStopAfterStage5, out taskExpectReconciledInput);
+                    string taskErr = ResolveTask(taskName, out HpcTask resolved);
                     if (taskErr != null)
                     {
                         LogError(taskErr);
                         return 1;
                     }
+                    selectedTask = resolved;
                 }
 
                 OspreyConfig config = ParseArgs(args);
-                // --task sets the pipeline-membership flags the tasks' IsIncluded
-                // methods read. ExpectReconciledInput additionally arms the
-                // strict-reconciled-input gate (every --input-scores parquet must
-                // carry osprey.reconciled = "true"). Mirrors Rust's main.rs wiring.
-                config.NoJoin = taskNoJoin;
-                config.StopAfterStage5 = taskStopAfterStage5;
-                config.ExpectReconciledInput = taskExpectReconciledInput;
+                // --task selects one pipeline task; derive the membership flags
+                // the tasks' IsIncluded methods read. ExpectReconciledInput also
+                // arms the strict-reconciled-input gate (every --input-scores
+                // parquet must carry osprey.reconciled = "true"). Mirrors Rust's
+                // main.rs wiring. SelectedTask is kept so ValidateArgs can enforce
+                // the task<->input-type contract and name the typed task.
+                config.SelectedTask = selectedTask;
+                config.NoJoin = selectedTask == HpcTask.PerFileScoring || selectedTask == HpcTask.PerFileRescore;
+                config.StopAfterStage5 = selectedTask == HpcTask.FirstJoin;
+                config.ExpectReconciledInput = selectedTask == HpcTask.MergeNode;
                 string err = ValidateArgs(config);
                 if (err != null)
                 {
@@ -588,135 +589,129 @@ namespace pwiz.OspreySharp
 
         /// <summary>
         /// Resolve a <c>--task &lt;Name&gt;</c> selector (case-insensitive,
-        /// matched against each task's stable <c>Name</c>) into the three
-        /// pipeline-membership config flags the four tasks' <c>IsIncluded</c>
-        /// methods read. One node = one task on HPC:
-        ///   PerFileScoring -> NoJoin                 (Stages 1-4 per file)
-        ///   FirstJoin      -> StopAfterStage5        (Stage 5 join)
-        ///   PerFileRescore -> NoJoin                 (Stage 6 rescore; with --input-scores)
-        ///   MergeNode      -> ExpectReconciledInput  (Stages 7-8)
-        /// PerFileScoring and PerFileRescore share <c>NoJoin</c>; the pipeline
-        /// distinguishes them by input type (mzML vs <c>--input-scores</c>).
-        /// <c>--input-scores</c> is an input specifier, not a mode flag, and is
-        /// validated separately by <see cref="ValidateArgs"/>.
+        /// matched against each task's stable <c>Name</c>) to its
+        /// <see cref="HpcTask"/>. One node = one task on HPC. The caller derives
+        /// the pipeline-membership flags (<c>NoJoin</c>, <c>StopAfterStage5</c>,
+        /// <c>ExpectReconciledInput</c>) from the result and keeps the
+        /// <see cref="HpcTask"/> on the config so <see cref="ValidateArgs"/> can
+        /// enforce the task&#8596;input-type contract.
         ///
         /// Returns null on success, or an error message string for an unknown
         /// task name. Internal so OspreySharp.Test can exercise it.
         /// </summary>
-        internal static string ResolveTask(string taskName, out bool noJoin, out bool stopAfterStage5,
-            out bool expectReconciledInput)
+        internal static string ResolveTask(string taskName, out HpcTask task)
         {
-            noJoin = false;
-            stopAfterStage5 = false;
-            expectReconciledInput = false;
-
             if (string.Equals(taskName, "PerFileScoring", StringComparison.OrdinalIgnoreCase))
             {
-                noJoin = true;
+                task = HpcTask.PerFileScoring;
                 return null;
             }
             if (string.Equals(taskName, "FirstJoin", StringComparison.OrdinalIgnoreCase))
             {
-                stopAfterStage5 = true;
+                task = HpcTask.FirstJoin;
                 return null;
             }
             if (string.Equals(taskName, "PerFileRescore", StringComparison.OrdinalIgnoreCase))
             {
-                noJoin = true;
+                task = HpcTask.PerFileRescore;
                 return null;
             }
             if (string.Equals(taskName, "MergeNode", StringComparison.OrdinalIgnoreCase))
             {
-                expectReconciledInput = true;
+                task = HpcTask.MergeNode;
                 return null;
             }
+            task = default;
             return string.Format(
                 "--task: unknown task '{0}'. Valid tasks: PerFileScoring, FirstJoin, PerFileRescore, MergeNode.",
                 taskName);
         }
 
         /// <summary>
-        /// Validate the parsed config against the selected <c>--task</c>
-        /// (whose three membership flags <see cref="ResolveTask"/> has already
-        /// set on the config: <see cref="OspreyConfig.NoJoin"/>,
-        /// <see cref="OspreyConfig.StopAfterStage5"/> = FirstJoin,
-        /// <see cref="OspreyConfig.ExpectReconciledInput"/> = MergeNode) and the
-        /// <c>--input-scores</c> input specifier. Returns null on success or an
-        /// error message string on failure. Does not log warnings (those stay
+        /// Validate the parsed config against the selected
+        /// <see cref="OspreyConfig.SelectedTask"/> (or the default full pipeline
+        /// when none was given). When a <c>--task</c> is selected the task is
+        /// authoritative: it dictates the input type, and the cross
+        /// (e.g. <c>--task PerFileScoring --input-scores</c>) is rejected rather
+        /// than silently dispatching the other task. Returns null on success or
+        /// an error message string on failure. Does not log warnings (those stay
         /// in <see cref="Main"/>). Internal so OspreySharp.Test can exercise it.
         /// </summary>
         internal static string ValidateArgs(OspreyConfig config)
         {
             bool hasInputScores = config.InputScores != null && config.InputScores.Count > 0;
+            bool hasInputFiles = config.InputFiles != null && config.InputFiles.Count > 0;
 
-            // --task FirstJoin (StopAfterStage5) consumes score parquets.
-            if (config.StopAfterStage5 && !hasInputScores)
-                return "--task FirstJoin requires --input-scores <path...>.";
-
-            if (config.NoJoin)
+            if (config.SelectedTask.HasValue)
             {
-                // PerFileScoring and PerFileRescore both set NoJoin; the input
-                // type tells them apart:
-                //   - --task PerFileScoring: Stage 1-4 worker (mzML in,
-                //     per-file .scores.parquet out).
-                //   - --task PerFileRescore: Stage 6 worker (--input-scores in,
-                //     reconciled per-file parquets out).
-                // Reject the cross.
-                if (hasInputScores)
+                switch (config.SelectedTask.Value)
                 {
-                    if (config.InputFiles.Count > 0)
-                        return "--task PerFileRescore cannot be combined with --input. " +
-                               "Use --input-scores; mzML paths are derived from the parquet stems.";
-                    if (config.LibrarySource == null || string.IsNullOrEmpty(config.OutputBlib))
-                        return "--task PerFileRescore requires --library and --output.";
-                    return null;
+                    case HpcTask.PerFileScoring:
+                        // Stage 1-4 worker: mzML in, per-file .scores.parquet out.
+                        if (hasInputScores)
+                            return "--task PerFileScoring takes -i <mzML>, not --input-scores " +
+                                   "(did you mean --task PerFileRescore?).";
+                        if (!hasInputFiles)
+                            return "--task PerFileScoring requires --input <mzML...>.";
+                        if (config.LibrarySource == null)
+                            return "--task PerFileScoring requires --library.";
+                        return null;
+
+                    case HpcTask.PerFileRescore:
+                        // Stage 6 worker: --input-scores in, reconciled per-file out.
+                        if (hasInputFiles)
+                            return "--task PerFileRescore takes --input-scores, not -i <mzML> " +
+                                   "(mzML paths are derived from the parquet stems).";
+                        if (!hasInputScores)
+                            return "--task PerFileRescore requires --input-scores <path...>.";
+                        if (config.LibrarySource == null || string.IsNullOrEmpty(config.OutputBlib))
+                            return "--task PerFileRescore requires --library and --output.";
+                        return null;
+
+                    case HpcTask.FirstJoin:
+                        if (hasInputFiles)
+                            return "--task FirstJoin cannot be combined with --input. Use --input-scores instead.";
+                        if (!hasInputScores)
+                            return "--task FirstJoin requires --input-scores <path...>.";
+                        if (config.LibrarySource == null || string.IsNullOrEmpty(config.OutputBlib))
+                            return "--task FirstJoin requires --library and --output.";
+                        // FirstJoin writes the Stage 5 → Stage 6 boundary file
+                        // pair, only meaningful with 2+ siblings to reconcile
+                        // against and reconciliation enabled. Reject early.
+                        if (config.InputScores.Count < 2)
+                            return string.Format(
+                                "--task FirstJoin requires --input-scores with 2+ parquet files " +
+                                "(got {0}). The Stage 5 → Stage 6 boundary file pair is only meaningful for " +
+                                "multi-file fan-back-in.",
+                                config.InputScores.Count);
+                        if (!config.Reconciliation.Enabled)
+                            return "--task FirstJoin requires Reconciliation.Enabled = true " +
+                                   "(got false from config). The Stage 5 → Stage 6 boundary file pair is " +
+                                   "only meaningful when reconciliation runs.";
+                        return null;
+
+                    case HpcTask.MergeNode:
+                        if (hasInputFiles)
+                            return "--task MergeNode cannot be combined with --input. Use --input-scores instead.";
+                        if (!hasInputScores)
+                            return "--task MergeNode requires --input-scores <path...>.";
+                        if (config.LibrarySource == null || string.IsNullOrEmpty(config.OutputBlib))
+                            return "--task MergeNode requires --library and --output.";
+                        return null;
                 }
-                if (config.InputFiles.Count == 0)
-                    return "--task PerFileScoring requires --input <mzML...>.";
-                if (config.LibrarySource == null)
-                    return "--task PerFileScoring requires --library.";
-                return null;
             }
 
-            // Any non-NoJoin run that consumes --input-scores: --task FirstJoin
-            // (StopAfterStage5), --task MergeNode (ExpectReconciledInput), or the
-            // default full pipeline started from --input-scores (neither). These
-            // share the same input requirements; name the task the user actually
-            // selected so the guidance is correct, falling back to the
-            // --input-scores trigger when no --task was given.
+            // No --task: the full pipeline, started from either -i mzML or
+            // --input-scores (PerFileScoring lazy-rehydrates the supplied scores).
             if (hasInputScores)
             {
-                string selector = config.StopAfterStage5 ? "--task FirstJoin"
-                    : config.ExpectReconciledInput ? "--task MergeNode"
-                    : "--input-scores";
-                if (config.InputFiles.Count > 0)
-                    return selector + " cannot be combined with --input. Use --input-scores instead.";
+                if (hasInputFiles)
+                    return "--input-scores cannot be combined with --input. Use one or the other.";
                 if (config.LibrarySource == null || string.IsNullOrEmpty(config.OutputBlib))
-                    return selector + " requires --library and --output.";
-                // --task FirstJoin writes the Stage 5 → Stage 6 boundary file
-                // pair, which is only meaningful when (a) there are siblings to
-                // reconcile against and (b) reconciliation is enabled. Reject
-                // early — running Stages 1-5 only to silently produce nothing
-                // useful (or to fall through to Stage 8 in single-file
-                // misconfigurations) is worse than failing fast.
-                if (config.StopAfterStage5)
-                {
-                    if (config.InputScores.Count < 2)
-                        return string.Format(
-                            "--task FirstJoin requires --input-scores with 2+ parquet files " +
-                            "(got {0}). The Stage 5 → Stage 6 boundary file pair is only meaningful for " +
-                            "multi-file fan-back-in.",
-                            config.InputScores.Count);
-                    if (!config.Reconciliation.Enabled)
-                        return "--task FirstJoin requires Reconciliation.Enabled = true " +
-                               "(got false from config). The Stage 5 → Stage 6 boundary file pair is " +
-                               "only meaningful when reconciliation runs.";
-                }
+                    return "--input-scores requires --library and --output.";
                 return null;
             }
-
-            // Default mode: original required-args checks.
-            if (config.InputFiles.Count == 0)
+            if (!hasInputFiles)
                 return "No input files specified. Use -i <file1.mzML> [file2.mzML ...]";
             if (config.LibrarySource == null)
                 return "No spectral library specified. Use -l <library.tsv>";

--- a/pwiz_tools/OspreySharp/OspreySharp/Program.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/Program.cs
@@ -68,43 +68,44 @@ namespace pwiz.OspreySharp
 
             try
             {
-                // Scan args for the HPC entry-point + modifier flags up
-                // front so error messages fire before --input-scores
-                // resolution. Mirrors the Rust pre-parse done by clap +
-                // normalize_hpc_args in osprey/src/main.rs.
-                bool joinOnlyFlag = false;
-                bool noJoinFlag = false;
-                int? joinAtPass = null;
+                // Scan args for the HPC task selector up front so error
+                // messages fire before --input-scores resolution. A single
+                // `--task <Name>` runs exactly one pipeline task (HPC: one
+                // node = one task); it maps to the internal
+                // (noJoinFlag, joinOnlyFlag, joinAtPass) tuple that the
+                // mode-routing wiring (NormalizeHpcArgs + the four tasks'
+                // IsIncluded) already reads. Default (no --task) runs the
+                // full straight-through pipeline.
+                string taskName = null;
                 for (int i = 0; i < args.Length; i++)
                 {
                     string a = args[i];
-                    if (a == "--no-join")
+                    if (a == "--task")
                     {
-                        noJoinFlag = true;
-                    }
-                    else if (a == "--join-only")
-                    {
-                        joinOnlyFlag = true;
-                    }
-                    else if (a.StartsWith("--join-at-pass=", StringComparison.Ordinal))
-                    {
-                        string v = a.Substring("--join-at-pass=".Length);
-                        if (!int.TryParse(v, out int parsed))
+                        if (i + 1 >= args.Length || args[i + 1].StartsWith("-", StringComparison.Ordinal))
                         {
-                            LogError(string.Format("--join-at-pass: invalid integer value '{0}'.", v));
+                            LogError("--task requires a task name (PerFileScoring, FirstJoin, PerFileRescore, or MergeNode).");
                             return 1;
                         }
-                        joinAtPass = parsed;
-                    }
-                    else if (a == "--join-at-pass")
-                    {
-                        if (i + 1 >= args.Length || !int.TryParse(args[i + 1], out int parsed))
-                        {
-                            LogError("--join-at-pass requires an integer value (e.g., --join-at-pass=1).");
-                            return 1;
-                        }
-                        joinAtPass = parsed;
+                        taskName = args[i + 1];
                         i++; // consume value
+                    }
+                    else if (a.StartsWith("--task=", StringComparison.Ordinal))
+                    {
+                        taskName = a.Substring("--task=".Length);
+                    }
+                }
+
+                bool joinOnlyFlag = false;
+                bool noJoinFlag = false;
+                int? joinAtPass = null;
+                if (taskName != null)
+                {
+                    string taskErr = ResolveTask(taskName, out noJoinFlag, out joinOnlyFlag, out joinAtPass);
+                    if (taskErr != null)
+                    {
+                        LogError(taskErr);
+                        return 1;
                     }
                 }
 
@@ -116,6 +117,10 @@ namespace pwiz.OspreySharp
                 }
 
                 OspreyConfig config = ParseArgs(args);
+                // --task PerFileScoring / PerFileRescore set noJoinFlag; the
+                // old --no-join CLI flag used to set config.NoJoin directly in
+                // ParseArgs. Carry it across from the resolved tuple now.
+                config.NoJoin = noJoinFlag;
                 config.StopAfterStage5 = joinOnlyModifier;
                 // --join-at-pass=2 sets the strict-reconciled-input gate;
                 // the pipeline asserts every --input-scores parquet has
@@ -131,15 +136,14 @@ namespace pwiz.OspreySharp
                 bool joinOnly = joinOnlyFlag
                                 || (config.InputScores != null && config.InputScores.Count > 0);
 
-                // Non-fatal warning: --no-join with --output supplied — but
-                // ONLY for the Stage 1-4 worker mode (`--no-join --input
-                // ...`) where --output truly is ignored. The Stage 6 worker
-                // mode (`--join-at-pass=1 --no-join --input-scores ...`)
-                // requires --output (per ValidateArgs at line ~642), so
-                // the warning would be incorrect/confusing there.
+                // Non-fatal warning: --task PerFileScoring with --output
+                // supplied — that Stage 1-4 worker mode ignores --output. The
+                // rescore worker (--task PerFileRescore, identified by
+                // --input-scores) requires --output, so the warning would be
+                // incorrect/confusing there.
                 if (config.NoJoin && !joinOnly && !string.IsNullOrEmpty(config.OutputBlib))
                 {
-                    LogWarning("--no-join: --output is ignored (no blib is written). " +
+                    LogWarning("--task PerFileScoring: --output is ignored (no blib is written). " +
                                "Per-file `.scores.parquet` files will be written next to each input mzML.");
                 }
 
@@ -182,8 +186,8 @@ namespace pwiz.OspreySharp
                 LogInfo(string.Format("Threads: {0}", config.NThreads));
                 LogInfo("");
 
-                // Single entry point. Stage 6 worker mode
-                // (--join-at-pass=1 --no-join --input-scores) includes only
+                // Single entry point. The rescore worker (--task
+                // PerFileRescore, with --input-scores) includes only
                 // PerFileRescoreTask (OspreyTask.IsIncluded); PerFileScoring's
                 // lazy-rehydrate (via ctx.Demand) populates the upstream state
                 // from the boundary files on disk.
@@ -216,10 +220,10 @@ namespace pwiz.OspreySharp
             {
                 string arg = args[i];
 
-                // The single-token `--join-at-pass=N` form is already parsed
-                // + validated in Main's pre-scan via NormalizeHpcArgs. Skip
-                // it here so the default branch doesn't flag it as unknown.
-                if (arg.StartsWith("--join-at-pass=", StringComparison.Ordinal))
+                // The single-token `--task=Name` form is resolved in Main's
+                // pre-scan. Skip it here so the default branch doesn't flag
+                // it as unknown.
+                if (arg.StartsWith("--task=", StringComparison.Ordinal))
                 {
                     i++;
                     continue;
@@ -370,25 +374,14 @@ namespace pwiz.OspreySharp
                         i++;
                         break;
 
-                    case "--no-join":
-                        config.NoJoin = true;
-                        i++;
-                        break;
-
-                    case "--join-at-pass":
-                        // Already parsed + validated in Main's pre-scan via
-                        // NormalizeHpcArgs. Consume the integer value here so
-                        // ParseArgs doesn't fall through to the unknown-flag
-                        // warning. Mutex/range checks happen up there.
+                    case "--task":
+                        // The HPC task selector is resolved in Main's pre-scan
+                        // (ResolveTask -> the join tuple -> NormalizeHpcArgs).
+                        // Consume the flag + its value here so ParseArgs
+                        // doesn't fall through to the unknown-flag warning.
                         i++; // consume flag
                         if (i < args.Length && !args[i].StartsWith("-"))
                             i++; // consume value
-                        break;
-
-                    case "--join-only":
-                        // Sentinel: --input-scores must follow (validated in Main).
-                        // No-op here; presence of InputScores is the actual switch.
-                        i++;
                         break;
 
                     case "--input-scores":
@@ -590,6 +583,59 @@ namespace pwiz.OspreySharp
         }
 
         /// <summary>
+        /// Resolve a <c>--task &lt;Name&gt;</c> selector (case-insensitive,
+        /// matched against each task's stable <c>Name</c>) into the internal
+        /// (<paramref name="noJoinFlag"/>, <paramref name="joinOnlyFlag"/>,
+        /// <paramref name="joinAtPass"/>) tuple that <see cref="NormalizeHpcArgs"/>
+        /// and the four tasks' <c>IsIncluded</c> already read. One node = one
+        /// task on HPC. The mapping is the 1:1 collapse of the retired
+        /// <c>--no-join</c> / <c>--join-only</c> / <c>--join-at-pass</c> mode
+        /// flags:
+        ///   PerFileScoring -> --no-join            (Stages 1-4 per file)
+        ///   FirstJoin      -> --join-at-pass=1 --join-only (Stage 5)
+        ///   PerFileRescore -> --join-at-pass=1 --no-join   (Stage 6 rescore)
+        ///   MergeNode      -> --join-at-pass=2             (Stages 7-8)
+        /// <c>--input-scores</c> is an input specifier, not a mode flag, and
+        /// is validated separately by <see cref="ValidateArgs"/>.
+        ///
+        /// Returns null on success, or an error message string for an unknown
+        /// task name. Internal so OspreySharp.Test can exercise it.
+        /// </summary>
+        internal static string ResolveTask(string taskName, out bool noJoinFlag, out bool joinOnlyFlag,
+            out int? joinAtPass)
+        {
+            noJoinFlag = false;
+            joinOnlyFlag = false;
+            joinAtPass = null;
+
+            if (string.Equals(taskName, "PerFileScoring", StringComparison.OrdinalIgnoreCase))
+            {
+                noJoinFlag = true;
+                return null;
+            }
+            if (string.Equals(taskName, "FirstJoin", StringComparison.OrdinalIgnoreCase))
+            {
+                joinOnlyFlag = true;
+                joinAtPass = 1;
+                return null;
+            }
+            if (string.Equals(taskName, "PerFileRescore", StringComparison.OrdinalIgnoreCase))
+            {
+                noJoinFlag = true;
+                joinAtPass = 1;
+                return null;
+            }
+            if (string.Equals(taskName, "MergeNode", StringComparison.OrdinalIgnoreCase))
+            {
+                joinAtPass = 2;
+                return null;
+            }
+            return string.Format(
+                "--task: unknown task '{0}'. Valid tasks: PerFileScoring, FirstJoin, PerFileRescore, MergeNode.",
+                taskName);
+        }
+
+        /// <summary>
         /// Normalize the HPC entry-point + modifier flags before
         /// <see cref="ValidateArgs"/>. Resolves the
         /// (<c>--join-at-pass=&lt;N&gt;</c>, <c>--join-only</c>,
@@ -685,56 +731,58 @@ namespace pwiz.OspreySharp
         }
 
         /// <summary>
-        /// Validate the HPC mode flags (--no-join, --join-only, --input-scores)
-        /// against the parsed config. Returns null on success or an error
-        /// message string on failure. Does not log warnings (those stay in
-        /// <see cref="Main"/>). Internal so OspreySharp.Test can exercise it.
+        /// Validate the resolved HPC task selection (<see cref="ResolveTask"/>
+        /// sets the noJoin/joinOnly/joinAtPass tuple; <c>--input-scores</c> is
+        /// the input specifier) against the parsed config. Returns null on
+        /// success or an error message string on failure. Does not log
+        /// warnings (those stay in <see cref="Main"/>). Internal so
+        /// OspreySharp.Test can exercise it.
         /// </summary>
         internal static string ValidateArgs(OspreyConfig config, bool noJoinFlag, bool joinOnlyFlag,
             bool joinOnlyModifier)
         {
             if (noJoinFlag && joinOnlyFlag)
-                return "--no-join and --join-only are mutually exclusive.";
+                return "--task PerFileScoring and --task FirstJoin are mutually exclusive.";
 
             bool hasInputScores = config.InputScores != null && config.InputScores.Count > 0;
             if (joinOnlyFlag && !hasInputScores)
-                return "--join-at-pass=1 requires --input-scores <path...>.";
+                return "--task FirstJoin requires --input-scores <path...>.";
 
             bool joinOnly = joinOnlyFlag || hasInputScores;
 
             if (config.NoJoin)
             {
-                // Two distinct --no-join modes (mutually exclusive):
-                //   - Standalone --no-join: Stage 1-4 worker (mzML in,
+                // Two distinct --no-join task modes (mutually exclusive):
+                //   - --task PerFileScoring: Stage 1-4 worker (mzML in,
                 //     per-file .scores.parquet out).
-                //   - --join-at-pass=1 --no-join: Stage 6 worker (Stage 4
+                //   - --task PerFileRescore: Stage 6 worker (Stage 4
                 //     parquets + boundary files in, reconciled per-file
                 //     parquets out).
-                // The Stage 6 worker mode is identified by the presence of
+                // The rescore worker mode is identified by the presence of
                 // --input-scores; the Stage 1-4 worker mode is identified
                 // by --input. Reject the cross.
                 if (hasInputScores)
                 {
                     if (config.InputFiles.Count > 0)
-                        return "--join-at-pass=1 --no-join cannot be combined with --input. " +
+                        return "--task PerFileRescore cannot be combined with --input. " +
                                "Use --input-scores; mzML paths are derived from the parquet stems.";
                     if (config.LibrarySource == null || string.IsNullOrEmpty(config.OutputBlib))
-                        return "--join-at-pass=1 --no-join requires --library and --output.";
+                        return "--task PerFileRescore requires --library and --output.";
                     return null;
                 }
                 if (config.InputFiles.Count == 0)
-                    return "--no-join requires --input <mzML...>.";
+                    return "--task PerFileScoring requires --input <mzML...>.";
                 if (config.LibrarySource == null)
-                    return "--no-join requires --library.";
+                    return "--task PerFileScoring requires --library.";
                 return null;
             }
             if (joinOnly)
             {
                 if (config.InputFiles.Count > 0)
-                    return "--join-at-pass=1 cannot be combined with --input. Use --input-scores instead.";
+                    return "--task FirstJoin cannot be combined with --input. Use --input-scores instead.";
                 if (config.LibrarySource == null || string.IsNullOrEmpty(config.OutputBlib))
-                    return "--join-at-pass=1 requires --library and --output.";
-                // `--join-at-pass=1 --join-only` (modifier present) writes the
+                    return "--task FirstJoin requires --library and --output.";
+                // --task FirstJoin (joinOnlyModifier present) writes the
                 // Stage 5 → Stage 6 boundary file pair, which is only
                 // meaningful when (a) there are siblings to reconcile against
                 // and (b) reconciliation is enabled. Reject early — running
@@ -745,12 +793,12 @@ namespace pwiz.OspreySharp
                 {
                     if (config.InputScores.Count < 2)
                         return string.Format(
-                            "--join-at-pass=1 --join-only requires --input-scores with 2+ parquet files " +
+                            "--task FirstJoin requires --input-scores with 2+ parquet files " +
                             "(got {0}). The Stage 5 → Stage 6 boundary file pair is only meaningful for " +
                             "multi-file fan-back-in.",
                             config.InputScores.Count);
                     if (!config.Reconciliation.Enabled)
-                        return "--join-at-pass=1 --join-only requires Reconciliation.Enabled = true " +
+                        return "--task FirstJoin requires Reconciliation.Enabled = true " +
                                "(got false from config). The Stage 5 → Stage 6 boundary file pair is " +
                                "only meaningful when reconciliation runs.";
                 }
@@ -866,20 +914,20 @@ namespace pwiz.OspreySharp
             Console.Error.WriteLine("                                    with --decoys-in-library. Manifest is the");
             Console.Error.WriteLine("                                    authoritative source for peptide_type and");
             Console.Error.WriteLine("                                    (optional) clean protein accessions.");
-            Console.Error.WriteLine("    --join-at-pass=<N>            HPC: enter the pipeline at a join checkpoint.");
-            Console.Error.WriteLine("                                    1 = consume Stage 4 outputs, run Stages 5-8.");
-            Console.Error.WriteLine("                                    2 = consume Stage 6 outputs, run Stages 7-8.");
-            Console.Error.WriteLine("                                    Requires --input-scores; mutex with --input.");
-            Console.Error.WriteLine("    --no-join                     HPC modifier: run only the per-file fan-out from");
-            Console.Error.WriteLine("                                    the entry point. With -i, runs Stages 1-4 (per-file");
-            Console.Error.WriteLine("                                    .scores.parquet written next to each mzML, no FDR,");
-            Console.Error.WriteLine("                                    no blib). Mutex with --join-only.");
-            Console.Error.WriteLine("    --join-only                   HPC modifier: run only the join phase from the entry");
-            Console.Error.WriteLine("                                    point, stopping before the per-file fan-out that");
-            Console.Error.WriteLine("                                    follows. Requires --join-at-pass=<N>.");
+            Console.Error.WriteLine("    --task <Name>                 HPC: run exactly one pipeline task (one node =");
+            Console.Error.WriteLine("                                    one task). Omit for the full pipeline. Names:");
+            Console.Error.WriteLine("                                    PerFileScoring  Stages 1-4 per file; -i mzML in,");
+            Console.Error.WriteLine("                                                    per-file .scores.parquet out.");
+            Console.Error.WriteLine("                                    FirstJoin       Stage 5 join; --input-scores in,");
+            Console.Error.WriteLine("                                                    boundary sidecar pair out.");
+            Console.Error.WriteLine("                                    PerFileRescore  Stage 6 rescore; --input-scores in,");
+            Console.Error.WriteLine("                                                    reconciled per-file parquet out.");
+            Console.Error.WriteLine("                                    MergeNode       Stages 7-8; reconciled --input-scores");
+            Console.Error.WriteLine("                                                    in, blib out.");
             Console.Error.WriteLine("    --input-scores <paths>        HPC: one or more .scores.parquet files,");
             Console.Error.WriteLine("                                    or a single directory (non-recursive scan).");
-            Console.Error.WriteLine("                                    Required when --join-at-pass is set.");
+            Console.Error.WriteLine("                                    Required for the FirstJoin/PerFileRescore/MergeNode");
+            Console.Error.WriteLine("                                    tasks; mutex with --input there.");
             Console.Error.WriteLine("    -h, --help                    Show this help message");
             Console.Error.WriteLine("    -v, --version                 Show version");
             Console.Error.WriteLine("");
@@ -888,13 +936,15 @@ namespace pwiz.OspreySharp
             Console.Error.WriteLine("    osprey -i *.mzML -l library.tsv -o results.blib --resolution hram");
             Console.Error.WriteLine("    osprey -i data1.mzML data2.mzML -l lib.tsv -o out.blib --protein-fdr 0.01");
             Console.Error.WriteLine("");
-            Console.Error.WriteLine("HPC SPLIT (per-node scoring + central merge):");
-            Console.Error.WriteLine("    # Worker node (one per mzML, in parallel on a cluster):");
-            Console.Error.WriteLine("    osprey --no-join -i data/file_N.mzML -l ref.blib --resolution hram");
+            Console.Error.WriteLine("HPC SPLIT (one node = one --task):");
+            Console.Error.WriteLine("    # Per-file scoring worker (one per mzML, in parallel on a cluster):");
+            Console.Error.WriteLine("    osprey --task PerFileScoring -i data/file_N.mzML -l ref.blib --resolution hram");
             Console.Error.WriteLine("");
-            Console.Error.WriteLine("    # Merge node (after all workers succeed):");
-            Console.Error.WriteLine("    osprey --join-at-pass=1 --input-scores data/*.scores.parquet \\");
-            Console.Error.WriteLine("           -l ref.blib -o experiment.blib --protein-fdr 0.01");
+            Console.Error.WriteLine("    # First-join node (Stage 5), then per-file rescore workers (Stage 6),");
+            Console.Error.WriteLine("    # then the merge node (Stages 7-8):");
+            Console.Error.WriteLine("    osprey --task FirstJoin      --input-scores data/*.scores.parquet -l ref.blib -o experiment.blib");
+            Console.Error.WriteLine("    osprey --task PerFileRescore --input-scores data/file_N.scores.parquet -l ref.blib -o experiment.blib");
+            Console.Error.WriteLine("    osprey --task MergeNode       --input-scores data/*.scores-reconciled.parquet -l ref.blib -o experiment.blib --protein-fdr 0.01");
         }
 
         internal static void LogInfo(string message)

--- a/pwiz_tools/OspreySharp/OspreySharp/Tasks/FirstJoinTask.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/Tasks/FirstJoinTask.cs
@@ -80,11 +80,11 @@ namespace pwiz.OspreySharp.Tasks
             var c = ctx.Config;
             bool inputs = c.InputScores != null && c.InputScores.Count > 0;
             // The (inputs && StopAfterStage5) clause leans on a CLI-enforced
-            // invariant: StopAfterStage5 (--join-only) is a modifier of
-            // --join-at-pass=<N>, and --join-at-pass=1 requires --input-scores,
-            // so StopAfterStage5 implies inputs at parse time -- a --join-only
-            // run can never reach here without InputScores.
-            // ProgramTests.TestValidateJoinOnlyRequiresInputScores pins that
+            // invariant: StopAfterStage5 is set by --task FirstJoin, which
+            // requires --input-scores, so StopAfterStage5 implies inputs at
+            // parse time -- a --task FirstJoin run can never reach here without
+            // InputScores.
+            // ProgramTests.TestValidateFirstJoinRequiresInputScores pins that
             // rejection, since the membership truth table (PipelineMembershipTest)
             // does not encode the cross-flag dependency on its own.
             return (!inputs && !c.NoJoin)

--- a/pwiz_tools/OspreySharp/OspreySharp/Tasks/FirstJoinTask.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/Tasks/FirstJoinTask.cs
@@ -72,7 +72,7 @@ namespace pwiz.OspreySharp.Tasks
         /// Computes the Stage 5 first-join (Percolator first-pass FDR + Stage 6
         /// planning) in straight-through, --task FirstJoin (StopAfterStage5), and
         /// the --input-scores full-pipeline. Excluded in --task PerFileScoring
-        /// (stops at Stage 1-4), the rescore worker, and the --task MergeNode
+        /// (stops at Stage 1-4), --task PerFileRescore, and the --task MergeNode
         /// stage (where it rehydrates the bundle rather than recomputing).
         /// </summary>
         public override bool IsIncluded(PipelineContext ctx)

--- a/pwiz_tools/OspreySharp/OspreySharp/Tasks/FirstJoinTask.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/Tasks/FirstJoinTask.cs
@@ -70,10 +70,10 @@ namespace pwiz.OspreySharp.Tasks
 
         /// <summary>
         /// Computes the Stage 5 first-join (Percolator first-pass FDR + Stage 6
-        /// planning) in straight-through, --join-only (StopAfterStage5), and
-        /// the --input-scores full-pipeline. Excluded in --no-join (stops at
-        /// Stage 1-4), the rescore worker, and the --join-at-pass=2 merge
-        /// (where it rehydrates the bundle rather than recomputing).
+        /// planning) in straight-through, --task FirstJoin (StopAfterStage5), and
+        /// the --input-scores full-pipeline. Excluded in --task PerFileScoring
+        /// (stops at Stage 1-4), the rescore worker, and the --task MergeNode
+        /// stage (where it rehydrates the bundle rather than recomputing).
         /// </summary>
         public override bool IsIncluded(PipelineContext ctx)
         {
@@ -247,7 +247,7 @@ namespace pwiz.OspreySharp.Tasks
             if (fdrSidecarFailures > 0 && config.StopAfterStage5)
             {
                 ctx.LogError(string.Format(
-                    @"--join-at-pass=1 --join-only: {0}/{1} 1st-pass fdr_scores.bin sidecar " +
+                    @"--task FirstJoin: {0}/{1} 1st-pass fdr_scores.bin sidecar " +
                     @"writes failed; boundary file pair is incomplete. See warnings above.",
                     fdrSidecarFailures, perFileEntries.Count));
                 ctx.ExitCode = 1;
@@ -820,14 +820,14 @@ namespace pwiz.OspreySharp.Tasks
                 if (reconWriteFailures > 0)
                 {
                     _ctx.LogError(string.Format(
-                        @"--join-at-pass=1 --join-only: {0}/{1} reconciliation.json " +
+                        @"--task FirstJoin: {0}/{1} reconciliation.json " +
                         @"writes failed; boundary file pair is incomplete. See warnings above.",
                         reconWriteFailures, perFileEntries.Count));
                     _ctx.ExitCode = 1;
                     return false;
                 }
                 _ctx.LogInfo(string.Format(
-                    @"--join-at-pass=1 --join-only: Stage 5 + reconciliation planning " +
+                    @"--task FirstJoin: Stage 5 + reconciliation planning " +
                     @"complete; wrote {0} reconciliation.json + matching fdr_scores.bin " +
                     @"sidecar pair(s). Exiting before Stage 6 rescore.",
                     perFileEntries.Count));

--- a/pwiz_tools/OspreySharp/OspreySharp/Tasks/MergeNodeTask.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/Tasks/MergeNodeTask.cs
@@ -58,7 +58,7 @@ namespace pwiz.OspreySharp.Tasks
         /// Computes Stage 7-8 (2nd-pass FDR + protein FDR + blib) in
         /// straight-through, the --task MergeNode stage, and the --input-scores
         /// full-pipeline. Excluded in --task PerFileScoring, --task FirstJoin,
-        /// and the rescore worker (all of which stop before the merge node).
+        /// and --task PerFileRescore (all of which stop before the merge node).
         /// </summary>
         public override bool IsIncluded(PipelineContext ctx)
         {

--- a/pwiz_tools/OspreySharp/OspreySharp/Tasks/MergeNodeTask.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/Tasks/MergeNodeTask.cs
@@ -56,9 +56,9 @@ namespace pwiz.OspreySharp.Tasks
 
         /// <summary>
         /// Computes Stage 7-8 (2nd-pass FDR + protein FDR + blib) in
-        /// straight-through, the --join-at-pass=2 merge, and the --input-scores
-        /// full-pipeline. Excluded in --no-join, --join-only, and the rescore
-        /// worker (all of which stop before the merge node).
+        /// straight-through, the --task MergeNode stage, and the --input-scores
+        /// full-pipeline. Excluded in --task PerFileScoring, --task FirstJoin,
+        /// and the rescore worker (all of which stop before the merge node).
         /// </summary>
         public override bool IsIncluded(PipelineContext ctx)
         {
@@ -164,7 +164,7 @@ namespace pwiz.OspreySharp.Tasks
                     if (unmatchedKeys.Count > 0)
                     {
                         ctx.LogWarning(string.Format(
-                            "--join-at-pass=2: {0} perFileEntries key(s) have no matching " +
+                            "--task MergeNode: {0} perFileEntries key(s) have no matching " +
                             "config.InputFiles entry and will be skipped: [{1}]. This usually " +
                             "indicates an input-file rename or path drift between Stage 5 and " +
                             "Stage 7; the skipped files will not get a 2nd-pass sidecar.",
@@ -184,7 +184,7 @@ namespace pwiz.OspreySharp.Tasks
                     if (missingPass2 > 0)
                     {
                         ctx.LogInfo(string.Format(
-                            "--join-at-pass=2: {0}/{1} file(s) lack a 2nd-pass sidecar -- running " +
+                            "--task MergeNode: {0}/{1} file(s) lack a 2nd-pass sidecar -- running " +
                             "second-pass FDR to compute scores from reconciled features " +
                             "(HPC distribution path; mirrors Rust pipeline.rs:4394-4468).",
                             missingPass2, totalFiles));
@@ -465,7 +465,7 @@ namespace pwiz.OspreySharp.Tasks
                     if (filesReloaded > 0)
                     {
                         ctx.LogInfo(string.Format(
-                            "--join-at-pass=2: reloaded 2nd-pass FDR sidecar for {0}/{1} file(s) post-compaction",
+                            "--task MergeNode: reloaded 2nd-pass FDR sidecar for {0}/{1} file(s) post-compaction",
                             filesReloaded, filesReloaded + filesMissing));
                     }
                 }

--- a/pwiz_tools/OspreySharp/OspreySharp/Tasks/PerFileScoringTask.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/Tasks/PerFileScoringTask.cs
@@ -567,7 +567,7 @@ namespace pwiz.OspreySharp.Tasks
             if (ctx.Config.NoJoin)
             {
                 ctx.LogInfo(string.Format(
-                    @"--no-join: Stage 1-4 complete. {0} entries scored across {1} file(s). " +
+                    @"--task PerFileScoring: Stage 1-4 complete. {0} entries scored across {1} file(s). " +
                     @"Per-file `.scores.parquet` written next to each input mzML. " +
                     @"Skipping FDR and blib output.",
                     totalScored, nFiles));
@@ -858,7 +858,7 @@ namespace pwiz.OspreySharp.Tasks
                 throw new InvalidDataException(validationError);
 
             _ctx.LogInfo(string.Format(
-                @"--join-only: loading {0} per-file score parquet(s)",
+                @"--input-scores: loading {0} per-file score parquet(s)",
                 config.InputScores.Count));
             for (int fileIdx = 0; fileIdx < config.InputScores.Count; fileIdx++)
             {
@@ -879,7 +879,7 @@ namespace pwiz.OspreySharp.Tasks
                 if (features.Count != stubs.Count)
                 {
                     throw new InvalidDataException(string.Format(
-                        @"--join-only: parquet {0} has {1} stubs but {2} feature rows",
+                        @"--input-scores: parquet {0} has {1} stubs but {2} feature rows",
                         parquetPath, stubs.Count, features.Count));
                 }
                 for (int j = 0; j < stubs.Count; j++)


### PR DESCRIPTION
## Summary

Replaces OspreySharp's HPC mode flags (`--no-join`, `--join-only`, `--join-at-pass=1|2`) with a single self-documenting `--task <Name>` that runs exactly one pipeline task — one HPC node = one task. This is the capstone of the PR-A→PR-E declarative-dataflow refactor: hydration is now mechanism-driven (each task rehydrates from whatever sidecars are valid on disk), so the flags that used to *steer* hydration are vestigial.

* `--task <Name>` selects one task by its stable `Name` (case-insensitive): `PerFileScoring`, `FirstJoin`, `PerFileRescore`, `MergeNode`. Omit `--task` for the full straight-through pipeline (incl. resume).
* `ResolveTask` maps each name directly to the three pipeline-membership config flags `(NoJoin, StopAfterStage5, ExpectReconciledInput)` the tasks' `IsIncluded` methods read — bit-for-bit identical to the old worker modes (proven on Stellar AND Astral).
* **Clean break, no compat shim** (unreleased software): the retired flags are gone. `ParseArgs` now **hard-errors on any unrecognized flag** rather than warning and silently running the full pipeline — so a stale `--no-join` invocation fails fast, and typos do too.
* Deleted the `NormalizeHpcArgs` mode-flag machinery and the `joinAtPass`/`joinOnlyFlag` plumbing entirely; `ValidateArgs(config)` now reads task identity from the config, so each task's validation errors name the right task.
* `--input-scores` is **kept** as an input specifier (the FirstJoin/PerFileRescore/MergeNode tasks still need their score parquets).

### Mode → task mapping

| Old flags | `--task` equivalent | config (NoJoin, StopAfterStage5, ExpectReconciled) |
|---|---|---|
| `--no-join` | `--task PerFileScoring` | (true, false, false) |
| `--join-at-pass=1 --join-only` | `--task FirstJoin` | (false, true, false) |
| `--join-at-pass=1 --no-join --input-scores` | `--task PerFileRescore` | (true, false, false) |
| `--join-at-pass=2` | `--task MergeNode` | (false, false, true) |
| *(none)* straight-through | default (no `--task`) | (false, false, false) |

## Test plan

- [x] `Build-OspreySharp.ps1 -RunTests -RunInspection` — build + unit tests + ReSharper clean
- [x] `--task` strict bit-parity gate (4-phase HPC chain) on **Stellar AND Astral** — Stage-5 sidecar SHA, Stage-6 reconciled parquet (tolerance 0), Stage-7 protein-FDR + blib 1e-9 all PASS; proves `--task` reproduces the retired flags bit-for-bit
- [x] Straight-through resume smoke (default no-`--task` path unchanged)
- [x] Copilot review addressed (task-aware validation messages + fail-fast on retired flags)

## Notes

* The shared diagnostic gate script `Compare-Stage7-Rehydration-Strict-CSharp.ps1` and the other C# diagnostic scripts migrate to `--task` in lockstep with this merge (pushed to pwiz-ai master at the same time). Rust-targeting scripts keep the old flags, since Rust `osprey` still uses them.

See ai/todos/active/TODO-20260605_ospreysharp_task_cli_hpc_cleanup.md

Co-Authored-By: Claude <noreply@anthropic.com>
