### PR TITLE
Decouple OspreySharp input dir from output/cache dir (--work-dir/--output-dir/--cache-dir)

### DIFF
--- a/pwiz_tools/OspreySharp/OspreySharp.Core/OspreyConfig.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Core/OspreyConfig.cs
@@ -44,6 +44,30 @@ namespace pwiz.OspreySharp.Core
         /// <summary>Optional: TSV report output path.</summary>
         public string OutputReport { get; set; }
 
+        /// <summary>
+        /// Optional base directory for all per-file <em>derived</em> artifacts
+        /// (<c>.scores.parquet</c>, <c>.calibration.json</c>,
+        /// <c>.scores-reconciled.parquet</c>, the FDR sidecars, and
+        /// <c>.reconciliation.json</c>). Null = write each artifact in its input
+        /// file's own directory (the historical behavior). Set by
+        /// <c>--output-dir</c> (or <c>--work-dir</c>), it lets an analysis read
+        /// read-only input data while writing only derived output elsewhere.
+        /// Maps to Rust <c>OspreyConfig::output_dir</c> (Track B).
+        /// </summary>
+        public string OutputDir { get; set; }
+
+        /// <summary>
+        /// Optional directory for the <c>.spectra.bin</c> cache only. Null =
+        /// resolve at write time: beside the data file if that directory is
+        /// writable, else <see cref="OutputDir"/> (or the input file's own
+        /// directory when <see cref="OutputDir"/> is also null). Set by
+        /// <c>--cache-dir</c> (or <c>--work-dir</c>). The cache is
+        /// settings-independent, so a shared CacheDir lets many analyses reuse
+        /// a single parse of the spectra.
+        /// Maps to Rust <c>OspreyConfig::cache_dir</c> (Track B).
+        /// </summary>
+        public string CacheDir { get; set; }
+
         /// <summary>Resolution mode for binning.</summary>
         public ResolutionMode ResolutionMode { get; set; } = ResolutionMode.Auto;
 

--- a/pwiz_tools/OspreySharp/OspreySharp.IO/ArtifactPaths.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.IO/ArtifactPaths.cs
@@ -62,8 +62,12 @@ namespace pwiz.OspreySharp.IO
         // Writability is probed (an ACL check is unreliable cross-platform) and
         // memoized per directory so resolution stays cheap when called for every
         // input file.
+        // Ordinal (case-sensitive) keys: on a case-sensitive file system
+        // (Linux/net8.0) two directories differing only by case are distinct, so
+        // a case-insensitive key could reuse the wrong writability result. The
+        // worst case on Windows is a couple of extra probes.
         private static readonly ConcurrentDictionary<string, bool> _writable =
-            new ConcurrentDictionary<string, bool>(StringComparer.OrdinalIgnoreCase);
+            new ConcurrentDictionary<string, bool>(StringComparer.Ordinal);
 
         /// <summary>
         /// Directory for a non-cache derived artifact of
@@ -118,10 +122,12 @@ namespace pwiz.OspreySharp.IO
                 if (!Directory.Exists(dir))
                     return false;
                 string probe = Path.Combine(dir, "." + Guid.NewGuid().ToString("N") + ".osprey-wtest");
-                using (File.Create(probe))
+                // DeleteOnClose keeps the probe self-cleaning even if disposal
+                // races with AV / permission edge cases -- no littered temp file.
+                using (new FileStream(probe, FileMode.CreateNew, FileAccess.Write,
+                           FileShare.None, 1, FileOptions.DeleteOnClose))
                 {
                 }
-                File.Delete(probe);
                 return true;
             }
             catch (Exception)

--- a/pwiz_tools/OspreySharp/OspreySharp.IO/ArtifactPaths.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.IO/ArtifactPaths.cs
@@ -1,0 +1,133 @@
+/*
+ * Original author: Brendan MacLean <brendanx .at. uw.edu>,
+ *                  MacCoss Lab, Department of Genome Sciences, UW
+ * AI assistance: Claude Code (Claude Opus 4.8) <noreply .at. anthropic.com>
+ *
+ * Based on osprey (https://github.com/MacCossLab/osprey)
+ *   by Michael J. MacCoss, MacCoss Lab, Department of Genome Sciences, UW
+ *
+ * Copyright 2026 University of Washington - Seattle, WA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
+using System.Collections.Concurrent;
+using System.IO;
+
+namespace pwiz.OspreySharp.IO
+{
+    /// <summary>
+    /// Process-wide overrides for where per-file <em>derived</em> artifacts are
+    /// written, set once from the parsed <c>OspreyConfig</c> at startup (see
+    /// <c>Program.Main</c>). Every per-file artifact path helper -- the scores
+    /// parquet (<see cref="ParquetScoreCache.GetScoresPath"/>) and its reconciled
+    /// sibling, the spectra cache (<see cref="SpectraCache.GetCachePath"/>), the
+    /// calibration JSON, and the FDR / reconciliation sidecars (which hang off the
+    /// scores-parquet path) -- resolves its directory through here, so the
+    /// output-dir / cache-dir redirection is applied to <em>all</em> artifacts
+    /// atomically and can never be applied to some while missed on others.
+    ///
+    /// Both properties default to null, which preserves the historical behavior
+    /// of writing each artifact in its input file's own directory.
+    /// <c>--work-dir</c> sets both; <c>--output-dir</c> / <c>--cache-dir</c> set
+    /// them individually. Maps to Rust <c>OspreyConfig::output_dir</c> /
+    /// <c>cache_dir</c> (Track B).
+    /// </summary>
+    public static class ArtifactPaths
+    {
+        /// <summary>
+        /// Base directory for non-cache derived artifacts, or null to use each
+        /// input file's own directory. Maps to <c>OspreyConfig.OutputDir</c>.
+        /// </summary>
+        public static string OutputDir { get; set; }
+
+        /// <summary>
+        /// Directory for the <c>.spectra.bin</c> cache, or null to resolve at
+        /// write time (beside the data file if writable, else
+        /// <see cref="OutputDir"/>). Maps to <c>OspreyConfig.CacheDir</c>.
+        /// </summary>
+        public static string CacheDir { get; set; }
+
+        // Writability is probed (an ACL check is unreliable cross-platform) and
+        // memoized per directory so resolution stays cheap when called for every
+        // input file.
+        private static readonly ConcurrentDictionary<string, bool> _writable =
+            new ConcurrentDictionary<string, bool>(StringComparer.OrdinalIgnoreCase);
+
+        /// <summary>
+        /// Directory for a non-cache derived artifact of
+        /// <paramref name="inputPath"/>: <see cref="OutputDir"/> when set, else
+        /// the input file's own directory (the historical default).
+        /// </summary>
+        public static string ResolveOutputDir(string inputPath)
+        {
+            if (!string.IsNullOrEmpty(OutputDir))
+                return OutputDir;
+            return InputDir(inputPath);
+        }
+
+        /// <summary>
+        /// Directory for the spectra cache of <paramref name="inputPath"/>.
+        /// Resolution order: explicit <see cref="CacheDir"/> -> beside the data
+        /// file if that directory is writable -> <see cref="OutputDir"/>. The
+        /// cache is settings-independent, so a shared CacheDir lets many analyses
+        /// (and the straight-through vs. resume passes) reuse one parse.
+        /// </summary>
+        public static string ResolveCacheDir(string inputPath)
+        {
+            if (!string.IsNullOrEmpty(CacheDir))
+                return CacheDir;
+            string inputDir = InputDir(inputPath);
+            // No redirection configured at all: this is exactly the historical
+            // location, so skip the writability probe entirely (a default run
+            // must not touch the data directory with a temp file).
+            if (string.IsNullOrEmpty(OutputDir))
+                return inputDir;
+            // OutputDir is set but no explicit CacheDir: prefer beside-data for
+            // cross-analysis reuse, falling back to OutputDir when the data
+            // directory is read-only.
+            return IsDirectoryWritable(inputDir) ? inputDir : OutputDir;
+        }
+
+        private static string InputDir(string inputPath)
+        {
+            return Path.GetDirectoryName(inputPath) ?? string.Empty;
+        }
+
+        private static bool IsDirectoryWritable(string dir)
+        {
+            string key = string.IsNullOrEmpty(dir) ? "." : dir;
+            return _writable.GetOrAdd(key, ProbeWritable);
+        }
+
+        private static bool ProbeWritable(string dir)
+        {
+            try
+            {
+                if (!Directory.Exists(dir))
+                    return false;
+                string probe = Path.Combine(dir, "." + Guid.NewGuid().ToString("N") + ".osprey-wtest");
+                using (File.Create(probe))
+                {
+                }
+                File.Delete(probe);
+                return true;
+            }
+            catch (Exception)
+            {
+                return false;
+            }
+        }
+    }
+}

--- a/pwiz_tools/OspreySharp/OspreySharp.IO/FdrScoresSidecar.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.IO/FdrScoresSidecar.cs
@@ -150,7 +150,11 @@ namespace pwiz.OspreySharp.IO
         private static string ScoresPath(string inputPath, string passLabel)
         {
             string stem = Path.GetFileNameWithoutExtension(inputPath) ?? "unknown";
-            string parent = Path.GetDirectoryName(inputPath);
+            // Route through ArtifactPaths so the sidecar follows the scores
+            // parquet into --output-dir (default = the input's own directory).
+            // Every caller -- straight-through writes, resume reads, and the
+            // resume-check iterators -- shares this, so they stay consistent.
+            string parent = ArtifactPaths.ResolveOutputDir(inputPath);
             string filename = string.Format("{0}.{1}.fdr_scores.bin", stem, passLabel);
             return string.IsNullOrEmpty(parent) ? filename : Path.Combine(parent, filename);
         }

--- a/pwiz_tools/OspreySharp/OspreySharp.IO/LibraryLoader.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.IO/LibraryLoader.cs
@@ -54,7 +54,13 @@ namespace pwiz.OspreySharp.IO
             logWarning = logWarning ?? (_ => { });
 
             string path = config.LibrarySource.Path;
-            string cachePath = path + ".libcache";
+            // Route the library cache through ArtifactPaths (like the spectra
+            // cache) so it follows --cache-dir / --work-dir and need not be
+            // written beside a read-only library. Filename form preserved
+            // ("<library-leaf>.libcache"); only the directory is redirected.
+            string cachePath = Path.Combine(
+                ArtifactPaths.ResolveCacheDir(path),
+                Path.GetFileName(path) + ".libcache");
 
             // Try loading from binary cache first
             if (File.Exists(cachePath))

--- a/pwiz_tools/OspreySharp/OspreySharp.IO/ParquetScoreCache.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.IO/ParquetScoreCache.cs
@@ -927,7 +927,7 @@ namespace pwiz.OspreySharp.IO
         /// </summary>
         public static string GetScoresPath(string mzmlPath)
         {
-            string dir = Path.GetDirectoryName(mzmlPath) ?? string.Empty;
+            string dir = ArtifactPaths.ResolveOutputDir(mzmlPath);
             string stem = Path.GetFileNameWithoutExtension(mzmlPath);
             return Path.Combine(dir, stem + ".scores.parquet");
         }
@@ -953,7 +953,7 @@ namespace pwiz.OspreySharp.IO
         /// </summary>
         public static string GetReconciledScoresPath(string mzmlPath)
         {
-            string dir = Path.GetDirectoryName(mzmlPath) ?? string.Empty;
+            string dir = ArtifactPaths.ResolveOutputDir(mzmlPath);
             string stem = Path.GetFileNameWithoutExtension(mzmlPath);
             return Path.Combine(dir, stem + ReconciledScoresParquetSuffix);
         }

--- a/pwiz_tools/OspreySharp/OspreySharp.IO/ReconciliationFile.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.IO/ReconciliationFile.cs
@@ -188,7 +188,10 @@ namespace pwiz.OspreySharp.IO
         public static string PathForInput(string inputPath)
         {
             string stem = Path.GetFileNameWithoutExtension(inputPath) ?? "unknown";
-            string parent = Path.GetDirectoryName(inputPath);
+            // Route through ArtifactPaths so the reconciliation JSON follows the
+            // scores parquet into --output-dir (default = the input's own dir),
+            // shared by the straight-through writer and the resume reader.
+            string parent = ArtifactPaths.ResolveOutputDir(inputPath);
             string filename = stem + ".reconciliation.json";
             return string.IsNullOrEmpty(parent) ? filename : Path.Combine(parent, filename);
         }

--- a/pwiz_tools/OspreySharp/OspreySharp.IO/SpectraCache.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.IO/SpectraCache.cs
@@ -37,6 +37,11 @@ namespace pwiz.OspreySharp.IO
     /// Format (little-endian):
     /// [magic: 8 bytes "OSPRSPC\0"]
     /// [version: uint32]
+    /// [source_size: uint64]   source file length, or 0 when unknown
+    /// [source_mtime: int64]   source last-write time, Unix milliseconds UTC,
+    ///                         or 0 when unknown. Unix-ms so OspreySharp and
+    ///                         Rust osprey compute identical values for the same
+    ///                         file and can share one cache (cross-impl gate).
     /// [n_ms2: uint32]
     /// [n_ms1: uint32]
     /// For each MS2 spectrum:
@@ -58,17 +63,24 @@ namespace pwiz.OspreySharp.IO
         // peaks that produce undefined-behavior divergence in fragment matching.
         // Old caches are invalidated on this version bump so the fresh load
         // path (which sorts) re-populates them.
-        private const uint VERSION = 2;
+        // VERSION 3 (2026-06-09): header now carries the source file's size +
+        // last-write-time (Unix ms) so a cache that lives apart from its data
+        // file (--cache-dir / --output-dir) is rejected when the source changes.
+        // Old caches re-populate on this bump.
+        private const uint VERSION = 3;
 
         /// <summary>
         /// Save spectra to a binary cache file.
         /// </summary>
-        public static void SaveSpectraCache(string path, List<Spectrum> ms2Spectra, List<MS1Spectrum> ms1Spectra)
+        public static void SaveSpectraCache(string path, List<Spectrum> ms2Spectra, List<MS1Spectrum> ms1Spectra,
+            string sourcePath = null)
         {
             if (ms2Spectra == null)
                 ms2Spectra = new List<Spectrum>();
             if (ms1Spectra == null)
                 ms1Spectra = new List<MS1Spectrum>();
+
+            ComputeSourceFingerprint(sourcePath, out long sourceSize, out long sourceMtimeMs);
 
             using (var fs = new FileStream(path, FileMode.Create, FileAccess.Write))
             using (var w = new BinaryWriter(fs))
@@ -76,6 +88,8 @@ namespace pwiz.OspreySharp.IO
                 // Header
                 w.Write(MAGIC);
                 w.Write(VERSION);
+                w.Write((ulong)sourceSize);
+                w.Write(sourceMtimeMs);
                 w.Write((uint)ms2Spectra.Count);
                 w.Write((uint)ms1Spectra.Count);
 
@@ -111,7 +125,7 @@ namespace pwiz.OspreySharp.IO
         /// Load spectra from a binary cache file.
         /// Returns null if the file does not exist or has invalid magic/version.
         /// </summary>
-        public static SpectraCacheResult LoadSpectraCache(string path)
+        public static SpectraCacheResult LoadSpectraCache(string path, string sourcePath = null)
         {
             if (!File.Exists(path))
                 return null;
@@ -133,6 +147,20 @@ namespace pwiz.OspreySharp.IO
                 uint version = r.ReadUInt32();
                 if (version != VERSION)
                     return null;
+
+                // Validate source fingerprint: reject a cache whose data file
+                // changed since it was written. Skipped when the cache recorded
+                // no fingerprint (storedSize == 0) or the source is unavailable
+                // for comparison (e.g. a resume run whose mzML is not beside the
+                // cache) -- a within-run cache is trusted in that case.
+                ulong storedSize = r.ReadUInt64();
+                long storedMtimeMs = r.ReadInt64();
+                if (storedSize != 0 && !string.IsNullOrEmpty(sourcePath))
+                {
+                    ComputeSourceFingerprint(sourcePath, out long actualSize, out long actualMtimeMs);
+                    if (actualSize != 0 && ((ulong)actualSize != storedSize || actualMtimeMs != storedMtimeMs))
+                        return null;
+                }
 
                 uint nMs2 = r.ReadUInt32();
                 uint nMs1 = r.ReadUInt32();
@@ -186,6 +214,32 @@ namespace pwiz.OspreySharp.IO
         }
 
         #region Private helpers
+
+        // Source file fingerprint: length + last-write-time as Unix milliseconds
+        // UTC. Unix-ms (not .NET ticks) so OspreySharp and Rust osprey derive the
+        // same value for the same file. Returns (0, 0) when the source is null,
+        // missing, or cannot be stat'd, which the load path treats as "no
+        // fingerprint -- trust the cache".
+        private static void ComputeSourceFingerprint(string sourcePath, out long size, out long mtimeMs)
+        {
+            size = 0;
+            mtimeMs = 0;
+            if (string.IsNullOrEmpty(sourcePath))
+                return;
+            try
+            {
+                var fi = new FileInfo(sourcePath);
+                if (!fi.Exists)
+                    return;
+                size = fi.Length;
+                mtimeMs = new DateTimeOffset(fi.LastWriteTimeUtc).ToUnixTimeMilliseconds();
+            }
+            catch (Exception)
+            {
+                size = 0;
+                mtimeMs = 0;
+            }
+        }
 
         private static void WriteDoubleArray(BinaryWriter w, double[] values)
         {

--- a/pwiz_tools/OspreySharp/OspreySharp.IO/SpectraCache.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.IO/SpectraCache.cs
@@ -177,7 +177,12 @@ namespace pwiz.OspreySharp.IO
         /// </summary>
         public static string GetCachePath(string inputFile)
         {
-            return Path.ChangeExtension(inputFile, "spectra.bin");
+            // Preserve the historical filename ("{stem}.spectra.bin", the same
+            // result Path.ChangeExtension produced); only the directory is
+            // redirected by ArtifactPaths (beside the data file by default, else
+            // the configured cache/output dir).
+            string fileName = Path.GetFileNameWithoutExtension(inputFile) + ".spectra.bin";
+            return Path.Combine(ArtifactPaths.ResolveCacheDir(inputFile), fileName);
         }
 
         #region Private helpers

--- a/pwiz_tools/OspreySharp/OspreySharp.Test/ArtifactPathsTest.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Test/ArtifactPathsTest.cs
@@ -1,0 +1,205 @@
+/*
+ * Original author: Brendan MacLean <brendanx .at. uw.edu>,
+ *                  MacCoss Lab, Department of Genome Sciences, UW
+ * AI assistance: Claude Code (Claude Opus 4.8) <noreply .at. anthropic.com>
+ *
+ * Based on osprey (https://github.com/MacCossLab/osprey)
+ *   by Michael J. MacCoss, MacCoss Lab, Department of Genome Sciences, UW
+ *
+ * Copyright 2026 University of Washington - Seattle, WA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System.Collections.Generic;
+using System.IO;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using pwiz.OspreySharp.Core;
+using pwiz.OspreySharp.IO;
+
+namespace pwiz.OspreySharp.Test
+{
+    /// <summary>
+    /// Tests for the output / cache directory decoupling: the
+    /// <see cref="ArtifactPaths"/> resolver, the artifact path helpers that route
+    /// through it, the <c>--work-dir</c>/<c>--output-dir</c>/<c>--cache-dir</c>
+    /// CLI precedence, and the spectra-cache source fingerprint.
+    /// </summary>
+    [TestClass]
+    public class ArtifactPathsTest
+    {
+        // Helper: run an action with ArtifactPaths overrides set, always resetting
+        // the process-wide statics afterward so other tests see the default
+        // (null = each input file's own directory).
+        private static void WithArtifactDirs(string outputDir, string cacheDir, System.Action body)
+        {
+            string savedOutput = ArtifactPaths.OutputDir;
+            string savedCache = ArtifactPaths.CacheDir;
+            try
+            {
+                ArtifactPaths.OutputDir = outputDir;
+                ArtifactPaths.CacheDir = cacheDir;
+                body();
+            }
+            finally
+            {
+                ArtifactPaths.OutputDir = savedOutput;
+                ArtifactPaths.CacheDir = savedCache;
+            }
+        }
+
+        /// <summary>
+        /// ResolveOutputDir / ResolveCacheDir and the path helpers honor the
+        /// configured directories, and the default (no overrides) is byte-identical
+        /// to writing in the input file's own directory.
+        /// </summary>
+        [TestMethod]
+        public void TestArtifactPathsResolution()
+        {
+            string inputDir = Path.Combine(Path.GetTempPath(), "osprey_ap_" + Path.GetRandomFileName());
+            Directory.CreateDirectory(inputDir);
+            try
+            {
+                string input = Path.Combine(inputDir, "sample.mzML");
+
+                // Default: no overrides -> input file's own directory, identical to
+                // the historical paths.
+                WithArtifactDirs(null, null, () =>
+                {
+                    Assert.AreEqual(inputDir, ArtifactPaths.ResolveOutputDir(input));
+                    Assert.AreEqual(inputDir, ArtifactPaths.ResolveCacheDir(input));
+                    Assert.AreEqual(Path.Combine(inputDir, "sample.scores.parquet"),
+                        ParquetScoreCache.GetScoresPath(input));
+                    Assert.AreEqual(Path.Combine(inputDir, "sample.scores-reconciled.parquet"),
+                        ParquetScoreCache.GetReconciledScoresPath(input));
+                    Assert.AreEqual(Path.Combine(inputDir, "sample.spectra.bin"),
+                        SpectraCache.GetCachePath(input));
+                });
+
+                // OutputDir set redirects the non-cache artifacts; CacheDir explicit
+                // redirects the spectra cache.
+                string outDir = Path.Combine(Path.GetTempPath(), "osprey_out_" + Path.GetRandomFileName());
+                string cacheDir = Path.Combine(Path.GetTempPath(), "osprey_cache_" + Path.GetRandomFileName());
+                WithArtifactDirs(outDir, cacheDir, () =>
+                {
+                    Assert.AreEqual(outDir, ArtifactPaths.ResolveOutputDir(input));
+                    Assert.AreEqual(cacheDir, ArtifactPaths.ResolveCacheDir(input));
+                    Assert.AreEqual(Path.Combine(outDir, "sample.scores.parquet"),
+                        ParquetScoreCache.GetScoresPath(input));
+                    Assert.AreEqual(Path.Combine(cacheDir, "sample.spectra.bin"),
+                        SpectraCache.GetCachePath(input));
+                });
+
+                // CacheDir unset + OutputDir set: prefer beside-data when writable
+                // (inputDir exists here), so the cache stays beside the data.
+                WithArtifactDirs(outDir, null, () =>
+                    Assert.AreEqual(inputDir, ArtifactPaths.ResolveCacheDir(input)));
+
+                // CacheDir unset + OutputDir set + a non-writable (here:
+                // non-existent) data directory -> fall back to OutputDir.
+                string missingDir = Path.Combine(inputDir, "does_not_exist");
+                string missingInput = Path.Combine(missingDir, "sample.mzML");
+                WithArtifactDirs(outDir, null, () =>
+                    Assert.AreEqual(outDir, ArtifactPaths.ResolveCacheDir(missingInput)));
+            }
+            finally
+            {
+                Directory.Delete(inputDir, true);
+            }
+        }
+
+        /// <summary>
+        /// --work-dir sets both output and cache directories; an explicit
+        /// --output-dir / --cache-dir overrides the matching component.
+        /// </summary>
+        [TestMethod]
+        public void TestWorkOutputCacheDirPrecedence()
+        {
+            OspreyConfig work = Program.ParseArgs(new[] { "--work-dir", "W" });
+            Assert.AreEqual("W", work.OutputDir);
+            Assert.AreEqual("W", work.CacheDir);
+
+            OspreyConfig split = Program.ParseArgs(new[] { "--work-dir", "W", "--output-dir", "O", "--cache-dir", "C" });
+            Assert.AreEqual("O", split.OutputDir);
+            Assert.AreEqual("C", split.CacheDir);
+
+            OspreyConfig outOnly = Program.ParseArgs(new[] { "--work-dir", "W", "--output-dir", "O" });
+            Assert.AreEqual("O", outOnly.OutputDir);
+            Assert.AreEqual("W", outOnly.CacheDir);
+
+            OspreyConfig none = Program.ParseArgs(new[] { "-i", "x.mzML" });
+            Assert.IsNull(none.OutputDir);
+            Assert.IsNull(none.CacheDir);
+        }
+
+        /// <summary>
+        /// The spectra cache rejects a cache whose source file changed (size /
+        /// mtime), reloads when the source matches, and skips the check when no
+        /// fingerprint was recorded or the source is unavailable.
+        /// </summary>
+        [TestMethod]
+        public void TestSpectraCacheFingerprint()
+        {
+            string dir = Path.Combine(Path.GetTempPath(), "osprey_fp_" + Path.GetRandomFileName());
+            Directory.CreateDirectory(dir);
+            try
+            {
+                string source = Path.Combine(dir, "sample.mzML");
+                File.WriteAllText(source, "fake mzML contents");
+                string cachePath = Path.Combine(dir, "sample.spectra.bin");
+
+                var ms2 = new List<Spectrum>
+                {
+                    new Spectrum
+                    {
+                        ScanNumber = 1, RetentionTime = 10.0, PrecursorMz = 500.0,
+                        IsolationWindow = new IsolationWindow(500.0, 1.0, 1.0),
+                        Mzs = new[] { 100.0, 200.0 }, Intensities = new[] { 1f, 2f }
+                    }
+                };
+                var ms1 = new List<MS1Spectrum>
+                {
+                    new MS1Spectrum
+                    {
+                        ScanNumber = 2, RetentionTime = 10.5,
+                        Mzs = new[] { 300.0 }, Intensities = new[] { 3f }
+                    }
+                };
+
+                // Fingerprinted cache loads when the source is unchanged.
+                SpectraCache.SaveSpectraCache(cachePath, ms2, ms1, source);
+                var loaded = SpectraCache.LoadSpectraCache(cachePath, source);
+                Assert.IsNotNull(loaded);
+                Assert.AreEqual(1, loaded.Ms2Spectra.Count);
+                Assert.AreEqual(1, loaded.Ms1Spectra.Count);
+
+                // Loading without a source path skips the check (resume path where
+                // the mzML is not beside the cache).
+                Assert.IsNotNull(SpectraCache.LoadSpectraCache(cachePath));
+
+                // A changed source (size + mtime) invalidates the cache.
+                File.WriteAllText(source, "fake mzML contents that are now longer");
+                Assert.IsNull(SpectraCache.LoadSpectraCache(cachePath, source));
+
+                // A cache written without a fingerprint is accepted even with a
+                // source path supplied (storedSize == 0 -> no check).
+                SpectraCache.SaveSpectraCache(cachePath, ms2, ms1);
+                Assert.IsNotNull(SpectraCache.LoadSpectraCache(cachePath, source));
+            }
+            finally
+            {
+                Directory.Delete(dir, true);
+            }
+        }
+    }
+}

--- a/pwiz_tools/OspreySharp/OspreySharp.Test/ArtifactPathsTest.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Test/ArtifactPathsTest.cs
@@ -84,6 +84,13 @@ namespace pwiz.OspreySharp.Test
                         ParquetScoreCache.GetReconciledScoresPath(input));
                     Assert.AreEqual(Path.Combine(inputDir, "sample.spectra.bin"),
                         SpectraCache.GetCachePath(input));
+                    // FDR / reconciliation sidecars route through the same dir.
+                    Assert.AreEqual(Path.Combine(inputDir, "sample.1st-pass.fdr_scores.bin"),
+                        FdrScoresSidecar.Pass1Path(input));
+                    Assert.AreEqual(Path.Combine(inputDir, "sample.2nd-pass.fdr_scores.bin"),
+                        FdrScoresSidecar.Pass2Path(input));
+                    Assert.AreEqual(Path.Combine(inputDir, "sample.reconciliation.json"),
+                        ReconciliationFile.PathForInput(input));
                 });
 
                 // OutputDir set redirects the non-cache artifacts; CacheDir explicit
@@ -98,6 +105,10 @@ namespace pwiz.OspreySharp.Test
                         ParquetScoreCache.GetScoresPath(input));
                     Assert.AreEqual(Path.Combine(cacheDir, "sample.spectra.bin"),
                         SpectraCache.GetCachePath(input));
+                    Assert.AreEqual(Path.Combine(outDir, "sample.1st-pass.fdr_scores.bin"),
+                        FdrScoresSidecar.Pass1Path(input));
+                    Assert.AreEqual(Path.Combine(outDir, "sample.reconciliation.json"),
+                        ReconciliationFile.PathForInput(input));
                 });
 
                 // CacheDir unset + OutputDir set: prefer beside-data when writable

--- a/pwiz_tools/OspreySharp/OspreySharp/Program.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/Program.cs
@@ -128,6 +128,12 @@ namespace pwiz.OspreySharp
                 // (each artifact in its input file's own directory).
                 ArtifactPaths.OutputDir = config.OutputDir;
                 ArtifactPaths.CacheDir = config.CacheDir;
+                // Create the configured directories up front so the first
+                // artifact write doesn't throw on a not-yet-existing --work-dir.
+                if (!string.IsNullOrEmpty(config.OutputDir))
+                    Directory.CreateDirectory(config.OutputDir);
+                if (!string.IsNullOrEmpty(config.CacheDir))
+                    Directory.CreateDirectory(config.CacheDir);
 
                 string err = ValidateArgs(config);
                 if (err != null)

--- a/pwiz_tools/OspreySharp/OspreySharp/Program.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/Program.cs
@@ -120,6 +120,15 @@ namespace pwiz.OspreySharp
                 config.NoJoin = selectedTask == HpcTask.PerFileScoring || selectedTask == HpcTask.PerFileRescore;
                 config.StopAfterStage5 = selectedTask == HpcTask.FirstJoin;
                 config.ExpectReconciledInput = selectedTask == HpcTask.MergeNode;
+
+                // Apply the output / cache directory overrides process-wide so
+                // every per-file artifact path helper (scores parquet, spectra
+                // cache, calibration JSON, FDR / reconciliation sidecars) writes
+                // to the configured location. Null leaves the historical behavior
+                // (each artifact in its input file's own directory).
+                ArtifactPaths.OutputDir = config.OutputDir;
+                ArtifactPaths.CacheDir = config.CacheDir;
+
                 string err = ValidateArgs(config);
                 if (err != null)
                 {
@@ -207,6 +216,9 @@ namespace pwiz.OspreySharp
             var inputFiles = new List<string>();
             string libraryPath = null;
             string outputPath = null;
+            string workDir = null;
+            string outputDir = null;
+            string cacheDir = null;
             string resolution = "auto";
             double? fragmentTolerance = null;
             string fragmentUnit = null;
@@ -247,6 +259,21 @@ namespace pwiz.OspreySharp
                     case "-o":
                     case "--output":
                         outputPath = RequireValue(args, ref i, arg);
+                        i++;
+                        break;
+
+                    case "--work-dir":
+                        workDir = RequireValue(args, ref i, arg);
+                        i++;
+                        break;
+
+                    case "--output-dir":
+                        outputDir = RequireValue(args, ref i, arg);
+                        i++;
+                        break;
+
+                    case "--cache-dir":
+                        cacheDir = RequireValue(args, ref i, arg);
                         i++;
                         break;
 
@@ -466,6 +493,12 @@ namespace pwiz.OspreySharp
 
             // Apply parsed values to config
             config.InputFiles = inputFiles;
+
+            // --work-dir is a convenience that sets both the derived-artifact
+            // output directory and the spectra-cache directory; an explicit
+            // --output-dir / --cache-dir overrides the matching component.
+            config.OutputDir = outputDir ?? workDir;
+            config.CacheDir = cacheDir ?? workDir;
 
             if (!string.IsNullOrEmpty(libraryPath))
                 config.LibrarySource = LibrarySource.FromPath(libraryPath);

--- a/pwiz_tools/OspreySharp/OspreySharp/Program.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/Program.cs
@@ -128,12 +128,6 @@ namespace pwiz.OspreySharp
                 // (each artifact in its input file's own directory).
                 ArtifactPaths.OutputDir = config.OutputDir;
                 ArtifactPaths.CacheDir = config.CacheDir;
-                // Create the configured directories up front so the first
-                // artifact write doesn't throw on a not-yet-existing --work-dir.
-                if (!string.IsNullOrEmpty(config.OutputDir))
-                    Directory.CreateDirectory(config.OutputDir);
-                if (!string.IsNullOrEmpty(config.CacheDir))
-                    Directory.CreateDirectory(config.CacheDir);
 
                 string err = ValidateArgs(config);
                 if (err != null)
@@ -141,6 +135,14 @@ namespace pwiz.OspreySharp
                     LogError(err);
                     return 1;
                 }
+
+                // Create the configured directories only after args validate, so
+                // an invalid command line surfaces the validation message instead
+                // of a Directory.CreateDirectory side effect / generic error.
+                if (!string.IsNullOrEmpty(config.OutputDir))
+                    Directory.CreateDirectory(config.OutputDir);
+                if (!string.IsNullOrEmpty(config.CacheDir))
+                    Directory.CreateDirectory(config.CacheDir);
                 // Runs that consume --input-scores (FirstJoin, PerFileRescore,
                 // MergeNode, or the default full pipeline started from scores)
                 // have no mzML inputs to validate and ignore --output handling
@@ -812,7 +814,7 @@ namespace pwiz.OspreySharp
             Console.Error.WriteLine("    --work-dir <dir>              Write derived artifacts AND the spectra cache here");
             Console.Error.WriteLine("                                 (so input data can be read-only); default: beside input");
             Console.Error.WriteLine("    --output-dir <dir>           Directory for derived artifacts (overrides --work-dir)");
-            Console.Error.WriteLine("    --cache-dir <dir>            Directory for the .spectra.bin cache (overrides --work-dir)");
+            Console.Error.WriteLine("    --cache-dir <dir>             Directory for the .spectra.bin cache (overrides --work-dir)");
             Console.Error.WriteLine("    --resolution <mode>           Resolution mode: unit, hram, auto (default: auto)");
             Console.Error.WriteLine("    --fragment-tolerance <value>  Fragment m/z tolerance (default: 10)");
             Console.Error.WriteLine("    --fragment-unit <unit>        Fragment tolerance unit: ppm, mz (default: ppm)");

--- a/pwiz_tools/OspreySharp/OspreySharp/Program.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/Program.cs
@@ -803,6 +803,10 @@ namespace pwiz.OspreySharp
             Console.Error.WriteLine("    -i, --input <files>           Input mzML file(s)");
             Console.Error.WriteLine("    -l, --library <file>          Spectral library (.tsv, .blib, .elib)");
             Console.Error.WriteLine("    -o, --output <file>           Output blib file");
+            Console.Error.WriteLine("    --work-dir <dir>              Write derived artifacts AND the spectra cache here");
+            Console.Error.WriteLine("                                 (so input data can be read-only); default: beside input");
+            Console.Error.WriteLine("    --output-dir <dir>           Directory for derived artifacts (overrides --work-dir)");
+            Console.Error.WriteLine("    --cache-dir <dir>            Directory for the .spectra.bin cache (overrides --work-dir)");
             Console.Error.WriteLine("    --resolution <mode>           Resolution mode: unit, hram, auto (default: auto)");
             Console.Error.WriteLine("    --fragment-tolerance <value>  Fragment m/z tolerance (default: 10)");
             Console.Error.WriteLine("    --fragment-unit <unit>        Fragment tolerance unit: ppm, mz (default: ppm)");

--- a/pwiz_tools/OspreySharp/OspreySharp/Tasks/PerFileRescoreTask.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/Tasks/PerFileRescoreTask.cs
@@ -1453,7 +1453,15 @@ namespace pwiz.OspreySharp.Tasks
             ms1Cal = MzCalibrationResult.Uncalibrated();
             rtMadFromCalJson = null;
 
-            string parent = Path.GetDirectoryName(Path.GetFullPath(inputFile));
+            // Stage 1-4 wrote the calibration sidecar to the configured output
+            // directory (ArtifactPaths), which for a straight-through --output-dir
+            // run is NOT the (possibly read-only) input mzML's directory. Resolve
+            // it the same way the writer did; fall back to the input's own dir
+            // (via GetFullPath so a bare-filename input still yields an absolute
+            // dir) when no output dir is configured.
+            string parent = !string.IsNullOrEmpty(ArtifactPaths.OutputDir)
+                ? ArtifactPaths.OutputDir
+                : Path.GetDirectoryName(Path.GetFullPath(inputFile));
             if (string.IsNullOrEmpty(parent))
             {
                 throw new InvalidDataException(string.Format(

--- a/pwiz_tools/OspreySharp/OspreySharp/Tasks/PerFileRescoreTask.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/Tasks/PerFileRescoreTask.cs
@@ -1407,7 +1407,7 @@ namespace pwiz.OspreySharp.Tasks
             {
                 try
                 {
-                    var result = SpectraCache.LoadSpectraCache(cachePath);
+                    var result = SpectraCache.LoadSpectraCache(cachePath, inputFile);
                     spectra = result.Ms2Spectra;
                     ms1Spectra = result.Ms1Spectra;
                     _ctx.LogInfo(string.Format(

--- a/pwiz_tools/OspreySharp/OspreySharp/Tasks/PerFileScoringTask.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/Tasks/PerFileScoringTask.cs
@@ -1496,7 +1496,7 @@ namespace pwiz.OspreySharp.Tasks
                 _ctx.LogInfo(string.Format("Loading spectra from cache: {0}", cachePath));
                 try
                 {
-                    var cacheResult = SpectraCache.LoadSpectraCache(cachePath);
+                    var cacheResult = SpectraCache.LoadSpectraCache(cachePath, inputFile);
                     ms2Spectra = cacheResult.Ms2Spectra;
                     ms1Spectra = cacheResult.Ms1Spectra;
                     return;
@@ -1530,7 +1530,7 @@ namespace pwiz.OspreySharp.Tasks
             // Save to cache for next run
             try
             {
-                SpectraCache.SaveSpectraCache(cachePath, ms2Spectra, ms1Spectra);
+                SpectraCache.SaveSpectraCache(cachePath, ms2Spectra, ms1Spectra, inputFile);
             }
             catch (Exception ex)
             {

--- a/pwiz_tools/OspreySharp/OspreySharp/Tasks/PerFileScoringTask.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/Tasks/PerFileScoringTask.cs
@@ -1485,12 +1485,10 @@ namespace pwiz.OspreySharp.Tasks
         private void LoadSpectra(string inputFile, bool serializeMzmlRead,
             out List<Spectrum> ms2Spectra, out List<MS1Spectrum> ms1Spectra)
         {
-            // Check for binary spectra cache. Filename form preserved
-            // ("{inputFile-leaf}.spectra.bin"); only the directory is redirected
-            // by ArtifactPaths (beside the data file by default).
-            string cachePath = Path.Combine(
-                ArtifactPaths.ResolveCacheDir(inputFile),
-                Path.GetFileName(inputFile) + ".spectra.bin");
+            // Check for binary spectra cache. Use the shared GetCachePath so the
+            // write and the rescore read (PerFileRescoreTask) derive an identical
+            // filename + directory (ArtifactPaths redirects the dir).
+            string cachePath = SpectraCache.GetCachePath(inputFile);
             if (File.Exists(cachePath))
             {
                 _ctx.LogInfo(string.Format("Loading spectra from cache: {0}", cachePath));

--- a/pwiz_tools/OspreySharp/OspreySharp/Tasks/PerFileScoringTask.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/Tasks/PerFileScoringTask.cs
@@ -1494,10 +1494,16 @@ namespace pwiz.OspreySharp.Tasks
                 _ctx.LogInfo(string.Format("Loading spectra from cache: {0}", cachePath));
                 try
                 {
+                    // null = stale (source changed) or invalid (bad magic/version)
+                    // cache: a normal miss, not an error. Re-parse the mzML below.
                     var cacheResult = SpectraCache.LoadSpectraCache(cachePath, inputFile);
-                    ms2Spectra = cacheResult.Ms2Spectra;
-                    ms1Spectra = cacheResult.Ms1Spectra;
-                    return;
+                    if (cacheResult != null)
+                    {
+                        ms2Spectra = cacheResult.Ms2Spectra;
+                        ms1Spectra = cacheResult.Ms1Spectra;
+                        return;
+                    }
+                    _ctx.LogInfo("Spectra cache stale or invalid; re-parsing mzML.");
                 }
                 catch (Exception ex)
                 {

--- a/pwiz_tools/OspreySharp/OspreySharp/Tasks/PerFileScoringTask.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/Tasks/PerFileScoringTask.cs
@@ -148,8 +148,7 @@ namespace pwiz.OspreySharp.Tasks
             foreach (var input in ctx.Config.InputFiles)
             {
                 yield return ParquetScoreCache.GetScoresPath(input);
-                string calDir = Path.GetDirectoryName(Path.GetFullPath(input)) ?? @".";
-                yield return CalibrationIO.CalibrationPathForInput(input, calDir);
+                yield return CalibrationIO.CalibrationPathForInput(input, ArtifactPaths.ResolveOutputDir(input));
             }
         }
 
@@ -1304,10 +1303,10 @@ namespace pwiz.OspreySharp.Tasks
                     RtCalibration = RTCalibrationJson.FromRTCalibration(rtCalibration),
                     SecondPassRt = null
                 };
-                // Path.GetDirectoryName can return null for a root path; default
-                // to the current dir so the calibration JSON still has a home.
-                string calDir = Path.GetDirectoryName(Path.GetFullPath(inputFile)) ?? ".";
-                string calPath = CalibrationIO.CalibrationPathForInput(inputFile, calDir);
+                // ArtifactPaths.ResolveOutputDir routes the calibration JSON to
+                // the configured output dir (or the input's own directory by
+                // default), matching where the resume-existence check looks.
+                string calPath = CalibrationIO.CalibrationPathForInput(inputFile, ArtifactPaths.ResolveOutputDir(inputFile));
                 CalibrationIO.SaveCalibration(calParams, calPath);
                 _ctx.LogInfo(string.Format("Saved calibration to {0}", calPath));
             }
@@ -1486,8 +1485,12 @@ namespace pwiz.OspreySharp.Tasks
         private void LoadSpectra(string inputFile, bool serializeMzmlRead,
             out List<Spectrum> ms2Spectra, out List<MS1Spectrum> ms1Spectra)
         {
-            // Check for binary spectra cache
-            string cachePath = inputFile + ".spectra.bin";
+            // Check for binary spectra cache. Filename form preserved
+            // ("{inputFile-leaf}.spectra.bin"); only the directory is redirected
+            // by ArtifactPaths (beside the data file by default).
+            string cachePath = Path.Combine(
+                ArtifactPaths.ResolveCacheDir(inputFile),
+                Path.GetFileName(inputFile) + ".spectra.bin");
             if (File.Exists(cachePath))
             {
                 _ctx.LogInfo(string.Format("Loading spectra from cache: {0}", cachePath));


### PR DESCRIPTION
## Summary

OspreySharp wrote every per-file derived artifact -- including the multi-GB
`.spectra.bin` cache -- *next to the input mzML*, forcing a copy of the raw data
to run an analysis on read-only data. This adds three CLI options so input data
can stay in place (read-only) while only derived output is written elsewhere:

* `--work-dir <dir>` -- sets both of the below (the simple/testing case)
* `--output-dir <dir>` -- base dir for non-cache artifacts (scores parquet,
  calibration JSON, reconciled parquet, FDR/reconciliation sidecars)
* `--cache-dir <dir>` -- the `.spectra.bin` cache only

Precedence: an explicit `--output-dir`/`--cache-dir` overrides the matching
`--work-dir` component. Cache-dir resolution when unset: beside the data file if
writable, else `--output-dir`. **Default (no flags) is byte-identical** to prior
behavior (each artifact in its input's own directory).

* New `ArtifactPaths` holder routes every per-file path through one place, so the
  redirect applies to all artifacts atomically; the FDR/reconciliation sidecars
  cascade off the scores-parquet path, and the rescore spectra-cache/calibration
  lookups resolve through the same holder so straight-through and resume agree.
* `SpectraCache` VERSION 3 records the source size + mtime (Unix ms) so a cache
  living apart from its data file re-parses when the source changes.
* Prerequisite for the overnight "Osprey Windows .NET Regression" TeamCity config
  (read-only test data, all writes under `OspreySharp/TestResults`). Kept
  symmetric with a Rust `maccoss/osprey` PR so cross-impl parity testing also
  stays copy-free.

See `ai/todos/active/TODO-20260609_osprey_output_cache_dir.md`.

## Test plan

- [x] `ArtifactPathsTest.TestArtifactPathsResolution` - resolver paths + byte-identical defaults
- [x] `ArtifactPathsTest.TestWorkOutputCacheDirPrecedence` - flag precedence
- [x] `ArtifactPathsTest.TestSpectraCacheFingerprint` - fingerprint reject/accept/skip
- [x] Build (net472 + net8.0) + ReSharper inspection: 0 warnings; 384 tests (382 pass / 2 pre-existing skip)
- [ ] End-to-end C#-side parity gate (`Compare-EndToEnd-Crossimpl -SkipRust`, Stellar + Astral) -- pre-merge
- [ ] `/pw-self-review` + Copilot

Co-Authored-By: Claude <noreply@anthropic.com>
