### PR TITLE
Injected OspreySharp diagnostics through PipelineContext, retiring the static facade

### DIFF
--- a/pwiz_tools/OspreySharp/OspreySharp.Diagnostics/IOspreyDiagnostics.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Diagnostics/IOspreyDiagnostics.cs
@@ -1,0 +1,215 @@
+/*
+ * Original author: Brendan MacLean <brendanx .at. uw.edu>,
+ *                  MacCoss Lab, Department of Genome Sciences, UW
+ * AI assistance: Claude Code (Claude Opus 4.8) <noreply .at. anthropic.com>
+ *
+ * Copyright 2026 University of Washington - Seattle, WA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System.Collections.Generic;
+using pwiz.OspreySharp.Chromatography;
+using pwiz.OspreySharp.Core;
+using pwiz.OspreySharp.FDR;
+using pwiz.OspreySharp.FDR.Reconciliation;
+using pwiz.OspreySharp.Scoring;
+
+namespace pwiz.OspreySharp
+{
+    /// <summary>
+    /// The cross-implementation bisection diagnostics seam for the whole
+    /// pipeline -- the full counterpart of the scoring-only
+    /// <see cref="IScoringDiagnostics"/>. Pipeline tasks read the OSPREY_DUMP_* /
+    /// OSPREY_DIAG_* gate flags and emit their byte-stable dumps through this
+    /// instance (carried on the pipeline context) rather than reaching the
+    /// exe-only <c>OspreyDiagnostics</c> static facade, so the task layer can
+    /// live in a library that does not reference the top-level exe project
+    /// (4th OOP review: "diagnostics-bleed is the keystone constraint").
+    ///
+    /// The exe's file-backed sink (<c>OspreyFileDiagnostics</c>) implements this.
+    /// When diagnostics are off the injected reference is <c>null</c> and call
+    /// sites invoke it through the null-conditional operator
+    /// (<c>diag?.ShouldDump() ?? false</c>, <c>diag?.Write(...)</c>), exactly like
+    /// <see cref="IScoringDiagnostics"/>: a single null check, no virtual
+    /// dispatch, and arguments short-circuited -- byte-identical to, and as fast
+    /// as, diagnostics-off today.
+    ///
+    /// Dump format must stay byte-for-byte stable; the contract for each method
+    /// lives on the concrete sink implementation.
+    /// </summary>
+    public interface IOspreyDiagnostics
+    {
+        // ----- Env-var gate flags -----
+
+        bool DumpCalSample { get; }
+        bool CalSampleOnly { get; }
+        bool DumpCalWindows { get; }
+        bool CalWindowsOnly { get; }
+        bool DumpCalMatch { get; }
+        bool CalMatchOnly { get; }
+        bool DumpMs2CalErrors { get; }
+        bool Ms2CalErrorsOnly { get; }
+        bool DumpLdaScores { get; }
+        bool LdaScoresOnly { get; }
+        bool DumpLoessInput { get; }
+        bool LoessInputOnly { get; }
+        bool DumpPercolator { get; }
+        bool PercolatorOnly { get; }
+        bool DumpRescored { get; }
+        bool RescoredOnly { get; }
+        bool DumpMpInputs { get; }
+        bool DumpPredictRt { get; }
+        bool DumpCwtPath { get; }
+        bool DumpConsensus { get; }
+        bool ConsensusOnly { get; }
+        bool DumpMulticharge { get; }
+        bool MultichargeOnly { get; }
+        bool DumpRefit { get; }
+        bool RefitOnly { get; }
+        bool DumpReconciliation { get; }
+        bool ReconciliationOnly { get; }
+        bool DumpCalibration { get; }
+        bool CalibrationOnly { get; }
+        bool DumpInvPredict { get; }
+        bool InvPredictOnly { get; }
+        bool DumpProteinFdr { get; }
+        bool ProteinFdrOnly { get; }
+        bool DumpStage7ProteinFdr { get; }
+        bool Stage7ProteinFdrOnly { get; }
+        bool DumpDetectedPeptides { get; }
+        bool DumpLoessFit { get; }
+        bool LoessFitOnly { get; }
+        bool CalWindowsCollecting { get; }
+
+        uint? DiagXicEntryId { get; }
+        int DiagXicPass { get; }
+        HashSet<uint> DiagSearchEntryIds { get; }
+        int? DiagMpScan { get; }
+
+        // ----- Stages 1-4: calibration + per-candidate search dumps -----
+
+        void WriteCalSampleDump(string fileName, IEnumerable<LibraryEntry> sampledEntries);
+
+        void WriteCalScalarsAndGridDump(
+            IReadOnlyList<LibraryEntry> targets,
+            IReadOnlyList<LibraryEntry> decoys,
+            int binsPerAxis,
+            double rtMin, double rtMax, double mzMin, double mzMax,
+            double rtRange, double mzRange, double rtBinWidth, double mzBinWidth,
+            int nOccupied, int perCell, ulong seed,
+            List<int>[,] grid);
+
+        void StartCalWindowCollection();
+
+        void AddCalWindowRow(LibraryEntry entry, IsolationWindow iso,
+            double expectedRt, double rtLo, double rtHi);
+
+        void WriteCalWindowsDump(int passNumber);
+
+        void WriteCalMatchDump(int passNumber,
+            IEnumerable<CalibrationMatch> matches,
+            IEnumerable<LibraryEntry> sampledEntries,
+            IDictionary<uint, KeyValuePair<double, double>> matchRts,
+            IDictionary<uint, double> snrByEntryId);
+
+        void WriteMs2CalErrorsDump(IEnumerable<CalibrationMatch> contributingMatches);
+
+        void WriteLdaScoresDump(int passNumber, IEnumerable<CalibrationMatch> matchArray);
+
+        void WriteLoessInputDump(int passNumber, double[] libRts, double[] measuredRts);
+
+        void WriteCalibrationSummary(
+            RTCalibration rtCal,
+            MzCalibrationResult ms1Cal,
+            MzCalibrationResult ms2Cal);
+
+        bool ShouldDumpCalXicFor(uint entryId, int currentPass);
+
+        void WriteCalXicEntryDumpAndExit(LibraryEntry entry, int currentPass,
+            RTCalibration calibrationModel, double expectedRt, double initialTolerance,
+            double rtSlope, double rtIntercept,
+            IReadOnlyList<Spectrum> candidateSpectra,
+            IReadOnlyList<XicData> xics);
+
+        bool ShouldDumpSearchXicFor(uint entryId);
+
+        void WriteSearchXicDump(LibraryEntry candidate,
+            double expectedRt, double rtTolerance,
+            int startScan, int endScan, int rangeLen,
+            IReadOnlyList<Spectrum> windowSpectra,
+            IReadOnlyList<XicData> xics);
+
+        bool ShouldDumpMpFor(uint apexScanNumber, string candidateModifiedSequence);
+
+        void WriteMpDump(LibraryEntry candidate, uint apexScanNumber,
+            XICPeakBounds bestPeak, int peakLen,
+            double mpCosine, double mpResidualRatio, double mpMinFragmentR2, double mpResidualCorr,
+            TukeyMedianPolishResult polish,
+            IReadOnlyList<KeyValuePair<int, double[]>> peakXics);
+
+        void WriteMpInputsRow(uint entryId, uint apexScan,
+            IList<KeyValuePair<int, double[]>> peakXics, double[] peakRts);
+
+        void CloseMpInputsDump();
+
+        void WritePredictRtArrays(string fileName, double[] libraryRts, double[] fittedValues);
+
+        void WritePredictRtCall(uint entryId, double libraryRt, double expectedRt);
+
+        void WriteCwtPathRow(string fileName, uint entryId,
+            int nCwtPeaks, int nFinalPeaks, int nScored, bool scored,
+            IReadOnlyList<XicData> xics);
+
+        void CloseCwtPathDump();
+
+        void ClosePredictRtDump();
+
+        // ----- Stages 5-7: join, rescore, reconciliation, protein FDR dumps -----
+
+        void WriteStage5PercolatorDump(List<KeyValuePair<string, List<FdrEntry>>> perFileEntries);
+
+        void WriteStage6RescoredDump(List<KeyValuePair<string, List<FdrEntry>>> perFileEntries);
+
+        void WriteStage6ConsensusDump(IReadOnlyList<PeptideConsensusRT> consensus);
+
+        void WriteStage6MultichargeDump(
+            IReadOnlyList<KeyValuePair<string, IReadOnlyList<FdrEntry>>> perFileEntries,
+            IReadOnlyDictionary<string, IReadOnlyList<(int Index, double Apex, double Start, double End)>> perFileTargets);
+
+        void WriteStage6RefitDump(
+            IReadOnlyDictionary<string, RTCalibration> refinedCalibrations);
+
+        void WriteStage6ReconciliationDump(
+            IReadOnlyDictionary<(string File, int Index), ReconcileAction> actions,
+            IReadOnlyList<KeyValuePair<string, IReadOnlyList<FdrEntry>>> perFileEntries);
+
+        void WriteStage6CalibrationDump(
+            string fileName, double[] libraryRts, double[] fittedValues);
+
+        void WriteStage6InvPredictDump(IList<InvPredictRecord> records);
+
+        void WriteStage6ProteinFdrDump(
+            IDictionary<string, PeptideScore> bestScores,
+            IDictionary<string, double> peptideQvalues);
+
+        void WriteStage7ProteinFdrDump(
+            ProteinParsimonyResult parsimony,
+            ProteinFdrResult fdrResult);
+
+        void WriteStage6LoessFitDump(
+            IReadOnlyDictionary<string, RTCalibration> refinedCalibrations);
+
+        void WriteStage7DetectedPeptidesDump(HashSet<string> detectedPeptides);
+    }
+}

--- a/pwiz_tools/OspreySharp/OspreySharp.Diagnostics/IOspreyDiagnostics.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Diagnostics/IOspreyDiagnostics.cs
@@ -93,6 +93,9 @@ namespace pwiz.OspreySharp
         bool CalWindowsCollecting { get; }
 
         uint? DiagXicEntryId { get; }
+        // Defaults to 1 (not 0) when unset; the default lives in the sink's
+        // parser (OspreyFileDiagnostics), so a consumer reading this through a
+        // null ctx.Diagnostics must use "?? 1" to preserve historical behavior.
         int DiagXicPass { get; }
         HashSet<uint> DiagSearchEntryIds { get; }
         int? DiagMpScan { get; }

--- a/pwiz_tools/OspreySharp/OspreySharp.Diagnostics/OspreyDiagnosticsLog.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Diagnostics/OspreyDiagnosticsLog.cs
@@ -1,0 +1,66 @@
+/*
+ * Original author: Brendan MacLean <brendanx .at. uw.edu>,
+ *                  MacCoss Lab, Department of Genome Sciences, UW
+ * AI assistance: Claude Code (Claude Opus 4.8) <noreply .at. anthropic.com>
+ *
+ * Copyright 2026 University of Washington - Seattle, WA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
+using System.Globalization;
+
+namespace pwiz.OspreySharp
+{
+    /// <summary>
+    /// Stateless cross-impl bisection diagnostics helpers, shared by the
+    /// pipeline task layer and the file-backed sink. Kept separate from the
+    /// exe-only <c>OspreyDiagnostics</c> bootstrap (which constructs the sink) so
+    /// the task layer can call these without referencing the top-level exe
+    /// project: the logging hook, the round-half-to-even f64 formatter, and the
+    /// "*_ONLY" abort-after-dump exit used by bisection runs.
+    /// </summary>
+    public static class OspreyDiagnosticsLog
+    {
+        /// <summary>
+        /// Delegate for logging. The pipeline hooks this to its LogInfo so dump
+        /// messages flow through the standard logging channel.
+        /// </summary>
+        public static Action<string> LogAction { get; set; } = Console.WriteLine;
+
+        /// <summary>
+        /// Format a double with 10 decimal places using round-half-to-even
+        /// (banker's) to match Rust's {:.10} formatter. .NET Framework's F10
+        /// default is round-half-away-from-zero, which flips the last digit on
+        /// exact .5 values. Pure helper, available regardless of whether
+        /// diagnostics are enabled.
+        /// </summary>
+        public static string F10(double v)
+        {
+            return Math.Round(v, 10, MidpointRounding.ToEven)
+                .ToString(@"F10", CultureInfo.InvariantCulture);
+        }
+
+        /// <summary>
+        /// Log the "aborting after dump" message for the given env var and call
+        /// Environment.Exit(0). Used after *_ONLY dumps where the bisection diff
+        /// is the only output we care about.
+        /// </summary>
+        public static void ExitAfterDump(string varName)
+        {
+            LogAction(string.Format(@"[BISECT] {0} set - aborting after dump", varName));
+            Environment.Exit(0);
+        }
+    }
+}

--- a/pwiz_tools/OspreySharp/OspreySharp.Diagnostics/OspreySharp.Diagnostics.csproj
+++ b/pwiz_tools/OspreySharp/OspreySharp.Diagnostics/OspreySharp.Diagnostics.csproj
@@ -1,0 +1,29 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <!-- Types live in the pwiz.OspreySharp namespace (not a .Diagnostics child)
+         on purpose: a child namespace named Diagnostics would shadow the
+         pwiz.OspreySharp.Core.Diagnostics float-format helper (referenced by
+         its bare name across the tree). Assembly name stays OspreySharp.Diagnostics. -->
+    <RootNamespace>pwiz.OspreySharp</RootNamespace>
+    <AssemblyName>OspreySharp.Diagnostics</AssemblyName>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="OspreySharp.Test" />
+  </ItemGroup>
+
+  <!-- The cross-impl dump surface (IOspreyDiagnostics) names domain types from
+       these layers: Chromatography (IsolationWindow, XicData, RTCalibration,
+       XICPeakBounds), Core (LibraryEntry, Spectrum), Scoring
+       (TukeyMedianPolishResult), and FDR (FdrEntry, ProteinParsimonyResult,
+       ReconcileAction, PeptideScore, ...). This is the union of references the
+       former exe-only OspreyFileDiagnostics sink needed. -->
+  <ItemGroup>
+    <ProjectReference Include="..\OspreySharp.Core\OspreySharp.Core.csproj" />
+    <ProjectReference Include="..\OspreySharp.Chromatography\OspreySharp.Chromatography.csproj" />
+    <ProjectReference Include="..\OspreySharp.Scoring\OspreySharp.Scoring.csproj" />
+    <ProjectReference Include="..\OspreySharp.FDR\OspreySharp.FDR.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/pwiz_tools/OspreySharp/OspreySharp.Tasks/OspreySharp.Tasks.csproj
+++ b/pwiz_tools/OspreySharp/OspreySharp.Tasks/OspreySharp.Tasks.csproj
@@ -10,8 +10,14 @@
     <InternalsVisibleTo Include="OspreySharp.Test" />
   </ItemGroup>
 
+  <!-- Diagnostics carries IOspreyDiagnostics, which PipelineContext exposes so
+       tasks emit dumps through the context instead of the exe-only static
+       facade. This pulls the Diagnostics seam (and, transitively, its
+       Chromatography/Scoring/FDR refs) into the formerly Core-only Tasks DLL,
+       a deliberate cost of hanging diagnostics off the pipeline context. -->
   <ItemGroup>
     <ProjectReference Include="..\OspreySharp.Core\OspreySharp.Core.csproj" />
+    <ProjectReference Include="..\OspreySharp.Diagnostics\OspreySharp.Diagnostics.csproj" />
   </ItemGroup>
 
 </Project>

--- a/pwiz_tools/OspreySharp/OspreySharp.Tasks/PipelineContext.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Tasks/PipelineContext.cs
@@ -142,13 +142,31 @@ namespace pwiz.OspreySharp.Tasks
         /// </summary>
         public IReadOnlyList<OspreyTask> Tasks { get; }
 
+        /// <summary>
+        /// The cross-implementation bisection diagnostics sink for this run, or
+        /// <c>null</c> when diagnostics are off (no <c>-d</c> / no OSPREY_DUMP_*
+        /// env var) -- the common case. Tasks read the gate flags and emit their
+        /// byte-stable dumps through the null-conditional operator (e.g.
+        /// <c>ctx.Diagnostics?.DumpPercolator ?? false</c>,
+        /// <c>ctx.Diagnostics?.WriteStage5PercolatorDump(...)</c>) instead of the
+        /// exe-only <c>OspreyDiagnostics</c> static facade, so the task layer does
+        /// not depend on the top-level exe project. Null-by-default is deliberate:
+        /// the <c>?.</c> short-circuit is a single null check -- no virtual call,
+        /// arguments not evaluated -- matching the existing <c>IScoringDiagnostics</c>
+        /// idiom. The driver injects the live sink at construction (see
+        /// <c>OspreyDiagnostics.Active</c>).
+        /// </summary>
+        public IOspreyDiagnostics Diagnostics { get; }
+
         public PipelineContext(OspreyConfig config,
             IEnumerable<OspreyTask> tasks,
             Action<string> logInfo,
             Action<string> logWarning,
-            Action<string> logError)
+            Action<string> logError,
+            IOspreyDiagnostics diagnostics = null)
         {
             Config = config ?? throw new ArgumentNullException(nameof(config));
+            Diagnostics = diagnostics;
             if (tasks == null) throw new ArgumentNullException(nameof(tasks));
             _logInfo = logInfo ?? (_ => { });
             _logWarning = logWarning ?? (_ => { });

--- a/pwiz_tools/OspreySharp/OspreySharp.sln
+++ b/pwiz_tools/OspreySharp/OspreySharp.sln
@@ -1,4 +1,4 @@
-﻿
+
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.0.31903.59

--- a/pwiz_tools/OspreySharp/OspreySharp.sln
+++ b/pwiz_tools/OspreySharp/OspreySharp.sln
@@ -1,4 +1,4 @@
-
+﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.0.31903.59
@@ -20,6 +20,8 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OspreySharp.Test", "OspreySharp.Test\OspreySharp.Test.csproj", "{EF7990A9-10A0-4E5A-BB4D-F0E6952F0684}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OspreySharp.Tasks", "OspreySharp.Tasks\OspreySharp.Tasks.csproj", "{4EEDA624-B5D0-4A43-9EDF-E1B24756FC49}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OspreySharp.Diagnostics", "OspreySharp.Diagnostics\OspreySharp.Diagnostics.csproj", "{5CB164A4-2B04-4FAE-B744-765AD5872D56}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -139,6 +141,18 @@ Global
 		{4EEDA624-B5D0-4A43-9EDF-E1B24756FC49}.Release|Any CPU.Build.0 = Release|Any CPU
 		{4EEDA624-B5D0-4A43-9EDF-E1B24756FC49}.Release|x86.ActiveCfg = Release|Any CPU
 		{4EEDA624-B5D0-4A43-9EDF-E1B24756FC49}.Release|x86.Build.0 = Release|Any CPU
+		{5CB164A4-2B04-4FAE-B744-765AD5872D56}.Debug|x64.ActiveCfg = Debug|x64
+		{5CB164A4-2B04-4FAE-B744-765AD5872D56}.Debug|x64.Build.0 = Debug|x64
+		{5CB164A4-2B04-4FAE-B744-765AD5872D56}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5CB164A4-2B04-4FAE-B744-765AD5872D56}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5CB164A4-2B04-4FAE-B744-765AD5872D56}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{5CB164A4-2B04-4FAE-B744-765AD5872D56}.Debug|x86.Build.0 = Debug|Any CPU
+		{5CB164A4-2B04-4FAE-B744-765AD5872D56}.Release|x64.ActiveCfg = Release|x64
+		{5CB164A4-2B04-4FAE-B744-765AD5872D56}.Release|x64.Build.0 = Release|x64
+		{5CB164A4-2B04-4FAE-B744-765AD5872D56}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5CB164A4-2B04-4FAE-B744-765AD5872D56}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5CB164A4-2B04-4FAE-B744-765AD5872D56}.Release|x86.ActiveCfg = Release|Any CPU
+		{5CB164A4-2B04-4FAE-B744-765AD5872D56}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/pwiz_tools/OspreySharp/OspreySharp/AnalysisPipeline.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/AnalysisPipeline.cs
@@ -84,7 +84,7 @@ namespace pwiz.OspreySharp
 
                 var pipelineTasks = CanonicalPipeline();
                 var ctx = new PipelineContext(config, pipelineTasks,
-                    LogInfo, LogWarning, LogError);
+                    LogInfo, LogWarning, LogError, OspreyDiagnostics.Active);
 
                 // Phase B5 driver-owned dataflow: walk the canonical pipeline
                 // and run each INCLUDED task whose outputs are not already

--- a/pwiz_tools/OspreySharp/OspreySharp/OspreyDiagnostics.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/OspreyDiagnostics.cs
@@ -19,77 +19,27 @@
  */
 
 using System;
-using System.Collections.Generic;
-using System.Globalization;
-using pwiz.OspreySharp.Chromatography;
-using pwiz.OspreySharp.Core;
-using pwiz.OspreySharp.FDR;
-using pwiz.OspreySharp.FDR.Reconciliation;
-using pwiz.OspreySharp.Scoring;
 
 namespace pwiz.OspreySharp
 {
     /// <summary>
-    /// Call-site facade for the cross-implementation bisection diagnostics.
-    /// All production code reaches the dumps through this static surface
-    /// (<c>OspreyDiagnostics.WriteX(...)</c>, <c>OspreyDiagnostics.DumpX</c>),
-    /// which delegates to a single swappable <see cref="OspreyFileDiagnostics"/>
-    /// sink. The sink is created only when diagnostics are enabled (a
+    /// Bootstrap for the cross-implementation bisection diagnostics sink. The
+    /// driver calls <see cref="Initialize"/> once at pipeline entry to select the
+    /// live <see cref="OspreyFileDiagnostics"/> sink (created only when a
     /// OSPREY_DUMP_* / OSPREY_DIAG_* env var is set, or <c>-d</c> was passed);
-    /// otherwise <see cref="s_sink"/> is <c>null</c> and every call here is a
-    /// no-op, so a production run carries no diagnostic state or writers. This
-    /// is the "no-op default, replaced by dependency injection" posture: the
-    /// driver calls <see cref="Initialize"/> once at pipeline entry to select
-    /// the live sink.
+    /// otherwise <see cref="s_sink"/> is <c>null</c> and <see cref="Active"/> is
+    /// <c>null</c>, so a production run carries no diagnostic state.
     ///
-    /// Pure helpers that are not part of the dump surface stay here: the
-    /// <see cref="F10"/> formatter, the <see cref="LogAction"/> logging hook,
-    /// and <see cref="ExitAfterDump"/>.
+    /// Tasks no longer reach a static dump surface here: they emit dumps through
+    /// the injected <c>ctx.Diagnostics?.X</c> (an <see cref="IOspreyDiagnostics"/>,
+    /// supplied by <see cref="Active"/>). The stateless logging / formatting /
+    /// abort helpers moved to <see cref="OspreyDiagnosticsLog"/> so the task
+    /// layer never references this exe-only bootstrap.
     /// </summary>
     public static class OspreyDiagnostics
     {
         // The live sink, or null when diagnostics are off (the no-op default).
         private static OspreyFileDiagnostics s_sink;
-        private static bool s_initialized;
-
-        // Contract: Initialize() runs once, single-threaded, at pipeline entry
-        // (Program.Main) before any diagnostics call. We deliberately do NOT
-        // lazily self-init here -- a lazy init first touched from the parallel
-        // scoring loop would be a data race. Accessing the sink before
-        // Initialize is a programming error (an entry point that forgot to call
-        // it), so it is surfaced loudly rather than racily self-initialized.
-        // Env-only bisection workflows still work: Initialize self-enables the
-        // sink from the OSPREY_DUMP_* / OSPREY_DIAG_* env vars.
-        private static OspreyFileDiagnostics Sink
-        {
-            get
-            {
-                if (!s_initialized)
-                    throw new InvalidOperationException(
-                        @"OspreyDiagnostics.Initialize must be called once at pipeline entry before any diagnostics call.");
-                return s_sink;
-            }
-        }
-
-        /// <summary>
-        /// The active scoring-diagnostics sink as an <see cref="IScoringDiagnostics"/>,
-        /// or null when diagnostics are off. The coelution scorer takes this so it can
-        /// emit its per-candidate dumps without referencing this exe-only facade; a null
-        /// reference means "no diagnostics" and is invoked via the null-conditional operator.
-        /// </summary>
-        public static IScoringDiagnostics ScoringDiagnostics => Sink;
-
-        /// <summary>
-        /// The active diagnostics sink as the full <see cref="IOspreyDiagnostics"/>,
-        /// or <c>null</c> when diagnostics are off. The pipeline driver injects
-        /// this into <c>PipelineContext</c> so tasks emit dumps through the context
-        /// (via the <c>?.</c> null-conditional operator) rather than this exe-only
-        /// static facade. It returns the same single sink the static members below
-        /// delegate to, so the injected path and the (transitional) static path
-        /// share one stateful sink instance. Unlike <see cref="Sink"/> it does not
-        /// require <see cref="Initialize"/> first: before init it is simply null.
-        /// </summary>
-        public static IOspreyDiagnostics Active => s_sink;
 
         /// <summary>
         /// OSPREY_DUMP_* env vars turned on by the <c>-d</c> master switch.
@@ -122,13 +72,14 @@ namespace pwiz.OspreySharp
         };
 
         /// <summary>
-        /// Select the live diagnostics sink. Call once at pipeline entry.
-        /// When <paramref name="forceDumps"/> is <c>true</c> (the <c>-d</c>
-        /// flag) the structured-dump env vars are turned on in-process first,
-        /// so the sink picks them up the same way an external env var would.
-        /// Otherwise the sink is created only if a diagnostic env var is already
-        /// set, preserving existing env-var-driven bisection workflows. When
-        /// nothing is enabled the sink stays <c>null</c> and the facade no-ops.
+        /// Select the live diagnostics sink. Call once at pipeline entry, before
+        /// constructing the <c>PipelineContext</c> that <see cref="Active"/> is
+        /// injected into. When <paramref name="forceDumps"/> is <c>true</c> (the
+        /// <c>-d</c> flag) the structured-dump env vars are turned on in-process
+        /// first, so the sink picks them up the same way an external env var
+        /// would. Otherwise the sink is created only if a diagnostic env var is
+        /// already set, preserving existing env-var-driven bisection workflows.
+        /// When nothing is enabled the sink stays <c>null</c>.
         /// </summary>
         public static void Initialize(bool forceDumps)
         {
@@ -143,308 +94,15 @@ namespace pwiz.OspreySharp
             }
             var sink = new OspreyFileDiagnostics();
             s_sink = sink.AnyEnabled ? sink : null;
-            s_initialized = true;   // publish s_sink before marking initialized
         }
 
         /// <summary>
-        /// Delegate for logging. The pipeline hooks this to its LogInfo so dump
-        /// messages flow through the standard logging channel.
+        /// The active diagnostics sink as the full <see cref="IOspreyDiagnostics"/>,
+        /// or <c>null</c> when diagnostics are off. The driver injects this into
+        /// <c>PipelineContext</c> so tasks emit dumps through the context (via the
+        /// <c>?.</c> null-conditional operator). Returns <c>null</c> before
+        /// <see cref="Initialize"/> has run.
         /// </summary>
-        public static Action<string> LogAction { get; set; } = Console.WriteLine;
-
-        /// <summary>
-        /// Format a double with 10 decimal places using round-half-to-even
-        /// (banker's) to match Rust's {:.10} formatter. .NET Framework's F10
-        /// default is round-half-away-from-zero, which flips the last digit on
-        /// exact .5 values. Pure helper, available regardless of whether
-        /// diagnostics are enabled.
-        /// </summary>
-        public static string F10(double v)
-        {
-            return Math.Round(v, 10, MidpointRounding.ToEven)
-                .ToString(@"F10", CultureInfo.InvariantCulture);
-        }
-
-        /// <summary>
-        /// Log the "aborting after dump" message for the given env var and call
-        /// Environment.Exit(0). Used after *_ONLY dumps where the bisection diff
-        /// is the only output we care about.
-        /// </summary>
-        public static void ExitAfterDump(string varName)
-        {
-            LogAction(string.Format(@"[BISECT] {0} set - aborting after dump", varName));
-            Environment.Exit(0);
-        }
-
-        // ----- Env-var gate flags (delegated to the live sink; false/default when off) -----
-
-        public static bool DumpCalSample => Sink?.DumpCalSample ?? false;
-        public static bool CalSampleOnly => Sink?.CalSampleOnly ?? false;
-        public static bool DumpCalWindows => Sink?.DumpCalWindows ?? false;
-        public static bool CalWindowsOnly => Sink?.CalWindowsOnly ?? false;
-        public static bool DumpCalMatch => Sink?.DumpCalMatch ?? false;
-        public static bool CalMatchOnly => Sink?.CalMatchOnly ?? false;
-        public static bool DumpMs2CalErrors => Sink?.DumpMs2CalErrors ?? false;
-        public static bool Ms2CalErrorsOnly => Sink?.Ms2CalErrorsOnly ?? false;
-        public static bool DumpLdaScores => Sink?.DumpLdaScores ?? false;
-        public static bool LdaScoresOnly => Sink?.LdaScoresOnly ?? false;
-        public static bool DumpLoessInput => Sink?.DumpLoessInput ?? false;
-        public static bool LoessInputOnly => Sink?.LoessInputOnly ?? false;
-        public static bool DumpPercolator => Sink?.DumpPercolator ?? false;
-        public static bool PercolatorOnly => Sink?.PercolatorOnly ?? false;
-        public static bool DumpRescored => Sink?.DumpRescored ?? false;
-        public static bool RescoredOnly => Sink?.RescoredOnly ?? false;
-        public static bool DumpMpInputs => Sink?.DumpMpInputs ?? false;
-        public static bool DumpPredictRt => Sink?.DumpPredictRt ?? false;
-        public static bool DumpCwtPath => Sink?.DumpCwtPath ?? false;
-        public static bool DumpConsensus => Sink?.DumpConsensus ?? false;
-        public static bool ConsensusOnly => Sink?.ConsensusOnly ?? false;
-        public static bool DumpMulticharge => Sink?.DumpMulticharge ?? false;
-        public static bool MultichargeOnly => Sink?.MultichargeOnly ?? false;
-        public static bool DumpRefit => Sink?.DumpRefit ?? false;
-        public static bool RefitOnly => Sink?.RefitOnly ?? false;
-        public static bool DumpReconciliation => Sink?.DumpReconciliation ?? false;
-        public static bool ReconciliationOnly => Sink?.ReconciliationOnly ?? false;
-        public static bool DumpCalibration => Sink?.DumpCalibration ?? false;
-        public static bool CalibrationOnly => Sink?.CalibrationOnly ?? false;
-        public static bool DumpInvPredict => Sink?.DumpInvPredict ?? false;
-        public static bool InvPredictOnly => Sink?.InvPredictOnly ?? false;
-        public static bool DumpProteinFdr => Sink?.DumpProteinFdr ?? false;
-        public static bool ProteinFdrOnly => Sink?.ProteinFdrOnly ?? false;
-        public static bool DumpStage7ProteinFdr => Sink?.DumpStage7ProteinFdr ?? false;
-        public static bool Stage7ProteinFdrOnly => Sink?.Stage7ProteinFdrOnly ?? false;
-        public static bool DumpDetectedPeptides => Sink?.DumpDetectedPeptides ?? false;
-        public static bool DumpLoessFit => Sink?.DumpLoessFit ?? false;
-        public static bool LoessFitOnly => Sink?.LoessFitOnly ?? false;
-
-        public static uint? DiagXicEntryId => Sink?.DiagXicEntryId;
-        public static int DiagXicPass => Sink?.DiagXicPass ?? 1;
-        public static HashSet<uint> DiagSearchEntryIds => Sink?.DiagSearchEntryIds;
-        public static int? DiagMpScan => Sink?.DiagMpScan;
-
-        public static bool CalWindowsCollecting => Sink?.CalWindowsCollecting ?? false;
-
-        // ----- Dump methods (no-op when no sink) -----
-
-        public static void WriteCalSampleDump(string fileName, IEnumerable<LibraryEntry> sampledEntries)
-        {
-            Sink?.WriteCalSampleDump(fileName, sampledEntries);
-        }
-
-        public static void WriteCalScalarsAndGridDump(
-            IReadOnlyList<LibraryEntry> targets,
-            IReadOnlyList<LibraryEntry> decoys,
-            int binsPerAxis,
-            double rtMin, double rtMax, double mzMin, double mzMax,
-            double rtRange, double mzRange, double rtBinWidth, double mzBinWidth,
-            int nOccupied, int perCell, ulong seed,
-            List<int>[,] grid)
-        {
-            Sink?.WriteCalScalarsAndGridDump(targets, decoys, binsPerAxis,
-                rtMin, rtMax, mzMin, mzMax, rtRange, mzRange, rtBinWidth, mzBinWidth,
-                nOccupied, perCell, seed, grid);
-        }
-
-        public static void StartCalWindowCollection()
-        {
-            Sink?.StartCalWindowCollection();
-        }
-
-        public static void AddCalWindowRow(LibraryEntry entry, IsolationWindow iso,
-            double expectedRt, double rtLo, double rtHi)
-        {
-            Sink?.AddCalWindowRow(entry, iso, expectedRt, rtLo, rtHi);
-        }
-
-        public static void WriteCalWindowsDump(int passNumber)
-        {
-            Sink?.WriteCalWindowsDump(passNumber);
-        }
-
-        public static void WriteCalMatchDump(int passNumber,
-            IEnumerable<CalibrationMatch> matches,
-            IEnumerable<LibraryEntry> sampledEntries,
-            IDictionary<uint, KeyValuePair<double, double>> matchRts,
-            IDictionary<uint, double> snrByEntryId)
-        {
-            Sink?.WriteCalMatchDump(passNumber, matches, sampledEntries, matchRts, snrByEntryId);
-        }
-
-        public static void WriteMs2CalErrorsDump(IEnumerable<CalibrationMatch> contributingMatches)
-        {
-            Sink?.WriteMs2CalErrorsDump(contributingMatches);
-        }
-
-        public static void WriteLdaScoresDump(int passNumber, IEnumerable<CalibrationMatch> matchArray)
-        {
-            Sink?.WriteLdaScoresDump(passNumber, matchArray);
-        }
-
-        public static void WriteLoessInputDump(int passNumber, double[] libRts, double[] measuredRts)
-        {
-            Sink?.WriteLoessInputDump(passNumber, libRts, measuredRts);
-        }
-
-        public static void WriteCalibrationSummary(
-            RTCalibration rtCal,
-            MzCalibrationResult ms1Cal,
-            MzCalibrationResult ms2Cal)
-        {
-            Sink?.WriteCalibrationSummary(rtCal, ms1Cal, ms2Cal);
-        }
-
-        public static bool ShouldDumpCalXicFor(uint entryId, int currentPass)
-        {
-            return Sink?.ShouldDumpCalXicFor(entryId, currentPass) ?? false;
-        }
-
-        public static void WriteCalXicEntryDumpAndExit(LibraryEntry entry, int currentPass,
-            RTCalibration calibrationModel, double expectedRt, double initialTolerance,
-            double rtSlope, double rtIntercept,
-            IReadOnlyList<Spectrum> candidateSpectra,
-            IReadOnlyList<XicData> xics)
-        {
-            Sink?.WriteCalXicEntryDumpAndExit(entry, currentPass, calibrationModel,
-                expectedRt, initialTolerance, rtSlope, rtIntercept, candidateSpectra, xics);
-        }
-
-        public static bool ShouldDumpSearchXicFor(uint entryId)
-        {
-            return Sink?.ShouldDumpSearchXicFor(entryId) ?? false;
-        }
-
-        public static void WriteSearchXicDump(LibraryEntry candidate,
-            double expectedRt, double rtTolerance,
-            int startScan, int endScan, int rangeLen,
-            IReadOnlyList<Spectrum> windowSpectra,
-            IReadOnlyList<XicData> xics)
-        {
-            Sink?.WriteSearchXicDump(candidate, expectedRt, rtTolerance,
-                startScan, endScan, rangeLen, windowSpectra, xics);
-        }
-
-        public static bool ShouldDumpMpFor(uint apexScanNumber, string candidateModifiedSequence)
-        {
-            return Sink?.ShouldDumpMpFor(apexScanNumber, candidateModifiedSequence) ?? false;
-        }
-
-        public static void WriteMpDump(LibraryEntry candidate, uint apexScanNumber,
-            XICPeakBounds bestPeak, int peakLen,
-            double mpCosine, double mpResidualRatio, double mpMinFragmentR2, double mpResidualCorr,
-            TukeyMedianPolishResult polish,
-            IReadOnlyList<KeyValuePair<int, double[]>> peakXics)
-        {
-            Sink?.WriteMpDump(candidate, apexScanNumber, bestPeak, peakLen,
-                mpCosine, mpResidualRatio, mpMinFragmentR2, mpResidualCorr, polish, peakXics);
-        }
-
-        public static void WriteMpInputsRow(uint entryId, uint apexScan,
-            IList<KeyValuePair<int, double[]>> peakXics, double[] peakRts)
-        {
-            Sink?.WriteMpInputsRow(entryId, apexScan, peakXics, peakRts);
-        }
-
-        public static void CloseMpInputsDump()
-        {
-            Sink?.CloseMpInputsDump();
-        }
-
-        public static void WritePredictRtArrays(string fileName, double[] libraryRts, double[] fittedValues)
-        {
-            Sink?.WritePredictRtArrays(fileName, libraryRts, fittedValues);
-        }
-
-        public static void WritePredictRtCall(uint entryId, double libraryRt, double expectedRt)
-        {
-            Sink?.WritePredictRtCall(entryId, libraryRt, expectedRt);
-        }
-
-        public static void WriteCwtPathRow(string fileName, uint entryId,
-            int nCwtPeaks, int nFinalPeaks, int nScored, bool scored,
-            List<XicData> xics)
-        {
-            Sink?.WriteCwtPathRow(fileName, entryId, nCwtPeaks, nFinalPeaks, nScored, scored, xics);
-        }
-
-        public static void CloseCwtPathDump()
-        {
-            Sink?.CloseCwtPathDump();
-        }
-
-        public static void ClosePredictRtDump()
-        {
-            Sink?.ClosePredictRtDump();
-        }
-
-        public static void WriteStage5PercolatorDump(List<KeyValuePair<string, List<FdrEntry>>> perFileEntries)
-        {
-            Sink?.WriteStage5PercolatorDump(perFileEntries);
-        }
-
-        public static void WriteStage6RescoredDump(List<KeyValuePair<string, List<FdrEntry>>> perFileEntries)
-        {
-            Sink?.WriteStage6RescoredDump(perFileEntries);
-        }
-
-        public static void WriteStage6ConsensusDump(IReadOnlyList<PeptideConsensusRT> consensus)
-        {
-            Sink?.WriteStage6ConsensusDump(consensus);
-        }
-
-        public static void WriteStage6MultichargeDump(
-            IReadOnlyList<KeyValuePair<string, IReadOnlyList<FdrEntry>>> perFileEntries,
-            IReadOnlyDictionary<string, IReadOnlyList<(int Index, double Apex, double Start, double End)>> perFileTargets)
-        {
-            Sink?.WriteStage6MultichargeDump(perFileEntries, perFileTargets);
-        }
-
-        public static void WriteStage6RefitDump(
-            IReadOnlyDictionary<string, RTCalibration> refinedCalibrations)
-        {
-            Sink?.WriteStage6RefitDump(refinedCalibrations);
-        }
-
-        public static void WriteStage6ReconciliationDump(
-            IReadOnlyDictionary<(string File, int Index), ReconcileAction> actions,
-            IReadOnlyList<KeyValuePair<string, IReadOnlyList<FdrEntry>>> perFileEntries)
-        {
-            Sink?.WriteStage6ReconciliationDump(actions, perFileEntries);
-        }
-
-        public static void WriteStage6CalibrationDump(
-            string fileName, double[] libraryRts, double[] fittedValues)
-        {
-            Sink?.WriteStage6CalibrationDump(fileName, libraryRts, fittedValues);
-        }
-
-        public static void WriteStage6InvPredictDump(IList<InvPredictRecord> records)
-        {
-            Sink?.WriteStage6InvPredictDump(records);
-        }
-
-        public static void WriteStage6ProteinFdrDump(
-            IDictionary<string, PeptideScore> bestScores,
-            IDictionary<string, double> peptideQvalues)
-        {
-            Sink?.WriteStage6ProteinFdrDump(bestScores, peptideQvalues);
-        }
-
-        public static void WriteStage7ProteinFdrDump(
-            ProteinParsimonyResult parsimony,
-            ProteinFdrResult fdrResult)
-        {
-            Sink?.WriteStage7ProteinFdrDump(parsimony, fdrResult);
-        }
-
-        public static void WriteStage6LoessFitDump(
-            IReadOnlyDictionary<string, RTCalibration> refinedCalibrations)
-        {
-            Sink?.WriteStage6LoessFitDump(refinedCalibrations);
-        }
-
-        public static void WriteStage7DetectedPeptidesDump(HashSet<string> detectedPeptides)
-        {
-            Sink?.WriteStage7DetectedPeptidesDump(detectedPeptides);
-        }
+        public static IOspreyDiagnostics Active => s_sink;
     }
 }

--- a/pwiz_tools/OspreySharp/OspreySharp/OspreyDiagnostics.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/OspreyDiagnostics.cs
@@ -80,6 +80,18 @@ namespace pwiz.OspreySharp
         public static IScoringDiagnostics ScoringDiagnostics => Sink;
 
         /// <summary>
+        /// The active diagnostics sink as the full <see cref="IOspreyDiagnostics"/>,
+        /// or <c>null</c> when diagnostics are off. The pipeline driver injects
+        /// this into <c>PipelineContext</c> so tasks emit dumps through the context
+        /// (via the <c>?.</c> null-conditional operator) rather than this exe-only
+        /// static facade. It returns the same single sink the static members below
+        /// delegate to, so the injected path and the (transitional) static path
+        /// share one stateful sink instance. Unlike <see cref="Sink"/> it does not
+        /// require <see cref="Initialize"/> first: before init it is simply null.
+        /// </summary>
+        public static IOspreyDiagnostics Active => s_sink;
+
+        /// <summary>
         /// OSPREY_DUMP_* env vars turned on by the <c>-d</c> master switch.
         /// Excludes the per-call firehose (OSPREY_DUMP_MP_INPUTS), the disabled
         /// predict-rt dump, the *_ONLY early-exit gates, and the OSPREY_DIAG_*

--- a/pwiz_tools/OspreySharp/OspreySharp/OspreyFileDiagnostics.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/OspreyFileDiagnostics.cs
@@ -65,7 +65,7 @@ namespace pwiz.OspreySharp
     /// production carries no diagnostic state. Internal: callers go through the
     /// <see cref="OspreyDiagnostics"/> facade, never this type directly.
     /// </summary>
-    internal sealed class OspreyFileDiagnostics : IScoringDiagnostics
+    internal sealed class OspreyFileDiagnostics : IScoringDiagnostics, IOspreyDiagnostics
     {
         /// <summary>
         /// Newline used by every Stage 6 cross-impl bisection dump writer.
@@ -88,28 +88,28 @@ namespace pwiz.OspreySharp
         /// (cs_cal_sample.txt) AND the calibration scalars+grid
         /// (cs_cal_scalars.txt / cs_cal_grid.txt).
         /// </summary>
-        public readonly bool DumpCalSample = IsOne(@"OSPREY_DUMP_CAL_SAMPLE");
+        public bool DumpCalSample { get; } = IsOne(@"OSPREY_DUMP_CAL_SAMPLE");
 
         /// <summary>OSPREY_CAL_SAMPLE_ONLY: exit after cs_cal_sample.txt dump.</summary>
-        public readonly bool CalSampleOnly = IsOne(@"OSPREY_CAL_SAMPLE_ONLY");
+        public bool CalSampleOnly { get; } = IsOne(@"OSPREY_CAL_SAMPLE_ONLY");
 
         /// <summary>
         /// OSPREY_DUMP_CAL_WINDOWS: dump per-entry calibration window
         /// selection (cs_cal_windows.txt).
         /// </summary>
-        public readonly bool DumpCalWindows = IsOne(@"OSPREY_DUMP_CAL_WINDOWS");
+        public bool DumpCalWindows { get; } = IsOne(@"OSPREY_DUMP_CAL_WINDOWS");
 
         /// <summary>OSPREY_CAL_WINDOWS_ONLY: exit after cs_cal_windows.txt dump.</summary>
-        public readonly bool CalWindowsOnly = IsOne(@"OSPREY_CAL_WINDOWS_ONLY");
+        public bool CalWindowsOnly { get; } = IsOne(@"OSPREY_CAL_WINDOWS_ONLY");
 
         /// <summary>
         /// OSPREY_DUMP_CAL_MATCH: dump per-entry calibration match info
         /// (cs_cal_match.txt).
         /// </summary>
-        public readonly bool DumpCalMatch = IsOne(@"OSPREY_DUMP_CAL_MATCH");
+        public bool DumpCalMatch { get; } = IsOne(@"OSPREY_DUMP_CAL_MATCH");
 
         /// <summary>OSPREY_CAL_MATCH_ONLY: exit after cs_cal_match.txt dump.</summary>
-        public readonly bool CalMatchOnly = IsOne(@"OSPREY_CAL_MATCH_ONLY");
+        public bool CalMatchOnly { get; } = IsOne(@"OSPREY_CAL_MATCH_ONLY");
 
         /// <summary>
         /// OSPREY_DUMP_MS2_CAL_ERRORS: dump the per-fragment MS2 mass errors
@@ -118,28 +118,28 @@ namespace pwiz.OspreySharp
         /// mean divergence cross-impl by checking whether the input
         /// fragment errors are identical in value AND order across impls.
         /// </summary>
-        public readonly bool DumpMs2CalErrors = IsOne(@"OSPREY_DUMP_MS2_CAL_ERRORS");
+        public bool DumpMs2CalErrors { get; } = IsOne(@"OSPREY_DUMP_MS2_CAL_ERRORS");
 
         /// <summary>OSPREY_MS2_CAL_ERRORS_ONLY: exit after cs_ms2_cal_errors.txt dump.</summary>
-        public readonly bool Ms2CalErrorsOnly = IsOne(@"OSPREY_MS2_CAL_ERRORS_ONLY");
+        public bool Ms2CalErrorsOnly { get; } = IsOne(@"OSPREY_MS2_CAL_ERRORS_ONLY");
 
         /// <summary>
         /// OSPREY_DUMP_LDA_SCORES: dump per-entry LDA discriminant + q-value
         /// after LDA scoring (cs_lda_scores.txt).
         /// </summary>
-        public readonly bool DumpLdaScores = IsOne(@"OSPREY_DUMP_LDA_SCORES");
+        public bool DumpLdaScores { get; } = IsOne(@"OSPREY_DUMP_LDA_SCORES");
 
         /// <summary>OSPREY_LDA_SCORES_ONLY: exit after cs_lda_scores.txt dump.</summary>
-        public readonly bool LdaScoresOnly = IsOne(@"OSPREY_LDA_SCORES_ONLY");
+        public bool LdaScoresOnly { get; } = IsOne(@"OSPREY_LDA_SCORES_ONLY");
 
         /// <summary>
         /// OSPREY_DUMP_LOESS_INPUT: dump the (lib_rt, measured_rt) pairs
         /// fed to LOESS (cs_loess_input.txt).
         /// </summary>
-        public readonly bool DumpLoessInput = IsOne(@"OSPREY_DUMP_LOESS_INPUT");
+        public bool DumpLoessInput { get; } = IsOne(@"OSPREY_DUMP_LOESS_INPUT");
 
         /// <summary>OSPREY_LOESS_INPUT_ONLY: exit after cs_loess_input.txt dump.</summary>
-        public readonly bool LoessInputOnly = IsOne(@"OSPREY_LOESS_INPUT_ONLY");
+        public bool LoessInputOnly { get; } = IsOne(@"OSPREY_LOESS_INPUT_ONLY");
 
         /// <summary>
         /// OSPREY_DUMP_PERCOLATOR: dump per-precursor Stage 5 state
@@ -147,10 +147,10 @@ namespace pwiz.OspreySharp
         /// completes and before first-pass protein FDR / compaction.
         /// Cross-impl parity gate (cs_stage5_percolator.tsv).
         /// </summary>
-        public readonly bool DumpPercolator = IsOne(@"OSPREY_DUMP_PERCOLATOR");
+        public bool DumpPercolator { get; } = IsOne(@"OSPREY_DUMP_PERCOLATOR");
 
         /// <summary>OSPREY_PERCOLATOR_ONLY: exit after cs_stage5_percolator.tsv dump.</summary>
-        public readonly bool PercolatorOnly = IsOne(@"OSPREY_PERCOLATOR_ONLY");
+        public bool PercolatorOnly { get; } = IsOne(@"OSPREY_PERCOLATOR_ONLY");
 
         /// <summary>
         /// OSPREY_DUMP_RESCORED: dump per-precursor state AFTER the
@@ -161,10 +161,10 @@ namespace pwiz.OspreySharp
         /// cs_stage6_rescored.tsv. Mirrors Rust's
         /// dump_stage6_rescored / OSPREY_DUMP_RESCORED gate.
         /// </summary>
-        public readonly bool DumpRescored = IsOne(@"OSPREY_DUMP_RESCORED");
+        public bool DumpRescored { get; } = IsOne(@"OSPREY_DUMP_RESCORED");
 
         /// <summary>OSPREY_RESCORED_ONLY: exit after cs_stage6_rescored.tsv dump.</summary>
-        public readonly bool RescoredOnly = IsOne(@"OSPREY_RESCORED_ONLY");
+        public bool RescoredOnly { get; } = IsOne(@"OSPREY_RESCORED_ONLY");
 
         /// <summary>
         /// OSPREY_DUMP_MP_INPUTS: bisection-grade diagnostic that dumps
@@ -180,7 +180,7 @@ namespace pwiz.OspreySharp
         /// upstream (XIC extraction / peak picking) or downstream
         /// (median polish / peak shape feature compute).
         /// </summary>
-        public readonly bool DumpMpInputs = IsOne(@"OSPREY_DUMP_MP_INPUTS");
+        public bool DumpMpInputs { get; } = IsOne(@"OSPREY_DUMP_MP_INPUTS");
 
         /// <summary>
         /// OSPREY_DUMP_PREDICT_RT: bisection-grade diagnostic that
@@ -197,7 +197,7 @@ namespace pwiz.OspreySharp
         /// hidden RTCalibration state is leaking; if both match, the
         /// divergence is downstream of RT calibration.
         /// </summary>
-        public readonly bool DumpPredictRt = IsOne(@"OSPREY_DUMP_PREDICT_RT");
+        public bool DumpPredictRt { get; } = IsOne(@"OSPREY_DUMP_PREDICT_RT");
 
         /// <summary>
         /// OSPREY_DUMP_CWT_PATH: per-(file, entry) dump of CWT path
@@ -209,36 +209,36 @@ namespace pwiz.OspreySharp
         /// and at which seam: CWT detection, fallback path, or
         /// apex-acceptance filter. Output: cs_stage6_cwt_path.tsv.
         /// </summary>
-        public readonly bool DumpCwtPath = IsOne(@"OSPREY_DUMP_CWT_PATH");
+        public bool DumpCwtPath { get; } = IsOne(@"OSPREY_DUMP_CWT_PATH");
 
         /// <summary>
         /// OSPREY_DUMP_CONSENSUS: dump the per-peptide consensus RT planning
         /// state at the start of Stage 6 (cs_stage6_consensus.tsv) for
         /// cross-impl parity at the planning checkpoint.
         /// </summary>
-        public readonly bool DumpConsensus = IsOne(@"OSPREY_DUMP_CONSENSUS");
+        public bool DumpConsensus { get; } = IsOne(@"OSPREY_DUMP_CONSENSUS");
 
         /// <summary>OSPREY_CONSENSUS_ONLY: exit after cs_stage6_consensus.tsv dump.</summary>
-        public readonly bool ConsensusOnly = IsOne(@"OSPREY_CONSENSUS_ONLY");
+        public bool ConsensusOnly { get; } = IsOne(@"OSPREY_CONSENSUS_ONLY");
 
         /// <summary>
         /// OSPREY_DUMP_MULTICHARGE: dump the per-file multi-charge consensus
         /// rescore targets (cs_stage6_multicharge.tsv) for cross-impl parity.
         /// </summary>
-        public readonly bool DumpMulticharge = IsOne(@"OSPREY_DUMP_MULTICHARGE");
+        public bool DumpMulticharge { get; } = IsOne(@"OSPREY_DUMP_MULTICHARGE");
 
         /// <summary>OSPREY_MULTICHARGE_ONLY: exit after cs_stage6_multicharge.tsv dump.</summary>
-        public readonly bool MultichargeOnly = IsOne(@"OSPREY_MULTICHARGE_ONLY");
+        public bool MultichargeOnly { get; } = IsOne(@"OSPREY_MULTICHARGE_ONLY");
 
         /// <summary>
         /// OSPREY_DUMP_REFIT: dump per-file refined-calibration statistics
         /// produced by CalibrationRefit (cs_stage6_refit.tsv) for cross-impl
         /// parity.
         /// </summary>
-        public readonly bool DumpRefit = IsOne(@"OSPREY_DUMP_REFIT");
+        public bool DumpRefit { get; } = IsOne(@"OSPREY_DUMP_REFIT");
 
         /// <summary>OSPREY_REFIT_ONLY: exit after cs_stage6_refit.tsv dump.</summary>
-        public readonly bool RefitOnly = IsOne(@"OSPREY_REFIT_ONLY");
+        public bool RefitOnly { get; } = IsOne(@"OSPREY_REFIT_ONLY");
 
         /// <summary>
         /// OSPREY_DUMP_RECONCILIATION: dump the per-(file, entry)
@@ -248,10 +248,10 @@ namespace pwiz.OspreySharp
         /// cross-impl parity at the planning step can be checked
         /// independently of the per-file rescoring that follows.
         /// </summary>
-        public readonly bool DumpReconciliation = IsOne(@"OSPREY_DUMP_RECONCILIATION");
+        public bool DumpReconciliation { get; } = IsOne(@"OSPREY_DUMP_RECONCILIATION");
 
         /// <summary>OSPREY_RECONCILIATION_ONLY: exit after cs_stage6_reconciliation.tsv dump.</summary>
-        public readonly bool ReconciliationOnly = IsOne(@"OSPREY_RECONCILIATION_ONLY");
+        public bool ReconciliationOnly { get; } = IsOne(@"OSPREY_RECONCILIATION_ONLY");
 
         /// <summary>
         /// OSPREY_DUMP_CALIBRATION: dump the loaded calibration JSON
@@ -264,10 +264,10 @@ namespace pwiz.OspreySharp
         /// later dump's _ONLY (e.g. OSPREY_INV_PREDICT_ONLY) to
         /// short-circuit after all files have written their rows.
         /// </summary>
-        public readonly bool DumpCalibration = IsOne(@"OSPREY_DUMP_CALIBRATION");
+        public bool DumpCalibration { get; } = IsOne(@"OSPREY_DUMP_CALIBRATION");
 
         /// <summary>OSPREY_CALIBRATION_ONLY: exit after cs_stage6_calibration.tsv dump.</summary>
-        public readonly bool CalibrationOnly = IsOne(@"OSPREY_CALIBRATION_ONLY");
+        public bool CalibrationOnly { get; } = IsOne(@"OSPREY_CALIBRATION_ONLY");
 
         /// <summary>
         /// OSPREY_DUMP_INV_PREDICT: capture per-detection
@@ -279,10 +279,10 @@ namespace pwiz.OspreySharp
         /// (apex_rt diverges) or inside LOESS InversePredict (only
         /// library_rt diverges).
         /// </summary>
-        public readonly bool DumpInvPredict = IsOne(@"OSPREY_DUMP_INV_PREDICT");
+        public bool DumpInvPredict { get; } = IsOne(@"OSPREY_DUMP_INV_PREDICT");
 
         /// <summary>OSPREY_INV_PREDICT_ONLY: exit after cs_stage6_inv_predict.tsv dump.</summary>
-        public readonly bool InvPredictOnly = IsOne(@"OSPREY_INV_PREDICT_ONLY");
+        public bool InvPredictOnly { get; } = IsOne(@"OSPREY_INV_PREDICT_ONLY");
 
         /// <summary>
         /// OSPREY_DUMP_PROTEIN_FDR: dump the per-peptide first-pass protein
@@ -294,10 +294,10 @@ namespace pwiz.OspreySharp
         /// (best_qvalue), the ranking input (score), or the algorithm output
         /// (protein_qvalue) is responsible.
         /// </summary>
-        public readonly bool DumpProteinFdr = IsOne(@"OSPREY_DUMP_PROTEIN_FDR");
+        public bool DumpProteinFdr { get; } = IsOne(@"OSPREY_DUMP_PROTEIN_FDR");
 
         /// <summary>OSPREY_PROTEIN_FDR_ONLY: exit after cs_stage6_protein_fdr.tsv dump.</summary>
-        public readonly bool ProteinFdrOnly = IsOne(@"OSPREY_PROTEIN_FDR_ONLY");
+        public bool ProteinFdrOnly { get; } = IsOne(@"OSPREY_PROTEIN_FDR_ONLY");
 
         /// <summary>
         /// OSPREY_DUMP_STAGE7_PROTEIN_FDR: dump per-protein-group state at the
@@ -309,10 +309,10 @@ namespace pwiz.OspreySharp
         /// (is_target_winner DESC, group_qvalue ASC, accessions ASC) keeps the
         /// target-winner rows that drive FDR calibration at the top.
         /// </summary>
-        public readonly bool DumpStage7ProteinFdr = IsOne(@"OSPREY_DUMP_STAGE7_PROTEIN_FDR");
+        public bool DumpStage7ProteinFdr { get; } = IsOne(@"OSPREY_DUMP_STAGE7_PROTEIN_FDR");
 
         /// <summary>OSPREY_STAGE7_PROTEIN_FDR_ONLY: exit after cs_stage7_protein_fdr.tsv dump.</summary>
-        public readonly bool Stage7ProteinFdrOnly = IsOne(@"OSPREY_STAGE7_PROTEIN_FDR_ONLY");
+        public bool Stage7ProteinFdrOnly { get; } = IsOne(@"OSPREY_STAGE7_PROTEIN_FDR_ONLY");
 
         /// <summary>
         /// OSPREY_DUMP_DETECTED_PEPTIDES: dump the sorted set of detected
@@ -321,7 +321,7 @@ namespace pwiz.OspreySharp
         /// dump_stage7_detected_peptides; lets the protein-FDR input set
         /// be diffed cross-impl before debugging downstream divergence.
         /// </summary>
-        public readonly bool DumpDetectedPeptides = IsOne(@"OSPREY_DUMP_DETECTED_PEPTIDES");
+        public bool DumpDetectedPeptides { get; } = IsOne(@"OSPREY_DUMP_DETECTED_PEPTIDES");
 
         /// <summary>
         /// OSPREY_DUMP_LOESS_FIT: dump the per-point LOESS fit state of the
@@ -331,37 +331,37 @@ namespace pwiz.OspreySharp
         /// stats computation (R²/SD/MAD). If fitted_value diverges, the
         /// LOESS smoother arithmetic itself differs.
         /// </summary>
-        public readonly bool DumpLoessFit = IsOne(@"OSPREY_DUMP_LOESS_FIT");
+        public bool DumpLoessFit { get; } = IsOne(@"OSPREY_DUMP_LOESS_FIT");
 
         /// <summary>OSPREY_LOESS_FIT_ONLY: exit after cs_stage6_loess_fit.tsv dump.</summary>
-        public readonly bool LoessFitOnly = IsOne(@"OSPREY_LOESS_FIT_ONLY");
+        public bool LoessFitOnly { get; } = IsOne(@"OSPREY_LOESS_FIT_ONLY");
 
         /// <summary>
         /// OSPREY_DIAG_XIC_ENTRY_ID: the entry ID to dump chromatogram for
         /// during calibration scoring. null = no dump.
         /// </summary>
-        public readonly uint? DiagXicEntryId = ParseNullableUint(@"OSPREY_DIAG_XIC_ENTRY_ID");
+        public uint? DiagXicEntryId { get; } = ParseNullableUint(@"OSPREY_DIAG_XIC_ENTRY_ID");
 
         /// <summary>
         /// OSPREY_DIAG_XIC_PASS: the calibration pass (1 or 2) at which to
         /// dump the XIC. Defaults to 1 because bisection walks downstream:
         /// until pass 1 chromatograms match, comparing pass 2 is premature.
         /// </summary>
-        public readonly int DiagXicPass = ParseIntOrDefault(@"OSPREY_DIAG_XIC_PASS", 1);
+        public int DiagXicPass { get; } = ParseIntOrDefault(@"OSPREY_DIAG_XIC_PASS", 1);
 
         /// <summary>
         /// OSPREY_DIAG_SEARCH_ENTRY_IDS: comma-separated entry IDs whose
         /// main-search XIC extraction should dump a
         /// cs_search_xic_entry_&lt;ID&gt;.txt. Does NOT exit.
         /// </summary>
-        public readonly HashSet<uint> DiagSearchEntryIds = ParseIdSet(@"OSPREY_DIAG_SEARCH_ENTRY_IDS");
+        public HashSet<uint> DiagSearchEntryIds { get; } = ParseIdSet(@"OSPREY_DIAG_SEARCH_ENTRY_IDS");
 
         /// <summary>
         /// OSPREY_DIAG_MP_SCAN: the MS2 scan number whose median polish
         /// should dump cs_mp_diag.txt (filtered additionally to a specific
         /// DECOY_ALQFAQWWK target by historical convention). null = no dump.
         /// </summary>
-        public readonly int? DiagMpScan = ParseNullableInt(@"OSPREY_DIAG_MP_SCAN");
+        public int? DiagMpScan { get; } = ParseNullableInt(@"OSPREY_DIAG_MP_SCAN");
 
         /// <summary>
         /// True if any dump / diagnostic gate is active. The

--- a/pwiz_tools/OspreySharp/OspreySharp/OspreyFileDiagnostics.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/OspreyFileDiagnostics.cs
@@ -439,7 +439,7 @@ namespace pwiz.OspreySharp
         // The pipeline-wired logger lives on the OspreyDiagnostics facade; the
         // sink's own dump methods log through it via this alias so [COUNT] /
         // [BISECT] lines flow through the same channel as before.
-        private static Action<string> LogAction => OspreyDiagnostics.LogAction;
+        private static Action<string> LogAction => OspreyDiagnosticsLog.LogAction;
 
         // ----- Cal sample dump -----
 

--- a/pwiz_tools/OspreySharp/OspreySharp/OspreySharp.csproj
+++ b/pwiz_tools/OspreySharp/OspreySharp/OspreySharp.csproj
@@ -16,6 +16,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\OspreySharp.Core\OspreySharp.Core.csproj" />
+    <ProjectReference Include="..\OspreySharp.Diagnostics\OspreySharp.Diagnostics.csproj" />
     <ProjectReference Include="..\OspreySharp.ML\OspreySharp.ML.csproj" />
     <ProjectReference Include="..\OspreySharp.IO\OspreySharp.IO.csproj" />
     <ProjectReference Include="..\OspreySharp.Chromatography\OspreySharp.Chromatography.csproj" />

--- a/pwiz_tools/OspreySharp/OspreySharp/Program.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/Program.cs
@@ -58,7 +58,7 @@ namespace pwiz.OspreySharp
             // Route OspreyDiagnostics dump messages through the same logging
             // channel as the rest of the pipeline so bisection logs appear
             // alongside normal output.
-            OspreyDiagnostics.LogAction = LogInfo;
+            OspreyDiagnosticsLog.LogAction = LogInfo;
 
             if (args.Length == 0)
             {

--- a/pwiz_tools/OspreySharp/OspreySharp/Tasks/AbstractScoringTask.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/Tasks/AbstractScoringTask.cs
@@ -83,7 +83,7 @@ namespace pwiz.OspreySharp.Tasks
         // The actual formatter lives in OspreyDiagnostics now.
         private static string F10(double v)
         {
-            return OspreyDiagnostics.F10(v);
+            return OspreyDiagnosticsLog.F10(v);
         }
 
 
@@ -272,7 +272,7 @@ namespace pwiz.OspreySharp.Tasks
 
             // Per-entry search XIC diagnostic: log the intent once at start.
             // The per-entry dump check happens inline in ScoreCandidate via
-            // OspreyDiagnostics.ShouldDumpSearchXicFor(entry.Id).
+            // the injected IScoringDiagnostics.ShouldDumpSearchXicFor(entry.Id).
             var diagSearchIds = ctx.Diagnostics?.DiagSearchEntryIds;
             if (diagSearchIds != null)
             {
@@ -318,7 +318,7 @@ namespace pwiz.OspreySharp.Tasks
             // Construct the per-window coelution scorer once. It captures the
             // log sink + the scoring-diagnostics sink (null when -d is off; the
             // scorer invokes it null-conditionally, so this is a no-op then).
-            var coelutionScorer = new CoelutionScorer(ctx.LogInfo, OspreyDiagnostics.ScoringDiagnostics);
+            var coelutionScorer = new CoelutionScorer(ctx.LogInfo, ctx.Diagnostics as IScoringDiagnostics);
 
             Parallel.For(0, windowsToScore.Count, new ParallelOptions
             {

--- a/pwiz_tools/OspreySharp/OspreySharp/Tasks/AbstractScoringTask.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/Tasks/AbstractScoringTask.cs
@@ -273,11 +273,12 @@ namespace pwiz.OspreySharp.Tasks
             // Per-entry search XIC diagnostic: log the intent once at start.
             // The per-entry dump check happens inline in ScoreCandidate via
             // OspreyDiagnostics.ShouldDumpSearchXicFor(entry.Id).
-            if (OspreyDiagnostics.DiagSearchEntryIds != null)
+            var diagSearchIds = ctx.Diagnostics?.DiagSearchEntryIds;
+            if (diagSearchIds != null)
             {
                 ctx.LogInfo(string.Format(
                     "[BISECT] OSPREY_DIAG_SEARCH_ENTRY_IDS: will dump {0} entries",
-                    OspreyDiagnostics.DiagSearchEntryIds.Count));
+                    diagSearchIds.Count));
             }
 
             // Per-window timings collected thread-safely for post-summary.

--- a/pwiz_tools/OspreySharp/OspreySharp/Tasks/Calibrator.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/Tasks/Calibrator.cs
@@ -43,9 +43,10 @@ namespace pwiz.OspreySharp.Tasks
     /// Standalone collaborator (does not inherit AbstractScoringTask): it owns
     /// the calibration unit-resolution XCorr scorer (<see cref="s_calXcorrScorer"/>),
     /// reaches the shared top-N constant via <see cref="TopFragmentExtractor"/>,
-    /// and takes the pipeline context for logging. Diagnostic dumps still route
-    /// through the OspreyDiagnostics facade, preserving the Stage-cal dump call
-    /// order bisection relies on.
+    /// and takes the pipeline context for logging. Diagnostic dumps route
+    /// through the injected <c>_ctx.Diagnostics</c> sink (the *_ONLY abort uses
+    /// <c>OspreyDiagnosticsLog.ExitAfterDump</c>), preserving the Stage-cal dump
+    /// call order bisection relies on.
     /// </summary>
     internal sealed class Calibrator
     {
@@ -193,7 +194,7 @@ namespace pwiz.OspreySharp.Tasks
             {
                 _ctx.Diagnostics?.WriteCalSampleDump(context.FileName, sampledEntries);
                 if (_ctx.Diagnostics?.CalSampleOnly ?? false)
-                    OspreyDiagnostics.ExitAfterDump("OSPREY_CAL_SAMPLE_ONLY");
+                    OspreyDiagnosticsLog.ExitAfterDump("OSPREY_CAL_SAMPLE_ONLY");
             }
             int nSampledTargets = 0;
             int nSampledDecoys = 0;
@@ -259,7 +260,7 @@ namespace pwiz.OspreySharp.Tasks
             {
                 _ctx.Diagnostics?.WriteLoessInputDump(1, pass1.LibRts, pass1.MeasuredRts);
                 if (_ctx.Diagnostics?.LoessInputOnly ?? false)
-                    OspreyDiagnostics.ExitAfterDump("OSPREY_LOESS_INPUT_ONLY");
+                    OspreyDiagnosticsLog.ExitAfterDump("OSPREY_LOESS_INPUT_ONLY");
             }
 
             // Match Rust accumulated_matches.len() semantics: report pass 1's
@@ -388,7 +389,7 @@ namespace pwiz.OspreySharp.Tasks
             {
                 _ctx.Diagnostics?.WriteCalWindowsDump(passNumber);
                 if (_ctx.Diagnostics?.CalWindowsOnly ?? false)
-                    OspreyDiagnostics.ExitAfterDump("OSPREY_CAL_WINDOWS_ONLY");
+                    OspreyDiagnosticsLog.ExitAfterDump("OSPREY_CAL_WINDOWS_ONLY");
             }
 
             // Cross-implementation diagnostic: dump per-entry calibration match info
@@ -398,7 +399,7 @@ namespace pwiz.OspreySharp.Tasks
             {
                 _ctx.Diagnostics?.WriteCalMatchDump(passNumber, matches, sampledEntries, matchRts, snrByEntryId);
                 if (_ctx.Diagnostics?.CalMatchOnly ?? false)
-                    OspreyDiagnostics.ExitAfterDump("OSPREY_CAL_MATCH_ONLY");
+                    OspreyDiagnosticsLog.ExitAfterDump("OSPREY_CAL_MATCH_ONLY");
             }
 
             if (matches.Count == 0)
@@ -452,7 +453,7 @@ namespace pwiz.OspreySharp.Tasks
             {
                 _ctx.Diagnostics?.WriteLdaScoresDump(passNumber, matchArray);
                 if (_ctx.Diagnostics?.LdaScoresOnly ?? false)
-                    OspreyDiagnostics.ExitAfterDump("OSPREY_LDA_SCORES_ONLY");
+                    OspreyDiagnosticsLog.ExitAfterDump("OSPREY_LDA_SCORES_ONLY");
             }
 
             // Collect high-confidence target matches that also meet the S/N
@@ -718,7 +719,7 @@ namespace pwiz.OspreySharp.Tasks
             {
                 _ctx.Diagnostics?.WriteMs2CalErrorsDump(contributingMatches);
                 if (_ctx.Diagnostics?.Ms2CalErrorsOnly ?? false)
-                    OspreyDiagnostics.ExitAfterDump("OSPREY_MS2_CAL_ERRORS_ONLY");
+                    OspreyDiagnosticsLog.ExitAfterDump("OSPREY_MS2_CAL_ERRORS_ONLY");
             }
             string unitStr = config.FragmentTolerance.Unit == ToleranceUnit.Ppm ? "ppm" : "Th";
             ms1Calibration = MzCalibration.CalculateSingleLevel(allMs1Errors.ToArray(), unitStr);

--- a/pwiz_tools/OspreySharp/OspreySharp/Tasks/Calibrator.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/Tasks/Calibrator.cs
@@ -183,16 +183,16 @@ namespace pwiz.OspreySharp.Tasks
             // first calibration attempt.
             var swSample = Stopwatch.StartNew();
             var sampledEntries = SampleLibraryForCalibration(
-                library, config.RtCalibration.CalibrationSampleSize, 43UL);
+                library, config.RtCalibration.CalibrationSampleSize, 43UL, _ctx.Diagnostics);
             swSample.Stop();
 
             // Diagnostic: dump sorted sampled entry IDs + (modseq, charge) for
             // direct comparison with Rust. Abort after dump if CAL_SAMPLE_ONLY
             // env var is set (bisection mode - stop once we agree here).
-            if (config.WritePin || OspreyDiagnostics.DumpCalSample)
+            if (config.WritePin || (_ctx.Diagnostics?.DumpCalSample ?? false))
             {
-                OspreyDiagnostics.WriteCalSampleDump(context.FileName, sampledEntries);
-                if (OspreyDiagnostics.CalSampleOnly)
+                _ctx.Diagnostics?.WriteCalSampleDump(context.FileName, sampledEntries);
+                if (_ctx.Diagnostics?.CalSampleOnly ?? false)
                     OspreyDiagnostics.ExitAfterDump("OSPREY_CAL_SAMPLE_ONLY");
             }
             int nSampledTargets = 0;
@@ -255,10 +255,10 @@ namespace pwiz.OspreySharp.Tasks
             // it will overwrite this with the pass-2 pairs; if pass 2 is
             // rejected (or never runs) the pass-1 dump stays, matching the
             // calibration actually used. Mirrors Rust pipeline.rs.
-            if (OspreyDiagnostics.DumpLoessInput)
+            if (_ctx.Diagnostics?.DumpLoessInput ?? false)
             {
-                OspreyDiagnostics.WriteLoessInputDump(1, pass1.LibRts, pass1.MeasuredRts);
-                if (OspreyDiagnostics.LoessInputOnly)
+                _ctx.Diagnostics?.WriteLoessInputDump(1, pass1.LibRts, pass1.MeasuredRts);
+                if (_ctx.Diagnostics?.LoessInputOnly ?? false)
                     OspreyDiagnostics.ExitAfterDump("OSPREY_LOESS_INPUT_ONLY");
             }
 
@@ -324,9 +324,9 @@ namespace pwiz.OspreySharp.Tasks
                         // pass 2's points so the diagnostic reflects the
                         // calibration actually being used. Mirrors Rust
                         // pipeline.rs; only fires on acceptance.
-                        if (OspreyDiagnostics.DumpLoessInput)
+                        if (_ctx.Diagnostics?.DumpLoessInput ?? false)
                         {
-                            OspreyDiagnostics.WriteLoessInputDump(
+                            _ctx.Diagnostics?.WriteLoessInputDump(
                                 2, pass2.LibRts, pass2.MeasuredRts);
                         }
                         ms1Calibration = pass2.Ms1Calibration;
@@ -371,7 +371,7 @@ namespace pwiz.OspreySharp.Tasks
             var fileName = context.FileName;
             // Activate per-entry window dump if requested. Cleared after the
             // matching loop completes (file written below).
-            OspreyDiagnostics.StartCalWindowCollection();
+            _ctx.Diagnostics?.StartCalWindowCollection();
 
             // Pre-preprocess all window spectra for XCorr (f32 unit-bin scorer).
             var preprocessedByWindowKey = PreprocessWindowsForXcorr(spectraByWindowKey);
@@ -384,20 +384,20 @@ namespace pwiz.OspreySharp.Tasks
             // Write per-entry window dump if requested. When two passes run, the
             // pass 2 dump overwrites pass 1 - same behaviour as Rust's
             // run_coelution_calibration_scoring dumping on every invocation.
-            if (OspreyDiagnostics.CalWindowsCollecting)
+            if (_ctx.Diagnostics?.CalWindowsCollecting ?? false)
             {
-                OspreyDiagnostics.WriteCalWindowsDump(passNumber);
-                if (OspreyDiagnostics.CalWindowsOnly)
+                _ctx.Diagnostics?.WriteCalWindowsDump(passNumber);
+                if (_ctx.Diagnostics?.CalWindowsOnly ?? false)
                     OspreyDiagnostics.ExitAfterDump("OSPREY_CAL_WINDOWS_ONLY");
             }
 
             // Cross-implementation diagnostic: dump per-entry calibration match info
             // for direct diff with Rust. Writes a row for EVERY sampled entry
             // (matched or not), sorted by entry_id for stable diff.
-            if (OspreyDiagnostics.DumpCalMatch)
+            if (_ctx.Diagnostics?.DumpCalMatch ?? false)
             {
-                OspreyDiagnostics.WriteCalMatchDump(passNumber, matches, sampledEntries, matchRts, snrByEntryId);
-                if (OspreyDiagnostics.CalMatchOnly)
+                _ctx.Diagnostics?.WriteCalMatchDump(passNumber, matches, sampledEntries, matchRts, snrByEntryId);
+                if (_ctx.Diagnostics?.CalMatchOnly ?? false)
                     OspreyDiagnostics.ExitAfterDump("OSPREY_CAL_MATCH_ONLY");
             }
 
@@ -448,10 +448,10 @@ namespace pwiz.OspreySharp.Tasks
             // Cross-implementation diagnostic: dump per-entry LDA discriminant + q-value
             // sorted by entry_id for stable diff with rust_lda_scores.txt. Gated by
             // OSPREY_DUMP_LDA_SCORES; exits after write when OSPREY_LDA_SCORES_ONLY is set.
-            if (OspreyDiagnostics.DumpLdaScores)
+            if (_ctx.Diagnostics?.DumpLdaScores ?? false)
             {
-                OspreyDiagnostics.WriteLdaScoresDump(passNumber, matchArray);
-                if (OspreyDiagnostics.LdaScoresOnly)
+                _ctx.Diagnostics?.WriteLdaScoresDump(passNumber, matchArray);
+                if (_ctx.Diagnostics?.LdaScoresOnly ?? false)
                     OspreyDiagnostics.ExitAfterDump("OSPREY_LDA_SCORES_ONLY");
             }
 
@@ -714,10 +714,10 @@ namespace pwiz.OspreySharp.Tasks
                 allMs2Errors.AddRange(m.Ms2MassErrors);
                 contributingMatches.Add(m);
             }
-            if (OspreyDiagnostics.DumpMs2CalErrors)
+            if (_ctx.Diagnostics?.DumpMs2CalErrors ?? false)
             {
-                OspreyDiagnostics.WriteMs2CalErrorsDump(contributingMatches);
-                if (OspreyDiagnostics.Ms2CalErrorsOnly)
+                _ctx.Diagnostics?.WriteMs2CalErrorsDump(contributingMatches);
+                if (_ctx.Diagnostics?.Ms2CalErrorsOnly ?? false)
                     OspreyDiagnostics.ExitAfterDump("OSPREY_MS2_CAL_ERRORS_ONLY");
             }
             string unitStr = config.FragmentTolerance.Unit == ToleranceUnit.Ppm ? "ppm" : "Th";
@@ -740,7 +740,7 @@ namespace pwiz.OspreySharp.Tasks
         /// Rust exactly for the two tools to process the same calibration peptides.
         /// </summary>
         private static List<LibraryEntry> SampleLibraryForCalibration(
-            List<LibraryEntry> library, int sampleSize, ulong seed)
+            List<LibraryEntry> library, int sampleSize, ulong seed, IOspreyDiagnostics diag)
         {
             if (sampleSize == 0)
                 return new List<LibraryEntry>(library);
@@ -816,9 +816,9 @@ namespace pwiz.OspreySharp.Tasks
 
             // Diagnostic dump: scalar parameters + full grid contents,
             // matching Rust's dump format for direct diff.
-            if (OspreyDiagnostics.DumpCalSample)
+            if (diag?.DumpCalSample ?? false)
             {
-                OspreyDiagnostics.WriteCalScalarsAndGridDump(
+                diag.WriteCalScalarsAndGridDump(
                     targets, decoys, binsPerAxis,
                     rtMin, rtMax, mzMin, mzMax,
                     rtRange, mzRange, rtBinWidth, mzBinWidth,
@@ -974,9 +974,9 @@ namespace pwiz.OspreySharp.Tasks
             // C# selects ONE window per entry (the first match in dictionary order),
             // unlike Rust which scores in ALL matching windows. Capturing this here
             // before the RT/2-of-6 filter so it matches Rust's pre-filter dump.
-            if (OspreyDiagnostics.CalWindowsCollecting)
+            if (_ctx.Diagnostics?.CalWindowsCollecting ?? false)
             {
-                OspreyDiagnostics.AddCalWindowRow(
+                _ctx.Diagnostics?.AddCalWindowRow(
                     entry, windowSpectra[0].IsolationWindow,
                     expectedRt,
                     expectedRt - initialTolerance,
@@ -1043,9 +1043,9 @@ namespace pwiz.OspreySharp.Tasks
             var xics = TopFragmentExtractor.ExtractTopNFragmentXics(
                 entry, candidateSpectra, rts, TopFragmentExtractor.CAL_TOP_N_FRAGMENTS, config);
 
-            if (OspreyDiagnostics.ShouldDumpCalXicFor(entry.Id, currentPass))
+            if (_ctx.Diagnostics?.ShouldDumpCalXicFor(entry.Id, currentPass) ?? false)
             {
-                OspreyDiagnostics.WriteCalXicEntryDumpAndExit(
+                _ctx.Diagnostics?.WriteCalXicEntryDumpAndExit(
                     entry, currentPass, calibrationModel,
                     expectedRt, initialTolerance, rtSlope, rtIntercept,
                     candidateSpectra, xics);

--- a/pwiz_tools/OspreySharp/OspreySharp/Tasks/FirstJoinTask.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/Tasks/FirstJoinTask.cs
@@ -442,9 +442,9 @@ namespace pwiz.OspreySharp.Tasks
         {
             LogFirstPassResults(perFileEntries, config, ctx);
 
-            if (OspreyDiagnostics.DumpPercolator)
-                OspreyDiagnostics.WriteStage5PercolatorDump(perFileEntries);
-            if (OspreyDiagnostics.PercolatorOnly)
+            if (ctx.Diagnostics?.DumpPercolator ?? false)
+                ctx.Diagnostics?.WriteStage5PercolatorDump(perFileEntries);
+            if (ctx.Diagnostics?.PercolatorOnly ?? false)
                 OspreyDiagnostics.ExitAfterDump(@"OSPREY_PERCOLATOR_ONLY");
         }
 
@@ -586,7 +586,7 @@ namespace pwiz.OspreySharp.Tasks
                 @"Stage 6 multi-charge consensus: {0} entries need re-scoring across {1} files",
                 totalMulticharge, perFileEntries.Count));
 
-            if (OspreyDiagnostics.DumpMulticharge)
+            if (ctx.Diagnostics?.DumpMulticharge ?? false)
             {
                 var perFileForDump = new List<KeyValuePair<string,
                     IReadOnlyList<FdrEntry>>>(perFileEntries.Count);
@@ -595,9 +595,9 @@ namespace pwiz.OspreySharp.Tasks
                     perFileForDump.Add(new KeyValuePair<string,
                         IReadOnlyList<FdrEntry>>(kvp.Key, kvp.Value));
                 }
-                OspreyDiagnostics.WriteStage6MultichargeDump(
+                ctx.Diagnostics?.WriteStage6MultichargeDump(
                     perFileForDump, perFileConsensusTargets);
-                if (OspreyDiagnostics.MultichargeOnly)
+                if (ctx.Diagnostics?.MultichargeOnly ?? false)
                     OspreyDiagnostics.ExitAfterDump(@"OSPREY_MULTICHARGE_ONLY");
             }
 
@@ -618,7 +618,7 @@ namespace pwiz.OspreySharp.Tasks
             // FDR project doesn't have to know about the diagnostic
             // file format.
             List<InvPredictRecord> invPredictTrace = null;
-            if (OspreyDiagnostics.DumpInvPredict)
+            if (ctx.Diagnostics?.DumpInvPredict ?? false)
                 invPredictTrace = new List<InvPredictRecord>();
 
             // Cross-file consensus is only meaningful with > 1 file.
@@ -638,8 +638,8 @@ namespace pwiz.OspreySharp.Tasks
 
             if (invPredictTrace != null)
             {
-                OspreyDiagnostics.WriteStage6InvPredictDump(invPredictTrace);
-                if (OspreyDiagnostics.InvPredictOnly)
+                ctx.Diagnostics?.WriteStage6InvPredictDump(invPredictTrace);
+                if (ctx.Diagnostics?.InvPredictOnly ?? false)
                     OspreyDiagnostics.ExitAfterDump(@"OSPREY_INV_PREDICT_ONLY");
             }
             int nTargets = 0, nDecoys = 0;
@@ -660,10 +660,10 @@ namespace pwiz.OspreySharp.Tasks
             // emits a header-only cs_stage6_consensus.tsv and
             // Test-Regression sees an asymmetric-absence FAIL
             // even though both sides agree on the empty result.
-            if (OspreyDiagnostics.DumpConsensus && consensus.Count > 0)
+            if ((ctx.Diagnostics?.DumpConsensus ?? false) && consensus.Count > 0)
             {
-                OspreyDiagnostics.WriteStage6ConsensusDump(consensus);
-                if (OspreyDiagnostics.ConsensusOnly)
+                ctx.Diagnostics?.WriteStage6ConsensusDump(consensus);
+                if (ctx.Diagnostics?.ConsensusOnly ?? false)
                     OspreyDiagnostics.ExitAfterDump(@"OSPREY_CONSENSUS_ONLY");
             }
 
@@ -680,17 +680,17 @@ namespace pwiz.OspreySharp.Tasks
                 @"Stage 6 refit: {0}/{1} files produced refined calibrations",
                 refinedCalibrations.Count, perFileEntries.Count));
 
-            if (OspreyDiagnostics.DumpLoessFit)
+            if (ctx.Diagnostics?.DumpLoessFit ?? false)
             {
-                OspreyDiagnostics.WriteStage6LoessFitDump(refinedCalibrations);
-                if (OspreyDiagnostics.LoessFitOnly)
+                ctx.Diagnostics?.WriteStage6LoessFitDump(refinedCalibrations);
+                if (ctx.Diagnostics?.LoessFitOnly ?? false)
                     OspreyDiagnostics.ExitAfterDump(@"OSPREY_LOESS_FIT_ONLY");
             }
 
-            if (OspreyDiagnostics.DumpRefit)
+            if (ctx.Diagnostics?.DumpRefit ?? false)
             {
-                OspreyDiagnostics.WriteStage6RefitDump(refinedCalibrations);
-                if (OspreyDiagnostics.RefitOnly)
+                ctx.Diagnostics?.WriteStage6RefitDump(refinedCalibrations);
+                if (ctx.Diagnostics?.RefitOnly ?? false)
                     OspreyDiagnostics.ExitAfterDump(@"OSPREY_REFIT_ONLY");
             }
 
@@ -796,13 +796,13 @@ namespace pwiz.OspreySharp.Tasks
             // for early exit. Mirrors the Rust side at
             // crates/osprey/src/pipeline.rs after the reconciliation
             // block closes.
-            if (OspreyDiagnostics.DumpReconciliation)
+            if (ctx.Diagnostics?.DumpReconciliation ?? false)
             {
                 var dumpActions = reconciliationActions
                     ?? new Dictionary<(string File, int Index), ReconcileAction>();
-                OspreyDiagnostics.WriteStage6ReconciliationDump(
+                ctx.Diagnostics?.WriteStage6ReconciliationDump(
                     dumpActions, perFileForPlan);
-                if (OspreyDiagnostics.ReconciliationOnly)
+                if (ctx.Diagnostics?.ReconciliationOnly ?? false)
                     OspreyDiagnostics.ExitAfterDump(@"OSPREY_RECONCILIATION_ONLY");
             }
 
@@ -1729,11 +1729,11 @@ namespace pwiz.OspreySharp.Tasks
                 "First-pass protein FDR: {0} target groups at {1:P1} FDR",
                 nAtRunFdr, config.RunFdr));
 
-            if (OspreyDiagnostics.DumpProteinFdr)
+            if (ctx.Diagnostics?.DumpProteinFdr ?? false)
             {
-                OspreyDiagnostics.WriteStage6ProteinFdrDump(
+                ctx.Diagnostics?.WriteStage6ProteinFdrDump(
                     bestScores, proteinFdr.PeptideQvalues);
-                if (OspreyDiagnostics.ProteinFdrOnly)
+                if (ctx.Diagnostics?.ProteinFdrOnly ?? false)
                     OspreyDiagnostics.ExitAfterDump(@"OSPREY_PROTEIN_FDR_ONLY");
             }
         }

--- a/pwiz_tools/OspreySharp/OspreySharp/Tasks/FirstJoinTask.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/Tasks/FirstJoinTask.cs
@@ -445,7 +445,7 @@ namespace pwiz.OspreySharp.Tasks
             if (ctx.Diagnostics?.DumpPercolator ?? false)
                 ctx.Diagnostics?.WriteStage5PercolatorDump(perFileEntries);
             if (ctx.Diagnostics?.PercolatorOnly ?? false)
-                OspreyDiagnostics.ExitAfterDump(@"OSPREY_PERCOLATOR_ONLY");
+                OspreyDiagnosticsLog.ExitAfterDump(@"OSPREY_PERCOLATOR_ONLY");
         }
 
         /// <summary>
@@ -598,7 +598,7 @@ namespace pwiz.OspreySharp.Tasks
                 ctx.Diagnostics?.WriteStage6MultichargeDump(
                     perFileForDump, perFileConsensusTargets);
                 if (ctx.Diagnostics?.MultichargeOnly ?? false)
-                    OspreyDiagnostics.ExitAfterDump(@"OSPREY_MULTICHARGE_ONLY");
+                    OspreyDiagnosticsLog.ExitAfterDump(@"OSPREY_MULTICHARGE_ONLY");
             }
 
             // 2. Cross-run consensus RTs (target peptides + paired
@@ -640,7 +640,7 @@ namespace pwiz.OspreySharp.Tasks
             {
                 ctx.Diagnostics?.WriteStage6InvPredictDump(invPredictTrace);
                 if (ctx.Diagnostics?.InvPredictOnly ?? false)
-                    OspreyDiagnostics.ExitAfterDump(@"OSPREY_INV_PREDICT_ONLY");
+                    OspreyDiagnosticsLog.ExitAfterDump(@"OSPREY_INV_PREDICT_ONLY");
             }
             int nTargets = 0, nDecoys = 0;
             foreach (var c in consensus)
@@ -664,7 +664,7 @@ namespace pwiz.OspreySharp.Tasks
             {
                 ctx.Diagnostics?.WriteStage6ConsensusDump(consensus);
                 if (ctx.Diagnostics?.ConsensusOnly ?? false)
-                    OspreyDiagnostics.ExitAfterDump(@"OSPREY_CONSENSUS_ONLY");
+                    OspreyDiagnosticsLog.ExitAfterDump(@"OSPREY_CONSENSUS_ONLY");
             }
 
             // 3. Per-file calibration refit on consensus peptides.
@@ -684,14 +684,14 @@ namespace pwiz.OspreySharp.Tasks
             {
                 ctx.Diagnostics?.WriteStage6LoessFitDump(refinedCalibrations);
                 if (ctx.Diagnostics?.LoessFitOnly ?? false)
-                    OspreyDiagnostics.ExitAfterDump(@"OSPREY_LOESS_FIT_ONLY");
+                    OspreyDiagnosticsLog.ExitAfterDump(@"OSPREY_LOESS_FIT_ONLY");
             }
 
             if (ctx.Diagnostics?.DumpRefit ?? false)
             {
                 ctx.Diagnostics?.WriteStage6RefitDump(refinedCalibrations);
                 if (ctx.Diagnostics?.RefitOnly ?? false)
-                    OspreyDiagnostics.ExitAfterDump(@"OSPREY_REFIT_ONLY");
+                    OspreyDiagnosticsLog.ExitAfterDump(@"OSPREY_REFIT_ONLY");
             }
 
             // 4. Reconciliation planning. Reads each file's CWT
@@ -803,7 +803,7 @@ namespace pwiz.OspreySharp.Tasks
                 ctx.Diagnostics?.WriteStage6ReconciliationDump(
                     dumpActions, perFileForPlan);
                 if (ctx.Diagnostics?.ReconciliationOnly ?? false)
-                    OspreyDiagnostics.ExitAfterDump(@"OSPREY_RECONCILIATION_ONLY");
+                    OspreyDiagnosticsLog.ExitAfterDump(@"OSPREY_RECONCILIATION_ONLY");
             }
 
             // Stage 5 → Stage 6 boundary: write the per-file
@@ -1734,7 +1734,7 @@ namespace pwiz.OspreySharp.Tasks
                 ctx.Diagnostics?.WriteStage6ProteinFdrDump(
                     bestScores, proteinFdr.PeptideQvalues);
                 if (ctx.Diagnostics?.ProteinFdrOnly ?? false)
-                    OspreyDiagnostics.ExitAfterDump(@"OSPREY_PROTEIN_FDR_ONLY");
+                    OspreyDiagnosticsLog.ExitAfterDump(@"OSPREY_PROTEIN_FDR_ONLY");
             }
         }
     }

--- a/pwiz_tools/OspreySharp/OspreySharp/Tasks/MergeNodeTask.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/Tasks/MergeNodeTask.cs
@@ -538,7 +538,7 @@ namespace pwiz.OspreySharp.Tasks
 
             // Cross-impl bisection dump (env-var-gated, no-op in production).
             if (ctx.Diagnostics?.DumpDetectedPeptides ?? false)
-                ctx.Diagnostics.WriteStage7DetectedPeptidesDump(detectedPeptides);
+                ctx.Diagnostics?.WriteStage7DetectedPeptidesDump(detectedPeptides);
 
             // Build protein parsimony
             var parsimony = ProteinFdr.BuildProteinParsimony(
@@ -574,8 +574,8 @@ namespace pwiz.OspreySharp.Tasks
             // isolation, matching Rust diagnostics.dump_stage7_protein_fdr.
             if (ctx.Diagnostics?.DumpStage7ProteinFdr ?? false)
             {
-                ctx.Diagnostics.WriteStage7ProteinFdrDump(parsimony, proteinFdr);
-                if (ctx.Diagnostics.Stage7ProteinFdrOnly)
+                ctx.Diagnostics?.WriteStage7ProteinFdrDump(parsimony, proteinFdr);
+                if (ctx.Diagnostics?.Stage7ProteinFdrOnly ?? false)
                     OspreyDiagnosticsLog.ExitAfterDump(@"OSPREY_STAGE7_PROTEIN_FDR_ONLY");
             }
 

--- a/pwiz_tools/OspreySharp/OspreySharp/Tasks/MergeNodeTask.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/Tasks/MergeNodeTask.cs
@@ -342,7 +342,7 @@ namespace pwiz.OspreySharp.Tasks
                     // .MergeNode.osprey.task sidecar carries an identical
                     // key. AnalysisPipeline.WriteTaskSidecars also writes
                     // these at end-of-Run, but that step is bypassed when
-                    // OspreyDiagnostics.ExitAfterDump calls Environment.Exit
+                    // OspreyDiagnosticsLog.ExitAfterDump calls Environment.Exit
                     // (the test-snapshot stage7 / OSPREY_STAGE7_PROTEIN_FDR_ONLY
                     // path). Writing inline next to each 2nd-pass binary
                     // makes the per-file resume contract survive that
@@ -576,7 +576,7 @@ namespace pwiz.OspreySharp.Tasks
             {
                 ctx.Diagnostics.WriteStage7ProteinFdrDump(parsimony, proteinFdr);
                 if (ctx.Diagnostics.Stage7ProteinFdrOnly)
-                    OspreyDiagnostics.ExitAfterDump(@"OSPREY_STAGE7_PROTEIN_FDR_ONLY");
+                    OspreyDiagnosticsLog.ExitAfterDump(@"OSPREY_STAGE7_PROTEIN_FDR_ONLY");
             }
 
             // Propagate protein q-values to FdrEntry stubs

--- a/pwiz_tools/OspreySharp/OspreySharp/Tasks/MergeNodeTask.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/Tasks/MergeNodeTask.cs
@@ -537,8 +537,8 @@ namespace pwiz.OspreySharp.Tasks
                 detectedPeptides.Count));
 
             // Cross-impl bisection dump (env-var-gated, no-op in production).
-            if (OspreyDiagnostics.DumpDetectedPeptides)
-                OspreyDiagnostics.WriteStage7DetectedPeptidesDump(detectedPeptides);
+            if (ctx.Diagnostics?.DumpDetectedPeptides ?? false)
+                ctx.Diagnostics.WriteStage7DetectedPeptidesDump(detectedPeptides);
 
             // Build protein parsimony
             var parsimony = ProteinFdr.BuildProteinParsimony(
@@ -572,10 +572,10 @@ namespace pwiz.OspreySharp.Tasks
             // OSPREY_DUMP_STAGE7_PROTEIN_FDR=1). Fires before propagation so
             // the dumped state captures the picked-protein computation in
             // isolation, matching Rust diagnostics.dump_stage7_protein_fdr.
-            if (OspreyDiagnostics.DumpStage7ProteinFdr)
+            if (ctx.Diagnostics?.DumpStage7ProteinFdr ?? false)
             {
-                OspreyDiagnostics.WriteStage7ProteinFdrDump(parsimony, proteinFdr);
-                if (OspreyDiagnostics.Stage7ProteinFdrOnly)
+                ctx.Diagnostics.WriteStage7ProteinFdrDump(parsimony, proteinFdr);
+                if (ctx.Diagnostics.Stage7ProteinFdrOnly)
                     OspreyDiagnostics.ExitAfterDump(@"OSPREY_STAGE7_PROTEIN_FDR_ONLY");
             }
 

--- a/pwiz_tools/OspreySharp/OspreySharp/Tasks/PerFileRescoreTask.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/Tasks/PerFileRescoreTask.cs
@@ -286,10 +286,10 @@ namespace pwiz.OspreySharp.Tasks
             // Cross-impl bisection seam: dump per-precursor state
             // immediately after the rescore loop. Mirrors Rust's
             // dump_stage6_rescored call from pipeline.rs.
-            if (OspreyDiagnostics.DumpRescored)
+            if (ctx.Diagnostics?.DumpRescored ?? false)
             {
-                OspreyDiagnostics.WriteStage6RescoredDump(_perFileEntries);
-                if (OspreyDiagnostics.RescoredOnly)
+                ctx.Diagnostics.WriteStage6RescoredDump(_perFileEntries);
+                if (ctx.Diagnostics.RescoredOnly)
                     OspreyDiagnostics.ExitAfterDump(@"OSPREY_RESCORED_ONLY");
             }
 
@@ -298,11 +298,11 @@ namespace pwiz.OspreySharp.Tasks
             // Mirrors the worker-mode close calls in RunWorker; without
             // these, the in-process pipeline path can leave the writers
             // unflushed and produce truncated bisection dumps.
-            OspreyDiagnostics.CloseMpInputsDump();
+            ctx.Diagnostics?.CloseMpInputsDump();
             // ClosePredictRtDump disabled with the rest of the predict-rt
             // diagnostic (perf hotspot); restore alongside WritePredictRtCall.
-            // OspreyDiagnostics.ClosePredictRtDump();
-            OspreyDiagnostics.CloseCwtPathDump();
+            // ctx.Diagnostics?.ClosePredictRtDump();
+            ctx.Diagnostics?.CloseCwtPathDump();
             return true;
         }
 

--- a/pwiz_tools/OspreySharp/OspreySharp/Tasks/PerFileRescoreTask.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/Tasks/PerFileRescoreTask.cs
@@ -290,7 +290,7 @@ namespace pwiz.OspreySharp.Tasks
             {
                 ctx.Diagnostics.WriteStage6RescoredDump(_perFileEntries);
                 if (ctx.Diagnostics.RescoredOnly)
-                    OspreyDiagnostics.ExitAfterDump(@"OSPREY_RESCORED_ONLY");
+                    OspreyDiagnosticsLog.ExitAfterDump(@"OSPREY_RESCORED_ONLY");
             }
 
             // Flush + close the persistent per-process diagnostic

--- a/pwiz_tools/OspreySharp/OspreySharp/Tasks/PerFileRescoreTask.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/Tasks/PerFileRescoreTask.cs
@@ -288,8 +288,8 @@ namespace pwiz.OspreySharp.Tasks
             // dump_stage6_rescored call from pipeline.rs.
             if (ctx.Diagnostics?.DumpRescored ?? false)
             {
-                ctx.Diagnostics.WriteStage6RescoredDump(_perFileEntries);
-                if (ctx.Diagnostics.RescoredOnly)
+                ctx.Diagnostics?.WriteStage6RescoredDump(_perFileEntries);
+                if (ctx.Diagnostics?.RescoredOnly ?? false)
                     OspreyDiagnosticsLog.ExitAfterDump(@"OSPREY_RESCORED_ONLY");
             }
 

--- a/pwiz_tools/OspreySharp/OspreySharp/Tasks/PerFileScoringTask.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/Tasks/PerFileScoringTask.cs
@@ -893,7 +893,7 @@ namespace pwiz.OspreySharp.Tasks
                 }
             }
             if (ctx.Diagnostics?.CalibrationOnly ?? false)
-                OspreyDiagnostics.ExitAfterDump(@"OSPREY_CALIBRATION_ONLY");
+                OspreyDiagnosticsLog.ExitAfterDump(@"OSPREY_CALIBRATION_ONLY");
         }
 
         /// <summary>

--- a/pwiz_tools/OspreySharp/OspreySharp/Tasks/PerFileScoringTask.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/Tasks/PerFileScoringTask.cs
@@ -876,7 +876,7 @@ namespace pwiz.OspreySharp.Tasks
                                 var mp = calParams.RtCalibration.ModelParams;
                                 if (ctx.Diagnostics?.DumpCalibration ?? false)
                                 {
-                                    ctx.Diagnostics.WriteStage6CalibrationDump(
+                                    ctx.Diagnostics?.WriteStage6CalibrationDump(
                                         fileName, mp.LibraryRts, mp.FittedRts);
                                 }
                                 var rtCal = RTCalibration.FromModelParams(

--- a/pwiz_tools/OspreySharp/OspreySharp/Tasks/PerFileScoringTask.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/Tasks/PerFileScoringTask.cs
@@ -874,9 +874,9 @@ namespace pwiz.OspreySharp.Tasks
                             if (calParams.RtCalibration != null && calParams.RtCalibration.ModelParams != null)
                             {
                                 var mp = calParams.RtCalibration.ModelParams;
-                                if (OspreyDiagnostics.DumpCalibration)
+                                if (ctx.Diagnostics?.DumpCalibration ?? false)
                                 {
-                                    OspreyDiagnostics.WriteStage6CalibrationDump(
+                                    ctx.Diagnostics.WriteStage6CalibrationDump(
                                         fileName, mp.LibraryRts, mp.FittedRts);
                                 }
                                 var rtCal = RTCalibration.FromModelParams(
@@ -892,7 +892,7 @@ namespace pwiz.OspreySharp.Tasks
                     ctx.LogWarning(string.Format(@"  Failed to load calibration for {0}: {1}", fileName, ex.Message));
                 }
             }
-            if (OspreyDiagnostics.CalibrationOnly)
+            if (ctx.Diagnostics?.CalibrationOnly ?? false)
                 OspreyDiagnostics.ExitAfterDump(@"OSPREY_CALIBRATION_ONLY");
         }
 
@@ -1273,7 +1273,7 @@ namespace pwiz.OspreySharp.Tasks
             // Dump 11 calibration summary scalars (MS1/MS2 mean/sd/count/
             // tolerance + RT n_points/r_squared/residual_sd) so the final
             // calibration state can be diff'd against Rust's cal JSON.
-            OspreyDiagnostics.WriteCalibrationSummary(rtCalibration, ms1Cal, ms2Cal);
+            ctx.Diagnostics?.WriteCalibrationSummary(rtCalibration, ms1Cal, ms2Cal);
 
             // Save the full calibration state to {inputStem}.calibration.json
             // in the same directory as the mzML input. Same schema as Rust


### PR DESCRIPTION
## Summary

* Added an `OspreySharp.Diagnostics` DLL with `IOspreyDiagnostics`; the cross-impl bisection dump sink is now injected on `PipelineContext` (null when diagnostics are off) instead of reached through the exe-only `OspreyDiagnostics` static facade.
* Migrated all ~90 task-layer dump/gate call sites to `ctx.Diagnostics?.X` (null short-circuit, no virtual call when off) across AbstractScoringTask, PerFileScoringTask, PerFileRescoreTask, MergeNodeTask, Calibrator, and FirstJoinTask.
* Retired the static dump surface: `OspreyDiagnostics` is now a two-member sink bootstrap (`Initialize`/`Active`); the stateless `LogAction`/`F10`/`ExitAfterDump` helpers moved to `OspreyDiagnosticsLog`. That commit was a net -275 LOC.
* The task bodies no longer reference the exe-only facade, which unblocks the planned lift of the task layer into a testable DLL. The 2076-line `OspreyFileDiagnostics` sink intentionally stays in the exe (its move is the next PR's exe-thinning scope).

## Test plan

- [x] regression.ps1 -Dataset All (Stellar + Astral) -- golden + resume, PASS at 1e-9 (also run per-commit on Stellar)
- [x] Data-rich dumps-on run (full OSPREY_DUMP_* bundle, Stellar) -- every migrated WriteX path fires on real data with correct results
- [x] Test-PerfGate.ps1 -Dataset Stellar -- PASS, total median -1.5% (perf-neutral)
- [x] Build + 382 unit tests + zero-warning inspection (net472 + net8.0)
- [x] Fresh-context self-review -- no CRITICAL/HIGH/MEDIUM findings

Co-Authored-By: Claude <noreply@anthropic.com>
