### PR TITLE
Relocated OspreyPeakData from the Tasks layer to OspreySharp.Scoring

### DIFF
--- a/pwiz_tools/OspreySharp/OspreySharp.Scoring/OspreyPeakData.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Scoring/OspreyPeakData.cs
@@ -24,9 +24,8 @@
 using System.Collections.Generic;
 using pwiz.OspreySharp.Chromatography;
 using pwiz.OspreySharp.Core;
-using pwiz.OspreySharp.Scoring;
 
-namespace pwiz.OspreySharp.Tasks
+namespace pwiz.OspreySharp.Scoring
 {
     /// <summary>
     /// Reusable <see cref="IOspreyDetailedPeakData"/> adapter over the harness's
@@ -35,8 +34,12 @@ namespace pwiz.OspreySharp.Tasks
     /// scoring loop allocates no peak-data objects. Windows are scored on separate
     /// threads, so each window owns its own instance -- this is never shared task
     /// state.
+    ///
+    /// Lives in Scoring (alongside the <see cref="IOspreyDetailedPeakData"/> seam it
+    /// implements and the feature calculators that consume it); relocated out of the
+    /// Tasks layer so the coelution scorer can move down here too.
     /// </summary>
-    internal sealed class OspreyPeakData : IOspreyDetailedPeakData
+    public sealed class OspreyPeakData : IOspreyDetailedPeakData
     {
         private LibraryEntry _candidate;
         private XICPeakBounds _peakBounds;


### PR DESCRIPTION
## Summary

* Relocated the `OspreyPeakData` adapter (an `IOspreyDetailedPeakData` implementation) out of the `OspreySharp` exe `Tasks` folder down into `OspreySharp.Scoring` — alongside the `IOspreyDetailedPeakData` seam it implements and the feature calculators that consume it. Made it `public` for cross-assembly construction (the exe still `new`s it).
* Pure relocation (namespace + visibility only), no logic change, so cross-impl byte parity is unaffected. Correct layering: a Scoring-layer per-candidate data adapter no longer lives in the top-level exe project.
* Enabling step for extracting the coelution scorer (`ScoreWindow`/`ScoreCandidate`) down into Scoring. That extraction is **not** in this PR — it is blocked on a separate "diagnostics-bleed" decision (`ScoreCandidate` calls `OspreyDiagnostics`, which is exe-only) and is tracked + handed off with full analysis in the TODO.
* Stage D step 1 of the `AbstractScoringTask` decomposition. **Stacked on Stage C (#4293).**

## Gate results

- [x] Pre-commit (`Build-OspreySharp -Configuration Debug -RunTests -RunInspection`): 382 pass / 2 skip, zero-warning inspection
- [x] Correctness (`regression.ps1 -Dataset Stellar`): mode-1 golden + mode-2 resume PASS @ 1e-9 (blib byte-identical, 52,514,816 bytes)
- [x] Performance (`Test-PerfGate.ps1 -Dataset Stellar` vs `pwiz-perfbase`@f4a05f0): total +2.8% median (per-rep +3.8/+2.8/-1.1), PASSED — pure type relocation, runtime-neutral

See ai/todos/active/TODO-20260611_ospreysharp_decouple_abstractscoring.md

Co-Authored-By: Claude <noreply@anthropic.com>
