### PR TITLE
Cleaned up retired-flag references and guarded value flags in OspreySharp

### DIFF
--- a/pwiz_tools/OspreySharp/OspreySharp.Core/OspreyEnvironment.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Core/OspreyEnvironment.cs
@@ -74,7 +74,7 @@ namespace pwiz.OspreySharp.Core
         public static readonly bool ExitAfterCalibration = IsSet(@"OSPREY_EXIT_AFTER_CALIBRATION");
 
         // Note: the OSPREY_EXIT_AFTER_SCORING env var that used to live here
-        // was retired in favor of the --no-join CLI flag. See the HPC
+        // was retired in favor of the --task PerFileScoring CLI flag. See the HPC
         // scoring split work in AnalysisPipeline.Run. ExitAfterCalibration
         // (Stage 3) stays because it has no production CLI analog.
 

--- a/pwiz_tools/OspreySharp/OspreySharp.Core/SearchIdentity.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Core/SearchIdentity.cs
@@ -251,7 +251,7 @@ namespace pwiz.OspreySharp.Core
         /// Compute the reconciliation parameter hash for an explicit set of
         /// file stems. Used by per-file Stage 6 rescore workers, whose
         /// <see cref="OspreyConfig.InputFiles"/> only carries this worker's single
-        /// parquet — the hash that the downstream <c>--join-at-pass=2</c>
+        /// parquet — the hash that the downstream <c>--task MergeNode</c>
         /// merge node expects is computed over ALL files in the join, so
         /// the worker must read the full set from the planner's
         /// <c>reconciliation.json</c> envelope and pass it in here. The

--- a/pwiz_tools/OspreySharp/OspreySharp.FDR/ProteinFdr.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.FDR/ProteinFdr.cs
@@ -648,12 +648,12 @@ namespace pwiz.OspreySharp.FDR
         /// and downstream consumption.
         ///
         /// Used by FirstJoinTask for the in-process pipeline (runs after first-pass FDR,
-        /// before compaction) and by PerFileRescoreTask for the <c>--join-at-pass=2</c>
+        /// before compaction) and by PerFileRescoreTask for the <c>--task MergeNode</c>
         /// rehydration path (runs after sidecar load, before compaction) so the protein-
         /// rescue branch of compaction has fresh <c>RunProteinQvalue</c> values matching
         /// what Rust computes inline. Without it, the rehydrated C# pipeline used only
         /// the <c>RunProteinQvalue</c> values stored in the 1st-pass FDR sidecar; for
-        /// single-file <c>--join-at-pass=2</c> runs that left 19 peptides outside Rust's
+        /// single-file <c>--task MergeNode</c> runs that left 19 peptides outside Rust's
         /// post-compaction detected set on Stellar Single, causing a 1-protein delta in
         /// Stage 7 picked-protein output.
         /// </summary>

--- a/pwiz_tools/OspreySharp/OspreySharp.IO/FdrScoresSidecar.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.IO/FdrScoresSidecar.cs
@@ -335,7 +335,7 @@ namespace pwiz.OspreySharp.IO
         /// <see cref="TryRead(string,IList{FdrEntry},Pass)"/>, but the
         /// caller supplies an entry_id-keyed dictionary directly so we
         /// skip rereading the source parquet just to size-check the
-        /// sidecar. Used by --join-at-pass=2 Stage 7 where the compacted
+        /// sidecar. Used by --task MergeNode Stage 7 where the compacted
         /// entry list already covers every sidecar record we care about.
         /// </summary>
         public static bool TryReadOverlay(string path,
@@ -381,7 +381,7 @@ namespace pwiz.OspreySharp.IO
                 {
                     // Sidecar can carry entries not in the (possibly
                     // compacted) caller dict — that's expected for
-                    // --join-at-pass=2 where compaction has already
+                    // --task MergeNode where compaction has already
                     // dropped failing precursors. Skip silently.
                     continue;
                 }

--- a/pwiz_tools/OspreySharp/OspreySharp.IO/ParquetScoreCache.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.IO/ParquetScoreCache.cs
@@ -89,10 +89,10 @@ namespace pwiz.OspreySharp.IO
 
         // Schema column types and names are aligned with the Rust impl's
         // parquet schema (UInt32 for entry_id/scan_number, UInt8 for charge)
-        // so a C#-written parquet can be loaded by Rust's `--join-only`
+        // so a C#-written parquet can be loaded by Rust's `--task FirstJoin`
         // (which does strict downcasts) and vice versa. Reading is also
         // strict: pre-2026-04-19 C#-written parquets used Int32 for these
-        // fields and need to be regenerated via a fresh `--no-join` run.
+        // fields and need to be regenerated via a fresh `--task PerFileScoring` run.
         //
         // Fields are declared in the same order Rust writes them. Order
         // doesn't affect Parquet correctness (columns are name-indexed),
@@ -301,7 +301,7 @@ namespace pwiz.OspreySharp.IO
 
         /// <summary>
         /// Write FdrEntry results to a Parquet file. Same schema as the
-        /// CoelutionScoredEntry overload — used by --no-join HPC mode where
+        /// CoelutionScoredEntry overload — used by --task PerFileScoring HPC mode where
         /// the pipeline keeps full features on the FdrEntry directly
         /// (FdrEntry.Features is the already-extracted 21-feature vector).
         /// Library lookup (by entry_id) supplies the sequence / precursor_mz
@@ -989,7 +989,7 @@ namespace pwiz.OspreySharp.IO
 
         /// <summary>
         /// The path a post-Stage-6 reader (Stage 7 feature reload, resume /
-        /// <c>--join-at-pass=2</c>) should consume for a given original
+        /// <c>--task MergeNode</c>) should consume for a given original
         /// <c>.scores.parquet</c> path: the reconciled sibling when it exists
         /// on disk, otherwise the original. This per-file selection is the
         /// read-side contract that makes the separate-reconciled-file design
@@ -1043,7 +1043,7 @@ namespace pwiz.OspreySharp.IO
 
         #endregion
 
-        #region Phase 3: --join-only group validation
+        #region Phase 3: --task FirstJoin group validation
 
         /// <summary>
         /// Read all key-value pairs from a parquet footer. Returns an empty
@@ -1153,7 +1153,7 @@ namespace pwiz.OspreySharp.IO
         /// library hashes. Returns null on success (logging a warning to
         /// <paramref name="logWarning"/> for any patch-version drift) or an
         /// error message naming the offending file. Used at the start of
-        /// --join-only mode.
+        /// --task FirstJoin mode.
         /// </summary>
         public static string ValidateScoresParquetGroup(
             IEnumerable<string> paths,
@@ -1189,7 +1189,7 @@ namespace pwiz.OspreySharp.IO
                 if (warning != null && logWarning != null)
                     logWarning(warning);
 
-                // --join-at-pass=2 strict reconciled-input gate. Mirrors
+                // --task MergeNode strict reconciled-input gate. Mirrors
                 // Rust pipeline.rs:3313-3344: every input parquet must
                 // carry osprey.reconciled = "true" so the operator
                 // cannot mix raw Stage 4 parquets into a Stages 7-8-only
@@ -1203,10 +1203,10 @@ namespace pwiz.OspreySharp.IO
                     if (!string.Equals(cachedReconciled, "true", StringComparison.Ordinal))
                     {
                         return string.Format(
-                            "--join-at-pass=2 requires a reconciled (post-Stage-6) parquet, " +
+                            "--task MergeNode requires a reconciled (post-Stage-6) parquet, " +
                             "but {0} has osprey.reconciled = '{1}'. Either it is a Stage 4 " +
-                            "(raw) parquet — in which case use --join-at-pass=1 — or run a " +
-                            "full pipeline first to produce reconciled parquets.",
+                            "(raw) parquet — run --task PerFileRescore to produce reconciled " +
+                            "parquets first — or run the full pipeline.",
                             path, cachedReconciled ?? "<unset>");
                     }
                 }

--- a/pwiz_tools/OspreySharp/OspreySharp.IO/ReconciliationFile.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.IO/ReconciliationFile.cs
@@ -56,7 +56,7 @@ namespace pwiz.OspreySharp.IO
         /// v1: initial format.
         /// v2: added <c>file_stems</c> so per-file Stage 6 rescore workers
         ///     can compute the reconciliation parameter hash that the
-        ///     downstream <c>--join-at-pass=2</c> merge node expects (the
+        ///     downstream <c>--task MergeNode</c> merge node expects (the
         ///     hash is computed over all files in the join, not the
         ///     worker's single parquet). Old v1 files deserialize with an
         ///     empty <see cref="FileStems"/> list; the worker falls back
@@ -114,7 +114,7 @@ namespace pwiz.OspreySharp.IO
             // v2 envelopes must carry the planner's full join file_stems set;
             // a deserialized v2 file with file_stems missing or empty would
             // silently flow through RescoreHydration with joinFileStems = []
-            // and cause downstream --join-at-pass=2 to compute a single-file
+            // and cause downstream --task MergeNode to compute a single-file
             // ReconciliationParameterHash for what was meant to be a
             // multi-file join. JsonProperty does not enforce required, so
             // assert it here. Matches the Rust serde behavior (file_stems is

--- a/pwiz_tools/OspreySharp/OspreySharp.Tasks/OspreyTask.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Tasks/OspreyTask.cs
@@ -49,7 +49,7 @@ namespace pwiz.OspreySharp.Tasks
     /// skips Run when every output exists with a matching key. The
     /// same skip-if-valid check applies to every CLI mode — cross-impl
     /// / worker-mode invocations (<c>--input-scores</c> /
-    /// <c>--join-at-pass=*</c>) flow through the same driver, so
+    /// <c>--task &lt;Name&gt;</c>) flow through the same driver, so
     /// validity-key match drives the decision rather than any CLI
     /// flag gate. (Cross-impl correctness on <c>--input-scores</c>
     /// parquets is enforced separately by the parquet

--- a/pwiz_tools/OspreySharp/OspreySharp.Tasks/PipelineContext.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Tasks/PipelineContext.cs
@@ -210,7 +210,7 @@ namespace pwiz.OspreySharp.Tasks
                 // (one that set a non-zero ExitCode -- e.g. a library load or
                 // empty-scores error) as a throw so the run fails loudly. A
                 // success-stop that returns false with ExitCode == 0 (e.g. the
-                // --no-join boundary, whose byproducts were already published
+                // --task PerFileScoring boundary, whose byproducts were already published
                 // before the stop) is intentionally left benign.
                 if (!task.Rehydrate(this) && ExitCode != 0)
                     throw new RehydrateFailedException(taskType, ExitCode);

--- a/pwiz_tools/OspreySharp/OspreySharp.Test/ByproductContextTest.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Test/ByproductContextTest.cs
@@ -145,7 +145,7 @@ namespace pwiz.OspreySharp.Test
         public void TestGetSucceedsWhenRehydrateStopsWithExitCodeZero()
         {
             // Rehydrate returns false but keeps ExitCode == 0 (a success-but-stop,
-            // e.g. the --no-join boundary) AFTER publishing its byproduct: Get
+            // e.g. the --task PerFileScoring boundary) AFTER publishing its byproduct: Get
             // must return the published value without throwing.
             var ctx = ContextFor(new StubProducerTask(publishBeforeStop: true, exitCode: 0));
             var info = ctx.Get<StubByproduct>();

--- a/pwiz_tools/OspreySharp/OspreySharp.Test/IOTest.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Test/IOTest.cs
@@ -1307,7 +1307,7 @@ namespace pwiz.OspreySharp.Test
         /// <summary>
         /// Verifies ReconciledPathFromScoresPath swaps the ".scores.parquet"
         /// suffix for ".scores-reconciled.parquet" and is idempotent on an
-        /// already-reconciled path (the --join-at-pass=2 case where the input IS
+        /// already-reconciled path (the --task MergeNode case where the input IS
         /// the reconciled file).
         /// </summary>
         [TestMethod]
@@ -1791,7 +1791,7 @@ namespace pwiz.OspreySharp.Test
 
         /// <summary>
         /// Caller may pass a SUPERSET of the sidecar's entries — a real
-        /// case for --join-at-pass=2 stage 7 entry where the reconciled
+        /// case for --task MergeNode stage 7 entry where the reconciled
         /// parquet has gap-fill stubs the 1st-pass sidecar (written
         /// pre-gap-fill) does not. Sidecar records overlay onto matching
         /// entry_ids; entries with no matching record keep their default

--- a/pwiz_tools/OspreySharp/OspreySharp.Test/ProgramTests.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Test/ProgramTests.cs
@@ -511,6 +511,34 @@ namespace pwiz.OspreySharp.Test
                 () => Program.ParseArgs(new[] { "--task", "-l", "ref.blib" }));
         }
 
+        [TestMethod]
+        public void TestParseArgsRejectsValueFlagsWithoutValue()
+        {
+            // Single-value option flags must reject both a missing value (flag
+            // is the last token) and a following option token (the next arg
+            // starts with '-'), so e.g. `-o -l x` can't silently swallow `-l`
+            // as the output path. Representative coverage across the path,
+            // numeric, and enum flags.
+            var missingOrFlagFollowed = new[]
+            {
+                new[] { "-l" },
+                new[] { "-o", "-l", "x.blib" },
+                new[] { "--output" },
+                new[] { "--resolution", "--protein-fdr", "0.01" },
+                new[] { "--protein-fdr" },
+                new[] { "--threads", "-i", "f.mzML" },
+                new[] { "--decoy-pairing-manifest" },
+                new[] { "--fdr-method", "-o", "out.blib" },
+                new[] { "--fdr-level" },
+                new[] { "--shared-peptides", "--threads", "4" },
+            };
+            foreach (var args in missingOrFlagFollowed)
+            {
+                Assert.ThrowsException<ArgumentException>(
+                    () => Program.ParseArgs(args));
+            }
+        }
+
         // --- ResolveInputScores -------------------------------------------
 
         [TestMethod]

--- a/pwiz_tools/OspreySharp/OspreySharp/AnalysisPipeline.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/AnalysisPipeline.cs
@@ -199,7 +199,7 @@ namespace pwiz.OspreySharp
             // non-zero exit code. Several tasks intentionally return
             // false on success to stop the pipeline at a configured
             // boundary (PerFileScoringTask under --task PerFileScoring, FirstJoinTask
-            // under --task FirstJoin-with-StopAfterStage5); gating on
+            // under --task FirstJoin with StopAfterStage5); gating on
             // keepGoing alone would skip sidecar writes for those
             // successful early-exit modes and break resume.
             if (ctx.ExitCode == 0)

--- a/pwiz_tools/OspreySharp/OspreySharp/AnalysisPipeline.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/AnalysisPipeline.cs
@@ -65,7 +65,7 @@ namespace pwiz.OspreySharp
                 // PipelineContext.Config. Previously this lived inside
                 // PerFileScoringTask's join-only load, which the driver never
                 // reached when PerFileScoring was the StartAt task, e.g.
-                // `--join-at-pass=1 --input-scores`.)
+                // `--task PerFileScoring --input-scores`.)
                 if (config.InputScores != null && config.InputScores.Count > 0
                     && (config.InputFiles == null || config.InputFiles.Count == 0))
                 {
@@ -198,8 +198,8 @@ namespace pwiz.OspreySharp
             // Write sidecars whenever the task ran without setting a
             // non-zero exit code. Several tasks intentionally return
             // false on success to stop the pipeline at a configured
-            // boundary (PerFileScoringTask under --no-join, FirstJoinTask
-            // under --join-only-with-StopAfterStage5); gating on
+            // boundary (PerFileScoringTask under --task PerFileScoring, FirstJoinTask
+            // under --task FirstJoin-with-StopAfterStage5); gating on
             // keepGoing alone would skip sidecar writes for those
             // successful early-exit modes and break resume.
             if (ctx.ExitCode == 0)

--- a/pwiz_tools/OspreySharp/OspreySharp/Program.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/Program.cs
@@ -130,14 +130,14 @@ namespace pwiz.OspreySharp
                 // MergeNode, or the default full pipeline started from scores)
                 // have no mzML inputs to validate and ignore --output handling
                 // differently from per-file scoring.
-                bool joinOnly = config.InputScores != null && config.InputScores.Count > 0;
+                bool fromInputScores = config.InputScores != null && config.InputScores.Count > 0;
 
                 // Non-fatal warning: --task PerFileScoring with --output
                 // supplied — that Stage 1-4 worker mode ignores --output. The
                 // rescore worker (--task PerFileRescore, identified by
                 // --input-scores) requires --output, so the warning would be
                 // incorrect/confusing there.
-                if (config.NoJoin && !joinOnly && !string.IsNullOrEmpty(config.OutputBlib))
+                if (config.NoJoin && !fromInputScores && !string.IsNullOrEmpty(config.OutputBlib))
                 {
                     LogWarning("--task PerFileScoring: --output is ignored (no blib is written). " +
                                "Per-file `.scores.parquet` files will be written next to each input mzML.");
@@ -146,7 +146,7 @@ namespace pwiz.OspreySharp
                 // Validate input files exist on disk (skip when consuming
                 // --input-scores, where there are no mzML inputs; --input-scores
                 // paths were already validated by ResolveInputScores during parsing).
-                if (!joinOnly)
+                if (!fromInputScores)
                 {
                     foreach (string inputFile in config.InputFiles)
                     {
@@ -240,94 +240,54 @@ namespace pwiz.OspreySharp
 
                     case "-l":
                     case "--library":
+                        libraryPath = RequireValue(args, ref i, arg);
                         i++;
-                        if (i < args.Length)
-                        {
-                            libraryPath = args[i];
-                            i++;
-                        }
                         break;
 
                     case "-o":
                     case "--output":
+                        outputPath = RequireValue(args, ref i, arg);
                         i++;
-                        if (i < args.Length)
-                        {
-                            outputPath = args[i];
-                            i++;
-                        }
                         break;
 
                     case "--resolution":
+                        resolution = RequireValue(args, ref i, arg).ToLowerInvariant();
                         i++;
-                        if (i < args.Length)
-                        {
-                            resolution = args[i].ToLowerInvariant();
-                            i++;
-                        }
                         break;
 
                     case "--run-fdr":
+                        config.RunFdr = ParseDouble(RequireValue(args, ref i, arg), "--run-fdr");
                         i++;
-                        if (i < args.Length)
-                        {
-                            config.RunFdr = ParseDouble(args[i], "--run-fdr");
-                            i++;
-                        }
                         break;
 
                     case "--experiment-fdr":
+                        config.ExperimentFdr = ParseDouble(RequireValue(args, ref i, arg), "--experiment-fdr");
                         i++;
-                        if (i < args.Length)
-                        {
-                            config.ExperimentFdr = ParseDouble(args[i], "--experiment-fdr");
-                            i++;
-                        }
                         break;
 
                     case "--protein-fdr":
+                        config.ProteinFdr = ParseDouble(RequireValue(args, ref i, arg), "--protein-fdr");
                         i++;
-                        if (i < args.Length)
-                        {
-                            config.ProteinFdr = ParseDouble(args[i], "--protein-fdr");
-                            i++;
-                        }
                         break;
 
                     case "--threads":
+                        config.NThreads = int.Parse(RequireValue(args, ref i, arg));
                         i++;
-                        if (i < args.Length)
-                        {
-                            config.NThreads = int.Parse(args[i]);
-                            i++;
-                        }
                         break;
 
                     case "--fragment-tolerance":
+                        fragmentTolerance = ParseDouble(RequireValue(args, ref i, arg), "--fragment-tolerance");
                         i++;
-                        if (i < args.Length)
-                        {
-                            fragmentTolerance = ParseDouble(args[i], "--fragment-tolerance");
-                            i++;
-                        }
                         break;
 
                     case "--fragment-unit":
+                        fragmentUnit = RequireValue(args, ref i, arg).ToLowerInvariant();
                         i++;
-                        if (i < args.Length)
-                        {
-                            fragmentUnit = args[i].ToLowerInvariant();
-                            i++;
-                        }
                         break;
 
                     case "--report":
+                        config.OutputReport = RequireValue(args, ref i, arg);
                         i++;
-                        if (i < args.Length)
-                        {
-                            config.OutputReport = args[i];
-                            i++;
-                        }
                         break;
 
                     case "--no-prefilter":
@@ -349,19 +309,11 @@ namespace pwiz.OspreySharp
                         break;
 
                     case "--decoy-pairing-manifest":
-                        i++;
-                        // Reject a missing value (end of args) AND reject
-                        // the next token starting with `--` (i.e. the next
-                        // option), which would otherwise silently consume
-                        // a sibling flag like --decoys-in-library as the
-                        // manifest path. Both produce the same usage
-                        // error so the user knows the option needs a path.
-                        if (i >= args.Length || args[i].StartsWith(@"--", StringComparison.Ordinal))
-                        {
-                            throw new ArgumentException(
-                                @"--decoy-pairing-manifest requires a path argument.");
-                        }
-                        config.DecoyPairingManifestPath = args[i];
+                        // Reject a missing value (end of args) AND reject a
+                        // following option token (starts with '-'), which would
+                        // otherwise silently consume a sibling flag like
+                        // --decoys-in-library as the manifest path.
+                        config.DecoyPairingManifestPath = RequireValue(args, ref i, arg);
                         i++;
                         break;
 
@@ -403,10 +355,9 @@ namespace pwiz.OspreySharp
                         break;
 
                     case "--fdr-method":
-                        i++;
-                        if (i < args.Length)
                         {
-                            switch (args[i].ToLowerInvariant())
+                            string fdrMethodValue = RequireValue(args, ref i, arg);
+                            switch (fdrMethodValue.ToLowerInvariant())
                             {
                                 case "percolator":
                                     config.FdrMethod = FdrMethod.Percolator;
@@ -416,7 +367,7 @@ namespace pwiz.OspreySharp
                                     break;
                                 default:
                                     LogWarning(string.Format(
-                                        "Unknown FDR method '{0}', defaulting to percolator", args[i]));
+                                        "Unknown FDR method '{0}', defaulting to percolator", fdrMethodValue));
                                     config.FdrMethod = FdrMethod.Percolator;
                                     break;
                             }
@@ -425,10 +376,9 @@ namespace pwiz.OspreySharp
                         break;
 
                     case "--fdr-level":
-                        i++;
-                        if (i < args.Length)
                         {
-                            switch (args[i].ToLowerInvariant())
+                            string fdrLevelValue = RequireValue(args, ref i, arg);
+                            switch (fdrLevelValue.ToLowerInvariant())
                             {
                                 case "precursor":
                                     config.FdrLevel = FdrLevel.Precursor;
@@ -441,7 +391,7 @@ namespace pwiz.OspreySharp
                                     break;
                                 default:
                                     LogWarning(string.Format(
-                                        "Unknown FDR level '{0}', defaulting to both", args[i]));
+                                        "Unknown FDR level '{0}', defaulting to both", fdrLevelValue));
                                     break;
                             }
                             i++;
@@ -449,10 +399,9 @@ namespace pwiz.OspreySharp
                         break;
 
                     case "--shared-peptides":
-                        i++;
-                        if (i < args.Length)
                         {
-                            switch (args[i].ToLowerInvariant())
+                            string sharedPeptidesValue = RequireValue(args, ref i, arg);
+                            switch (sharedPeptidesValue.ToLowerInvariant())
                             {
                                 case "all":
                                     config.SharedPeptides = SharedPeptideMode.All;
@@ -466,7 +415,7 @@ namespace pwiz.OspreySharp
                                 default:
                                     LogWarning(string.Format(
                                         "Unknown shared peptides mode '{0}', defaulting to all",
-                                        args[i]));
+                                        sharedPeptidesValue));
                                     break;
                             }
                             i++;
@@ -588,6 +537,21 @@ namespace pwiz.OspreySharp
             }
 
             return config;
+        }
+
+        /// <summary>
+        /// Consumes the value token following a single-value option flag.
+        /// Advances <paramref name="i"/> to the value and returns it; throws if
+        /// the value is missing or looks like the next option (starts with '-'),
+        /// so e.g. <c>-o -l x</c> fails fast instead of swallowing <c>-l</c> as
+        /// the value. Callers advance past the value with their own <c>i++</c>.
+        /// </summary>
+        private static string RequireValue(string[] args, ref int i, string flag)
+        {
+            i++;
+            if (i >= args.Length || args[i].StartsWith("-"))
+                throw new ArgumentException(string.Format("{0} requires a value.", flag));
+            return args[i];
         }
 
         /// <summary>

--- a/pwiz_tools/OspreySharp/OspreySharp/RescoreHydration.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/RescoreHydration.cs
@@ -92,7 +92,7 @@ namespace pwiz.OspreySharp
         /// they can compute the join-wide reconciliation parameter hash —
         /// the worker's <c>OspreyConfig.InputFiles</c> only has its single
         /// parquet, but the hash that the downstream
-        /// <c>--join-at-pass=2</c> merge node validates is computed over
+        /// <c>--task MergeNode</c> merge node validates is computed over
         /// all files. Empty list when reading a v1 envelope (the worker
         /// falls back to its <c>InputFiles</c> stems in that case).
         /// </summary>

--- a/pwiz_tools/OspreySharp/OspreySharp/RescoreWorker.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/RescoreWorker.cs
@@ -26,7 +26,7 @@ using pwiz.OspreySharp.Core;
 namespace pwiz.OspreySharp
 {
     /// <summary>
-    /// Top-level entry point for the <c>--join-at-pass=1 --no-join</c>
+    /// Top-level entry point for the <c>--task PerFileRescore</c>
     /// per-file rescore worker. Mirrors <c>run_rescore</c> in
     /// <c>osprey/crates/osprey/src/rescore.rs</c>.
     ///

--- a/pwiz_tools/OspreySharp/OspreySharp/Tasks/FirstJoinTask.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/Tasks/FirstJoinTask.cs
@@ -186,7 +186,7 @@ namespace pwiz.OspreySharp.Tasks
             // this run owns the full first-join work. The bundle-present
             // disk-load counterpart lives in Rehydrate. The driver reaches this
             // task here only in the bundle-absent modes (straight-through,
-            // --join-only); a worker-mode consumer materializes it via
+            // --task FirstJoin); a worker-mode consumer materializes it via
             // ctx.Demand which routes to Rehydrate.
             _ctx = ctx;
             var config = ctx.Config;
@@ -543,7 +543,7 @@ namespace pwiz.OspreySharp.Tasks
         /// <see cref="_didPlan"/> output fields the next task
         /// (PerFileRescoreTask) consumes and returns true. Returns false
         /// (with <see cref="PipelineContext.ExitCode"/> set) on the
-        /// --join-at-pass=1 --join-only StopAfterStage5 exit paths.
+        /// --task FirstJoin StopAfterStage5 exit paths.
         /// Mirrors pipeline.rs Stage 6 entry
         /// block at lines 3208-3273. The caller gates this on
         /// bundle == null (Stage 6 state already exists upstream on the
@@ -799,7 +799,7 @@ namespace pwiz.OspreySharp.Tasks
             // Stage 5 → Stage 6 boundary: write the per-file
             // .reconciliation.json envelope (the .fdr_scores.bin
             // companion was already written above pre-compaction).
-            // Pairs with the --join-at-pass=1 --no-join Stage 6
+            // Pairs with the --task PerFileRescore Stage 6
             // worker mode (next sprint).
             //
             // Surfaces gap-fill targets via out param so the in-
@@ -833,7 +833,7 @@ namespace pwiz.OspreySharp.Tasks
                     perFileEntries.Count));
                 // Success: return true (not false). The stop after Stage 5 is now
                 // a membership fact -- PerFileRescore and MergeNode are excluded
-                // by IsIncluded under --join-only, so the driver loop iterates no
+                // by IsIncluded under --task FirstJoin, so the driver loop iterates no
                 // further. The failure path above keeps ExitCode=1; return false.
                 _ctx.ExitCode = 0;
                 return true;
@@ -906,7 +906,7 @@ namespace pwiz.OspreySharp.Tasks
         /// pre-compaction). Mirrors the matching block in
         /// osprey/src/pipeline.rs immediately after
         /// dump_stage6_reconciliation. The file is written sibling to
-        /// the input mzML (or, in --join-only mode, the synthetic input
+        /// the input mzML (or, in --task FirstJoin mode, the synthetic input
         /// path derived from the parquet stem).
         /// </summary>
         /// <returns>
@@ -1006,7 +1006,7 @@ namespace pwiz.OspreySharp.Tasks
             // The multi-file stems set goes into every per-file
             // reconciliation.json so a worker rescoring its single
             // parquet can compute the join-wide reconciliation hash that
-            // --join-at-pass=2 will validate against. Sort + dedup once;
+            // --task MergeNode will validate against. Sort + dedup once;
             // BuildReconciliationFile copies the list into the wire form.
             var joinFileStems = new List<string>(perFileEntries.Count);
             foreach (var fEntry in perFileEntries)
@@ -1068,7 +1068,7 @@ namespace pwiz.OspreySharp.Tasks
         /// Resolve a path whose stem matches <paramref name="fileName"/>, used
         /// only as the base for sidecar file naming (the path itself need
         /// not exist). In normal mode this is the input mzML; in
-        /// --join-only mode where InputFiles is empty we synthesize the
+        /// --task FirstJoin mode where InputFiles is empty we synthesize the
         /// path from the matching .scores.parquet by replacing the
         /// `.scores.parquet` suffix with `.mzML`. Mirrors the Rust
         /// `synthetic_input_from_parquet` helper.
@@ -1093,7 +1093,7 @@ namespace pwiz.OspreySharp.Tasks
                     }
                 }
             }
-            // --join-only fallback: derive a synthetic mzML path from the
+            // --task FirstJoin fallback: derive a synthetic mzML path from the
             // matching parquet stem so all the existing sidecar path
             // helpers keep working without conditional branches.
             if (perFileParquetPaths != null
@@ -1695,7 +1695,7 @@ namespace pwiz.OspreySharp.Tasks
         {
             // Detected-peptide count for logging only; the core computation +
             // propagation lives in ProteinFdr.RunFirstPassProteinFdr so the
-            // join-at-pass=2 rehydration path (PerFileRescoreTask) can run the
+            // --task MergeNode rehydration path (PerFileRescoreTask) can run the
             // same logic without duplicating it.
             int detectedCount = 0;
             var detectedTracker = new HashSet<string>(StringComparer.Ordinal);

--- a/pwiz_tools/OspreySharp/OspreySharp/Tasks/MergeNodeTask.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/Tasks/MergeNodeTask.cs
@@ -424,7 +424,7 @@ namespace pwiz.OspreySharp.Tasks
                 // written to it). RunProteinFdr's detected_peptides gate filters on
                 // ExperimentPrecursorQvalue, which has to be the 2nd-pass value to
                 // match Rust pipeline.rs:4480-4494's reload-then-second-pass-FDR
-                // sequence. Without this reload, single-file --join-at-pass=2 runs
+                // sequence. Without this reload, single-file --task MergeNode runs
                 // include ~19 borderline peptides whose 1st-pass q-value passes
                 // <=1% but 2nd-pass q-value does not, producing a 1-protein delta
                 // in the Stage 7 picked-protein output cross-impl.

--- a/pwiz_tools/OspreySharp/OspreySharp/Tasks/PerFileRescoreTask.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/Tasks/PerFileRescoreTask.cs
@@ -78,7 +78,7 @@ namespace pwiz.OspreySharp.Tasks
     /// Single entry point: <see cref="Run"/> is invoked by
     /// <see cref="AnalysisPipeline"/>'s task driver during both
     /// straight-through pipeline runs and the stage6 worker mode
-    /// (<c>--join-at-pass=1 --no-join --input-scores</c>). The worker
+    /// (<c>--task PerFileRescore</c>). The worker
     /// mode previously had a separate <c>RunWorker</c> entry that
     /// hand-assembled the upstream hydration; Phase C collapsed that
     /// path so the canonical pipeline's IsIncluded membership + the
@@ -107,9 +107,9 @@ namespace pwiz.OspreySharp.Tasks
 
         /// <summary>
         /// Computes the Stage 6 rescore in straight-through, the rescore worker
-        /// (--join-at-pass=1 --no-join --input-scores), and the --input-scores
-        /// full-pipeline. Excluded in --no-join, --join-only (stops at Stage 5),
-        /// and the --join-at-pass=2 merge (where it rehydrates rather than
+        /// (--task PerFileRescore), and the --input-scores
+        /// full-pipeline. Excluded in --task PerFileScoring, --task FirstJoin (stops at Stage 5),
+        /// and the --task MergeNode merge (where it rehydrates rather than
         /// re-scoring, the merge node having no mzMLs).
         /// </summary>
         public override bool IsIncluded(PipelineContext ctx)
@@ -122,7 +122,7 @@ namespace pwiz.OspreySharp.Tasks
         }
 
         // The final milestone of the shared mutable entry buffer: this task
-        // overlays the Stage 6 rescore (or, in the --join-at-pass=2 merge path,
+        // overlays the Stage 6 rescore (or, in the --task MergeNode merge path,
         // applies its own compaction) onto the same backing list. MergeNode
         // pulls RescoredEntries, so a cache miss lazily materializes this task --
         // which is exactly what triggers the rescore/compaction in merge mode
@@ -179,7 +179,7 @@ namespace pwiz.OspreySharp.Tasks
             // Compute path (Stage 6 rescore): re-score each file's entries
             // against the consensus + reconciliation boundaries and write the
             // reconciled parquets. Used by the straight-through pipeline and
-            // the stage6 rescore worker. The --join-at-pass=2 merge node,
+            // the stage6 rescore worker. The --task MergeNode merge node,
             // which has only reconciled parquets + sidecars (no mzMLs to
             // rescore from), takes Rehydrate instead: the driver reaches this
             // task here only in the rescore-capable modes, and a merge-node
@@ -214,7 +214,7 @@ namespace pwiz.OspreySharp.Tasks
             // ExpectReconciledInput gate (Phase C: mechanism-driven, not
             // flag-driven) for the worker self-gate cases below;
             // ExpectReconciledInput keeps the hard short-circuit above for
-            // the strict --join-at-pass=2 merge path. Downstream MergeNodeTask
+            // the strict --task MergeNode merge path. Downstream MergeNodeTask
             // reads the RescoredEntries milestone of this same backing list.
             var firstJoin = ctx.Demand<FirstJoinTask>();
             bool didPlan = firstJoin.DidPlan(ctx);
@@ -241,7 +241,7 @@ namespace pwiz.OspreySharp.Tasks
 
             // Join file stems for the reconciled parquet metadata hash.
             // In the in-process pipeline _perFileEntries has every file in
-            // the run; in worker mode (--join-at-pass=1 --no-join) it has
+            // the run; in worker mode (--task PerFileRescore) it has
             // a single file and the planner's full set comes from
             // RescoreInputs.JoinFileStems (read from reconciliation.json
             // v2+). Pass _perFileEntries keys when there's more than one;
@@ -301,7 +301,7 @@ namespace pwiz.OspreySharp.Tasks
 
         public override bool Rehydrate(PipelineContext ctx)
         {
-            // Disk-load path for --join-at-pass=2: every input parquet already
+            // Disk-load path for --task MergeNode: every input parquet already
             // has osprey.reconciled = "true" (asserted by
             // ParquetScoreCache.CheckParquetMetadata when ExpectReconciledInput
             // is set), so Stage 5 first-pass Percolator AND Stage 6 planning /
@@ -343,7 +343,7 @@ namespace pwiz.OspreySharp.Tasks
             // Reproduce exactly that end state by loading the CompactedEntries
             // milestone (which materializes FirstJoin's own pure rehydrate) and
             // publishing it as RescoredEntries -- never calling Run, so Rehydrate
-            // stays pure. The --join-at-pass=2 merge path (ExpectReconciledInput)
+            // stays pure. The --task MergeNode merge path (ExpectReconciledInput)
             // below is a different rehydrate that must NOT materialize FirstJoin.
             if (!ctx.Config.ExpectReconciledInput)
             {
@@ -408,7 +408,7 @@ namespace pwiz.OspreySharp.Tasks
                 // sidecar v3 already carries RunProteinQvalue from the original
                 // straight-through pipeline, but Rust pipeline.rs:4292 (gated by
                 // `!can_skip_fdr || config.expect_reconciled_input`) recomputes
-                // it inline in the --join-at-pass=2 path. The recompute uses the
+                // it inline in the --task MergeNode path. The recompute uses the
                 // post-rehydration detected_peptides set + best_peptide_scores
                 // (which differ from the original write-time inputs whenever any
                 // upstream rebuild has nudged peptide q-values or score values
@@ -426,7 +426,7 @@ namespace pwiz.OspreySharp.Tasks
                 }
                 var stats = RescoreCompaction.Apply(bundle, ctx.Config);
                 ctx.LogInfo(string.Format(
-                    @"--join-at-pass=2 compaction: {0} -> {1} entries ({2} passing base_ids; {3} action(s) dropped)",
+                    @"--task MergeNode compaction: {0} -> {1} entries ({2} passing base_ids; {3} action(s) dropped)",
                     stats.EntriesBefore, stats.EntriesAfter,
                     stats.FirstPassBaseIds, stats.DroppedActions));
             }
@@ -435,7 +435,7 @@ namespace pwiz.OspreySharp.Tasks
 
         // RunWorker + its helpers (AddIfNotNull, LoadOriginalRtCalibration)
         // were removed in Phase C. The stage6 worker mode
-        // (--join-at-pass=1 --no-join --input-scores) now routes through
+        // (--task PerFileRescore) now routes through
         // AnalysisPipeline.Run with StartAt = StopAfter =
         // PerFileRescoreTask. Upstream state previously assembled in
         // RunWorker (library load, hydration, compaction, consensus,
@@ -518,7 +518,7 @@ namespace pwiz.OspreySharp.Tasks
 
             // 3. Append gap-fill rows at the end. Reassign each gap-fill
             //    stub's ParquetIndex to its new row position so a
-            //    downstream --join-at-pass=2 worker can locate its
+            //    downstream --task MergeNode worker can locate its
             //    features.
             int nAppended = 0;
             foreach (var entry in fdrEntries)
@@ -543,7 +543,7 @@ namespace pwiz.OspreySharp.Tasks
             //    (over every file in the planner step), not the worker's
             //    single-file InputFiles hash; without that, a worker
             //    rescoring a single parquet stamps a single-file hash
-            //    that the downstream --join-at-pass=2 merge node rejects
+            //    that the downstream --task MergeNode merge node rejects
             //    on hash mismatch. The join file stems come from the
             //    planner's reconciliation.json (v2+) via
             //    RescoreInputs.JoinFileStems; fall back to config-derived
@@ -729,7 +729,7 @@ namespace pwiz.OspreySharp.Tasks
                 // config, leaks into subsequent files, AND poisons the
                 // WriteReconciledParquet hash stamp (config.Identity.SearchParameterHash()
                 // would then reflect the calibrated tolerance, not the value
-                // a fresh --join-at-pass=2 invocation recomputes from CLI
+                // a fresh --task MergeNode invocation recomputes from CLI
                 // defaults -- causing search_hash mismatch errors). Mirrors
                 // the per-file clone pattern in ProcessFile.
                 var fileConfig = config.ShallowClone();

--- a/pwiz_tools/OspreySharp/OspreySharp/Tasks/PerFileScoringTask.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/Tasks/PerFileScoringTask.cs
@@ -49,7 +49,7 @@ namespace pwiz.OspreySharp.Tasks
     /// Phase A scope: this task is a thin orchestration wrapper that
     /// delegates to AnalysisPipeline's existing private (now
     /// <c>internal</c>) methods (LoadLibrary, GenerateDecoys,
-    /// ProcessFile) plus the --join-only / --join-at-pass=2 input
+    /// ProcessFile) plus the --task FirstJoin / --task MergeNode input
     /// loading paths that share the same per-file collection layout.
     /// The inline Stage 1-4 block from <c>AnalysisPipeline.Run</c>
     /// moved here verbatim; the only changes are LogInfo / LogWarning
@@ -223,7 +223,7 @@ namespace pwiz.OspreySharp.Tasks
             // reconciliation needs the per-file .scores.parquet on disk to
             // lazily load CWT candidates -- matches Rust's end-to-end
             // behavior, which always writes the parquet sidecar regardless
-            // of --no-join.
+            // of --task PerFileScoring.
             var parquetFooterMetadata = new Dictionary<string, string>
             {
                 { @"osprey.version", Program.VERSION },
@@ -522,7 +522,7 @@ namespace pwiz.OspreySharp.Tasks
         /// surface the per-file outputs for downstream tasks (before any
         /// early-exit, so a partial-success caller still sees the populated
         /// collections), then apply the two success-but-stop boundaries --
-        /// an empty score set (cannot run FDR) and <c>--no-join</c> (Stage
+        /// an empty score set (cannot run FDR) and <c>--task PerFileScoring</c> (Stage
         /// 1-4 only). Returns <c>true</c> to continue the pipeline, or
         /// <c>false</c> with <see cref="PipelineContext.ExitCode"/> = 0 at
         /// either boundary.
@@ -561,8 +561,8 @@ namespace pwiz.OspreySharp.Tasks
                 return false;
             }
 
-            // --no-join: stop here. Per-file `.scores.parquet` files are
-            // now on disk; a separate `--join-only` invocation (typically
+            // --task PerFileScoring: stop here. Per-file `.scores.parquet` files are
+            // now on disk; a separate `--task FirstJoin` invocation (typically
             // on a merge node) will pick them up and run Stage 5+.
             if (ctx.Config.NoJoin)
             {
@@ -636,7 +636,7 @@ namespace pwiz.OspreySharp.Tasks
             List<LibraryEntry> decoys;
             if (config.ExpectReconciledInput)
             {
-                // --join-at-pass=2: decoy LibraryEntries are unused
+                // --task MergeNode: decoy LibraryEntries are unused
                 // downstream. The reconciled parquet already carries
                 // both target and decoy FDR rows with their stage-1-4
                 // scores; Stage 5 is skipped, Stage 6 is skipped, and
@@ -826,7 +826,7 @@ namespace pwiz.OspreySharp.Tasks
         }
 
         /// <summary>
-        /// --join-only: load per-file FdrEntry stubs + PIN features directly
+        /// --task FirstJoin: load per-file FdrEntry stubs + PIN features directly
         /// from each <c>.scores.parquet</c> listed via <c>--input-scores</c>
         /// (skips the per-file Stage 2-4 scoring; Stage 1 library load
         /// already ran in <see cref="Run"/>), plus a best-effort
@@ -843,7 +843,7 @@ namespace pwiz.OspreySharp.Tasks
             Dictionary<string, string> perFileParquetPaths,
             ConcurrentDictionary<string, RTCalibration> perFileCalibrations)
         {
-            // --join-only: load per-file FdrEntry stubs directly from
+            // --task FirstJoin: load per-file FdrEntry stubs directly from
             // each .scores.parquet listed via --input-scores. Skips the
             // per-file Stage 2-4 scoring (Stage 1 library load already ran
             // in Run). Also loads a best-effort calibration JSON sibling
@@ -1076,7 +1076,7 @@ namespace pwiz.OspreySharp.Tasks
         /// certified the outputs valid and there is NO rescore fallback) a
         /// failure is a genuine fault and logs an error instead -- no misleading
         /// "will rescore" messaging. Mirrors the load logic in the
-        /// <c>--join-only</c> branch above.
+        /// <c>--task FirstJoin</c> branch above.
         /// </summary>
         private static List<FdrEntry> TryLoadStubsAndCalibration(
             string scoresPath,
@@ -1417,13 +1417,13 @@ namespace pwiz.OspreySharp.Tasks
 
             // Persist the full FdrEntry results (with features) to
             // {stem}.scores.parquet so (a) Stage 6 reconciliation can lazy-load
-            // CWT candidates per file, and (b) a subsequent --join-only
+            // CWT candidates per file, and (b) a subsequent --task FirstJoin
             // invocation can pick them up without re-running Stages 1-4.
             // Same path convention as Rust (`scores_path_for_input`).
             // Snappy-compressed; cross-impl ZSTD/Snappy compatibility tracked
             // as a Phase 4 follow-up. The metadata dictionary is precomputed
             // in Run() against the original (un-mutated) outer config — see
-            // Run() for why. Skipped only in --join-only mode (no Stages 1-4
+            // Run() for why. Skipped only in --task FirstJoin mode (no Stages 1-4
             // ran here, so there is nothing fresh to persist).
             if (parquetFooterMetadata != null)
             {


### PR DESCRIPTION
## Summary

* Swept the retired `--no-join` / `--join-only` / `--join-at-pass` flag names to the `--task` vocabulary (PerFileScoring / FirstJoin / PerFileRescore / MergeNode) across OspreySharp comments and the ParquetScoreCache reconciled-input error message -- the CLI rejects those flags now, so the references were stale.
* Added a `RequireValue` guard so single-value flags (`-l` / `-o` / `--resolution` / `--protein-fdr` / `--threads` / `--report` / `--fdr-method` / `--fdr-level` / `--shared-peptides`) fail fast on a missing or `-`-prefixed value instead of silently swallowing the next option (e.g. `-o -l x`).
* Renamed the misleading `joinOnly` local (a retired-flag name) to `fromInputScores`.

Post-#4273 cleanup of its deferred items, ahead of an OOP review.

## Test plan

- [x] Build + ReSharper inspection (zero warnings/errors)
- [x] 374 tests (372 pass / 2 skip / 0 fail)
- [x] TestParseArgsRejectsValueFlagsWithoutValue (new) + existing retired-flag-rejection tests still pass

Co-Authored-By: Claude <noreply@anthropic.com>