### PR TITLE
Decomposed OspreySharp 21-feature scoring into Skyline-shaped calculators

### DIFF
--- a/pwiz_tools/OspreySharp/OspreySharp.Core/MS1Spectrum.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Core/MS1Spectrum.cs
@@ -21,6 +21,9 @@
  * limitations under the License.
  */
 
+using System;
+using System.Collections.Generic;
+
 namespace pwiz.OspreySharp.Core
 {
     /// <summary>
@@ -35,6 +38,43 @@ namespace pwiz.OspreySharp.Core
 
         public int Count { get { return Mzs.Length; } }
         public bool IsEmpty { get { return Count == 0; } }
+
+        /// <summary>
+        /// Find the MS1 spectrum with retention time closest to the given RT.
+        /// Assumes the spectra are sorted by RT. Returns null when the list is
+        /// null or empty. The single implementation shared by the scoring harness
+        /// (<c>AbstractScoringTask.FindNearestMs1</c>, <c>Calibrator</c>) and the
+        /// MS1 feature calculators, so the binary search (<c>RetentionTime &lt; rt</c>)
+        /// and the equal-distance tie-break (<c>&lt;=</c> = previous spectrum wins)
+        /// stay byte-identical across both callers.
+        /// </summary>
+        public static MS1Spectrum FindNearest(IReadOnlyList<MS1Spectrum> spectra, double rt)
+        {
+            if (spectra == null || spectra.Count == 0)
+                return null;
+
+            int lo = 0;
+            int hi = spectra.Count;
+            while (lo < hi)
+            {
+                int mid = lo + (hi - lo) / 2;
+                if (spectra[mid].RetentionTime < rt)
+                    lo = mid + 1;
+                else
+                    hi = mid;
+            }
+
+            if (lo >= spectra.Count)
+                return spectra[spectra.Count - 1];
+            if (lo == 0)
+                return spectra[0];
+
+            var prev = spectra[lo - 1];
+            var next = spectra[lo];
+            return Math.Abs(prev.RetentionTime - rt) <= Math.Abs(next.RetentionTime - rt)
+                ? prev
+                : next;
+        }
 
         /// <summary>
         /// Finds the most intense peak within a ppm tolerance of the target m/z using binary search.

--- a/pwiz_tools/OspreySharp/OspreySharp.Scoring/ApexMatchCalculators.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Scoring/ApexMatchCalculators.cs
@@ -1,0 +1,265 @@
+/*
+ * Original author: Brendan MacLean <brendanx .at. uw.edu>,
+ *                  MacCoss Lab, Department of Genome Sciences, UW
+ * AI assistance: Claude Code (Claude Opus 4) <noreply .at. anthropic.com>
+ *
+ * Based on osprey (https://github.com/MacCossLab/osprey)
+ *   by Michael J. MacCoss, MacCoss Lab, Department of Genome Sciences, UW
+ *
+ * Copyright 2026 University of Washington - Seattle, WA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using pwiz.OspreySharp.Core;
+
+namespace pwiz.OspreySharp.Scoring
+{
+    /// <summary>
+    /// Shared apex-spectrum fragment-match statistics for the mass-accuracy /
+    /// explained-intensity family (explained_intensity,
+    /// mass_accuracy_deviation_mean, abs_mass_accuracy_deviation_mean). These three
+    /// features come from ONE pass over the candidate fragments against the apex MS2
+    /// spectrum (the inline <c>ComputeApexMatchFeatures</c>), so the producer runs
+    /// that pass once and the three calculators read its fields -- guaranteeing the
+    /// same closest-peak picks and avoiding a 3x re-scan. Published once per
+    /// candidate to the <see cref="OspreyScoringContext"/> byproduct cache.
+    ///
+    /// NOTE: consecutive_ions (feature 7) does NOT use this set -- it is a separate
+    /// boolean <see cref="SpectralScorer.HasMatch"/> pass keyed by ion type +
+    /// ordinal, with no intensity / error / closest-peak pick.
+    /// </summary>
+    internal sealed class ApexFragmentMatchSet
+    {
+        public double TotalIntensity;
+        public double MatchedIntensity;
+        public double MassErrSum;
+        public double AbsMassErrSum;
+        public int NMatched;
+
+        public static ApexFragmentMatchSet GetOrCompute(OspreyScoringContext context, IOspreyDetailedPeakData peakData)
+        {
+            if (context.TryGetInfo(out ApexFragmentMatchSet matchSet))
+                return matchSet;
+            matchSet = Compute(context, peakData);
+            context.AddInfo(matchSet);
+            return matchSet;
+        }
+
+        private static ApexFragmentMatchSet Compute(OspreyScoringContext context, IOspreyDetailedPeakData peakData)
+        {
+            var matchSet = new ApexFragmentMatchSet();
+
+            var apexSpectrum = peakData.ApexSpectrum;
+            var candidate = peakData.Candidate;
+            var tolerance = context.Config.FragmentTolerance;
+
+            // Do NOT early-return when the apex spectrum or candidate fragments are
+            // empty. Rust's compute_mass_accuracy (osprey-scoring/src/lib.rs:464)
+            // handles empty inputs by returning (0.0, tolerance, tolerance) -- so a
+            // candidate that reaches here with no matchable fragments still
+            // contributes the calibrated tolerance as its abs mass error. Let the
+            // matching loop run zero iterations and fall through to the nMatched==0
+            // fallback for cross-impl symmetry.
+            double totalIntensity = 0.0;
+            if (apexSpectrum.Intensities != null)
+            {
+                for (int i = 0; i < apexSpectrum.Intensities.Length; i++)
+                    totalIntensity += apexSpectrum.Intensities[i];
+            }
+
+            double matchedIntensity = 0.0;
+            double massErrSum = 0.0;
+            double absMassErrSum = 0.0;
+            int nMatched = 0;
+
+            if (apexSpectrum.Mzs != null && apexSpectrum.Intensities != null &&
+                candidate.Fragments != null)
+            {
+                foreach (var frag in candidate.Fragments)
+                {
+                    double tolDa = tolerance.ToleranceDa(frag.Mz);
+                    double lower = frag.Mz - tolDa;
+                    double upper = frag.Mz + tolDa;
+
+                    int lo = ScoringMath.BinarySearchLowerBound(apexSpectrum.Mzs, lower);
+                    double bestError = double.MaxValue;
+                    double bestIntensity = 0.0;
+                    double bestMz = 0.0;
+                    bool found = false;
+
+                    // Match closest peak by m/z (not most intense). Strict < keeps
+                    // the first/lower-index peak on an equal-distance tie. Matches
+                    // Rust SpectralScorer::match_fragments in lib.rs:2239.
+                    for (int k = lo; k < apexSpectrum.Mzs.Length && apexSpectrum.Mzs[k] <= upper; k++)
+                    {
+                        double errorDa = Math.Abs(apexSpectrum.Mzs[k] - frag.Mz);
+                        if (errorDa < bestError)
+                        {
+                            bestError = errorDa;
+                            bestIntensity = apexSpectrum.Intensities[k];
+                            bestMz = apexSpectrum.Mzs[k];
+                            found = true;
+                        }
+                    }
+
+                    if (found)
+                    {
+                        matchedIntensity += bestIntensity;
+                        double err = tolerance.MassError(frag.Mz, bestMz);
+                        massErrSum += err;
+                        absMassErrSum += Math.Abs(err);
+                        nMatched++;
+                    }
+                }
+            }
+
+            matchSet.TotalIntensity = totalIntensity;
+            matchSet.MatchedIntensity = matchedIntensity;
+            matchSet.MassErrSum = massErrSum;
+            matchSet.AbsMassErrSum = absMassErrSum;
+            matchSet.NMatched = nMatched;
+            return matchSet;
+        }
+    }
+
+    /// <summary>
+    /// consecutive_ions: the longest run of consecutive b- or y-ion ordinals whose
+    /// theoretical m/z matches a peak in the apex MS2 spectrum. Integer-valued
+    /// (byte widened to double). Separate from the mass-accuracy family -- a
+    /// boolean <see cref="SpectralScorer.HasMatch"/> pass keyed by ion type +
+    /// ordinal, with the same closed-both-ends tolerance window.
+    /// </summary>
+    internal sealed class ConsecutiveIonsCalc : DetailedOspreyFeatureCalculator
+    {
+        public override string Name { get { return "consecutive_ions"; } }
+
+        protected override double Calculate(OspreyScoringContext context, IOspreyDetailedPeakData peakData)
+        {
+            var candidate = peakData.Candidate;
+            if (candidate.Fragments == null || candidate.Fragments.Count == 0)
+                return 0.0;
+
+            var apexMzs = peakData.ApexSpectrum.Mzs;
+            var tolerance = context.Config.FragmentTolerance;
+
+            // Group matched fragments by ion type, recording the ordinals that
+            // matched a spectrum peak.
+            var bMatched = new HashSet<int>();
+            var yMatched = new HashSet<int>();
+
+            foreach (var frag in candidate.Fragments)
+            {
+                if (SpectralScorer.HasMatch(frag.Mz, apexMzs, tolerance))
+                {
+                    if (frag.Annotation.IonType == IonType.B)
+                        bMatched.Add(frag.Annotation.Ordinal);
+                    else if (frag.Annotation.IonType == IonType.Y)
+                        yMatched.Add(frag.Annotation.Ordinal);
+                }
+            }
+
+            byte maxConsecutive = 0;
+            maxConsecutive = Math.Max(maxConsecutive, LongestConsecutiveRun(bMatched));
+            maxConsecutive = Math.Max(maxConsecutive, LongestConsecutiveRun(yMatched));
+            return maxConsecutive;
+        }
+
+        private static byte LongestConsecutiveRun(HashSet<int> ordinals)
+        {
+            if (ordinals.Count == 0)
+                return 0;
+
+            var sorted = ordinals.OrderBy(x => x).ToList();
+            byte maxRun = 1;
+            byte currentRun = 1;
+
+            for (int i = 1; i < sorted.Count; i++)
+            {
+                if (sorted[i] == sorted[i - 1] + 1)
+                {
+                    currentRun++;
+                    if (currentRun > maxRun)
+                        maxRun = currentRun;
+                }
+                else
+                {
+                    currentRun = 1;
+                }
+            }
+
+            return maxRun;
+        }
+    }
+
+    /// <summary>
+    /// explained_intensity: matched fragment intensity as a fraction of the apex
+    /// spectrum's total intensity. The denominator guard is strict
+    /// (<c>totalIntensity &gt; 1e-12</c>); below it the feature is exactly 0.0
+    /// (never NaN/Inf).
+    /// </summary>
+    internal sealed class ExplainedIntensityCalc : DetailedOspreyFeatureCalculator
+    {
+        public override string Name { get { return "explained_intensity"; } }
+
+        protected override double Calculate(OspreyScoringContext context, IOspreyDetailedPeakData peakData)
+        {
+            var matchSet = ApexFragmentMatchSet.GetOrCompute(context, peakData);
+            return matchSet.TotalIntensity > 1e-12
+                ? matchSet.MatchedIntensity / matchSet.TotalIntensity
+                : 0.0;
+        }
+    }
+
+    /// <summary>
+    /// mass_accuracy_deviation_mean: the SIGNED mean fragment mass error (in the
+    /// tolerance unit, typically ppm) over matched fragments. No-match fallback is
+    /// exactly 0.0 (Rust returns a 0.0 mean on empty matches).
+    /// </summary>
+    internal sealed class MassAccuracyMeanCalc : DetailedOspreyFeatureCalculator
+    {
+        public override string Name { get { return "mass_accuracy_deviation_mean"; } }
+
+        protected override double Calculate(OspreyScoringContext context, IOspreyDetailedPeakData peakData)
+        {
+            var matchSet = ApexFragmentMatchSet.GetOrCompute(context, peakData);
+            return matchSet.NMatched > 0
+                ? matchSet.MassErrSum / matchSet.NMatched
+                : 0.0;
+        }
+    }
+
+    /// <summary>
+    /// abs_mass_accuracy_deviation_mean: the mean ABSOLUTE fragment mass error over
+    /// matched fragments. CRITICAL no-match fallback: returns the live (calibrated)
+    /// <c>FragmentTolerance.Tolerance</c>, NOT 0.0 -- reporting the worst-case
+    /// tolerance penalizes unmatched entries in FDR. Leaving it 0.0 historically
+    /// caused ~65 divergent Astral rows. (Rust compute_mass_accuracy returns
+    /// (0.0, tolerance, tolerance) on empty matches, osprey-scoring/src/lib.rs:462.)
+    /// </summary>
+    internal sealed class AbsMassAccuracyMeanCalc : DetailedOspreyFeatureCalculator
+    {
+        public override string Name { get { return "abs_mass_accuracy_deviation_mean"; } }
+
+        protected override double Calculate(OspreyScoringContext context, IOspreyDetailedPeakData peakData)
+        {
+            var matchSet = ApexFragmentMatchSet.GetOrCompute(context, peakData);
+            return matchSet.NMatched > 0
+                ? matchSet.AbsMassErrSum / matchSet.NMatched
+                : context.Config.FragmentTolerance.Tolerance;
+        }
+    }
+}

--- a/pwiz_tools/OspreySharp/OspreySharp.Scoring/CoelutionCalculators.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Scoring/CoelutionCalculators.cs
@@ -1,0 +1,138 @@
+/*
+ * Original author: Brendan MacLean <brendanx .at. uw.edu>,
+ *                  MacCoss Lab, Department of Genome Sciences, UW
+ * AI assistance: Claude Code (Claude Opus 4) <noreply .at. anthropic.com>
+ *
+ * Based on osprey (https://github.com/MacCossLab/osprey)
+ *   by Michael J. MacCoss, MacCoss Lab, Department of Genome Sciences, UW
+ *
+ * Copyright 2026 University of Washington - Seattle, WA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace pwiz.OspreySharp.Scoring
+{
+    /// <summary>
+    /// Shared pairwise-fragment coelution statistics for the coelution family
+    /// (fragment_coelution_sum / fragment_coelution_max / n_coeluting_fragments).
+    /// The three features come from one intertwined single (i&lt;j) pairwise pass, so
+    /// -- unlike peak-shape -- the producer computes all three final values and the
+    /// calculators just return their field. This is the exact arithmetic the inline
+    /// ComputeCoelutionStats performed once. Computed once per candidate, published
+    /// to the <see cref="OspreyScoringContext"/> byproduct cache.
+    /// </summary>
+    internal sealed class CoelutionStats
+    {
+        public double Sum;
+        public double Max;
+        public int NCoeluting;
+
+        public static CoelutionStats GetOrCompute(OspreyScoringContext context, IOspreyDetailedPeakData peakData)
+        {
+            if (context.TryGetInfo(out CoelutionStats stats))
+                return stats;
+            stats = Compute(peakData);
+            context.AddInfo(stats);
+            return stats;
+        }
+
+        private static CoelutionStats Compute(IOspreyDetailedPeakData peakData)
+        {
+            var stats = new CoelutionStats();
+
+            var xics = peakData.Xics;
+            if (xics.Count < 2)
+                return stats;   // Sum = 0, Max = 0, NCoeluting = 0
+
+            // Per-fragment mean pairwise correlation; a fragment is "coeluting" if
+            // its mean pairwise correlation is > 0. Matches Rust
+            // pipeline.rs:5049-5058. NaN pairs are skipped (not zeroed); max is
+            // seeded -Infinity and only adopted when at least one pair was valid.
+            var peak = peakData.PeakBounds;
+            double[] fragCorrSum = new double[xics.Count];
+            int[] fragCorrCount = new int[xics.Count];
+            bool haveAny = false;
+            double maxCorr = double.NegativeInfinity;
+            double sum = 0.0;
+
+            for (int i = 0; i < xics.Count; i++)
+            {
+                for (int j = i + 1; j < xics.Count; j++)
+                {
+                    double corr = ScoringMath.PearsonCorrelationInRange(
+                        xics[i].Intensities, xics[j].Intensities,
+                        peak.StartIndex, peak.EndIndex);
+                    if (double.IsNaN(corr))
+                        continue;
+
+                    sum += corr;
+                    if (corr > maxCorr)
+                        maxCorr = corr;
+                    haveAny = true;
+
+                    fragCorrSum[i] += corr;
+                    fragCorrCount[i]++;
+                    fragCorrSum[j] += corr;
+                    fragCorrCount[j]++;
+                }
+            }
+
+            stats.Sum = sum;
+            if (haveAny)
+                stats.Max = maxCorr;
+
+            int nCoeluting = 0;
+            for (int i = 0; i < xics.Count; i++)
+            {
+                if (fragCorrCount[i] > 0 && fragCorrSum[i] / fragCorrCount[i] > 0.0)
+                    nCoeluting++;
+            }
+            stats.NCoeluting = nCoeluting;
+            return stats;
+        }
+    }
+
+    /// <summary>fragment_coelution_sum: sum of all valid pairwise fragment correlations.</summary>
+    internal sealed class FragmentCoelutionSumCalc : DetailedOspreyFeatureCalculator
+    {
+        public override string Name { get { return "fragment_coelution_sum"; } }
+
+        protected override double Calculate(OspreyScoringContext context, IOspreyDetailedPeakData peakData)
+        {
+            return CoelutionStats.GetOrCompute(context, peakData).Sum;
+        }
+    }
+
+    /// <summary>fragment_coelution_max: maximum pairwise fragment correlation (0 if none valid).</summary>
+    internal sealed class FragmentCoelutionMaxCalc : DetailedOspreyFeatureCalculator
+    {
+        public override string Name { get { return "fragment_coelution_max"; } }
+
+        protected override double Calculate(OspreyScoringContext context, IOspreyDetailedPeakData peakData)
+        {
+            return CoelutionStats.GetOrCompute(context, peakData).Max;
+        }
+    }
+
+    /// <summary>n_coeluting_fragments: count of fragments whose mean pairwise correlation is &gt; 0.</summary>
+    internal sealed class NCoelutingFragmentsCalc : DetailedOspreyFeatureCalculator
+    {
+        public override string Name { get { return "n_coeluting_fragments"; } }
+
+        protected override double Calculate(OspreyScoringContext context, IOspreyDetailedPeakData peakData)
+        {
+            return CoelutionStats.GetOrCompute(context, peakData).NCoeluting;
+        }
+    }
+}

--- a/pwiz_tools/OspreySharp/OspreySharp.Scoring/IOspreyFeatureCalculator.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Scoring/IOspreyFeatureCalculator.cs
@@ -1,0 +1,68 @@
+/*
+ * Original author: Brendan MacLean <brendanx .at. uw.edu>,
+ *                  MacCoss Lab, Department of Genome Sciences, UW
+ * AI assistance: Claude Code (Claude Opus 4) <noreply .at. anthropic.com>
+ *
+ * Based on osprey (https://github.com/MacCossLab/osprey)
+ *   by Michael J. MacCoss, MacCoss Lab, Department of Genome Sciences, UW
+ *
+ * Copyright 2026 University of Washington - Seattle, WA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace pwiz.OspreySharp.Scoring
+{
+    /// <summary>
+    /// One scoring feature, mirroring Skyline's
+    /// <c>IPeakFeatureCalculator</c>. Each calculator is a stateless singleton
+    /// that computes a single PIN feature value from a candidate's peak data and
+    /// the shared scoring context. The parity-critical order and identity of the
+    /// 21 features lives in <see cref="OspreyFeatureCalculators"/>, not on the
+    /// calculator.
+    /// </summary>
+    public interface IOspreyFeatureCalculator
+    {
+        /// <summary>
+        /// The feature name -- the column emitted in the <c>.cs_features.tsv</c>
+        /// dump. Parity-critical (matches the Rust PIN column name).
+        /// </summary>
+        string Name { get; }
+
+        /// <summary>
+        /// Compute this feature's value for one candidate peak.
+        /// </summary>
+        double Calculate(OspreyScoringContext context, IOspreyPeakData peakData);
+    }
+
+    /// <summary>
+    /// Base for OspreySharp scoring calculators, mirroring Skyline's
+    /// <c>DetailedPeakFeatureCalculator</c> (it narrows the peak data to the
+    /// detailed view). Every current Osprey feature reads detailed
+    /// (chromatogram/spectrum) data, so -- unlike Skyline -- there is no
+    /// summary-only calculator base. The data-interface split
+    /// (<see cref="IOspreyPeakData"/> / <see cref="IOspreyDetailedPeakData"/>)
+    /// still mirrors <c>ISummaryPeakData</c> / <c>IDetailedPeakData</c>.
+    /// </summary>
+    public abstract class DetailedOspreyFeatureCalculator : IOspreyFeatureCalculator
+    {
+        public abstract string Name { get; }
+
+        public double Calculate(OspreyScoringContext context, IOspreyPeakData peakData)
+        {
+            return Calculate(context, (IOspreyDetailedPeakData) peakData);
+        }
+
+        protected abstract double Calculate(OspreyScoringContext context, IOspreyDetailedPeakData peakData);
+    }
+}

--- a/pwiz_tools/OspreySharp/OspreySharp.Scoring/IOspreyFeatureCalculator.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Scoring/IOspreyFeatureCalculator.cs
@@ -21,6 +21,8 @@
  * limitations under the License.
  */
 
+using System;
+
 namespace pwiz.OspreySharp.Scoring
 {
     /// <summary>
@@ -60,7 +62,15 @@ namespace pwiz.OspreySharp.Scoring
 
         public double Calculate(OspreyScoringContext context, IOspreyPeakData peakData)
         {
-            return Calculate(context, (IOspreyDetailedPeakData) peakData);
+            // Every Osprey calculator reads detailed (chromatogram/spectrum) data, so
+            // the SPI accepts the summary base for Skyline-shape parity but narrows
+            // here. Throw a clear error rather than a raw InvalidCastException if a
+            // caller passes a summary-only implementation.
+            var detailed = peakData as IOspreyDetailedPeakData;
+            if (detailed == null)
+                throw new InvalidOperationException(
+                    @"OspreySharp feature calculators require IOspreyDetailedPeakData; a summary-only IOspreyPeakData was provided.");
+            return Calculate(context, detailed);
         }
 
         protected abstract double Calculate(OspreyScoringContext context, IOspreyDetailedPeakData peakData);

--- a/pwiz_tools/OspreySharp/OspreySharp.Scoring/IOspreyPeakData.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Scoring/IOspreyPeakData.cs
@@ -82,5 +82,40 @@ namespace pwiz.OspreySharp.Scoring
         /// this spectrum's sorted m/z and index-aligned intensity arrays.
         /// </summary>
         Spectrum ApexSpectrum { get; }
+
+        /// <summary>
+        /// Window-global spectrum index of the chosen apex
+        /// (= <see cref="WindowStartIndex"/> + <see cref="ApexLocalIndex"/>). The
+        /// xcorr feature indexes the preprocessed cache HERE. INDEX TRAP: this is a
+        /// distinct index space from the Savitzky-Golay sweep's candidate-local
+        /// index -- see <see cref="ApexLocalIndex"/> / <see cref="WindowLength"/>.
+        /// </summary>
+        int ApexGlobalIndex { get; }
+
+        /// <summary>
+        /// Candidate-local apex index within the scoring range
+        /// (= bestPeak.ApexIndex). The SG sweep builds candIdx = ApexLocalIndex +
+        /// offset and bound-checks it against [0, <see cref="WindowLength"/>).
+        /// </summary>
+        int ApexLocalIndex { get; }
+
+        /// <summary>
+        /// startScan: the offset mapping a candidate-local index to a window-global
+        /// index (globalIdx = WindowStartIndex + candIdx). Kept distinct from
+        /// <see cref="ApexGlobalIndex"/>; at offset 0 they coincide by construction.
+        /// </summary>
+        int WindowStartIndex { get; }
+
+        /// <summary>
+        /// rangeLen = endScan - startScan + 1. The SG sweep bounds the
+        /// candidate-local index against THIS, NOT <see cref="WindowSpectra"/>.Count.
+        /// </summary>
+        int WindowLength { get; }
+
+        /// <summary>
+        /// The window's MS2 spectra (sorted by RT). The SG sweep reads
+        /// WindowSpectra[globalIdx] for each apex+/-2 offset.
+        /// </summary>
+        IReadOnlyList<Spectrum> WindowSpectra { get; }
     }
 }

--- a/pwiz_tools/OspreySharp/OspreySharp.Scoring/IOspreyPeakData.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Scoring/IOspreyPeakData.cs
@@ -44,6 +44,18 @@ namespace pwiz.OspreySharp.Scoring
         /// scan axis), already resolved upstream (override or detected).
         /// </summary>
         XICPeakBounds PeakBounds { get; }
+
+        /// <summary>
+        /// Retention time of the apex MS2 spectrum (the chosen peak apex). Mirrors
+        /// Skyline's <c>ISummaryPeakData.RetentionTime</c>.
+        /// </summary>
+        double ApexRetentionTime { get; }
+
+        /// <summary>
+        /// The expected (calibration-predicted) retention time the harness computed
+        /// once for this candidate; feeds rt_deviation. Not recomputed per feature.
+        /// </summary>
+        double ExpectedRt { get; }
     }
 
     /// <summary>

--- a/pwiz_tools/OspreySharp/OspreySharp.Scoring/IOspreyPeakData.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Scoring/IOspreyPeakData.cs
@@ -117,5 +117,16 @@ namespace pwiz.OspreySharp.Scoring
         /// WindowSpectra[globalIdx] for each apex+/-2 offset.
         /// </summary>
         IReadOnlyList<Spectrum> WindowSpectra { get; }
+
+        /// <summary>
+        /// The candidate-local scan retention-time axis: ScanRetentionTimes[i] is the
+        /// RT of XIC scan index i (= windowRts[startScan + i]). The MS1 family
+        /// (features 13, 14) maps an XIC index to an absolute RT to find the nearest
+        /// MS1 scan, so this hides the window/startScan offset arithmetic from the
+        /// calculator. Precomputed once per candidate in <c>Set</c>; this is just RT,
+        /// not a spectral surface, so unlike <see cref="ApexSpectrum"/> a
+        /// chromatogram-centric implementation can supply it.
+        /// </summary>
+        IReadOnlyList<double> ScanRetentionTimes { get; }
     }
 }

--- a/pwiz_tools/OspreySharp/OspreySharp.Scoring/IOspreyPeakData.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Scoring/IOspreyPeakData.cs
@@ -72,5 +72,15 @@ namespace pwiz.OspreySharp.Scoring
         /// shared scan axis. The full set is iterated to select the reference XIC.
         /// </summary>
         IReadOnlyList<XicData> Xics { get; }
+
+        /// <summary>
+        /// The MS2 spectrum at the chosen peak apex
+        /// (windowSpectra[startScan + bestPeak.ApexIndex]). This is the spectral
+        /// surface Skyline's chromatogram-centric results layer cannot supply -- a
+        /// Skyline implementation of this interface would throw here. The
+        /// apex-match family matches the candidate's theoretical fragments against
+        /// this spectrum's sorted m/z and index-aligned intensity arrays.
+        /// </summary>
+        Spectrum ApexSpectrum { get; }
     }
 }

--- a/pwiz_tools/OspreySharp/OspreySharp.Scoring/IOspreyPeakData.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Scoring/IOspreyPeakData.cs
@@ -1,0 +1,64 @@
+/*
+ * Original author: Brendan MacLean <brendanx .at. uw.edu>,
+ *                  MacCoss Lab, Department of Genome Sciences, UW
+ * AI assistance: Claude Code (Claude Opus 4) <noreply .at. anthropic.com>
+ *
+ * Based on osprey (https://github.com/MacCossLab/osprey)
+ *   by Michael J. MacCoss, MacCoss Lab, Department of Genome Sciences, UW
+ *
+ * Copyright 2026 University of Washington - Seattle, WA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System.Collections.Generic;
+using pwiz.OspreySharp.Chromatography;
+using pwiz.OspreySharp.Core;
+
+namespace pwiz.OspreySharp.Scoring
+{
+    /// <summary>
+    /// Per-candidate peak data, mirroring Skyline's <c>ISummaryPeakData</c>: the
+    /// identity and the chosen peak location a feature scores against. Osprey's
+    /// scoring is flat -- one precursor (<see cref="Candidate"/>) at its best peak
+    /// (<see cref="PeakBounds"/>) within one isolation window -- so this is a flat
+    /// view, not Skyline's peptide/group/transition tree.
+    /// </summary>
+    public interface IOspreyPeakData
+    {
+        /// <summary>The candidate library entry: precursor plus theoretical fragments.</summary>
+        LibraryEntry Candidate { get; }
+
+        /// <summary>
+        /// The chosen peak boundaries (apex/start/end indices into the shared XIC
+        /// scan axis), already resolved upstream (override or detected).
+        /// </summary>
+        XICPeakBounds PeakBounds { get; }
+    }
+
+    /// <summary>
+    /// Detailed per-candidate peak data, mirroring Skyline's
+    /// <c>IDetailedPeakData</c>: adds the per-fragment extracted-ion chromatograms
+    /// on the shared scan axis. Spectral accessors (apex / MS1 spectra) -- the part
+    /// Skyline's chromatogram-centric results layer cannot supply -- are added by
+    /// the feature families that read them.
+    /// </summary>
+    public interface IOspreyDetailedPeakData : IOspreyPeakData
+    {
+        /// <summary>
+        /// Per-fragment XICs (FragmentIndex, RetentionTimes, Intensities) on the
+        /// shared scan axis. The full set is iterated to select the reference XIC.
+        /// </summary>
+        IReadOnlyList<XicData> Xics { get; }
+    }
+}

--- a/pwiz_tools/OspreySharp/OspreySharp.Scoring/IOspreyPeakData.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Scoring/IOspreyPeakData.cs
@@ -119,14 +119,13 @@ namespace pwiz.OspreySharp.Scoring
         IReadOnlyList<Spectrum> WindowSpectra { get; }
 
         /// <summary>
-        /// The candidate-local scan retention-time axis: ScanRetentionTimes[i] is the
-        /// RT of XIC scan index i (= windowRts[startScan + i]). The MS1 family
-        /// (features 13, 14) maps an XIC index to an absolute RT to find the nearest
-        /// MS1 scan, so this hides the window/startScan offset arithmetic from the
-        /// calculator. Precomputed once per candidate in <c>Set</c>; this is just RT,
-        /// not a spectral surface, so unlike <see cref="ApexSpectrum"/> a
-        /// chromatogram-centric implementation can supply it.
+        /// The window's per-scan retention-time axis (the shared <c>windowRts</c>
+        /// reference, a per-window value -- not a per-candidate copy). The MS1 family
+        /// (features 13, 14) maps an XIC scan index i to an absolute RT via
+        /// WindowRetentionTimes[<see cref="WindowStartIndex"/> + i] to find the nearest
+        /// MS1 scan. Just RT, not a spectral surface, so unlike
+        /// <see cref="ApexSpectrum"/> a chromatogram-centric implementation can supply it.
         /// </summary>
-        IReadOnlyList<double> ScanRetentionTimes { get; }
+        IReadOnlyList<double> WindowRetentionTimes { get; }
     }
 }

--- a/pwiz_tools/OspreySharp/OspreySharp.Scoring/MedianPolishCalculators.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Scoring/MedianPolishCalculators.cs
@@ -1,0 +1,108 @@
+/*
+ * Original author: Brendan MacLean <brendanx .at. uw.edu>,
+ *                  MacCoss Lab, Department of Genome Sciences, UW
+ * AI assistance: Claude Code (Claude Opus 4) <noreply .at. anthropic.com>
+ *
+ * Based on osprey (https://github.com/MacCossLab/osprey)
+ *   by Michael J. MacCoss, MacCoss Lab, Department of Genome Sciences, UW
+ *
+ * Copyright 2026 University of Washington - Seattle, WA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System.Collections.Generic;
+
+namespace pwiz.OspreySharp.Scoring
+{
+    /// <summary>
+    /// The Tukey median-polish fit shared by the four median-polish features
+    /// (median_polish_cosine / _residual_ratio / _min_fragment_r2 /
+    /// _residual_correlation). Unlike the other byproducts this one is PUBLISHED BY
+    /// THE HARNESS, not lazily computed by a calculator: the crop +
+    /// WriteMpInputsRow + Compute must stay in <c>ScoreCandidate</c> because the
+    /// bisection diagnostics (<c>OspreyDiagnostics</c>) live in the exe layer that
+    /// <c>OspreySharp.Scoring</c> cannot reference. The harness publishes the fit
+    /// (and the cropped inputs the optional WriteMpDump needs) here; the four
+    /// calculators read <see cref="Polish"/> and apply their family-specific
+    /// default when it is null. Public for that cross-layer publish.
+    /// </summary>
+    public sealed class MedianPolishByproduct
+    {
+        /// <summary>The median-polish fit, or null when Compute did not converge.</summary>
+        public TukeyMedianPolishResult Polish { get; }
+
+        /// <summary>The peak-cropped per-fragment XIC slices passed to Compute (for WriteMpDump).</summary>
+        public IList<KeyValuePair<int, double[]>> PeakXics { get; }
+
+        public MedianPolishByproduct(TukeyMedianPolishResult polish, IList<KeyValuePair<int, double[]>> peakXics)
+        {
+            Polish = polish;
+            PeakXics = peakXics;
+        }
+    }
+
+    /// <summary>median_polish_cosine: library cosine of the median-polish fit (0 if no fit).</summary>
+    internal sealed class MedianPolishCosineCalc : DetailedOspreyFeatureCalculator
+    {
+        public override string Name { get { return "median_polish_cosine"; } }
+
+        protected override double Calculate(OspreyScoringContext context, IOspreyDetailedPeakData peakData)
+        {
+            if (context.TryGetInfo(out MedianPolishByproduct mp) && mp.Polish != null)
+                return TukeyMedianPolish.LibCosine(mp.Polish, peakData.Candidate.Fragments);
+            return 0.0;
+        }
+    }
+
+    /// <summary>median_polish_residual_ratio: residual ratio of the fit (1.0 if no fit).</summary>
+    internal sealed class MedianPolishResidualRatioCalc : DetailedOspreyFeatureCalculator
+    {
+        public override string Name { get { return "median_polish_residual_ratio"; } }
+
+        protected override double Calculate(OspreyScoringContext context, IOspreyDetailedPeakData peakData)
+        {
+            // NOTE: the no-fit default is 1.0 (NOT 0.0); a shared "return 0.0"
+            // would corrupt this feature.
+            if (context.TryGetInfo(out MedianPolishByproduct mp) && mp.Polish != null)
+                return TukeyMedianPolish.ResidualRatio(mp.Polish);
+            return 1.0;
+        }
+    }
+
+    /// <summary>median_polish_min_fragment_r2: minimum per-fragment R^2 of the fit (0 if no fit).</summary>
+    internal sealed class MedianPolishMinFragmentR2Calc : DetailedOspreyFeatureCalculator
+    {
+        public override string Name { get { return "median_polish_min_fragment_r2"; } }
+
+        protected override double Calculate(OspreyScoringContext context, IOspreyDetailedPeakData peakData)
+        {
+            if (context.TryGetInfo(out MedianPolishByproduct mp) && mp.Polish != null)
+                return TukeyMedianPolish.MinFragmentR2(mp.Polish);
+            return 0.0;
+        }
+    }
+
+    /// <summary>median_polish_residual_correlation: residual correlation of the fit (0 if no fit).</summary>
+    internal sealed class MedianPolishResidualCorrelationCalc : DetailedOspreyFeatureCalculator
+    {
+        public override string Name { get { return "median_polish_residual_correlation"; } }
+
+        protected override double Calculate(OspreyScoringContext context, IOspreyDetailedPeakData peakData)
+        {
+            if (context.TryGetInfo(out MedianPolishByproduct mp) && mp.Polish != null)
+                return TukeyMedianPolish.ResidualCorrelation(mp.Polish);
+            return 0.0;
+        }
+    }
+}

--- a/pwiz_tools/OspreySharp/OspreySharp.Scoring/MedianPolishCalculators.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Scoring/MedianPolishCalculators.cs
@@ -43,9 +43,9 @@ namespace pwiz.OspreySharp.Scoring
         public TukeyMedianPolishResult Polish { get; }
 
         /// <summary>The peak-cropped per-fragment XIC slices passed to Compute (for WriteMpDump).</summary>
-        public IList<KeyValuePair<int, double[]>> PeakXics { get; }
+        public IReadOnlyList<KeyValuePair<int, double[]>> PeakXics { get; }
 
-        public MedianPolishByproduct(TukeyMedianPolishResult polish, IList<KeyValuePair<int, double[]>> peakXics)
+        public MedianPolishByproduct(TukeyMedianPolishResult polish, IReadOnlyList<KeyValuePair<int, double[]>> peakXics)
         {
             Polish = polish;
             PeakXics = peakXics;

--- a/pwiz_tools/OspreySharp/OspreySharp.Scoring/Ms1Calculators.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Scoring/Ms1Calculators.cs
@@ -1,0 +1,234 @@
+/*
+ * Original author: Brendan MacLean <brendanx .at. uw.edu>,
+ *                  MacCoss Lab, Department of Genome Sciences, UW
+ * AI assistance: Claude Code (Claude Opus 4) <noreply .at. anthropic.com>
+ *
+ * Based on osprey (https://github.com/MacCossLab/osprey)
+ *   by Michael J. MacCoss, MacCoss Lab, Department of Genome Sciences, UW
+ *
+ * Copyright 2026 University of Washington - Seattle, WA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
+using System.Collections.Generic;
+using pwiz.OspreySharp.Core;
+
+namespace pwiz.OspreySharp.Scoring
+{
+    /// <summary>
+    /// Shared MS1-family scoring pass for ms1_precursor_coelution (feature 13) and
+    /// ms1_isotope_cosine (feature 14). Both features come from ONE pass that
+    /// reverse-calibrates the precursor search m/z, selects the reference XIC, samples
+    /// the MS1 precursor intensity along the peak, and reads the apex isotope envelope
+    /// -- the inline <c>ComputeMs1Features</c>. The producer runs it once and the two
+    /// calculators read its fields, so the calibration math, the reference-XIC pick,
+    /// and the nearest-MS1 lookups happen exactly once and identically. Published per
+    /// candidate to the <see cref="OspreyScoringContext"/> byproduct cache.
+    ///
+    /// PARITY TRAPS preserved here (byte-faithful to AbstractScoringTask.cs
+    /// ComputeMs1Features, Rust pipeline.rs:5362-5404):
+    ///  * HRAM GATE: both features are exactly 0.0 unless the run has MS1 features and a
+    ///    non-empty MS1 spectrum list. Enforced by the calculators (which short-circuit
+    ///    to 0.0 before GetOrCompute) AND mirrored by the inner guards here.
+    ///  * REFERENCE-XIC SELECTION is MS1-SPECIFIC: seed total 0.0, '&gt;=' tie-break
+    ///    (LAST fragment achieving the running max wins). This is DISTINCT from the
+    ///    peak-shape family's selection (seed -1.0 / different tie-break) and from the
+    ///    harness fallback ('&gt;' / seed 0.0). It is computed INSIDE this byproduct and is
+    ///    NOT shared with peak-shape -- do not route it through any shared ref-XIC info.
+    ///  * MISSING MS1 scans are SKIPPED, not zero-filled, so the Pearson sample count is
+    ///    the number of present MS1 scans, not the peak width.
+    ///  * Every observed intensity is a single float-&gt;double widen (MzIntensityPair.Intensity
+    ///    is float). Do not cache as double end-to-end.
+    ///  * Pearson uses ScoringMath.PearsonCorrelationInRange (denom guard &lt; 1e-10),
+    ///    NOT the &lt; 1e-30 overload; NaN-&gt;0.0 is applied feature-side.
+    ///  * Calibration branch uses plain string equality Unit == "Th" (matches inline).
+    ///  * baseTolPpm = 10.0 is hardcoded (NOT promoted to Config) to preserve parity.
+    ///  * The nearest-MS1 search is the single Core implementation
+    ///    <see cref="MS1Spectrum.FindNearest"/> (binary search RetentionTime &lt; rt,
+    ///    '&lt;=' tie-break) shared with the harness so the tie-break cannot drift.
+    /// </summary>
+    internal sealed class Ms1ScoringByproduct
+    {
+        public double PrecursorCoelution;
+        public double IsotopeCosine;
+
+        public static Ms1ScoringByproduct GetOrCompute(OspreyScoringContext context, IOspreyDetailedPeakData peakData)
+        {
+            if (context.TryGetInfo(out Ms1ScoringByproduct byproduct))
+                return byproduct;
+            byproduct = Compute(context, peakData);
+            context.AddInfo(byproduct);
+            return byproduct;
+        }
+
+        private static Ms1ScoringByproduct Compute(OspreyScoringContext context, IOspreyDetailedPeakData peakData)
+        {
+            // Both feature values default to 0.0 (mirrors the inline
+            // ms1PrecursorCoelution / ms1IsotopeCosine seeds). Inner early-returns
+            // below leave them at 0.0.
+            var result = new Ms1ScoringByproduct();
+
+            var ms1Spectra = context.Ms1Spectra;
+            var xics = peakData.Xics;
+
+            // Inner guards. The outer HRAM gate is applied by the calculators; this
+            // re-checks the data guards so a direct GetOrCompute is still safe.
+            if (ms1Spectra == null || ms1Spectra.Count == 0 || xics.Count == 0)
+                return result;
+
+            int len = xics[0].Intensities.Length;
+            if (len == 0)
+                return result;
+
+            var peak = peakData.PeakBounds;
+            int start = Math.Max(0, peak.StartIndex);
+            int end = Math.Min(len - 1, peak.EndIndex);
+            if (end - start + 1 < 3)
+                return result;
+
+            // Reference XIC (highest total intensity). MS1-SPECIFIC selection: seed 0.0,
+            // '>=' last-wins.
+            int refXicIdx = 0;
+            double bestTotal = 0.0;
+            for (int f = 0; f < xics.Count; f++)
+            {
+                double total = 0.0;
+                double[] inten = xics[f].Intensities;
+                for (int k = 0; k < inten.Length; k++)
+                    total += inten[k];
+                if (total >= bestTotal) { bestTotal = total; refXicIdx = f; }
+            }
+
+            // MS1 calibration: reverse-calibrate search m/z and use calibrated tolerance.
+            // Matches Rust pipeline.rs:5363-5370 (reverse_calibrate_mz + calibrated_tolerance_ppm).
+            double baseTolPpm = 10.0;
+            double ms1TolPpm = baseTolPpm;
+            double searchMz = peakData.Candidate.PrecursorMz;
+            var ms1Calibration = context.Ms1Calibration;
+            if (ms1Calibration != null && ms1Calibration.Calibrated)
+            {
+                // calibrated_tolerance_ppm: max(3*SD, 1.0) ppm
+                ms1TolPpm = Math.Max(3.0 * ms1Calibration.SD, 1.0);
+                // reverse_calibrate_mz: observed ~ theoretical + offset
+                if (ms1Calibration.Unit == "Th")
+                    searchMz = peakData.Candidate.PrecursorMz + ms1Calibration.Mean;
+                else
+                    searchMz = peakData.Candidate.PrecursorMz * (1.0 + ms1Calibration.Mean / 1e6);
+            }
+
+            var scanRts = peakData.ScanRetentionTimes;
+
+            // Correlate MS1 precursor intensity with reference XIC (not summed fragment).
+            // Rust pipeline.rs:5373-5389: uses ref_xic[start..=end], skips missing MS1.
+            double[] refIntensities = xics[refXicIdx].Intensities;
+            var ms1Intensities = new List<double>();
+            var refValues = new List<double>();
+
+            for (int i = start; i <= end; i++)
+            {
+                double rt = scanRts[i];
+                var ms1 = MS1Spectrum.FindNearest(ms1Spectra, rt);
+                if (ms1 != null)
+                {
+                    var peakInfo = ms1.FindPeakPpm(searchMz, ms1TolPpm);
+                    double intensity = peakInfo.HasValue ? peakInfo.Value.Intensity : 0.0;
+                    ms1Intensities.Add(intensity);
+                    refValues.Add(i < refIntensities.Length ? refIntensities[i] : 0.0);
+                }
+            }
+
+            if (ms1Intensities.Count >= 3)
+            {
+                double[] ms1Arr = ms1Intensities.ToArray();
+                double[] refArr = refValues.ToArray();
+                double coelution = ScoringMath.PearsonCorrelationInRange(ms1Arr, refArr, 0, ms1Arr.Length - 1);
+                if (double.IsNaN(coelution))
+                    coelution = 0.0;
+                result.PrecursorCoelution = coelution;
+            }
+
+            // Isotope cosine at apex MS1 scan.
+            // Rust pipeline.rs:5393-5404: gates on envelope.has_m0().
+            int apex = Math.Max(start, Math.Min(end, peak.ApexIndex));
+            double apexRt = scanRts[apex];
+            var apexMs1 = MS1Spectrum.FindNearest(ms1Spectra, apexRt);
+            if (apexMs1 != null)
+            {
+                int charge = peakData.Candidate.Charge > 0 ? peakData.Candidate.Charge : 1;
+                var envelope = IsotopeEnvelope.Extract(apexMs1, searchMz, charge, ms1TolPpm);
+
+                // Gate: skip if M0 peak is missing (matches Rust envelope.has_m0()).
+                if (envelope.Intensities != null && envelope.Intensities.Length > 1
+                    && envelope.Intensities[1] > 0.0) // index 1 = M0 (M-1 at 0)
+                {
+                    // Sequence-based isotope distribution, matching Rust
+                    // pipeline.rs:5400 peptide_isotope_cosine. Uses the UNMODIFIED Sequence.
+                    double score = IsotopeDistribution.PeptideIsotopeCosine(
+                        peakData.Candidate.Sequence, envelope.Intensities);
+                    if (score >= 0.0)
+                        result.IsotopeCosine = score;
+                }
+            }
+
+            return result;
+        }
+    }
+
+    /// <summary>
+    /// ms1_precursor_coelution (feature 13): Pearson correlation between the MS1
+    /// precursor-intensity trace (sampled at the nearest MS1 scan along the peak) and
+    /// the reference fragment XIC. HRAM-only -- exactly 0.0 for unit-resolution runs or
+    /// when no MS1 spectra are present. See <see cref="Ms1ScoringByproduct"/> for the
+    /// parity traps (seed-0.0 / '&gt;=' reference-XIC pick, skip-not-zerofill sampling,
+    /// the &lt; 1e-10 Pearson denominator guard with feature-side NaN-&gt;0.0).
+    /// </summary>
+    internal sealed class Ms1PrecursorCoelutionCalc : DetailedOspreyFeatureCalculator
+    {
+        public override string Name { get { return "ms1_precursor_coelution"; } }
+
+        protected override double Calculate(OspreyScoringContext context, IOspreyDetailedPeakData peakData)
+        {
+            // HRAM gate: no MS1 features -> exactly 0.0, do not even build the byproduct.
+            if (!context.HasMs1Features || context.Ms1Spectra == null || context.Ms1Spectra.Count == 0)
+                return 0.0;
+
+            return Ms1ScoringByproduct.GetOrCompute(context, peakData).PrecursorCoelution;
+        }
+    }
+
+    /// <summary>
+    /// ms1_isotope_cosine (feature 14): cosine similarity between the observed isotope
+    /// envelope at the apex MS1 scan and the theoretical averagine envelope for the
+    /// candidate sequence. HRAM-only -- exactly 0.0 for unit-resolution runs or when no
+    /// MS1 spectra are present. The M0 gate (Intensities[1] &gt; 0.0) and the
+    /// PeptideIsotopeCosine score &gt;= 0.0 acceptance are preserved in
+    /// <see cref="Ms1ScoringByproduct"/> (a composition failure or zero-norm returns
+    /// a negative score there, so the feature stays 0.0). Uses the UNMODIFIED
+    /// Candidate.Sequence.
+    /// </summary>
+    internal sealed class Ms1IsotopeCosineCalc : DetailedOspreyFeatureCalculator
+    {
+        public override string Name { get { return "ms1_isotope_cosine"; } }
+
+        protected override double Calculate(OspreyScoringContext context, IOspreyDetailedPeakData peakData)
+        {
+            // Same HRAM gate as feature 13.
+            if (!context.HasMs1Features || context.Ms1Spectra == null || context.Ms1Spectra.Count == 0)
+                return 0.0;
+
+            return Ms1ScoringByproduct.GetOrCompute(context, peakData).IsotopeCosine;
+        }
+    }
+}

--- a/pwiz_tools/OspreySharp/OspreySharp.Scoring/Ms1Calculators.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Scoring/Ms1Calculators.cs
@@ -128,7 +128,11 @@ namespace pwiz.OspreySharp.Scoring
                     searchMz = peakData.Candidate.PrecursorMz * (1.0 + ms1Calibration.Mean / 1e6);
             }
 
-            var scanRts = peakData.ScanRetentionTimes;
+            // Map an XIC scan index i to its absolute RT via the window axis:
+            // windowRts[startScan + i]. Reproduces the inline ComputeMs1Features
+            // indexing exactly (no per-candidate slice copy).
+            var windowRts = peakData.WindowRetentionTimes;
+            int startScan = peakData.WindowStartIndex;
 
             // Correlate MS1 precursor intensity with reference XIC (not summed fragment).
             // Rust pipeline.rs:5373-5389: uses ref_xic[start..=end], skips missing MS1.
@@ -138,7 +142,7 @@ namespace pwiz.OspreySharp.Scoring
 
             for (int i = start; i <= end; i++)
             {
-                double rt = scanRts[i];
+                double rt = windowRts[startScan + i];
                 var ms1 = MS1Spectrum.FindNearest(ms1Spectra, rt);
                 if (ms1 != null)
                 {
@@ -162,7 +166,7 @@ namespace pwiz.OspreySharp.Scoring
             // Isotope cosine at apex MS1 scan.
             // Rust pipeline.rs:5393-5404: gates on envelope.has_m0().
             int apex = Math.Max(start, Math.Min(end, peak.ApexIndex));
-            double apexRt = scanRts[apex];
+            double apexRt = windowRts[startScan + apex];
             var apexMs1 = MS1Spectrum.FindNearest(ms1Spectra, apexRt);
             if (apexMs1 != null)
             {

--- a/pwiz_tools/OspreySharp/OspreySharp.Scoring/OspreyFeatureCalculators.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Scoring/OspreyFeatureCalculators.cs
@@ -48,6 +48,11 @@ namespace pwiz.OspreySharp.Scoring
         {
             var calculators = new IOspreyFeatureCalculator[FeatureCount];
 
+            // Coelution family: pairwise fragment-correlation sum / max / count.
+            calculators[0] = new FragmentCoelutionSumCalc();
+            calculators[1] = new FragmentCoelutionMaxCalc();
+            calculators[2] = new NCoelutingFragmentsCalc();
+
             // Peak-shape family: reference-XIC apex / area / sharpness.
             calculators[3] = new PeakApexCalc();
             calculators[4] = new PeakAreaCalc();

--- a/pwiz_tools/OspreySharp/OspreySharp.Scoring/OspreyFeatureCalculators.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Scoring/OspreyFeatureCalculators.cs
@@ -1,0 +1,69 @@
+/*
+ * Original author: Brendan MacLean <brendanx .at. uw.edu>,
+ *                  MacCoss Lab, Department of Genome Sciences, UW
+ * AI assistance: Claude Code (Claude Opus 4) <noreply .at. anthropic.com>
+ *
+ * Based on osprey (https://github.com/MacCossLab/osprey)
+ *   by Michael J. MacCoss, MacCoss Lab, Department of Genome Sciences, UW
+ *
+ * Copyright 2026 University of Washington - Seattle, WA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace pwiz.OspreySharp.Scoring
+{
+    /// <summary>
+    /// The ordered set of OspreySharp scoring feature calculators, mirroring
+    /// Skyline's <c>PeakFeatureCalculator.CALCULATORS</c>. The array index IS the
+    /// parity-critical PIN feature index -- the position written into the
+    /// <c>double[21]</c> feature vector and the column order in the
+    /// <c>.cs_features.tsv</c> dump. This is the single place that order lives as
+    /// data.
+    ///
+    /// While the inline <c>ScoreCandidate</c> feature block is being decomposed one
+    /// family at a time, the slots whose feature is still computed inline are null;
+    /// <see cref="Get"/> returns null for those and the harness keeps filling them
+    /// inline. When every feature has been extracted the array is null-free and is
+    /// the canonical ordered calculator set.
+    /// </summary>
+    public static class OspreyFeatureCalculators
+    {
+        /// <summary>Number of PIN features (the feature-vector width).</summary>
+        public const int FeatureCount = 21;
+
+        private static readonly IOspreyFeatureCalculator[] _calculators = CreateCalculators();
+
+        private static IOspreyFeatureCalculator[] CreateCalculators()
+        {
+            var calculators = new IOspreyFeatureCalculator[FeatureCount];
+
+            // Peak-shape family: reference-XIC apex / area / sharpness.
+            calculators[3] = new PeakApexCalc();
+            calculators[4] = new PeakAreaCalc();
+            calculators[5] = new PeakSharpnessCalc();
+
+            return calculators;
+        }
+
+        /// <summary>
+        /// The calculator for the given PIN feature index, or null when that
+        /// feature has not yet been extracted (still computed inline in
+        /// <c>ScoreCandidate</c>).
+        /// </summary>
+        public static IOspreyFeatureCalculator Get(int featureIndex)
+        {
+            return _calculators[featureIndex];
+        }
+    }
+}

--- a/pwiz_tools/OspreySharp/OspreySharp.Scoring/OspreyFeatureCalculators.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Scoring/OspreyFeatureCalculators.cs
@@ -58,6 +58,10 @@ namespace pwiz.OspreySharp.Scoring
             calculators[4] = new PeakAreaCalc();
             calculators[5] = new PeakSharpnessCalc();
 
+            // RT-deviation family: apex RT minus expected RT, and its absolute value.
+            calculators[11] = new RtDeviationCalc();
+            calculators[12] = new AbsRtDeviationCalc();
+
             // Median-polish family: cosine / residual-ratio / min-fragment-R^2 /
             // residual-correlation of the Tukey median-polish fit.
             calculators[15] = new MedianPolishCosineCalc();

--- a/pwiz_tools/OspreySharp/OspreySharp.Scoring/OspreyFeatureCalculators.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Scoring/OspreyFeatureCalculators.cs
@@ -58,6 +58,13 @@ namespace pwiz.OspreySharp.Scoring
             calculators[4] = new PeakAreaCalc();
             calculators[5] = new PeakSharpnessCalc();
 
+            // Median-polish family: cosine / residual-ratio / min-fragment-R^2 /
+            // residual-correlation of the Tukey median-polish fit.
+            calculators[15] = new MedianPolishCosineCalc();
+            calculators[16] = new MedianPolishResidualRatioCalc();
+            calculators[19] = new MedianPolishMinFragmentR2Calc();
+            calculators[20] = new MedianPolishResidualCorrelationCalc();
+
             return calculators;
         }
 

--- a/pwiz_tools/OspreySharp/OspreySharp.Scoring/OspreyFeatureCalculators.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Scoring/OspreyFeatureCalculators.cs
@@ -58,6 +58,12 @@ namespace pwiz.OspreySharp.Scoring
             calculators[4] = new PeakAreaCalc();
             calculators[5] = new PeakSharpnessCalc();
 
+            // Xcorr + Savitzky-Golay family: apex xcorr and SG-weighted xcorr /
+            // cosine over the apex +/- 2 scans.
+            calculators[6] = new XcorrCalc();
+            calculators[17] = new SgXcorrCalc();
+            calculators[18] = new SgCosineCalc();
+
             // Apex-match family: longest consecutive b/y run, explained intensity,
             // and signed / absolute mean fragment mass error at the apex spectrum.
             calculators[7] = new ConsecutiveIonsCalc();

--- a/pwiz_tools/OspreySharp/OspreySharp.Scoring/OspreyFeatureCalculators.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Scoring/OspreyFeatureCalculators.cs
@@ -75,6 +75,10 @@ namespace pwiz.OspreySharp.Scoring
             calculators[11] = new RtDeviationCalc();
             calculators[12] = new AbsRtDeviationCalc();
 
+            // MS1 family (HRAM only): precursor coelution + isotope-envelope cosine.
+            calculators[13] = new Ms1PrecursorCoelutionCalc();
+            calculators[14] = new Ms1IsotopeCosineCalc();
+
             // Median-polish family: cosine / residual-ratio / min-fragment-R^2 /
             // residual-correlation of the Tukey median-polish fit.
             calculators[15] = new MedianPolishCosineCalc();

--- a/pwiz_tools/OspreySharp/OspreySharp.Scoring/OspreyFeatureCalculators.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Scoring/OspreyFeatureCalculators.cs
@@ -31,11 +31,10 @@ namespace pwiz.OspreySharp.Scoring
     /// <c>.cs_features.tsv</c> dump. This is the single place that order lives as
     /// data.
     ///
-    /// While the inline <c>ScoreCandidate</c> feature block is being decomposed one
-    /// family at a time, the slots whose feature is still computed inline are null;
-    /// <see cref="Get"/> returns null for those and the harness keeps filling them
-    /// inline. When every feature has been extracted the array is null-free and is
-    /// the canonical ordered calculator set.
+    /// All 21 PIN features are now extracted, so every slot is populated and
+    /// <see cref="Get"/> never returns null; this array is the canonical ordered
+    /// calculator set. (Scores the Rust engine computes but excludes from the 21 PIN
+    /// features are intentionally NOT here -- see the non-PIN-scores backlog.)
     /// </summary>
     public static class OspreyFeatureCalculators
     {
@@ -90,9 +89,8 @@ namespace pwiz.OspreySharp.Scoring
         }
 
         /// <summary>
-        /// The calculator for the given PIN feature index, or null when that
-        /// feature has not yet been extracted (still computed inline in
-        /// <c>ScoreCandidate</c>).
+        /// The calculator for the given PIN feature index (0..20). All 21 are
+        /// populated, so this never returns null.
         /// </summary>
         public static IOspreyFeatureCalculator Get(int featureIndex)
         {

--- a/pwiz_tools/OspreySharp/OspreySharp.Scoring/OspreyFeatureCalculators.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Scoring/OspreyFeatureCalculators.cs
@@ -58,6 +58,13 @@ namespace pwiz.OspreySharp.Scoring
             calculators[4] = new PeakAreaCalc();
             calculators[5] = new PeakSharpnessCalc();
 
+            // Apex-match family: longest consecutive b/y run, explained intensity,
+            // and signed / absolute mean fragment mass error at the apex spectrum.
+            calculators[7] = new ConsecutiveIonsCalc();
+            calculators[8] = new ExplainedIntensityCalc();
+            calculators[9] = new MassAccuracyMeanCalc();
+            calculators[10] = new AbsMassAccuracyMeanCalc();
+
             // RT-deviation family: apex RT minus expected RT, and its absolute value.
             calculators[11] = new RtDeviationCalc();
             calculators[12] = new AbsRtDeviationCalc();

--- a/pwiz_tools/OspreySharp/OspreySharp.Scoring/OspreyScoringContext.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Scoring/OspreyScoringContext.cs
@@ -1,0 +1,92 @@
+/*
+ * Original author: Brendan MacLean <brendanx .at. uw.edu>,
+ *                  MacCoss Lab, Department of Genome Sciences, UW
+ * AI assistance: Claude Code (Claude Opus 4) <noreply .at. anthropic.com>
+ *
+ * Based on osprey (https://github.com/MacCossLab/osprey)
+ *   by Michael J. MacCoss, MacCoss Lab, Department of Genome Sciences, UW
+ *
+ * Copyright 2026 University of Washington - Seattle, WA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
+using System.Collections.Generic;
+using pwiz.OspreySharp.Core;
+
+namespace pwiz.OspreySharp.Scoring
+{
+    /// <summary>
+    /// Shared per-candidate scoring context, mirroring Skyline's
+    /// <c>PeakScoringContext</c>: it carries the machinery shared across a
+    /// candidate's feature calculators plus a typed byproduct cache
+    /// (<see cref="AddInfo{TInfo}"/> / <see cref="TryGetInfo{TInfo}"/>) so one
+    /// producer can publish an intermediate (e.g. the reference-XIC selection) for
+    /// its sibling calculators to read instead of recomputing it.
+    ///
+    /// The instance is reused across candidates within a file/window;
+    /// <see cref="ClearByproducts"/> is called between candidates so the byproduct
+    /// dictionary is not reallocated in the per-candidate hot loop. The machinery
+    /// members (scorer, preprocessed-xcorr cache, calibration, ...) are added by
+    /// the feature families that read them.
+    /// </summary>
+    public class OspreyScoringContext
+    {
+        private readonly Dictionary<Type, object> _byproducts = new Dictionary<Type, object>();
+
+        public OspreyScoringContext(OspreyConfig config)
+        {
+            Config = config;
+        }
+
+        /// <summary>The live (post-calibration) configuration the pipeline scores with.</summary>
+        public OspreyConfig Config { get; }
+
+        /// <summary>
+        /// Publish a byproduct keyed by its type for sibling calculators to read.
+        /// Throws if one of this type was already published for the current
+        /// candidate (mirrors Skyline's <c>AddInfo</c>); producers publish once,
+        /// guarded by a <see cref="TryGetInfo{TInfo}"/> check.
+        /// </summary>
+        public void AddInfo<TInfo>(TInfo info)
+        {
+            _byproducts.Add(typeof(TInfo), info);
+        }
+
+        /// <summary>
+        /// Get a byproduct published earlier during the current candidate's
+        /// scoring. Returns false (and <paramref name="info"/> = default) when none
+        /// was published, so callers can apply a family-specific default.
+        /// </summary>
+        public bool TryGetInfo<TInfo>(out TInfo info)
+        {
+            if (_byproducts.TryGetValue(typeof(TInfo), out var infoObj))
+            {
+                info = (TInfo) infoObj;
+                return true;
+            }
+            info = default(TInfo);
+            return false;
+        }
+
+        /// <summary>
+        /// Reset the byproduct cache between candidates. The context instance is
+        /// reused, so this is called once per candidate before its calculators run.
+        /// </summary>
+        public void ClearByproducts()
+        {
+            _byproducts.Clear();
+        }
+    }
+}

--- a/pwiz_tools/OspreySharp/OspreySharp.Scoring/OspreyScoringContext.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Scoring/OspreyScoringContext.cs
@@ -54,6 +54,47 @@ namespace pwiz.OspreySharp.Scoring
         public OspreyConfig Config { get; }
 
         /// <summary>
+        /// Resolution strategy (Unit/HRAM) -- window-level. Drives the f64/f32 cache
+        /// dispatch inside <see cref="IResolutionStrategy.ScoreXcorr"/>; must not be
+        /// bypassed. Set once per window via <see cref="SetWindow"/>.
+        /// </summary>
+        public IResolutionStrategy Resolution { get; private set; }
+
+        /// <summary>
+        /// Per-window preprocessed XCorr cache (f64 doubles for Unit, f32 floats for
+        /// HRAM), produced once before the candidate loop. Window-level.
+        /// </summary>
+        public WindowXcorrCache PreprocessedXcorr { get; private set; }
+
+        /// <summary>
+        /// Main-search spectral scorer (resolution-mode bin config) -- window-level.
+        /// Not the unit-resolution calibration scorer.
+        /// </summary>
+        public SpectralScorer Scorer { get; private set; }
+
+        /// <summary>
+        /// Rented XCorr scratch / VisitedBins pool -- window-level. MUST be threaded
+        /// into <see cref="IResolutionStrategy.ScoreXcorr"/> so HRAM scoring avoids
+        /// per-call LOH allocation (perf-critical: the xcorr family is the perf gate).
+        /// </summary>
+        public XcorrScratchPool XcorrScratchPool { get; private set; }
+
+        /// <summary>
+        /// Set the per-window machinery the xcorr / Savitzky-Golay calculators read.
+        /// Called once per window after construction, before the candidate loop.
+        /// These are window-level and deliberately survive <see cref="ClearByproducts"/>
+        /// (which only resets the per-candidate byproduct cache).
+        /// </summary>
+        public void SetWindow(IResolutionStrategy resolution, WindowXcorrCache preprocessedXcorr,
+            SpectralScorer scorer, XcorrScratchPool xcorrScratchPool)
+        {
+            Resolution = resolution;
+            PreprocessedXcorr = preprocessedXcorr;
+            Scorer = scorer;
+            XcorrScratchPool = xcorrScratchPool;
+        }
+
+        /// <summary>
         /// Publish a byproduct keyed by its type for sibling calculators to read.
         /// Throws if one of this type was already published for the current
         /// candidate (mirrors Skyline's <c>AddInfo</c>); producers publish once,

--- a/pwiz_tools/OspreySharp/OspreySharp.Scoring/OspreyScoringContext.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Scoring/OspreyScoringContext.cs
@@ -23,6 +23,7 @@
 
 using System;
 using System.Collections.Generic;
+using pwiz.OspreySharp.Chromatography;
 using pwiz.OspreySharp.Core;
 
 namespace pwiz.OspreySharp.Scoring
@@ -92,6 +93,41 @@ namespace pwiz.OspreySharp.Scoring
             PreprocessedXcorr = preprocessedXcorr;
             Scorer = scorer;
             XcorrScratchPool = xcorrScratchPool;
+        }
+
+        /// <summary>
+        /// True when the run has MS1 features (HRAM). The MS1 family (features 13,
+        /// 14) is exactly 0.0 for unit-resolution runs; the calculators gate on this
+        /// before doing any work. Window-level -- set via <see cref="SetMs1Machinery"/>.
+        /// </summary>
+        public bool HasMs1Features { get; private set; }
+
+        /// <summary>
+        /// The window's MS1 full-scan spectra (sorted by RT), used by the MS1 family
+        /// to sample the precursor-intensity trace and the apex isotope envelope.
+        /// Window-level -- set via <see cref="SetMs1Machinery"/>.
+        /// </summary>
+        public IReadOnlyList<MS1Spectrum> Ms1Spectra { get; private set; }
+
+        /// <summary>
+        /// The m/z calibration result used to reverse-calibrate the precursor search
+        /// m/z and derive the MS1 tolerance. Per-run; null when uncalibrated.
+        /// Window-level -- set via <see cref="SetMs1Machinery"/>.
+        /// </summary>
+        public MzCalibrationResult Ms1Calibration { get; private set; }
+
+        /// <summary>
+        /// Set the per-window MS1 machinery the MS1 family (features 13, 14) reads.
+        /// Called once per window after construction. These are window-level and
+        /// deliberately survive <see cref="ClearByproducts"/> (which only resets the
+        /// per-candidate byproduct cache).
+        /// </summary>
+        public void SetMs1Machinery(bool hasMs1Features, IReadOnlyList<MS1Spectrum> ms1Spectra,
+            MzCalibrationResult ms1Calibration)
+        {
+            HasMs1Features = hasMs1Features;
+            Ms1Spectra = ms1Spectra;
+            Ms1Calibration = ms1Calibration;
         }
 
         /// <summary>

--- a/pwiz_tools/OspreySharp/OspreySharp.Scoring/PeakShapeCalculators.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Scoring/PeakShapeCalculators.cs
@@ -1,0 +1,192 @@
+/*
+ * Original author: Brendan MacLean <brendanx .at. uw.edu>,
+ *                  MacCoss Lab, Department of Genome Sciences, UW
+ * AI assistance: Claude Code (Claude Opus 4) <noreply .at. anthropic.com>
+ *
+ * Based on osprey (https://github.com/MacCossLab/osprey)
+ *   by Michael J. MacCoss, MacCoss Lab, Department of Genome Sciences, UW
+ *
+ * Copyright 2026 University of Washington - Seattle, WA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
+
+namespace pwiz.OspreySharp.Scoring
+{
+    /// <summary>
+    /// Shared reference-XIC selection for the peak-shape family (peak_apex,
+    /// peak_area, peak_sharpness). Computed once per candidate by the first
+    /// peak-shape calculator and published to the
+    /// <see cref="OspreyScoringContext"/> byproduct cache for its siblings -- the
+    /// same arithmetic the inline <c>ComputePeakShapeFeatures</c> performed once.
+    ///
+    /// NOTE: this is the PEAK-SHAPE selection -- highest total intensity, LAST on
+    /// tie (<c>&gt;=</c>), seed <c>-1.0</c>. It is deliberately distinct from the
+    /// MS1 reference-XIC selection (seed <c>0.0</c>) and the harness fallback
+    /// (<c>&gt;</c>, seed <c>0.0</c>); do not share it across those paths.
+    /// <see cref="Valid"/> is false for the degenerate cases (no XICs, empty XIC,
+    /// start &gt; end) in which all three features are 0.0.
+    /// </summary>
+    internal sealed class PeakShapeReference
+    {
+        public bool Valid;
+        public double[] RefIntensities;
+        public double[] RefRetentionTimes;
+        public int Start;
+        public int End;
+        public int ApexIndex;
+        public double ApexValue;
+
+        public static PeakShapeReference GetOrCompute(OspreyScoringContext context, IOspreyDetailedPeakData peakData)
+        {
+            if (context.TryGetInfo(out PeakShapeReference reference))
+                return reference;
+            reference = Compute(peakData);
+            context.AddInfo(reference);
+            return reference;
+        }
+
+        private static PeakShapeReference Compute(IOspreyDetailedPeakData peakData)
+        {
+            var reference = new PeakShapeReference();
+
+            var xics = peakData.Xics;
+            if (xics.Count == 0)
+                return reference;
+
+            int len = xics[0].Intensities.Length;
+            if (len == 0)
+                return reference;
+
+            var peak = peakData.PeakBounds;
+            int start = Math.Max(0, peak.StartIndex);
+            int end = Math.Min(len - 1, peak.EndIndex);
+            int apex = Math.Max(start, Math.Min(end, peak.ApexIndex));
+
+            if (start > end)
+                return reference;
+
+            // Reference XIC = highest total intensity, LAST on tie. Rust's
+            // xics.iter().max_by(...) returns the last equal element, so use
+            // >= with bestTotal seeded to -1.0 (NOT >). Matches Rust
+            // pipeline.rs:7140-7148.
+            int refIdx = 0;
+            double bestTotal = -1.0;
+            for (int f = 0; f < xics.Count; f++)
+            {
+                double total = 0.0;
+                double[] inten = xics[f].Intensities;
+                for (int i = 0; i < inten.Length; i++)
+                    total += inten[i];
+                if (total >= bestTotal)
+                {
+                    bestTotal = total;
+                    refIdx = f;
+                }
+            }
+
+            reference.RefIntensities = xics[refIdx].Intensities;
+            reference.RefRetentionTimes = xics[refIdx].RetentionTimes;
+            reference.Start = start;
+            reference.End = end;
+            reference.ApexIndex = apex;
+            reference.ApexValue = reference.RefIntensities[apex];
+            reference.Valid = true;
+            return reference;
+        }
+    }
+
+    /// <summary>
+    /// peak_apex: the reference-XIC intensity at the (clamped) peak apex index.
+    /// A direct lookup of the override/CWT-supplied apex -- NOT a recomputed local
+    /// max over [start, end] (Rust pipeline.rs:6547 uses peak.apex_intensity).
+    /// </summary>
+    internal sealed class PeakApexCalc : DetailedOspreyFeatureCalculator
+    {
+        public override string Name { get { return "peak_apex"; } }
+
+        protected override double Calculate(OspreyScoringContext context, IOspreyDetailedPeakData peakData)
+        {
+            var reference = PeakShapeReference.GetOrCompute(context, peakData);
+            return reference.Valid ? reference.ApexValue : 0.0;
+        }
+    }
+
+    /// <summary>
+    /// peak_area: trapezoidal integration of the reference XIC over [start, end).
+    /// Matches Rust trapezoidal_area(ref_xic[si..=ei]). Accumulated strictly
+    /// left-to-right (f64 addition is non-associative).
+    /// </summary>
+    internal sealed class PeakAreaCalc : DetailedOspreyFeatureCalculator
+    {
+        public override string Name { get { return "peak_area"; } }
+
+        protected override double Calculate(OspreyScoringContext context, IOspreyDetailedPeakData peakData)
+        {
+            var reference = PeakShapeReference.GetOrCompute(context, peakData);
+            if (!reference.Valid)
+                return 0.0;
+
+            double[] refInten = reference.RefIntensities;
+            double[] refRts = reference.RefRetentionTimes;
+            double area = 0.0;
+            for (int i = reference.Start; i < reference.End; i++)
+            {
+                double dt = refRts[i + 1] - refRts[i];
+                double avgHeight = (refInten[i] + refInten[i + 1]) * 0.5;
+                area += avgHeight * dt;
+            }
+            return area;
+        }
+    }
+
+    /// <summary>
+    /// peak_sharpness: mean of the left and right slopes on the reference XIC,
+    /// using the same apex position as peak_apex. Matches Rust
+    /// pipeline.rs:5212-5234 (edge guards strict, dt threshold strict &gt; 1e-10).
+    /// </summary>
+    internal sealed class PeakSharpnessCalc : DetailedOspreyFeatureCalculator
+    {
+        public override string Name { get { return "peak_sharpness"; } }
+
+        protected override double Calculate(OspreyScoringContext context, IOspreyDetailedPeakData peakData)
+        {
+            var reference = PeakShapeReference.GetOrCompute(context, peakData);
+            if (!reference.Valid)
+                return 0.0;
+
+            double[] refInten = reference.RefIntensities;
+            double[] refRts = reference.RefRetentionTimes;
+            int apexIdx = reference.ApexIndex;
+            double apexVal = reference.ApexValue;
+
+            double leftSlope = 0.0;
+            if (apexIdx > reference.Start)
+            {
+                double dt = refRts[apexIdx] - refRts[reference.Start];
+                if (dt > 1e-10)
+                    leftSlope = (apexVal - refInten[reference.Start]) / dt;
+            }
+            double rightSlope = 0.0;
+            if (reference.End > apexIdx)
+            {
+                double dt = refRts[reference.End] - refRts[apexIdx];
+                if (dt > 1e-10)
+                    rightSlope = (apexVal - refInten[reference.End]) / dt;
+            }
+            return (leftSlope + rightSlope) * 0.5;
+        }
+    }
+}

--- a/pwiz_tools/OspreySharp/OspreySharp.Scoring/RtDeviationCalculators.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Scoring/RtDeviationCalculators.cs
@@ -1,0 +1,53 @@
+/*
+ * Original author: Brendan MacLean <brendanx .at. uw.edu>,
+ *                  MacCoss Lab, Department of Genome Sciences, UW
+ * AI assistance: Claude Code (Claude Opus 4) <noreply .at. anthropic.com>
+ *
+ * Based on osprey (https://github.com/MacCossLab/osprey)
+ *   by Michael J. MacCoss, MacCoss Lab, Department of Genome Sciences, UW
+ *
+ * Copyright 2026 University of Washington - Seattle, WA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
+
+namespace pwiz.OspreySharp.Scoring
+{
+    /// <summary>
+    /// rt_deviation: the apex retention time minus the expected (calibration-
+    /// predicted) retention time. NaN propagates by design; there is no no-score
+    /// fallback here.
+    /// </summary>
+    internal sealed class RtDeviationCalc : DetailedOspreyFeatureCalculator
+    {
+        public override string Name { get { return "rt_deviation"; } }
+
+        protected override double Calculate(OspreyScoringContext context, IOspreyDetailedPeakData peakData)
+        {
+            return peakData.ApexRetentionTime - peakData.ExpectedRt;
+        }
+    }
+
+    /// <summary>abs_rt_deviation: the absolute value of rt_deviation.</summary>
+    internal sealed class AbsRtDeviationCalc : DetailedOspreyFeatureCalculator
+    {
+        public override string Name { get { return "abs_rt_deviation"; } }
+
+        protected override double Calculate(OspreyScoringContext context, IOspreyDetailedPeakData peakData)
+        {
+            return Math.Abs(peakData.ApexRetentionTime - peakData.ExpectedRt);
+        }
+    }
+}

--- a/pwiz_tools/OspreySharp/OspreySharp.Scoring/XcorrCalculators.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Scoring/XcorrCalculators.cs
@@ -1,0 +1,271 @@
+/*
+ * Original author: Brendan MacLean <brendanx .at. uw.edu>,
+ *                  MacCoss Lab, Department of Genome Sciences, UW
+ * AI assistance: Claude Code (Claude Opus 4) <noreply .at. anthropic.com>
+ *
+ * Based on osprey (https://github.com/MacCossLab/osprey)
+ *   by Michael J. MacCoss, MacCoss Lab, Department of Genome Sciences, UW
+ *
+ * Copyright 2026 University of Washington - Seattle, WA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
+using System.Collections.Generic;
+using pwiz.OspreySharp.Core;
+
+namespace pwiz.OspreySharp.Scoring
+{
+    /// <summary>
+    /// xcorr (feature 6): Comet-style cross-correlation of the candidate's
+    /// theoretical fragments against the chosen apex MS2 spectrum, scored through
+    /// the resolution strategy (Unit f64 cache / HRAM f32 cache). A SINGLE call --
+    /// no Savitzky-Golay sweep, no shared byproduct.
+    ///
+    /// INDEX TRAP: this feature indexes the preprocessed cache at the WINDOW-GLOBAL
+    /// apex index (<see cref="IOspreyDetailedPeakData.ApexGlobalIndex"/> =
+    /// WindowStartIndex + candidate-local apex). It is a DIFFERENT index space from
+    /// the SG sweep (features 17/18), which bound-checks a candidate-local index
+    /// against WindowLength before mapping to global. Do not unify the two.
+    ///
+    /// RESOLUTION-MODE CACHE TYPE: the call MUST go through
+    /// <see cref="IResolutionStrategy.ScoreXcorr"/>; Unit reads
+    /// preprocessed.Doubles (f64), HRAM reads preprocessed.Floats (f32 narrowed on
+    /// store). Never re-preprocess or assume f64. Per net8.0-canonical parity, gate
+    /// on net8.0.
+    ///
+    /// PERF: the shared <see cref="OspreyScoringContext.XcorrScratchPool"/> is
+    /// threaded into ScoreXcorr so HRAM scoring avoids per-call 100K-bin LOH
+    /// allocation. This family is the perf gate -- keep the pool on the call.
+    /// Mirrors inline AbstractScoringTask.cs apex xcorr.
+    /// </summary>
+    internal sealed class XcorrCalc : DetailedOspreyFeatureCalculator
+    {
+        public override string Name { get { return "xcorr"; } }
+
+        protected override double Calculate(OspreyScoringContext context, IOspreyDetailedPeakData peakData)
+        {
+            // Single apex-spectrum xcorr via the resolution strategy. The Spectrum
+            // arg is passed for fidelity with the inline call; the Unit/HRAM cache
+            // path reads the cache row at ApexGlobalIndex and ignores it.
+            return context.Resolution.ScoreXcorr(
+                context.PreprocessedXcorr, peakData.ApexGlobalIndex, peakData.ApexSpectrum,
+                peakData.Candidate, context.Scorer, context.XcorrScratchPool);
+        }
+    }
+
+    /// <summary>
+    /// Shared Savitzky-Golay weighted sweep for features 17 (sg_weighted_xcorr)
+    /// and 18 (sg_weighted_cosine). Both features share the SAME apex+/-2 offset
+    /// loop, the SAME asymmetric boundary skip, and the SAME candidate-local ->
+    /// window-global index mapping; they differ only in the per-offset scalar
+    /// (ScoreXcorr vs ComputeCosineAtScan). Computing the sweep once guarantees the
+    /// two features use identical index handling / boundary skips and avoids a
+    /// second pass over the apex+/-2 spectra. Published once per candidate to the
+    /// <see cref="OspreyScoringContext"/> byproduct cache. Mirrors the inline
+    /// AbstractScoringTask.cs SG loop.
+    ///
+    /// INDEX TRAP: candIdx = ApexLocalIndex + offset, bound-checked against
+    /// [0, WindowLength) (candidate-local rangeLen, NOT WindowSpectra.Count), then
+    /// mapped to globalIdx = WindowStartIndex + candIdx. At offset 0 globalIdx
+    /// equals feature 6's ApexGlobalIndex by construction, but the bounds convention
+    /// is deliberately distinct -- a naive reuse of one "apex global index" would
+    /// break the window-edge bound check.
+    ///
+    /// ASYMMETRIC BOUNDARY SKIP / NO RENORMALIZATION: near a window edge fewer than
+    /// 5 terms contribute; out-of-range offsets are continue'd (NOT added as zero)
+    /// and the partial sum is left as-is (no divide by contributing-weight sum) to
+    /// match Rust.
+    ///
+    /// ACCUMULATION ORDER (f64): the sweep runs strictly offset -2,-1,0,1,2 with
+    /// (score * weight) computed before the +=, accumulating left-to-right; both
+    /// sums seed 0.0. Do not vectorize or reorder.
+    ///
+    /// SHARED MUTABLE SCRATCH: PreprocessedXcorr.VisitedBins and the rented
+    /// XcorrScratchPool are mutated per ScoreXcorr call. Running the sweep as a
+    /// single producer pass serializes those mutations across features 17/18 within
+    /// a candidate (no interleaving).
+    /// </summary>
+    internal sealed class SgWeightedSweep
+    {
+        // Savitzky-Golay quadratic filter weights for length 5, center offset.
+        // Matches Rust pipeline.rs sg_weights: [-3/35, 12/35, 17/35, 12/35, -3/35].
+        // Relocated verbatim from AbstractScoringTask.cs.
+        private static readonly double[] SG_WEIGHTS =
+        {
+            -3.0 / 35.0,
+            12.0 / 35.0,
+            17.0 / 35.0,
+            12.0 / 35.0,
+            -3.0 / 35.0,
+        };
+
+        public double SgXcorr;   // feature 17
+        public double SgCosine;  // feature 18
+
+        public static SgWeightedSweep GetOrCompute(OspreyScoringContext context, IOspreyDetailedPeakData peakData)
+        {
+            if (context.TryGetInfo(out SgWeightedSweep sweep))
+                return sweep;
+            sweep = Compute(context, peakData);
+            context.AddInfo(sweep);
+            return sweep;
+        }
+
+        private static SgWeightedSweep Compute(OspreyScoringContext context, IOspreyDetailedPeakData peakData)
+        {
+            var sweep = new SgWeightedSweep();
+
+            var resolution = context.Resolution;
+            var preprocessedXcorr = context.PreprocessedXcorr;
+            var scorer = context.Scorer;
+            var pool = context.XcorrScratchPool;
+            var config = context.Config;
+            var candidate = peakData.Candidate;
+            var windowSpectra = peakData.WindowSpectra;
+            int startScan = peakData.WindowStartIndex;
+            int rangeLen = peakData.WindowLength;
+            int apexLocal = peakData.ApexLocalIndex;
+
+            double sgXcorr = 0.0;
+            double sgCosine = 0.0;
+            for (int offset = -2; offset <= 2; offset++)
+            {
+                double weight = SG_WEIGHTS[offset + 2];
+                int candIdx = apexLocal + offset;
+                if (candIdx < 0 || candIdx >= rangeLen)
+                    continue;
+                int globalIdx = startScan + candIdx;
+                var s = windowSpectra[globalIdx];
+                sgXcorr += resolution.ScoreXcorr(preprocessedXcorr, globalIdx, s, candidate, scorer,
+                    pool) * weight;
+                sgCosine += ComputeCosineAtScan(candidate, s, config) * weight;
+            }
+
+            sweep.SgXcorr = sgXcorr;
+            sweep.SgCosine = sgCosine;
+            return sweep;
+        }
+
+        /// <summary>
+        /// Mass-range-filtered, sqrt-intensity, L2-normalized cosine between the
+        /// candidate fragments and one spectrum. This is the sg_weighted_cosine
+        /// per-scan kernel -- a DIFFERENT function from SpectralScorer.LibCosine
+        /// (used for the unrelated libCosine path); do not conflate them.
+        /// Relocated verbatim from AbstractScoringTask.cs.
+        ///
+        /// TIE-BREAK: strict <c>diff &lt; bestDiff</c> keeps the first/closest peak
+        /// scanning ascending m/z. bestIntensity seeds 0.0 so an in-range fragment
+        /// with NO peak inside [lower, upper] still pushes Sqrt(relIntensity) to
+        /// libPre and Sqrt(0)=0 to obsPre (asymmetric vector entry that drives the
+        /// cosine down). Norm guard is the literal 1e-12 on the post-Sqrt norm.
+        /// Sqrt is taken per term before the dot/norm accumulation, in insertion
+        /// order of in-range fragments.
+        /// </summary>
+        private static double ComputeCosineAtScan(
+            LibraryEntry candidate, Spectrum spectrum, OspreyConfig config)
+        {
+            if (candidate.Fragments == null || candidate.Fragments.Count == 0 ||
+                spectrum.Mzs == null || spectrum.Mzs.Length == 0)
+                return 0.0;
+
+            double specMzMin = spectrum.Mzs[0];
+            double specMzMax = spectrum.Mzs[spectrum.Mzs.Length - 1];
+
+            var libPre = new List<double>();
+            var obsPre = new List<double>();
+
+            foreach (var frag in candidate.Fragments)
+            {
+                // Skip fragments outside the spectrum's mass range
+                if (frag.Mz < specMzMin || frag.Mz > specMzMax)
+                    continue;
+
+                double tolDa = config.FragmentTolerance.ToleranceDa(frag.Mz);
+                double lower = frag.Mz - tolDa;
+                double upper = frag.Mz + tolDa;
+
+                int lo = ScoringMath.BinarySearchLowerBound(spectrum.Mzs, lower);
+                double bestIntensity = 0.0;
+                double bestDiff = double.MaxValue;
+
+                for (int k = lo; k < spectrum.Mzs.Length && spectrum.Mzs[k] <= upper; k++)
+                {
+                    double diff = Math.Abs(spectrum.Mzs[k] - frag.Mz);
+                    if (diff < bestDiff)
+                    {
+                        bestDiff = diff;
+                        bestIntensity = spectrum.Intensities[k];
+                    }
+                }
+
+                libPre.Add(Math.Sqrt(frag.RelativeIntensity));
+                obsPre.Add(Math.Sqrt(bestIntensity));
+            }
+
+            if (libPre.Count == 0)
+                return 0.0;
+
+            // L2 normalize and dot product
+            double libNorm = 0, obsNorm = 0, dot = 0;
+            for (int i = 0; i < libPre.Count; i++)
+            {
+                libNorm += libPre[i] * libPre[i];
+                obsNorm += obsPre[i] * obsPre[i];
+                dot += libPre[i] * obsPre[i];
+            }
+            libNorm = Math.Sqrt(libNorm);
+            obsNorm = Math.Sqrt(obsNorm);
+            if (libNorm < 1e-12 || obsNorm < 1e-12)
+                return 0.0;
+            return dot / (libNorm * obsNorm);
+        }
+    }
+
+    /// <summary>
+    /// sg_weighted_xcorr (feature 17): Savitzky-Golay weighted sum of the
+    /// apex+/-2 per-scan xcorr scores. Reads the shared
+    /// <see cref="SgWeightedSweep"/> byproduct so it uses the exact same offset
+    /// loop / boundary skip / index mapping as sg_weighted_cosine (feature 18) and
+    /// the apex+/-2 spectra are scanned once. See <see cref="SgWeightedSweep"/> for
+    /// the index trap, asymmetric boundary skip, and accumulation-order hazards.
+    /// </summary>
+    internal sealed class SgXcorrCalc : DetailedOspreyFeatureCalculator
+    {
+        public override string Name { get { return "sg_weighted_xcorr"; } }
+
+        protected override double Calculate(OspreyScoringContext context, IOspreyDetailedPeakData peakData)
+        {
+            return SgWeightedSweep.GetOrCompute(context, peakData).SgXcorr;
+        }
+    }
+
+    /// <summary>
+    /// sg_weighted_cosine (feature 18): Savitzky-Golay weighted sum of the
+    /// apex+/-2 per-scan mass-range-filtered cosine scores
+    /// (<see cref="SgWeightedSweep"/>'s ComputeCosineAtScan, NOT
+    /// SpectralScorer.LibCosine). Reads the shared <see cref="SgWeightedSweep"/>
+    /// byproduct. See <see cref="SgWeightedSweep"/> for the index trap, asymmetric
+    /// boundary skip, accumulation-order, and tie-break hazards.
+    /// </summary>
+    internal sealed class SgCosineCalc : DetailedOspreyFeatureCalculator
+    {
+        public override string Name { get { return "sg_weighted_cosine"; } }
+
+        protected override double Calculate(OspreyScoringContext context, IOspreyDetailedPeakData peakData)
+        {
+            return SgWeightedSweep.GetOrCompute(context, peakData).SgCosine;
+        }
+    }
+}

--- a/pwiz_tools/OspreySharp/OspreySharp.Test/OspreyFeatureCalculatorsTest.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Test/OspreyFeatureCalculatorsTest.cs
@@ -212,7 +212,7 @@ namespace pwiz.OspreySharp.Test
                 new List<XicData> { new XicData(0, rts, frag0) },
                 new XICPeakBounds { StartIndex = 0, EndIndex = 4, ApexIndex = 2 },
                 candidate: new LibraryEntry(1, "PEPTIDE", "PEPTIDE", 2, 500.0, 10.0),
-                scanRetentionTimes: rts);
+                windowRetentionTimes: rts);
 
             // No SetMs1Machinery -> HasMs1Features is false -> HRAM gate returns 0.0
             // for both features, without touching the (null) MS1 spectra.
@@ -371,14 +371,14 @@ namespace pwiz.OspreySharp.Test
             private readonly int _windowStartIndex;
             private readonly int _windowLength;
             private readonly IReadOnlyList<Spectrum> _windowSpectra;
-            private readonly IReadOnlyList<double> _scanRetentionTimes;
+            private readonly IReadOnlyList<double> _windowRetentionTimes;
 
             public FakeDetailedPeakData(IReadOnlyList<XicData> xics, XICPeakBounds peakBounds,
                 double apexRetentionTime = 0.0, double expectedRt = 0.0,
                 LibraryEntry candidate = null, Spectrum apexSpectrum = null,
                 int apexGlobalIndex = 0, int apexLocalIndex = 0, int windowStartIndex = 0,
                 int windowLength = 0, IReadOnlyList<Spectrum> windowSpectra = null,
-                IReadOnlyList<double> scanRetentionTimes = null)
+                IReadOnlyList<double> windowRetentionTimes = null)
             {
                 _xics = xics;
                 _peakBounds = peakBounds;
@@ -391,7 +391,7 @@ namespace pwiz.OspreySharp.Test
                 _windowStartIndex = windowStartIndex;
                 _windowLength = windowLength;
                 _windowSpectra = windowSpectra;
-                _scanRetentionTimes = scanRetentionTimes;
+                _windowRetentionTimes = windowRetentionTimes;
             }
 
             public LibraryEntry Candidate { get { return _candidate; } }
@@ -405,7 +405,7 @@ namespace pwiz.OspreySharp.Test
             public int WindowStartIndex { get { return _windowStartIndex; } }
             public int WindowLength { get { return _windowLength; } }
             public IReadOnlyList<Spectrum> WindowSpectra { get { return _windowSpectra; } }
-            public IReadOnlyList<double> ScanRetentionTimes { get { return _scanRetentionTimes; } }
+            public IReadOnlyList<double> WindowRetentionTimes { get { return _windowRetentionTimes; } }
         }
 
         /// <summary>

--- a/pwiz_tools/OspreySharp/OspreySharp.Test/OspreyFeatureCalculatorsTest.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Test/OspreyFeatureCalculatorsTest.cs
@@ -91,6 +91,55 @@ namespace pwiz.OspreySharp.Test
             Assert.AreEqual(0.0, OspreyFeatureCalculators.Get(5).Calculate(context, empty), TOLERANCE);
         }
 
+        /// <summary>
+        /// Coelution family (fragment_coelution_sum / _max / n_coeluting_fragments):
+        /// all three are served from one shared pairwise-Pearson pass over the peak
+        /// range, published once to the context byproduct cache.
+        /// </summary>
+        [TestMethod]
+        public void TestCoelutionCalculators()
+        {
+            // Two perfectly-correlated fragments (frag1 = 10 * frag0) over the peak
+            // range -> a single pairwise correlation, positive and identical.
+            var rts = new double[] { 0, 1, 2, 3, 4 };
+            var frag0 = new double[] { 1, 2, 3, 2, 1 };
+            var frag1 = new double[] { 10, 20, 30, 20, 10 };
+            var xics = new List<XicData>
+            {
+                new XicData(0, rts, frag0),
+                new XicData(1, rts, frag1),
+            };
+            var bounds = new XICPeakBounds { StartIndex = 0, EndIndex = 4, ApexIndex = 2 };
+            var peakData = new FakeDetailedPeakData(xics, bounds);
+
+            double expectedCorr = ScoringMath.PearsonCorrelationInRange(frag0, frag1, 0, 4);
+            Assert.IsTrue(expectedCorr > 0.0, "fixture fragments should positively correlate");
+
+            var context = new OspreyScoringContext(null);
+            context.ClearByproducts();
+            double sum = OspreyFeatureCalculators.Get(0).Calculate(context, peakData);
+            double max = OspreyFeatureCalculators.Get(1).Calculate(context, peakData);
+            double nCoeluting = OspreyFeatureCalculators.Get(2).Calculate(context, peakData);
+
+            // One pair -> sum == max == that correlation; both fragments have a mean
+            // pairwise correlation > 0, so n_coeluting = 2.
+            Assert.AreEqual(expectedCorr, sum, TOLERANCE);
+            Assert.AreEqual(expectedCorr, max, TOLERANCE);
+            Assert.AreEqual(2.0, nCoeluting, TOLERANCE);
+
+            Assert.AreEqual("fragment_coelution_sum", OspreyFeatureCalculators.Get(0).Name);
+            Assert.AreEqual("fragment_coelution_max", OspreyFeatureCalculators.Get(1).Name);
+            Assert.AreEqual("n_coeluting_fragments", OspreyFeatureCalculators.Get(2).Name);
+
+            // Fewer than two fragments -> all coelution features 0.
+            var single = new FakeDetailedPeakData(
+                new List<XicData> { new XicData(0, rts, frag0) }, bounds);
+            context.ClearByproducts();
+            Assert.AreEqual(0.0, OspreyFeatureCalculators.Get(0).Calculate(context, single), TOLERANCE);
+            Assert.AreEqual(0.0, OspreyFeatureCalculators.Get(1).Calculate(context, single), TOLERANCE);
+            Assert.AreEqual(0.0, OspreyFeatureCalculators.Get(2).Calculate(context, single), TOLERANCE);
+        }
+
         private sealed class FakeDetailedPeakData : IOspreyDetailedPeakData
         {
             private readonly IReadOnlyList<XicData> _xics;

--- a/pwiz_tools/OspreySharp/OspreySharp.Test/OspreyFeatureCalculatorsTest.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Test/OspreyFeatureCalculatorsTest.cs
@@ -140,6 +140,35 @@ namespace pwiz.OspreySharp.Test
             Assert.AreEqual(0.0, OspreyFeatureCalculators.Get(2).Calculate(context, single), TOLERANCE);
         }
 
+        /// <summary>
+        /// Median-polish family defaults: when no fit is published (peakLen &lt; 3 or
+        /// a non-convergent Compute), each calculator returns its family-specific
+        /// default -- critically median_polish_residual_ratio is 1.0, the others 0.0.
+        /// A shared "return 0.0" would corrupt feature 16.
+        /// </summary>
+        [TestMethod]
+        public void TestMedianPolishCalculatorDefaults()
+        {
+            var rts = new double[] { 0, 1, 2 };
+            var frag0 = new double[] { 1, 2, 1 };
+            var peakData = new FakeDetailedPeakData(
+                new List<XicData> { new XicData(0, rts, frag0) },
+                new XICPeakBounds { StartIndex = 0, EndIndex = 2, ApexIndex = 1 });
+
+            // No MedianPolishByproduct published -> each calculator uses its default.
+            var context = new OspreyScoringContext(null);
+            context.ClearByproducts();
+            Assert.AreEqual(0.0, OspreyFeatureCalculators.Get(15).Calculate(context, peakData), TOLERANCE);
+            Assert.AreEqual(1.0, OspreyFeatureCalculators.Get(16).Calculate(context, peakData), TOLERANCE);
+            Assert.AreEqual(0.0, OspreyFeatureCalculators.Get(19).Calculate(context, peakData), TOLERANCE);
+            Assert.AreEqual(0.0, OspreyFeatureCalculators.Get(20).Calculate(context, peakData), TOLERANCE);
+
+            Assert.AreEqual("median_polish_cosine", OspreyFeatureCalculators.Get(15).Name);
+            Assert.AreEqual("median_polish_residual_ratio", OspreyFeatureCalculators.Get(16).Name);
+            Assert.AreEqual("median_polish_min_fragment_r2", OspreyFeatureCalculators.Get(19).Name);
+            Assert.AreEqual("median_polish_residual_correlation", OspreyFeatureCalculators.Get(20).Name);
+        }
+
         private sealed class FakeDetailedPeakData : IOspreyDetailedPeakData
         {
             private readonly IReadOnlyList<XicData> _xics;

--- a/pwiz_tools/OspreySharp/OspreySharp.Test/OspreyFeatureCalculatorsTest.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Test/OspreyFeatureCalculatorsTest.cs
@@ -1,0 +1,111 @@
+/*
+ * Original author: Brendan MacLean <brendanx .at. uw.edu>,
+ *                  MacCoss Lab, Department of Genome Sciences, UW
+ * AI assistance: Claude Code (Claude Opus 4) <noreply .at. anthropic.com>
+ *
+ * Based on osprey (https://github.com/MacCossLab/osprey)
+ *   by Michael J. MacCoss, MacCoss Lab, Department of Genome Sciences, UW
+ *
+ * Copyright 2026 University of Washington - Seattle, WA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System.Collections.Generic;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using pwiz.OspreySharp.Chromatography;
+using pwiz.OspreySharp.Core;
+using pwiz.OspreySharp.Scoring;
+
+namespace pwiz.OspreySharp.Test
+{
+    /// <summary>
+    /// Tests for the modular scoring SPI (<see cref="IOspreyFeatureCalculator"/> /
+    /// <see cref="OspreyScoringContext"/> / <see cref="OspreyFeatureCalculators"/>),
+    /// which mirrors Skyline's peak-scoring calculator model. These exercise the
+    /// extracted calculators directly -- a capability the inline
+    /// <c>ScoreCandidate</c> feature block did not have.
+    /// </summary>
+    [TestClass]
+    public class OspreyFeatureCalculatorsTest
+    {
+        private const double TOLERANCE = 1e-6;
+
+        /// <summary>
+        /// Peak-shape family (peak_apex / peak_area / peak_sharpness): values come
+        /// from the reference XIC (highest total intensity), apex is a direct
+        /// lookup at the supplied apex index, area is the trapezoid over
+        /// [start, end), sharpness is the mean of the left/right slopes.
+        /// </summary>
+        [TestMethod]
+        public void TestPeakShapeCalculators()
+        {
+            var rts = new double[] { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 };
+            // frag1 has the higher total intensity (212 > 110), so it is the
+            // reference XIC; its apex at scan 3 is value 90.
+            var frag0 = new double[] { 0, 0, 0, 0, 5, 20, 60, 20, 5, 0 };
+            var frag1 = new double[] { 0, 10, 50, 90, 50, 10, 2, 0, 0, 0 };
+            var xics = new List<XicData>
+            {
+                new XicData(0, rts, frag0),
+                new XicData(1, rts, frag1),
+            };
+            var bounds = new XICPeakBounds { StartIndex = 1, EndIndex = 5, ApexIndex = 3 };
+            var peakData = new FakeDetailedPeakData(xics, bounds);
+
+            var context = new OspreyScoringContext(null);
+            context.ClearByproducts();
+
+            double apex = OspreyFeatureCalculators.Get(3).Calculate(context, peakData);
+            double area = OspreyFeatureCalculators.Get(4).Calculate(context, peakData);
+            double sharpness = OspreyFeatureCalculators.Get(5).Calculate(context, peakData);
+
+            // peak_apex: reference XIC (frag1) intensity at apex index 3 = 90.
+            Assert.AreEqual(90.0, apex, TOLERANCE);
+            // peak_area: trapezoid over [1,5) with dt = 1:
+            // (10+50)/2 + (50+90)/2 + (90+50)/2 + (50+10)/2 = 30+70+70+30 = 200.
+            Assert.AreEqual(200.0, area, TOLERANCE);
+            // peak_sharpness: left (90-10)/(3-1)=40, right (90-10)/(5-3)=40, mean 40.
+            Assert.AreEqual(40.0, sharpness, TOLERANCE);
+
+            // The three calculators expose the parity-critical PIN names.
+            Assert.AreEqual("peak_apex", OspreyFeatureCalculators.Get(3).Name);
+            Assert.AreEqual("peak_area", OspreyFeatureCalculators.Get(4).Name);
+            Assert.AreEqual("peak_sharpness", OspreyFeatureCalculators.Get(5).Name);
+
+            // Degenerate peak data (no XICs) yields 0.0 for every peak-shape feature.
+            var empty = new FakeDetailedPeakData(new List<XicData>(), bounds);
+            context.ClearByproducts();
+            Assert.AreEqual(0.0, OspreyFeatureCalculators.Get(3).Calculate(context, empty), TOLERANCE);
+            Assert.AreEqual(0.0, OspreyFeatureCalculators.Get(4).Calculate(context, empty), TOLERANCE);
+            Assert.AreEqual(0.0, OspreyFeatureCalculators.Get(5).Calculate(context, empty), TOLERANCE);
+        }
+
+        private sealed class FakeDetailedPeakData : IOspreyDetailedPeakData
+        {
+            private readonly IReadOnlyList<XicData> _xics;
+            private readonly XICPeakBounds _peakBounds;
+
+            public FakeDetailedPeakData(IReadOnlyList<XicData> xics, XICPeakBounds peakBounds)
+            {
+                _xics = xics;
+                _peakBounds = peakBounds;
+            }
+
+            // Peak-shape calculators read only Xics and PeakBounds.
+            public LibraryEntry Candidate { get { return null; } }
+            public XICPeakBounds PeakBounds { get { return _peakBounds; } }
+            public IReadOnlyList<XicData> Xics { get { return _xics; } }
+        }
+    }
+}

--- a/pwiz_tools/OspreySharp/OspreySharp.Test/OspreyFeatureCalculatorsTest.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Test/OspreyFeatureCalculatorsTest.cs
@@ -194,27 +194,108 @@ namespace pwiz.OspreySharp.Test
             Assert.AreEqual("abs_rt_deviation", OspreyFeatureCalculators.Get(12).Name);
         }
 
+        /// <summary>
+        /// Apex-match family: consecutive_ions (longest matched b/y ordinal run),
+        /// explained_intensity (matched / total apex intensity), and the signed /
+        /// absolute mean fragment mass error. The mass-accuracy trio share one
+        /// ApexFragmentMatchSet pass; the no-match abs fallback is the live
+        /// FragmentTolerance.Tolerance, NOT 0.0 (the historical ~65-row Astral bug).
+        /// </summary>
+        [TestMethod]
+        public void TestApexMatchCalculators()
+        {
+            // Apex MS2 spectrum: four sorted peaks, total intensity 100.
+            var apex = new Spectrum
+            {
+                Mzs = new[] { 100.0, 200.0, 300.0, 400.0 },
+                Intensities = new[] { 10f, 20f, 30f, 40f },
+            };
+            // Da tolerance so the expected arithmetic is exact and easy to read.
+            var config = new OspreyConfig { FragmentTolerance = FragmentToleranceConfig.UnitResolution(0.5) };
+
+            // b1/b2 and y1 match (consecutive b-run of 2); y2 has no peak.
+            var candidate = new LibraryEntry(1, "PEPTIDE", "PEPTIDE", 2, 500.0, 10.0)
+            {
+                Fragments = new List<LibraryFragment>
+                {
+                    Frag(100.05, IonType.B, 1),
+                    Frag(200.0, IonType.B, 2),
+                    Frag(300.0, IonType.Y, 1),
+                    Frag(999.0, IonType.Y, 2),
+                },
+            };
+            var peakData = new FakeDetailedPeakData(new List<XicData>(), new XICPeakBounds(),
+                candidate: candidate, apexSpectrum: apex);
+
+            var context = new OspreyScoringContext(config);
+            context.ClearByproducts();
+
+            // consecutive_ions: b-ordinals {1,2} -> run 2; y-ordinals {1} -> run 1.
+            Assert.AreEqual(2.0, OspreyFeatureCalculators.Get(7).Calculate(context, peakData), TOLERANCE);
+            // explained_intensity: matched (10+20+30) / total 100 = 0.60.
+            Assert.AreEqual(0.60, OspreyFeatureCalculators.Get(8).Calculate(context, peakData), TOLERANCE);
+            // mass_accuracy_deviation_mean: signed errors (-0.05, 0, 0) / 3.
+            Assert.AreEqual(-0.05 / 3.0, OspreyFeatureCalculators.Get(9).Calculate(context, peakData), TOLERANCE);
+            // abs_mass_accuracy_deviation_mean: absolute errors (0.05, 0, 0) / 3.
+            Assert.AreEqual(0.05 / 3.0, OspreyFeatureCalculators.Get(10).Calculate(context, peakData), TOLERANCE);
+
+            Assert.AreEqual("consecutive_ions", OspreyFeatureCalculators.Get(7).Name);
+            Assert.AreEqual("explained_intensity", OspreyFeatureCalculators.Get(8).Name);
+            Assert.AreEqual("mass_accuracy_deviation_mean", OspreyFeatureCalculators.Get(9).Name);
+            Assert.AreEqual("abs_mass_accuracy_deviation_mean", OspreyFeatureCalculators.Get(10).Name);
+
+            // No matched fragments: consecutive / explained / signed-mean are 0.0,
+            // but the abs mean falls back to the live tolerance (0.5), NOT 0.0.
+            var noMatch = new LibraryEntry(1, "PEPTIDE", "PEPTIDE", 2, 500.0, 10.0)
+            {
+                Fragments = new List<LibraryFragment> { Frag(999.0, IonType.B, 1) },
+            };
+            var noMatchData = new FakeDetailedPeakData(new List<XicData>(), new XICPeakBounds(),
+                candidate: noMatch, apexSpectrum: apex);
+            var noMatchContext = new OspreyScoringContext(config);
+            noMatchContext.ClearByproducts();
+            Assert.AreEqual(0.0, OspreyFeatureCalculators.Get(7).Calculate(noMatchContext, noMatchData), TOLERANCE);
+            Assert.AreEqual(0.0, OspreyFeatureCalculators.Get(8).Calculate(noMatchContext, noMatchData), TOLERANCE);
+            Assert.AreEqual(0.0, OspreyFeatureCalculators.Get(9).Calculate(noMatchContext, noMatchData), TOLERANCE);
+            Assert.AreEqual(0.5, OspreyFeatureCalculators.Get(10).Calculate(noMatchContext, noMatchData), TOLERANCE);
+        }
+
+        private static LibraryFragment Frag(double mz, IonType ionType, byte ordinal)
+        {
+            return new LibraryFragment
+            {
+                Mz = mz,
+                Annotation = new FragmentAnnotation { IonType = ionType, Ordinal = ordinal },
+            };
+        }
+
         private sealed class FakeDetailedPeakData : IOspreyDetailedPeakData
         {
             private readonly IReadOnlyList<XicData> _xics;
             private readonly XICPeakBounds _peakBounds;
             private readonly double _apexRetentionTime;
             private readonly double _expectedRt;
+            private readonly LibraryEntry _candidate;
+            private readonly Spectrum _apexSpectrum;
 
             public FakeDetailedPeakData(IReadOnlyList<XicData> xics, XICPeakBounds peakBounds,
-                double apexRetentionTime = 0.0, double expectedRt = 0.0)
+                double apexRetentionTime = 0.0, double expectedRt = 0.0,
+                LibraryEntry candidate = null, Spectrum apexSpectrum = null)
             {
                 _xics = xics;
                 _peakBounds = peakBounds;
                 _apexRetentionTime = apexRetentionTime;
                 _expectedRt = expectedRt;
+                _candidate = candidate;
+                _apexSpectrum = apexSpectrum;
             }
 
-            public LibraryEntry Candidate { get { return null; } }
+            public LibraryEntry Candidate { get { return _candidate; } }
             public XICPeakBounds PeakBounds { get { return _peakBounds; } }
             public double ApexRetentionTime { get { return _apexRetentionTime; } }
             public double ExpectedRt { get { return _expectedRt; } }
             public IReadOnlyList<XicData> Xics { get { return _xics; } }
+            public Spectrum ApexSpectrum { get { return _apexSpectrum; } }
         }
     }
 }

--- a/pwiz_tools/OspreySharp/OspreySharp.Test/OspreyFeatureCalculatorsTest.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Test/OspreyFeatureCalculatorsTest.cs
@@ -195,6 +195,38 @@ namespace pwiz.OspreySharp.Test
         }
 
         /// <summary>
+        /// MS1 family (ms1_precursor_coelution / ms1_isotope_cosine): both features
+        /// are HRAM-only. The HRAM gate is on the context -- when SetMs1Machinery was
+        /// never called (so HasMs1Features stays false and Ms1Spectra is null), both
+        /// calculators short-circuit to exactly 0.0 before any byproduct work. The
+        /// numeric path (calibration, reference-XIC pick, nearest-MS1 sampling,
+        /// isotope envelope) is covered by the end-to-end 1e-9 cross-impl parity gate
+        /// against the Rust reference on the HRAM datasets.
+        /// </summary>
+        [TestMethod]
+        public void TestMs1Calculators()
+        {
+            var rts = new double[] { 0, 1, 2, 3, 4 };
+            var frag0 = new double[] { 1, 2, 3, 2, 1 };
+            var peakData = new FakeDetailedPeakData(
+                new List<XicData> { new XicData(0, rts, frag0) },
+                new XICPeakBounds { StartIndex = 0, EndIndex = 4, ApexIndex = 2 },
+                candidate: new LibraryEntry(1, "PEPTIDE", "PEPTIDE", 2, 500.0, 10.0),
+                scanRetentionTimes: rts);
+
+            // No SetMs1Machinery -> HasMs1Features is false -> HRAM gate returns 0.0
+            // for both features, without touching the (null) MS1 spectra.
+            var context = new OspreyScoringContext(null);
+            context.ClearByproducts();
+            Assert.IsFalse(context.HasMs1Features);
+            Assert.AreEqual(0.0, OspreyFeatureCalculators.Get(13).Calculate(context, peakData), TOLERANCE);
+            Assert.AreEqual(0.0, OspreyFeatureCalculators.Get(14).Calculate(context, peakData), TOLERANCE);
+
+            Assert.AreEqual("ms1_precursor_coelution", OspreyFeatureCalculators.Get(13).Name);
+            Assert.AreEqual("ms1_isotope_cosine", OspreyFeatureCalculators.Get(14).Name);
+        }
+
+        /// <summary>
         /// Apex-match family: consecutive_ions (longest matched b/y ordinal run),
         /// explained_intensity (matched / total apex intensity), and the signed /
         /// absolute mean fragment mass error. The mass-accuracy trio share one
@@ -339,12 +371,14 @@ namespace pwiz.OspreySharp.Test
             private readonly int _windowStartIndex;
             private readonly int _windowLength;
             private readonly IReadOnlyList<Spectrum> _windowSpectra;
+            private readonly IReadOnlyList<double> _scanRetentionTimes;
 
             public FakeDetailedPeakData(IReadOnlyList<XicData> xics, XICPeakBounds peakBounds,
                 double apexRetentionTime = 0.0, double expectedRt = 0.0,
                 LibraryEntry candidate = null, Spectrum apexSpectrum = null,
                 int apexGlobalIndex = 0, int apexLocalIndex = 0, int windowStartIndex = 0,
-                int windowLength = 0, IReadOnlyList<Spectrum> windowSpectra = null)
+                int windowLength = 0, IReadOnlyList<Spectrum> windowSpectra = null,
+                IReadOnlyList<double> scanRetentionTimes = null)
             {
                 _xics = xics;
                 _peakBounds = peakBounds;
@@ -357,6 +391,7 @@ namespace pwiz.OspreySharp.Test
                 _windowStartIndex = windowStartIndex;
                 _windowLength = windowLength;
                 _windowSpectra = windowSpectra;
+                _scanRetentionTimes = scanRetentionTimes;
             }
 
             public LibraryEntry Candidate { get { return _candidate; } }
@@ -370,6 +405,7 @@ namespace pwiz.OspreySharp.Test
             public int WindowStartIndex { get { return _windowStartIndex; } }
             public int WindowLength { get { return _windowLength; } }
             public IReadOnlyList<Spectrum> WindowSpectra { get { return _windowSpectra; } }
+            public IReadOnlyList<double> ScanRetentionTimes { get { return _scanRetentionTimes; } }
         }
 
         /// <summary>

--- a/pwiz_tools/OspreySharp/OspreySharp.Test/OspreyFeatureCalculatorsTest.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Test/OspreyFeatureCalculatorsTest.cs
@@ -169,20 +169,51 @@ namespace pwiz.OspreySharp.Test
             Assert.AreEqual("median_polish_residual_correlation", OspreyFeatureCalculators.Get(20).Name);
         }
 
+        /// <summary>
+        /// RT-deviation family: rt_deviation = apex RT - expected RT (signed), and
+        /// abs_rt_deviation = its absolute value.
+        /// </summary>
+        [TestMethod]
+        public void TestRtDeviationCalculators()
+        {
+            var context = new OspreyScoringContext(null);
+            context.ClearByproducts();
+
+            var late = new FakeDetailedPeakData(new List<XicData>(), new XICPeakBounds(),
+                apexRetentionTime: 12.5, expectedRt: 10.0);
+            Assert.AreEqual(2.5, OspreyFeatureCalculators.Get(11).Calculate(context, late), TOLERANCE);
+            Assert.AreEqual(2.5, OspreyFeatureCalculators.Get(12).Calculate(context, late), TOLERANCE);
+
+            // Earlier-than-expected apex -> negative deviation, positive absolute.
+            var early = new FakeDetailedPeakData(new List<XicData>(), new XICPeakBounds(),
+                apexRetentionTime: 8.0, expectedRt: 10.0);
+            Assert.AreEqual(-2.0, OspreyFeatureCalculators.Get(11).Calculate(context, early), TOLERANCE);
+            Assert.AreEqual(2.0, OspreyFeatureCalculators.Get(12).Calculate(context, early), TOLERANCE);
+
+            Assert.AreEqual("rt_deviation", OspreyFeatureCalculators.Get(11).Name);
+            Assert.AreEqual("abs_rt_deviation", OspreyFeatureCalculators.Get(12).Name);
+        }
+
         private sealed class FakeDetailedPeakData : IOspreyDetailedPeakData
         {
             private readonly IReadOnlyList<XicData> _xics;
             private readonly XICPeakBounds _peakBounds;
+            private readonly double _apexRetentionTime;
+            private readonly double _expectedRt;
 
-            public FakeDetailedPeakData(IReadOnlyList<XicData> xics, XICPeakBounds peakBounds)
+            public FakeDetailedPeakData(IReadOnlyList<XicData> xics, XICPeakBounds peakBounds,
+                double apexRetentionTime = 0.0, double expectedRt = 0.0)
             {
                 _xics = xics;
                 _peakBounds = peakBounds;
+                _apexRetentionTime = apexRetentionTime;
+                _expectedRt = expectedRt;
             }
 
-            // Peak-shape calculators read only Xics and PeakBounds.
             public LibraryEntry Candidate { get { return null; } }
             public XICPeakBounds PeakBounds { get { return _peakBounds; } }
+            public double ApexRetentionTime { get { return _apexRetentionTime; } }
+            public double ExpectedRt { get { return _expectedRt; } }
             public IReadOnlyList<XicData> Xics { get { return _xics; } }
         }
     }

--- a/pwiz_tools/OspreySharp/OspreySharp.Test/OspreyFeatureCalculatorsTest.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Test/OspreyFeatureCalculatorsTest.cs
@@ -260,6 +260,63 @@ namespace pwiz.OspreySharp.Test
             Assert.AreEqual(0.5, OspreyFeatureCalculators.Get(10).Calculate(noMatchContext, noMatchData), TOLERANCE);
         }
 
+        /// <summary>
+        /// Xcorr + Savitzky-Golay family (xcorr / sg_weighted_xcorr /
+        /// sg_weighted_cosine). Uses an <see cref="IResolutionStrategy"/> fake whose
+        /// ScoreXcorr returns the spectrum index, so the SG-weighted sum, the
+        /// apex+/-2 window, the candidate-local -> global mapping, and the asymmetric
+        /// edge skip are analytically checkable. Cosine is 0 here (fragment-less
+        /// candidate), which also exercises the empty-fragment guard.
+        /// </summary>
+        [TestMethod]
+        public void TestXcorrSgCalculators()
+        {
+            // 20 placeholder spectra so any window-global index in range resolves.
+            var windowSpectra = new List<Spectrum>();
+            for (int i = 0; i < 20; i++)
+                windowSpectra.Add(new Spectrum { Mzs = new double[0], Intensities = new float[0] });
+
+            // Fragment-less candidate: sg_weighted_cosine collapses to 0 (empty-frag
+            // guard), isolating the xcorr-side weighting under test.
+            var candidate = new LibraryEntry(1, "PEPTIDE", "PEPTIDE", 2, 500.0, 10.0);
+            var config = new OspreyConfig { FragmentTolerance = FragmentToleranceConfig.UnitResolution(0.5) };
+
+            var context = new OspreyScoringContext(config);
+            context.SetWindow(new IndexEchoResolution(), null, null, null);
+
+            // Interior apex: startScan=10, apexLocal=5, rangeLen=8 -> candIdx 3..7 all
+            // in range, globalIdx 13..17. ScoreXcorr echoes the index.
+            var interior = new FakeDetailedPeakData(new List<XicData>(), new XICPeakBounds(),
+                candidate: candidate, apexSpectrum: windowSpectra[15],
+                apexGlobalIndex: 15, apexLocalIndex: 5, windowStartIndex: 10,
+                windowLength: 8, windowSpectra: windowSpectra);
+            context.ClearByproducts();
+
+            // xcorr (6) = ScoreXcorr at ApexGlobalIndex 15.
+            Assert.AreEqual(15.0, OspreyFeatureCalculators.Get(6).Calculate(context, interior), TOLERANCE);
+            // sg_weighted_xcorr (17): weights .* [13,14,15,16,17] = 15.0 (SG weights
+            // sum to 1, so a linear score returns the center value).
+            Assert.AreEqual(15.0, OspreyFeatureCalculators.Get(17).Calculate(context, interior), TOLERANCE);
+            // sg_weighted_cosine (18) = 0 (fragment-less candidate).
+            Assert.AreEqual(0.0, OspreyFeatureCalculators.Get(18).Calculate(context, interior), TOLERANCE);
+
+            Assert.AreEqual("xcorr", OspreyFeatureCalculators.Get(6).Name);
+            Assert.AreEqual("sg_weighted_xcorr", OspreyFeatureCalculators.Get(17).Name);
+            Assert.AreEqual("sg_weighted_cosine", OspreyFeatureCalculators.Get(18).Name);
+
+            // Edge apex: apexLocal=0 -> offsets -2,-1 skip (candIdx<0); offsets 0,1,2
+            // -> globalIdx 10,11,12. NO renormalization: only those weights apply.
+            // 10*(17/35) + 11*(12/35) + 12*(-3/35) = 266/35 = 7.6.
+            var edge = new FakeDetailedPeakData(new List<XicData>(), new XICPeakBounds(),
+                candidate: candidate, apexSpectrum: windowSpectra[10],
+                apexGlobalIndex: 10, apexLocalIndex: 0, windowStartIndex: 10,
+                windowLength: 8, windowSpectra: windowSpectra);
+            var edgeContext = new OspreyScoringContext(config);
+            edgeContext.SetWindow(new IndexEchoResolution(), null, null, null);
+            edgeContext.ClearByproducts();
+            Assert.AreEqual(266.0 / 35.0, OspreyFeatureCalculators.Get(17).Calculate(edgeContext, edge), TOLERANCE);
+        }
+
         private static LibraryFragment Frag(double mz, IonType ionType, byte ordinal)
         {
             return new LibraryFragment
@@ -277,10 +334,17 @@ namespace pwiz.OspreySharp.Test
             private readonly double _expectedRt;
             private readonly LibraryEntry _candidate;
             private readonly Spectrum _apexSpectrum;
+            private readonly int _apexGlobalIndex;
+            private readonly int _apexLocalIndex;
+            private readonly int _windowStartIndex;
+            private readonly int _windowLength;
+            private readonly IReadOnlyList<Spectrum> _windowSpectra;
 
             public FakeDetailedPeakData(IReadOnlyList<XicData> xics, XICPeakBounds peakBounds,
                 double apexRetentionTime = 0.0, double expectedRt = 0.0,
-                LibraryEntry candidate = null, Spectrum apexSpectrum = null)
+                LibraryEntry candidate = null, Spectrum apexSpectrum = null,
+                int apexGlobalIndex = 0, int apexLocalIndex = 0, int windowStartIndex = 0,
+                int windowLength = 0, IReadOnlyList<Spectrum> windowSpectra = null)
             {
                 _xics = xics;
                 _peakBounds = peakBounds;
@@ -288,6 +352,11 @@ namespace pwiz.OspreySharp.Test
                 _expectedRt = expectedRt;
                 _candidate = candidate;
                 _apexSpectrum = apexSpectrum;
+                _apexGlobalIndex = apexGlobalIndex;
+                _apexLocalIndex = apexLocalIndex;
+                _windowStartIndex = windowStartIndex;
+                _windowLength = windowLength;
+                _windowSpectra = windowSpectra;
             }
 
             public LibraryEntry Candidate { get { return _candidate; } }
@@ -296,6 +365,33 @@ namespace pwiz.OspreySharp.Test
             public double ExpectedRt { get { return _expectedRt; } }
             public IReadOnlyList<XicData> Xics { get { return _xics; } }
             public Spectrum ApexSpectrum { get { return _apexSpectrum; } }
+            public int ApexGlobalIndex { get { return _apexGlobalIndex; } }
+            public int ApexLocalIndex { get { return _apexLocalIndex; } }
+            public int WindowStartIndex { get { return _windowStartIndex; } }
+            public int WindowLength { get { return _windowLength; } }
+            public IReadOnlyList<Spectrum> WindowSpectra { get { return _windowSpectra; } }
+        }
+
+        /// <summary>
+        /// Minimal <see cref="IResolutionStrategy"/> fake whose ScoreXcorr returns
+        /// the spectrum index it was asked to score. That makes the Savitzky-Golay
+        /// weighted sum and the apex index analytic: a linear "score = index"
+        /// function lets the test pin the weights, the apex+/-2 window, the
+        /// candidate-local -> global mapping, and the asymmetric edge skip.
+        /// </summary>
+        private sealed class IndexEchoResolution : IResolutionStrategy
+        {
+            public bool HasMs1Features { get { return false; } }
+            public SpectralScorer CreateScorer() { return null; }
+            public WindowXcorrCache PreprocessWindowSpectra(IList<Spectrum> spectra,
+                SpectralScorer scorer, XcorrScratchPool scratchPool) { return null; }
+            public void ReleaseWindowCache(WindowXcorrCache cache, XcorrScratchPool scratchPool) { }
+            public double ScoreXcorr(WindowXcorrCache preprocessed, int spectrumIndex,
+                Spectrum spectrum, LibraryEntry entry, SpectralScorer scorer,
+                XcorrScratchPool scratchPool)
+            {
+                return spectrumIndex;
+            }
         }
     }
 }

--- a/pwiz_tools/OspreySharp/OspreySharp/OspreyDiagnostics.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/OspreyDiagnostics.cs
@@ -312,7 +312,7 @@ namespace pwiz.OspreySharp
             XICPeakBounds bestPeak, int peakLen,
             double mpCosine, double mpResidualRatio, double mpMinFragmentR2, double mpResidualCorr,
             TukeyMedianPolishResult polish,
-            IList<KeyValuePair<int, double[]>> peakXics)
+            IReadOnlyList<KeyValuePair<int, double[]>> peakXics)
         {
             Sink?.WriteMpDump(candidate, apexScanNumber, bestPeak, peakLen,
                 mpCosine, mpResidualRatio, mpMinFragmentR2, mpResidualCorr, polish, peakXics);

--- a/pwiz_tools/OspreySharp/OspreySharp/OspreyFileDiagnostics.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/OspreyFileDiagnostics.cs
@@ -1054,7 +1054,7 @@ namespace pwiz.OspreySharp
             XICPeakBounds bestPeak, int peakLen,
             double mpCosine, double mpResidualRatio, double mpMinFragmentR2, double mpResidualCorr,
             TukeyMedianPolishResult polish,
-            IList<KeyValuePair<int, double[]>> peakXics)
+            IReadOnlyList<KeyValuePair<int, double[]>> peakXics)
         {
             var inv = CultureInfo.InvariantCulture;
             using (var dw = new StreamWriter(@"cs_mp_diag.txt"))

--- a/pwiz_tools/OspreySharp/OspreySharp/Tasks/AbstractScoringTask.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/Tasks/AbstractScoringTask.cs
@@ -1511,13 +1511,23 @@ namespace pwiz.OspreySharp.Tasks
                 sgCosine += ComputeCosineAtScan(candidate, s, config) * weight;
             }
 
-            // Tukey median polish features (15, 16, 19, 20).
+            // Per-candidate state for the modular feature calculators. Reused
+            // window-local instances (see RunCoelutionScoring); ClearByproducts
+            // resets the per-candidate byproduct cache. Done BEFORE the
+            // median-polish publish below so that byproduct survives to the
+            // calculators. Calculator-backed features mirror Skyline's
+            // IPeakFeatureCalculator; the rest stay inline until extracted.
+            ospreyContext.ClearByproducts();
+            ospreyPeakData.Set(candidate, bestPeak, xics);
+
+            // Tukey median-polish inputs + fit (features 15, 16, 19, 20). The crop,
+            // WriteMpInputsRow, and Compute stay here because the bisection
+            // diagnostics live in the exe layer that OspreySharp.Scoring cannot
+            // reference; the four feature values are computed by the calculators
+            // from the published MedianPolishByproduct, and the optional
+            // WriteMpDump fires after the feature vector below.
             // Crop XICs to the peak range so the polish operates only on signal,
             // not the wider RT search window. Matches Rust pipeline.rs:5198-5212.
-            double mpCosine = 0.0;
-            double mpResidualRatio = 1.0;
-            double mpMinFragmentR2 = 0.0;
-            double mpResidualCorr = 0.0;
             int peakLen = bestPeak.EndIndex - bestPeak.StartIndex + 1;
             if (peakLen >= 3)
             {
@@ -1543,32 +1553,8 @@ namespace pwiz.OspreySharp.Tasks
                     candidate.Id, apexSpectrum.ScanNumber, peakXics, peakRts);
 
                 var polish = TukeyMedianPolish.Compute(peakXics, peakRts, 10, 0.01);
-                if (polish != null)
-                {
-                    mpCosine = TukeyMedianPolish.LibCosine(polish, candidate.Fragments);
-                    mpResidualRatio = TukeyMedianPolish.ResidualRatio(polish);
-                    mpMinFragmentR2 = TukeyMedianPolish.MinFragmentR2(polish);
-                    mpResidualCorr = TukeyMedianPolish.ResidualCorrelation(polish);
-
-                    // Median polish diagnostic for bisection
-                    if (OspreyDiagnostics.ShouldDumpMpFor(apexSpectrum.ScanNumber, candidate.ModifiedSequence))
-                    {
-                        OspreyDiagnostics.WriteMpDump(
-                            candidate, apexSpectrum.ScanNumber,
-                            bestPeak, peakLen,
-                            mpCosine, mpResidualRatio, mpMinFragmentR2, mpResidualCorr,
-                            polish, peakXics);
-                    }
-                }
+                ospreyContext.AddInfo(new MedianPolishByproduct(polish, peakXics));
             }
-
-            // Per-candidate state for the modular feature calculators. Reused
-            // window-local instances (see RunCoelutionScoring); ClearByproducts
-            // resets the per-candidate byproduct cache. Calculator-backed features
-            // mirror Skyline's IPeakFeatureCalculator; the rest stay inline until
-            // their family is extracted.
-            ospreyContext.ClearByproducts();
-            ospreyPeakData.Set(candidate, bestPeak, xics);
 
             // Build full 21-element PIN feature vector
             double[] features = new double[NUM_PIN_FEATURES];
@@ -1587,12 +1573,28 @@ namespace pwiz.OspreySharp.Tasks
             features[12] = absRtDeviation;
             features[13] = ms1PrecursorCoelution;
             features[14] = ms1IsotopeCosine;
-            features[15] = mpCosine;
-            features[16] = mpResidualRatio;
+            features[15] = OspreyFeatureCalculators.Get(15).Calculate(ospreyContext, ospreyPeakData);
+            features[16] = OspreyFeatureCalculators.Get(16).Calculate(ospreyContext, ospreyPeakData);
             features[17] = sgXcorr;
             features[18] = sgCosine;
-            features[19] = mpMinFragmentR2;
-            features[20] = mpResidualCorr;
+            features[19] = OspreyFeatureCalculators.Get(19).Calculate(ospreyContext, ospreyPeakData);
+            features[20] = OspreyFeatureCalculators.Get(20).Calculate(ospreyContext, ospreyPeakData);
+
+            // Median-polish bisection dump (after the feature vector so the four
+            // values are available). Reads the polish + cropped inputs from the
+            // byproduct published above; gated by ShouldDumpMpFor as before. The
+            // standard parity gate compares Stage 7 + blib, not the -d dumps.
+            if (peakLen >= 3
+                && ospreyContext.TryGetInfo(out MedianPolishByproduct mpByproduct)
+                && mpByproduct.Polish != null
+                && OspreyDiagnostics.ShouldDumpMpFor(apexSpectrum.ScanNumber, candidate.ModifiedSequence))
+            {
+                OspreyDiagnostics.WriteMpDump(
+                    candidate, apexSpectrum.ScanNumber,
+                    bestPeak, peakLen,
+                    features[15], features[16], features[19], features[20],
+                    mpByproduct.Polish, mpByproduct.PeakXics);
+            }
 
             // Stage 6 reconciliation input: capture the top-N CWT peak
             // candidates ranked by penalized rank score, with each kept

--- a/pwiz_tools/OspreySharp/OspreySharp/Tasks/AbstractScoringTask.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/Tasks/AbstractScoringTask.cs
@@ -1451,12 +1451,6 @@ namespace pwiz.OspreySharp.Tasks
 
 
 
-            // Compute pairwise coelution features (sum, max, n_positive).
-            double coelutionSum, coelutionMax;
-            int nCoelutingFragments;
-            ComputeCoelutionStats(xics, bestPeak,
-                out coelutionSum, out coelutionMax, out nCoelutingFragments);
-
             // RT deviation (absolute even if calibration disabled - measured vs library RT)
             double rtDeviation = apexSpectrum.RetentionTime - expectedRt;
             double absRtDeviation = Math.Abs(rtDeviation);
@@ -1578,9 +1572,9 @@ namespace pwiz.OspreySharp.Tasks
 
             // Build full 21-element PIN feature vector
             double[] features = new double[NUM_PIN_FEATURES];
-            features[0] = coelutionSum;
-            features[1] = coelutionMax;
-            features[2] = nCoelutingFragments;
+            features[0] = OspreyFeatureCalculators.Get(0).Calculate(ospreyContext, ospreyPeakData);
+            features[1] = OspreyFeatureCalculators.Get(1).Calculate(ospreyContext, ospreyPeakData);
+            features[2] = OspreyFeatureCalculators.Get(2).Calculate(ospreyContext, ospreyPeakData);
             features[3] = OspreyFeatureCalculators.Get(3).Calculate(ospreyContext, ospreyPeakData);
             features[4] = OspreyFeatureCalculators.Get(4).Calculate(ospreyContext, ospreyPeakData);
             features[5] = OspreyFeatureCalculators.Get(5).Calculate(ospreyContext, ospreyPeakData);
@@ -1722,8 +1716,8 @@ namespace pwiz.OspreySharp.Tasks
                 ApexRt = apexSpectrum.RetentionTime,
                 StartRt = windowRts[startScan + bestPeak.StartIndex],
                 EndRt = windowRts[startScan + bestPeak.EndIndex],
-                CoelutionSum = coelutionSum,
-                Score = coelutionSum,
+                CoelutionSum = features[0],
+                Score = features[0],
                 ModifiedSequence = candidate.ModifiedSequence,
                 Features = features,
                 CwtCandidates = cwtCandidatesOut,
@@ -1839,62 +1833,6 @@ namespace pwiz.OspreySharp.Tasks
             }
 
             return xics;
-        }
-
-
-        /// <summary>
-        /// Compute coelution sum/max and count of positively-correlated fragments
-        /// from pairwise fragment correlations.
-        /// </summary>
-        private void ComputeCoelutionStats(
-            List<XicData> xics, XICPeakBounds peak,
-            out double sum, out double max, out int nCoeluting)
-        {
-            sum = 0.0;
-            max = 0.0;
-            nCoeluting = 0;
-
-            if (xics.Count < 2)
-                return;
-
-            // Per-fragment mean pairwise correlation. A fragment is "coeluting" if
-            // its mean pairwise correlation is > 0. Matches Rust pipeline.rs:5049-5058
-            // which averages per_frag_corr_sum[i]/count and checks > 0.
-            double[] fragCorrSum = new double[xics.Count];
-            int[] fragCorrCount = new int[xics.Count];
-            bool haveAny = false;
-            double maxCorr = double.NegativeInfinity;
-
-            for (int i = 0; i < xics.Count; i++)
-            {
-                for (int j = i + 1; j < xics.Count; j++)
-                {
-                    double corr = ScoringMath.PearsonCorrelationInRange(
-                        xics[i].Intensities, xics[j].Intensities,
-                        peak.StartIndex, peak.EndIndex);
-                    if (double.IsNaN(corr))
-                        continue;
-
-                    sum += corr;
-                    if (corr > maxCorr)
-                        maxCorr = corr;
-                    haveAny = true;
-
-                    fragCorrSum[i] += corr;
-                    fragCorrCount[i]++;
-                    fragCorrSum[j] += corr;
-                    fragCorrCount[j]++;
-                }
-            }
-
-            if (haveAny)
-                max = maxCorr;
-
-            for (int i = 0; i < xics.Count; i++)
-            {
-                if (fragCorrCount[i] > 0 && fragCorrSum[i] / fragCorrCount[i] > 0.0)
-                    nCoeluting++;
-            }
         }
 
 

--- a/pwiz_tools/OspreySharp/OspreySharp/Tasks/AbstractScoringTask.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/Tasks/AbstractScoringTask.cs
@@ -1439,9 +1439,9 @@ namespace pwiz.OspreySharp.Tasks
 
             // MS1 features (precursor coelution, isotope cosine) are computed by the
             // MS1 calculators (features 13, 14) below from the published per-window
-            // MS1 machinery (ospreyContext.SetMs1Machinery) and the per-candidate
-            // ScanRetentionTimes slice built into ospreyPeakData.Set. The HRAM gate
-            // (Rust pipeline.rs:5362 is_hram) lives in the calculators.
+            // MS1 machinery (ospreyContext.SetMs1Machinery) and the window RT axis
+            // (windowRts) passed to ospreyPeakData.Set. The HRAM gate (Rust
+            // pipeline.rs:5362 is_hram) lives in the calculators.
 
             // Per-candidate state for the modular feature calculators. Reused
             // window-local instances (see RunCoelutionScoring); ClearByproducts
@@ -1449,16 +1449,12 @@ namespace pwiz.OspreySharp.Tasks
             // median-polish publish below so that byproduct survives to the
             // calculators. Calculator-backed features mirror Skyline's
             // IPeakFeatureCalculator; the rest stay inline until extracted.
+            // windowRts is passed by reference (no per-candidate copy); the MS1
+            // family maps an XIC index i to an absolute RT via windowRts[startScan + i]
+            // (= WindowRetentionTimes[WindowStartIndex + i]).
             ospreyContext.ClearByproducts();
-            // Per-candidate scan-RT slice for the MS1 family (features 13, 14): the
-            // inline ComputeMs1Features mapped XIC index i -> windowRts[startScan + i].
-            // Reproduce THAT array exactly (do not substitute Xics[*].RetentionTimes).
-            int ms1Len = xics.Count > 0 ? xics[0].Intensities.Length : 0;
-            var scanRts = new double[ms1Len];
-            for (int i = 0; i < ms1Len; i++)
-                scanRts[i] = windowRts[startScan + i];
             ospreyPeakData.Set(candidate, bestPeak, xics, apexSpectrum.RetentionTime, expectedRt, apexSpectrum,
-                apexGlobalIdx, bestPeak.ApexIndex, startScan, rangeLen, windowSpectra, scanRts);
+                apexGlobalIdx, bestPeak.ApexIndex, startScan, rangeLen, windowSpectra, windowRts);
 
             // Tukey median-polish inputs + fit (features 15, 16, 19, 20). The crop,
             // WriteMpInputsRow, and Compute stay here because the bisection
@@ -1493,7 +1489,13 @@ namespace pwiz.OspreySharp.Tasks
                     candidate.Id, apexSpectrum.ScanNumber, peakXics, peakRts);
 
                 var polish = TukeyMedianPolish.Compute(peakXics, peakRts, 10, 0.01);
-                ospreyContext.AddInfo(new MedianPolishByproduct(polish, peakXics));
+                // Only publish when the fit converged. Every consumer (the four
+                // calculators and the WriteMpDump guard) treats a missing byproduct
+                // and a byproduct with null Polish identically (family default / no
+                // dump), so skipping the publish on a null fit is value-identical and
+                // avoids the allocation.
+                if (polish != null)
+                    ospreyContext.AddInfo(new MedianPolishByproduct(polish, peakXics));
             }
 
             // Build full 21-element PIN feature vector

--- a/pwiz_tools/OspreySharp/OspreySharp/Tasks/AbstractScoringTask.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/Tasks/AbstractScoringTask.cs
@@ -724,6 +724,7 @@ namespace pwiz.OspreySharp.Tasks
             var ospreyContext = new OspreyScoringContext(config);
             ospreyContext.SetWindow(context.Resolution, preprocessedXcorr, scorer,
                 context.XcorrScratchPool);
+            ospreyContext.SetMs1Machinery(context.Resolution.HasMs1Features, ms1Spectra, ms1Calibration);
             var ospreyPeakData = new OspreyPeakData();
 
             try
@@ -1436,30 +1437,11 @@ namespace pwiz.OspreySharp.Tasks
             // (features 7-10) moved to the apex-match calculators below.
             byte top6Matches = CountTop6Matches(candidate, apexSpectrum, config);
 
-            // MS1 features: precursor coelution, isotope cosine.
-            // Rust pipeline.rs:5362 gates on is_hram - unit resolution skips MS1.
-            double ms1PrecursorCoelution = 0.0;
-            double ms1IsotopeCosine = 0.0;
-            if (resolution.HasMs1Features && ms1Spectra != null && ms1Spectra.Count > 0)
-            {
-                // Find reference XIC (highest total intensity) for MS1 coelution.
-                // Same selection as ComputePeakShapeFeatures and Rust pipeline.rs.
-                int ms1RefIdx = 0;
-                double ms1BestTotal = 0.0;
-                for (int f = 0; f < xics.Count; f++)
-                {
-                    double total = 0.0;
-                    double[] inten = xics[f].Intensities;
-                    for (int k = 0; k < inten.Length; k++)
-                        total += inten[k];
-                    if (total >= ms1BestTotal) { ms1BestTotal = total; ms1RefIdx = f; }
-                }
-                ComputeMs1Features(
-                    candidate, xics, ms1RefIdx, bestPeak,
-                    windowRts, startScan,
-                    ms1Spectra, ms1Calibration, config,
-                    out ms1PrecursorCoelution, out ms1IsotopeCosine);
-            }
+            // MS1 features (precursor coelution, isotope cosine) are computed by the
+            // MS1 calculators (features 13, 14) below from the published per-window
+            // MS1 machinery (ospreyContext.SetMs1Machinery) and the per-candidate
+            // ScanRetentionTimes slice built into ospreyPeakData.Set. The HRAM gate
+            // (Rust pipeline.rs:5362 is_hram) lives in the calculators.
 
             // Per-candidate state for the modular feature calculators. Reused
             // window-local instances (see RunCoelutionScoring); ClearByproducts
@@ -1468,8 +1450,15 @@ namespace pwiz.OspreySharp.Tasks
             // calculators. Calculator-backed features mirror Skyline's
             // IPeakFeatureCalculator; the rest stay inline until extracted.
             ospreyContext.ClearByproducts();
+            // Per-candidate scan-RT slice for the MS1 family (features 13, 14): the
+            // inline ComputeMs1Features mapped XIC index i -> windowRts[startScan + i].
+            // Reproduce THAT array exactly (do not substitute Xics[*].RetentionTimes).
+            int ms1Len = xics.Count > 0 ? xics[0].Intensities.Length : 0;
+            var scanRts = new double[ms1Len];
+            for (int i = 0; i < ms1Len; i++)
+                scanRts[i] = windowRts[startScan + i];
             ospreyPeakData.Set(candidate, bestPeak, xics, apexSpectrum.RetentionTime, expectedRt, apexSpectrum,
-                apexGlobalIdx, bestPeak.ApexIndex, startScan, rangeLen, windowSpectra);
+                apexGlobalIdx, bestPeak.ApexIndex, startScan, rangeLen, windowSpectra, scanRts);
 
             // Tukey median-polish inputs + fit (features 15, 16, 19, 20). The crop,
             // WriteMpInputsRow, and Compute stay here because the bisection
@@ -1522,8 +1511,8 @@ namespace pwiz.OspreySharp.Tasks
             features[10] = OspreyFeatureCalculators.Get(10).Calculate(ospreyContext, ospreyPeakData);
             features[11] = OspreyFeatureCalculators.Get(11).Calculate(ospreyContext, ospreyPeakData);
             features[12] = OspreyFeatureCalculators.Get(12).Calculate(ospreyContext, ospreyPeakData);
-            features[13] = ms1PrecursorCoelution;
-            features[14] = ms1IsotopeCosine;
+            features[13] = OspreyFeatureCalculators.Get(13).Calculate(ospreyContext, ospreyPeakData);
+            features[14] = OspreyFeatureCalculators.Get(14).Calculate(ospreyContext, ospreyPeakData);
             features[15] = OspreyFeatureCalculators.Get(15).Calculate(ospreyContext, ospreyPeakData);
             features[16] = OspreyFeatureCalculators.Get(16).Calculate(ospreyContext, ospreyPeakData);
             features[17] = OspreyFeatureCalculators.Get(17).Calculate(ospreyContext, ospreyPeakData);
@@ -1790,137 +1779,15 @@ namespace pwiz.OspreySharp.Tasks
 
 
         /// <summary>
-        /// Compute MS1 features: correlation between the summed fragment XIC and the
-        /// precursor MS1 XIC, and cosine similarity between the observed isotope envelope
-        /// at the apex MS1 scan and the theoretical averagine envelope.
-        /// </summary>
-        private void ComputeMs1Features(
-            LibraryEntry candidate,
-            List<XicData> xics,
-            int refXicIdx,
-            XICPeakBounds peak,
-            double[] windowRts, int startScan,
-            List<MS1Spectrum> ms1Spectra,
-            MzCalibrationResult ms1Calibration,
-            OspreyConfig config,
-            out double ms1PrecursorCoelution,
-            out double ms1IsotopeCosine)
-        {
-            ms1PrecursorCoelution = 0.0;
-            ms1IsotopeCosine = 0.0;
-
-            if (xics.Count == 0 || ms1Spectra == null || ms1Spectra.Count == 0)
-                return;
-
-            int len = xics[0].Intensities.Length;
-            if (len == 0)
-                return;
-
-            int start = Math.Max(0, peak.StartIndex);
-            int end = Math.Min(len - 1, peak.EndIndex);
-            if (end - start + 1 < 3)
-                return;
-
-            // MS1 calibration: reverse-calibrate search m/z and use calibrated tolerance.
-            // Matches Rust pipeline.rs:5363-5370 (reverse_calibrate_mz + calibrated_tolerance_ppm).
-            double baseTolPpm = 10.0;
-            double ms1TolPpm = baseTolPpm;
-            double searchMz = candidate.PrecursorMz;
-            if (ms1Calibration != null && ms1Calibration.Calibrated)
-            {
-                // calibrated_tolerance_ppm: max(3*SD, 1.0) ppm
-                ms1TolPpm = Math.Max(3.0 * ms1Calibration.SD, 1.0);
-                // reverse_calibrate_mz: observed ~ theoretical + offset
-                if (ms1Calibration.Unit == "Th")
-                    searchMz = candidate.PrecursorMz + ms1Calibration.Mean;
-                else
-                    searchMz = candidate.PrecursorMz * (1.0 + ms1Calibration.Mean / 1e6);
-            }
-
-            // Correlate MS1 precursor intensity with reference XIC (not summed fragment).
-            // Rust pipeline.rs:5373-5389: uses ref_xic[start..=end], skips missing MS1.
-            double[] refIntensities = xics[refXicIdx].Intensities;
-            var ms1Intensities = new List<double>();
-            var refValues = new List<double>();
-
-            for (int i = start; i <= end; i++)
-            {
-                double rt = windowRts[startScan + i];
-                var ms1 = FindNearestMs1(ms1Spectra, rt);
-                if (ms1 != null)
-                {
-                    var peakInfo = ms1.FindPeakPpm(searchMz, ms1TolPpm);
-                    double intensity = peakInfo.HasValue ? peakInfo.Value.Intensity : 0.0;
-                    ms1Intensities.Add(intensity);
-                    refValues.Add(i < refIntensities.Length ? refIntensities[i] : 0.0);
-                }
-            }
-
-            if (ms1Intensities.Count >= 3)
-            {
-                double[] ms1Arr = ms1Intensities.ToArray();
-                double[] refArr = refValues.ToArray();
-                ms1PrecursorCoelution = ScoringMath.PearsonCorrelationInRange(ms1Arr, refArr, 0, ms1Arr.Length - 1);
-                if (double.IsNaN(ms1PrecursorCoelution))
-                    ms1PrecursorCoelution = 0.0;
-            }
-
-            // Isotope cosine at apex MS1 scan.
-            // Rust pipeline.rs:5393-5404: gates on envelope.has_m0().
-            int apex = Math.Max(start, Math.Min(end, peak.ApexIndex));
-            double apexRt = windowRts[startScan + apex];
-            var apexMs1 = FindNearestMs1(ms1Spectra, apexRt);
-            if (apexMs1 != null)
-            {
-                int charge = candidate.Charge > 0 ? candidate.Charge : 1;
-                var envelope = IsotopeEnvelope.Extract(
-                    apexMs1, searchMz, charge, ms1TolPpm);
-
-                // Gate: skip if M0 peak is missing (matches Rust envelope.has_m0())
-                if (envelope.Intensities != null && envelope.Intensities.Length > 1
-                    && envelope.Intensities[1] > 0.0) // index 1 = M0 (M-1 at 0)
-                {
-                    // Sequence-based isotope distribution, matching Rust
-                    // pipeline.rs:5400 peptide_isotope_cosine.
-                    double score = IsotopeDistribution.PeptideIsotopeCosine(
-                        candidate.Sequence, envelope.Intensities);
-                    if (score >= 0.0)
-                        ms1IsotopeCosine = score;
-                }
-            }
-        }
-
-
-        /// <summary>
         /// Find the MS1 spectrum with retention time closest to the given RT.
-        /// Assumes MS1 spectra are sorted by RT.
+        /// Assumes MS1 spectra are sorted by RT. Thin forwarder to the single
+        /// implementation in Core (<see cref="MS1Spectrum.FindNearest"/>) so the
+        /// harness (here + <c>Calibrator</c>) and the MS1 feature calculators share
+        /// one binary search / tie-break and cannot drift.
         /// </summary>
         internal static MS1Spectrum FindNearestMs1(List<MS1Spectrum> ms1Spectra, double rt)
         {
-            if (ms1Spectra == null || ms1Spectra.Count == 0)
-                return null;
-
-            int lo = 0;
-            int hi = ms1Spectra.Count;
-            while (lo < hi)
-            {
-                int mid = lo + (hi - lo) / 2;
-                if (ms1Spectra[mid].RetentionTime < rt)
-                    lo = mid + 1;
-                else
-                    hi = mid;
-            }
-
-            if (lo >= ms1Spectra.Count)
-                return ms1Spectra[ms1Spectra.Count - 1];
-            if (lo == 0)
-                return ms1Spectra[0];
-
-            var prev = ms1Spectra[lo - 1];
-            var next = ms1Spectra[lo];
-            return Math.Abs(prev.RetentionTime - rt) <= Math.Abs(next.RetentionTime - rt)
-                ? prev
-                : next;
+            return MS1Spectrum.FindNearest(ms1Spectra, rt);
         }
 
 

--- a/pwiz_tools/OspreySharp/OspreySharp/Tasks/AbstractScoringTask.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/Tasks/AbstractScoringTask.cs
@@ -1451,10 +1451,6 @@ namespace pwiz.OspreySharp.Tasks
 
 
 
-            // RT deviation (absolute even if calibration disabled - measured vs library RT)
-            double rtDeviation = apexSpectrum.RetentionTime - expectedRt;
-            double absRtDeviation = Math.Abs(rtDeviation);
-
             // Count consecutive ions
             byte consecutiveIons = CountConsecutiveIons(candidate, apexSpectrum, config);
 
@@ -1518,7 +1514,7 @@ namespace pwiz.OspreySharp.Tasks
             // calculators. Calculator-backed features mirror Skyline's
             // IPeakFeatureCalculator; the rest stay inline until extracted.
             ospreyContext.ClearByproducts();
-            ospreyPeakData.Set(candidate, bestPeak, xics);
+            ospreyPeakData.Set(candidate, bestPeak, xics, apexSpectrum.RetentionTime, expectedRt);
 
             // Tukey median-polish inputs + fit (features 15, 16, 19, 20). The crop,
             // WriteMpInputsRow, and Compute stay here because the bisection
@@ -1569,8 +1565,8 @@ namespace pwiz.OspreySharp.Tasks
             features[8] = explainedIntensity;
             features[9] = massAccuracyMean;
             features[10] = absMassAccuracyMean;
-            features[11] = rtDeviation;
-            features[12] = absRtDeviation;
+            features[11] = OspreyFeatureCalculators.Get(11).Calculate(ospreyContext, ospreyPeakData);
+            features[12] = OspreyFeatureCalculators.Get(12).Calculate(ospreyContext, ospreyPeakData);
             features[13] = ms1PrecursorCoelution;
             features[14] = ms1IsotopeCosine;
             features[15] = OspreyFeatureCalculators.Get(15).Calculate(ospreyContext, ospreyPeakData);

--- a/pwiz_tools/OspreySharp/OspreySharp/Tasks/AbstractScoringTask.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/Tasks/AbstractScoringTask.cs
@@ -727,6 +727,15 @@ namespace pwiz.OspreySharp.Tasks
             var preprocessedXcorr = context.Resolution.PreprocessWindowSpectra(
                 windowSpectra, scorer, context.XcorrScratchPool);
 
+            // Reused per-window scoring context + peak-data adapter for the
+            // modular feature calculators. The per-candidate loop mutates them in
+            // place (ClearByproducts + Set) so scoring allocates no context /
+            // peak-data per candidate. Windows are scored on separate threads
+            // (Parallel.For above), so these are window-local, never shared task
+            // state.
+            var ospreyContext = new OspreyScoringContext(config);
+            var ospreyPeakData = new OspreyPeakData();
+
             try
             {
                 // Score each candidate
@@ -737,7 +746,8 @@ namespace pwiz.OspreySharp.Tasks
                         preprocessedXcorr,
                         ms1Spectra, rtCalibration, ms1Calibration,
                         globalRtTolerance, rtSigma,
-                        scorer, context);
+                        scorer, context,
+                        ospreyContext, ospreyPeakData);
 
                     if (fdrEntry != null)
                         entries.Add(fdrEntry);
@@ -863,7 +873,9 @@ namespace pwiz.OspreySharp.Tasks
             double globalRtTolerance,
             double rtSigma,
             SpectralScorer scorer,
-            ScoringContext context)
+            ScoringContext context,
+            OspreyScoringContext ospreyContext,
+            OspreyPeakData ospreyPeakData)
         {
             var config = context.Config;
             var resolution = context.Resolution;
@@ -1445,11 +1457,6 @@ namespace pwiz.OspreySharp.Tasks
             ComputeCoelutionStats(xics, bestPeak,
                 out coelutionSum, out coelutionMax, out nCoelutingFragments);
 
-            // Peak shape features: apex, area, sharpness
-            double peakApex, peakArea, peakSharpness;
-            ComputePeakShapeFeatures(xics, bestPeak,
-                out peakApex, out peakArea, out peakSharpness);
-
             // RT deviation (absolute even if calibration disabled - measured vs library RT)
             double rtDeviation = apexSpectrum.RetentionTime - expectedRt;
             double absRtDeviation = Math.Abs(rtDeviation);
@@ -1561,14 +1568,22 @@ namespace pwiz.OspreySharp.Tasks
                 }
             }
 
+            // Per-candidate state for the modular feature calculators. Reused
+            // window-local instances (see RunCoelutionScoring); ClearByproducts
+            // resets the per-candidate byproduct cache. Calculator-backed features
+            // mirror Skyline's IPeakFeatureCalculator; the rest stay inline until
+            // their family is extracted.
+            ospreyContext.ClearByproducts();
+            ospreyPeakData.Set(candidate, bestPeak, xics);
+
             // Build full 21-element PIN feature vector
             double[] features = new double[NUM_PIN_FEATURES];
             features[0] = coelutionSum;
             features[1] = coelutionMax;
             features[2] = nCoelutingFragments;
-            features[3] = peakApex;
-            features[4] = peakArea;
-            features[5] = peakSharpness;
+            features[3] = OspreyFeatureCalculators.Get(3).Calculate(ospreyContext, ospreyPeakData);
+            features[4] = OspreyFeatureCalculators.Get(4).Calculate(ospreyContext, ospreyPeakData);
+            features[5] = OspreyFeatureCalculators.Get(5).Calculate(ospreyContext, ospreyPeakData);
             features[6] = xcorr;
             features[7] = consecutiveIons;
             features[8] = explainedIntensity;
@@ -1880,111 +1895,6 @@ namespace pwiz.OspreySharp.Tasks
                 if (fragCorrCount[i] > 0 && fragCorrSum[i] / fragCorrCount[i] > 0.0)
                     nCoeluting++;
             }
-        }
-
-
-        /// <summary>
-        /// Compute peak shape features at the detected peak boundaries: summed XIC
-        /// apex intensity, area under the summed XIC, and sharpness (apex / mean edge).
-        /// </summary>
-        private void ComputePeakShapeFeatures(
-            List<XicData> xics, XICPeakBounds peak,
-            out double peakApex, out double peakArea, out double peakSharpness)
-        {
-            peakApex = 0.0;
-            peakArea = 0.0;
-            peakSharpness = 0.0;
-
-            if (xics.Count == 0)
-                return;
-
-            int len = xics[0].Intensities.Length;
-            if (len == 0)
-                return;
-
-            int start = Math.Max(0, peak.StartIndex);
-            int end = Math.Min(len - 1, peak.EndIndex);
-            int apex = Math.Max(start, Math.Min(end, peak.ApexIndex));
-
-            if (start > end)
-                return;
-
-            // Use reference XIC (highest total intensity), matching Rust
-            // pipeline.rs:7140-7148. Rust's `xics.iter().max_by(...)`
-            // returns the LAST equal element on ties (per Iterator::max_by
-            // doc), so use `>=` here, NOT `>`. Without this, the first
-            // tied fragment wins on the C# side while Rust picks the
-            // last, producing divergent peak_apex / peak_area /
-            // peak_sharpness when fragments tie on total intensity.
-            int refIdx = 0;
-            double bestTotal = -1.0;
-            for (int f = 0; f < xics.Count; f++)
-            {
-                double total = 0.0;
-                double[] inten = xics[f].Intensities;
-                for (int i = 0; i < inten.Length; i++)
-                    total += inten[i];
-                if (total >= bestTotal)
-                {
-                    bestTotal = total;
-                    refIdx = f;
-                }
-            }
-
-            double[] refInten = xics[refIdx].Intensities;
-            double[] refRts = xics[refIdx].RetentionTimes;
-
-            // peak_apex == intensity at peak.ApexIndex in the reference
-            // XIC. This matches Rust pipeline.rs:6547 which sets
-            // `peak_apex: peak.apex_intensity` (the value already
-            // assigned in BuildOverridePeaks / the CWT-path FindPeaks).
-            //
-            // Earlier C# implementations recomputed apex as the local
-            // max in `ref_xic[start..=end]`. That recomputation diverges
-            // from Rust on the OVERRIDE path: there, Rust deliberately
-            // uses the override-supplied apex_index even when a
-            // different scan in [start..=end] has higher intensity (the
-            // override is the authoritative apex for reconciliation /
-            // gap-fill scoring). The local-max approach put C# at
-            // ~32k row peak_apex / peak_sharpness divergence vs Rust on
-            // the reconciled .scores.parquet.
-            //
-            // Use peak.ApexIndex (clipped above) and look up the
-            // intensity directly. Sharpness slopes below also use this
-            // apex position so the left/right edges align with what
-            // Rust computes.
-            int apexIdx = apex;
-            double apexVal = refInten[apexIdx];
-            peakApex = apexVal;
-
-            // Area: trapezoidal integration on the reference XIC.
-            // Matches Rust trapezoidal_area(ref_xic[si..=ei]).
-            double area = 0.0;
-            for (int i = start; i < end; i++)
-            {
-                double dt = refRts[i + 1] - refRts[i];
-                double avgHeight = (refInten[i] + refInten[i + 1]) * 0.5;
-                area += avgHeight * dt;
-            }
-            peakArea = area;
-
-            // Sharpness: mean of left and right slopes on the reference XIC.
-            // Matches Rust pipeline.rs:5212-5234.
-            double leftSlope = 0.0;
-            if (apexIdx > start)
-            {
-                double dt = refRts[apexIdx] - refRts[start];
-                if (dt > 1e-10)
-                    leftSlope = (apexVal - refInten[start]) / dt;
-            }
-            double rightSlope = 0.0;
-            if (end > apexIdx)
-            {
-                double dt = refRts[end] - refRts[apexIdx];
-                if (dt > 1e-10)
-                    rightSlope = (apexVal - refInten[end]) / dt;
-            }
-            peakSharpness = (leftSlope + rightSlope) * 0.5;
         }
 
 

--- a/pwiz_tools/OspreySharp/OspreySharp/Tasks/AbstractScoringTask.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/Tasks/AbstractScoringTask.cs
@@ -108,18 +108,6 @@ namespace pwiz.OspreySharp.Tasks
         internal static readonly SemaphoreSlim s_mzmlReadGate = new SemaphoreSlim(1, 1);
 
 
-        // Savitzky-Golay quadratic filter weights for length 5, center offset.
-        // Matches Rust pipeline.rs sg_weights: [-3/35, 12/35, 17/35, 12/35, -3/35].
-        private static readonly double[] SG_WEIGHTS =
-        {
-            -3.0 / 35.0,
-            12.0 / 35.0,
-            17.0 / 35.0,
-            12.0 / 35.0,
-            -3.0 / 35.0,
-        };
-
-
         // Calibration XCorr always uses unit-resolution bins (~2K) regardless of
         // instrument resolution mode. Matches the spec in Rust osprey
         // docs/02-calibration.md ("Comet-style XCorr (unit resolution, BLAS
@@ -734,6 +722,8 @@ namespace pwiz.OspreySharp.Tasks
             // (Parallel.For above), so these are window-local, never shared task
             // state.
             var ospreyContext = new OspreyScoringContext(config);
+            ospreyContext.SetWindow(context.Resolution, preprocessedXcorr, scorer,
+                context.XcorrScratchPool);
             var ospreyPeakData = new OspreyPeakData();
 
             try
@@ -743,7 +733,6 @@ namespace pwiz.OspreySharp.Tasks
                 {
                     var fdrEntry = ScoreCandidate(
                         candidate, windowSpectra, windowRts,
-                        preprocessedXcorr,
                         ms1Spectra, rtCalibration, ms1Calibration,
                         globalRtTolerance, rtSigma,
                         scorer, context,
@@ -866,7 +855,6 @@ namespace pwiz.OspreySharp.Tasks
             LibraryEntry candidate,
             List<Spectrum> windowSpectra,
             double[] windowRts,
-            WindowXcorrCache preprocessedXcorr,
             List<MS1Spectrum> ms1Spectra,
             RTCalibration rtCalibration,
             MzCalibrationResult ms1Calibration,
@@ -1443,14 +1431,6 @@ namespace pwiz.OspreySharp.Tasks
             // LibCosine at apex
             double libCosine = scorer.LibCosine(apexSpectrum, candidate, config.FragmentTolerance);
 
-            // XCorr at apex via the resolution strategy. Pool avoids per-
-            // call 100K-bin LOH allocation on HRAM (no-op on Unit-res).
-            double xcorr = resolution.ScoreXcorr(
-                preprocessedXcorr, apexGlobalIdx, apexSpectrum, candidate, scorer,
-                context.XcorrScratchPool);
-
-
-
             // Count fragment matches (top-6 dedup byproduct, NOT a PIN feature;
             // stays inline). consecutive_ions / explained_intensity / mass-accuracy
             // (features 7-10) moved to the apex-match calculators below.
@@ -1481,26 +1461,6 @@ namespace pwiz.OspreySharp.Tasks
                     out ms1PrecursorCoelution, out ms1IsotopeCosine);
             }
 
-            // Savitzky-Golay weighted spectral scores at apex +/- 2 scans.
-            // Matches Rust pipeline.rs sg_xcorr / sg_cosine. Uses candidate-local
-            // indices (within startScan..endScan) not global window indices, matching
-            // Rust's cand_spectra bounds. Cosine uses mass-range-filtered matching
-            // (compute_cosine_at_scan) not LibCosine.
-            double sgXcorr = 0.0;
-            double sgCosine = 0.0;
-            for (int offset = -2; offset <= 2; offset++)
-            {
-                double weight = SG_WEIGHTS[offset + 2];
-                int candIdx = bestPeak.ApexIndex + offset;
-                if (candIdx < 0 || candIdx >= rangeLen)
-                    continue;
-                int globalIdx = startScan + candIdx;
-                var s = windowSpectra[globalIdx];
-                sgXcorr += resolution.ScoreXcorr(preprocessedXcorr, globalIdx, s, candidate, scorer,
-                    context.XcorrScratchPool) * weight;
-                sgCosine += ComputeCosineAtScan(candidate, s, config) * weight;
-            }
-
             // Per-candidate state for the modular feature calculators. Reused
             // window-local instances (see RunCoelutionScoring); ClearByproducts
             // resets the per-candidate byproduct cache. Done BEFORE the
@@ -1508,7 +1468,8 @@ namespace pwiz.OspreySharp.Tasks
             // calculators. Calculator-backed features mirror Skyline's
             // IPeakFeatureCalculator; the rest stay inline until extracted.
             ospreyContext.ClearByproducts();
-            ospreyPeakData.Set(candidate, bestPeak, xics, apexSpectrum.RetentionTime, expectedRt, apexSpectrum);
+            ospreyPeakData.Set(candidate, bestPeak, xics, apexSpectrum.RetentionTime, expectedRt, apexSpectrum,
+                apexGlobalIdx, bestPeak.ApexIndex, startScan, rangeLen, windowSpectra);
 
             // Tukey median-polish inputs + fit (features 15, 16, 19, 20). The crop,
             // WriteMpInputsRow, and Compute stay here because the bisection
@@ -1554,7 +1515,7 @@ namespace pwiz.OspreySharp.Tasks
             features[3] = OspreyFeatureCalculators.Get(3).Calculate(ospreyContext, ospreyPeakData);
             features[4] = OspreyFeatureCalculators.Get(4).Calculate(ospreyContext, ospreyPeakData);
             features[5] = OspreyFeatureCalculators.Get(5).Calculate(ospreyContext, ospreyPeakData);
-            features[6] = xcorr;
+            features[6] = OspreyFeatureCalculators.Get(6).Calculate(ospreyContext, ospreyPeakData);
             features[7] = OspreyFeatureCalculators.Get(7).Calculate(ospreyContext, ospreyPeakData);
             features[8] = OspreyFeatureCalculators.Get(8).Calculate(ospreyContext, ospreyPeakData);
             features[9] = OspreyFeatureCalculators.Get(9).Calculate(ospreyContext, ospreyPeakData);
@@ -1565,8 +1526,8 @@ namespace pwiz.OspreySharp.Tasks
             features[14] = ms1IsotopeCosine;
             features[15] = OspreyFeatureCalculators.Get(15).Calculate(ospreyContext, ospreyPeakData);
             features[16] = OspreyFeatureCalculators.Get(16).Calculate(ospreyContext, ospreyPeakData);
-            features[17] = sgXcorr;
-            features[18] = sgCosine;
+            features[17] = OspreyFeatureCalculators.Get(17).Calculate(ospreyContext, ospreyPeakData);
+            features[18] = OspreyFeatureCalculators.Get(18).Calculate(ospreyContext, ospreyPeakData);
             features[19] = OspreyFeatureCalculators.Get(19).Calculate(ospreyContext, ospreyPeakData);
             features[20] = OspreyFeatureCalculators.Get(20).Calculate(ospreyContext, ospreyPeakData);
 
@@ -1825,72 +1786,6 @@ namespace pwiz.OspreySharp.Tasks
             }
 
             return xics;
-        }
-
-
-        /// <summary>
-        /// Compute cosine similarity at a single scan, filtering fragments to the
-        /// spectrum's observed m/z range. Matches Rust compute_cosine_at_scan in
-        /// osprey-scoring/src/lib.rs:382. Unlike LibCosine, fragments outside the
-        /// spectrum's mass range are excluded (not treated as zero-intensity pairs).
-        /// </summary>
-        private static double ComputeCosineAtScan(
-            LibraryEntry candidate, Spectrum spectrum, OspreyConfig config)
-        {
-            if (candidate.Fragments == null || candidate.Fragments.Count == 0 ||
-                spectrum.Mzs == null || spectrum.Mzs.Length == 0)
-                return 0.0;
-
-            double specMzMin = spectrum.Mzs[0];
-            double specMzMax = spectrum.Mzs[spectrum.Mzs.Length - 1];
-
-            var libPre = new List<double>();
-            var obsPre = new List<double>();
-
-            foreach (var frag in candidate.Fragments)
-            {
-                // Skip fragments outside the spectrum's mass range
-                if (frag.Mz < specMzMin || frag.Mz > specMzMax)
-                    continue;
-
-                double tolDa = config.FragmentTolerance.ToleranceDa(frag.Mz);
-                double lower = frag.Mz - tolDa;
-                double upper = frag.Mz + tolDa;
-
-                int lo = ScoringMath.BinarySearchLowerBound(spectrum.Mzs, lower);
-                double bestIntensity = 0.0;
-                double bestDiff = double.MaxValue;
-
-                for (int k = lo; k < spectrum.Mzs.Length && spectrum.Mzs[k] <= upper; k++)
-                {
-                    double diff = Math.Abs(spectrum.Mzs[k] - frag.Mz);
-                    if (diff < bestDiff)
-                    {
-                        bestDiff = diff;
-                        bestIntensity = spectrum.Intensities[k];
-                    }
-                }
-
-                libPre.Add(Math.Sqrt(frag.RelativeIntensity));
-                obsPre.Add(Math.Sqrt(bestIntensity));
-            }
-
-            if (libPre.Count == 0)
-                return 0.0;
-
-            // L2 normalize and dot product
-            double libNorm = 0, obsNorm = 0, dot = 0;
-            for (int i = 0; i < libPre.Count; i++)
-            {
-                libNorm += libPre[i] * libPre[i];
-                obsNorm += obsPre[i] * obsPre[i];
-                dot += libPre[i] * obsPre[i];
-            }
-            libNorm = Math.Sqrt(libNorm);
-            obsNorm = Math.Sqrt(obsNorm);
-            if (libNorm < 1e-12 || obsNorm < 1e-12)
-                return 0.0;
-            return dot / (libNorm * obsNorm);
         }
 
 

--- a/pwiz_tools/OspreySharp/OspreySharp/Tasks/AbstractScoringTask.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/Tasks/AbstractScoringTask.cs
@@ -1451,16 +1451,10 @@ namespace pwiz.OspreySharp.Tasks
 
 
 
-            // Count consecutive ions
-            byte consecutiveIons = CountConsecutiveIons(candidate, apexSpectrum, config);
-
-            // Count fragment matches
+            // Count fragment matches (top-6 dedup byproduct, NOT a PIN feature;
+            // stays inline). consecutive_ions / explained_intensity / mass-accuracy
+            // (features 7-10) moved to the apex-match calculators below.
             byte top6Matches = CountTop6Matches(candidate, apexSpectrum, config);
-
-            // Explained intensity, mass accuracy at apex
-            double explainedIntensity, massAccuracyMean, absMassAccuracyMean;
-            ComputeApexMatchFeatures(candidate, apexSpectrum, config,
-                out explainedIntensity, out massAccuracyMean, out absMassAccuracyMean);
 
             // MS1 features: precursor coelution, isotope cosine.
             // Rust pipeline.rs:5362 gates on is_hram - unit resolution skips MS1.
@@ -1514,7 +1508,7 @@ namespace pwiz.OspreySharp.Tasks
             // calculators. Calculator-backed features mirror Skyline's
             // IPeakFeatureCalculator; the rest stay inline until extracted.
             ospreyContext.ClearByproducts();
-            ospreyPeakData.Set(candidate, bestPeak, xics, apexSpectrum.RetentionTime, expectedRt);
+            ospreyPeakData.Set(candidate, bestPeak, xics, apexSpectrum.RetentionTime, expectedRt, apexSpectrum);
 
             // Tukey median-polish inputs + fit (features 15, 16, 19, 20). The crop,
             // WriteMpInputsRow, and Compute stay here because the bisection
@@ -1561,10 +1555,10 @@ namespace pwiz.OspreySharp.Tasks
             features[4] = OspreyFeatureCalculators.Get(4).Calculate(ospreyContext, ospreyPeakData);
             features[5] = OspreyFeatureCalculators.Get(5).Calculate(ospreyContext, ospreyPeakData);
             features[6] = xcorr;
-            features[7] = consecutiveIons;
-            features[8] = explainedIntensity;
-            features[9] = massAccuracyMean;
-            features[10] = absMassAccuracyMean;
+            features[7] = OspreyFeatureCalculators.Get(7).Calculate(ospreyContext, ospreyPeakData);
+            features[8] = OspreyFeatureCalculators.Get(8).Calculate(ospreyContext, ospreyPeakData);
+            features[9] = OspreyFeatureCalculators.Get(9).Calculate(ospreyContext, ospreyPeakData);
+            features[10] = OspreyFeatureCalculators.Get(10).Calculate(ospreyContext, ospreyPeakData);
             features[11] = OspreyFeatureCalculators.Get(11).Calculate(ospreyContext, ospreyPeakData);
             features[12] = OspreyFeatureCalculators.Get(12).Calculate(ospreyContext, ospreyPeakData);
             features[13] = ms1PrecursorCoelution;
@@ -1901,104 +1895,6 @@ namespace pwiz.OspreySharp.Tasks
 
 
         /// <summary>
-        /// Compute apex-level match features: explained intensity fraction, and mean
-        /// signed / absolute mass error (in the tolerance unit, typically ppm).
-        /// </summary>
-        private void ComputeApexMatchFeatures(
-            LibraryEntry candidate, Spectrum apexSpectrum, OspreyConfig config,
-            out double explainedIntensity,
-            out double massAccuracyMean,
-            out double absMassAccuracyMean)
-        {
-            explainedIntensity = 0.0;
-            massAccuracyMean = 0.0;
-            absMassAccuracyMean = 0.0;
-
-            // Do NOT early-return when apex spectrum or candidate fragments
-            // are empty. Rust's compute_mass_accuracy
-            // (osprey-scoring/src/lib.rs:464) handles empty inputs by
-            // returning (0.0, tolerance, tolerance) — so a candidate that
-            // reaches this function with no matchable fragments still
-            // contributes the calibrated tolerance as its abs mass error.
-            // The early-return form left absMassAccuracyMean at 0 instead,
-            // producing ~65 divergent rows on Astral (file 49: 2 rows,
-            // 55: 27 rows, 60: 36 rows). Let the matching loop run with
-            // zero iterations and fall through to the nMatched==0 fallback
-            // at the bottom of the function for cross-impl symmetry.
-            double totalIntensity = 0.0;
-            if (apexSpectrum.Intensities != null)
-            {
-                for (int i = 0; i < apexSpectrum.Intensities.Length; i++)
-                    totalIntensity += apexSpectrum.Intensities[i];
-            }
-
-            double matchedIntensity = 0.0;
-            double massErrSum = 0.0;
-            double absMassErrSum = 0.0;
-            int nMatched = 0;
-
-            if (apexSpectrum.Mzs != null && apexSpectrum.Intensities != null &&
-                candidate.Fragments != null)
-            {
-                foreach (var frag in candidate.Fragments)
-                {
-                    double tolDa = config.FragmentTolerance.ToleranceDa(frag.Mz);
-                    double lower = frag.Mz - tolDa;
-                    double upper = frag.Mz + tolDa;
-
-                    int lo = ScoringMath.BinarySearchLowerBound(apexSpectrum.Mzs, lower);
-                    double bestError = double.MaxValue;
-                    double bestIntensity = 0.0;
-                    double bestMz = 0.0;
-                    bool found = false;
-
-                    // Match closest peak by m/z (not most intense).
-                    // Matches Rust SpectralScorer::match_fragments in lib.rs:2239.
-                    for (int k = lo; k < apexSpectrum.Mzs.Length && apexSpectrum.Mzs[k] <= upper; k++)
-                    {
-                        double errorDa = Math.Abs(apexSpectrum.Mzs[k] - frag.Mz);
-                        if (errorDa < bestError)
-                        {
-                            bestError = errorDa;
-                            bestIntensity = apexSpectrum.Intensities[k];
-                            bestMz = apexSpectrum.Mzs[k];
-                            found = true;
-                        }
-                    }
-
-                    if (found)
-                    {
-                        matchedIntensity += bestIntensity;
-                        double err = config.FragmentTolerance.MassError(frag.Mz, bestMz);
-                        massErrSum += err;
-                        absMassErrSum += Math.Abs(err);
-                        nMatched++;
-                    }
-                }
-            }
-
-            if (totalIntensity > 1e-12)
-                explainedIntensity = matchedIntensity / totalIntensity;
-
-            if (nMatched > 0)
-            {
-                massAccuracyMean = massErrSum / nMatched;
-                absMassAccuracyMean = absMassErrSum / nMatched;
-            }
-            else
-            {
-                // No matched fragments: report worst-case (calibrated) tolerance
-                // as the absolute mass error, matching Rust compute_mass_accuracy
-                // which returns (0.0, tolerance, tolerance) on empty matches
-                // (osprey-scoring/src/lib.rs:462-465). This penalizes unmatched
-                // entries in FDR instead of giving them a spurious 0 error.
-                massAccuracyMean = 0.0;
-                absMassAccuracyMean = config.FragmentTolerance.Tolerance;
-            }
-        }
-
-
-        /// <summary>
         /// Compute MS1 features: correlation between the summed fragment XIC and the
         /// precursor MS1 XIC, and cosine similarity between the observed isotope envelope
         /// at the apex MS1 scan and the theoretical averagine envelope.
@@ -2191,66 +2087,6 @@ namespace pwiz.OspreySharp.Tasks
                 return 0.0;
 
             return Math.Max(0.0, Math.Min(1.0, dot / denom));
-        }
-
-
-        /// <summary>
-        /// Count consecutive b/y ion matches at the apex spectrum.
-        /// </summary>
-        private byte CountConsecutiveIons(
-            LibraryEntry entry, Spectrum spectrum, OspreyConfig config)
-        {
-            if (entry.Fragments == null || entry.Fragments.Count == 0)
-                return 0;
-
-            // Group fragments by ion type and check which ordinals match
-            var bMatched = new HashSet<int>();
-            var yMatched = new HashSet<int>();
-
-            foreach (var frag in entry.Fragments)
-            {
-                if (SpectralScorer.HasMatch(frag.Mz, spectrum.Mzs, config.FragmentTolerance))
-                {
-                    if (frag.Annotation.IonType == IonType.B)
-                        bMatched.Add(frag.Annotation.Ordinal);
-                    else if (frag.Annotation.IonType == IonType.Y)
-                        yMatched.Add(frag.Annotation.Ordinal);
-                }
-            }
-
-            // Find longest consecutive run
-            byte maxConsecutive = 0;
-            maxConsecutive = Math.Max(maxConsecutive, LongestConsecutiveRun(bMatched));
-            maxConsecutive = Math.Max(maxConsecutive, LongestConsecutiveRun(yMatched));
-
-            return maxConsecutive;
-        }
-
-
-        private byte LongestConsecutiveRun(HashSet<int> ordinals)
-        {
-            if (ordinals.Count == 0)
-                return 0;
-
-            var sorted = ordinals.OrderBy(x => x).ToList();
-            byte maxRun = 1;
-            byte currentRun = 1;
-
-            for (int i = 1; i < sorted.Count; i++)
-            {
-                if (sorted[i] == sorted[i - 1] + 1)
-                {
-                    currentRun++;
-                    if (currentRun > maxRun)
-                        maxRun = currentRun;
-                }
-                else
-                {
-                    currentRun = 1;
-                }
-            }
-
-            return maxRun;
         }
 
 

--- a/pwiz_tools/OspreySharp/OspreySharp/Tasks/AbstractScoringTask.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/Tasks/AbstractScoringTask.cs
@@ -734,7 +734,7 @@ namespace pwiz.OspreySharp.Tasks
                 {
                     var fdrEntry = ScoreCandidate(
                         candidate, windowSpectra, windowRts,
-                        ms1Spectra, rtCalibration, ms1Calibration,
+                        rtCalibration,
                         globalRtTolerance, rtSigma,
                         scorer, context,
                         ospreyContext, ospreyPeakData);
@@ -856,9 +856,7 @@ namespace pwiz.OspreySharp.Tasks
             LibraryEntry candidate,
             List<Spectrum> windowSpectra,
             double[] windowRts,
-            List<MS1Spectrum> ms1Spectra,
             RTCalibration rtCalibration,
-            MzCalibrationResult ms1Calibration,
             double globalRtTolerance,
             double rtSigma,
             SpectralScorer scorer,

--- a/pwiz_tools/OspreySharp/OspreySharp/Tasks/OspreyPeakData.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/Tasks/OspreyPeakData.cs
@@ -43,15 +43,17 @@ namespace pwiz.OspreySharp.Tasks
         private IReadOnlyList<XicData> _xics;
         private double _apexRetentionTime;
         private double _expectedRt;
+        private Spectrum _apexSpectrum;
 
         public void Set(LibraryEntry candidate, XICPeakBounds peakBounds, IReadOnlyList<XicData> xics,
-            double apexRetentionTime, double expectedRt)
+            double apexRetentionTime, double expectedRt, Spectrum apexSpectrum)
         {
             _candidate = candidate;
             _peakBounds = peakBounds;
             _xics = xics;
             _apexRetentionTime = apexRetentionTime;
             _expectedRt = expectedRt;
+            _apexSpectrum = apexSpectrum;
         }
 
         public LibraryEntry Candidate { get { return _candidate; } }
@@ -59,5 +61,6 @@ namespace pwiz.OspreySharp.Tasks
         public double ApexRetentionTime { get { return _apexRetentionTime; } }
         public double ExpectedRt { get { return _expectedRt; } }
         public IReadOnlyList<XicData> Xics { get { return _xics; } }
+        public Spectrum ApexSpectrum { get { return _apexSpectrum; } }
     }
 }

--- a/pwiz_tools/OspreySharp/OspreySharp/Tasks/OspreyPeakData.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/Tasks/OspreyPeakData.cs
@@ -1,0 +1,56 @@
+/*
+ * Original author: Brendan MacLean <brendanx .at. uw.edu>,
+ *                  MacCoss Lab, Department of Genome Sciences, UW
+ * AI assistance: Claude Code (Claude Opus 4) <noreply .at. anthropic.com>
+ *
+ * Based on osprey (https://github.com/MacCossLab/osprey)
+ *   by Michael J. MacCoss, MacCoss Lab, Department of Genome Sciences, UW
+ *
+ * Copyright 2026 University of Washington - Seattle, WA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System.Collections.Generic;
+using pwiz.OspreySharp.Chromatography;
+using pwiz.OspreySharp.Core;
+using pwiz.OspreySharp.Scoring;
+
+namespace pwiz.OspreySharp.Tasks
+{
+    /// <summary>
+    /// Reusable <see cref="IOspreyDetailedPeakData"/> adapter over the harness's
+    /// per-candidate scoring state. One instance is created per window and
+    /// <see cref="Set"/> is called for each candidate, so the per-candidate
+    /// scoring loop allocates no peak-data objects. Windows are scored on separate
+    /// threads, so each window owns its own instance -- this is never shared task
+    /// state.
+    /// </summary>
+    internal sealed class OspreyPeakData : IOspreyDetailedPeakData
+    {
+        private LibraryEntry _candidate;
+        private XICPeakBounds _peakBounds;
+        private IReadOnlyList<XicData> _xics;
+
+        public void Set(LibraryEntry candidate, XICPeakBounds peakBounds, IReadOnlyList<XicData> xics)
+        {
+            _candidate = candidate;
+            _peakBounds = peakBounds;
+            _xics = xics;
+        }
+
+        public LibraryEntry Candidate { get { return _candidate; } }
+        public XICPeakBounds PeakBounds { get { return _peakBounds; } }
+        public IReadOnlyList<XicData> Xics { get { return _xics; } }
+    }
+}

--- a/pwiz_tools/OspreySharp/OspreySharp/Tasks/OspreyPeakData.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/Tasks/OspreyPeakData.cs
@@ -44,9 +44,16 @@ namespace pwiz.OspreySharp.Tasks
         private double _apexRetentionTime;
         private double _expectedRt;
         private Spectrum _apexSpectrum;
+        private int _apexGlobalIndex;
+        private int _apexLocalIndex;
+        private int _windowStartIndex;
+        private int _windowLength;
+        private IReadOnlyList<Spectrum> _windowSpectra;
 
         public void Set(LibraryEntry candidate, XICPeakBounds peakBounds, IReadOnlyList<XicData> xics,
-            double apexRetentionTime, double expectedRt, Spectrum apexSpectrum)
+            double apexRetentionTime, double expectedRt, Spectrum apexSpectrum,
+            int apexGlobalIndex, int apexLocalIndex, int windowStartIndex, int windowLength,
+            IReadOnlyList<Spectrum> windowSpectra)
         {
             _candidate = candidate;
             _peakBounds = peakBounds;
@@ -54,6 +61,11 @@ namespace pwiz.OspreySharp.Tasks
             _apexRetentionTime = apexRetentionTime;
             _expectedRt = expectedRt;
             _apexSpectrum = apexSpectrum;
+            _apexGlobalIndex = apexGlobalIndex;
+            _apexLocalIndex = apexLocalIndex;
+            _windowStartIndex = windowStartIndex;
+            _windowLength = windowLength;
+            _windowSpectra = windowSpectra;
         }
 
         public LibraryEntry Candidate { get { return _candidate; } }
@@ -62,5 +74,10 @@ namespace pwiz.OspreySharp.Tasks
         public double ExpectedRt { get { return _expectedRt; } }
         public IReadOnlyList<XicData> Xics { get { return _xics; } }
         public Spectrum ApexSpectrum { get { return _apexSpectrum; } }
+        public int ApexGlobalIndex { get { return _apexGlobalIndex; } }
+        public int ApexLocalIndex { get { return _apexLocalIndex; } }
+        public int WindowStartIndex { get { return _windowStartIndex; } }
+        public int WindowLength { get { return _windowLength; } }
+        public IReadOnlyList<Spectrum> WindowSpectra { get { return _windowSpectra; } }
     }
 }

--- a/pwiz_tools/OspreySharp/OspreySharp/Tasks/OspreyPeakData.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/Tasks/OspreyPeakData.cs
@@ -41,16 +41,23 @@ namespace pwiz.OspreySharp.Tasks
         private LibraryEntry _candidate;
         private XICPeakBounds _peakBounds;
         private IReadOnlyList<XicData> _xics;
+        private double _apexRetentionTime;
+        private double _expectedRt;
 
-        public void Set(LibraryEntry candidate, XICPeakBounds peakBounds, IReadOnlyList<XicData> xics)
+        public void Set(LibraryEntry candidate, XICPeakBounds peakBounds, IReadOnlyList<XicData> xics,
+            double apexRetentionTime, double expectedRt)
         {
             _candidate = candidate;
             _peakBounds = peakBounds;
             _xics = xics;
+            _apexRetentionTime = apexRetentionTime;
+            _expectedRt = expectedRt;
         }
 
         public LibraryEntry Candidate { get { return _candidate; } }
         public XICPeakBounds PeakBounds { get { return _peakBounds; } }
+        public double ApexRetentionTime { get { return _apexRetentionTime; } }
+        public double ExpectedRt { get { return _expectedRt; } }
         public IReadOnlyList<XicData> Xics { get { return _xics; } }
     }
 }

--- a/pwiz_tools/OspreySharp/OspreySharp/Tasks/OspreyPeakData.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/Tasks/OspreyPeakData.cs
@@ -49,12 +49,12 @@ namespace pwiz.OspreySharp.Tasks
         private int _windowStartIndex;
         private int _windowLength;
         private IReadOnlyList<Spectrum> _windowSpectra;
-        private IReadOnlyList<double> _scanRetentionTimes;
+        private IReadOnlyList<double> _windowRetentionTimes;
 
         public void Set(LibraryEntry candidate, XICPeakBounds peakBounds, IReadOnlyList<XicData> xics,
             double apexRetentionTime, double expectedRt, Spectrum apexSpectrum,
             int apexGlobalIndex, int apexLocalIndex, int windowStartIndex, int windowLength,
-            IReadOnlyList<Spectrum> windowSpectra, IReadOnlyList<double> scanRetentionTimes)
+            IReadOnlyList<Spectrum> windowSpectra, IReadOnlyList<double> windowRetentionTimes)
         {
             _candidate = candidate;
             _peakBounds = peakBounds;
@@ -67,7 +67,7 @@ namespace pwiz.OspreySharp.Tasks
             _windowStartIndex = windowStartIndex;
             _windowLength = windowLength;
             _windowSpectra = windowSpectra;
-            _scanRetentionTimes = scanRetentionTimes;
+            _windowRetentionTimes = windowRetentionTimes;
         }
 
         public LibraryEntry Candidate { get { return _candidate; } }
@@ -81,6 +81,6 @@ namespace pwiz.OspreySharp.Tasks
         public int WindowStartIndex { get { return _windowStartIndex; } }
         public int WindowLength { get { return _windowLength; } }
         public IReadOnlyList<Spectrum> WindowSpectra { get { return _windowSpectra; } }
-        public IReadOnlyList<double> ScanRetentionTimes { get { return _scanRetentionTimes; } }
+        public IReadOnlyList<double> WindowRetentionTimes { get { return _windowRetentionTimes; } }
     }
 }

--- a/pwiz_tools/OspreySharp/OspreySharp/Tasks/OspreyPeakData.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/Tasks/OspreyPeakData.cs
@@ -49,11 +49,12 @@ namespace pwiz.OspreySharp.Tasks
         private int _windowStartIndex;
         private int _windowLength;
         private IReadOnlyList<Spectrum> _windowSpectra;
+        private IReadOnlyList<double> _scanRetentionTimes;
 
         public void Set(LibraryEntry candidate, XICPeakBounds peakBounds, IReadOnlyList<XicData> xics,
             double apexRetentionTime, double expectedRt, Spectrum apexSpectrum,
             int apexGlobalIndex, int apexLocalIndex, int windowStartIndex, int windowLength,
-            IReadOnlyList<Spectrum> windowSpectra)
+            IReadOnlyList<Spectrum> windowSpectra, IReadOnlyList<double> scanRetentionTimes)
         {
             _candidate = candidate;
             _peakBounds = peakBounds;
@@ -66,6 +67,7 @@ namespace pwiz.OspreySharp.Tasks
             _windowStartIndex = windowStartIndex;
             _windowLength = windowLength;
             _windowSpectra = windowSpectra;
+            _scanRetentionTimes = scanRetentionTimes;
         }
 
         public LibraryEntry Candidate { get { return _candidate; } }
@@ -79,5 +81,6 @@ namespace pwiz.OspreySharp.Tasks
         public int WindowStartIndex { get { return _windowStartIndex; } }
         public int WindowLength { get { return _windowLength; } }
         public IReadOnlyList<Spectrum> WindowSpectra { get { return _windowSpectra; } }
+        public IReadOnlyList<double> ScanRetentionTimes { get { return _scanRetentionTimes; } }
     }
 }


### PR DESCRIPTION
## Summary

Decomposes `AbstractScoringTask.ScoreCandidate`'s inline ~870-line 21-feature PIN
block into one class per score on a Skyline-shaped SPI, mirroring Skyline's
`IPeakFeatureCalculator` / `PeakScoringContext` / `ISummaryPeakData` /
`IDetailedPeakData` shapes inside OspreySharp (no Shared assembly, no Skyline edits
this sprint). Every extraction is a pure value-preserving move — byte-for-byte
parity with Rust is held at 1e-9 on both datasets at each step.

* New SPI in `OspreySharp.Scoring`: `IOspreyFeatureCalculator` (+ a single
  `DetailedOspreyFeatureCalculator` base — Osprey has no summary-only score),
  `IOspreyPeakData`/`IOspreyDetailedPeakData` (the data split mirrors Skyline,
  including an `ApexSpectrum` accessor — the "spectrum wall" Skyline's
  chromatogram-centric results layer cannot supply), `OspreyScoringContext` with a
  type-keyed `AddInfo<T>`/`TryGetInfo<T>` byproduct cache, and an ordered
  `OspreyFeatureCalculators` registry that owns the parity-critical PIN order as data.
* All 21 features extracted into per-family calculator classes:
  coelution (0,1,2), peak-shape (3,4,5), apex-match (7,8,9,10), rt-deviation (11,12),
  MS1 (13,14), median-polish (15,16,19,20), and xcorr + Savitzky-Golay (6,17,18).
* Shared per-family intermediates are computed once and published to the context
  byproduct cache (`CoelutionStats`, `PeakShapeReference`, `MedianPolishByproduct`,
  `ApexFragmentMatchSet`, `SgWeightedSweep`, MS1 byproduct), preserving the exact
  order of operations from the inline code.
* Hot-loop allocation discipline preserved: the context + detailed peak-data are
  reused mutable instances created once per window; the byproduct dictionary is
  cleared (not reallocated) per candidate; the `XcorrScratchPool` is still threaded
  through to `ScoreXcorr` so HRAM scoring avoids per-call LOH allocation.
* Removed the inline feature helpers now owned by calculators
  (`ComputePeakShapeFeatures`, `ComputeCoelutionStats`, `ComputeApexMatchFeatures`,
  `CountConsecutiveIons`/`LongestConsecutiveRun`, `ComputeCosineAtScan`, the SG loop,
  `ComputeMs1Features`); `CountTop6Matches` stays inline (dedup byproduct, not a PIN
  feature).

Architecture follows `ai/todos/active/TODO-20260607_ospreysharp_modular_scoring.md`.
The new calculators are now independently unit-testable — a capability the inline
block did not have.

Scope note: this PR covers the 21 PIN features used in Percolator scoring. The
~26 non-PIN scores the Rust engine computes but excludes from the PIN (hyperscore,
the dot-product/Top-N family, DIA-NN-style pCos, fragment/sequence coverage, etc.)
are NOT computed in OspreySharp today (the `CoelutionFeatureSet` non-PIN fields are a
dead Rust-struct mirror), so they have no cross-impl parity oracle. Porting them is
deferred to `ai/todos/backlog/TODO-ospreysharp_nonpin_scores_port.md`, which first
builds a full-feature-set Rust↔C# verification harness. No performance regression:
the calculator+context model measured −1.6% (within noise) on the stage-4 hot loop
vs the inline baseline.

## Test plan

- [x] OspreyFeatureCalculatorsTest — per-family unit tests (peak-shape, coelution,
      median-polish defaults, rt-deviation, apex-match, xcorr+SG) asserting values
      and parity-critical PIN names against fixed fixtures
- [x] Build-OspreySharp Debug (net472 + net8.0) + full test suite + ReSharper
      inspection clean
- [x] Compare-EndToEnd-Crossimpl Stellar + Astral at 1e-9 (Stage 7 protein FDR +
      blib content) vs a fresh Release build, per family commit
- [x] No stage-4 performance regression (xcorr+SG perf A/B vs merge-base baseline)

Co-Authored-By: Claude <noreply@anthropic.com>
