### PR TITLE
Closed the two FirstJoin/FDR coupling escapes from the spine

### DIFF
--- a/pwiz_tools/OspreySharp/OspreySharp.FDR/PercolatorFdr.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.FDR/PercolatorFdr.cs
@@ -276,7 +276,14 @@ namespace pwiz.OspreySharp.FDR
             //     that treated multi-file repeats of the same precursor as
             //     independent samples. Rust was patched to match this dedup
             //     (osprey-fdr/src/percolator.rs::run_percolator direct path).
-            int[] bestPerPrecursor = SelectBestPerPrecursor(labels, entryIds, entries);
+            // 3b. ...then, if still > MaxTrainSize, subsample by peptide groups
+            //     (so target/decoy pairs and same-peptide multi-charge stay
+            //     together). Both selection steps live in BuildTrainingSubset so
+            //     this direct path and the streaming path cannot drift.
+            int[] bestPerPrecursor;
+            int[] trainSubset = BuildTrainingSubset(
+                labels, entryIds, peptides, entries, config.MaxTrainSize, config.Seed,
+                out bestPerPrecursor);
 
             int dedupTargets = 0, dedupDecoys = 0;
             for (int i = 0; i < bestPerPrecursor.Length; i++)
@@ -287,31 +294,6 @@ namespace pwiz.OspreySharp.FDR
             }
             Console.Error.WriteLine("[COUNT]   Percolator best-per-precursor: {0} entries ({1} targets, {2} decoys) from {3} total",
                 bestPerPrecursor.Length, dedupTargets, dedupDecoys, n);
-
-            // 3b. If still > MaxTrainSize, subsample by peptide groups
-            //     (so target/decoy pairs and same-peptide multi-charge stay together).
-            int[] trainSubset = bestPerPrecursor;
-            if (config.MaxTrainSize > 0 && bestPerPrecursor.Length > config.MaxTrainSize)
-            {
-                var dedupLabels = new bool[bestPerPrecursor.Length];
-                var dedupEntryIds = new uint[bestPerPrecursor.Length];
-                var dedupPeptides = new string[bestPerPrecursor.Length];
-                for (int i = 0; i < bestPerPrecursor.Length; i++)
-                {
-                    int gi = bestPerPrecursor[i];
-                    dedupLabels[i] = labels[gi];
-                    dedupEntryIds[i] = entryIds[gi];
-                    dedupPeptides[i] = peptides[gi];
-                }
-
-                int[] localSelected = SubsampleByPeptideGroup(
-                    dedupLabels, dedupEntryIds, dedupPeptides,
-                    config.MaxTrainSize, config.Seed);
-
-                trainSubset = new int[localSelected.Length];
-                for (int i = 0; i < localSelected.Length; i++)
-                    trainSubset[i] = bestPerPrecursor[localSelected[i]];
-            }
 
             int subN = trainSubset.Length;
             int subTargets = 0, subDecoys = 0;
@@ -1993,6 +1975,48 @@ namespace pwiz.OspreySharp.FDR
         // ============================================================
         // Subsampling
         // ============================================================
+
+        /// <summary>
+        /// Build the SVM training subset for one Percolator pass: best-per-precursor
+        /// dedup, then -- only when the deduped count still exceeds
+        /// <paramref name="maxTrainSize"/> -- a peptide-grouped subsample. Returns
+        /// indices into the original <paramref name="entries"/> list;
+        /// <paramref name="bestPerPrecursor"/> returns the post-dedup indices so the
+        /// caller can emit its own path-specific [COUNT] dedup line. Owned here so
+        /// the direct (<see cref="RunPercolator"/>) and streaming
+        /// (FirstJoin.RunPercolatorStreaming) paths select identical subsets for
+        /// identical input instead of hand-mirroring the dedup + index map-back.
+        /// </summary>
+        public static int[] BuildTrainingSubset(
+            bool[] labels, uint[] entryIds, string[] peptides,
+            IList<PercolatorEntry> entries, int maxTrainSize, ulong seed,
+            out int[] bestPerPrecursor)
+        {
+            bestPerPrecursor = SelectBestPerPrecursor(labels, entryIds, entries);
+            if (maxTrainSize <= 0 || bestPerPrecursor.Length <= maxTrainSize)
+                return bestPerPrecursor;
+
+            // Project the deduped rows into local arrays, subsample by peptide
+            // group, then map the local selection back to entries indices.
+            int m = bestPerPrecursor.Length;
+            var dedupLabels = new bool[m];
+            var dedupEntryIds = new uint[m];
+            var dedupPeptides = new string[m];
+            for (int i = 0; i < m; i++)
+            {
+                int gi = bestPerPrecursor[i];
+                dedupLabels[i] = labels[gi];
+                dedupEntryIds[i] = entryIds[gi];
+                dedupPeptides[i] = peptides[gi];
+            }
+
+            int[] localSelected = SubsampleByPeptideGroup(
+                dedupLabels, dedupEntryIds, dedupPeptides, maxTrainSize, seed);
+            var trainSubset = new int[localSelected.Length];
+            for (int i = 0; i < localSelected.Length; i++)
+                trainSubset[i] = bestPerPrecursor[localSelected[i]];
+            return trainSubset;
+        }
 
         /// <summary>
         /// Pick the best-scoring observation per (base_id, isDecoy) tuple across all

--- a/pwiz_tools/OspreySharp/OspreySharp.FDR/PercolatorFdr.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.FDR/PercolatorFdr.cs
@@ -1984,7 +1984,7 @@ namespace pwiz.OspreySharp.FDR
         /// <paramref name="bestPerPrecursor"/> returns the post-dedup indices so the
         /// caller can emit its own path-specific [COUNT] dedup line. Owned here so
         /// the direct (<see cref="RunPercolator"/>) and streaming
-        /// (FirstJoin.RunPercolatorStreaming) paths select identical subsets for
+        /// (FirstJoinTask.RunPercolatorStreaming) paths select identical subsets for
         /// identical input instead of hand-mirroring the dedup + index map-back.
         /// </summary>
         public static int[] BuildTrainingSubset(

--- a/pwiz_tools/OspreySharp/OspreySharp/Tasks/FirstJoinTask.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/Tasks/FirstJoinTask.cs
@@ -1581,8 +1581,14 @@ namespace pwiz.OspreySharp.Tasks
                 peptides[i] = percEntries[i].Peptide;
             }
 
-            // 1. Best-per-precursor dedup.
-            int[] bestIdx = PercolatorFdr.SelectBestPerPrecursor(labels, entryIds, percEntries);
+            // 1. Best-per-precursor dedup, then 2. peptide-grouped subsample when
+            //    the dedup count still exceeds MaxTrainSize. Both steps are owned
+            //    by PercolatorFdr.BuildTrainingSubset so this streaming path and
+            //    the direct path select identical subsets for identical input.
+            int[] bestIdx;
+            int[] trainSubsetGlobalIdx = PercolatorFdr.BuildTrainingSubset(
+                labels, entryIds, peptides, percEntries, maxTrain, percConfig.Seed,
+                out bestIdx);
             int dedupTargets = 0, dedupDecoys = 0;
             for (int i = 0; i < bestIdx.Length; i++)
             {
@@ -1592,31 +1598,6 @@ namespace pwiz.OspreySharp.Tasks
             ctx.LogInfo(string.Format(
                 "[COUNT] {0} Percolator streaming best-per-precursor: {1} entries ({2} targets, {3} decoys) from {4} total",
                 passLabel, bestIdx.Length, dedupTargets, dedupDecoys, n));
-
-            // 2. Peptide-grouped subsample if dedup count still exceeds MaxTrainSize.
-            int[] trainSubsetGlobalIdx;
-            if (maxTrain > 0 && bestIdx.Length > maxTrain)
-            {
-                var dedupLabels = new bool[bestIdx.Length];
-                var dedupEntryIds = new uint[bestIdx.Length];
-                var dedupPeptides = new string[bestIdx.Length];
-                for (int i = 0; i < bestIdx.Length; i++)
-                {
-                    int gi = bestIdx[i];
-                    dedupLabels[i] = labels[gi];
-                    dedupEntryIds[i] = entryIds[gi];
-                    dedupPeptides[i] = peptides[gi];
-                }
-                int[] localSelected = PercolatorFdr.SubsampleByPeptideGroup(
-                    dedupLabels, dedupEntryIds, dedupPeptides, maxTrain, percConfig.Seed);
-                trainSubsetGlobalIdx = new int[localSelected.Length];
-                for (int i = 0; i < localSelected.Length; i++)
-                    trainSubsetGlobalIdx[i] = bestIdx[localSelected[i]];
-            }
-            else
-            {
-                trainSubsetGlobalIdx = bestIdx;
-            }
 
             int subTargets = 0, subDecoys = 0;
             for (int i = 0; i < trainSubsetGlobalIdx.Length; i++)

--- a/pwiz_tools/OspreySharp/OspreySharp/Tasks/FirstJoinTask.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/Tasks/FirstJoinTask.cs
@@ -60,9 +60,9 @@ namespace pwiz.OspreySharp.Tasks
     /// Outputs (PerFileConsensusTargets, ReconciliationActions,
     /// RefinedCalibrations, PerFileGapFillForRescore) are exposed as
     /// instance properties for the next task (PerFileRescoreTask) to
-    /// consume after this one completes successfully. <c>DidPlan</c>
-    /// is the gate for that next task — it flips to <c>true</c> only
-    /// when the Stage 6 planning block actually ran.
+    /// consume after this one completes successfully. The
+    /// <c>PlanningPerformed</c> byproduct is the gate for that next task —
+    /// it is <c>true</c> only when the Stage 6 planning block actually ran.
     /// </summary>
     internal sealed class FirstJoinTask : AbstractScoringTask
     {
@@ -102,16 +102,17 @@ namespace pwiz.OspreySharp.Tasks
         {
             typeof(PerFileConsensusTargets), typeof(ReconciliationActions),
             typeof(RefinedCalibrations), typeof(PerFileGapFillForRescore),
-            typeof(CompactedEntries)
+            typeof(CompactedEntries), typeof(PlanningPerformed)
         };
 
         // Stage 6 planning state. Set by PlanStage6 (Run) and published into the
         // typed byproduct slots that downstream consumers pull via ctx.Get<T>();
         // the bundle-adopt Rehydrate path publishes the same slots from the
-        // worker bundle instead. DidPlan remains the gate PerFileRescore's
-        // self-gate checks to tell "planning ran" from "planning was skipped."
-        // Defaults are non-null empty collections so a published slot from a
-        // no-op / stopped-after-Stage-5 run is never null.
+        // worker bundle instead. _didPlan feeds the published PlanningPerformed
+        // slot -- the gate PerFileRescore's self-gate reads to tell "planning
+        // ran" from "planning was skipped." Defaults are non-null empty
+        // collections so a published slot from a no-op / stopped-after-Stage-5
+        // run is never null.
         private bool _didPlan;
         private IReadOnlyDictionary<string, IReadOnlyList<(int Index, double Apex, double Start, double End)>> _perFileConsensusTargets
             = new Dictionary<string, IReadOnlyList<(int, double, double, double)>>();
@@ -121,8 +122,6 @@ namespace pwiz.OspreySharp.Tasks
             = new Dictionary<string, RTCalibration>();
         private IReadOnlyDictionary<string, List<GapFillTarget>> _perFileGapFillForRescore
             = new Dictionary<string, List<GapFillTarget>>();
-
-        public bool DidPlan(PipelineContext ctx) { return _didPlan; }
 
         // Bundle.PerFileConsensusTargets is null at hydration time (consensus
         // is meaningful only post-compaction); compute on demand from the
@@ -297,6 +296,10 @@ namespace pwiz.OspreySharp.Tasks
             ctx.Publish(new RefinedCalibrations(_refinedCalibrations));
             ctx.Publish(new PerFileGapFillForRescore(_perFileGapFillForRescore));
             ctx.Publish(new CompactedEntries(perFileEntries));
+            // PlanStage6 (above) sets _didPlan only when the planning block ran;
+            // publish it so PerFileRescore reads the gate from the registry
+            // instead of reaching for this concrete task.
+            ctx.Publish(new PlanningPerformed(_didPlan));
             return true;
         }
 
@@ -352,6 +355,11 @@ namespace pwiz.OspreySharp.Tasks
             ctx.Publish(new PerFileGapFillForRescore(bundle.PerFileGapFill));
             ctx.Publish(new PerFileConsensusTargets(ConsensusTargetsFromBundle(ctx, bundle)));
             ctx.Publish(new CompactedEntries(perFileEntries));
+            // The bundle-adopt / resume path never plans, so the rescore gate is
+            // false (PerFileRescore falls back to the no-op unless a worker
+            // RescoreBundle is present). Mirrors the old "FirstJoin rehydrates ->
+            // DidPlan is false" semantics, now as a published slot.
+            ctx.Publish(new PlanningPerformed(false));
             return true;
         }
 

--- a/pwiz_tools/OspreySharp/OspreySharp/Tasks/PerFileRescoreTask.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/Tasks/PerFileRescoreTask.cs
@@ -215,8 +215,11 @@ namespace pwiz.OspreySharp.Tasks
             // ExpectReconciledInput keeps the hard short-circuit above for
             // the strict --task MergeNode merge path. Downstream MergeNodeTask
             // reads the RescoredEntries milestone of this same backing list.
-            var firstJoin = ctx.Demand<FirstJoinTask>();
-            bool didPlan = firstJoin.DidPlan(ctx);
+            // Read the planning gate from the typed byproduct registry rather
+            // than reaching for the concrete FirstJoinTask. ctx.Get materializes
+            // FirstJoin's producer if it has not run yet (the Get<CompactedEntries>
+            // above already forced it), so the slot is populated here.
+            bool didPlan = ctx.Get<PlanningPerformed>().Value;
             var rescoreBundle = ctx.Get<RescoreBundle>().Value;
             bool anyPass2Present = false;
             if (ctx.Config.InputFiles != null)

--- a/pwiz_tools/OspreySharp/OspreySharp/Tasks/PerFileRescoreTask.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/Tasks/PerFileRescoreTask.cs
@@ -216,9 +216,11 @@ namespace pwiz.OspreySharp.Tasks
             // the strict --task MergeNode merge path. Downstream MergeNodeTask
             // reads the RescoredEntries milestone of this same backing list.
             // Read the planning gate from the typed byproduct registry rather
-            // than reaching for the concrete FirstJoinTask. ctx.Get materializes
-            // FirstJoin's producer if it has not run yet (the Get<CompactedEntries>
-            // above already forced it), so the slot is populated here.
+            // than reaching for the concrete FirstJoinTask. ctx.Get lazily
+            // materializes the slot's producer (FirstJoinTask) if it has not run
+            // yet, so the value is always populated; FirstJoin publishes
+            // PlanningPerformed alongside CompactedEntries (already read above)
+            // from every materialization path.
             bool didPlan = ctx.Get<PlanningPerformed>().Value;
             var rescoreBundle = ctx.Get<RescoreBundle>().Value;
             bool anyPass2Present = false;

--- a/pwiz_tools/OspreySharp/OspreySharp/Tasks/PipelineByproducts.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/Tasks/PipelineByproducts.cs
@@ -97,6 +97,22 @@ namespace pwiz.OspreySharp.Tasks
         }
     }
 
+    /// <summary>
+    /// Whether FirstJoin's Stage 6 planning block actually ran (<c>true</c>) vs
+    /// was skipped (single-file / reconciliation off) or rehydrated from disk
+    /// (<c>false</c>). This is the gate PerFileRescore's self-gate checks to tell
+    /// "planning ran" from "planning was skipped." Routing it through the typed
+    /// byproduct registry replaces PerFileRescore's former concrete-type reach
+    /// (<c>ctx.Demand&lt;FirstJoinTask&gt;().DidPlan(ctx)</c>) -- the last
+    /// compile-time edge to a sibling task in the otherwise uniform
+    /// <c>ctx.Get&lt;T&gt;()</c> spine.
+    /// </summary>
+    internal sealed class PlanningPerformed
+    {
+        public bool Value { get; }
+        public PlanningPerformed(bool value) { Value = value; }
+    }
+
     /// <summary>Stage 6 reconciliation actions keyed by (file, post-compaction index).</summary>
     internal sealed class ReconciliationActions
     {


### PR DESCRIPTION
## Summary

Closes the last named coupling finding from the 3rd OspreySharp OOP review (rec #2) -- the two escapes from the otherwise-uniform `ctx.Get<T>()` task spine. Orthogonal to #4299 (different files; only a non-overlapping region of `PerFileRescoreTask.cs` is shared).

* **Planning gate via the registry**: added a `PlanningPerformed` typed byproduct that FirstJoin publishes (the real `_didPlan` from `Run`; `false` from the bundle-adopt / resume `Rehydrate`). `PerFileRescore` now reads `ctx.Get<PlanningPerformed>().Value` instead of `ctx.Demand<FirstJoinTask>().DidPlan(ctx)`, removing the last compile-time edge to a sibling task; the dead `DidPlan` method is gone.
* **Single training-subset entry point**: added `PercolatorFdr.BuildTrainingSubset` (best-per-precursor dedup + conditional peptide-grouped subsample + index map-back) so the policy is owned once instead of hand-mirrored across the FDR/EXE boundary. Rewired the direct `RunPercolator` path and FirstJoin's streaming `RunPercolatorStreaming` path onto it; each path's distinct `[COUNT]` log lines are preserved via the `out bestPerPrecursor` parameter.

### Notes (from self-review)

* `BuildTrainingSubset` is `public` with no null/empty guards -- consistent with its sibling public statics (`SelectBestPerPrecursor`, `SubsampleByPeptideGroup`) and the prior open-coded blocks, which also assumed populated arrays.
* Follow-up (deferred): a targeted `ByproductContextTest`-style case for the `didPlan == true` branch read purely through `ctx.Get<PlanningPerformed>()` would guard the co-production ordering against a future reorder. The `-Dataset All` regression covers the behavior end-to-end today.

## Test plan

- [x] Pre-commit (per commit): build + 382 unit tests pass + zero-warning ReSharper inspection
- [x] Correctness: `regression.ps1 -Dataset All` golden + resume PASS @ 1e-9 on Stellar (direct selection path) AND Astral (streaming selection path), all four blibs byte-identical
- [x] Perf: `Test-PerfGate.ps1 -Dataset Stellar` vs `pwiz-perfbase` -- +0.5% total (no regression); stage5 -0.2%
- [x] Fresh-context self-review -- clean (2 LOW; one comment tightened, one acceptable)

See ai/todos/active/TODO-20260613_ospreysharp_oop_cleanup_continued.md

Co-Authored-By: Claude <noreply@anthropic.com>
