### PR TITLE
OspreySharp debt-paydown PR 3: extract resume/IO collaborators and decompose the per-file orchestration methods

### DIFF
--- a/pwiz_tools/OspreySharp/OspreySharp.Tasks/PerFileRescoreTask.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Tasks/PerFileRescoreTask.cs
@@ -493,267 +493,38 @@ namespace pwiz.OspreySharp.Tasks
             // path for spectra cache load + sibling .calibration.json.
             var fileNameToIdx = BuildFileNameToIndex(config.InputFiles);
 
+            // Cross-file inputs every per-file rescore reads, bundled so
+            // RescoreOneFile takes one collaborator object instead of a dozen
+            // positional parameters.
+            var inputs = new RescorePassInputs
+            {
+                ConsensusTargets = perFileConsensusTargets,
+                ReconTargets = perFileReconTargets,
+                RefinedCalibrations = refinedCalibrations,
+                PerFileCalibrations = perFileCalibrations,
+                GapFill = perFileGapFill,
+                ParquetPaths = perFileParquetPaths,
+                FullLibrary = fullLibrary,
+                Config = config,
+                FileNameToIdx = fileNameToIdx,
+                TaskValidityKey = ValidityKey(ctx),
+                JoinFileStems = joinFileStems,
+            };
+
             int totalRescored = 0;
             int totalGapCwt = 0;
             int totalGapForced = 0;
             int nTotalFiles = perFileEntries.Count;
-            string taskValidityKey = ValidityKey(ctx);
 
             for (int fileNum = 0; fileNum < nTotalFiles; fileNum++)
             {
-                var fileName = perFileEntries[fileNum].Key;
-                var fdrEntries = perFileEntries[fileNum].Value;
-
-                // Per-file resume: if the file's reconciled parquet is
-                // already on disk with a matching <output>.PerFileRescore.osprey.task
-                // sidecar, skip the rescore for that file. Pairs with the
-                // worker (stage6) crash-resume contract: re-invoking the
-                // same CLI on the same inputs is a no-op for files whose
-                // rescore completed; only files missing a valid sidecar
-                // get re-rescored. The skipped file's in-memory entries
-                // remain at the pre-rescore state (1st-pass overlay)
-                // because the worker's StopAfter terminates the pipeline
-                // here -- no downstream consumer reads them.
-                // The rescore READS the original Stage 4 parquet and WRITES a
-                // separate <stem>.scores-reconciled.parquet. Resume validity is
-                // keyed on the reconciled output (the task's declared Output),
-                // not on the original read source.
-                bool hasParquetPath = perFileParquetPaths.TryGetValue(fileName, out string perFileParquetPath);
-                string reconciledPath = hasParquetPath
-                    ? ParquetScoreCache.ReconciledPathFromScoresPath(perFileParquetPath)
-                    : null;
-                if (hasParquetPath
-                    && PerFileResumeDriver.IsCurrent(reconciledPath, Name, taskValidityKey))
-                {
-                    ctx.LogInfo(string.Format(
-                        @"[file] {0}/{1} {2}: skipping (outputs valid)",
-                        fileNum + 1, nTotalFiles, fileName));
-
-                    // PR-E: a partial resume skips this already-rescored file, but
-                    // a downstream consumer (MergeNode, in the full pipeline) reads
-                    // ApexRt/StartRt/EndRt/BoundsArea straight off these in-memory
-                    // entries. Without overlaying the reconciled values they stay at
-                    // the 1st-pass state and the final blib carries 1st-pass RTs.
-                    // Reproduce the fresh end state in place from the valid reconciled
-                    // parquet we just confirmed on disk + this file's gap-fill targets.
-                    IReadOnlyList<GapFillTarget> gapFillForFile = null;
-                    if (perFileGapFill != null &&
-                        perFileGapFill.TryGetValue(fileName, out var gfList))
-                        gapFillForFile = gfList;
-                    OverlayReconciledIntoBuffer(fdrEntries, reconciledPath, gapFillForFile);
-                    SortFileEntriesCanonical(fdrEntries);
-                    continue;
-                }
-                // About to (re-)rescore this file: clear any stale sidecar
-                // so a mid-Run crash leaves no false-positive pointing at
-                // the partially-written reconciled parquet.
-                if (hasParquetPath)
-                    PerFileResumeDriver.ClearStale(reconciledPath, Name);
-
-                IReadOnlyList<(int Index, double Apex, double Start, double End)> consensusTargets;
-                if (!perFileConsensusTargets.TryGetValue(fileName, out consensusTargets))
-                    consensusTargets = new List<(int, double, double, double)>();
-
-                List<(int Index, double Apex, double Start, double End)> reconTargets;
-                if (!perFileReconTargets.TryGetValue(fileName, out reconTargets))
-                    reconTargets = new List<(int, double, double, double)>();
-
-                // PHASE 2 (gap-fill): per-file gap-fill targets land here.
-                List<GapFillTarget> gapFillTargets;
-                if (perFileGapFill == null ||
-                    !perFileGapFill.TryGetValue(fileName, out gapFillTargets))
-                {
-                    gapFillTargets = new List<GapFillTarget>();
-                }
-
-                // Merge consensus + reconciliation into a per-(idx, override)
-                // map. Reconciliation wins on conflict -- the inter-replicate
-                // peak boundary is more authoritative than the multi-charge
-                // consensus boundary.
-                var combinedTargets =
-                    new Dictionary<int, (double Apex, double Start, double End)>();
-                foreach (var t in consensusTargets)
-                    combinedTargets[t.Index] = (t.Apex, t.Start, t.End);
-                foreach (var t in reconTargets)
-                    combinedTargets[t.Index] = (t.Apex, t.Start, t.End);
-
-                // Skip files with no work to do.
-                if (combinedTargets.Count == 0 && gapFillTargets.Count == 0)
-                    continue;
-
-                if (!fileNameToIdx.TryGetValue(fileName, out int inputIdx))
-                {
-                    ctx.LogWarning(string.Format(
-                        "Stage 6 rescore: no input_files entry for {0} (skipping)", fileName));
-                    continue;
-                }
-                string inputFile = config.InputFiles[inputIdx];
-
-                // Clone the outer config for this file's ScoringContexts.
-                // RunCoelutionScoring reassigns config.FragmentTolerance to
-                // the MS2-calibrated tolerance (AnalysisPipeline.cs ~line 3552);
-                // without a per-file clone the mutation persists on the outer
-                // config, leaks into subsequent files, AND poisons the
-                // WriteReconciledParquet hash stamp (config.Identity.SearchParameterHash()
-                // would then reflect the calibrated tolerance, not the value
-                // a fresh --task MergeNode invocation recomputes from CLI
-                // defaults -- causing search_hash mismatch errors). Mirrors
-                // the per-file clone pattern in ProcessFile.
-                var fileConfig = config.ShallowClone();
-
-                ctx.LogInfo(string.Format(
-                    "Re-scoring file {0}/{1}: {2}", fileNum + 1, nTotalFiles, fileName));
-                ctx.LogInfo(string.Format(
-                    "  {0} entries ({1} consensus, {2} reconciliation, {3} gap-fill, {4} unique after dedup)",
-                    combinedTargets.Count + gapFillTargets.Count * 2,
-                    consensusTargets.Count,
-                    reconTargets.Count,
-                    gapFillTargets.Count,
-                    combinedTargets.Count));
-
-                // Build the per-file scoring subset: boundary_overrides keyed
-                // by entry_id + the subset library RunCoelutionScoring scores.
-                var (boundaryOverrides, subsetLibrary) =
-                    BuildScoringSubset(combinedTargets, fdrEntries, fullLibrary);
-
-                // Load spectra: prefer the .spectra.bin cache the original
-                // Stage 1 wrote; fall back to mzML if the cache is missing
-                // or unreadable.
-                List<Spectrum> spectra;
-                List<MS1Spectrum> ms1Spectra;
-                LoadSpectraForRescore(inputFile, fileName, out spectra, out ms1Spectra, ctx);
-
-                // Load the sibling .calibration.json so the search uses the
-                // same MS2/MS1 mass calibrations the original Stage 1-4 run
-                // used. The file is written by the original ProcessFile call
-                // and read here -- same disk-roundtrip path the worker uses.
-                LoadMassCalibrations(inputFile,
-                    out MzCalibrationResult ms2Cal,
-                    out MzCalibrationResult ms1Cal,
-                    out double? rtMadFromCalJson);
-
-                // Pick the RT calibration: refined (from Stage 6 planning's
-                // calibration refit) wins; original first-pass falls back.
-                if (!refinedCalibrations.TryGetValue(fileName, out RTCalibration rtCal))
-                    perFileCalibrations.TryGetValue(fileName, out rtCal);
-
-                // Bisection seam DISABLED (paired with the per-candidate
-                // WritePredictRtCall, which was removed from the scoring
-                // hotspot). Dumped the cal's library_rts + fitted_values once
-                // per file. Mirrors Rust's dump_predict_rt_arrays at
-                // pipeline.rs ~2886. To restore, re-enable this and the
-                // WritePredictRtCall in CoelutionScorer. See
-                // ai/todos/active/TODO-20260606_ospreysharp_diagnostics_di.md.
-                // if (rtCal != null)
-                // {
-                //     ctx.Diagnostics.WritePredictRtArrays(
-                //         fileName, rtCal.LibraryRts, rtCal.FittedValues);
-                // }
-
-                // Build the scoring context with the boundary overrides.
-                // RunCoelutionScoring inspects context.BoundaryOverrides
-                // inside ScoreCandidate and routes through the override
-                // peak-construction path.
-                var context = new ScoringContext(fileConfig, fileName);
-                context.BoundaryOverrides = boundaryOverrides;
-                context.OriginalRtMad = rtMadFromCalJson;
-
-                // Build isolation windows from the loaded spectra (same as
-                // the first-pass ProcessFile path).
-                var isolationWindows = ExtractIsolationWindows(spectra);
-
-                // Re-score the subset.
-                var swRescore = Stopwatch.StartNew();
-                List<FdrEntry> rescored;
-                if (subsetLibrary.Count > 0)
-                {
-                    rescored = RunCoelutionScoring(
-                        subsetLibrary, spectra, ms1Spectra,
-                        isolationWindows, rtCal,
-                        ms2Cal, ms1Cal,
-                        context, ctx);
-                }
-                else
-                {
-                    rescored = new List<FdrEntry>();
-                }
-                swRescore.Stop();
-
-                // Overlay the re-scored subset back onto the per-file stubs,
-                // resetting discriminant fields to Rust to_fdr_entry defaults.
-                var (nOverlay, nNoPeak) =
-                    OverlayRescoredEntries(fdrEntries, combinedTargets, rescored);
-                totalRescored += nOverlay;
-                if (nNoPeak > 0)
-                {
-                    ctx.LogInfo(string.Format(
-                        "  {0} targets had no peak at override boundary (reset to defaults)",
-                        nNoPeak));
-                }
-
-                ctx.LogInfo(string.Format(
-                    "  {0} of {1} existing entries re-scored ({2:F1}s)",
-                    nOverlay, combinedTargets.Count, swRescore.Elapsed.TotalSeconds));
-
-                // PHASE 2 -- gap-fill two-pass.
-                if (gapFillTargets.Count > 0)
-                {
-                    var (nGapCwt, nGapForced) = RunGapFillTwoPass(
-                        gapFillTargets, fullLibrary, spectra, ms1Spectra,
-                        isolationWindows, rtCal, ms2Cal, ms1Cal,
-                        fileConfig, fileName, rtMadFromCalJson, fdrEntries, ctx);
-                    totalGapCwt += nGapCwt;
-                    totalGapForced += nGapForced;
-                    totalRescored += nGapCwt + nGapForced;
-                }
-
-                // PHASE 3 -- reconciled parquet write-back. Read the original
-                // Stage 4 parquet, write a separate .scores-reconciled.parquet
-                // sibling (leaving the original intact).
-                if (perFileParquetPaths != null &&
-                    perFileParquetPaths.TryGetValue(fileName, out string parquetPath) &&
-                    File.Exists(parquetPath))
-                {
-                    string reconciledOutPath = ParquetScoreCache.ReconciledPathFromScoresPath(parquetPath);
-                    bool wrote = ReconciledParquetWriter.Write(parquetPath, reconciledOutPath, fdrEntries, fileName,
-                        fullLibrary, config, joinFileStems, ctx.LogInfo, ctx.LogWarning);
-
-                    // Only stamp the per-file resume sidecar when the reconciled
-                    // parquet was actually written. Stamping it after a failed
-                    // write could mark a STALE reconciled parquet (left from a
-                    // prior run with a different validity key) as valid, letting
-                    // Stage 7 / a future resume consume old rescored content. On
-                    // failure, clear any such stale output + sidecar so the next
-                    // run re-rescores this file from scratch.
-                    if (wrote)
-                    {
-                        var perFileInputs = new List<string>
-                        {
-                            FdrScoresSidecar.Pass1Path(inputFile),
-                        };
-                        if (config.Reconciliation != null && config.Reconciliation.Enabled)
-                            perFileInputs.Add(ReconciliationFile.PathForInput(inputFile));
-                        PerFileResumeDriver.Stamp(reconciledOutPath, Name, OspreyVersion.Current,
-                            taskValidityKey, perFileInputs, ctx.LogWarning);
-                    }
-                    else
-                    {
-                        // Clear the stale sidecar AND remove the partially-written
-                        // reconciled parquet (output mechanics, the task's own
-                        // concern) so the next run re-rescores from scratch.
-                        PerFileResumeDriver.ClearStale(reconciledOutPath, Name);
-                        try
-                        {
-                            if (File.Exists(reconciledOutPath)) File.Delete(reconciledOutPath);
-                        }
-                        catch (Exception ex)
-                        {
-                            ctx.LogWarning(string.Format(
-                                @"  Failed to remove stale reconciled parquet {0} after a failed write: {1}",
-                                reconciledOutPath, ex.Message));
-                        }
-                    }
-                }
+                var counts = RescoreOneFile(
+                    fileNum, nTotalFiles,
+                    perFileEntries[fileNum].Key, perFileEntries[fileNum].Value,
+                    inputs, ctx);
+                totalRescored += counts.Rescored;
+                totalGapCwt += counts.GapCwt;
+                totalGapForced += counts.GapForced;
             }
 
             return new RescoreStats
@@ -763,6 +534,310 @@ namespace pwiz.OspreySharp.Tasks
                 TotalGapCwt = totalGapCwt,
                 TotalGapForced = totalGapForced,
             };
+        }
+
+        /// <summary>
+        /// Cross-file inputs shared by every <see cref="RescoreOneFile"/> call:
+        /// the planner's per-file byproducts, the library/config, and the
+        /// resume/identity keys. Bundled so the per-file worker takes one
+        /// collaborator object rather than a dozen positional parameters.
+        /// </summary>
+        private sealed class RescorePassInputs
+        {
+            public IReadOnlyDictionary<string, IReadOnlyList<(int Index, double Apex, double Start, double End)>> ConsensusTargets;
+            public IReadOnlyDictionary<string, List<(int Index, double Apex, double Start, double End)>> ReconTargets;
+            public IReadOnlyDictionary<string, RTCalibration> RefinedCalibrations;
+            public IReadOnlyDictionary<string, RTCalibration> PerFileCalibrations;
+            public IReadOnlyDictionary<string, List<GapFillTarget>> GapFill;
+            public IReadOnlyDictionary<string, string> ParquetPaths;
+            public List<LibraryEntry> FullLibrary;
+            public OspreyConfig Config;
+            public Dictionary<string, int> FileNameToIdx;
+            public string TaskValidityKey;
+            public IReadOnlyList<string> JoinFileStems;
+        }
+
+        /// <summary>
+        /// Run the Stage 6 rescore for a single file: resume-skip check, target
+        /// assembly, subset scoring + overlay, gap-fill, and the reconciled
+        /// parquet write-back. The per-file <paramref name="fdrEntries"/> buffer
+        /// is updated in place. Returns the per-file (rescored, gap-CWT,
+        /// gap-forced) counts the caller accumulates. The scoring orchestration
+        /// is kept whole here (parity-locked); only the cross-file plumbing was
+        /// lifted up into <see cref="ExecuteRescore"/>.
+        /// </summary>
+        private (int Rescored, int GapCwt, int GapForced) RescoreOneFile(
+            int fileNum, int nTotalFiles, string fileName, List<FdrEntry> fdrEntries,
+            RescorePassInputs inputs, PipelineContext ctx)
+        {
+            var perFileConsensusTargets = inputs.ConsensusTargets;
+            var perFileReconTargets = inputs.ReconTargets;
+            var refinedCalibrations = inputs.RefinedCalibrations;
+            var perFileCalibrations = inputs.PerFileCalibrations;
+            var perFileGapFill = inputs.GapFill;
+            var perFileParquetPaths = inputs.ParquetPaths;
+            var fullLibrary = inputs.FullLibrary;
+            var config = inputs.Config;
+            var fileNameToIdx = inputs.FileNameToIdx;
+            string taskValidityKey = inputs.TaskValidityKey;
+            var joinFileStems = inputs.JoinFileStems;
+
+            int totalRescored = 0;
+            int totalGapCwt = 0;
+            int totalGapForced = 0;
+
+            // Per-file resume: if the file's reconciled parquet is
+            // already on disk with a matching <output>.PerFileRescore.osprey.task
+            // sidecar, skip the rescore for that file. Pairs with the
+            // worker (stage6) crash-resume contract: re-invoking the
+            // same CLI on the same inputs is a no-op for files whose
+            // rescore completed; only files missing a valid sidecar
+            // get re-rescored. The skipped file's in-memory entries
+            // remain at the pre-rescore state (1st-pass overlay)
+            // because the worker's StopAfter terminates the pipeline
+            // here -- no downstream consumer reads them.
+            // The rescore READS the original Stage 4 parquet and WRITES a
+            // separate <stem>.scores-reconciled.parquet. Resume validity is
+            // keyed on the reconciled output (the task's declared Output),
+            // not on the original read source.
+            bool hasParquetPath = perFileParquetPaths.TryGetValue(fileName, out string perFileParquetPath);
+            string reconciledPath = hasParquetPath
+                ? ParquetScoreCache.ReconciledPathFromScoresPath(perFileParquetPath)
+                : null;
+            if (hasParquetPath
+                && PerFileResumeDriver.IsCurrent(reconciledPath, Name, taskValidityKey))
+            {
+                ctx.LogInfo(string.Format(
+                    @"[file] {0}/{1} {2}: skipping (outputs valid)",
+                    fileNum + 1, nTotalFiles, fileName));
+
+                // PR-E: a partial resume skips this already-rescored file, but
+                // a downstream consumer (MergeNode, in the full pipeline) reads
+                // ApexRt/StartRt/EndRt/BoundsArea straight off these in-memory
+                // entries. Without overlaying the reconciled values they stay at
+                // the 1st-pass state and the final blib carries 1st-pass RTs.
+                // Reproduce the fresh end state in place from the valid reconciled
+                // parquet we just confirmed on disk + this file's gap-fill targets.
+                IReadOnlyList<GapFillTarget> gapFillForFile = null;
+                if (perFileGapFill != null &&
+                    perFileGapFill.TryGetValue(fileName, out var gfList))
+                    gapFillForFile = gfList;
+                OverlayReconciledIntoBuffer(fdrEntries, reconciledPath, gapFillForFile);
+                SortFileEntriesCanonical(fdrEntries);
+                return (totalRescored, totalGapCwt, totalGapForced);
+            }
+            // About to (re-)rescore this file: clear any stale sidecar
+            // so a mid-Run crash leaves no false-positive pointing at
+            // the partially-written reconciled parquet.
+            if (hasParquetPath)
+                PerFileResumeDriver.ClearStale(reconciledPath, Name);
+
+            IReadOnlyList<(int Index, double Apex, double Start, double End)> consensusTargets;
+            if (!perFileConsensusTargets.TryGetValue(fileName, out consensusTargets))
+                consensusTargets = new List<(int, double, double, double)>();
+
+            List<(int Index, double Apex, double Start, double End)> reconTargets;
+            if (!perFileReconTargets.TryGetValue(fileName, out reconTargets))
+                reconTargets = new List<(int, double, double, double)>();
+
+            // PHASE 2 (gap-fill): per-file gap-fill targets land here.
+            List<GapFillTarget> gapFillTargets;
+            if (perFileGapFill == null ||
+                !perFileGapFill.TryGetValue(fileName, out gapFillTargets))
+            {
+                gapFillTargets = new List<GapFillTarget>();
+            }
+
+            // Merge consensus + reconciliation into a per-(idx, override)
+            // map. Reconciliation wins on conflict -- the inter-replicate
+            // peak boundary is more authoritative than the multi-charge
+            // consensus boundary.
+            var combinedTargets =
+                new Dictionary<int, (double Apex, double Start, double End)>();
+            foreach (var t in consensusTargets)
+                combinedTargets[t.Index] = (t.Apex, t.Start, t.End);
+            foreach (var t in reconTargets)
+                combinedTargets[t.Index] = (t.Apex, t.Start, t.End);
+
+            // Skip files with no work to do.
+            if (combinedTargets.Count == 0 && gapFillTargets.Count == 0)
+                return (totalRescored, totalGapCwt, totalGapForced);
+
+            if (!fileNameToIdx.TryGetValue(fileName, out int inputIdx))
+            {
+                ctx.LogWarning(string.Format(
+                    "Stage 6 rescore: no input_files entry for {0} (skipping)", fileName));
+                return (totalRescored, totalGapCwt, totalGapForced);
+            }
+            string inputFile = config.InputFiles[inputIdx];
+
+            // Clone the outer config for this file's ScoringContexts.
+            // RunCoelutionScoring reassigns config.FragmentTolerance to
+            // the MS2-calibrated tolerance (AnalysisPipeline.cs ~line 3552);
+            // without a per-file clone the mutation persists on the outer
+            // config, leaks into subsequent files, AND poisons the
+            // WriteReconciledParquet hash stamp (config.Identity.SearchParameterHash()
+            // would then reflect the calibrated tolerance, not the value
+            // a fresh --task MergeNode invocation recomputes from CLI
+            // defaults -- causing search_hash mismatch errors). Mirrors
+            // the per-file clone pattern in ProcessFile.
+            var fileConfig = config.ShallowClone();
+
+            ctx.LogInfo(string.Format(
+                "Re-scoring file {0}/{1}: {2}", fileNum + 1, nTotalFiles, fileName));
+            ctx.LogInfo(string.Format(
+                "  {0} entries ({1} consensus, {2} reconciliation, {3} gap-fill, {4} unique after dedup)",
+                combinedTargets.Count + gapFillTargets.Count * 2,
+                consensusTargets.Count,
+                reconTargets.Count,
+                gapFillTargets.Count,
+                combinedTargets.Count));
+
+            // Build the per-file scoring subset: boundary_overrides keyed
+            // by entry_id + the subset library RunCoelutionScoring scores.
+            var (boundaryOverrides, subsetLibrary) =
+                BuildScoringSubset(combinedTargets, fdrEntries, fullLibrary);
+
+            // Load spectra: prefer the .spectra.bin cache the original
+            // Stage 1 wrote; fall back to mzML if the cache is missing
+            // or unreadable.
+            List<Spectrum> spectra;
+            List<MS1Spectrum> ms1Spectra;
+            LoadSpectraForRescore(inputFile, fileName, out spectra, out ms1Spectra, ctx);
+
+            // Load the sibling .calibration.json so the search uses the
+            // same MS2/MS1 mass calibrations the original Stage 1-4 run
+            // used. The file is written by the original ProcessFile call
+            // and read here -- same disk-roundtrip path the worker uses.
+            LoadMassCalibrations(inputFile,
+                out MzCalibrationResult ms2Cal,
+                out MzCalibrationResult ms1Cal,
+                out double? rtMadFromCalJson);
+
+            // Pick the RT calibration: refined (from Stage 6 planning's
+            // calibration refit) wins; original first-pass falls back.
+            if (!refinedCalibrations.TryGetValue(fileName, out RTCalibration rtCal))
+                perFileCalibrations.TryGetValue(fileName, out rtCal);
+
+            // Bisection seam DISABLED (paired with the per-candidate
+            // WritePredictRtCall, which was removed from the scoring
+            // hotspot). Dumped the cal's library_rts + fitted_values once
+            // per file. Mirrors Rust's dump_predict_rt_arrays at
+            // pipeline.rs ~2886. To restore, re-enable this and the
+            // WritePredictRtCall in CoelutionScorer. See
+            // ai/todos/active/TODO-20260606_ospreysharp_diagnostics_di.md.
+            // if (rtCal != null)
+            // {
+            //     ctx.Diagnostics.WritePredictRtArrays(
+            //         fileName, rtCal.LibraryRts, rtCal.FittedValues);
+            // }
+
+            // Build the scoring context with the boundary overrides.
+            // RunCoelutionScoring inspects context.BoundaryOverrides
+            // inside ScoreCandidate and routes through the override
+            // peak-construction path.
+            var context = new ScoringContext(fileConfig, fileName);
+            context.BoundaryOverrides = boundaryOverrides;
+            context.OriginalRtMad = rtMadFromCalJson;
+
+            // Build isolation windows from the loaded spectra (same as
+            // the first-pass ProcessFile path).
+            var isolationWindows = ExtractIsolationWindows(spectra);
+
+            // Re-score the subset.
+            var swRescore = Stopwatch.StartNew();
+            List<FdrEntry> rescored;
+            if (subsetLibrary.Count > 0)
+            {
+                rescored = RunCoelutionScoring(
+                    subsetLibrary, spectra, ms1Spectra,
+                    isolationWindows, rtCal,
+                    ms2Cal, ms1Cal,
+                    context, ctx);
+            }
+            else
+            {
+                rescored = new List<FdrEntry>();
+            }
+            swRescore.Stop();
+
+            // Overlay the re-scored subset back onto the per-file stubs,
+            // resetting discriminant fields to Rust to_fdr_entry defaults.
+            var (nOverlay, nNoPeak) =
+                OverlayRescoredEntries(fdrEntries, combinedTargets, rescored);
+            totalRescored += nOverlay;
+            if (nNoPeak > 0)
+            {
+                ctx.LogInfo(string.Format(
+                    "  {0} targets had no peak at override boundary (reset to defaults)",
+                    nNoPeak));
+            }
+
+            ctx.LogInfo(string.Format(
+                "  {0} of {1} existing entries re-scored ({2:F1}s)",
+                nOverlay, combinedTargets.Count, swRescore.Elapsed.TotalSeconds));
+
+            // PHASE 2 -- gap-fill two-pass.
+            if (gapFillTargets.Count > 0)
+            {
+                var (nGapCwt, nGapForced) = RunGapFillTwoPass(
+                    gapFillTargets, fullLibrary, spectra, ms1Spectra,
+                    isolationWindows, rtCal, ms2Cal, ms1Cal,
+                    fileConfig, fileName, rtMadFromCalJson, fdrEntries, ctx);
+                totalGapCwt += nGapCwt;
+                totalGapForced += nGapForced;
+                totalRescored += nGapCwt + nGapForced;
+            }
+
+            // PHASE 3 -- reconciled parquet write-back. Read the original
+            // Stage 4 parquet, write a separate .scores-reconciled.parquet
+            // sibling (leaving the original intact). perFileParquetPaths is
+            // non-null here (dereferenced at the resume probe above).
+            if (perFileParquetPaths.TryGetValue(fileName, out string parquetPath) &&
+                File.Exists(parquetPath))
+            {
+                string reconciledOutPath = ParquetScoreCache.ReconciledPathFromScoresPath(parquetPath);
+                bool wrote = ReconciledParquetWriter.Write(parquetPath, reconciledOutPath, fdrEntries, fileName,
+                    fullLibrary, config, joinFileStems, ctx.LogInfo, ctx.LogWarning);
+
+                // Only stamp the per-file resume sidecar when the reconciled
+                // parquet was actually written. Stamping it after a failed
+                // write could mark a STALE reconciled parquet (left from a
+                // prior run with a different validity key) as valid, letting
+                // Stage 7 / a future resume consume old rescored content. On
+                // failure, clear any such stale output + sidecar so the next
+                // run re-rescores this file from scratch.
+                if (wrote)
+                {
+                    var perFileInputs = new List<string>
+                    {
+                        FdrScoresSidecar.Pass1Path(inputFile),
+                    };
+                    if (config.Reconciliation != null && config.Reconciliation.Enabled)
+                        perFileInputs.Add(ReconciliationFile.PathForInput(inputFile));
+                    PerFileResumeDriver.Stamp(reconciledOutPath, Name, OspreyVersion.Current,
+                        taskValidityKey, perFileInputs, ctx.LogWarning);
+                }
+                else
+                {
+                    // Clear the stale sidecar AND remove the partially-written
+                    // reconciled parquet (output mechanics, the task's own
+                    // concern) so the next run re-rescores from scratch.
+                    PerFileResumeDriver.ClearStale(reconciledOutPath, Name);
+                    try
+                    {
+                        if (File.Exists(reconciledOutPath)) File.Delete(reconciledOutPath);
+                    }
+                    catch (Exception ex)
+                    {
+                        ctx.LogWarning(string.Format(
+                            @"  Failed to remove stale reconciled parquet {0} after a failed write: {1}",
+                            reconciledOutPath, ex.Message));
+                    }
+                }
+            }
+
+            return (totalRescored, totalGapCwt, totalGapForced);
         }
 
         /// <summary>

--- a/pwiz_tools/OspreySharp/OspreySharp.Tasks/PerFileRescoreTask.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Tasks/PerFileRescoreTask.cs
@@ -523,8 +523,7 @@ namespace pwiz.OspreySharp.Tasks
                     ? ParquetScoreCache.ReconciledPathFromScoresPath(perFileParquetPath)
                     : null;
                 if (hasParquetPath
-                    && File.Exists(reconciledPath)
-                    && TaskValiditySidecar.IsValid(reconciledPath, Name, taskValidityKey))
+                    && PerFileResumeDriver.IsCurrent(reconciledPath, Name, taskValidityKey))
                 {
                     ctx.LogInfo(string.Format(
                         @"[file] {0}/{1} {2}: skipping (outputs valid)",
@@ -549,7 +548,7 @@ namespace pwiz.OspreySharp.Tasks
                 // so a mid-Run crash leaves no false-positive pointing at
                 // the partially-written reconciled parquet.
                 if (hasParquetPath)
-                    TaskValiditySidecar.Delete(reconciledPath, Name);
+                    PerFileResumeDriver.ClearStale(reconciledPath, Name);
 
                 IReadOnlyList<(int Index, double Apex, double Start, double End)> consensusTargets;
                 if (!perFileConsensusTargets.TryGetValue(fileName, out consensusTargets))
@@ -734,21 +733,15 @@ namespace pwiz.OspreySharp.Tasks
                         };
                         if (config.Reconciliation != null && config.Reconciliation.Enabled)
                             perFileInputs.Add(ReconciliationFile.PathForInput(inputFile));
-                        try
-                        {
-                            TaskValiditySidecar.Write(reconciledOutPath, Name, OspreyVersion.Current,
-                                taskValidityKey, perFileInputs);
-                        }
-                        catch (Exception ex)
-                        {
-                            ctx.LogWarning(string.Format(
-                                @"  Failed to write {0} sidecar for {1}: {2}",
-                                Name, reconciledOutPath, ex.Message));
-                        }
+                        PerFileResumeDriver.Stamp(reconciledOutPath, Name, OspreyVersion.Current,
+                            taskValidityKey, perFileInputs, ctx.LogWarning);
                     }
                     else
                     {
-                        TaskValiditySidecar.Delete(reconciledOutPath, Name);
+                        // Clear the stale sidecar AND remove the partially-written
+                        // reconciled parquet (output mechanics, the task's own
+                        // concern) so the next run re-rescores from scratch.
+                        PerFileResumeDriver.ClearStale(reconciledOutPath, Name);
                         try
                         {
                             if (File.Exists(reconciledOutPath)) File.Delete(reconciledOutPath);

--- a/pwiz_tools/OspreySharp/OspreySharp.Tasks/PerFileRescoreTask.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Tasks/PerFileRescoreTask.cs
@@ -449,144 +449,6 @@ namespace pwiz.OspreySharp.Tasks
         // accessors. Run() above is the only entry point.
 
         /// <summary>
-        /// Phase 3 -- write the reconciled per-file
-        /// <c>.scores-reconciled.parquet</c>.
-        ///
-        /// Reload the original Stage 4 parquet's full per-row data
-        /// (identity, boundaries, 21 PIN features, CWT candidate lists) from
-        /// <paramref name="originalPath"/>, replace re-scored rows in place by
-        /// <see cref="FdrEntry.ParquetIndex"/> (NOT by post-compaction Vec
-        /// position; the two diverge after first-pass FDR drops non-passing
-        /// entries), append gap-fill rows at the end, reassign each gap-fill
-        /// stub's <see cref="FdrEntry.ParquetIndex"/> to the actual row it now
-        /// occupies, then write to the SEPARATE
-        /// <paramref name="reconciledPath"/> via
-        /// <see cref="ParquetScoreCache.WriteScoresParquet(string, List{FdrEntry}, Dictionary{string, string}, Dictionary{uint, LibraryEntry}, string)"/>
-        /// with reconciliation metadata
-        /// (<c>osprey.reconciled = "true"</c> +
-        /// <c>osprey.reconciliation_hash = config.Identity.ReconciliationParameterHash()</c>).
-        /// The original parquet is read-only here -- it is never overwritten,
-        /// so it survives intact for files whose reconciliation is a no-op and
-        /// as a crash-safe Stage 4 record. Mirrors Rust pipeline.rs:3050-3110.
-        /// Returns true when the reconciled parquet was written; false on a
-        /// reload/write failure (so the caller does not stamp a validity sidecar
-        /// over a stale or absent output).
-        /// </summary>
-        private bool WriteReconciledParquet(string originalPath, string reconciledPath,
-            List<FdrEntry> fdrEntries,
-            string fileName, List<LibraryEntry> fullLibrary, OspreyConfig config,
-            IReadOnlyList<string> joinFileStems, PipelineContext ctx)
-        {
-            // 1. Reload the original parquet's per-row state (read-only).
-            List<FdrEntry> fullEntries;
-            try
-            {
-                fullEntries = ParquetScoreCache.LoadFullFdrEntries(originalPath);
-            }
-            catch (Exception ex)
-            {
-                ctx.LogWarning(string.Format(
-                    "Stage 6 write-back: failed to reload {0}: {1} (skipping)",
-                    originalPath, ex.Message));
-                return false;
-            }
-            int origRowCount = fullEntries.Count;
-
-            // 2. Replace re-scored rows (Phase 1 + Phase 2 existing-entry
-            //    overlay) by ParquetIndex. Detect rescored entries by
-            //    Features != null -- hydration's LoadFdrStubsFromParquet
-            //    does NOT populate Features, so unchanged post-compaction
-            //    stubs have Features=null and we leave their corresponding
-            //    fullEntries row alone (preserving Features + CwtCandidates
-            //    + the binary blob columns loaded from the original
-            //    parquet). Rescored entries have Features populated by
-            //    RunCoelutionScoring. Gap-fill stubs have ParquetIndex =
-            //    uint.MaxValue and are appended next.
-            int nReplaced = 0;
-            foreach (var entry in fdrEntries)
-            {
-                if (entry.ParquetIndex == uint.MaxValue)
-                    continue;
-                if (entry.Features == null)
-                    continue;  // hydrated stub, never re-scored
-                int pqIdx = (int)entry.ParquetIndex;
-                if (pqIdx < 0 || pqIdx >= fullEntries.Count)
-                {
-                    ctx.LogWarning(string.Format(
-                        "Stage 6 write-back: ParquetIndex {0} out of range for {1} ({2} rows)",
-                        pqIdx, fileName, fullEntries.Count));
-                    continue;
-                }
-                fullEntries[pqIdx] = entry;
-                nReplaced++;
-            }
-
-            // 3. Append gap-fill rows at the end. Reassign each gap-fill
-            //    stub's ParquetIndex to its new row position so a
-            //    downstream --task MergeNode worker can locate its
-            //    features.
-            int nAppended = 0;
-            foreach (var entry in fdrEntries)
-            {
-                if (entry.ParquetIndex != uint.MaxValue)
-                    continue;
-                entry.ParquetIndex = (uint)fullEntries.Count;
-                fullEntries.Add(entry);
-                nAppended++;
-            }
-
-            // 4. Build libraryById for the WriteScoresParquet sequence /
-            //    precursor_mz / protein_ids columns.
-            var libraryById = new Dictionary<uint, LibraryEntry>(fullLibrary.Count);
-            foreach (var libEntry in fullLibrary)
-                libraryById[libEntry.Id] = libEntry;
-
-            // 5. Reconciliation metadata (mirrors Rust
-            //    build_reconciled_metadata). osprey.version is what the
-            //    next reload's CacheValidity check compares against.
-            //    The reconciliation_hash must be the JOIN-wide hash
-            //    (over every file in the planner step), not the worker's
-            //    single-file InputFiles hash; without that, a worker
-            //    rescoring a single parquet stamps a single-file hash
-            //    that the downstream --task MergeNode merge node rejects
-            //    on hash mismatch. The join file stems come from the
-            //    planner's reconciliation.json (v2+) via
-            //    RescoreInputs.JoinFileStems; fall back to config-derived
-            //    stems when the caller didn't pass any (in-process
-            //    pipeline where config.InputFiles already has all files,
-            //    or v1 backward compat).
-            string reconciliationHash = (joinFileStems != null && joinFileStems.Count > 0)
-                ? config.Identity.ReconciliationParameterHashForStems(joinFileStems)
-                : config.Identity.ReconciliationParameterHash();
-            var metadata = new Dictionary<string, string>
-            {
-                { @"osprey.version", OspreyVersion.Current },
-                { @"osprey.search_hash", config.Identity.SearchParameterHash() },
-                { @"osprey.library_hash", config.Identity.LibraryIdentityHash() },
-                { @"osprey.reconciled", @"true" },
-                { @"osprey.reconciliation_hash", reconciliationHash },
-            };
-
-            try
-            {
-                ParquetScoreCache.WriteScoresParquet(reconciledPath, fullEntries,
-                    metadata, libraryById, fileName);
-            }
-            catch (Exception ex)
-            {
-                ctx.LogWarning(string.Format(
-                    "Stage 6 write-back: failed to write reconciled scores for {0}: {1}",
-                    fileName, ex.Message));
-                return false;
-            }
-
-            ctx.LogInfo(string.Format(
-                "  Wrote reconciled parquet for {0}: {1} rows ({2} replaced + {3} appended; original {4} rows)",
-                fileName, fullEntries.Count, nReplaced, nAppended, origRowCount));
-            return true;
-        }
-
-        /// <summary>
         /// Execute the per-file Stage 6 rescore loop. Mirrors
         /// <c>rescore_per_file_loop</c> in
         /// <c>osprey/crates/osprey/src/pipeline.rs</c>.
@@ -854,8 +716,8 @@ namespace pwiz.OspreySharp.Tasks
                     File.Exists(parquetPath))
                 {
                     string reconciledOutPath = ParquetScoreCache.ReconciledPathFromScoresPath(parquetPath);
-                    bool wrote = WriteReconciledParquet(parquetPath, reconciledOutPath, fdrEntries, fileName,
-                        fullLibrary, config, joinFileStems, ctx);
+                    bool wrote = ReconciledParquetWriter.Write(parquetPath, reconciledOutPath, fdrEntries, fileName,
+                        fullLibrary, config, joinFileStems, ctx.LogInfo, ctx.LogWarning);
 
                     // Only stamp the per-file resume sidecar when the reconciled
                     // parquet was actually written. Stamping it after a failed

--- a/pwiz_tools/OspreySharp/OspreySharp.Tasks/PerFileRescoreTask.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Tasks/PerFileRescoreTask.cs
@@ -826,7 +826,8 @@ namespace pwiz.OspreySharp.Tasks
                     PerFileResumeDriver.ClearStale(reconciledOutPath, Name);
                     try
                     {
-                        if (File.Exists(reconciledOutPath)) File.Delete(reconciledOutPath);
+                        if (File.Exists(reconciledOutPath))
+                            File.Delete(reconciledOutPath);
                     }
                     catch (Exception ex)
                     {

--- a/pwiz_tools/OspreySharp/OspreySharp.Tasks/PerFileResumeDriver.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Tasks/PerFileResumeDriver.cs
@@ -1,0 +1,92 @@
+/*
+ * Original author: Brendan MacLean <brendanx .at. uw.edu>,
+ *                  MacCoss Lab, Department of Genome Sciences, UW
+ * AI assistance: Claude Code (Claude Opus 4.8) <noreply .at. anthropic.com>
+ *
+ * Based on osprey (https://github.com/MacCossLab/osprey)
+ *   by Michael J. MacCoss, MacCoss Lab, Department of Genome Sciences, UW
+ *
+ * Copyright 2026 University of Washington - Seattle, WA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+
+namespace pwiz.OspreySharp.Tasks
+{
+    /// <summary>
+    /// The per-file resume sidecar mechanics shared by the two per-file tasks
+    /// (<see cref="PerFileScoringTask"/> and <see cref="PerFileRescoreTask"/>):
+    /// probe an output for a current validity sidecar, clear a stale one before
+    /// recomputing, and stamp a fresh one after a successful write. Each task
+    /// keeps its own load / compute / output shape; only the
+    /// <see cref="TaskValiditySidecar"/> dance is centralized here so the two
+    /// tasks cannot drift on it.
+    ///
+    /// This is sidecar mechanics only -- it never touches the task's actual
+    /// output file. (A task that must delete a failed output, e.g. the rescore
+    /// task removing a partially-written reconciled parquet, does that itself.)
+    /// </summary>
+    internal static class PerFileResumeDriver
+    {
+        /// <summary>
+        /// True when <paramref name="outputPath"/> exists on disk AND carries a
+        /// validity sidecar for <paramref name="taskName"/> whose key matches
+        /// <paramref name="validityKey"/> -- i.e. the output is durably present
+        /// and can be reused instead of recomputed. The file-existence gate
+        /// matters: a sidecar can outlive its output (or a different invocation
+        /// may have left one), so a matching key alone is not enough.
+        /// </summary>
+        internal static bool IsCurrent(string outputPath, string taskName, string validityKey)
+        {
+            return File.Exists(outputPath)
+                && TaskValiditySidecar.IsValid(outputPath, taskName, validityKey);
+        }
+
+        /// <summary>
+        /// Remove any validity sidecar for the (output, task) pair so a stale one
+        /// cannot mark a partially-written or superseded output as valid. Called
+        /// before recomputing an output and after a failed write. Best-effort;
+        /// never throws.
+        /// </summary>
+        internal static void ClearStale(string outputPath, string taskName)
+        {
+            TaskValiditySidecar.Delete(outputPath, taskName);
+        }
+
+        /// <summary>
+        /// Stamp a fresh validity sidecar next to <paramref name="outputPath"/>
+        /// after a successful write. A sidecar-write failure is non-fatal -- the
+        /// output is already on disk; we just lose the ability to skip it on a
+        /// later resume -- so the failure is logged via
+        /// <paramref name="logWarning"/> and swallowed rather than thrown.
+        /// </summary>
+        internal static void Stamp(string outputPath, string taskName, string version,
+            string validityKey, IEnumerable<string> inputs, Action<string> logWarning)
+        {
+            try
+            {
+                TaskValiditySidecar.Write(outputPath, taskName, version, validityKey, inputs);
+            }
+            catch (Exception ex)
+            {
+                logWarning(string.Format(
+                    @"  Failed to write {0} sidecar for {1}: {2}",
+                    taskName, outputPath, ex.Message));
+            }
+        }
+    }
+}

--- a/pwiz_tools/OspreySharp/OspreySharp.Tasks/PerFileScoringTask.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Tasks/PerFileScoringTask.cs
@@ -993,8 +993,7 @@ namespace pwiz.OspreySharp.Tasks
             PipelineContext ctx)
         {
             string scoresPath = ParquetScoreCache.GetScoresPath(inputFile);
-            if (File.Exists(scoresPath)
-                && TaskValiditySidecar.IsValid(scoresPath, Name, validityKey))
+            if (PerFileResumeDriver.IsCurrent(scoresPath, Name, validityKey))
             {
                 var loaded = TryLoadStubsAndCalibration(scoresPath, fileName, perFileCalibrations, ctx);
                 if (loaded != null)
@@ -1012,21 +1011,12 @@ namespace pwiz.OspreySharp.Tasks
                 fileIdx + 1, totalFiles, inputFile));
             // Clear stale sidecar so a mid-ProcessFile crash leaves no
             // false-positive sidecar on the next invocation.
-            TaskValiditySidecar.Delete(scoresPath, Name);
+            PerFileResumeDriver.ClearStale(scoresPath, Name);
             var fileResult = ProcessFile(inputFile, fileName, fullLibrary, config, parquetFooterMetadata, perFileCalibrations, ctx);
             if (fileResult != null)
             {
-                try
-                {
-                    TaskValiditySidecar.Write(scoresPath, Name, OspreyVersion.Current,
-                        validityKey, new[] { inputFile });
-                }
-                catch (Exception ex)
-                {
-                    ctx.LogWarning(string.Format(
-                        @"  Failed to write {0} sidecar for {1}: {2}",
-                        Name, scoresPath, ex.Message));
-                }
+                PerFileResumeDriver.Stamp(scoresPath, Name, OspreyVersion.Current,
+                    validityKey, new[] { inputFile }, ctx.LogWarning);
             }
             return fileResult;
         }

--- a/pwiz_tools/OspreySharp/OspreySharp.Tasks/PerFileScoringTask.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Tasks/PerFileScoringTask.cs
@@ -1189,10 +1189,127 @@ namespace pwiz.OspreySharp.Tasks
             ctx.LogInfo(string.Format("[COUNT] Isolation windows [{0}]: {1}",
                 fileName, isolationWindows.Count));
 
-            // RT calibration
+            // Resolve the per-file calibration (load a cached/Rust JSON or
+            // compute via Calibrator) and persist the calibration JSON.
+            RTCalibration rtCalibration = ResolveCalibration(
+                inputFile, fileName, fullLibrary, spectra, ms1Spectra,
+                context, config, out MzCalibrationResult ms2Cal, out MzCalibrationResult ms1Cal, ctx);
+
+            // Optional early exit after Stage 3 (calibration only, no main search).
+            // Used for Stage 1-3 perf benchmarking and walking up to the main
+            // search incrementally without paying the Stage 4 cost.
+            if (OspreyEnvironment.ExitAfterCalibration)
+            {
+                ctx.LogInfo("[BENCH] OSPREY_EXIT_AFTER_CALIBRATION set - exiting after Stage 3 (calibration done)");
+                return new List<FdrEntry>();
+            }
+
+            // Surface the per-file calibration to Stage 6 reconciliation
+            // (multi-file runs only). Threaded calls share a
+            // ConcurrentDictionary; null on single-file paths that don't
+            // need cross-file consensus.
+            if (perFileCalibrationsOut != null && rtCalibration != null)
+                perFileCalibrationsOut[fileName] = rtCalibration;
+
+            // Run coelution scoring across all isolation windows
+            var swScoring = Stopwatch.StartNew();
+            var scoredEntries = RunCoelutionScoring(
+                fullLibrary, spectra, ms1Spectra,
+                isolationWindows, rtCalibration,
+                ms2Cal, ms1Cal,
+                context, ctx);
+            swScoring.Stop();
+            double scoringSeconds = swScoring.Elapsed.TotalSeconds;
+            double ratePerSec = scoringSeconds > 0.001
+                ? scoredEntries.Count / scoringSeconds
+                : 0.0;
+            ctx.LogInfo(string.Format(
+                "[TIMING] Coelution scoring: {0:F1}s ({1} candidates, {2:F0} cand/s)",
+                scoringSeconds, scoredEntries.Count, ratePerSec));
+
+            int nScoredTargets = scoredEntries.Count(e => !e.IsDecoy);
+            int nScoredDecoys = scoredEntries.Count(e => e.IsDecoy);
+            ctx.LogInfo(string.Format("Scored {0} entries ({1} targets, {2} decoys) for {3}",
+                scoredEntries.Count,
+                nScoredTargets,
+                nScoredDecoys,
+                fileName));
+
+            // Drop double-counted entries (different precursors that latch
+            // onto the same chromatographic feature within an isolation
+            // window). Mirrors osprey/crates/osprey/src/pipeline.rs at the
+            // same call site, between scoring and pair-deduplication.
+            scoredEntries = DeduplicateDoubleCounting(
+                scoredEntries, fullLibrary, spectra, ms2Cal,
+                isolationWindows, config, ctx);
+            nScoredTargets = scoredEntries.Count(e => !e.IsDecoy);
+            nScoredDecoys = scoredEntries.Count(e => e.IsDecoy);
+            ctx.LogInfo(string.Format(
+                "[COUNT] Coelution scored [{0}]: {1} entries ({2} targets, {3} decoys)",
+                fileName, scoredEntries.Count, nScoredTargets, nScoredDecoys));
+
+            // Deduplicate: keep best target and best decoy per base_id
+            int nBeforeDedup = scoredEntries.Count;
+            scoredEntries = DeduplicatePairs(scoredEntries, ctx);
+            int nAfterDedup = scoredEntries.Count;
+            ctx.LogInfo(string.Format(
+                "[COUNT] Deduplication [{0}]: {1} -> {2} ({3} removed)",
+                fileName, nBeforeDedup, nAfterDedup, nBeforeDedup - nAfterDedup));
+
+            // Optional: write per-entry feature TSV for comparison against Rust's PIN output
+            if (config.WritePin)
+            {
+                WriteFeatureDump(inputFile, fileName, scoredEntries, ctx);
+            }
+
+            // Persist the full FdrEntry results (with features) to
+            // {stem}.scores.parquet so (a) Stage 6 reconciliation can lazy-load
+            // CWT candidates per file, and (b) a subsequent --task FirstJoin
+            // invocation can pick them up without re-running Stages 1-4.
+            // Same path convention as Rust (`scores_path_for_input`).
+            // Snappy-compressed; cross-impl ZSTD/Snappy compatibility tracked
+            // as a Phase 4 follow-up. The metadata dictionary is precomputed
+            // in Run() against the original (un-mutated) outer config — see
+            // Run() for why. Skipped only in --task FirstJoin mode (no Stages 1-4
+            // ran here, so there is nothing fresh to persist).
+            if (parquetFooterMetadata != null)
+            {
+                string parquetPath = ParquetScoreCache.GetScoresPath(inputFile);
+                // Reuse the entry-id -> LibraryEntry map Run() built once
+                // before the per-file fan-out (WriteScoresParquet needs
+                // it to pull sequence / precursor_mz / protein_ids from
+                // the library since FdrEntry doesn't carry these).
+                var swParquet = Stopwatch.StartNew();
+                ParquetScoreCache.WriteScoresParquet(
+                    parquetPath, scoredEntries, parquetFooterMetadata, _libraryById, fileName);
+                swParquet.Stop();
+                ctx.LogInfo(string.Format(
+                    "Wrote {0} scored entries to {1} ({2:F1}s)",
+                    scoredEntries.Count, parquetPath, swParquet.Elapsed.TotalSeconds));
+            }
+
+            return scoredEntries;
+        }
+
+        /// <summary>
+        /// Resolve the per-file RT/MS1/MS2 calibration: load a cached/Rust
+        /// calibration JSON when OSPREY_LOAD_CALIBRATION points at one, else
+        /// compute it via <see cref="Calibrator"/>; then persist the full
+        /// calibration JSON next to the input. Returns the RT calibration (null
+        /// when disabled / not computed); <paramref name="ms2Cal"/> and
+        /// <paramref name="ms1Cal"/> receive the mass calibrations (Uncalibrated
+        /// when none). Extracted from ProcessFile (pure code motion).
+        /// </summary>
+        private RTCalibration ResolveCalibration(
+            string inputFile, string fileName,
+            List<LibraryEntry> fullLibrary, List<Spectrum> spectra, List<MS1Spectrum> ms1Spectra,
+            ScoringContext context, OspreyConfig config,
+            out MzCalibrationResult ms2Cal, out MzCalibrationResult ms1Cal,
+            PipelineContext ctx)
+        {
             RTCalibration rtCalibration = null;
-            MzCalibrationResult ms2Cal = MzCalibrationResult.Uncalibrated();
-            MzCalibrationResult ms1Cal = MzCalibrationResult.Uncalibrated();
+            ms2Cal = MzCalibrationResult.Uncalibrated();
+            ms1Cal = MzCalibrationResult.Uncalibrated();
             // Total matches scored during pass 1 of calibration; threaded
             // into CalibrationMetadata.NumSampledPrecursors to match Rust's
             // accumulated_matches.len() (Stellar Single: 192289). Stays 0
@@ -1306,100 +1423,7 @@ namespace pwiz.OspreySharp.Tasks
                 ctx.LogInfo("Warning: failed to save calibration JSON: " + ex.Message);
             }
 
-            // Optional early exit after Stage 3 (calibration only, no main search).
-            // Used for Stage 1-3 perf benchmarking and walking up to the main
-            // search incrementally without paying the Stage 4 cost.
-            if (OspreyEnvironment.ExitAfterCalibration)
-            {
-                ctx.LogInfo("[BENCH] OSPREY_EXIT_AFTER_CALIBRATION set - exiting after Stage 3 (calibration done)");
-                return new List<FdrEntry>();
-            }
-
-            // Surface the per-file calibration to Stage 6 reconciliation
-            // (multi-file runs only). Threaded calls share a
-            // ConcurrentDictionary; null on single-file paths that don't
-            // need cross-file consensus.
-            if (perFileCalibrationsOut != null && rtCalibration != null)
-                perFileCalibrationsOut[fileName] = rtCalibration;
-
-            // Run coelution scoring across all isolation windows
-            var swScoring = Stopwatch.StartNew();
-            var scoredEntries = RunCoelutionScoring(
-                fullLibrary, spectra, ms1Spectra,
-                isolationWindows, rtCalibration,
-                ms2Cal, ms1Cal,
-                context, ctx);
-            swScoring.Stop();
-            double scoringSeconds = swScoring.Elapsed.TotalSeconds;
-            double ratePerSec = scoringSeconds > 0.001
-                ? scoredEntries.Count / scoringSeconds
-                : 0.0;
-            ctx.LogInfo(string.Format(
-                "[TIMING] Coelution scoring: {0:F1}s ({1} candidates, {2:F0} cand/s)",
-                scoringSeconds, scoredEntries.Count, ratePerSec));
-
-            int nScoredTargets = scoredEntries.Count(e => !e.IsDecoy);
-            int nScoredDecoys = scoredEntries.Count(e => e.IsDecoy);
-            ctx.LogInfo(string.Format("Scored {0} entries ({1} targets, {2} decoys) for {3}",
-                scoredEntries.Count,
-                nScoredTargets,
-                nScoredDecoys,
-                fileName));
-
-            // Drop double-counted entries (different precursors that latch
-            // onto the same chromatographic feature within an isolation
-            // window). Mirrors osprey/crates/osprey/src/pipeline.rs at the
-            // same call site, between scoring and pair-deduplication.
-            scoredEntries = DeduplicateDoubleCounting(
-                scoredEntries, fullLibrary, spectra, ms2Cal,
-                isolationWindows, config, ctx);
-            nScoredTargets = scoredEntries.Count(e => !e.IsDecoy);
-            nScoredDecoys = scoredEntries.Count(e => e.IsDecoy);
-            ctx.LogInfo(string.Format(
-                "[COUNT] Coelution scored [{0}]: {1} entries ({2} targets, {3} decoys)",
-                fileName, scoredEntries.Count, nScoredTargets, nScoredDecoys));
-
-            // Deduplicate: keep best target and best decoy per base_id
-            int nBeforeDedup = scoredEntries.Count;
-            scoredEntries = DeduplicatePairs(scoredEntries, ctx);
-            int nAfterDedup = scoredEntries.Count;
-            ctx.LogInfo(string.Format(
-                "[COUNT] Deduplication [{0}]: {1} -> {2} ({3} removed)",
-                fileName, nBeforeDedup, nAfterDedup, nBeforeDedup - nAfterDedup));
-
-            // Optional: write per-entry feature TSV for comparison against Rust's PIN output
-            if (config.WritePin)
-            {
-                WriteFeatureDump(inputFile, fileName, scoredEntries, ctx);
-            }
-
-            // Persist the full FdrEntry results (with features) to
-            // {stem}.scores.parquet so (a) Stage 6 reconciliation can lazy-load
-            // CWT candidates per file, and (b) a subsequent --task FirstJoin
-            // invocation can pick them up without re-running Stages 1-4.
-            // Same path convention as Rust (`scores_path_for_input`).
-            // Snappy-compressed; cross-impl ZSTD/Snappy compatibility tracked
-            // as a Phase 4 follow-up. The metadata dictionary is precomputed
-            // in Run() against the original (un-mutated) outer config — see
-            // Run() for why. Skipped only in --task FirstJoin mode (no Stages 1-4
-            // ran here, so there is nothing fresh to persist).
-            if (parquetFooterMetadata != null)
-            {
-                string parquetPath = ParquetScoreCache.GetScoresPath(inputFile);
-                // Reuse the entry-id -> LibraryEntry map Run() built once
-                // before the per-file fan-out (WriteScoresParquet needs
-                // it to pull sequence / precursor_mz / protein_ids from
-                // the library since FdrEntry doesn't carry these).
-                var swParquet = Stopwatch.StartNew();
-                ParquetScoreCache.WriteScoresParquet(
-                    parquetPath, scoredEntries, parquetFooterMetadata, _libraryById, fileName);
-                swParquet.Stop();
-                ctx.LogInfo(string.Format(
-                    "Wrote {0} scored entries to {1} ({2:F1}s)",
-                    scoredEntries.Count, parquetPath, swParquet.Elapsed.TotalSeconds));
-            }
-
-            return scoredEntries;
+            return rtCalibration;
         }
 
         /// <summary>

--- a/pwiz_tools/OspreySharp/OspreySharp.Tasks/ReconciledParquetWriter.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Tasks/ReconciledParquetWriter.cs
@@ -1,0 +1,195 @@
+/*
+ * Original author: Brendan MacLean <brendanx .at. uw.edu>,
+ *                  MacCoss Lab, Department of Genome Sciences, UW
+ * AI assistance: Claude Code (Claude Opus 4.8) <noreply .at. anthropic.com>
+ *
+ * Based on osprey (https://github.com/MacCossLab/osprey)
+ *   by Michael J. MacCoss, MacCoss Lab, Department of Genome Sciences, UW
+ *
+ * Copyright 2026 University of Washington - Seattle, WA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
+using System.Collections.Generic;
+using pwiz.OspreySharp.Core;
+using pwiz.OspreySharp.IO;
+
+namespace pwiz.OspreySharp.Tasks
+{
+    /// <summary>
+    /// Writes the reconciled per-file <c>.scores-reconciled.parquet</c> for
+    /// Stage 6. Reloads the original Stage 4 parquet's full per-row data
+    /// (identity, boundaries, 21 PIN features, CWT candidate lists), overlays the
+    /// re-scored rows in place by <see cref="FdrEntry.ParquetIndex"/>, appends
+    /// gap-fill rows at the end, then writes a SEPARATE reconciled sibling with
+    /// reconciliation metadata -- the original parquet is never overwritten.
+    ///
+    /// Extracted verbatim from <c>PerFileRescoreTask.WriteReconciledParquet</c> so
+    /// the row-overlay and metadata-hash logic can be unit-tested without a live
+    /// <see cref="PipelineContext"/>: the only context dependency was logging, now
+    /// taken as <see cref="Action{T}"/> callbacks. Behavior (and therefore the
+    /// reconciled parquet bytes) is unchanged. Mirrors Rust pipeline.rs:3050-3110.
+    /// </summary>
+    internal static class ReconciledParquetWriter
+    {
+        /// <summary>
+        /// Reload <paramref name="originalPath"/>, overlay re-scored + gap-fill
+        /// rows from <paramref name="fdrEntries"/>, and write the result to
+        /// <paramref name="reconciledPath"/>. Returns true when the reconciled
+        /// parquet was written; false on a reload/write failure (so the caller
+        /// does not stamp a validity sidecar over a stale or absent output).
+        /// </summary>
+        internal static bool Write(string originalPath, string reconciledPath,
+            List<FdrEntry> fdrEntries,
+            string fileName, List<LibraryEntry> fullLibrary, OspreyConfig config,
+            IReadOnlyList<string> joinFileStems,
+            Action<string> logInfo, Action<string> logWarning)
+        {
+            // 1. Reload the original parquet's per-row state (read-only).
+            List<FdrEntry> fullEntries;
+            try
+            {
+                fullEntries = ParquetScoreCache.LoadFullFdrEntries(originalPath);
+            }
+            catch (Exception ex)
+            {
+                logWarning(string.Format(
+                    "Stage 6 write-back: failed to reload {0}: {1} (skipping)",
+                    originalPath, ex.Message));
+                return false;
+            }
+            int origRowCount = fullEntries.Count;
+
+            // 2-3. Overlay re-scored rows by ParquetIndex and append gap-fill rows.
+            int nReplaced = ApplyRescoredRows(fullEntries, fdrEntries, fileName,
+                logWarning, out int nAppended);
+
+            // 4. Build libraryById for the WriteScoresParquet sequence /
+            //    precursor_mz / protein_ids columns.
+            var libraryById = new Dictionary<uint, LibraryEntry>(fullLibrary.Count);
+            foreach (var libEntry in fullLibrary)
+                libraryById[libEntry.Id] = libEntry;
+
+            // 5. Reconciliation metadata (mirrors Rust build_reconciled_metadata).
+            var metadata = BuildReconciliationMetadata(config, joinFileStems);
+
+            try
+            {
+                ParquetScoreCache.WriteScoresParquet(reconciledPath, fullEntries,
+                    metadata, libraryById, fileName);
+            }
+            catch (Exception ex)
+            {
+                logWarning(string.Format(
+                    "Stage 6 write-back: failed to write reconciled scores for {0}: {1}",
+                    fileName, ex.Message));
+                return false;
+            }
+
+            logInfo(string.Format(
+                "  Wrote reconciled parquet for {0}: {1} rows ({2} replaced + {3} appended; original {4} rows)",
+                fileName, fullEntries.Count, nReplaced, nAppended, origRowCount));
+            return true;
+        }
+
+        /// <summary>
+        /// Overlay the re-scored rows in <paramref name="fdrEntries"/> onto
+        /// <paramref name="fullEntries"/> (loaded from the original parquet) in
+        /// place by <see cref="FdrEntry.ParquetIndex"/>, then append the gap-fill
+        /// rows at the end, reassigning each gap-fill stub's
+        /// <see cref="FdrEntry.ParquetIndex"/> to the row it now occupies so a
+        /// downstream worker can locate its features. Returns the replaced-row
+        /// count; <paramref name="nAppended"/> receives the appended-row count.
+        ///
+        /// Replacement is keyed on <see cref="FdrEntry.ParquetIndex"/> (NOT
+        /// post-compaction Vec position; the two diverge after first-pass FDR
+        /// drops non-passing entries). Re-scored rows are detected by
+        /// <see cref="FdrEntry.Features"/> != null: hydration's
+        /// LoadFdrStubsFromParquet does NOT populate Features, so unchanged
+        /// post-compaction stubs (Features == null) leave their corresponding
+        /// <paramref name="fullEntries"/> row alone, preserving Features +
+        /// CwtCandidates + the binary blob columns from the original parquet.
+        /// Gap-fill stubs carry ParquetIndex == uint.MaxValue and are appended.
+        /// </summary>
+        internal static int ApplyRescoredRows(List<FdrEntry> fullEntries,
+            List<FdrEntry> fdrEntries, string fileName,
+            Action<string> logWarning, out int nAppended)
+        {
+            // Replace re-scored rows (Phase 1 + Phase 2 existing-entry overlay).
+            int nReplaced = 0;
+            foreach (var entry in fdrEntries)
+            {
+                if (entry.ParquetIndex == uint.MaxValue)
+                    continue;
+                if (entry.Features == null)
+                    continue;  // hydrated stub, never re-scored
+                int pqIdx = (int)entry.ParquetIndex;
+                if (pqIdx < 0 || pqIdx >= fullEntries.Count)
+                {
+                    logWarning(string.Format(
+                        "Stage 6 write-back: ParquetIndex {0} out of range for {1} ({2} rows)",
+                        pqIdx, fileName, fullEntries.Count));
+                    continue;
+                }
+                fullEntries[pqIdx] = entry;
+                nReplaced++;
+            }
+
+            // Append gap-fill rows at the end, reassigning ParquetIndex.
+            nAppended = 0;
+            foreach (var entry in fdrEntries)
+            {
+                if (entry.ParquetIndex != uint.MaxValue)
+                    continue;
+                entry.ParquetIndex = (uint)fullEntries.Count;
+                fullEntries.Add(entry);
+                nAppended++;
+            }
+
+            return nReplaced;
+        }
+
+        /// <summary>
+        /// Build the reconciliation parquet metadata (mirrors Rust
+        /// build_reconciled_metadata). <c>osprey.version</c> is what the next
+        /// reload's CacheValidity check compares against.
+        ///
+        /// The reconciliation hash must be the JOIN-wide hash (over every file in
+        /// the planner step), not the worker's single-file InputFiles hash;
+        /// without that, a worker rescoring a single parquet stamps a single-file
+        /// hash that the downstream --task MergeNode merge node rejects on
+        /// mismatch. The join file stems come from the planner's
+        /// reconciliation.json (v2+) via <see cref="RescoreInputs.JoinFileStems"/>;
+        /// fall back to the config-derived hash when the caller passed none
+        /// (in-process pipeline where config.InputFiles already has all files, or
+        /// v1 backward compat).
+        /// </summary>
+        internal static Dictionary<string, string> BuildReconciliationMetadata(
+            OspreyConfig config, IReadOnlyList<string> joinFileStems)
+        {
+            string reconciliationHash = (joinFileStems != null && joinFileStems.Count > 0)
+                ? config.Identity.ReconciliationParameterHashForStems(joinFileStems)
+                : config.Identity.ReconciliationParameterHash();
+            return new Dictionary<string, string>
+            {
+                { @"osprey.version", OspreyVersion.Current },
+                { @"osprey.search_hash", config.Identity.SearchParameterHash() },
+                { @"osprey.library_hash", config.Identity.LibraryIdentityHash() },
+                { @"osprey.reconciled", @"true" },
+                { @"osprey.reconciliation_hash", reconciliationHash },
+            };
+        }
+    }
+}

--- a/pwiz_tools/OspreySharp/OspreySharp.Test/PerFileResumeDriverTest.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Test/PerFileResumeDriverTest.cs
@@ -74,8 +74,10 @@ namespace pwiz.OspreySharp.Test
             }
             finally
             {
-                if (File.Exists(outputPath)) File.Delete(outputPath);
-                if (File.Exists(sidecarPath)) File.Delete(sidecarPath);
+                if (File.Exists(outputPath))
+                    File.Delete(outputPath);
+                if (File.Exists(sidecarPath))
+                    File.Delete(sidecarPath);
             }
         }
 

--- a/pwiz_tools/OspreySharp/OspreySharp.Test/PerFileResumeDriverTest.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Test/PerFileResumeDriverTest.cs
@@ -1,0 +1,101 @@
+/*
+ * Original author: Brendan MacLean <brendanx .at. uw.edu>,
+ *                  MacCoss Lab, Department of Genome Sciences, UW
+ * AI assistance: Claude Code (Claude Opus 4.8) <noreply .at. anthropic.com>
+ *
+ * Based on osprey (https://github.com/MacCossLab/osprey)
+ *   by Michael J. MacCoss, MacCoss Lab, Department of Genome Sciences, UW
+ *
+ * Copyright 2026 University of Washington - Seattle, WA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System.Collections.Generic;
+using System.IO;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using pwiz.OspreySharp.Tasks;
+
+namespace pwiz.OspreySharp.Test
+{
+    /// <summary>
+    /// Unit tests for <see cref="PerFileResumeDriver"/>, the per-file resume
+    /// sidecar mechanics shared by PerFileScoringTask and PerFileRescoreTask.
+    /// </summary>
+    [TestClass]
+    public class PerFileResumeDriverTest
+    {
+        private const string TASK = "PerFileResumeDriverTest";
+        private const string VERSION = "26.1.1.0";
+
+        /// <summary>
+        /// IsCurrent must require BOTH the output file on disk AND a matching
+        /// validity sidecar; Stamp writes that sidecar and ClearStale removes it.
+        /// </summary>
+        [TestMethod]
+        public void TestIsCurrentStampAndClearStale()
+        {
+            string outputPath = Path.GetTempFileName();
+            string sidecarPath = TaskValiditySidecar.PathFor(outputPath, TASK);
+            var warnings = new List<string>();
+            try
+            {
+                // Output exists but no sidecar yet -> not current.
+                Assert.IsFalse(PerFileResumeDriver.IsCurrent(outputPath, TASK, "key1"));
+
+                // After a successful stamp the matching key is current; a
+                // different key is not (a foreign invocation's output).
+                PerFileResumeDriver.Stamp(outputPath, TASK, VERSION, "key1",
+                    new[] { "input.mzML" }, warnings.Add);
+                Assert.AreEqual(0, warnings.Count);
+                Assert.IsTrue(PerFileResumeDriver.IsCurrent(outputPath, TASK, "key1"));
+                Assert.IsFalse(PerFileResumeDriver.IsCurrent(outputPath, TASK, "key2"));
+
+                // The file-existence gate: a valid sidecar without its output is
+                // NOT current (the sidecar can outlive a deleted output).
+                File.Delete(outputPath);
+                Assert.IsFalse(PerFileResumeDriver.IsCurrent(outputPath, TASK, "key1"));
+
+                // ClearStale removes the sidecar so the next probe re-runs.
+                File.WriteAllText(outputPath, "rebuilt");
+                Assert.IsTrue(PerFileResumeDriver.IsCurrent(outputPath, TASK, "key1"));
+                PerFileResumeDriver.ClearStale(outputPath, TASK);
+                Assert.IsFalse(PerFileResumeDriver.IsCurrent(outputPath, TASK, "key1"));
+            }
+            finally
+            {
+                if (File.Exists(outputPath)) File.Delete(outputPath);
+                if (File.Exists(sidecarPath)) File.Delete(sidecarPath);
+            }
+        }
+
+        /// <summary>
+        /// A sidecar-write failure is non-fatal: Stamp must route it to the
+        /// warning callback and not throw (the output is already on disk; only
+        /// the resume-skip hint is lost). Writing under a non-existent directory
+        /// forces the failure.
+        /// </summary>
+        [TestMethod]
+        public void TestStampSwallowsWriteFailure()
+        {
+            string missingDir = Path.Combine(Path.GetTempPath(),
+                "osprey-resume-driver-missing-dir", "out.parquet");
+            var warnings = new List<string>();
+
+            PerFileResumeDriver.Stamp(missingDir, TASK, VERSION, "key1",
+                new[] { "input.mzML" }, warnings.Add);
+
+            Assert.AreEqual(1, warnings.Count);
+        }
+    }
+}

--- a/pwiz_tools/OspreySharp/OspreySharp.Test/ReconciledParquetWriterTest.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Test/ReconciledParquetWriterTest.cs
@@ -1,0 +1,128 @@
+/*
+ * Original author: Brendan MacLean <brendanx .at. uw.edu>,
+ *                  MacCoss Lab, Department of Genome Sciences, UW
+ * AI assistance: Claude Code (Claude Opus 4.8) <noreply .at. anthropic.com>
+ *
+ * Based on osprey (https://github.com/MacCossLab/osprey)
+ *   by Michael J. MacCoss, MacCoss Lab, Department of Genome Sciences, UW
+ *
+ * Copyright 2026 University of Washington - Seattle, WA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System.Collections.Generic;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using pwiz.OspreySharp.Core;
+using pwiz.OspreySharp.Tasks;
+
+namespace pwiz.OspreySharp.Test
+{
+    /// <summary>
+    /// Unit tests for <see cref="ReconciledParquetWriter"/>, the Stage 6
+    /// reconciled-parquet seam extracted from PerFileRescoreTask. These cover the
+    /// two pure helpers (row overlay/append and metadata-hash selection) that
+    /// previously rode only the 41-min nightly regression.
+    /// </summary>
+    [TestClass]
+    public class ReconciledParquetWriterTest
+    {
+        /// <summary>
+        /// ApplyRescoredRows must: overlay re-scored rows in place by
+        /// ParquetIndex, leave hydrated stubs (Features == null) untouched,
+        /// append gap-fill rows (ParquetIndex == uint.MaxValue) at the end with a
+        /// reassigned ParquetIndex, and warn-and-skip an out-of-range index.
+        /// </summary>
+        [TestMethod]
+        public void TestApplyRescoredRowsOverlayAndAppend()
+        {
+            // Original parquet rows (loaded read-only). Identified by EntryId.
+            var fullEntries = new List<FdrEntry>
+            {
+                new FdrEntry { EntryId = 100 },
+                new FdrEntry { EntryId = 101 },
+                new FdrEntry { EntryId = 102 },
+            };
+
+            var rescored = new FdrEntry { EntryId = 201, ParquetIndex = 1, Features = new[] { 1.0 } };
+            var hydratedStub = new FdrEntry { EntryId = 202, ParquetIndex = 0, Features = null };
+            var gapFill = new FdrEntry { EntryId = 203, ParquetIndex = uint.MaxValue, Features = new[] { 2.0 } };
+            var outOfRange = new FdrEntry { EntryId = 204, ParquetIndex = 99, Features = new[] { 3.0 } };
+            var fdrEntries = new List<FdrEntry> { rescored, hydratedStub, gapFill, outOfRange };
+
+            var warnings = new List<string>();
+            int nReplaced = ReconciledParquetWriter.ApplyRescoredRows(
+                fullEntries, fdrEntries, "file1", warnings.Add, out int nAppended);
+
+            // Only the in-range rescored row counts as a replacement.
+            Assert.AreEqual(1, nReplaced);
+            // Only the gap-fill row is appended.
+            Assert.AreEqual(1, nAppended);
+
+            // Row 1 was overlaid with the rescored entry; rows 0 and 2 untouched
+            // (hydrated stub at index 0 must NOT clobber its original row).
+            Assert.AreEqual(4, fullEntries.Count);
+            Assert.AreEqual(100u, fullEntries[0].EntryId);
+            Assert.AreEqual(201u, fullEntries[1].EntryId);
+            Assert.AreEqual(102u, fullEntries[2].EntryId);
+
+            // Gap-fill row appended at the end with ParquetIndex reassigned to the
+            // row it now occupies.
+            Assert.AreEqual(203u, fullEntries[3].EntryId);
+            Assert.AreEqual(3u, gapFill.ParquetIndex);
+
+            // The out-of-range index is dropped (not replaced, not appended) with
+            // exactly one warning emitted.
+            Assert.AreEqual(1, warnings.Count);
+        }
+
+        /// <summary>
+        /// BuildReconciliationMetadata must stamp the fixed parquet metadata keys
+        /// and choose the join-wide reconciliation hash when join file stems are
+        /// supplied, falling back to the config-derived hash when they are absent
+        /// or empty.
+        /// </summary>
+        [TestMethod]
+        public void TestBuildReconciliationMetadataHashSelection()
+        {
+            var config = new OspreyConfig();
+            var stems = new List<string> { "fileA", "fileB" };
+
+            var withStems = ReconciledParquetWriter.BuildReconciliationMetadata(config, stems);
+            var withNull = ReconciledParquetWriter.BuildReconciliationMetadata(config, null);
+            var withEmpty = ReconciledParquetWriter.BuildReconciliationMetadata(config, new List<string>());
+
+            // Fixed contract keys are always present and constant.
+            foreach (var metadata in new[] { withStems, withNull, withEmpty })
+            {
+                Assert.AreEqual(OspreyVersion.Current, metadata["osprey.version"]);
+                Assert.AreEqual(config.Identity.SearchParameterHash(), metadata["osprey.search_hash"]);
+                Assert.AreEqual(config.Identity.LibraryIdentityHash(), metadata["osprey.library_hash"]);
+                Assert.AreEqual("true", metadata["osprey.reconciled"]);
+            }
+
+            // Stems supplied -> join-wide hash; absent/empty -> config-derived hash.
+            Assert.AreEqual(config.Identity.ReconciliationParameterHashForStems(stems),
+                withStems["osprey.reconciliation_hash"]);
+            Assert.AreEqual(config.Identity.ReconciliationParameterHash(),
+                withNull["osprey.reconciliation_hash"]);
+            Assert.AreEqual(config.Identity.ReconciliationParameterHash(),
+                withEmpty["osprey.reconciliation_hash"]);
+
+            // The two hash regimes must actually differ, or the join-wide branch
+            // would be doing nothing.
+            Assert.AreNotEqual(withNull["osprey.reconciliation_hash"],
+                withStems["osprey.reconciliation_hash"]);
+        }
+    }
+}


### PR DESCRIPTION
PR 3 of the OspreySharp OOP debt-paydown arc. This is a pure structural
refactor of the per-file pipeline tasks (OspreySharp.Tasks) - output is
byte-identical and performance is unchanged. It follows the blind OOP
review that opened this sprint: the orchestration spine is sound; the work
here is the low cohesion inside the task bodies.

## What changed

* Extracted ReconciledParquetWriter from PerFileRescoreTask.WriteReconciledParquet,
  with pure, unit-testable helpers (ApplyRescoredRows row overlay/append,
  BuildReconciliationMetadata hash selection). Logging via callbacks, no
  PipelineContext dependency.
* Extracted PerFileResumeDriver - the per-file resume sidecar mechanics
  (IsCurrent probe, ClearStale, Stamp) shared by PerFileScoringTask and
  PerFileRescoreTask, removing the duplicated try/catch sidecar-write block
  from both. Output-file deletion on a failed write stays in the task (it is
  not sidecar mechanics).
* Decomposed PerFileRescoreTask.ExecuteRescore: the ~250-line per-file loop
  body moved into a named RescoreOneFile; ExecuteRescore is now a ~50-line
  setup-and-accumulate sequencer. Cross-file inputs are bundled in a private
  RescorePassInputs (one collaborator object instead of a dozen parameters).
* Decomposed PerFileScoringTask.ProcessFile: the ~115-line calibration phase
  moved into a named ResolveCalibration (~294 to ~180 lines).

The parity-locked scoring / Percolator / calibration cores were kept whole
and are characterized at their boundary by the committed regression golden,
not decomposed for testability.

## Validation

* Per commit: build + 0 ReSharper warnings + 389 unit tests (4 new) +
  Stellar regression (golden + resume), all green.
* Full regression (Dataset All): Stellar and Astral, mode 1 (vs golden) and
  mode 2 (resume == straight-through), all byte-identical.
* Perf gate (A/B vs pinned pwiz-perfbase, Stellar): perf-neutral
  (total -1.6% median; within run-to-run noise).
* Fresh-context self-review pass: no findings.

See ai/todos/active/TODO-20260616_ospreysharp_debt_paydown_pr3.md for the
full engineering context.

Co-Authored-By: Claude <noreply@anthropic.com>
