### PR TITLE
Consolidated OspreySharp scoring helpers and relocated the calibration XCorr scorer

### DIFF
--- a/pwiz_tools/OspreySharp/OspreySharp.Scoring/IScoringDiagnostics.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Scoring/IScoringDiagnostics.cs
@@ -35,7 +35,7 @@ namespace pwiz.OspreySharp.Scoring
     /// the top-level exe project (OOP-review rec #3, "diagnostics-bleed").
     ///
     /// The exe's file-backed sink implements this. When diagnostics are off (no
-    /// <c>--d</c> flag) the injected reference is <c>null</c>, and the scorer
+    /// <c>-d</c> flag) the injected reference is <c>null</c>, and the scorer
     /// invokes it with the null-conditional operator (<c>diag?.ShouldDump...() ??
     /// false</c>, <c>diag?.Write...(...)</c>). That mirrors the existing
     /// <c>Sink?.X()</c> idiom exactly -- zero hot-path overhead, argument
@@ -64,6 +64,6 @@ namespace pwiz.OspreySharp.Scoring
 
         void WriteCwtPathRow(string fileName, uint entryId,
             int nCwtPeaks, int nFinalPeaks, int nScored, bool scored,
-            List<XicData> xics);
+            IReadOnlyList<XicData> xics);
     }
 }

--- a/pwiz_tools/OspreySharp/OspreySharp.Scoring/TopFragmentExtractor.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Scoring/TopFragmentExtractor.cs
@@ -61,26 +61,7 @@ namespace pwiz.OspreySharp.Scoring
             if (entry.Fragments == null || entry.Fragments.Count == 0)
                 return xics;
 
-            // Select top N fragment indices by descending relative intensity.
-            int nFrags = entry.Fragments.Count;
-            int nTop = Math.Min(nFrags, maxFragments);
-            int[] topIndices;
-            if (nFrags <= maxFragments)
-            {
-                topIndices = new int[nFrags];
-                for (int i = 0; i < nFrags; i++)
-                    topIndices[i] = i;
-            }
-            else
-            {
-                // Stable sort matching Rust slice::sort_by on
-                // RelativeIntensity ties; List<T>.Sort with
-                // Comparison<T> is introsort and unstable.
-                topIndices = Enumerable.Range(0, nFrags)
-                    .OrderByDescending(i => entry.Fragments[i].RelativeIntensity)
-                    .Take(nTop)
-                    .ToArray();
-            }
+            int[] topIndices = SelectTopFragmentIndices(entry.Fragments, maxFragments);
 
             int nScans = candidateSpectra.Count;
             foreach (int fragIdx in topIndices)
@@ -95,27 +76,9 @@ namespace pwiz.OspreySharp.Scoring
                 for (int scanIdx = 0; scanIdx < nScans; scanIdx++)
                 {
                     var spectrum = candidateSpectra[scanIdx];
-                    if (spectrum.Mzs == null || spectrum.Mzs.Length == 0)
-                        continue;
-
-                    int lo = ScoringMath.BinarySearchLowerBound(spectrum.Mzs, lower);
-                    if (lo >= spectrum.Mzs.Length || spectrum.Mzs[lo] > upper)
-                        continue;
-
-                    // Pick CLOSEST peak by m/z (not most intense). Matches
-                    // Rust extract_fragment_xics in osprey-scoring/src/batch.rs.
-                    double bestDiff = Math.Abs(spectrum.Mzs[lo] - fragment.Mz);
-                    double bestIntensity = spectrum.Intensities[lo];
-                    for (int k = lo + 1; k < spectrum.Mzs.Length && spectrum.Mzs[k] <= upper; k++)
-                    {
-                        double diff = Math.Abs(spectrum.Mzs[k] - fragment.Mz);
-                        if (diff < bestDiff)
-                        {
-                            bestDiff = diff;
-                            bestIntensity = spectrum.Intensities[k];
-                        }
-                    }
-                    intensities[scanIdx] = bestIntensity;
+                    int best = FindClosestPeakInWindow(spectrum.Mzs, fragment.Mz, lower, upper);
+                    if (best >= 0)
+                        intensities[scanIdx] = spectrum.Intensities[best];
                 }
 
                 // Always include the fragment XIC, even all-zero. Rust:
@@ -147,32 +110,7 @@ namespace pwiz.OspreySharp.Scoring
             if (candidate.Fragments == null || candidate.Fragments.Count == 0)
                 return xics;
 
-            int nFrags = candidate.Fragments.Count;
-            int nTop = Math.Min(nFrags, CAL_TOP_N_FRAGMENTS);
-            int[] topIndices;
-            if (nFrags <= CAL_TOP_N_FRAGMENTS)
-            {
-                topIndices = new int[nFrags];
-                for (int i = 0; i < nFrags; i++)
-                    topIndices[i] = i;
-            }
-            else
-            {
-                // Rust's `indexed.sort_by(|a, b| b.1.total_cmp(&a.1))` at
-                // osprey-scoring/src/lib.rs:528 is STABLE (slice::sort_by
-                // is stable). Switch from `List<T>.Sort` (introsort,
-                // unstable) to LINQ `OrderByDescending` (stable per .NET
-                // contract) so that ties on RelativeIntensity preserve
-                // the library's fragment order, matching Rust. Without
-                // this, a peptide with two fragments at equal relative
-                // intensity can land different fragments in its top-N on
-                // the C# side, which cascades through XIC extraction →
-                // peak detection → rankScore → bestPeak selection.
-                topIndices = Enumerable.Range(0, nFrags)
-                    .OrderByDescending(i => candidate.Fragments[i].RelativeIntensity)
-                    .Take(nTop)
-                    .ToArray();
-            }
+            int[] topIndices = SelectTopFragmentIndices(candidate.Fragments, CAL_TOP_N_FRAGMENTS);
 
             // Build shared RT array for this range
             double[] rangeRts = new double[rangeLen];
@@ -191,26 +129,9 @@ namespace pwiz.OspreySharp.Scoring
                 for (int scanIdx = 0; scanIdx < rangeLen; scanIdx++)
                 {
                     var spectrum = windowSpectra[startScan + scanIdx];
-                    if (spectrum.Mzs == null || spectrum.Mzs.Length == 0)
-                        continue;
-
-                    int lo = ScoringMath.BinarySearchLowerBound(spectrum.Mzs, lower);
-                    if (lo >= spectrum.Mzs.Length || spectrum.Mzs[lo] > upper)
-                        continue;
-
-                    // Find closest peak by m/z within tolerance (matches Rust).
-                    double bestDiff = Math.Abs(spectrum.Mzs[lo] - fragment.Mz);
-                    double bestIntensity = spectrum.Intensities[lo];
-                    for (int k = lo + 1; k < spectrum.Mzs.Length && spectrum.Mzs[k] <= upper; k++)
-                    {
-                        double diff = Math.Abs(spectrum.Mzs[k] - fragment.Mz);
-                        if (diff < bestDiff)
-                        {
-                            bestDiff = diff;
-                            bestIntensity = spectrum.Intensities[k];
-                        }
-                    }
-                    intensities[scanIdx] = bestIntensity;
+                    int best = FindClosestPeakInWindow(spectrum.Mzs, fragment.Mz, lower, upper);
+                    if (best >= 0)
+                        intensities[scanIdx] = spectrum.Intensities[best];
                 }
 
                 // Always include the fragment XIC, even if all zero. Zero intensities
@@ -234,36 +155,81 @@ namespace pwiz.OspreySharp.Scoring
             if (entry.Fragments == null || entry.Fragments.Count == 0)
                 return 0;
 
-            int nTop = Math.Min(entry.Fragments.Count, 6);
+            int[] topIndices = SelectTopFragmentIndices(entry.Fragments, 6);
             byte matched = 0;
-
-            if (entry.Fragments.Count <= 6)
+            foreach (int fragIdx in topIndices)
             {
-                for (int i = 0; i < entry.Fragments.Count; i++)
-                {
-                    if (SpectralScorer.HasMatch(entry.Fragments[i].Mz,
-                        spectrum.Mzs, config.FragmentTolerance))
-                        matched++;
-                }
-            }
-            else
-            {
-                // Stable top-6 by RelativeIntensity, matching Rust
-                // slice::sort_by ties (Array.Sort with Comparison<T>
-                // is introsort and unstable).
-                var indices = Enumerable.Range(0, entry.Fragments.Count)
-                    .OrderByDescending(i => entry.Fragments[i].RelativeIntensity)
-                    .Take(nTop)
-                    .ToArray();
-
-                for (int t = 0; t < indices.Length; t++)
-                {
-                    if (SpectralScorer.HasMatch(entry.Fragments[indices[t]].Mz,
-                        spectrum.Mzs, config.FragmentTolerance))
-                        matched++;
-                }
+                if (SpectralScorer.HasMatch(entry.Fragments[fragIdx].Mz,
+                    spectrum.Mzs, config.FragmentTolerance))
+                    matched++;
             }
             return matched;
+        }
+
+        /// <summary>
+        /// Select the indices of the top <paramref name="maxFragments"/> library
+        /// fragments by descending <see cref="LibraryFragment.RelativeIntensity"/>.
+        /// When there are at most <paramref name="maxFragments"/> fragments, every
+        /// index is returned in library order.
+        /// </summary>
+        /// <remarks>
+        /// The sort is a STABLE <c>OrderByDescending</c> (stable per the .NET
+        /// contract) so ties on RelativeIntensity preserve the library's fragment
+        /// order, matching Rust's stable <c>slice::sort_by</c>
+        /// (osprey-scoring/src/lib.rs:528). <c>List&lt;T&gt;.Sort</c> /
+        /// <c>Array.Sort</c> with a <c>Comparison&lt;T&gt;</c> is introsort and
+        /// unstable, which would pick different fragments on ties and cascade
+        /// through XIC extraction -> peak detection -> rankScore -> bestPeak.
+        /// </remarks>
+        public static int[] SelectTopFragmentIndices(
+            IReadOnlyList<LibraryFragment> fragments, int maxFragments)
+        {
+            int nFrags = fragments.Count;
+            if (nFrags <= maxFragments)
+            {
+                var allIndices = new int[nFrags];
+                for (int i = 0; i < nFrags; i++)
+                    allIndices[i] = i;
+                return allIndices;
+            }
+            return Enumerable.Range(0, nFrags)
+                .OrderByDescending(i => fragments[i].RelativeIntensity)
+                .Take(maxFragments)
+                .ToArray();
+        }
+
+        /// <summary>
+        /// Index of the peak whose m/z is closest to <paramref name="targetMz"/>
+        /// within the inclusive window [<paramref name="lower"/>,
+        /// <paramref name="upper"/>], or -1 when no peak falls in the window.
+        /// </summary>
+        /// <remarks>
+        /// Picks CLOSEST by m/z (not most intense). The ascending scan with a
+        /// strict-less-than replacement keeps the first (lowest-index) peak on
+        /// exact ties. Matches Rust extract_fragment_xics in
+        /// osprey-scoring/src/batch.rs. Callers read the intensity or the m/z at
+        /// the returned index as needed.
+        /// </remarks>
+        public static int FindClosestPeakInWindow(
+            double[] mzs, double targetMz, double lower, double upper)
+        {
+            if (mzs == null || mzs.Length == 0)
+                return -1;
+            int lo = ScoringMath.BinarySearchLowerBound(mzs, lower);
+            if (lo >= mzs.Length || mzs[lo] > upper)
+                return -1;
+            int best = lo;
+            double bestDiff = Math.Abs(mzs[lo] - targetMz);
+            for (int k = lo + 1; k < mzs.Length && mzs[k] <= upper; k++)
+            {
+                double diff = Math.Abs(mzs[k] - targetMz);
+                if (diff < bestDiff)
+                {
+                    bestDiff = diff;
+                    best = k;
+                }
+            }
+            return best;
         }
     }
 }

--- a/pwiz_tools/OspreySharp/OspreySharp.Test/CalibrationTest.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Test/CalibrationTest.cs
@@ -532,7 +532,7 @@ namespace pwiz.OspreySharp.Test
         /// LOH and trigger gen-2 GC pressure during the all-windows-at-once
         /// pre-preprocessing step.
         ///
-        /// If a future change makes AbstractScoringTask.s_calXcorrScorer
+        /// If a future change makes Calibrator.s_calXcorrScorer
         /// construct with BinConfig.HRAM() (or any other non-unit bin config),
         /// these asserts fail loudly and cite the Rust design doc. Mirrors
         /// the calibration_scorer_uses_unit_bins_for_* tests in Rust osprey
@@ -541,7 +541,7 @@ namespace pwiz.OspreySharp.Test
         [TestMethod]
         public void TestCalibrationXcorrScorerUsesUnitBins()
         {
-            int calBins = AbstractScoringTask.s_calXcorrScorer.BinConfig.NBins;
+            int calBins = Calibrator.s_calXcorrScorer.BinConfig.NBins;
             int unitBins = new SpectralScorer(BinConfig.UnitResolution()).BinConfig.NBins;
             int hramBins = new SpectralScorer(BinConfig.HRAM()).BinConfig.NBins;
 

--- a/pwiz_tools/OspreySharp/OspreySharp/OspreyFileDiagnostics.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/OspreyFileDiagnostics.cs
@@ -1284,7 +1284,7 @@ namespace pwiz.OspreySharp
         /// </summary>
         public void WriteCwtPathRow(string fileName, uint entryId,
             int nCwtPeaks, int nFinalPeaks, int nScored, bool scored,
-            List<XicData> xics)
+            IReadOnlyList<XicData> xics)
         {
             if (!DumpCwtPath)
                 return;
@@ -1301,7 +1301,8 @@ namespace pwiz.OspreySharp
             int consensusArgmax = -1;
             if (xics != null)
             {
-                double[] consensus = CwtPeakDetector.GetConsensusSignal(xics, out sigma);
+                var xicList = xics is List<XicData> xicL ? xicL : new List<XicData>(xics);
+                double[] consensus = CwtPeakDetector.GetConsensusSignal(xicList, out sigma);
                 if (consensus != null)
                 {
                     double sum = 0.0;

--- a/pwiz_tools/OspreySharp/OspreySharp/Tasks/AbstractScoringTask.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/Tasks/AbstractScoringTask.cs
@@ -79,19 +79,6 @@ namespace pwiz.OspreySharp.Tasks
         internal static readonly SemaphoreSlim s_mzmlReadGate = new SemaphoreSlim(1, 1);
 
 
-        // Calibration XCorr always uses unit-resolution bins (~2K) regardless of
-        // instrument resolution mode. Matches the spec in Rust osprey
-        // docs/02-calibration.md ("Comet-style XCorr (unit resolution, BLAS
-        // sdot)") and the calibration_xcorr_scorer helper in
-        // osprey/crates/osprey/src/pipeline.rs, and avoids the LOH allocation
-        // pressure that 100K-bin arrays cause on .NET Framework's large-object
-        // heap. Main search XCorr still uses the resolution-mode bins via the
-        // IResolutionStrategy abstraction. Exposed as internal so
-        // OspreySharp.Test can assert the bin-config invariant.
-        internal static readonly SpectralScorer s_calXcorrScorer =
-            new SpectralScorer(BinConfig.UnitResolution());
-
-
         // Local alias so existing dump code using F10 continues to read cleanly.
         // The actual formatter lives in OspreyDiagnostics now.
         private static string F10(double v)

--- a/pwiz_tools/OspreySharp/OspreySharp/Tasks/Calibrator.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/Tasks/Calibrator.cs
@@ -40,11 +40,12 @@ namespace pwiz.OspreySharp.Tasks
     /// calibrations for one file. Ports osprey/src/pipeline.rs
     /// run_calibration_discovery_windowed.
     ///
-    /// Standalone collaborator (does not inherit AbstractScoringTask): it
-    /// reaches the shared calibration scorer and top-N constant via
-    /// AbstractScoringTask's internal statics and takes the pipeline context
-    /// for logging. Diagnostic dumps still route through the OspreyDiagnostics
-    /// facade, preserving the Stage-cal dump call order bisection relies on.
+    /// Standalone collaborator (does not inherit AbstractScoringTask): it owns
+    /// the calibration unit-resolution XCorr scorer (<see cref="s_calXcorrScorer"/>),
+    /// reaches the shared top-N constant via <see cref="TopFragmentExtractor"/>,
+    /// and takes the pipeline context for logging. Diagnostic dumps still route
+    /// through the OspreyDiagnostics facade, preserving the Stage-cal dump call
+    /// order bisection relies on.
     /// </summary>
     internal sealed class Calibrator
     {
@@ -56,6 +57,19 @@ namespace pwiz.OspreySharp.Tasks
         // refinement. Matches Rust's ABSOLUTE_MIN_CALIBRATION_POINTS
         // in pipeline.rs:652.
         private const int ABSOLUTE_MIN_CALIBRATION_POINTS = 50;
+
+        // Calibration XCorr always uses unit-resolution bins (~2K) regardless of
+        // instrument resolution mode. Matches the spec in Rust osprey
+        // docs/02-calibration.md ("Comet-style XCorr (unit resolution, BLAS
+        // sdot)") and the calibration_xcorr_scorer helper in
+        // osprey/crates/osprey/src/pipeline.rs, and avoids the LOH allocation
+        // pressure that 100K-bin arrays cause on .NET Framework's large-object
+        // heap. Main search XCorr still uses the resolution-mode bins via the
+        // IResolutionStrategy abstraction. Owned by the calibration subsystem
+        // (its sole consumer); exposed as internal so OspreySharp.Test can
+        // assert the bin-config invariant.
+        internal static readonly SpectralScorer s_calXcorrScorer =
+            new SpectralScorer(BinConfig.UnitResolution());
 
         /// <summary>
         /// Result of one calibration scoring pass (scoring + LDA +
@@ -539,7 +553,7 @@ namespace pwiz.OspreySharp.Tasks
                 var pp = new double[kvp.Value.Count][];
                 for (int i = 0; i < kvp.Value.Count; i++)
                 {
-                    float[] f32pp = AbstractScoringTask.s_calXcorrScorer.PreprocessSpectrumForXcorrF32(kvp.Value[i]);
+                    float[] f32pp = s_calXcorrScorer.PreprocessSpectrumForXcorrF32(kvp.Value[i]);
                     var widened = new double[f32pp.Length];
                     for (int k = 0; k < f32pp.Length; k++)
                         widened[k] = f32pp[k];
@@ -1156,11 +1170,11 @@ namespace pwiz.OspreySharp.Tasks
             double libCosineApex = scorer.LibCosine(
                 apexSpectrum, entry, config.FragmentTolerance);
             // XCorr at apex always uses the calibration unit-bin scorer
-            // (matches the pre-preprocessed arrays built with AbstractScoringTask.s_calXcorrScorer).
+            // (matches the pre-preprocessed arrays built with s_calXcorrScorer).
             int apexWindowIdx = candidateWindowIndices[apexSpecLocalIdx];
             double xcorrApex = (windowPreprocessed != null && apexWindowIdx < windowPreprocessed.Length)
-                ? AbstractScoringTask.s_calXcorrScorer.XcorrFromPreprocessed(windowPreprocessed[apexWindowIdx], entry)
-                : AbstractScoringTask.s_calXcorrScorer.XcorrAtScan(apexSpectrum, entry);
+                ? s_calXcorrScorer.XcorrFromPreprocessed(windowPreprocessed[apexWindowIdx], entry)
+                : s_calXcorrScorer.XcorrAtScan(apexSpectrum, entry);
             byte top6Matched = TopFragmentExtractor.CountTop6Matches(entry, apexSpectrum, config);
 
             // Collect MS2 fragment mass errors at apex for m/z calibration.

--- a/pwiz_tools/OspreySharp/OspreySharp/Tasks/Calibrator.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/Tasks/Calibrator.cs
@@ -25,7 +25,6 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
 using System.Threading.Tasks;
 using pwiz.OspreySharp.Chromatography;
 using pwiz.OspreySharp.Core;
@@ -1242,28 +1241,8 @@ namespace pwiz.OspreySharp.Tasks
             LibraryEntry entry, Spectrum apexSpectrum, OspreyConfig config)
         {
             var ms2Errors = new List<double>();
-            // Select top-6 fragment indices by descending intensity
-            int nFragsForErrors = entry.Fragments.Count;
-            int nTopForErrors = Math.Min(nFragsForErrors, TopFragmentExtractor.CAL_TOP_N_FRAGMENTS);
-            int[] topErrorIndices;
-            if (nFragsForErrors <= TopFragmentExtractor.CAL_TOP_N_FRAGMENTS)
-            {
-                topErrorIndices = new int[nFragsForErrors];
-                for (int ti = 0; ti < nFragsForErrors; ti++)
-                    topErrorIndices[ti] = ti;
-            }
-            else
-            {
-                // LINQ OrderByDescending is stable per .NET contract;
-                // List<T>.Sort with Comparison<T> is unstable
-                // (introsort) and produces different top-N picks
-                // than Rust's stable slice::sort_by on RelativeIntensity
-                // ties. Match Rust by using the stable sort.
-                topErrorIndices = Enumerable.Range(0, nFragsForErrors)
-                    .OrderByDescending(ti => entry.Fragments[ti].RelativeIntensity)
-                    .Take(nTopForErrors)
-                    .ToArray();
-            }
+            int[] topErrorIndices = TopFragmentExtractor.SelectTopFragmentIndices(
+                entry.Fragments, TopFragmentExtractor.CAL_TOP_N_FRAGMENTS);
 
             foreach (int fragIdx in topErrorIndices)
             {
@@ -1272,22 +1251,10 @@ namespace pwiz.OspreySharp.Tasks
                 double lower = frag.Mz - tolDa;
                 double upper = frag.Mz + tolDa;
 
-                int lo = ScoringMath.BinarySearchLowerBound(apexSpectrum.Mzs, lower);
-                if (lo < apexSpectrum.Mzs.Length && apexSpectrum.Mzs[lo] <= upper)
-                {
-                    double bestMz = apexSpectrum.Mzs[lo];
-                    double bestDiff = Math.Abs(bestMz - frag.Mz);
-                    for (int k = lo + 1; k < apexSpectrum.Mzs.Length && apexSpectrum.Mzs[k] <= upper; k++)
-                    {
-                        double diff = Math.Abs(apexSpectrum.Mzs[k] - frag.Mz);
-                        if (diff < bestDiff)
-                        {
-                            bestDiff = diff;
-                            bestMz = apexSpectrum.Mzs[k];
-                        }
-                    }
-                    ms2Errors.Add(config.FragmentTolerance.MassError(frag.Mz, bestMz));
-                }
+                int best = TopFragmentExtractor.FindClosestPeakInWindow(
+                    apexSpectrum.Mzs, frag.Mz, lower, upper);
+                if (best >= 0)
+                    ms2Errors.Add(config.FragmentTolerance.MassError(frag.Mz, apexSpectrum.Mzs[best]));
             }
             return ms2Errors;
         }

--- a/pwiz_tools/OspreySharp/OspreySharp/Tasks/PerFileRescoreTask.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/Tasks/PerFileRescoreTask.cs
@@ -776,7 +776,7 @@ namespace pwiz.OspreySharp.Tasks
                 // hotspot). Dumped the cal's library_rts + fitted_values once
                 // per file. Mirrors Rust's dump_predict_rt_arrays at
                 // pipeline.rs ~2886. To restore, re-enable this and the
-                // WritePredictRtCall in AbstractScoringTask. See
+                // WritePredictRtCall in CoelutionScorer. See
                 // ai/todos/active/TODO-20260606_ospreysharp_diagnostics_di.md.
                 // if (rtCal != null)
                 // {


### PR DESCRIPTION
## Summary

Continues the OspreySharp 3rd-OOP-review cleanup toward a 4th review -- three behavior-neutral structural commits.

* **Diagnostics-seam nits**: `--d` -> `-d` doc fix; widened `IScoringDiagnostics.WriteCwtPathRow` to `IReadOnlyList<XicData>` (matches the sibling `WriteSearchXicDump`, `OspreyFileDiagnostics` bridges via the is-List zero-copy path); fixed a stale restore-breadcrumb (now `CoelutionScorer`).
* **Consolidated a triplicated pattern**: the "top-N fragments by RelativeIntensity + closest-peak-by-m/z" logic (open-coded in `ExtractTopNFragmentXics`, `ExtractFragmentXics`, `CountTop6Matches`, and `Calibrator.CollectMs2FragmentErrors`) is now two shared helpers in `TopFragmentExtractor`: `SelectTopFragmentIndices` and `FindClosestPeakInWindow` (returns the peak index so callers read intensity or m/z). Net -67 lines.
* **Relocated `s_calXcorrScorer`**: the unit-resolution calibration `SpectralScorer` moved off the `AbstractScoringTask` god-class onto its sole consumer `Calibrator` (`AbstractScoringTask` never used it). Single consumer -> kept on `Calibrator` rather than introducing a one-field holder class.

### Behavior notes (from self-review)

* `FindClosestPeakInWindow` returns -1 on null/empty m/z arrays. In `Calibrator.CollectMs2FragmentErrors` this replaces an implicit assumption that `apexSpectrum.Mzs` is non-null (skip vs would-be NRE). The apex spectrum is the apex of a detected co-eluting peak and always has peaks, so the -1 path is dead in practice -- goldens stay byte-identical. Strictly safer.
* The stable `OrderByDescending` tie-break on RelativeIntensity is preserved verbatim from the original code. It uses `float.CompareTo`, which differs from Rust's `total_cmp` only for NaN / signed-zero -- neither occurs for non-negative intensities. Not a regression; called out for future readers.

## Test plan

- [x] Pre-commit (per commit): build + 382 unit tests pass + zero-warning ReSharper inspection
- [x] Correctness: `regression.ps1 -Dataset Stellar` golden + resume self-consistency PASS @ 1e-9 (blib byte-identical) after items #2 and #3
- [x] Perf: `Test-PerfGate.ps1 -Dataset Stellar` vs `pwiz-perfbase` -- no real total-wall regression
- [x] Fresh-context self-review -- clean (2 LOW doc-only findings, captured above)

See ai/todos/active/TODO-20260613_ospreysharp_oop_cleanup_continued.md

Co-Authored-By: Claude <noreply@anthropic.com>
