### PR TITLE
Extracted stateless fragment XIC/match helpers to TopFragmentExtractor

### DIFF
--- a/pwiz_tools/OspreySharp/OspreySharp.Scoring/TopFragmentExtractor.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Scoring/TopFragmentExtractor.cs
@@ -1,0 +1,268 @@
+/*
+ * Original author: Brendan MacLean <brendanx .at. uw.edu>,
+ *                  MacCoss Lab, Department of Genome Sciences, UW
+ * AI assistance: Claude Code (Claude Opus 4.8) <noreply .at. anthropic.com>
+ *
+ * Based on osprey (https://github.com/MacCossLab/osprey)
+ *   by Michael J. MacCoss, MacCoss Lab, Department of Genome Sciences, UW
+ *
+ * Copyright 2026 University of Washington - Seattle, WA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using pwiz.OspreySharp.Chromatography;
+using pwiz.OspreySharp.Core;
+
+namespace pwiz.OspreySharp.Scoring
+{
+    /// <summary>
+    /// Stateless helpers that select a library entry's top-N fragments (by
+    /// relative intensity, with a stable tie-break that matches Rust
+    /// slice::sort_by) and probe spectra for them: extract their XICs or count
+    /// how many match. Relocated verbatim out of AbstractScoringTask, which
+    /// carried these as tangled instance/static members; the arithmetic and the
+    /// stable-sort tie-break are unchanged, so cross-impl parity is unaffected.
+    /// </summary>
+    public static class TopFragmentExtractor
+    {
+        // Number of top-intensity library fragments used for calibration
+        // scoring + dedup top-6 overlap. Public so the Tasks layer
+        // (Calibrator) can reuse the same width.
+        public const int CAL_TOP_N_FRAGMENTS = 6;
+
+        /// <summary>
+        /// Extract XICs for the top N most intense library fragments across the
+        /// supplied (pre-filtered) spectra list. Returns only fragments that have
+        /// at least one non-zero intensity point.
+        /// </summary>
+        public static List<XicData> ExtractTopNFragmentXics(
+            LibraryEntry entry,
+            List<Spectrum> candidateSpectra,
+            double[] rts,
+            int maxFragments,
+            OspreyConfig config)
+        {
+            var xics = new List<XicData>();
+            if (entry.Fragments == null || entry.Fragments.Count == 0)
+                return xics;
+
+            // Select top N fragment indices by descending relative intensity.
+            int nFrags = entry.Fragments.Count;
+            int nTop = Math.Min(nFrags, maxFragments);
+            int[] topIndices;
+            if (nFrags <= maxFragments)
+            {
+                topIndices = new int[nFrags];
+                for (int i = 0; i < nFrags; i++)
+                    topIndices[i] = i;
+            }
+            else
+            {
+                // Stable sort matching Rust slice::sort_by on
+                // RelativeIntensity ties; List<T>.Sort with
+                // Comparison<T> is introsort and unstable.
+                topIndices = Enumerable.Range(0, nFrags)
+                    .OrderByDescending(i => entry.Fragments[i].RelativeIntensity)
+                    .Take(nTop)
+                    .ToArray();
+            }
+
+            int nScans = candidateSpectra.Count;
+            foreach (int fragIdx in topIndices)
+            {
+                var fragment = entry.Fragments[fragIdx];
+                double tolDa = config.FragmentTolerance.ToleranceDa(fragment.Mz);
+                double lower = fragment.Mz - tolDa;
+                double upper = fragment.Mz + tolDa;
+
+                double[] intensities = new double[nScans];
+
+                for (int scanIdx = 0; scanIdx < nScans; scanIdx++)
+                {
+                    var spectrum = candidateSpectra[scanIdx];
+                    if (spectrum.Mzs == null || spectrum.Mzs.Length == 0)
+                        continue;
+
+                    int lo = ScoringMath.BinarySearchLowerBound(spectrum.Mzs, lower);
+                    if (lo >= spectrum.Mzs.Length || spectrum.Mzs[lo] > upper)
+                        continue;
+
+                    // Pick CLOSEST peak by m/z (not most intense). Matches
+                    // Rust extract_fragment_xics in osprey-scoring/src/batch.rs.
+                    double bestDiff = Math.Abs(spectrum.Mzs[lo] - fragment.Mz);
+                    double bestIntensity = spectrum.Intensities[lo];
+                    for (int k = lo + 1; k < spectrum.Mzs.Length && spectrum.Mzs[k] <= upper; k++)
+                    {
+                        double diff = Math.Abs(spectrum.Mzs[k] - fragment.Mz);
+                        if (diff < bestDiff)
+                        {
+                            bestDiff = diff;
+                            bestIntensity = spectrum.Intensities[k];
+                        }
+                    }
+                    intensities[scanIdx] = bestIntensity;
+                }
+
+                // Always include the fragment XIC, even all-zero. Rust:
+                // "Dropping all-zero fragments biases decoys to higher R^2".
+                xics.Add(new XicData(fragIdx, rts, intensities));
+            }
+
+            return xics;
+        }
+
+        /// <summary>
+        /// Extract fragment XICs for a candidate across the scan range.
+        /// </summary>
+        public static List<XicData> ExtractFragmentXics(
+            LibraryEntry candidate,
+            List<Spectrum> windowSpectra,
+            double[] windowRts,
+            int startScan, int endScan,
+            OspreyConfig config)
+        {
+            // Port of Rust extract_fragment_xics (osprey-scoring/src/lib.rs:505).
+            // Differences from the previous C# implementation:
+            //   1. Use top-6 fragments by relative intensity (not all fragments)
+            //   2. Pick the closest peak by m/z within tolerance (not most intense)
+            //   3. Always include all selected fragments, even all-zero XICs
+            //      (dropping all-zero fragments biases decoys to higher R^2)
+            int rangeLen = endScan - startScan + 1;
+            var xics = new List<XicData>();
+            if (candidate.Fragments == null || candidate.Fragments.Count == 0)
+                return xics;
+
+            int nFrags = candidate.Fragments.Count;
+            int nTop = Math.Min(nFrags, CAL_TOP_N_FRAGMENTS);
+            int[] topIndices;
+            if (nFrags <= CAL_TOP_N_FRAGMENTS)
+            {
+                topIndices = new int[nFrags];
+                for (int i = 0; i < nFrags; i++)
+                    topIndices[i] = i;
+            }
+            else
+            {
+                // Rust's `indexed.sort_by(|a, b| b.1.total_cmp(&a.1))` at
+                // osprey-scoring/src/lib.rs:528 is STABLE (slice::sort_by
+                // is stable). Switch from `List<T>.Sort` (introsort,
+                // unstable) to LINQ `OrderByDescending` (stable per .NET
+                // contract) so that ties on RelativeIntensity preserve
+                // the library's fragment order, matching Rust. Without
+                // this, a peptide with two fragments at equal relative
+                // intensity can land different fragments in its top-N on
+                // the C# side, which cascades through XIC extraction →
+                // peak detection → rankScore → bestPeak selection.
+                topIndices = Enumerable.Range(0, nFrags)
+                    .OrderByDescending(i => candidate.Fragments[i].RelativeIntensity)
+                    .Take(nTop)
+                    .ToArray();
+            }
+
+            // Build shared RT array for this range
+            double[] rangeRts = new double[rangeLen];
+            for (int i = 0; i < rangeLen; i++)
+                rangeRts[i] = windowRts[startScan + i];
+
+            foreach (int fragIdx in topIndices)
+            {
+                var fragment = candidate.Fragments[fragIdx];
+                double tolDa = config.FragmentTolerance.ToleranceDa(fragment.Mz);
+                double lower = fragment.Mz - tolDa;
+                double upper = fragment.Mz + tolDa;
+
+                double[] intensities = new double[rangeLen];
+
+                for (int scanIdx = 0; scanIdx < rangeLen; scanIdx++)
+                {
+                    var spectrum = windowSpectra[startScan + scanIdx];
+                    if (spectrum.Mzs == null || spectrum.Mzs.Length == 0)
+                        continue;
+
+                    int lo = ScoringMath.BinarySearchLowerBound(spectrum.Mzs, lower);
+                    if (lo >= spectrum.Mzs.Length || spectrum.Mzs[lo] > upper)
+                        continue;
+
+                    // Find closest peak by m/z within tolerance (matches Rust).
+                    double bestDiff = Math.Abs(spectrum.Mzs[lo] - fragment.Mz);
+                    double bestIntensity = spectrum.Intensities[lo];
+                    for (int k = lo + 1; k < spectrum.Mzs.Length && spectrum.Mzs[k] <= upper; k++)
+                    {
+                        double diff = Math.Abs(spectrum.Mzs[k] - fragment.Mz);
+                        if (diff < bestDiff)
+                        {
+                            bestDiff = diff;
+                            bestIntensity = spectrum.Intensities[k];
+                        }
+                    }
+                    intensities[scanIdx] = bestIntensity;
+                }
+
+                // Always include the fragment XIC, even if all zero. Zero intensities
+                // are valid data (no centroided peak found) and dropping all-zero
+                // fragments biases decoys to higher R^2. Matches Rust behavior.
+                xics.Add(new XicData(fragIdx, rangeRts, intensities));
+            }
+
+            return xics;
+        }
+
+        /// <summary>
+        /// Count how many of the top 6 library fragments (by intensity) have
+        /// matching peaks in the spectrum. Used for the top6_matched feature
+        /// value (called once per scored entry, not in the hot prefilter loop).
+        /// The prefilter uses HasTopNFragmentMatch instead for speed.
+        /// </summary>
+        public static byte CountTop6Matches(
+            LibraryEntry entry, Spectrum spectrum, OspreyConfig config)
+        {
+            if (entry.Fragments == null || entry.Fragments.Count == 0)
+                return 0;
+
+            int nTop = Math.Min(entry.Fragments.Count, 6);
+            byte matched = 0;
+
+            if (entry.Fragments.Count <= 6)
+            {
+                for (int i = 0; i < entry.Fragments.Count; i++)
+                {
+                    if (SpectralScorer.HasMatch(entry.Fragments[i].Mz,
+                        spectrum.Mzs, config.FragmentTolerance))
+                        matched++;
+                }
+            }
+            else
+            {
+                // Stable top-6 by RelativeIntensity, matching Rust
+                // slice::sort_by ties (Array.Sort with Comparison<T>
+                // is introsort and unstable).
+                var indices = Enumerable.Range(0, entry.Fragments.Count)
+                    .OrderByDescending(i => entry.Fragments[i].RelativeIntensity)
+                    .Take(nTop)
+                    .ToArray();
+
+                for (int t = 0; t < indices.Length; t++)
+                {
+                    if (SpectralScorer.HasMatch(entry.Fragments[indices[t]].Mz,
+                        spectrum.Mzs, config.FragmentTolerance))
+                        matched++;
+                }
+            }
+            return matched;
+        }
+    }
+}

--- a/pwiz_tools/OspreySharp/OspreySharp.Scoring/TopFragmentExtractor.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Scoring/TopFragmentExtractor.cs
@@ -46,8 +46,9 @@ namespace pwiz.OspreySharp.Scoring
 
         /// <summary>
         /// Extract XICs for the top N most intense library fragments across the
-        /// supplied (pre-filtered) spectra list. Returns only fragments that have
-        /// at least one non-zero intensity point.
+        /// supplied (pre-filtered) spectra list. Includes an XIC for every selected
+        /// fragment, even all-zero ones -- dropping all-zero fragments biases decoys
+        /// to higher R^2 (matches Rust).
         /// </summary>
         public static List<XicData> ExtractTopNFragmentXics(
             LibraryEntry entry,

--- a/pwiz_tools/OspreySharp/OspreySharp/Tasks/AbstractScoringTask.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/Tasks/AbstractScoringTask.cs
@@ -60,11 +60,6 @@ namespace pwiz.OspreySharp.Tasks
         internal PipelineContext _ctx;
 
 
-        // Number of top-intensity library fragments used for
-        // calibration scoring + dedup top-6 overlap. Read both
-        // from PerFileScoringTask (calibration) and from the
-        // shared scoring engine here.
-        internal const int CAL_TOP_N_FRAGMENTS = 6;
         // Internal so FirstJoinTask (which now owns RunPercolatorFdr +
         // RunPercolatorStreaming + BuildBasicFeatures) can reuse the
         // same 21-feature width without redeclaring it.
@@ -131,90 +126,6 @@ namespace pwiz.OspreySharp.Tasks
             // Sort by center m/z
             windows.Sort((a, b) => a.Center.CompareTo(b.Center));
             return windows;
-        }
-
-
-        /// <summary>
-        /// Extract XICs for the top N most intense library fragments across the
-        /// supplied (pre-filtered) spectra list. Returns only fragments that have
-        /// at least one non-zero intensity point.
-        /// Calibration-only today; <c>internal static</c> so the extracted
-        /// <see cref="Calibrator"/> can call it without inheriting this class.
-        /// </summary>
-        internal static List<XicData> ExtractTopNFragmentXics(
-            LibraryEntry entry,
-            List<Spectrum> candidateSpectra,
-            double[] rts,
-            int maxFragments,
-            OspreyConfig config)
-        {
-            var xics = new List<XicData>();
-            if (entry.Fragments == null || entry.Fragments.Count == 0)
-                return xics;
-
-            // Select top N fragment indices by descending relative intensity.
-            int nFrags = entry.Fragments.Count;
-            int nTop = Math.Min(nFrags, maxFragments);
-            int[] topIndices;
-            if (nFrags <= maxFragments)
-            {
-                topIndices = new int[nFrags];
-                for (int i = 0; i < nFrags; i++)
-                    topIndices[i] = i;
-            }
-            else
-            {
-                // Stable sort matching Rust slice::sort_by on
-                // RelativeIntensity ties; List<T>.Sort with
-                // Comparison<T> is introsort and unstable.
-                topIndices = Enumerable.Range(0, nFrags)
-                    .OrderByDescending(i => entry.Fragments[i].RelativeIntensity)
-                    .Take(nTop)
-                    .ToArray();
-            }
-
-            int nScans = candidateSpectra.Count;
-            foreach (int fragIdx in topIndices)
-            {
-                var fragment = entry.Fragments[fragIdx];
-                double tolDa = config.FragmentTolerance.ToleranceDa(fragment.Mz);
-                double lower = fragment.Mz - tolDa;
-                double upper = fragment.Mz + tolDa;
-
-                double[] intensities = new double[nScans];
-
-                for (int scanIdx = 0; scanIdx < nScans; scanIdx++)
-                {
-                    var spectrum = candidateSpectra[scanIdx];
-                    if (spectrum.Mzs == null || spectrum.Mzs.Length == 0)
-                        continue;
-
-                    int lo = ScoringMath.BinarySearchLowerBound(spectrum.Mzs, lower);
-                    if (lo >= spectrum.Mzs.Length || spectrum.Mzs[lo] > upper)
-                        continue;
-
-                    // Pick CLOSEST peak by m/z (not most intense). Matches
-                    // Rust extract_fragment_xics in osprey-scoring/src/batch.rs.
-                    double bestDiff = Math.Abs(spectrum.Mzs[lo] - fragment.Mz);
-                    double bestIntensity = spectrum.Intensities[lo];
-                    for (int k = lo + 1; k < spectrum.Mzs.Length && spectrum.Mzs[k] <= upper; k++)
-                    {
-                        double diff = Math.Abs(spectrum.Mzs[k] - fragment.Mz);
-                        if (diff < bestDiff)
-                        {
-                            bestDiff = diff;
-                            bestIntensity = spectrum.Intensities[k];
-                        }
-                    }
-                    intensities[scanIdx] = bestIntensity;
-                }
-
-                // Always include the fragment XIC, even all-zero. Rust:
-                // "Dropping all-zero fragments biases decoys to higher R^2".
-                xics.Add(new XicData(fragIdx, rts, intensities));
-            }
-
-            return xics;
         }
 
 
@@ -880,7 +791,7 @@ namespace pwiz.OspreySharp.Tasks
             }
 
             // Extract fragment XICs within the RT range
-            var xics = ExtractFragmentXics(
+            var xics = TopFragmentExtractor.ExtractFragmentXics(
                 candidate, windowSpectra, windowRts, startScan, endScan, config);
 
             // Per-entry search XIC diagnostic. Fires for every scoring
@@ -1276,7 +1187,7 @@ namespace pwiz.OspreySharp.Tasks
             // Count fragment matches (top-6 dedup byproduct, NOT a PIN feature;
             // stays inline). consecutive_ions / explained_intensity / mass-accuracy
             // (features 7-10) moved to the apex-match calculators below.
-            byte top6Matches = CountTop6Matches(candidate, apexSpectrum, config);
+            byte top6Matches = TopFragmentExtractor.CountTop6Matches(candidate, apexSpectrum, config);
 
             // MS1 features (precursor coelution, isotope cosine) are computed by the
             // MS1 calculators (features 13, 14) below from the published per-window
@@ -1525,103 +1436,6 @@ namespace pwiz.OspreySharp.Tasks
 
 
         /// <summary>
-        /// Extract fragment XICs for a candidate across the scan range.
-        /// </summary>
-        private List<XicData> ExtractFragmentXics(
-            LibraryEntry candidate,
-            List<Spectrum> windowSpectra,
-            double[] windowRts,
-            int startScan, int endScan,
-            OspreyConfig config)
-        {
-            // Port of Rust extract_fragment_xics (osprey-scoring/src/lib.rs:505).
-            // Differences from the previous C# implementation:
-            //   1. Use top-6 fragments by relative intensity (not all fragments)
-            //   2. Pick the closest peak by m/z within tolerance (not most intense)
-            //   3. Always include all selected fragments, even all-zero XICs
-            //      (dropping all-zero fragments biases decoys to higher R^2)
-            int rangeLen = endScan - startScan + 1;
-            var xics = new List<XicData>();
-            if (candidate.Fragments == null || candidate.Fragments.Count == 0)
-                return xics;
-
-            int nFrags = candidate.Fragments.Count;
-            int nTop = Math.Min(nFrags, CAL_TOP_N_FRAGMENTS);
-            int[] topIndices;
-            if (nFrags <= CAL_TOP_N_FRAGMENTS)
-            {
-                topIndices = new int[nFrags];
-                for (int i = 0; i < nFrags; i++)
-                    topIndices[i] = i;
-            }
-            else
-            {
-                // Rust's `indexed.sort_by(|a, b| b.1.total_cmp(&a.1))` at
-                // osprey-scoring/src/lib.rs:528 is STABLE (slice::sort_by
-                // is stable). Switch from `List<T>.Sort` (introsort,
-                // unstable) to LINQ `OrderByDescending` (stable per .NET
-                // contract) so that ties on RelativeIntensity preserve
-                // the library's fragment order, matching Rust. Without
-                // this, a peptide with two fragments at equal relative
-                // intensity can land different fragments in its top-N on
-                // the C# side, which cascades through XIC extraction →
-                // peak detection → rankScore → bestPeak selection.
-                topIndices = Enumerable.Range(0, nFrags)
-                    .OrderByDescending(i => candidate.Fragments[i].RelativeIntensity)
-                    .Take(nTop)
-                    .ToArray();
-            }
-
-            // Build shared RT array for this range
-            double[] rangeRts = new double[rangeLen];
-            for (int i = 0; i < rangeLen; i++)
-                rangeRts[i] = windowRts[startScan + i];
-
-            foreach (int fragIdx in topIndices)
-            {
-                var fragment = candidate.Fragments[fragIdx];
-                double tolDa = config.FragmentTolerance.ToleranceDa(fragment.Mz);
-                double lower = fragment.Mz - tolDa;
-                double upper = fragment.Mz + tolDa;
-
-                double[] intensities = new double[rangeLen];
-
-                for (int scanIdx = 0; scanIdx < rangeLen; scanIdx++)
-                {
-                    var spectrum = windowSpectra[startScan + scanIdx];
-                    if (spectrum.Mzs == null || spectrum.Mzs.Length == 0)
-                        continue;
-
-                    int lo = ScoringMath.BinarySearchLowerBound(spectrum.Mzs, lower);
-                    if (lo >= spectrum.Mzs.Length || spectrum.Mzs[lo] > upper)
-                        continue;
-
-                    // Find closest peak by m/z within tolerance (matches Rust).
-                    double bestDiff = Math.Abs(spectrum.Mzs[lo] - fragment.Mz);
-                    double bestIntensity = spectrum.Intensities[lo];
-                    for (int k = lo + 1; k < spectrum.Mzs.Length && spectrum.Mzs[k] <= upper; k++)
-                    {
-                        double diff = Math.Abs(spectrum.Mzs[k] - fragment.Mz);
-                        if (diff < bestDiff)
-                        {
-                            bestDiff = diff;
-                            bestIntensity = spectrum.Intensities[k];
-                        }
-                    }
-                    intensities[scanIdx] = bestIntensity;
-                }
-
-                // Always include the fragment XIC, even if all zero. Zero intensities
-                // are valid data (no centroided peak found) and dropping all-zero
-                // fragments biases decoys to higher R^2. Matches Rust behavior.
-                xics.Add(new XicData(fragIdx, rangeRts, intensities));
-            }
-
-            return xics;
-        }
-
-
-        /// <summary>
         /// Find the MS1 spectrum with retention time closest to the given RT.
         /// Assumes MS1 spectra are sorted by RT. Thin forwarder to the single
         /// implementation in Core (<see cref="MS1Spectrum.FindNearest"/>) so the
@@ -1631,54 +1445,6 @@ namespace pwiz.OspreySharp.Tasks
         internal static MS1Spectrum FindNearestMs1(List<MS1Spectrum> ms1Spectra, double rt)
         {
             return MS1Spectrum.FindNearest(ms1Spectra, rt);
-        }
-
-
-        /// <summary>
-        /// Count top-6 fragment matches at the apex spectrum.
-        /// </summary>
-        /// <summary>
-        /// Count how many of the top 6 library fragments (by intensity) have
-        /// matching peaks in the spectrum. Used for the top6_matched feature
-        /// value (called once per scored entry, not in the hot prefilter loop).
-        /// The prefilter uses HasTopNFragmentMatch instead for speed.
-        /// </summary>
-        internal static byte CountTop6Matches(
-            LibraryEntry entry, Spectrum spectrum, OspreyConfig config)
-        {
-            if (entry.Fragments == null || entry.Fragments.Count == 0)
-                return 0;
-
-            int nTop = Math.Min(entry.Fragments.Count, 6);
-            byte matched = 0;
-
-            if (entry.Fragments.Count <= 6)
-            {
-                for (int i = 0; i < entry.Fragments.Count; i++)
-                {
-                    if (SpectralScorer.HasMatch(entry.Fragments[i].Mz,
-                        spectrum.Mzs, config.FragmentTolerance))
-                        matched++;
-                }
-            }
-            else
-            {
-                // Stable top-6 by RelativeIntensity, matching Rust
-                // slice::sort_by ties (Array.Sort with Comparison<T>
-                // is introsort and unstable).
-                var indices = Enumerable.Range(0, entry.Fragments.Count)
-                    .OrderByDescending(i => entry.Fragments[i].RelativeIntensity)
-                    .Take(nTop)
-                    .ToArray();
-
-                for (int t = 0; t < indices.Length; t++)
-                {
-                    if (SpectralScorer.HasMatch(entry.Fragments[indices[t]].Mz,
-                        spectrum.Mzs, config.FragmentTolerance))
-                        matched++;
-                }
-            }
-            return matched;
         }
 
 

--- a/pwiz_tools/OspreySharp/OspreySharp/Tasks/Calibrator.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/Tasks/Calibrator.cs
@@ -1027,8 +1027,8 @@ namespace pwiz.OspreySharp.Tasks
             int currentPass = calibrationModel != null ? 2 : 1;
 
             // Extract XICs for the top-N most intense library fragments.
-            var xics = AbstractScoringTask.ExtractTopNFragmentXics(
-                entry, candidateSpectra, rts, AbstractScoringTask.CAL_TOP_N_FRAGMENTS, config);
+            var xics = TopFragmentExtractor.ExtractTopNFragmentXics(
+                entry, candidateSpectra, rts, TopFragmentExtractor.CAL_TOP_N_FRAGMENTS, config);
 
             if (OspreyDiagnostics.ShouldDumpCalXicFor(entry.Id, currentPass))
             {
@@ -1162,7 +1162,7 @@ namespace pwiz.OspreySharp.Tasks
             double xcorrApex = (windowPreprocessed != null && apexWindowIdx < windowPreprocessed.Length)
                 ? AbstractScoringTask.s_calXcorrScorer.XcorrFromPreprocessed(windowPreprocessed[apexWindowIdx], entry)
                 : AbstractScoringTask.s_calXcorrScorer.XcorrAtScan(apexSpectrum, entry);
-            byte top6Matched = AbstractScoringTask.CountTop6Matches(entry, apexSpectrum, config);
+            byte top6Matched = TopFragmentExtractor.CountTop6Matches(entry, apexSpectrum, config);
 
             // Collect MS2 fragment mass errors at apex for m/z calibration.
             var ms2Errors = CollectMs2FragmentErrors(entry, apexSpectrum, config);
@@ -1244,9 +1244,9 @@ namespace pwiz.OspreySharp.Tasks
             var ms2Errors = new List<double>();
             // Select top-6 fragment indices by descending intensity
             int nFragsForErrors = entry.Fragments.Count;
-            int nTopForErrors = Math.Min(nFragsForErrors, AbstractScoringTask.CAL_TOP_N_FRAGMENTS);
+            int nTopForErrors = Math.Min(nFragsForErrors, TopFragmentExtractor.CAL_TOP_N_FRAGMENTS);
             int[] topErrorIndices;
-            if (nFragsForErrors <= AbstractScoringTask.CAL_TOP_N_FRAGMENTS)
+            if (nFragsForErrors <= TopFragmentExtractor.CAL_TOP_N_FRAGMENTS)
             {
                 topErrorIndices = new int[nFragsForErrors];
                 for (int ti = 0; ti < nFragsForErrors; ti++)


### PR DESCRIPTION
## Summary

* Extracted three stateless fragment helpers (`ExtractTopNFragmentXics`, `ExtractFragmentXics`, `CountTop6Matches`) plus the `CAL_TOP_N_FRAGMENTS` constant out of `AbstractScoringTask` into a new `OspreySharp.Scoring.TopFragmentExtractor`. Arithmetic and the Rust-matching stable-sort tie-break are verbatim, so cross-impl byte parity is unaffected.
* Target project is Scoring (not Core's `FragmentMath`): the methods depend on `ScoringMath`/`SpectralScorer` (Scoring) and `XicData` (Chromatography), which Core cannot reference.
* Rewired call sites in `AbstractScoringTask` and `Calibrator`; left `s_calXcorrScorer` in place (deferred). Consolidated a duplicated `<summary>` tag.
* Stage B of the `AbstractScoringTask` decomposition; now based directly on `master` (Stage A merged as #4291).

> Supersedes #4292, which GitHub auto-closed when Stage A's branch was deleted during its squash-merge (the `--delete-branch` retired #4292's base). Same branch, same commits — the two Copilot comments on #4292 were already addressed (doc corrected; `CountTop6Matches` literal kept intentionally).

## Gate results

- [x] Pre-commit: 382 pass / 2 skip, zero-warning inspection
- [x] Correctness (`regression.ps1 -Dataset Stellar`): golden + resume PASS @ 1e-9 (blib byte-identical)
- [x] Performance (`Test-PerfGate.ps1 -Dataset Stellar`): total -1.7% median, PASSED
- [x] Cumulative stack also passed Astral 1e-9 overnight

See ai/todos/active/TODO-20260611_ospreysharp_decouple_abstractscoring.md

Co-Authored-By: Claude <noreply@anthropic.com>
