### PR TITLE
Removed the ambient _ctx field and threaded PipelineContext through the scoring tasks

### DIFF
--- a/pwiz_tools/OspreySharp/OspreySharp/Tasks/AbstractScoringTask.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/Tasks/AbstractScoringTask.cs
@@ -54,12 +54,6 @@ namespace pwiz.OspreySharp.Tasks
     /// </summary>
     public abstract class AbstractScoringTask : OspreyTask
     {
-        // PipelineContext is set on Run entry by the concrete subclass
-        // before any of the moved methods log; the base class never
-        // calls Run itself.
-        internal PipelineContext _ctx;
-
-
         // Internal so FirstJoinTask (which now owns RunPercolatorFdr +
         // RunPercolatorStreaming + BuildBasicFeatures) can reuse the
         // same 21-feature width without redeclaring it.
@@ -142,7 +136,8 @@ namespace pwiz.OspreySharp.Tasks
             RTCalibration rtCalibration,
             MzCalibrationResult ms2Calibration,
             MzCalibrationResult ms1Calibration,
-            ScoringContext context)
+            ScoringContext context,
+            PipelineContext ctx)
         {
             var config = context.Config;
             var allEntries = new List<FdrEntry>();
@@ -245,7 +240,7 @@ namespace pwiz.OspreySharp.Tasks
                     config.RtCalibration.MinRtTolerance,
                     Math.Min(config.RtCalibration.MaxRtTolerance, rtToleranceMad));
                 rtSigmaGlobal = Math.Max(robustSd * 5.0, 0.1);
-                _ctx.LogInfo(string.Format(
+                ctx.LogInfo(string.Format(
                     "Coelution search RT tolerance: {0:F2} min (3*MAD*1.4826, MAD={1:F3}{2})",
                     rtToleranceGlobal, mad,
                     context.OriginalRtMad.HasValue ? " from .calibration.json" : " from cal stats"));
@@ -273,7 +268,7 @@ namespace pwiz.OspreySharp.Tasks
                     Unit = calUnit
                 };
                 string unitStr = calUnit == ToleranceUnit.Ppm ? "ppm" : "Th";
-                _ctx.LogInfo(string.Format(
+                ctx.LogInfo(string.Format(
                     "Coelution search using calibrated fragment tolerance: {0:F4} {1}",
                     calTol, unitStr));
 
@@ -283,7 +278,7 @@ namespace pwiz.OspreySharp.Tasks
                 // built, so no rebuild is needed here.)
                 config.FragmentTolerance = searchFragTol;
 
-                _ctx.LogInfo(string.Format(
+                ctx.LogInfo(string.Format(
                     "Applying MS2 calibration: mean error = {0:F4} {1} -> correcting by {2:+F4;-F4;0} {1}",
                     ms2Calibration.Mean, ms2Calibration.Unit, -ms2Calibration.Mean));
             }
@@ -293,7 +288,7 @@ namespace pwiz.OspreySharp.Tasks
             // OspreyDiagnostics.ShouldDumpSearchXicFor(entry.Id).
             if (OspreyDiagnostics.DiagSearchEntryIds != null)
             {
-                _ctx.LogInfo(string.Format(
+                ctx.LogInfo(string.Format(
                     "[BISECT] OSPREY_DIAG_SEARCH_ENTRY_IDS: will dump {0} entries",
                     OspreyDiagnostics.DiagSearchEntryIds.Count));
             }
@@ -310,7 +305,7 @@ namespace pwiz.OspreySharp.Tasks
             if (maxWindows > 0 && maxWindows < isolationWindows.Count)
             {
                 windowsToScore = isolationWindows.Take(maxWindows).ToList();
-                _ctx.LogInfo(string.Format(
+                ctx.LogInfo(string.Format(
                     "[BENCH] OSPREY_MAX_SCORING_WINDOWS={0} - capping {1} windows to first {0}",
                     maxWindows, isolationWindows.Count));
             }
@@ -318,7 +313,7 @@ namespace pwiz.OspreySharp.Tasks
             // Bracket the main-search parallel loop with the dotTrace Measure
             // API and peak-memory logging. When no profiler is attached the
             // ProfilerHooks calls are inexpensive no-ops.
-            ProfilerHooks.LogMemoryStats(_ctx.LogInfo, "pre-main-search");
+            ProfilerHooks.LogMemoryStats(ctx.LogInfo, "pre-main-search");
             ProfilerHooks.StartMeasure();
 
             // Process each isolation window (parallelizable). Per-window
@@ -343,7 +338,7 @@ namespace pwiz.OspreySharp.Tasks
                 var windowEntries = ScoreWindow(
                     window, fullLibrary, spectraByWindowKey, ms1Spectra,
                     rtCalibration, ms1Calibration, rtToleranceGlobal, rtSigmaGlobal,
-                    scorer, context);
+                    scorer, context, ctx);
                 swWindow.Stop();
 
                 windowTimings.Add(new WindowTiming
@@ -360,7 +355,7 @@ namespace pwiz.OspreySharp.Tasks
                     windowsProcessed++;
                     if (windowsProcessed % 10 == 0 || windowsProcessed == windowsToScore.Count)
                     {
-                        _ctx.LogInfo(string.Format("  Scored {0}/{1} isolation windows",
+                        ctx.LogInfo(string.Format("  Scored {0}/{1} isolation windows",
                             windowsProcessed, windowsToScore.Count));
                     }
                 }
@@ -374,18 +369,18 @@ namespace pwiz.OspreySharp.Tasks
             }
 
             ProfilerHooks.SaveAndStopMeasure();
-            ProfilerHooks.LogMemoryStats(_ctx.LogInfo, "post-main-search");
+            ProfilerHooks.LogMemoryStats(ctx.LogInfo, "post-main-search");
 
             if (context.XcorrScratchPool != null)
             {
-                _ctx.LogInfo(string.Format(
+                ctx.LogInfo(string.Format(
                     "[POOL] scratch_allocs={0}, bins_allocs={1}",
                     context.XcorrScratchPool.ScratchAllocCount,
                     context.XcorrScratchPool.BinsAllocCount));
             }
 
             // Summarize per-window timings.
-            LogWindowTimingSummary(windowTimings);
+            LogWindowTimingSummary(windowTimings, ctx);
 
             return allEntries;
         }
@@ -405,7 +400,7 @@ namespace pwiz.OspreySharp.Tasks
         /// <summary>
         /// Log min/median/max per-window scoring times and the slowest window's candidate count.
         /// </summary>
-        private void LogWindowTimingSummary(ConcurrentBag<WindowTiming> timings)
+        private void LogWindowTimingSummary(ConcurrentBag<WindowTiming> timings, PipelineContext ctx)
         {
             if (timings == null || timings.Count == 0)
                 return;
@@ -416,7 +411,7 @@ namespace pwiz.OspreySharp.Tasks
             double maxS = sorted[n - 1].Seconds;
             double medS = sorted[n / 2].Seconds;
             var slowest = sorted[n - 1];
-            _ctx.LogInfo(string.Format(
+            ctx.LogInfo(string.Format(
                 "[TIMING] Per-window: min={0:F2}s, median={1:F2}s, max={2:F2}s (slowest m/z={3:F1} had {4} candidates)",
                 minS, medS, maxS, slowest.CenterMz, slowest.CandidateCount));
         }
@@ -440,7 +435,8 @@ namespace pwiz.OspreySharp.Tasks
             double globalRtTolerance,
             double rtSigma,
             SpectralScorer scorer,
-            ScoringContext context)
+            ScoringContext context,
+            PipelineContext ctx)
         {
             var config = context.Config;
             var entries = new List<FdrEntry>();
@@ -508,7 +504,7 @@ namespace pwiz.OspreySharp.Tasks
                         rtCalibration,
                         globalRtTolerance, rtSigma,
                         scorer, context,
-                        ospreyContext, ospreyPeakData);
+                        ospreyContext, ospreyPeakData, ctx);
 
                     if (fdrEntry != null)
                         entries.Add(fdrEntry);
@@ -616,7 +612,8 @@ namespace pwiz.OspreySharp.Tasks
             SpectralScorer scorer,
             ScoringContext context,
             OspreyScoringContext ospreyContext,
-            OspreyPeakData ospreyPeakData)
+            OspreyPeakData ospreyPeakData,
+            PipelineContext ctx)
         {
             var config = context.Config;
             var resolution = context.Resolution;
@@ -661,11 +658,11 @@ namespace pwiz.OspreySharp.Tasks
 
             if (diag)
             {
-                _ctx.LogInfo(string.Format(
+                ctx.LogInfo(string.Format(
                     "[DIAG] {0} charge {1}: library_rt={2:F3}, expected_rt={3:F3}, tolerance={4:F3}",
                     candidate.ModifiedSequence, candidate.Charge,
                     candidate.RetentionTime, expectedRt, rtTolerance));
-                _ctx.LogInfo(string.Format(
+                ctx.LogInfo(string.Format(
                     "[DIAG] {0}: window m/z={1:F3}, fragments={2}, window_spectra={3}",
                     candidate.ModifiedSequence, candidate.PrecursorMz,
                     candidate.Fragments.Count, nScans));
@@ -733,12 +730,12 @@ namespace pwiz.OspreySharp.Tasks
             {
                 if (startScan >= 0 && endScan >= 0)
                 {
-                    _ctx.LogInfo(string.Format(
+                    ctx.LogInfo(string.Format(
                         "[DIAG] {0}: scan range [{1}..{2}] RT [{3:F3}..{4:F3}] ({5} scans)",
                         candidate.ModifiedSequence, startScan, endScan,
                         windowRts[startScan], windowRts[endScan],
                         endScan - startScan + 1));
-                    _ctx.LogInfo(string.Format(
+                    ctx.LogInfo(string.Format(
                         "[DIAG] {0}: spectrum scan_numbers in range: first={1}, last={2}",
                         candidate.ModifiedSequence,
                         windowSpectra[startScan].ScanNumber,
@@ -746,7 +743,7 @@ namespace pwiz.OspreySharp.Tasks
                 }
                 else
                 {
-                    _ctx.LogInfo(string.Format(
+                    ctx.LogInfo(string.Format(
                         "[DIAG] {0}: no scans in RT window around expected_rt={1:F3}",
                         candidate.ModifiedSequence, expectedRt));
                 }
@@ -887,7 +884,7 @@ namespace pwiz.OspreySharp.Tasks
 
             if (diag)
             {
-                _ctx.LogInfo(string.Format(
+                ctx.LogInfo(string.Format(
                     "[DIAG] {0}: xics extracted={1}, peaks={2}",
                     candidate.ModifiedSequence, xics.Count, peaks.Count));
                 for (int i = 0; i < peaks.Count; i++)
@@ -896,7 +893,7 @@ namespace pwiz.OspreySharp.Tasks
                     int apexAbsIdx = startScan + p.ApexIndex;
                     double apexRt = windowRts[apexAbsIdx];
                     uint apexScanNum = windowSpectra[apexAbsIdx].ScanNumber;
-                    _ctx.LogInfo(string.Format(
+                    ctx.LogInfo(string.Format(
                         "[DIAG] {0}: peak[{1}] apex_local={2} apex_rt={3:F3} scan#={4} range=[{5}..{6}]",
                         candidate.ModifiedSequence, i, p.ApexIndex,
                         apexRt, apexScanNum, p.StartIndex, p.EndIndex));
@@ -1021,7 +1018,7 @@ namespace pwiz.OspreySharp.Tasks
 
                 if (diag)
                 {
-                    _ctx.LogInfo(string.Format(
+                    ctx.LogInfo(string.Format(
                         "[DIAG] {0}: peak[{1}] pairwise_corr_mean={2:F4} rt_penalty={3:F4} int_weight={4:F2} rank={5:F4}",
                         candidate.ModifiedSequence, pi, coelutionScore, rtPenalty, intensityWeight, rankScore));
                 }
@@ -1048,7 +1045,7 @@ namespace pwiz.OspreySharp.Tasks
             if (diag && bestPeak != null)
             {
                 int apexAbsIdx = startScan + bestPeak.ApexIndex;
-                _ctx.LogInfo(string.Format(
+                ctx.LogInfo(string.Format(
                     "[DIAG] {0}: WINNER peak[{1}] apex_rt={2:F3} scan#={3}",
                     candidate.ModifiedSequence, bestPeakIdx,
                     windowRts[apexAbsIdx], windowSpectra[apexAbsIdx].ScanNumber));
@@ -1463,7 +1460,8 @@ namespace pwiz.OspreySharp.Tasks
             IList<Spectrum> spectra,
             MzCalibrationResult ms2Cal,
             List<IsolationWindow> isolationWindows,
-            OspreyConfig config)
+            OspreyConfig config,
+            PipelineContext ctx)
         {
             int originalCount = entries.Count;
             if (originalCount == 0 || isolationWindows == null || isolationWindows.Count == 0)
@@ -1645,7 +1643,7 @@ namespace pwiz.OspreySharp.Tasks
             int removedDecoys = removedCount - removedTargets;
             if (removedCount > 0)
             {
-                _ctx.LogInfo(string.Format(
+                ctx.LogInfo(string.Format(
                     "Double-counting deduplication: removed {0} entries " +
                     "({1} targets, {2} decoys; {3} remaining)",
                     removedCount, removedTargets, removedDecoys,
@@ -1659,7 +1657,7 @@ namespace pwiz.OspreySharp.Tasks
         }
 
 
-        protected List<FdrEntry> DeduplicatePairs(List<FdrEntry> entries)
+        protected List<FdrEntry> DeduplicatePairs(List<FdrEntry> entries, PipelineContext ctx)
         {
             // Group by base_id (mask off high bit)
             var groups = new Dictionary<uint, KeyValuePair<FdrEntry, FdrEntry>>();
@@ -1715,7 +1713,7 @@ namespace pwiz.OspreySharp.Tasks
             int removed = entries.Count - deduped.Count;
             if (removed > 0)
             {
-                _ctx.LogInfo(string.Format("Deduplicated: {0} -> {1} entries ({2} removed)",
+                ctx.LogInfo(string.Format("Deduplicated: {0} -> {1} entries ({2} removed)",
                     entries.Count, deduped.Count, removed));
             }
 

--- a/pwiz_tools/OspreySharp/OspreySharp/Tasks/FirstJoinTask.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/Tasks/FirstJoinTask.cs
@@ -188,7 +188,6 @@ namespace pwiz.OspreySharp.Tasks
             // task here only in the bundle-absent modes (straight-through,
             // --task FirstJoin); a worker-mode consumer materializes it via
             // ctx.Demand which routes to Rehydrate.
-            _ctx = ctx;
             var config = ctx.Config;
 
             // Mid-Run crash safety: clear stale sidecars for the outputs
@@ -211,12 +210,12 @@ namespace pwiz.OspreySharp.Tasks
                 config.FdrMethod));
 
             var swFdr = Stopwatch.StartNew();
-            RunFdr(perFileEntries, fullLibrary, config);
+            RunFdr(perFileEntries, fullLibrary, config, ctx);
             swFdr.Stop();
             ctx.LogInfo(string.Format(@"[TIMING] Percolator/Simple FDR: {0:F1}s",
                 swFdr.Elapsed.TotalSeconds));
 
-            LogFirstPassResultsAndDump(perFileEntries, config);
+            LogFirstPassResultsAndDump(perFileEntries, config, ctx);
 
             // First-pass protein FDR: runs on the full pre-compaction
             // peptide pool so target and decoy proteins compete on a
@@ -229,7 +228,7 @@ namespace pwiz.OspreySharp.Tasks
                 ctx.LogInfo(string.Empty);
                 ctx.LogInfo(@"First-pass protein FDR");
                 var swFirstPassProtein = Stopwatch.StartNew();
-                RunFirstPassProteinFdr(perFileEntries, fullLibrary, config);
+                RunFirstPassProteinFdr(perFileEntries, fullLibrary, config, ctx);
                 swFirstPassProtein.Stop();
                 ctx.LogInfo(string.Format(@"[TIMING] First-pass protein FDR: {0:F1}s",
                     swFirstPassProtein.Elapsed.TotalSeconds));
@@ -243,7 +242,7 @@ namespace pwiz.OspreySharp.Tasks
             // threshold themselves, so they need every entry's q-values
             // -- not just the survivors.
             int fdrSidecarFailures = WriteFdrScoresSidecars(
-                perFileEntries, perFileParquetPaths, config);
+                perFileEntries, perFileParquetPaths, config, ctx);
             if (fdrSidecarFailures > 0 && config.StopAfterStage5)
             {
                 ctx.LogError(string.Format(
@@ -263,7 +262,7 @@ namespace pwiz.OspreySharp.Tasks
             // includes non-passing charge states that Rust has already
             // dropped, producing different rescore-target sets and
             // different per-file Vec positions.
-            CompactFirstPass(perFileEntries, null, config);
+            CompactFirstPass(perFileEntries, null, config, ctx);
 
             // NOTE: no 2nd-pass FDR sidecar overlay here. Stage 7
             // (MergeNodeTask) owns its own 2nd-pass rehydrate -- it reloads (or
@@ -284,7 +283,7 @@ namespace pwiz.OspreySharp.Tasks
             if (perFileEntries.Count >= 1 && config.Reconciliation.Enabled)
             {
                 if (!PlanStage6(perFileEntries, perFileCalibrations,
-                        perFileParquetPaths, fullLibrary, config))
+                        perFileParquetPaths, fullLibrary, config, ctx))
                     return false;
             }
 
@@ -312,7 +311,6 @@ namespace pwiz.OspreySharp.Tasks
             // compute_fdr_from_stubs skip, pipeline.rs:3916). All that remains
             // is to adopt a post-Stage-5 bundle and compact. The compute
             // counterpart is Run.
-            _ctx = ctx;
             var config = ctx.Config;
             var perFileEntries = ctx.Get<ScoredEntries>().Value;
 
@@ -335,13 +333,13 @@ namespace pwiz.OspreySharp.Tasks
 
             ctx.LogInfo(@"Bundle hydration: skipping first-pass Percolator (sidecar provides q-values).");
 
-            LogFirstPassResultsAndDump(perFileEntries, config);
+            LogFirstPassResultsAndDump(perFileEntries, config, ctx);
 
             // Compaction delegates to RescoreCompaction.Apply on the bundle
             // path so the pre-compaction (file, vec_idx) keys in
             // bundle.ReconciliationActions get rebuilt to post-compaction
             // indices for PerFileRescoreTask.
-            CompactFirstPass(perFileEntries, bundle, config);
+            CompactFirstPass(perFileEntries, bundle, config, ctx);
 
             // Publish the SAME four planning byproducts as Run, but sourced from
             // the adopted bundle (post-compaction). A consumer pulls
@@ -431,9 +429,10 @@ namespace pwiz.OspreySharp.Tasks
         /// </summary>
         private void LogFirstPassResultsAndDump(
             List<KeyValuePair<string, List<FdrEntry>>> perFileEntries,
-            OspreyConfig config)
+            OspreyConfig config,
+            PipelineContext ctx)
         {
-            LogFirstPassResults(perFileEntries, config);
+            LogFirstPassResults(perFileEntries, config, ctx);
 
             if (OspreyDiagnostics.DumpPercolator)
                 OspreyDiagnostics.WriteStage5PercolatorDump(perFileEntries);
@@ -447,7 +446,8 @@ namespace pwiz.OspreySharp.Tasks
         /// </summary>
         private void LogFirstPassResults(
             List<KeyValuePair<string, List<FdrEntry>>> perFileEntries,
-            OspreyConfig config)
+            OspreyConfig config,
+            PipelineContext ctx)
         {
             int passingTargets = 0;
             foreach (var kvp in perFileEntries)
@@ -461,11 +461,11 @@ namespace pwiz.OspreySharp.Tasks
                         fileTargets++;
                     }
                 }
-                _ctx.LogInfo(string.Format(@"  {0}: {1} precursors at {2:P1} run-level FDR",
+                ctx.LogInfo(string.Format(@"  {0}: {1} precursors at {2:P1} run-level FDR",
                     kvp.Key, fileTargets, config.RunFdr));
                 passingTargets += fileTargets;
             }
-            _ctx.LogInfo(string.Format(@"Total: {0} precursors pass run-level FDR across all files",
+            ctx.LogInfo(string.Format(@"Total: {0} precursors pass run-level FDR across all files",
                 passingTargets));
         }
 
@@ -481,7 +481,8 @@ namespace pwiz.OspreySharp.Tasks
         private void CompactFirstPass(
             List<KeyValuePair<string, List<FdrEntry>>> perFileEntries,
             RescoreInputs bundle,
-            OspreyConfig config)
+            OspreyConfig config,
+            PipelineContext ctx)
         {
             if (perFileEntries.Count > 0)
             {
@@ -497,7 +498,7 @@ namespace pwiz.OspreySharp.Tasks
                     // failure the worker's hand-rolled compaction at
                     // RescoreCompaction.Apply was written to avoid.
                     var stats = RescoreCompaction.Apply(bundle, config);
-                    _ctx.LogInfo(string.Format(
+                    ctx.LogInfo(string.Format(
                         @"First-pass compaction: {0} -> {1} entries ({2} passing base_ids; {3} action(s) dropped)",
                         stats.EntriesBefore, stats.EntriesAfter,
                         stats.FirstPassBaseIds, stats.DroppedActions));
@@ -528,7 +529,7 @@ namespace pwiz.OspreySharp.Tasks
                         kvp.Value.TrimExcess();
                         afterCount += kvp.Value.Count;
                     }
-                    _ctx.LogInfo(string.Format(
+                    ctx.LogInfo(string.Format(
                         @"First-pass compaction: {0} -> {1} entries ({2} passing base_ids)",
                         beforeCount, afterCount, firstPassBaseIds.Count));
                 }
@@ -554,10 +555,11 @@ namespace pwiz.OspreySharp.Tasks
             IReadOnlyDictionary<string, RTCalibration> perFileCalibrations,
             IReadOnlyDictionary<string, string> perFileParquetPaths,
             List<LibraryEntry> fullLibrary,
-            OspreyConfig config)
+            OspreyConfig config,
+            PipelineContext ctx)
         {
-            _ctx.LogInfo(string.Empty);
-            _ctx.LogInfo(@"Stage 6: planning");
+            ctx.LogInfo(string.Empty);
+            ctx.LogInfo(@"Stage 6: planning");
 
             // 1. Multi-charge consensus per file (independent — runs
             //    first per Rust pipeline.rs:3217, before consensus
@@ -572,7 +574,7 @@ namespace pwiz.OspreySharp.Tasks
             int totalMulticharge = 0;
             foreach (var kvp in perFileConsensusTargets)
                 totalMulticharge += kvp.Value.Count;
-            _ctx.LogInfo(string.Format(
+            ctx.LogInfo(string.Format(
                 @"Stage 6 multi-charge consensus: {0} entries need re-scoring across {1} files",
                 totalMulticharge, perFileEntries.Count));
 
@@ -638,7 +640,7 @@ namespace pwiz.OspreySharp.Tasks
                 if (c.IsDecoy) nDecoys++;
                 else nTargets++;
             }
-            _ctx.LogInfo(string.Format(
+            ctx.LogInfo(string.Format(
                 @"Stage 6 consensus: {0} target peptides, {1} decoy peptides",
                 nTargets, nDecoys));
 
@@ -666,7 +668,7 @@ namespace pwiz.OspreySharp.Tasks
                 if (refined != null)
                     refinedCalibrations[kvp.Key] = refined;
             }
-            _ctx.LogInfo(string.Format(
+            ctx.LogInfo(string.Format(
                 @"Stage 6 refit: {0}/{1} files produced refined calibrations",
                 refinedCalibrations.Count, perFileEntries.Count));
 
@@ -720,7 +722,7 @@ namespace pwiz.OspreySharp.Tasks
                         }
                         if (kvp.Value.Count > 0 && maxIdx >= cwtRows.Count)
                         {
-                            _ctx.LogWarning(string.Format(
+                            ctx.LogWarning(string.Format(
                                 @"CWT candidate row count out of range for {0}: " +
                                 @"max stub ParquetIndex={1}, parquet has {2} rows -- " +
                                 @"skipping reconciliation planning for this file",
@@ -734,7 +736,7 @@ namespace pwiz.OspreySharp.Tasks
                     }
                     catch (Exception ex)
                     {
-                        _ctx.LogWarning(string.Format(
+                        ctx.LogWarning(string.Format(
                             @"Failed to load CWT candidates for {0}: {1}",
                             kvp.Key, ex.Message));
                     }
@@ -764,17 +766,17 @@ namespace pwiz.OspreySharp.Tasks
                     refinedCalibrations,
                     perFileCalibrations,
                     config.Reconciliation.ConsensusFdr);
-                _ctx.LogInfo(string.Format(
+                ctx.LogInfo(string.Format(
                     @"Stage 6 reconciliation: {0} per-(file, entry) actions planned",
                     reconciliationActions.Count));
             }
             else if (consensus.Count == 0)
             {
-                _ctx.LogInfo(@"Stage 6 reconciliation: skipped (empty consensus; single-file or no cross-file evidence)");
+                ctx.LogInfo(@"Stage 6 reconciliation: skipped (empty consensus; single-file or no cross-file evidence)");
             }
             else
             {
-                _ctx.LogInfo(string.Format(
+                ctx.LogInfo(string.Format(
                     @"Stage 6 reconciliation: skipped (CWT candidates loaded for {0}/{1} files)",
                     perFileCwtCandidates.Count, perFileEntries.Count));
             }
@@ -813,20 +815,21 @@ namespace pwiz.OspreySharp.Tasks
                 fullLibrary,
                 perFileParquetPaths,
                 config,
-                out var perFileGapFillForRescore);
+                out var perFileGapFillForRescore,
+                ctx);
 
             if (config.StopAfterStage5)
             {
                 if (reconWriteFailures > 0)
                 {
-                    _ctx.LogError(string.Format(
+                    ctx.LogError(string.Format(
                         @"--task FirstJoin: {0}/{1} reconciliation.json " +
                         @"writes failed; boundary file pair is incomplete. See warnings above.",
                         reconWriteFailures, perFileEntries.Count));
-                    _ctx.ExitCode = 1;
+                    ctx.ExitCode = 1;
                     return false;
                 }
-                _ctx.LogInfo(string.Format(
+                ctx.LogInfo(string.Format(
                     @"--task FirstJoin: Stage 5 + reconciliation planning " +
                     @"complete; wrote {0} reconciliation.json + matching fdr_scores.bin " +
                     @"sidecar pair(s). Exiting before Stage 6 rescore.",
@@ -835,7 +838,7 @@ namespace pwiz.OspreySharp.Tasks
                 // a membership fact -- PerFileRescore and MergeNode are excluded
                 // by IsIncluded under --task FirstJoin, so the driver loop iterates no
                 // further. The failure path above keeps ExitCode=1; return false.
-                _ctx.ExitCode = 0;
+                ctx.ExitCode = 0;
                 return true;
             }
 
@@ -870,7 +873,8 @@ namespace pwiz.OspreySharp.Tasks
         private int WriteFdrScoresSidecars(
             List<KeyValuePair<string, List<FdrEntry>>> perFileEntries,
             IReadOnlyDictionary<string, string> perFileParquetPaths,
-            OspreyConfig config)
+            OspreyConfig config,
+            PipelineContext ctx)
         {
             int failures = 0;
             foreach (var kvp in perFileEntries)
@@ -879,7 +883,7 @@ namespace pwiz.OspreySharp.Tasks
                 string sidecarBase = ResolveSidecarBasePath(fileName, perFileParquetPaths, config);
                 if (string.IsNullOrEmpty(sidecarBase))
                 {
-                    _ctx.LogWarning(string.Format(
+                    ctx.LogWarning(string.Format(
                         "No sidecar base path for `{0}` — skipping fdr_scores.bin write", fileName));
                     failures++;
                     continue;
@@ -891,7 +895,7 @@ namespace pwiz.OspreySharp.Tasks
                 }
                 catch (Exception ex)
                 {
-                    _ctx.LogWarning(string.Format(
+                    ctx.LogWarning(string.Format(
                         "Failed to write 1st-pass fdr_scores.bin for {0}: {1}", fileName, ex.Message));
                     failures++;
                 }
@@ -926,7 +930,8 @@ namespace pwiz.OspreySharp.Tasks
             List<LibraryEntry> fullLibrary,
             IReadOnlyDictionary<string, string> perFileParquetPaths,
             OspreyConfig config,
-            out Dictionary<string, List<GapFillTarget>> gapFillByFileOut)
+            out Dictionary<string, List<GapFillTarget>> gapFillByFileOut,
+            PipelineContext ctx)
         {
             string searchHash = config.Identity.SearchParameterHash();
             string libraryHash = config.Identity.LibraryIdentityHash();
@@ -1030,7 +1035,7 @@ namespace pwiz.OspreySharp.Tasks
                 string sidecarBase = ResolveSidecarBasePath(fileName, perFileParquetPaths, config);
                 if (string.IsNullOrEmpty(sidecarBase))
                 {
-                    _ctx.LogWarning(string.Format(
+                    ctx.LogWarning(string.Format(
                         "No sidecar base path for `{0}` — skipping reconciliation.json write", fileName));
                     failures++;
                     continue;
@@ -1047,7 +1052,7 @@ namespace pwiz.OspreySharp.Tasks
                 try
                 {
                     ReconciliationFile.Save(reconPath, reconFile);
-                    _ctx.LogInfo(string.Format(
+                    ctx.LogInfo(string.Format(
                         "Wrote reconciliation.json for {0} ({1} use_cwt + {2} forced + {3} gap-fill)",
                         fileName,
                         reconFile.UseCwtPeakActions.Count,
@@ -1056,7 +1061,7 @@ namespace pwiz.OspreySharp.Tasks
                 }
                 catch (Exception ex)
                 {
-                    _ctx.LogWarning(string.Format(
+                    ctx.LogWarning(string.Format(
                         "Failed to write reconciliation.json for {0}: {1}", fileName, ex.Message));
                     failures++;
                 }
@@ -1219,23 +1224,24 @@ namespace pwiz.OspreySharp.Tasks
         private void RunFdr(
             List<KeyValuePair<string, List<FdrEntry>>> perFileEntries,
             List<LibraryEntry> fullLibrary,
-            OspreyConfig config)
+            OspreyConfig config,
+            PipelineContext ctx)
         {
             switch (config.FdrMethod)
             {
                 case FdrMethod.Percolator:
-                    RunPercolatorFdr(perFileEntries, fullLibrary, config, _ctx);
+                    RunPercolatorFdr(perFileEntries, fullLibrary, config, ctx);
                     break;
 
                 case FdrMethod.Simple:
-                    RunSimpleFdr(perFileEntries, config);
+                    RunSimpleFdr(perFileEntries, config, ctx);
                     break;
 
                 default:
-                    _ctx.LogWarning(string.Format(
+                    ctx.LogWarning(string.Format(
                         "FDR method {0} not yet supported, falling back to simple",
                         config.FdrMethod));
-                    RunSimpleFdr(perFileEntries, config);
+                    RunSimpleFdr(perFileEntries, config, ctx);
                     break;
             }
         }
@@ -1642,7 +1648,8 @@ namespace pwiz.OspreySharp.Tasks
         /// </summary>
         private void RunSimpleFdr(
             List<KeyValuePair<string, List<FdrEntry>>> perFileEntries,
-            OspreyConfig config)
+            OspreyConfig config,
+            PipelineContext ctx)
         {
             var fdrController = new FdrController(config.RunFdr);
 
@@ -1654,7 +1661,7 @@ namespace pwiz.OspreySharp.Tasks
                     e => e.IsDecoy,
                     e => e.EntryId);
 
-                _ctx.LogInfo(string.Format(
+                ctx.LogInfo(string.Format(
                     "  {0}: {1} targets pass (FDR={2:F4}, {3} target wins, {4} decoy wins)",
                     kvp.Key, result.PassingTargets.Count, result.FdrAtThreshold,
                     result.NTargetWins, result.NDecoyWins));
@@ -1691,7 +1698,8 @@ namespace pwiz.OspreySharp.Tasks
         private void RunFirstPassProteinFdr(
             List<KeyValuePair<string, List<FdrEntry>>> perFileEntries,
             List<LibraryEntry> fullLibrary,
-            OspreyConfig config)
+            OspreyConfig config,
+            PipelineContext ctx)
         {
             // Detected-peptide count for logging only; the core computation +
             // propagation lives in ProteinFdr.RunFirstPassProteinFdr so the
@@ -1708,7 +1716,7 @@ namespace pwiz.OspreySharp.Tasks
                 }
             }
             detectedCount = detectedTracker.Count;
-            _ctx.LogInfo(string.Format(
+            ctx.LogInfo(string.Format(
                 "[COUNT] First-pass detected peptides for protein FDR: {0} unique",
                 detectedCount));
 
@@ -1728,7 +1736,7 @@ namespace pwiz.OspreySharp.Tasks
                 if (qv <= config.RunFdr)
                     nAtRunFdr++;
             }
-            _ctx.LogInfo(string.Format(
+            ctx.LogInfo(string.Format(
                 "First-pass protein FDR: {0} target groups at {1:P1} FDR",
                 nAtRunFdr, config.RunFdr));
 

--- a/pwiz_tools/OspreySharp/OspreySharp/Tasks/MergeNodeTask.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/Tasks/MergeNodeTask.cs
@@ -47,11 +47,6 @@ namespace pwiz.OspreySharp.Tasks
     /// </summary>
     internal sealed class MergeNodeTask : OspreyTask
     {
-        // PipelineContext is set on Run entry so the moved
-        // RunProteinFdr / WriteBlibOutput methods can log
-        // through the same callbacks the pipeline driver uses.
-        private PipelineContext _ctx;
-
         public override string Name => @"MergeNode";
 
         /// <summary>
@@ -117,7 +112,6 @@ namespace pwiz.OspreySharp.Tasks
 
         public override bool Run(PipelineContext ctx)
         {
-            _ctx = ctx;
             // Mid-Run crash safety: see FirstJoinTask.Run for rationale.
             foreach (var output in Outputs(ctx))
                 TaskValiditySidecar.Delete(output, Name);
@@ -474,7 +468,7 @@ namespace pwiz.OspreySharp.Tasks
                 ctx.LogInfo(string.Format(@"Running protein-level FDR at {0:P1}...",
                     config.ProteinFdr.Value));
                 var swProtein = Stopwatch.StartNew();
-                RunProteinFdr(perFileEntries, fullLibrary, config);
+                RunProteinFdr(perFileEntries, fullLibrary, config, ctx);
                 swProtein.Stop();
                 ctx.LogInfo(string.Format(@"[STAGE-WALL] stage7: {0:F1}s",
                     swProtein.Elapsed.TotalSeconds));
@@ -484,7 +478,7 @@ namespace pwiz.OspreySharp.Tasks
             ctx.LogInfo(string.Empty);
             ctx.LogInfo(string.Format(@"Writing output to {0}...", config.OutputBlib));
             var swBlib = Stopwatch.StartNew();
-            WriteBlibOutput(perFileEntries, fullLibrary, libraryById, config);
+            WriteBlibOutput(perFileEntries, fullLibrary, libraryById, config, ctx);
             swBlib.Stop();
             ctx.LogInfo(string.Format(@"[STAGE-WALL] blib: {0:F1}s",
                 swBlib.Elapsed.TotalSeconds));
@@ -499,11 +493,12 @@ namespace pwiz.OspreySharp.Tasks
         private void RunProteinFdr(
             List<KeyValuePair<string, List<FdrEntry>>> perFileEntries,
             List<LibraryEntry> fullLibrary,
-            OspreyConfig config)
+            OspreyConfig config,
+            PipelineContext ctx)
         {
             // Collect best peptide scores
             var bestScores = ProteinFdr.CollectBestPeptideScores(perFileEntries);
-            _ctx.LogInfo(string.Format("Collected scores for {0} unique peptides", bestScores.Count));
+            ctx.LogInfo(string.Format("Collected scores for {0} unique peptides", bestScores.Count));
 
             // Get detected peptide set: targets passing experiment-level
             // q-value at the configured fdr_level (matches Rust pipeline.rs
@@ -535,9 +530,9 @@ namespace pwiz.OspreySharp.Tasks
                 }
             }
 
-            _ctx.LogInfo(string.Format("Detected {0} unique peptides at {1:P1} experiment FDR ({2})",
+            ctx.LogInfo(string.Format("Detected {0} unique peptides at {1:P1} experiment FDR ({2})",
                 detectedPeptides.Count, config.ExperimentFdr, peptideGateLevel));
-            _ctx.LogInfo(string.Format(
+            ctx.LogInfo(string.Format(
                 "[COUNT] Detected peptides for protein FDR: {0} unique",
                 detectedPeptides.Count));
 
@@ -549,8 +544,8 @@ namespace pwiz.OspreySharp.Tasks
             var parsimony = ProteinFdr.BuildProteinParsimony(
                 fullLibrary, config.SharedPeptides, detectedPeptides);
 
-            _ctx.LogInfo(string.Format("Protein parsimony: {0} groups", parsimony.Groups.Count));
-            _ctx.LogInfo(string.Format(
+            ctx.LogInfo(string.Format("Protein parsimony: {0} groups", parsimony.Groups.Count));
+            ctx.LogInfo(string.Format(
                 "[COUNT] Protein parsimony groups: {0}", parsimony.Groups.Count));
 
             // Compute protein FDR. Gate is config.RunFdr (1x) per Savitski's
@@ -567,9 +562,9 @@ namespace pwiz.OspreySharp.Tasks
                     passingProteins++;
             }
 
-            _ctx.LogInfo(string.Format("{0} protein groups pass {1:P1} protein FDR",
+            ctx.LogInfo(string.Format("{0} protein groups pass {1:P1} protein FDR",
                 passingProteins, config.ProteinFdr.Value));
-            _ctx.LogInfo(string.Format(
+            ctx.LogInfo(string.Format(
                 "[COUNT] Protein groups passing FDR: {0} at {1:P0}",
                 passingProteins, config.ProteinFdr.Value));
 
@@ -595,7 +590,8 @@ namespace pwiz.OspreySharp.Tasks
             List<KeyValuePair<string, List<FdrEntry>>> perFileEntries,
             List<LibraryEntry> fullLibrary,
             IReadOnlyDictionary<uint, LibraryEntry> libraryById,
-            OspreyConfig config)
+            OspreyConfig config,
+            PipelineContext ctx)
         {
             // Two-stage blib output gate, mirroring Rust pipeline.rs:4596-4668.
             //
@@ -619,22 +615,22 @@ namespace pwiz.OspreySharp.Tasks
                 perFileEntries, config, passingPeptides, out int nFallback);
             if (nFallback > 0)
             {
-                _ctx.LogInfo(string.Format(
+                ctx.LogInfo(string.Format(
                     "{0} peptides had no charge state passing precursor-level FDR; best charge state kept as fallback",
                     nFallback));
             }
 
             var passingEntries = CollectPassingEntries(perFileEntries, passingPrecursors);
 
-            _ctx.LogInfo(string.Format(
+            ctx.LogInfo(string.Format(
                 "[COUNT] Stage 1 passing peptides: {0}", passingPeptides.Count));
-            _ctx.LogInfo(string.Format(
+            ctx.LogInfo(string.Format(
                 "[COUNT] Stage 2 passing precursors: {0}", passingPrecursors.Count));
-            _ctx.LogInfo(string.Format("Writing {0} passing entries to blib", passingEntries.Count));
+            ctx.LogInfo(string.Format("Writing {0} passing entries to blib", passingEntries.Count));
 
             if (passingEntries.Count == 0)
             {
-                _ctx.LogWarning("No entries pass FDR threshold. Creating empty blib.");
+                ctx.LogWarning("No entries pass FDR threshold. Creating empty blib.");
             }
 
             // Ensure output directory exists
@@ -644,7 +640,7 @@ namespace pwiz.OspreySharp.Tasks
 
             var bestByPrecursor = BuildBestByPrecursor(passingEntries);
 
-            _ctx.LogInfo(string.Format(
+            ctx.LogInfo(string.Format(
                 "[COUNT] Best-per-precursor for blib: {0}", bestByPrecursor.Count));
 
             var bestExpPrecursorQ = BuildBestExpPrecursorQ(perFileEntries, passingPrecursors);
@@ -654,13 +650,13 @@ namespace pwiz.OspreySharp.Tasks
             var entriesByPrecursor = BuildCrossFileObservations(
                 perFileEntries, out int nCrossFileObservations);
 
-            _ctx.LogInfo(string.Format(
+            ctx.LogInfo(string.Format(
                 "[COUNT] Cross-file observations to write: {0}", nCrossFileObservations));
 
             WriteBlibFile(config, perFileEntries, libraryById, bestByPrecursor,
                 bestExpPrecursorQ, sharedBounds, entriesByPrecursor);
 
-            _ctx.LogInfo(string.Format("Wrote {0} spectra to {1}",
+            ctx.LogInfo(string.Format("Wrote {0} spectra to {1}",
                 bestByPrecursor.Count, config.OutputBlib));
         }
 

--- a/pwiz_tools/OspreySharp/OspreySharp/Tasks/PerFileRescoreTask.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/Tasks/PerFileRescoreTask.cs
@@ -89,7 +89,7 @@ namespace pwiz.OspreySharp.Tasks
     /// <see cref="ExecuteRescore"/>, then runs the per-process
     /// diagnostic-writer close + cross-impl bisection dump. Inherits
     /// the scoring engine (RunCoelutionScoring, LoadLibrary,
-    /// GenerateDecoys, ExtractIsolationWindows, ...) from
+    /// ExtractIsolationWindows, ...) from
     /// <see cref="AbstractScoringTask"/>.
     /// </summary>
     internal sealed class PerFileRescoreTask : AbstractScoringTask
@@ -184,7 +184,6 @@ namespace pwiz.OspreySharp.Tasks
             // rescore from), takes Rehydrate instead: the driver reaches this
             // task here only in the rescore-capable modes, and a merge-node
             // consumer materializes it via ctx.Demand, which routes to Rehydrate.
-            _ctx = ctx;
             // CompactedEntries: the post-first-join buffer. Demanding it
             // materializes FirstJoin (running its compaction + Stage 6 planning
             // when the driver skipped it in worker-rescore mode), which is also
@@ -273,6 +272,7 @@ namespace pwiz.OspreySharp.Tasks
                 ctx.Get<PerFileParquetPaths>().Value,
                 ctx.Get<FullLibrary>().Value,
                 ctx.Config,
+                ctx,
                 joinFileStems);
             ctx.LogInfo(string.Format(
                 @"Stage 6 rescore: {0} entries re-scored ({1} reconciliation actions executed)",
@@ -349,7 +349,6 @@ namespace pwiz.OspreySharp.Tasks
             // below is a different rehydrate that must NOT materialize FirstJoin.
             if (!ctx.Config.ExpectReconciledInput)
             {
-                _ctx = ctx;
                 _perFileEntries = ctx.Get<CompactedEntries>().Value;
 
                 // PR-E: a fresh ExecuteRescore would overlay each file's reconciled
@@ -391,7 +390,6 @@ namespace pwiz.OspreySharp.Tasks
                 return true;
             }
 
-            _ctx = ctx;
             // ScoredEntries, NOT CompactedEntries: the merge path must NOT
             // materialize FirstJoin (that would re-run Stage 5 Percolator on the
             // reconciled parquets); it applies its own compaction below. Reading
@@ -472,7 +470,7 @@ namespace pwiz.OspreySharp.Tasks
         private bool WriteReconciledParquet(string originalPath, string reconciledPath,
             List<FdrEntry> fdrEntries,
             string fileName, List<LibraryEntry> fullLibrary, OspreyConfig config,
-            IReadOnlyList<string> joinFileStems)
+            IReadOnlyList<string> joinFileStems, PipelineContext ctx)
         {
             // 1. Reload the original parquet's per-row state (read-only).
             List<FdrEntry> fullEntries;
@@ -482,7 +480,7 @@ namespace pwiz.OspreySharp.Tasks
             }
             catch (Exception ex)
             {
-                _ctx.LogWarning(string.Format(
+                ctx.LogWarning(string.Format(
                     "Stage 6 write-back: failed to reload {0}: {1} (skipping)",
                     originalPath, ex.Message));
                 return false;
@@ -509,7 +507,7 @@ namespace pwiz.OspreySharp.Tasks
                 int pqIdx = (int)entry.ParquetIndex;
                 if (pqIdx < 0 || pqIdx >= fullEntries.Count)
                 {
-                    _ctx.LogWarning(string.Format(
+                    ctx.LogWarning(string.Format(
                         "Stage 6 write-back: ParquetIndex {0} out of range for {1} ({2} rows)",
                         pqIdx, fileName, fullEntries.Count));
                     continue;
@@ -571,13 +569,13 @@ namespace pwiz.OspreySharp.Tasks
             }
             catch (Exception ex)
             {
-                _ctx.LogWarning(string.Format(
+                ctx.LogWarning(string.Format(
                     "Stage 6 write-back: failed to write reconciled scores for {0}: {1}",
                     fileName, ex.Message));
                 return false;
             }
 
-            _ctx.LogInfo(string.Format(
+            ctx.LogInfo(string.Format(
                 "  Wrote reconciled parquet for {0}: {1} rows ({2} replaced + {3} appended; original {4} rows)",
                 fileName, fullEntries.Count, nReplaced, nAppended, origRowCount));
             return true;
@@ -616,6 +614,7 @@ namespace pwiz.OspreySharp.Tasks
             IReadOnlyDictionary<string, string> perFileParquetPaths,
             List<LibraryEntry> fullLibrary,
             OspreyConfig config,
+            PipelineContext ctx,
             IReadOnlyList<string> joinFileStems = null)
         {
             // Pre-group reconciliation actions by file so the per-file loop
@@ -631,7 +630,7 @@ namespace pwiz.OspreySharp.Tasks
             int totalGapCwt = 0;
             int totalGapForced = 0;
             int nTotalFiles = perFileEntries.Count;
-            string taskValidityKey = ValidityKey(_ctx);
+            string taskValidityKey = ValidityKey(ctx);
 
             for (int fileNum = 0; fileNum < nTotalFiles; fileNum++)
             {
@@ -660,7 +659,7 @@ namespace pwiz.OspreySharp.Tasks
                     && File.Exists(reconciledPath)
                     && TaskValiditySidecar.IsValid(reconciledPath, Name, taskValidityKey))
                 {
-                    _ctx.LogInfo(string.Format(
+                    ctx.LogInfo(string.Format(
                         @"[file] {0}/{1} {2}: skipping (outputs valid)",
                         fileNum + 1, nTotalFiles, fileName));
 
@@ -718,7 +717,7 @@ namespace pwiz.OspreySharp.Tasks
 
                 if (!fileNameToIdx.TryGetValue(fileName, out int inputIdx))
                 {
-                    _ctx.LogWarning(string.Format(
+                    ctx.LogWarning(string.Format(
                         "Stage 6 rescore: no input_files entry for {0} (skipping)", fileName));
                     continue;
                 }
@@ -736,9 +735,9 @@ namespace pwiz.OspreySharp.Tasks
                 // the per-file clone pattern in ProcessFile.
                 var fileConfig = config.ShallowClone();
 
-                _ctx.LogInfo(string.Format(
+                ctx.LogInfo(string.Format(
                     "Re-scoring file {0}/{1}: {2}", fileNum + 1, nTotalFiles, fileName));
-                _ctx.LogInfo(string.Format(
+                ctx.LogInfo(string.Format(
                     "  {0} entries ({1} consensus, {2} reconciliation, {3} gap-fill, {4} unique after dedup)",
                     combinedTargets.Count + gapFillTargets.Count * 2,
                     consensusTargets.Count,
@@ -756,7 +755,7 @@ namespace pwiz.OspreySharp.Tasks
                 // or unreadable.
                 List<Spectrum> spectra;
                 List<MS1Spectrum> ms1Spectra;
-                LoadSpectraForRescore(inputFile, fileName, out spectra, out ms1Spectra);
+                LoadSpectraForRescore(inputFile, fileName, out spectra, out ms1Spectra, ctx);
 
                 // Load the sibling .calibration.json so the search uses the
                 // same MS2/MS1 mass calibrations the original Stage 1-4 run
@@ -806,7 +805,7 @@ namespace pwiz.OspreySharp.Tasks
                         subsetLibrary, spectra, ms1Spectra,
                         isolationWindows, rtCal,
                         ms2Cal, ms1Cal,
-                        context);
+                        context, ctx);
                 }
                 else
                 {
@@ -821,12 +820,12 @@ namespace pwiz.OspreySharp.Tasks
                 totalRescored += nOverlay;
                 if (nNoPeak > 0)
                 {
-                    _ctx.LogInfo(string.Format(
+                    ctx.LogInfo(string.Format(
                         "  {0} targets had no peak at override boundary (reset to defaults)",
                         nNoPeak));
                 }
 
-                _ctx.LogInfo(string.Format(
+                ctx.LogInfo(string.Format(
                     "  {0} of {1} existing entries re-scored ({2:F1}s)",
                     nOverlay, combinedTargets.Count, swRescore.Elapsed.TotalSeconds));
 
@@ -836,7 +835,7 @@ namespace pwiz.OspreySharp.Tasks
                     var (nGapCwt, nGapForced) = RunGapFillTwoPass(
                         gapFillTargets, fullLibrary, spectra, ms1Spectra,
                         isolationWindows, rtCal, ms2Cal, ms1Cal,
-                        fileConfig, fileName, rtMadFromCalJson, fdrEntries);
+                        fileConfig, fileName, rtMadFromCalJson, fdrEntries, ctx);
                     totalGapCwt += nGapCwt;
                     totalGapForced += nGapForced;
                     totalRescored += nGapCwt + nGapForced;
@@ -851,7 +850,7 @@ namespace pwiz.OspreySharp.Tasks
                 {
                     string reconciledOutPath = ParquetScoreCache.ReconciledPathFromScoresPath(parquetPath);
                     bool wrote = WriteReconciledParquet(parquetPath, reconciledOutPath, fdrEntries, fileName,
-                        fullLibrary, config, joinFileStems);
+                        fullLibrary, config, joinFileStems, ctx);
 
                     // Only stamp the per-file resume sidecar when the reconciled
                     // parquet was actually written. Stamping it after a failed
@@ -875,7 +874,7 @@ namespace pwiz.OspreySharp.Tasks
                         }
                         catch (Exception ex)
                         {
-                            _ctx.LogWarning(string.Format(
+                            ctx.LogWarning(string.Format(
                                 @"  Failed to write {0} sidecar for {1}: {2}",
                                 Name, reconciledOutPath, ex.Message));
                         }
@@ -889,7 +888,7 @@ namespace pwiz.OspreySharp.Tasks
                         }
                         catch (Exception ex)
                         {
-                            _ctx.LogWarning(string.Format(
+                            ctx.LogWarning(string.Format(
                                 @"  Failed to remove stale reconciled parquet {0} after a failed write: {1}",
                                 reconciledOutPath, ex.Message));
                         }
@@ -1263,7 +1262,7 @@ namespace pwiz.OspreySharp.Tasks
             OspreyConfig fileConfig,
             string fileName,
             double? rtMadFromCalJson,
-            List<FdrEntry> fdrEntries)
+            List<FdrEntry> fdrEntries, PipelineContext ctx)
         {
             int nGapCwt = 0;
             int nGapForced = 0;
@@ -1299,7 +1298,7 @@ namespace pwiz.OspreySharp.Tasks
                     gapFillLibrary, spectra, ms1Spectra,
                     isolationWindows, rtCal,
                     ms2Cal, ms1Cal,
-                    cwtContext);
+                    cwtContext, ctx);
                 swCwt.Stop();
 
                 cwtHitIds = new HashSet<uint>();
@@ -1324,7 +1323,7 @@ namespace pwiz.OspreySharp.Tasks
                     fdrEntries.Add(entry);
                 }
 
-                _ctx.LogInfo(string.Format(
+                ctx.LogInfo(string.Format(
                     "  Gap-fill CWT: {0} hits ({1:F1}s)",
                     nGapCwt, swCwt.Elapsed.TotalSeconds));
             }
@@ -1367,7 +1366,7 @@ namespace pwiz.OspreySharp.Tasks
                     forcedLibrary, spectra, ms1Spectra,
                     isolationWindows, rtCal,
                     ms2Cal, ms1Cal,
-                    forcedContext);
+                    forcedContext, ctx);
                 swForced.Stop();
                 nGapForced = forcedResults.Count;
 
@@ -1385,7 +1384,7 @@ namespace pwiz.OspreySharp.Tasks
                     fdrEntries.Add(entry);
                 }
 
-                _ctx.LogInfo(string.Format(
+                ctx.LogInfo(string.Format(
                     "  Gap-fill forced: {0} integrated ({1:F1}s)",
                     nGapForced, swForced.Elapsed.TotalSeconds));
             }
@@ -1400,7 +1399,7 @@ namespace pwiz.OspreySharp.Tasks
         /// Rust spectra-load block at pipeline.rs:2851-2872.
         /// </summary>
         private void LoadSpectraForRescore(string inputFile, string fileName,
-            out List<Spectrum> spectra, out List<MS1Spectrum> ms1Spectra)
+            out List<Spectrum> spectra, out List<MS1Spectrum> ms1Spectra, PipelineContext ctx)
         {
             string cachePath = SpectraCache.GetCachePath(inputFile);
             if (File.Exists(cachePath))
@@ -1410,14 +1409,14 @@ namespace pwiz.OspreySharp.Tasks
                     var result = SpectraCache.LoadSpectraCache(cachePath, inputFile);
                     spectra = result.Ms2Spectra;
                     ms1Spectra = result.Ms1Spectra;
-                    _ctx.LogInfo(string.Format(
+                    ctx.LogInfo(string.Format(
                         "  Loaded {0} MS2 + {1} MS1 spectra from cache for {2}",
                         spectra.Count, ms1Spectra.Count, fileName));
                     return;
                 }
                 catch (Exception ex)
                 {
-                    _ctx.LogWarning(string.Format(
+                    ctx.LogWarning(string.Format(
                         "Failed to load spectra cache {0}: {1}; falling back to mzML",
                         cachePath, ex.Message));
                 }
@@ -1425,7 +1424,7 @@ namespace pwiz.OspreySharp.Tasks
             var fresh = MzmlReader.LoadAllSpectra(inputFile);
             spectra = fresh.Ms2Spectra;
             ms1Spectra = fresh.Ms1Spectra;
-            _ctx.LogInfo(string.Format(
+            ctx.LogInfo(string.Format(
                 "  Loaded {0} MS2 + {1} MS1 spectra from mzML for {2}",
                 spectra.Count, ms1Spectra.Count, fileName));
         }

--- a/pwiz_tools/OspreySharp/OspreySharp/Tasks/PerFileScoringTask.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/Tasks/PerFileScoringTask.cs
@@ -48,7 +48,7 @@ namespace pwiz.OspreySharp.Tasks
     ///
     /// Phase A scope: this task is a thin orchestration wrapper that
     /// delegates to AnalysisPipeline's existing private (now
-    /// <c>internal</c>) methods (LoadLibrary, GenerateDecoys,
+    /// <c>internal</c>) methods (LoadLibrary,
     /// ProcessFile) plus the --task FirstJoin / --task MergeNode input
     /// loading paths that share the same per-file collection layout.
     /// The inline Stage 1-4 block from <c>AnalysisPipeline.Run</c>
@@ -160,12 +160,11 @@ namespace pwiz.OspreySharp.Tasks
             // here only in the non---input-scores modes (where computing from
             // spectra is right), and a worker-mode consumer materializes it via
             // ctx.Demand, which routes to Rehydrate.
-            _ctx = ctx;
             var config = ctx.Config;
 
             // Stage 1: Load library + generate/pair decoys, then build the
             // full target+decoy library and its by-id lookup.
-            if (!LoadLibraryAndDecoys(config, out var fullLibrary))
+            if (!LoadLibraryAndDecoys(config, out var fullLibrary, ctx))
                 return false;
 
             // Stage 2-4: Per-file calibration + coelution scoring
@@ -331,12 +330,11 @@ namespace pwiz.OspreySharp.Tasks
             // recomputing them from spectra, then adopt any reconciliation
             // bundle that the merge node will read. The compute-from-spectra
             // counterpart is Run.
-            _ctx = ctx;
             var config = ctx.Config;
 
             // Stage 1: library + decoys (needed by Stage 5+ even though the
             // per-file scores are loaded rather than computed).
-            if (!LoadLibraryAndDecoys(config, out _))
+            if (!LoadLibraryAndDecoys(config, out _, ctx))
                 return false;
 
             var perFileEntries = new List<KeyValuePair<string, List<FdrEntry>>>();
@@ -364,7 +362,7 @@ namespace pwiz.OspreySharp.Tasks
                 ctx.RunPlan.EffectiveFileParallelism = Math.Min(nFiles, Environment.ProcessorCount);
 
             var swAllFiles = Stopwatch.StartNew();
-            LoadJoinOnlyScores(config, perFileEntries, perFileParquetPaths, perFileCalibrations);
+            LoadJoinOnlyScores(config, perFileEntries, perFileParquetPaths, perFileCalibrations, ctx);
             swAllFiles.Stop();
             ctx.LogInfo(string.Format(@"[TIMING] All files processed: {0:F1}s",
                 swAllFiles.Elapsed.TotalSeconds));
@@ -392,7 +390,7 @@ namespace pwiz.OspreySharp.Tasks
             //
             // The disk state determines the hydration shape, not the CLI
             // flag (Phase C principle: mechanism-driven, not flag-driven).
-            if (!HydrateRescoreBundleIfPresent(config, perFileEntries))
+            if (!HydrateRescoreBundleIfPresent(config, perFileEntries, ctx))
                 return false;
 
             return FinalizeAndCheck(ctx, perFileEntries, perFileCalibrations,
@@ -418,12 +416,11 @@ namespace pwiz.OspreySharp.Tasks
         /// </summary>
         private bool RehydrateFromOwnOutputs(PipelineContext ctx)
         {
-            _ctx = ctx;
             var config = ctx.Config;
 
             // Stage 1: library + decoys (needed by Stage 5+ even though the
             // per-file scores are loaded rather than computed).
-            if (!LoadLibraryAndDecoys(config, out _))
+            if (!LoadLibraryAndDecoys(config, out _, ctx))
                 return false;
 
             var perFileEntries = new List<KeyValuePair<string, List<FdrEntry>>>();
@@ -556,16 +553,16 @@ namespace pwiz.OspreySharp.Tasks
         /// missing library decoys, an unreadable pairing manifest, or a
         /// pairing fraction below the configured threshold.
         /// </summary>
-        private bool LoadLibraryAndDecoys(OspreyConfig config, out List<LibraryEntry> fullLibrary)
+        private bool LoadLibraryAndDecoys(OspreyConfig config, out List<LibraryEntry> fullLibrary, PipelineContext ctx)
         {
             fullLibrary = null;
 
             var swLibrary = Stopwatch.StartNew();
-            var library = LibraryLoader.Load(config, _ctx.LogInfo, _ctx.LogWarning);
+            var library = LibraryLoader.Load(config, ctx.LogInfo, ctx.LogWarning);
             if (library == null || library.Count == 0)
             {
-                _ctx.LogError(@"Library is empty after loading");
-                _ctx.ExitCode = 1;
+                ctx.LogError(@"Library is empty after loading");
+                ctx.ExitCode = 1;
                 return false;
             }
 
@@ -583,10 +580,10 @@ namespace pwiz.OspreySharp.Tasks
             {
                 LibraryDecoyMarker.ApplyLibraryDecoyMarking(
                     library, config.DecoyPrefixes, out var markingStats);
-                _ctx.LogInfo(string.Format(
+                ctx.LogInfo(string.Format(
                     @"Library-decoy mode: matched prefixes {0}",
                     FormatPrefixList(config.DecoyPrefixes)));
-                _ctx.LogInfo(string.Format(
+                ctx.LogInfo(string.Format(
                     @"[COUNT] Library-decoy mode: {0} flagged ({1} via Decoy column, {2} via protein-accession prefix)",
                     markingStats.NMarked, markingStats.NViaColumn, markingStats.NViaPrefix));
             }
@@ -598,7 +595,7 @@ namespace pwiz.OspreySharp.Tasks
                     nLibraryTargets++;
             }
             double libLoadSec = swLibrary.Elapsed.TotalSeconds;
-            _ctx.LogInfo(string.Format(@"[COUNT] Library targets loaded: {0}", nLibraryTargets));
+            ctx.LogInfo(string.Format(@"[COUNT] Library targets loaded: {0}", nLibraryTargets));
 
             List<LibraryEntry> decoys;
             if (config.ExpectReconciledInput)
@@ -621,7 +618,7 @@ namespace pwiz.OspreySharp.Tasks
             else if (!librarySuppliesDecoys)
             {
                 decoys = DecoyGenerator.GenerateAllWithCollisionDetection(
-                    library, config, _ctx.LogInfo, out List<LibraryEntry> validTargets);
+                    library, config, ctx.LogInfo, out List<LibraryEntry> validTargets);
                 library = validTargets;
             }
             else
@@ -642,12 +639,12 @@ namespace pwiz.OspreySharp.Tasks
                 int nLibraryDecoys = library.Count - nLibraryTargets;
                 if (nLibraryDecoys == 0)
                 {
-                    _ctx.LogError(string.Format(
+                    ctx.LogError(string.Format(
                         @"decoys_in_library mode requested but no library entries match prefixes {0}. " +
                         @"Check that the library actually contains decoys with one of these prefixes on " +
                         @"a protein accession, or unset decoys_in_library so Osprey generates decoys.",
                         FormatPrefixList(config.DecoyPrefixes)));
-                    _ctx.ExitCode = 1;
+                    ctx.ExitCode = 1;
                     return false;
                 }
 
@@ -669,7 +666,7 @@ namespace pwiz.OspreySharp.Tasks
                 };
                 if (!string.IsNullOrEmpty(config.DecoyPairingManifestPath))
                 {
-                    _ctx.LogInfo(string.Format(
+                    ctx.LogInfo(string.Format(
                         @"Loading decoy pairing manifest from {0}",
                         config.DecoyPairingManifestPath));
                     DecoyPairingManifest manifest;
@@ -680,17 +677,17 @@ namespace pwiz.OspreySharp.Tasks
                     }
                     catch (Exception ex)
                     {
-                        _ctx.LogError(string.Format(
+                        ctx.LogError(string.Format(
                             @"Failed to read decoy pairing manifest {0}: {1}",
                             config.DecoyPairingManifestPath, ex.Message));
-                        _ctx.ExitCode = 1;
+                        ctx.ExitCode = 1;
                         return false;
                     }
                     var manifestStats = manifest.ApplyToLibrary(library, pairingState);
                     pairingStats.NPairedViaManifest = manifestStats.NPaired;
                     if (manifestStats.NProteinsReplaced > 0)
                     {
-                        _ctx.LogInfo(string.Format(
+                        ctx.LogInfo(string.Format(
                             @"Library-decoy mode: manifest replaced protein_ids on {0} library " +
                             @"entries (clean source-protein accessions from the manifest's " +
                             @"`proteins` column)",
@@ -702,7 +699,7 @@ namespace pwiz.OspreySharp.Tasks
                         // loaded as targets (the predictor stripped the
                         // decoy prefix). Update the decoy count so the
                         // pairing fraction is honest.
-                        _ctx.LogInfo(string.Format(
+                        ctx.LogInfo(string.Format(
                             @"Library-decoy mode: manifest classified {0} additional library " +
                             @"entries as decoys (their protein accessions lacked a decoy prefix)",
                             manifestStats.NNewlyMarkedDecoy));
@@ -714,7 +711,7 @@ namespace pwiz.OspreySharp.Tasks
                 }
                 else
                 {
-                    _ctx.LogInfo(
+                    ctx.LogInfo(
                         @"Pairing library decoys to targets by amino-acid composition " +
                         @"(no manifest provided).");
                 }
@@ -729,7 +726,7 @@ namespace pwiz.OspreySharp.Tasks
                     pairingStats.NDecoys - pairingStats.NPaired);
                 pairingStats.NUnpairedTargets = Math.Max(0,
                     pairingStats.NTargets - pairingState.ClaimedTargets.Count);
-                _ctx.LogInfo(string.Format(
+                ctx.LogInfo(string.Format(
                     @"Library-decoy pairing: paired {0}/{1} decoys ({2:F1}%); " +
                     @"manifest={3}, composition={4}; {5} unpaired decoys, {6} unpaired targets",
                     pairingStats.NPaired, pairingStats.NDecoys,
@@ -738,7 +735,7 @@ namespace pwiz.OspreySharp.Tasks
                     pairingStats.NUnpairedDecoys, pairingStats.NUnpairedTargets));
                 if (pairingStats.PairedFraction < config.DecoyPairMinFraction)
                 {
-                    _ctx.LogError(string.Format(
+                    ctx.LogError(string.Format(
                         @"Library-decoy pairing failed: only {0:F1}% of decoys paired with a target " +
                         @"(threshold: {1:F0}%). FDR estimates would be unreliable without proper " +
                         @"target-decoy competition. Either supply a pairing manifest, ensure the " +
@@ -747,24 +744,24 @@ namespace pwiz.OspreySharp.Tasks
                         pairingStats.PairedFraction * 100.0,
                         config.DecoyPairMinFraction * 100.0,
                         FormatPrefixList(config.DecoyPrefixes)));
-                    _ctx.ExitCode = 1;
+                    ctx.ExitCode = 1;
                     return false;
                 }
             }
             swLibrary.Stop();
             double totalSec = swLibrary.Elapsed.TotalSeconds;
-            _ctx.LogInfo(string.Format(@"[TIMING] Library loading + decoys: {0:F1}s (load: {1:F1}s, decoys: {2:F1}s)",
+            ctx.LogInfo(string.Format(@"[TIMING] Library loading + decoys: {0:F1}s (load: {1:F1}s, decoys: {2:F1}s)",
                 totalSec, libLoadSec, totalSec - libLoadSec));
 
-            _ctx.LogInfo(string.Format(@"[COUNT] Library decoys generated: {0}", decoys.Count));
+            ctx.LogInfo(string.Format(@"[COUNT] Library decoys generated: {0}", decoys.Count));
 
             fullLibrary = new List<LibraryEntry>(library.Count + decoys.Count);
             fullLibrary.AddRange(library);
             fullLibrary.AddRange(decoys);
 
-            _ctx.LogInfo(string.Format(@"Full library: {0} entries ({1} targets + {2} decoys)",
+            ctx.LogInfo(string.Format(@"Full library: {0} entries ({1} targets + {2} decoys)",
                 fullLibrary.Count, library.Count, decoys.Count));
-            _ctx.LogInfo(string.Format(@"[COUNT] Full library: {0} ({1} targets + {2} decoys)",
+            ctx.LogInfo(string.Format(@"[COUNT] Full library: {0} ({1} targets + {2} decoys)",
                 fullLibrary.Count, library.Count, decoys.Count));
 
             // Count entries with few fragments (diagnostic for entry count parity)
@@ -780,7 +777,7 @@ namespace pwiz.OspreySharp.Tasks
                     nTwoFrag++;
             }
             if (nZeroFrag + nOneFrag + nTwoFrag > 0)
-                _ctx.LogInfo(string.Format(@"[COUNT] Entries with <3 fragments: {0} (0={1}, 1={2}, 2={3})",
+                ctx.LogInfo(string.Format(@"[COUNT] Entries with <3 fragments: {0} (0={1}, 1={2}, 2={3})",
                     nZeroFrag + nOneFrag + nTwoFrag, nZeroFrag, nOneFrag, nTwoFrag));
 
             // Build library lookup by ID for fast access
@@ -809,7 +806,8 @@ namespace pwiz.OspreySharp.Tasks
             OspreyConfig config,
             List<KeyValuePair<string, List<FdrEntry>>> perFileEntries,
             Dictionary<string, string> perFileParquetPaths,
-            ConcurrentDictionary<string, RTCalibration> perFileCalibrations)
+            ConcurrentDictionary<string, RTCalibration> perFileCalibrations,
+            PipelineContext ctx)
         {
             // --task FirstJoin: load per-file FdrEntry stubs directly from
             // each .scores.parquet listed via --input-scores. Skips the
@@ -821,11 +819,11 @@ namespace pwiz.OspreySharp.Tasks
             // Aborts with a clear, file-named error if the operator points
             // the merge node at parquets from a different scoring run.
             string validationError = ParquetScoreCache.ValidateScoresParquetGroup(
-                config.InputScores, config, Program.VERSION, _ctx.LogWarning);
+                config.InputScores, config, Program.VERSION, ctx.LogWarning);
             if (validationError != null)
                 throw new InvalidDataException(validationError);
 
-            _ctx.LogInfo(string.Format(
+            ctx.LogInfo(string.Format(
                 @"--input-scores: loading {0} per-file score parquet(s)",
                 config.InputScores.Count));
             for (int fileIdx = 0; fileIdx < config.InputScores.Count; fileIdx++)
@@ -837,7 +835,7 @@ namespace pwiz.OspreySharp.Tasks
                 // ".scores" strip would leave the bogus key "<stem>.reconciled").
                 string fileName = Path.GetFileNameWithoutExtension(
                     RescoreHydration.SyntheticInputFromParquet(parquetPath)) ?? string.Empty;
-                _ctx.LogInfo(string.Format(@"===== Loading file {0}/{1}: {2} (from {3}) =====",
+                ctx.LogInfo(string.Format(@"===== Loading file {0}/{1}: {2} (from {3}) =====",
                     fileIdx + 1, config.InputScores.Count, fileName, parquetPath));
                 var stubs = ParquetScoreCache.LoadFdrStubsFromParquet(parquetPath);
                 // Stage 5+ (Percolator SVM) requires the 21 PIN features
@@ -852,7 +850,7 @@ namespace pwiz.OspreySharp.Tasks
                 }
                 for (int j = 0; j < stubs.Count; j++)
                     stubs[j].Features = features[j];
-                _ctx.LogInfo(string.Format(@"  Loaded {0} FDR stubs + features", stubs.Count));
+                ctx.LogInfo(string.Format(@"  Loaded {0} FDR stubs + features", stubs.Count));
                 perFileEntries.Add(new KeyValuePair<string, List<FdrEntry>>(fileName, stubs));
                 perFileParquetPaths[fileName] = parquetPath;
 
@@ -891,7 +889,7 @@ namespace pwiz.OspreySharp.Tasks
                 }
                 catch (Exception ex)
                 {
-                    _ctx.LogWarning(string.Format(@"  Failed to load calibration for {0}: {1}", fileName, ex.Message));
+                    ctx.LogWarning(string.Format(@"  Failed to load calibration for {0}: {1}", fileName, ex.Message));
                 }
             }
             if (OspreyDiagnostics.CalibrationOnly)
@@ -914,7 +912,8 @@ namespace pwiz.OspreySharp.Tasks
         /// </summary>
         private bool HydrateRescoreBundleIfPresent(
             OspreyConfig config,
-            List<KeyValuePair<string, List<FdrEntry>>> perFileEntries)
+            List<KeyValuePair<string, List<FdrEntry>>> perFileEntries,
+            PipelineContext ctx)
         {
             bool allHave1stPassAndRecon = true;
             foreach (var parquetPath in config.InputScores)
@@ -936,9 +935,9 @@ namespace pwiz.OspreySharp.Tasks
                 }
                 catch (InvalidDataException ex)
                 {
-                    _ctx.LogError(string.Format(
+                    ctx.LogError(string.Format(
                         @"--input-scores hydration failed: {0}", ex.Message));
-                    _ctx.ExitCode = 1;
+                    ctx.ExitCode = 1;
                     return false;
                 }
                 // Clear PIN features on bundle-hydrated stubs so
@@ -954,7 +953,7 @@ namespace pwiz.OspreySharp.Tasks
                 foreach (var kvp in perFileEntries)
                     foreach (var entry in kvp.Value)
                         entry.Features = null;
-                _ctx.LogInfo(string.Format(
+                ctx.LogInfo(string.Format(
                     @"Hydrated rescore bundle for {0} file(s) ({1} reconciliation actions, " +
                     @"{2} refined RT calibration(s), {3} gap-fill target(s))",
                     perFileEntries.Count,
@@ -1014,7 +1013,7 @@ namespace pwiz.OspreySharp.Tasks
             // Clear stale sidecar so a mid-ProcessFile crash leaves no
             // false-positive sidecar on the next invocation.
             TaskValiditySidecar.Delete(scoresPath, Name);
-            var fileResult = ProcessFile(inputFile, fileName, fullLibrary, config, parquetFooterMetadata, perFileCalibrations);
+            var fileResult = ProcessFile(inputFile, fileName, fullLibrary, config, parquetFooterMetadata, perFileCalibrations, ctx);
             if (fileResult != null)
             {
                 try
@@ -1121,7 +1120,8 @@ namespace pwiz.OspreySharp.Tasks
             string inputFile, string fileName,
             List<LibraryEntry> fullLibrary, OspreyConfig config,
             Dictionary<string, string> parquetFooterMetadata,
-            ConcurrentDictionary<string, RTCalibration> perFileCalibrationsOut)
+            ConcurrentDictionary<string, RTCalibration> perFileCalibrationsOut,
+            PipelineContext ctx)
         {
             if (inputFile == null)
                 throw new ArgumentNullException(nameof(inputFile));
@@ -1140,12 +1140,12 @@ namespace pwiz.OspreySharp.Tasks
             // 32 threads on a 32-core box, the prior 96-way oversubscription
             // produced 45-95s wall-time variance on Stellar; a fair share
             // (10 threads each) holds the run near steady-state.
-            if (_ctx.RunPlan.EffectiveFileParallelism > 1)
+            if (ctx.RunPlan.EffectiveFileParallelism > 1)
             {
-                int perFileThreads = Math.Max(1, config.NThreads / _ctx.RunPlan.EffectiveFileParallelism);
-                _ctx.LogInfo(string.Format(
+                int perFileThreads = Math.Max(1, config.NThreads / ctx.RunPlan.EffectiveFileParallelism);
+                ctx.LogInfo(string.Format(
                     "[BENCH] Per-file thread cap: {0} ({1} total / {2} files in parallel)",
-                    perFileThreads, config.NThreads, _ctx.RunPlan.EffectiveFileParallelism));
+                    perFileThreads, config.NThreads, ctx.RunPlan.EffectiveFileParallelism));
                 config.NThreads = perFileThreads;
             }
 
@@ -1155,8 +1155,8 @@ namespace pwiz.OspreySharp.Tasks
             List<Spectrum> spectra;
             List<MS1Spectrum> ms1Spectra;
             var swParse = Stopwatch.StartNew();
-            LoadSpectra(inputFile, _ctx.RunPlan.EffectiveFileParallelism > 1,
-                out spectra, out ms1Spectra);
+            LoadSpectra(inputFile, ctx.RunPlan.EffectiveFileParallelism > 1,
+                out spectra, out ms1Spectra, ctx);
             swParse.Stop();
 
             long inputBytes = 0;
@@ -1174,29 +1174,29 @@ namespace pwiz.OspreySharp.Tasks
             if (inputBytes > 0 && parseSeconds > 0.001)
             {
                 double mbPerSec = (inputBytes / 1024.0 / 1024.0) / parseSeconds;
-                _ctx.LogInfo(string.Format("[TIMING] mzML parsing: {0:F1}s ({1:F1} MB/s)",
+                ctx.LogInfo(string.Format("[TIMING] mzML parsing: {0:F1}s ({1:F1} MB/s)",
                     parseSeconds, mbPerSec));
             }
             else
             {
-                _ctx.LogInfo(string.Format("[TIMING] mzML parsing: {0:F1}s", parseSeconds));
+                ctx.LogInfo(string.Format("[TIMING] mzML parsing: {0:F1}s", parseSeconds));
             }
 
             if (spectra == null || spectra.Count == 0)
             {
-                _ctx.LogWarning(string.Format("No spectra found in {0}", inputFile));
+                ctx.LogWarning(string.Format("No spectra found in {0}", inputFile));
                 return null;
             }
 
-            _ctx.LogInfo(string.Format("Loaded {0} MS2 spectra and {1} MS1 spectra",
+            ctx.LogInfo(string.Format("Loaded {0} MS2 spectra and {1} MS1 spectra",
                 spectra.Count, ms1Spectra != null ? ms1Spectra.Count : 0));
-            _ctx.LogInfo(string.Format("[COUNT] mzML spectra loaded [{0}]: {1} MS2 + {2} MS1",
+            ctx.LogInfo(string.Format("[COUNT] mzML spectra loaded [{0}]: {1} MS2 + {2} MS1",
                 fileName, spectra.Count, ms1Spectra != null ? ms1Spectra.Count : 0));
 
             // Extract isolation windows from spectra
             var isolationWindows = ExtractIsolationWindows(spectra);
-            _ctx.LogInfo(string.Format("Found {0} unique isolation windows", isolationWindows.Count));
-            _ctx.LogInfo(string.Format("[COUNT] Isolation windows [{0}]: {1}",
+            ctx.LogInfo(string.Format("Found {0} unique isolation windows", isolationWindows.Count));
+            ctx.LogInfo(string.Format("[COUNT] Isolation windows [{0}]: {1}",
                 fileName, isolationWindows.Count));
 
             // RT calibration
@@ -1215,7 +1215,7 @@ namespace pwiz.OspreySharp.Tasks
             string loadCalPath = OspreyEnvironment.LoadCalibrationPath;
             if (!string.IsNullOrEmpty(loadCalPath) && File.Exists(loadCalPath))
             {
-                _ctx.LogInfo(string.Format("[BISECT] Loading calibration from: {0}", loadCalPath));
+                ctx.LogInfo(string.Format("[BISECT] Loading calibration from: {0}", loadCalPath));
                 var calParams = CalibrationIO.LoadCalibration(loadCalPath);
                 if (calParams.RtCalibration != null && calParams.RtCalibration.ModelParams != null)
                 {
@@ -1223,7 +1223,7 @@ namespace pwiz.OspreySharp.Tasks
                     rtCalibration = RTCalibration.FromModelParams(
                         mp.LibraryRts, mp.FittedRts, mp.AbsResiduals,
                         calParams.RtCalibration.ResidualSD);
-                    _ctx.LogInfo(string.Format("Loaded RT calibration: {0} points, R2={1:F4}",
+                    ctx.LogInfo(string.Format("Loaded RT calibration: {0} points, R2={1:F4}",
                         calParams.RtCalibration.NPoints, calParams.RtCalibration.RSquared));
                 }
                 if (calParams.Ms2Calibration != null && calParams.Ms2Calibration.Calibrated)
@@ -1238,7 +1238,7 @@ namespace pwiz.OspreySharp.Tasks
                         AdjustedTolerance = calParams.Ms2Calibration.AdjustedTolerance,
                         Calibrated = true
                     };
-                    _ctx.LogInfo(string.Format("Loaded MS2 calibration: mean={0:F4} {1}, SD={2:F4}",
+                    ctx.LogInfo(string.Format("Loaded MS2 calibration: mean={0:F4} {1}, SD={2:F4}",
                         ms2Cal.Mean, ms2Cal.Unit, ms2Cal.SD));
                 }
                 if (calParams.Ms1Calibration != null && calParams.Ms1Calibration.Calibrated)
@@ -1253,19 +1253,19 @@ namespace pwiz.OspreySharp.Tasks
                         AdjustedTolerance = calParams.Ms1Calibration.AdjustedTolerance,
                         Calibrated = true
                     };
-                    _ctx.LogInfo(string.Format("Loaded MS1 calibration: mean={0:F4} {1}, SD={2:F4}",
+                    ctx.LogInfo(string.Format("Loaded MS1 calibration: mean={0:F4} {1}, SD={2:F4}",
                         ms1Cal.Mean, ms1Cal.Unit, ms1Cal.SD));
                 }
             }
             else if (config.RtCalibration.Enabled)
             {
                 var swCal = Stopwatch.StartNew();
-                rtCalibration = new Calibrator(_ctx).RunCalibration(
+                rtCalibration = new Calibrator(ctx).RunCalibration(
                     fullLibrary, spectra, ms1Spectra, context,
                     out ms1Cal, out ms2Cal, out numSampledPrecursorsForMetadata);
                 swCal.Stop();
                 int nPoints = rtCalibration != null ? rtCalibration.Stats().NPoints : 0;
-                _ctx.LogInfo(string.Format(
+                ctx.LogInfo(string.Format(
                     "[TIMING] RT calibration: {0:F1}s ({1} calibration points)",
                     swCal.Elapsed.TotalSeconds, nPoints));
             }
@@ -1309,11 +1309,11 @@ namespace pwiz.OspreySharp.Tasks
                 // default), matching where the resume-existence check looks.
                 string calPath = CalibrationIO.CalibrationPathForInput(inputFile, ArtifactPaths.ResolveOutputDir(inputFile));
                 CalibrationIO.SaveCalibration(calParams, calPath);
-                _ctx.LogInfo(string.Format("Saved calibration to {0}", calPath));
+                ctx.LogInfo(string.Format("Saved calibration to {0}", calPath));
             }
             catch (Exception ex)
             {
-                _ctx.LogInfo("Warning: failed to save calibration JSON: " + ex.Message);
+                ctx.LogInfo("Warning: failed to save calibration JSON: " + ex.Message);
             }
 
             // Optional early exit after Stage 3 (calibration only, no main search).
@@ -1321,7 +1321,7 @@ namespace pwiz.OspreySharp.Tasks
             // search incrementally without paying the Stage 4 cost.
             if (OspreyEnvironment.ExitAfterCalibration)
             {
-                _ctx.LogInfo("[BENCH] OSPREY_EXIT_AFTER_CALIBRATION set - exiting after Stage 3 (calibration done)");
+                ctx.LogInfo("[BENCH] OSPREY_EXIT_AFTER_CALIBRATION set - exiting after Stage 3 (calibration done)");
                 return new List<FdrEntry>();
             }
 
@@ -1338,19 +1338,19 @@ namespace pwiz.OspreySharp.Tasks
                 fullLibrary, spectra, ms1Spectra,
                 isolationWindows, rtCalibration,
                 ms2Cal, ms1Cal,
-                context);
+                context, ctx);
             swScoring.Stop();
             double scoringSeconds = swScoring.Elapsed.TotalSeconds;
             double ratePerSec = scoringSeconds > 0.001
                 ? scoredEntries.Count / scoringSeconds
                 : 0.0;
-            _ctx.LogInfo(string.Format(
+            ctx.LogInfo(string.Format(
                 "[TIMING] Coelution scoring: {0:F1}s ({1} candidates, {2:F0} cand/s)",
                 scoringSeconds, scoredEntries.Count, ratePerSec));
 
             int nScoredTargets = scoredEntries.Count(e => !e.IsDecoy);
             int nScoredDecoys = scoredEntries.Count(e => e.IsDecoy);
-            _ctx.LogInfo(string.Format("Scored {0} entries ({1} targets, {2} decoys) for {3}",
+            ctx.LogInfo(string.Format("Scored {0} entries ({1} targets, {2} decoys) for {3}",
                 scoredEntries.Count,
                 nScoredTargets,
                 nScoredDecoys,
@@ -1362,25 +1362,25 @@ namespace pwiz.OspreySharp.Tasks
             // same call site, between scoring and pair-deduplication.
             scoredEntries = DeduplicateDoubleCounting(
                 scoredEntries, fullLibrary, spectra, ms2Cal,
-                isolationWindows, config);
+                isolationWindows, config, ctx);
             nScoredTargets = scoredEntries.Count(e => !e.IsDecoy);
             nScoredDecoys = scoredEntries.Count(e => e.IsDecoy);
-            _ctx.LogInfo(string.Format(
+            ctx.LogInfo(string.Format(
                 "[COUNT] Coelution scored [{0}]: {1} entries ({2} targets, {3} decoys)",
                 fileName, scoredEntries.Count, nScoredTargets, nScoredDecoys));
 
             // Deduplicate: keep best target and best decoy per base_id
             int nBeforeDedup = scoredEntries.Count;
-            scoredEntries = DeduplicatePairs(scoredEntries);
+            scoredEntries = DeduplicatePairs(scoredEntries, ctx);
             int nAfterDedup = scoredEntries.Count;
-            _ctx.LogInfo(string.Format(
+            ctx.LogInfo(string.Format(
                 "[COUNT] Deduplication [{0}]: {1} -> {2} ({3} removed)",
                 fileName, nBeforeDedup, nAfterDedup, nBeforeDedup - nAfterDedup));
 
             // Optional: write per-entry feature TSV for comparison against Rust's PIN output
             if (config.WritePin)
             {
-                WriteFeatureDump(inputFile, fileName, scoredEntries);
+                WriteFeatureDump(inputFile, fileName, scoredEntries, ctx);
             }
 
             // Persist the full FdrEntry results (with features) to
@@ -1404,7 +1404,7 @@ namespace pwiz.OspreySharp.Tasks
                 ParquetScoreCache.WriteScoresParquet(
                     parquetPath, scoredEntries, parquetFooterMetadata, _libraryById, fileName);
                 swParquet.Stop();
-                _ctx.LogInfo(string.Format(
+                ctx.LogInfo(string.Format(
                     "Wrote {0} scored entries to {1} ({2:F1}s)",
                     scoredEntries.Count, parquetPath, swParquet.Elapsed.TotalSeconds));
             }
@@ -1420,7 +1420,7 @@ namespace pwiz.OspreySharp.Tasks
         /// </summary>
         private void WriteFeatureDump(
             string inputFile, string fileName,
-            List<FdrEntry> scoredEntries)
+            List<FdrEntry> scoredEntries, PipelineContext ctx)
         {
             string dumpPath = Path.Combine(
                 Path.GetDirectoryName(inputFile) ?? ".",
@@ -1474,7 +1474,7 @@ namespace pwiz.OspreySharp.Tasks
                 }
             }
 
-            _ctx.LogInfo(string.Format("[COUNT] Wrote feature dump: {0} ({1} entries)",
+            ctx.LogInfo(string.Format("[COUNT] Wrote feature dump: {0} ({1} entries)",
                 dumpPath, sorted.Count));
         }
 
@@ -1484,7 +1484,7 @@ namespace pwiz.OspreySharp.Tasks
         /// only one disk scan runs at a time (see s_mzmlReadGate).
         /// </summary>
         private void LoadSpectra(string inputFile, bool serializeMzmlRead,
-            out List<Spectrum> ms2Spectra, out List<MS1Spectrum> ms1Spectra)
+            out List<Spectrum> ms2Spectra, out List<MS1Spectrum> ms1Spectra, PipelineContext ctx)
         {
             // Check for binary spectra cache. Use the shared GetCachePath so the
             // write and the rescore read (PerFileRescoreTask) derive an identical
@@ -1492,7 +1492,7 @@ namespace pwiz.OspreySharp.Tasks
             string cachePath = SpectraCache.GetCachePath(inputFile);
             if (File.Exists(cachePath))
             {
-                _ctx.LogInfo(string.Format("Loading spectra from cache: {0}", cachePath));
+                ctx.LogInfo(string.Format("Loading spectra from cache: {0}", cachePath));
                 try
                 {
                     // null = stale (source changed) or invalid (bad magic/version)
@@ -1504,17 +1504,17 @@ namespace pwiz.OspreySharp.Tasks
                         ms1Spectra = cacheResult.Ms1Spectra;
                         return;
                     }
-                    _ctx.LogInfo("Spectra cache stale or invalid; re-parsing mzML.");
+                    ctx.LogInfo("Spectra cache stale or invalid; re-parsing mzML.");
                 }
                 catch (Exception ex)
                 {
-                    _ctx.LogWarning(string.Format(
+                    ctx.LogWarning(string.Format(
                         "Failed to load spectra cache: {0}. Falling back to mzML.", ex.Message));
                 }
             }
 
             // Parse mzML directly, optionally serialized across files.
-            _ctx.LogInfo(string.Format("Parsing mzML: {0}", inputFile));
+            ctx.LogInfo(string.Format("Parsing mzML: {0}", inputFile));
             MzmlResult mzmlResult;
             if (serializeMzmlRead)
                 s_mzmlReadGate.Wait();
@@ -1529,7 +1529,7 @@ namespace pwiz.OspreySharp.Tasks
             }
             ms2Spectra = mzmlResult.Ms2Spectra;
             ms1Spectra = mzmlResult.Ms1Spectra;
-            _ctx.LogInfo(string.Format("Loaded {0} MS2 + {1} MS1 spectra",
+            ctx.LogInfo(string.Format("Loaded {0} MS2 + {1} MS1 spectra",
                 ms2Spectra.Count, ms1Spectra.Count));
 
             // Save to cache for next run
@@ -1539,7 +1539,7 @@ namespace pwiz.OspreySharp.Tasks
             }
             catch (Exception ex)
             {
-                _ctx.LogWarning(string.Format("Failed to save spectra cache: {0}", ex.Message));
+                ctx.LogWarning(string.Format("Failed to save spectra cache: {0}", ex.Message));
             }
         }
 


### PR DESCRIPTION
## Summary

* Removed the ambient mutable `_ctx` (`PipelineContext`) field from `AbstractScoringTask` and `MergeNodeTask`, and threaded the `ctx` that already arrives at the task entry points (`Run(ctx)`/`Rehydrate(ctx)`) through every helper that used it, as an explicit parameter.
* This kills a shared-mutable-state smell: the field was reassigned on every `Run`/`Rehydrate` entry. Because each entry point did `_ctx = ctx;` before any use, the field and the threaded parameter are the **same object**, so the change is behavior-identical — no arithmetic, ordering, or logic change.
* `Calibrator` is left untouched: its `_ctx` is already `private readonly` + constructor-injected (the pattern this stage moves toward). Ctor-injection of the task field itself is blocked because tasks are constructed in `CanonicalPipeline()` before any `ctx` exists, so parameter-threading is the chosen route.
* Refreshed two class-summary doc comments (`PerFileScoringTask`, `PerFileRescoreTask`) that still listed `GenerateDecoys` after it was relocated in Stage A.
* Stage C of the `AbstractScoringTask` decomposition. **Stacked on Stage B (#4292)** — base is the Stage B branch.

Methods that gained a `ctx` parameter (all within the Tasks folder; no external callers): `RunCoelutionScoring`, `ScoreWindow`, `ScoreCandidate`, `LogWindowTimingSummary`, `DeduplicateDoubleCounting`, `DeduplicatePairs` (AbstractScoringTask); `RunProteinFdr`, `WriteBlibOutput` (MergeNodeTask); plus load/process/FDR/dump helpers in the three subclasses.

## Gate results

- [x] Pre-commit (`Build-OspreySharp -Configuration Debug -RunTests -RunInspection`): 382 pass / 2 skip, zero-warning inspection (re-verified independently after the sub-agent run)
- [x] Correctness (`regression.ps1 -Dataset Stellar`): mode-1 golden + mode-2 resume PASS @ 1e-9 (blib byte-identical, 52,514,816 bytes)
- [x] Performance (`Test-PerfGate.ps1 -Dataset Stellar` vs `pwiz-perfbase`@f4a05f0): total +2.0% median (per-rep +2.0/+2.4/+0.3), PASSED — pure plumbing, runtime-neutral

See ai/todos/active/TODO-20260611_ospreysharp_decouple_abstractscoring.md

Co-Authored-By: Claude <noreply@anthropic.com>
