### PR TITLE
Refactored ExportMethodDlg tooltip reset to eliminate ReSharper inspection CLI false positives

### DIFF
--- a/pwiz_tools/Skyline/FileUI/ExportMethodDlg.cs
+++ b/pwiz_tools/Skyline/FileUI/ExportMethodDlg.cs
@@ -2755,6 +2755,11 @@ namespace pwiz.Skyline.FileUI
             get => textTemplateFile;
         }
 
+        public string TemplateFileToolTip
+        {
+            get => helpTip.GetToolTip(textTemplateFile);
+        }
+
         public int CalculationTime
         {
             get { return _exportProperties.MultiplexIsolationListCalculationTime; }

--- a/pwiz_tools/Skyline/FileUI/ExportMethodDlg.cs
+++ b/pwiz_tools/Skyline/FileUI/ExportMethodDlg.cs
@@ -68,11 +68,16 @@ namespace pwiz.Skyline.FileUI
 
         private readonly ExportDlgProperties _exportProperties;
 
+        // Capture the initial culture-specific value the designer applied at load time
+        // so we can restore it after temporary overrides (URL preview / errors).
+        private readonly string _initialTemplateFileToolTip;
+
         private CancellationTokenSource _cancellationTokenSource;
 
         public ExportMethodDlg(SrmDocument document, ExportFileType fileType)
         {
             InitializeComponent();
+            _initialTemplateFileToolTip = helpTip.GetToolTip(textTemplateFile);
 
             _cancellationTokenSource = new CancellationTokenSource();
             _exportProperties = new ExportDlgProperties(this, _cancellationTokenSource.Token);
@@ -1966,8 +1971,7 @@ namespace pwiz.Skyline.FileUI
                     textTemplateFile.Text = string.Empty;
                     textTemplateFile.Tag = null;
                     // Reset the tooltip to the original text
-                    var resources = new ComponentResourceManager(typeof(ExportMethodDlg));
-                    helpTip.SetToolTip(textTemplateFile, resources.GetString("textTemplateFile.ToolTip"));
+                    ResetTemplateFileToolTip();
                 }
                 wcDecideBuckets.Visible = true;
                 // Shift radio buttons up if transitioning from 3-button to 4-button layout
@@ -1986,8 +1990,8 @@ namespace pwiz.Skyline.FileUI
                         : string.Empty;
                 textTemplateFile.Tag = null;
                 EnableTextTemplateFileField(true);
-                var resources = new ComponentResourceManager(typeof(ExportMethodDlg));
-                helpTip.SetToolTip(textTemplateFile, resources.GetString("textTemplateFile.ToolTip"));
+                // Reset the tooltip to the original text
+                ResetTemplateFileToolTip();
                 wcDecideBuckets.Visible = false;
                 // Shift radio buttons down if transitioning from 4-button to 3-button layout
                 if (inFourButtonLayout)
@@ -2021,6 +2025,12 @@ namespace pwiz.Skyline.FileUI
             CalcMethodCount();
 
             UpdateCovControls();
+        }
+
+        private void ResetTemplateFileToolTip()
+        {
+            // Restore the original localized tooltip
+            helpTip.SetToolTip(textTemplateFile, _initialTemplateFileToolTip);
         }
 
         private void EnableTextTemplateFileField(bool enable)
@@ -2446,8 +2456,7 @@ namespace pwiz.Skyline.FileUI
             //  Clear since not Waters Connect
             textTemplateFile.Tag = null;
             // Reset the tooltip to the original text
-            var resources = new ComponentResourceManager(typeof(ExportMethodDlg));
-            helpTip.SetToolTip(textTemplateFile, resources.GetString("textTemplateFile.ToolTip"));
+            ResetTemplateFileToolTip();
 
             string templateName = textTemplateFile.Text;
             if (Equals(InstrumentType, ExportInstrumentType.AGILENT6400) || Equals(InstrumentType, ExportInstrumentType.AGILENT_MASSHUNTER_12_METHOD) ||

--- a/pwiz_tools/Skyline/TestFunctional/WatersConnectMethodExportTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/WatersConnectMethodExportTest.cs
@@ -18,6 +18,7 @@
  */
 
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Diagnostics;
 using System.Globalization;
 using System.IO;
@@ -56,6 +57,8 @@ namespace pwiz.SkylineTestFunctional
             RunUI(() => SkylineWindow.OpenFile(TestFilesDir.GetTestPath("MixedPolarity02.sky")));
             WaitForDocumentLoaded();
 
+            TestTemplateFileToolTipRestore();
+
             var exportMethodDlg = ShowDialog<ExportMethodDlg>(() =>
                 SkylineWindow.ShowExportMethodDialog(ExportFileType.Method));
             TestTemplateSelection(exportMethodDlg);
@@ -66,6 +69,71 @@ namespace pwiz.SkylineTestFunctional
                 SkylineWindow.ShowExportMethodDialog(ExportFileType.Method));
             WaitForOpenForm<ExportMethodDlg>(1000);
             TestAuthenticationError(exportMethodDlg);
+        }
+
+        /// <summary>
+        /// Verifies that the template-file tooltip is captured once at load time and
+        /// restored verbatim after a temporary override. Guards the refactor that replaced
+        /// per-call ComponentResourceManager.GetString("textTemplateFile.ToolTip") lookups
+        /// (which tripped a ReSharper inspectcode CLI false positive) with a single captured
+        /// field restored via ResetTemplateFileToolTip().
+        /// </summary>
+        private void TestTemplateFileToolTipRestore()
+        {
+            var exportMethodDlg = ShowDialog<ExportMethodDlg>(() =>
+                SkylineWindow.ShowExportMethodDialog(ExportFileType.Method));
+
+            string originalToolTip = null;
+            RunUI(() =>
+            {
+                // At load time the tooltip is the localized value the designer applied. The refactor
+                // must capture exactly the string the old code fetched via ComponentResourceManager.
+                originalToolTip = exportMethodDlg.TemplateFileToolTip;
+                var resources = new ComponentResourceManager(typeof(ExportMethodDlg));
+                Assert.AreEqual(resources.GetString("textTemplateFile.ToolTip"), originalToolTip,
+                    "Captured initial template-file tooltip does not match the designer/resx value.");
+                Assert.IsFalse(string.IsNullOrEmpty(originalToolTip), "Expected a non-empty designer tooltip.");
+
+                exportMethodDlg.InstrumentType = ExportInstrumentType.WATERS_XEVO_TQ_WATERS_CONNECT;
+                exportMethodDlg.MethodType = ExportMethodType.Scheduled;
+                exportMethodDlg.ExportStrategy = ExportStrategy.WcDecide;
+            });
+
+            // Select a Waters Connect template, which overrides the tooltip with the method URL.
+            var templateDlg = ShowDialog<WatersConnectSelectMethodFileDialog>(() => exportMethodDlg.ClickTemplateButton());
+            WaitForConditionUI(1000, () => templateDlg.ListViewItems.Count == 1);
+            RunUI(() =>
+            {
+                templateDlg.ListViewItems[0].Selected = true;
+                templateDlg.KeyPressHandler(Keys.Enter);
+            });
+            WaitForConditionUI(1000,
+                () => templateDlg.ListViewItems.Count == 1 && templateDlg.ListViewItems[0].Text == @"Skyline");
+            RunUI(() =>
+            {
+                templateDlg.ListViewItems[0].Selected = true;
+                templateDlg.KeyPressHandler(Keys.Enter);
+            });
+            ValidateSkylineFolder(templateDlg);
+            RunUI(() => templateDlg.KeyPressHandler(Keys.Enter));
+
+            RunUI(() =>
+            {
+                Assert.AreEqual("Company/Skyline/Test Method 37", exportMethodDlg.TemplatePathField.Text);
+                // Selecting a template overrides the tooltip with the URL string.
+                var overriddenToolTip = exportMethodDlg.TemplateFileToolTip;
+                Assert.AreNotEqual(originalToolTip, overriddenToolTip,
+                    "Selecting a Waters Connect template should override the template-file tooltip.");
+                Assert.IsFalse(string.IsNullOrEmpty(overriddenToolTip));
+
+                // Switching to a non-Waters-Connect instrument must restore the captured original.
+                // Use MassLynx (local-file export) to avoid the Thermo installation probe dialog.
+                exportMethodDlg.InstrumentType = ExportInstrumentType.WATERS_XEVO_TQ_MASS_LYNX;
+                Assert.AreEqual(originalToolTip, exportMethodDlg.TemplateFileToolTip,
+                    "Template-file tooltip was not restored to its original value after reset.");
+            });
+
+            CancelDialog(exportMethodDlg);
         }
 
         /// <summary>

--- a/pwiz_tools/Skyline/TestFunctional/WatersConnectMethodExportTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/WatersConnectMethodExportTest.cs
@@ -83,19 +83,31 @@ namespace pwiz.SkylineTestFunctional
             var exportMethodDlg = ShowDialog<ExportMethodDlg>(() =>
                 SkylineWindow.ShowExportMethodDialog(ExportFileType.Method));
 
+            const string toolTipKey = "textTemplateFile.ToolTip";
             string originalToolTip = null;
             RunUI(() =>
             {
                 // At load time the tooltip is the localized value the designer applied. The refactor
-                // must capture exactly the string the old code fetched via ComponentResourceManager.
+                // must capture the genuine localized resource, not a hardcoded or fallback string.
                 // This relies on the dialog opening on a non-Waters-Connect instrument (or WC with no
                 // saved template), so the tooltip is the designer value and not a URL override. That
                 // holds because this runs first, before any test persists a WC instrument/template.
                 originalToolTip = exportMethodDlg.TemplateFileToolTip;
-                var resources = new ComponentResourceManager(typeof(ExportMethodDlg));
-                Assert.AreEqual(resources.GetString("textTemplateFile.ToolTip"), originalToolTip,
-                    "Captured initial template-file tooltip does not match the designer/resx value.");
                 Assert.IsFalse(string.IsNullOrEmpty(originalToolTip), "Expected a non-empty designer tooltip.");
+
+                // The tooltip is genuinely localized: Japanese is translated (ExportMethodDlg.ja.resx)
+                // while French has no resx and falls back to invariant English, so the two differ. This
+                // makes the capture assertion below non-vacuous - it proves the captured value tracks
+                // the running culture rather than just echoing a single same-culture resx lookup.
+                var resources = new ComponentResourceManager(typeof(ExportMethodDlg));
+                var frenchToolTip = resources.GetString(toolTipKey, new CultureInfo("fr"));
+                var japaneseToolTip = resources.GetString(toolTipKey, new CultureInfo("ja"));
+                Assert.AreNotEqual(frenchToolTip, japaneseToolTip,
+                    "Expected the template-file tooltip to differ between French and Japanese.");
+
+                // The captured live tooltip must equal the resx value for the culture this test runs in.
+                Assert.AreEqual(resources.GetString(toolTipKey, CultureInfo.CurrentUICulture), originalToolTip,
+                    "Captured tooltip does not match the localized resx value for the current culture.");
 
                 exportMethodDlg.InstrumentType = ExportInstrumentType.WATERS_XEVO_TQ_WATERS_CONNECT;
                 exportMethodDlg.MethodType = ExportMethodType.Scheduled;

--- a/pwiz_tools/Skyline/TestFunctional/WatersConnectMethodExportTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/WatersConnectMethodExportTest.cs
@@ -88,6 +88,9 @@ namespace pwiz.SkylineTestFunctional
             {
                 // At load time the tooltip is the localized value the designer applied. The refactor
                 // must capture exactly the string the old code fetched via ComponentResourceManager.
+                // This relies on the dialog opening on a non-Waters-Connect instrument (or WC with no
+                // saved template), so the tooltip is the designer value and not a URL override. That
+                // holds because this runs first, before any test persists a WC instrument/template.
                 originalToolTip = exportMethodDlg.TemplateFileToolTip;
                 var resources = new ComponentResourceManager(typeof(ExportMethodDlg));
                 Assert.AreEqual(resources.GetString("textTemplateFile.ToolTip"), originalToolTip,
@@ -104,6 +107,7 @@ namespace pwiz.SkylineTestFunctional
             WaitForConditionUI(1000, () => templateDlg.ListViewItems.Count == 1);
             RunUI(() =>
             {
+                Assert.AreEqual("Company", templateDlg.ListViewItems[0].Text);
                 templateDlg.ListViewItems[0].Selected = true;
                 templateDlg.KeyPressHandler(Keys.Enter);
             });


### PR DESCRIPTION
## Summary

I was just trying to get more automation around running ReSharper code inspection from the shell (not too terribly slow if you use the latest version) but kept hitting an inspection error that (for whatever reason) TeamCity and the IDE do not. It's a false positive, but I had to do a little code rewrite to get around it.

* Removed direct reference to the magic "textTemplateFile.ToolTip" resx key that the jb (.NET-build) inspectcode CLI mis-flagged 3x as "Ambiguous reference" (apparently doesn't understand how localization works)
* Captured the localized tooltip once at construction and restore from it via a single ResetTemplateFileToolTip() helper, replacing three duplicated inline ComponentResourceManager blocks
* Refactor-safe if the control is renamed; no suppression needed

## Test plan

- [x] CodeInspection - passes
- [x] ReSharper inspectcode - 3 errors → 0 on this branch
- [x] Build - succeeds

Co-Authored-By: Claude <noreply@anthropic.com>