### PR TITLE
Fix shape correlation for manually adjusted peak boundaries

### DIFF
--- a/pwiz_tools/Skyline/Model/Results/TransitionGroupIntegrator.cs
+++ b/pwiz_tools/Skyline/Model/Results/TransitionGroupIntegrator.cs
@@ -135,7 +135,10 @@ namespace pwiz.Skyline.Model.Results
                         ?.MakePeakIntegrator(peakGroupIntegrator, _interpolatedTimes)).ToArray();
                 foreach (var peakIntegrator in _peakIntegrators)
                 {
-                    peakGroupIntegrator.AddPeakIntegrator(peakIntegrator);
+                    if (peakIntegrator != null)
+                    {
+                        peakGroupIntegrator.AddPeakIntegrator(peakIntegrator);
+                    }
                 }
                 _peakGroupIntegrator = peakGroupIntegrator;
             }

--- a/pwiz_tools/Skyline/Model/Results/TransitionGroupIntegrator.cs
+++ b/pwiz_tools/Skyline/Model/Results/TransitionGroupIntegrator.cs
@@ -133,6 +133,10 @@ namespace pwiz.Skyline.Model.Results
                 _peakIntegrators = EnsureOptStepChromatograms().Zip(TransitionGroupDocNode.Transitions,
                     (optStepChromatograms, transition) => optStepChromatograms?.GetChromatogramForStep(0)
                         ?.MakePeakIntegrator(peakGroupIntegrator, _interpolatedTimes)).ToArray();
+                foreach (var peakIntegrator in _peakIntegrators)
+                {
+                    peakGroupIntegrator.AddPeakIntegrator(peakIntegrator);
+                }
                 _peakGroupIntegrator = peakGroupIntegrator;
             }
             return _peakGroupIntegrator;

--- a/pwiz_tools/Skyline/TestFunctional/InteractiveCommandLineToolTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/InteractiveCommandLineToolTest.cs
@@ -17,12 +17,10 @@
  * limitations under the License.
  */
 
-using System;
 using System.Linq;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using pwiz.Skyline.Model;
 using pwiz.Skyline.ToolsUI;
-using pwiz.Skyline.Util.Extensions;
 using pwiz.SkylineTestUtil;
 
 namespace pwiz.SkylineTestFunctional
@@ -72,19 +70,7 @@ namespace pwiz.SkylineTestFunctional
             var originalPeakWidth = GetPeakWidth(idPath);
             Assert.AreNotEqual(0, originalPeakWidth);
             RunUI(()=>SkylineWindow.RunTool(3));
-            try
-            {
-                WaitForCondition(() => originalPeakWidth != GetPeakWidth(idPath));
-            }
-            catch (Exception exception)
-            {
-                // The tool runs as a separate process whose output goes to the Immediate Window.
-                // Include that text in the failure so we can see what the tool reported (or whether
-                // it ran at all) when it times out.
-                string immediateWindowText = CallUI(() => SkylineWindow.ImmediateWindow?.TextContent);
-                throw new AssertFailedException(TextUtil.LineSeparate("Immediate Window text:", immediateWindowText),
-                    exception);
-            }
+            WaitForCondition(() => originalPeakWidth != GetPeakWidth(idPath));
             var newPeakWidth = GetPeakWidth(idPath);
             Assert.AreEqual(originalPeakWidth / 2, newPeakWidth, .001);
         }

--- a/pwiz_tools/Skyline/TestFunctional/InteractiveCommandLineToolTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/InteractiveCommandLineToolTest.cs
@@ -17,10 +17,12 @@
  * limitations under the License.
  */
 
+using System;
 using System.Linq;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using pwiz.Skyline.Model;
 using pwiz.Skyline.ToolsUI;
+using pwiz.Skyline.Util.Extensions;
 using pwiz.SkylineTestUtil;
 
 namespace pwiz.SkylineTestFunctional
@@ -70,7 +72,19 @@ namespace pwiz.SkylineTestFunctional
             var originalPeakWidth = GetPeakWidth(idPath);
             Assert.AreNotEqual(0, originalPeakWidth);
             RunUI(()=>SkylineWindow.RunTool(3));
-            WaitForCondition(() => originalPeakWidth != GetPeakWidth(idPath));
+            try
+            {
+                WaitForCondition(() => originalPeakWidth != GetPeakWidth(idPath));
+            }
+            catch (Exception exception)
+            {
+                // The tool runs as a separate process whose output goes to the Immediate Window.
+                // Include that text in the failure so we can see what the tool reported (or whether
+                // it ran at all) when it times out.
+                string immediateWindowText = CallUI(() => SkylineWindow.ImmediateWindow?.TextContent);
+                throw new AssertFailedException(TextUtil.LineSeparate("Immediate Window text:", immediateWindowText),
+                    exception);
+            }
             var newPeakWidth = GetPeakWidth(idPath);
             Assert.AreEqual(originalPeakWidth / 2, newPeakWidth, .001);
         }

--- a/pwiz_tools/Skyline/TestFunctional/ReimportResultsTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/ReimportResultsTest.cs
@@ -69,6 +69,10 @@ namespace pwiz.SkylineTestFunctional
                 Assert.AreEqual(peak1.Item1, transitionChromInfo.StartRetentionTime, deltaRetentionTime);
                 Assert.AreEqual(peak1.Item2, transitionChromInfo.EndRetentionTime, deltaRetentionTime);
                 Assert.AreEqual(expectedArea1, transitionChromInfo.Area, 10);
+                // The shape correlation (and other peak shape values) must be present after
+                // manually adjusting the peak boundaries
+                Assert.IsNotNull(transitionChromInfo.PeakShapeValues);
+                Assert.AreEqual(0.9995, transitionChromInfo.PeakShapeValues.Value.ShapeCorrelation, 1e-4);
 
                 SkylineWindow.SelectedPath =
                     SkylineWindow.Document.GetPathTo((int) SrmDocument.Level.Transitions, 1);


### PR DESCRIPTION
Fixed shape correlation is missing after manually adjusting peak boundaries (reported by Philip)