### PR TITLE
Introduced ProteinFdrEngine to consolidate cross-task protein FDR (debt-paydown PR 6)

### DIFF
--- a/pwiz_tools/OspreySharp/OspreySharp.FDR/ProteinFdr.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.FDR/ProteinFdr.cs
@@ -164,6 +164,37 @@ namespace pwiz.OspreySharp.FDR
     }
 
     /// <summary>
+    /// The computed artifacts of a second-pass / run-wide protein-FDR run, returned
+    /// by <see cref="ProteinFdrEngine.RunSecondPass"/> so the Tasks-layer caller can
+    /// emit the Stage-7 detected-peptides and protein-FDR diagnostic dumps (and the
+    /// <c>Stage7ProteinFdrOnly</c> early-exit decision) WITHOUT recomputing parsimony
+    /// / FDR. The run has already propagated <c>RunProteinQvalue</c> and
+    /// <c>ExperimentProteinQvalue</c> onto the stubs; these are the same intermediate
+    /// objects it used.
+    /// </summary>
+    public class SecondPassProteinFdrResult
+    {
+        /// <summary>Target peptides passing experiment-level run FDR (the detected set).</summary>
+        public HashSet<string> DetectedPeptides { get; }
+
+        /// <summary>Parsimony grouping built from the detected peptides.</summary>
+        public ProteinParsimonyResult Parsimony { get; }
+
+        /// <summary>The picked-protein FDR result (group + peptide q-values).</summary>
+        public ProteinFdrResult ProteinFdr { get; }
+
+        public SecondPassProteinFdrResult(
+            HashSet<string> detectedPeptides,
+            ProteinParsimonyResult parsimony,
+            ProteinFdrResult proteinFdr)
+        {
+            DetectedPeptides = detectedPeptides;
+            Parsimony = parsimony;
+            ProteinFdr = proteinFdr;
+        }
+    }
+
+    /// <summary>
     /// Protein parsimony and FDR computation.
     /// Port of osprey-fdr/src/protein.rs.
     /// </summary>

--- a/pwiz_tools/OspreySharp/OspreySharp.FDR/ProteinFdrEngine.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.FDR/ProteinFdrEngine.cs
@@ -94,7 +94,8 @@ namespace pwiz.OspreySharp.FDR
         /// <see cref="OspreyConfig.RunFdr"/>, and propagates both
         /// <see cref="FdrEntry.RunProteinQvalue"/> and
         /// <see cref="FdrEntry.ExperimentProteinQvalue"/> onto every stub. Logs
-        /// summary counts via <paramref name="logInfo"/> and returns the parsimony /
+        /// summary counts via <paramref name="logInfo"/> (which may be null for a
+        /// silent run, like <see cref="RunFirstPass"/>) and returns the parsimony /
         /// FDR artifacts so the Tasks facade can emit the Stage-7 detected-peptides
         /// and protein-FDR diagnostic dumps + the <c>Stage7ProteinFdrOnly</c>
         /// early-exit WITHOUT recomputing them. Moved here from
@@ -109,7 +110,7 @@ namespace pwiz.OspreySharp.FDR
         {
             // Collect best peptide scores
             var bestScores = ProteinFdr.CollectBestPeptideScores(perFileEntries);
-            logInfo(string.Format("Collected scores for {0} unique peptides", bestScores.Count));
+            logInfo?.Invoke(string.Format("Collected scores for {0} unique peptides", bestScores.Count));
 
             // Get detected peptide set: targets passing experiment-level
             // q-value at the configured fdr_level (matches Rust pipeline.rs
@@ -141,9 +142,9 @@ namespace pwiz.OspreySharp.FDR
                 }
             }
 
-            logInfo(string.Format("Detected {0} unique peptides at {1:P1} experiment FDR ({2})",
+            logInfo?.Invoke(string.Format("Detected {0} unique peptides at {1:P1} experiment FDR ({2})",
                 detectedPeptides.Count, config.ExperimentFdr, peptideGateLevel));
-            logInfo(string.Format(
+            logInfo?.Invoke(string.Format(
                 "[COUNT] Detected peptides for protein FDR: {0} unique",
                 detectedPeptides.Count));
 
@@ -151,8 +152,8 @@ namespace pwiz.OspreySharp.FDR
             var parsimony = ProteinFdr.BuildProteinParsimony(
                 fullLibrary, config.SharedPeptides, detectedPeptides);
 
-            logInfo(string.Format("Protein parsimony: {0} groups", parsimony.Groups.Count));
-            logInfo(string.Format(
+            logInfo?.Invoke(string.Format("Protein parsimony: {0} groups", parsimony.Groups.Count));
+            logInfo?.Invoke(string.Format(
                 "[COUNT] Protein parsimony groups: {0}", parsimony.Groups.Count));
 
             // Compute protein FDR. Gate is config.RunFdr (1x) per Savitski's
@@ -169,9 +170,9 @@ namespace pwiz.OspreySharp.FDR
                     passingProteins++;
             }
 
-            logInfo(string.Format("{0} protein groups pass {1:P1} protein FDR",
+            logInfo?.Invoke(string.Format("{0} protein groups pass {1:P1} protein FDR",
                 passingProteins, config.ProteinFdr.Value));
-            logInfo(string.Format(
+            logInfo?.Invoke(string.Format(
                 "[COUNT] Protein groups passing FDR: {0} at {1:P0}",
                 passingProteins, config.ProteinFdr.Value));
 

--- a/pwiz_tools/OspreySharp/OspreySharp.FDR/ProteinFdrEngine.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.FDR/ProteinFdrEngine.cs
@@ -1,0 +1,191 @@
+/*
+ * Original author: Brendan MacLean <brendanx .at. uw.edu>,
+ *                  MacCoss Lab, Department of Genome Sciences, UW
+ * AI assistance: Claude Code (Claude Opus 4.8) <noreply .at. anthropic.com>
+ *
+ * Based on osprey (https://github.com/MacCossLab/osprey)
+ *   by Michael J. MacCoss, MacCoss Lab, Department of Genome Sciences, UW
+ *
+ * Copyright 2026 University of Washington - Seattle, WA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
+using System.Collections.Generic;
+using pwiz.OspreySharp.Core;
+
+namespace pwiz.OspreySharp.FDR
+{
+    /// <summary>
+    /// Owns protein-FDR orchestration shared by the Tasks layer: the first-pass
+    /// run (pre-Stage-6, on the full pre-compaction pool) and the second-pass /
+    /// run-wide run (merge node, post Stage-6). Consolidates the glue that was
+    /// previously duplicated across three tasks (<c>FirstJoinTask</c>,
+    /// <c>MergeNodeTask</c>, <c>PerFileRescoreTask</c>) so FDR orchestration
+    /// physically lives in the FDR project; the tasks call this through a thin
+    /// facade, passing <c>ctx.LogInfo</c> as the log sink.
+    ///
+    /// Pure: takes data + a log delegate, never the pipeline context. It does NOT
+    /// take <c>IOspreyDiagnostics</c> and does NOT call
+    /// <c>OspreyDiagnosticsLog.ExitAfterDump</c> -- the Diagnostics project
+    /// references this FDR project (a back-edge), so an FDR -> Diagnostics
+    /// dependency would be a project-reference cycle. Instead each method RETURNS
+    /// the parsimony / FDR artifacts; the Tasks facade owns the diagnostic dump
+    /// and the early-exit decision. Mirrors the PercolatorEngine pattern.
+    /// </summary>
+    public static class ProteinFdrEngine
+    {
+        /// <summary>
+        /// First-pass protein FDR (pre-Stage-6, full pre-compaction pool): builds
+        /// parsimony from peptides passing peptide-level run FDR, runs picked-protein
+        /// FDR at <see cref="OspreyConfig.RunFdr"/>, and writes
+        /// <see cref="FdrEntry.RunProteinQvalue"/> on every stub. The pure computation
+        /// lives in <see cref="ProteinFdr.RunFirstPassProteinFdr"/>; this adds the
+        /// summary logging and returns the artifacts so the Tasks facade can emit the
+        /// Stage-6 diagnostic dump + <c>ProteinFdrOnly</c> early-exit WITHOUT
+        /// recomputing them. <paramref name="logInfo"/> may be null for the
+        /// <c>--task MergeNode</c> rehydration path (<c>PerFileRescoreTask</c>), which
+        /// runs the recompute silently before compaction.
+        /// </summary>
+        public static FirstPassProteinFdrResult RunFirstPass(
+            IList<KeyValuePair<string, List<FdrEntry>>> perFileEntries,
+            IList<LibraryEntry> fullLibrary,
+            OspreyConfig config,
+            Action<string> logInfo)
+        {
+            var result = ProteinFdr.RunFirstPassProteinFdr(
+                perFileEntries, fullLibrary, config);
+
+            if (logInfo != null)
+            {
+                logInfo(string.Format(
+                    "[COUNT] First-pass detected peptides for protein FDR: {0} unique",
+                    result.DetectedPeptides.Count));
+
+                int nAtRunFdr = 0;
+                foreach (var qv in result.ProteinFdr.GroupQvalues.Values)
+                {
+                    if (qv <= config.RunFdr)
+                        nAtRunFdr++;
+                }
+                logInfo(string.Format(
+                    "First-pass protein FDR: {0} target groups at {1:P1} FDR",
+                    nAtRunFdr, config.RunFdr));
+            }
+
+            return result;
+        }
+
+        /// <summary>
+        /// Second-pass / run-wide protein FDR (merge node, post Stage-6): collects
+        /// best peptide scores, gates the detected-peptide set on experiment-level
+        /// q-value, builds parsimony, runs picked-protein FDR at
+        /// <see cref="OspreyConfig.RunFdr"/>, and propagates both
+        /// <see cref="FdrEntry.RunProteinQvalue"/> and
+        /// <see cref="FdrEntry.ExperimentProteinQvalue"/> onto every stub. Logs
+        /// summary counts via <paramref name="logInfo"/> and returns the parsimony /
+        /// FDR artifacts so the Tasks facade can emit the Stage-7 detected-peptides
+        /// and protein-FDR diagnostic dumps + the <c>Stage7ProteinFdrOnly</c>
+        /// early-exit WITHOUT recomputing them. Moved here from
+        /// <c>MergeNodeTask.RunProteinFdr</c> (the dump / early-exit blocks stay in
+        /// the Tasks facade -- see the type remarks for why).
+        /// </summary>
+        public static SecondPassProteinFdrResult RunSecondPass(
+            IList<KeyValuePair<string, List<FdrEntry>>> perFileEntries,
+            IList<LibraryEntry> fullLibrary,
+            OspreyConfig config,
+            Action<string> logInfo)
+        {
+            // Collect best peptide scores
+            var bestScores = ProteinFdr.CollectBestPeptideScores(perFileEntries);
+            logInfo(string.Format("Collected scores for {0} unique peptides", bestScores.Count));
+
+            // Get detected peptide set: targets passing experiment-level
+            // q-value at the configured fdr_level (matches Rust pipeline.rs
+            // second-pass parsimony input which filters on
+            // `effective_experiment_qvalue(peptide_gate_level) <= experiment_fdr`
+            // where peptide_gate_level = config.fdr_level (Peptide if config
+            // is Protein, otherwise the config value). The Rust default
+            // `FdrLevel::Precursor` means a default run filters on precursor-
+            // level experiment q-values, NOT peptide-level. Matching that
+            // here prevents losing ~1500 peptides to an unintentionally
+            // stricter Peptide-level gate.
+            // Rust pipeline.rs:4510 maps `FdrLevel::Protein -> Peptide` and
+            // passes other variants through. C#'s FdrLevel enum doesn't
+            // include `Protein` (just Precursor/Peptide/Both), so the remap
+            // is a no-op here -- pass config.FdrLevel through directly. The
+            // important property is that the gate level matches Rust's
+            // default `FdrLevel::Precursor`, NOT a hardcoded Peptide.
+            var peptideGateLevel = config.FdrLevel;
+            var detectedPeptides = new HashSet<string>(StringComparer.Ordinal);
+            foreach (var kvp in perFileEntries)
+            {
+                foreach (var entry in kvp.Value)
+                {
+                    if (!entry.IsDecoy &&
+                        entry.EffectiveExperimentQvalue(peptideGateLevel) <= config.ExperimentFdr)
+                    {
+                        detectedPeptides.Add(entry.ModifiedSequence);
+                    }
+                }
+            }
+
+            logInfo(string.Format("Detected {0} unique peptides at {1:P1} experiment FDR ({2})",
+                detectedPeptides.Count, config.ExperimentFdr, peptideGateLevel));
+            logInfo(string.Format(
+                "[COUNT] Detected peptides for protein FDR: {0} unique",
+                detectedPeptides.Count));
+
+            // Build protein parsimony
+            var parsimony = ProteinFdr.BuildProteinParsimony(
+                fullLibrary, config.SharedPeptides, detectedPeptides);
+
+            logInfo(string.Format("Protein parsimony: {0} groups", parsimony.Groups.Count));
+            logInfo(string.Format(
+                "[COUNT] Protein parsimony groups: {0}", parsimony.Groups.Count));
+
+            // Compute protein FDR. Gate is config.RunFdr (1x) per Savitski's
+            // convention, matching Rust pipeline.rs:4389
+            // (compute_protein_fdr at config.run_fdr). The previous 2x gate
+            // was a divergence from Rust that has since been corrected.
+            var proteinFdr = ProteinFdr.ComputeProteinFdr(parsimony, bestScores, config.RunFdr);
+
+            // Count passing proteins
+            int passingProteins = 0;
+            foreach (var kvp in proteinFdr.GroupQvalues)
+            {
+                if (kvp.Value <= config.ProteinFdr.Value)
+                    passingProteins++;
+            }
+
+            logInfo(string.Format("{0} protein groups pass {1:P1} protein FDR",
+                passingProteins, config.ProteinFdr.Value));
+            logInfo(string.Format(
+                "[COUNT] Protein groups passing FDR: {0} at {1:P0}",
+                passingProteins, config.ProteinFdr.Value));
+
+            // Propagate protein q-values to FdrEntry stubs. The Stage-7
+            // diagnostic dumps + Stage7ProteinFdrOnly early-exit are owned by
+            // the Tasks facade (they need IOspreyDiagnostics, which this FDR
+            // project cannot reference); the facade fires them from the
+            // returned artifacts. Propagation only mutates the stubs, which
+            // the dumps do not read, so emitting the dump after propagation is
+            // output-invariant -- and matches the first-pass ordering, where
+            // RunFirstPassProteinFdr likewise propagates before the facade dump.
+            ProteinFdr.PropagateProteinQvalues(perFileEntries, proteinFdr, true, true);
+
+            return new SecondPassProteinFdrResult(detectedPeptides, parsimony, proteinFdr);
+        }
+    }
+}

--- a/pwiz_tools/OspreySharp/OspreySharp.Tasks/FirstJoinTask.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Tasks/FirstJoinTask.cs
@@ -1243,27 +1243,15 @@ namespace pwiz.OspreySharp.Tasks
             OspreyConfig config,
             PipelineContext ctx)
         {
-            // The core computation + propagation lives in
-            // ProteinFdr.RunFirstPassProteinFdr (also driven by the --task
-            // MergeNode rehydration path in PerFileRescoreTask). It returns the
-            // parsimony / FDR artifacts it computed so we can log summary counts
-            // and emit the diagnostic dump here WITHOUT recomputing them.
-            var result = ProteinFdr.RunFirstPassProteinFdr(
-                perFileEntries, fullLibrary, config);
-
-            ctx.LogInfo(string.Format(
-                "[COUNT] First-pass detected peptides for protein FDR: {0} unique",
-                result.DetectedPeptides.Count));
-
-            int nAtRunFdr = 0;
-            foreach (var qv in result.ProteinFdr.GroupQvalues.Values)
-            {
-                if (qv <= config.RunFdr)
-                    nAtRunFdr++;
-            }
-            ctx.LogInfo(string.Format(
-                "First-pass protein FDR: {0} target groups at {1:P1} FDR",
-                nAtRunFdr, config.RunFdr));
+            // Orchestration (compute + propagation + summary logging) lives in
+            // ProteinFdrEngine.RunFirstPass (shared with the --task MergeNode
+            // rehydration path in PerFileRescoreTask). It returns the parsimony /
+            // FDR artifacts so we can emit the Stage-6 diagnostic dump here WITHOUT
+            // recomputing them. The dump + ProteinFdrOnly early-exit stay in this
+            // Tasks facade because OspreySharp.FDR cannot reference
+            // OspreySharp.Diagnostics (the Diagnostics project references FDR).
+            var result = ProteinFdrEngine.RunFirstPass(
+                perFileEntries, fullLibrary, config, ctx.LogInfo);
 
             if (ctx.Diagnostics?.DumpProteinFdr ?? false)
             {

--- a/pwiz_tools/OspreySharp/OspreySharp.Tasks/MergeNodeTask.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Tasks/MergeNodeTask.cs
@@ -158,8 +158,15 @@ namespace pwiz.OspreySharp.Tasks
 
         /// <summary>
         /// Run protein-level FDR using parsimony and picked-protein
-        /// competition. Moved here from AnalysisPipeline as part of
-        /// the Phase A monolith breakup.
+        /// competition. The orchestration (collect best scores, detected-peptide
+        /// gate, parsimony, picked-protein FDR, summary logging, q-value
+        /// propagation) lives in <see cref="ProteinFdrEngine.RunSecondPass"/>,
+        /// shared with the first-pass / rehydration paths. It returns the
+        /// parsimony / FDR artifacts so the Stage-7 diagnostic dumps and the
+        /// <c>Stage7ProteinFdrOnly</c> early-exit can stay in this Tasks facade --
+        /// OspreySharp.FDR cannot reference OspreySharp.Diagnostics (the
+        /// Diagnostics project references FDR), so the dump / Environment.Exit
+        /// cannot move into the engine.
         /// </summary>
         private void RunProteinFdr(
             List<KeyValuePair<string, List<FdrEntry>>> perFileEntries,
@@ -167,91 +174,24 @@ namespace pwiz.OspreySharp.Tasks
             OspreyConfig config,
             PipelineContext ctx)
         {
-            // Collect best peptide scores
-            var bestScores = ProteinFdr.CollectBestPeptideScores(perFileEntries);
-            ctx.LogInfo(string.Format("Collected scores for {0} unique peptides", bestScores.Count));
-
-            // Get detected peptide set: targets passing experiment-level
-            // q-value at the configured fdr_level (matches Rust pipeline.rs
-            // second-pass parsimony input which filters on
-            // `effective_experiment_qvalue(peptide_gate_level) <= experiment_fdr`
-            // where peptide_gate_level = config.fdr_level (Peptide if config
-            // is Protein, otherwise the config value). The Rust default
-            // `FdrLevel::Precursor` means a default run filters on precursor-
-            // level experiment q-values, NOT peptide-level. Matching that
-            // here prevents losing ~1500 peptides to an unintentionally
-            // stricter Peptide-level gate.
-            // Rust pipeline.rs:4510 maps `FdrLevel::Protein -> Peptide` and
-            // passes other variants through. C#'s FdrLevel enum doesn't
-            // include `Protein` (just Precursor/Peptide/Both), so the remap
-            // is a no-op here -- pass config.FdrLevel through directly. The
-            // important property is that the gate level matches Rust's
-            // default `FdrLevel::Precursor`, NOT a hardcoded Peptide.
-            var peptideGateLevel = config.FdrLevel;
-            var detectedPeptides = new HashSet<string>(StringComparer.Ordinal);
-            foreach (var kvp in perFileEntries)
-            {
-                foreach (var entry in kvp.Value)
-                {
-                    if (!entry.IsDecoy &&
-                        entry.EffectiveExperimentQvalue(peptideGateLevel) <= config.ExperimentFdr)
-                    {
-                        detectedPeptides.Add(entry.ModifiedSequence);
-                    }
-                }
-            }
-
-            ctx.LogInfo(string.Format("Detected {0} unique peptides at {1:P1} experiment FDR ({2})",
-                detectedPeptides.Count, config.ExperimentFdr, peptideGateLevel));
-            ctx.LogInfo(string.Format(
-                "[COUNT] Detected peptides for protein FDR: {0} unique",
-                detectedPeptides.Count));
+            var result = ProteinFdrEngine.RunSecondPass(
+                perFileEntries, fullLibrary, config, ctx.LogInfo);
 
             // Cross-impl bisection dump (env-var-gated, no-op in production).
             if (ctx.Diagnostics?.DumpDetectedPeptides ?? false)
-                ctx.Diagnostics?.WriteStage7DetectedPeptidesDump(detectedPeptides);
-
-            // Build protein parsimony
-            var parsimony = ProteinFdr.BuildProteinParsimony(
-                fullLibrary, config.SharedPeptides, detectedPeptides);
-
-            ctx.LogInfo(string.Format("Protein parsimony: {0} groups", parsimony.Groups.Count));
-            ctx.LogInfo(string.Format(
-                "[COUNT] Protein parsimony groups: {0}", parsimony.Groups.Count));
-
-            // Compute protein FDR. Gate is config.RunFdr (1x) per Savitski's
-            // convention, matching Rust pipeline.rs:4389
-            // (compute_protein_fdr at config.run_fdr). The previous 2x gate
-            // was a divergence from Rust that has since been corrected.
-            var proteinFdr = ProteinFdr.ComputeProteinFdr(parsimony, bestScores, config.RunFdr);
-
-            // Count passing proteins
-            int passingProteins = 0;
-            foreach (var kvp in proteinFdr.GroupQvalues)
-            {
-                if (kvp.Value <= config.ProteinFdr.Value)
-                    passingProteins++;
-            }
-
-            ctx.LogInfo(string.Format("{0} protein groups pass {1:P1} protein FDR",
-                passingProteins, config.ProteinFdr.Value));
-            ctx.LogInfo(string.Format(
-                "[COUNT] Protein groups passing FDR: {0} at {1:P0}",
-                passingProteins, config.ProteinFdr.Value));
+                ctx.Diagnostics?.WriteStage7DetectedPeptidesDump(result.DetectedPeptides);
 
             // Stage 7 cross-impl bisection dump (no-op unless
-            // OSPREY_DUMP_STAGE7_PROTEIN_FDR=1). Fires before propagation so
-            // the dumped state captures the picked-protein computation in
-            // isolation, matching Rust diagnostics.dump_stage7_protein_fdr.
+            // OSPREY_DUMP_STAGE7_PROTEIN_FDR=1). Mirrors Rust
+            // diagnostics.dump_stage7_protein_fdr. The engine has already
+            // propagated q-values onto the stubs, but the dump reads only the
+            // parsimony / FDR result (not the stubs), so it is unaffected.
             if (ctx.Diagnostics?.DumpStage7ProteinFdr ?? false)
             {
-                ctx.Diagnostics?.WriteStage7ProteinFdrDump(parsimony, proteinFdr);
+                ctx.Diagnostics?.WriteStage7ProteinFdrDump(result.Parsimony, result.ProteinFdr);
                 if (ctx.Diagnostics?.Stage7ProteinFdrOnly ?? false)
                     OspreyDiagnosticsLog.ExitAfterDump(@"OSPREY_STAGE7_PROTEIN_FDR_ONLY");
             }
-
-            // Propagate protein q-values to FdrEntry stubs
-            ProteinFdr.PropagateProteinQvalues(perFileEntries, proteinFdr, true, true);
         }
 
         /// <summary>

--- a/pwiz_tools/OspreySharp/OspreySharp.Tasks/PerFileRescoreTask.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Tasks/PerFileRescoreTask.cs
@@ -426,8 +426,11 @@ namespace pwiz.OspreySharp.Tasks
                 if (ctx.Config.ProteinFdr.HasValue && bundle.PerFileEntries.Count > 0)
                 {
                     var fullLibrary = ctx.Get<FullLibrary>().Value;
-                    ProteinFdr.RunFirstPassProteinFdr(
-                        bundle.PerFileEntries, fullLibrary, ctx.Config);
+                    // Silent (logInfo: null) -- the rehydration recompute runs
+                    // before compaction with no log output, as it did when it
+                    // called ProteinFdr.RunFirstPassProteinFdr directly.
+                    ProteinFdrEngine.RunFirstPass(
+                        bundle.PerFileEntries, fullLibrary, ctx.Config, null);
                 }
                 var stats = RescoreCompaction.Apply(bundle, ctx.Config);
                 ctx.LogInfo(string.Format(

--- a/pwiz_tools/OspreySharp/OspreySharp/OspreyFileDiagnostics.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/OspreyFileDiagnostics.cs
@@ -1870,6 +1870,12 @@ namespace pwiz.OspreySharp
         /// not in proteinFdr.PeptideQvalues, matching the
         /// PropagateProteinQvalues default). Rows sorted by
         /// (is_decoy, modified_sequence) for stable diff.
+        ///
+        /// INVARIANT: dump only from the passed-in protein-FDR artifacts
+        /// (bestScores / peptideQvalues), never from the FdrEntry stubs.
+        /// ProteinFdrEngine propagates q-values onto the stubs BEFORE the
+        /// Tasks facade calls this, so reading stub q-values here would break
+        /// the byte-identical output the regression golden depends on.
         /// </summary>
         public void WriteStage6ProteinFdrDump(
             IDictionary<string, PeptideScore> bestScores,
@@ -1929,6 +1935,12 @@ namespace pwiz.OspreySharp
         /// BuildProteinParsimony assigns it in dictionary iteration order, which
         /// is non-deterministic across runs. Joining on accessions instead
         /// keeps the dump diff-stable for cross-impl bisection.
+        ///
+        /// INVARIANT: dump only from the passed-in parsimony / fdrResult,
+        /// never from the FdrEntry stubs. ProteinFdrEngine propagates q-values
+        /// onto the stubs BEFORE the Tasks facade calls this, so reading stub
+        /// q-values here would break the byte-identical output the regression
+        /// golden depends on.
         /// </summary>
         public void WriteStage7ProteinFdrDump(
             ProteinParsimonyResult parsimony,


### PR DESCRIPTION
## Summary

* Introduced `ProteinFdrEngine` (`OspreySharp.FDR`) owning first-pass and second-pass protein-FDR orchestration, consolidating glue that was split across `FirstJoinTask`, `MergeNodeTask`, and `PerFileRescoreTask`.
* `MergeNodeTask.RunProteinFdr`'s run-wide composite (collect best scores / detected-peptide gate / parsimony / picked-protein FDR / q-value propagation) moved into `RunSecondPass`; `FirstJoinTask`'s first-pass summary logging moved into `RunFirstPass`. The three task sites are now thin facades.
* Diagnostic dumps and `ExitAfterDump` stay in the Tasks facades: `OspreySharp.FDR` cannot reference `OspreySharp.Diagnostics` (the Diagnostics project references FDR), so the engine returns artifacts (`SecondPassProteinFdrResult`) and the facade owns the dumps + early-exit decision.
* Pure code motion -- byte-identical output. PR 6 of the OspreySharp OOP debt-paydown arc (follows PR 5 #4314). The `PercolatorFdr.RunPercolator` carve is deferred to a follow-up tranche.

## Test plan

- [x] `Build-OspreySharp.ps1 -Configuration Debug -RunTests -RunInspection` -- 0 warnings, 390 pass (2 cross-impl skipped)
- [x] `regression.ps1 -Dataset All` -- Stellar + Astral, both modes byte-identical (blib 52,514,816 / 136,622,080 B)
- [x] Fresh-context self-review (`/pw-self-review`) -- clean; two LOW findings addressed in a follow-up commit
- [x] `Test-PerfGate.ps1 -Dataset Stellar` -- PASSED (total median -2.2%, no regression)

Co-Authored-By: Claude <noreply@anthropic.com>
