### PR TITLE
OspreySharp debt-paydown PR 8: decomposed the Tasks-layer orchestration monoliths

### DIFF
--- a/pwiz_tools/OspreySharp/OspreySharp.Tasks/FirstJoinTask.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Tasks/FirstJoinTask.cs
@@ -569,196 +569,11 @@ namespace pwiz.OspreySharp.Tasks
             ctx.LogInfo(string.Empty);
             ctx.LogInfo(@"Stage 6: planning");
 
-            // 1. Multi-charge consensus per file (independent — runs
-            //    first per Rust pipeline.rs:3217, before consensus
-            //    RT computation).
-            var perFileConsensusTargets = new Dictionary<string,
-                IReadOnlyList<(int Index, double Apex, double Start, double End)>>();
-            foreach (var kvp in perFileEntries)
-            {
-                perFileConsensusTargets[kvp.Key] =
-                    MultiChargeConsensus.SelectRescoreTargets(kvp.Value, config.RunFdr);
-            }
-            int totalMulticharge = 0;
-            foreach (var kvp in perFileConsensusTargets)
-                totalMulticharge += kvp.Value.Count;
-            ctx.LogInfo(string.Format(
-                @"Stage 6 multi-charge consensus: {0} entries need re-scoring across {1} files",
-                totalMulticharge, perFileEntries.Count));
-
-            if (ctx.Diagnostics?.DumpMulticharge ?? false)
-            {
-                var perFileForDump = new List<KeyValuePair<string,
-                    IReadOnlyList<FdrEntry>>>(perFileEntries.Count);
-                foreach (var kvp in perFileEntries)
-                {
-                    perFileForDump.Add(new KeyValuePair<string,
-                        IReadOnlyList<FdrEntry>>(kvp.Key, kvp.Value));
-                }
-                ctx.Diagnostics?.WriteStage6MultichargeDump(
-                    perFileForDump, perFileConsensusTargets);
-                if (ctx.Diagnostics?.MultichargeOnly ?? false)
-                    OspreyDiagnosticsLog.ExitAfterDump(@"OSPREY_MULTICHARGE_ONLY");
-            }
-
-            // 2. Cross-run consensus RTs (target peptides + paired
-            //    decoys, sigmoid(score)-weighted median, hard
-            //    run_precursor_qvalue gate).
-            var perFileForRecon = new List<KeyValuePair<string,
-                IReadOnlyList<FdrEntry>>>(perFileEntries.Count);
-            foreach (var kvp in perFileEntries)
-            {
-                perFileForRecon.Add(new KeyValuePair<string,
-                    IReadOnlyList<FdrEntry>>(kvp.Key, kvp.Value));
-            }
-            // Cross-impl bisection trace for InversePredict: if the
-            // OSPREY_DUMP_INV_PREDICT env var is set, ConsensusRts
-            // populates this list with one row per detection. The
-            // caller drives the dump via OspreyDiagnostics so the
-            // FDR project doesn't have to know about the diagnostic
-            // file format.
-            List<InvPredictRecord> invPredictTrace = null;
-            if (ctx.Diagnostics?.DumpInvPredict ?? false)
-                invPredictTrace = new List<InvPredictRecord>();
-
-            // Cross-file consensus is only meaningful with > 1 file.
-            // Mirrors Rust pipeline.rs:4146 where reconciliation_enabled
-            // requires per_file_entries.len() > 1 — single-file runs
-            // skip consensus computation, refit, and reconciliation
-            // entirely, leaving multi-charge consensus rescore as the
-            // only Stage 6 work performed.
-            IReadOnlyList<PeptideConsensusRT> consensus =
-                perFileEntries.Count > 1
-                    ? ConsensusRts.Compute(
-                        perFileForRecon, perFileCalibrations,
-                        config.Reconciliation.ConsensusFdr,
-                        config.ProteinFdr ?? 0.0,
-                        invPredictTrace)
-                    : Array.Empty<PeptideConsensusRT>();
-
-            if (invPredictTrace != null)
-            {
-                ctx.Diagnostics?.WriteStage6InvPredictDump(invPredictTrace);
-                if (ctx.Diagnostics?.InvPredictOnly ?? false)
-                    OspreyDiagnosticsLog.ExitAfterDump(@"OSPREY_INV_PREDICT_ONLY");
-            }
-            int nTargets = 0, nDecoys = 0;
-            foreach (var c in consensus)
-            {
-                if (c.IsDecoy) nDecoys++;
-                else nTargets++;
-            }
-            ctx.LogInfo(string.Format(
-                @"Stage 6 consensus: {0} target peptides, {1} decoy peptides",
-                nTargets, nDecoys));
-
-            // Skip the dump on empty consensus to match Rust's
-            // dump_stage6_consensus, which silently elides the
-            // file when there is nothing to write (the dump is
-            // gated on Some(file) in Rust, derived from
-            // !consensus.is_empty()). Without this gate, C#
-            // emits a header-only cs_stage6_consensus.tsv and
-            // Test-Regression sees an asymmetric-absence FAIL
-            // even though both sides agree on the empty result.
-            if ((ctx.Diagnostics?.DumpConsensus ?? false) && consensus.Count > 0)
-            {
-                ctx.Diagnostics?.WriteStage6ConsensusDump(consensus);
-                if (ctx.Diagnostics?.ConsensusOnly ?? false)
-                    OspreyDiagnosticsLog.ExitAfterDump(@"OSPREY_CONSENSUS_ONLY");
-            }
-
-            // 3. Per-file calibration refit on consensus peptides.
-            var refinedCalibrations = new Dictionary<string, RTCalibration>();
-            foreach (var kvp in perFileEntries)
-            {
-                var refined = CalibrationRefit.Refit(consensus, kvp.Value,
-                    config.Reconciliation.ConsensusFdr);
-                if (refined != null)
-                    refinedCalibrations[kvp.Key] = refined;
-            }
-            ctx.LogInfo(string.Format(
-                @"Stage 6 refit: {0}/{1} files produced refined calibrations",
-                refinedCalibrations.Count, perFileEntries.Count));
-
-            if (ctx.Diagnostics?.DumpLoessFit ?? false)
-            {
-                ctx.Diagnostics?.WriteStage6LoessFitDump(refinedCalibrations);
-                if (ctx.Diagnostics?.LoessFitOnly ?? false)
-                    OspreyDiagnosticsLog.ExitAfterDump(@"OSPREY_LOESS_FIT_ONLY");
-            }
-
-            if (ctx.Diagnostics?.DumpRefit ?? false)
-            {
-                ctx.Diagnostics?.WriteStage6RefitDump(refinedCalibrations);
-                if (ctx.Diagnostics?.RefitOnly ?? false)
-                    OspreyDiagnosticsLog.ExitAfterDump(@"OSPREY_REFIT_ONLY");
-            }
-
-            // 4. Reconciliation planning. Reads each file's CWT
-            //    candidates from the parquet cache and asks the
-            //    planner to choose, per (file, entry), whether to
-            //    keep the existing peak, switch to a stored CWT
-            //    candidate at the consensus RT, or force an
-            //    integration window. Mirrors Rust pipeline.rs
-            //    reconciliation block at ~3260-3380.
-            IReadOnlyDictionary<(string File, int Index), ReconcileAction> reconciliationActions = null;
-            var perFileCwtCandidates = CwtCandidateLoader.Load(
-                perFileEntries, perFileParquetPaths, ctx.LogWarning);
-            var perFileForPlan = new List<KeyValuePair<string,
-                IReadOnlyList<FdrEntry>>>(perFileEntries.Count);
-            foreach (var kvp in perFileEntries)
-            {
-                perFileForPlan.Add(new KeyValuePair<string,
-                    IReadOnlyList<FdrEntry>>(kvp.Key, kvp.Value));
-            }
-            // Match Rust pipeline.rs:4223: only run the reconciliation
-            // planner when the cross-file consensus is non-empty.
-            // Single-file runs (or any case where no peptide had
-            // enough cross-replicate evidence to form a consensus
-            // RT) degenerate to zero reconciliation actions in
-            // Rust; C# previously planned regardless and produced
-            // ~22k spurious use_cwt actions on Stellar single-file.
-            if (perFileCwtCandidates.Count == perFileEntries.Count
-                && consensus.Count > 0)
-            {
-                reconciliationActions = ReconciliationPlanner.Plan(
-                    consensus,
-                    perFileForPlan,
-                    perFileCwtCandidates,
-                    refinedCalibrations,
-                    perFileCalibrations,
-                    config.Reconciliation.ConsensusFdr);
-                ctx.LogInfo(string.Format(
-                    @"Stage 6 reconciliation: {0} per-(file, entry) actions planned",
-                    reconciliationActions.Count));
-            }
-            else if (consensus.Count == 0)
-            {
-                ctx.LogInfo(@"Stage 6 reconciliation: skipped (empty consensus; single-file or no cross-file evidence)");
-            }
-            else
-            {
-                ctx.LogInfo(string.Format(
-                    @"Stage 6 reconciliation: skipped (CWT candidates loaded for {0}/{1} files)",
-                    perFileCwtCandidates.Count, perFileEntries.Count));
-            }
-
-            // Stage 6 cross-impl bisection dump for the planner output.
-            // Fires unconditionally when OSPREY_DUMP_RECONCILIATION=1
-            // is set so the skipped / empty paths still produce a
-            // header-only TSV and still honor OSPREY_RECONCILIATION_ONLY
-            // for early exit. Mirrors the Rust side at
-            // crates/osprey/src/pipeline.rs after the reconciliation
-            // block closes.
-            if (ctx.Diagnostics?.DumpReconciliation ?? false)
-            {
-                var dumpActions = reconciliationActions
-                    ?? new Dictionary<(string File, int Index), ReconcileAction>();
-                ctx.Diagnostics?.WriteStage6ReconciliationDump(
-                    dumpActions, perFileForPlan);
-                if (ctx.Diagnostics?.ReconciliationOnly ?? false)
-                    OspreyDiagnosticsLog.ExitAfterDump(@"OSPREY_RECONCILIATION_ONLY");
-            }
+            // Four cross-file planning phases (multi-charge consensus, cross-run
+            // consensus RTs, per-file calibration refit, reconciliation
+            // planning), each routing its diagnostic dump through ctx.Diagnostics.
+            var plan = new Stage6Planner(ctx).Plan(
+                perFileEntries, perFileCalibrations, perFileParquetPaths, config);
 
             // Stage 5 → Stage 6 boundary: write the per-file
             // .reconciliation.json envelope (the .fdr_scores.bin
@@ -770,9 +585,9 @@ namespace pwiz.OspreySharp.Tasks
             // process Stage 6 rescore call below can execute them.
             int reconWriteFailures = WriteReconciliationFiles(
                 perFileEntries,
-                reconciliationActions,
-                consensus,
-                refinedCalibrations,
+                plan.ReconciliationActions,
+                plan.Consensus,
+                plan.RefinedCalibrations,
                 perFileCalibrations,
                 fullLibrary,
                 perFileParquetPaths,
@@ -806,10 +621,10 @@ namespace pwiz.OspreySharp.Tasks
 
             // Surface outputs for the next task.
             _didPlan = true;
-            _perFileConsensusTargets = perFileConsensusTargets;
-            _reconciliationActions = reconciliationActions
+            _perFileConsensusTargets = plan.PerFileConsensusTargets;
+            _reconciliationActions = plan.ReconciliationActions
                 ?? new Dictionary<(string, int), ReconcileAction>();
-            _refinedCalibrations = refinedCalibrations;
+            _refinedCalibrations = plan.RefinedCalibrations;
             _perFileGapFillForRescore = perFileGapFillForRescore
                 ?? new Dictionary<string, List<GapFillTarget>>();
             return true;

--- a/pwiz_tools/OspreySharp/OspreySharp.Tasks/PerFileRescoreTask.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Tasks/PerFileRescoreTask.cs
@@ -585,7 +585,7 @@ namespace pwiz.OspreySharp.Tasks
             // Assemble this file's rescore targets (multi-charge consensus +
             // reconciliation dedup + gap-fill) and resolve its input mzML.
             // Bails when there is no work or the file has no input_files entry.
-            if (!TryAssembleRescoreTargets(fileNum, nTotalFiles, fileName, fdrEntries, inputs, ctx,
+            if (!TryAssembleRescoreTargets(fileNum, nTotalFiles, fileName, inputs, ctx,
                     out var combinedTargets, out var gapFillTargets, out string inputFile))
                 return (totalRescored, totalGapCwt, totalGapForced);
 
@@ -771,7 +771,7 @@ namespace pwiz.OspreySharp.Tasks
         /// file has no input_files entry.
         /// </summary>
         private bool TryAssembleRescoreTargets(
-            int fileNum, int nTotalFiles, string fileName, List<FdrEntry> fdrEntries,
+            int fileNum, int nTotalFiles, string fileName,
             RescorePassInputs inputs, PipelineContext ctx,
             out Dictionary<int, (double Apex, double Start, double End)> combinedTargets,
             out List<GapFillTarget> gapFillTargets,

--- a/pwiz_tools/OspreySharp/OspreySharp.Tasks/PerFileRescoreTask.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Tasks/PerFileRescoreTask.cs
@@ -573,106 +573,24 @@ namespace pwiz.OspreySharp.Tasks
             int fileNum, int nTotalFiles, string fileName, List<FdrEntry> fdrEntries,
             RescorePassInputs inputs, PipelineContext ctx)
         {
-            var perFileConsensusTargets = inputs.ConsensusTargets;
-            var perFileReconTargets = inputs.ReconTargets;
-            var refinedCalibrations = inputs.RefinedCalibrations;
-            var perFileCalibrations = inputs.PerFileCalibrations;
-            var perFileGapFill = inputs.GapFill;
-            var perFileParquetPaths = inputs.ParquetPaths;
-            var fullLibrary = inputs.FullLibrary;
-            var config = inputs.Config;
-            var fileNameToIdx = inputs.FileNameToIdx;
-            string taskValidityKey = inputs.TaskValidityKey;
-            var joinFileStems = inputs.JoinFileStems;
-
             int totalRescored = 0;
             int totalGapCwt = 0;
             int totalGapForced = 0;
 
-            // Per-file resume: if the file's reconciled parquet is
-            // already on disk with a matching <output>.PerFileRescore.osprey.task
-            // sidecar, skip the rescore for that file. Pairs with the
-            // worker (stage6) crash-resume contract: re-invoking the
-            // same CLI on the same inputs is a no-op for files whose
-            // rescore completed; only files missing a valid sidecar
-            // get re-rescored. The skipped file's in-memory entries
-            // remain at the pre-rescore state (1st-pass overlay)
-            // because the worker's StopAfter terminates the pipeline
-            // here -- no downstream consumer reads them.
-            // The rescore READS the original Stage 4 parquet and WRITES a
-            // separate <stem>.scores-reconciled.parquet. Resume validity is
-            // keyed on the reconciled output (the task's declared Output),
-            // not on the original read source.
-            bool hasParquetPath = perFileParquetPaths.TryGetValue(fileName, out string perFileParquetPath);
-            string reconciledPath = hasParquetPath
-                ? ParquetScoreCache.ReconciledPathFromScoresPath(perFileParquetPath)
-                : null;
-            if (hasParquetPath
-                && PerFileResumeDriver.IsCurrent(reconciledPath, Name, taskValidityKey))
-            {
-                ctx.LogInfo(string.Format(
-                    @"[file] {0}/{1} {2}: skipping (outputs valid)",
-                    fileNum + 1, nTotalFiles, fileName));
-
-                // PR-E: a partial resume skips this already-rescored file, but
-                // a downstream consumer (MergeNode, in the full pipeline) reads
-                // ApexRt/StartRt/EndRt/BoundsArea straight off these in-memory
-                // entries. Without overlaying the reconciled values they stay at
-                // the 1st-pass state and the final blib carries 1st-pass RTs.
-                // Reproduce the fresh end state in place from the valid reconciled
-                // parquet we just confirmed on disk + this file's gap-fill targets.
-                IReadOnlyList<GapFillTarget> gapFillForFile = null;
-                if (perFileGapFill != null &&
-                    perFileGapFill.TryGetValue(fileName, out var gfList))
-                    gapFillForFile = gfList;
-                OverlayReconciledIntoBuffer(fdrEntries, reconciledPath, gapFillForFile);
-                SortFileEntriesCanonical(fdrEntries);
-                return (totalRescored, totalGapCwt, totalGapForced);
-            }
-            // About to (re-)rescore this file: clear any stale sidecar
-            // so a mid-Run crash leaves no false-positive pointing at
-            // the partially-written reconciled parquet.
-            if (hasParquetPath)
-                PerFileResumeDriver.ClearStale(reconciledPath, Name);
-
-            IReadOnlyList<(int Index, double Apex, double Start, double End)> consensusTargets;
-            if (!perFileConsensusTargets.TryGetValue(fileName, out consensusTargets))
-                consensusTargets = new List<(int, double, double, double)>();
-
-            List<(int Index, double Apex, double Start, double End)> reconTargets;
-            if (!perFileReconTargets.TryGetValue(fileName, out reconTargets))
-                reconTargets = new List<(int, double, double, double)>();
-
-            // PHASE 2 (gap-fill): per-file gap-fill targets land here.
-            List<GapFillTarget> gapFillTargets;
-            if (perFileGapFill == null ||
-                !perFileGapFill.TryGetValue(fileName, out gapFillTargets))
-            {
-                gapFillTargets = new List<GapFillTarget>();
-            }
-
-            // Merge consensus + reconciliation into a per-(idx, override)
-            // map. Reconciliation wins on conflict -- the inter-replicate
-            // peak boundary is more authoritative than the multi-charge
-            // consensus boundary.
-            var combinedTargets =
-                new Dictionary<int, (double Apex, double Start, double End)>();
-            foreach (var t in consensusTargets)
-                combinedTargets[t.Index] = (t.Apex, t.Start, t.End);
-            foreach (var t in reconTargets)
-                combinedTargets[t.Index] = (t.Apex, t.Start, t.End);
-
-            // Skip files with no work to do.
-            if (combinedTargets.Count == 0 && gapFillTargets.Count == 0)
+            // Per-file resume: a file whose reconciled parquet is already on
+            // disk with a matching sidecar is overlaid in place and skipped.
+            if (TryResumeRescoredFile(fileNum, nTotalFiles, fileName, fdrEntries, inputs, ctx))
                 return (totalRescored, totalGapCwt, totalGapForced);
 
-            if (!fileNameToIdx.TryGetValue(fileName, out int inputIdx))
-            {
-                ctx.LogWarning(string.Format(
-                    "Stage 6 rescore: no input_files entry for {0} (skipping)", fileName));
+            // Assemble this file's rescore targets (multi-charge consensus +
+            // reconciliation dedup + gap-fill) and resolve its input mzML.
+            // Bails when there is no work or the file has no input_files entry.
+            if (!TryAssembleRescoreTargets(fileNum, nTotalFiles, fileName, fdrEntries, inputs, ctx,
+                    out var combinedTargets, out var gapFillTargets, out string inputFile))
                 return (totalRescored, totalGapCwt, totalGapForced);
-            }
-            string inputFile = config.InputFiles[inputIdx];
+
+            var config = inputs.Config;
+            var fullLibrary = inputs.FullLibrary;
 
             // Clone the outer config for this file's ScoringContexts.
             // RunCoelutionScoring reassigns config.FragmentTolerance to
@@ -685,16 +603,6 @@ namespace pwiz.OspreySharp.Tasks
             // defaults -- causing search_hash mismatch errors). Mirrors
             // the per-file clone pattern in ProcessFile.
             var fileConfig = config.ShallowClone();
-
-            ctx.LogInfo(string.Format(
-                "Re-scoring file {0}/{1}: {2}", fileNum + 1, nTotalFiles, fileName));
-            ctx.LogInfo(string.Format(
-                "  {0} entries ({1} consensus, {2} reconciliation, {3} gap-fill, {4} unique after dedup)",
-                combinedTargets.Count + gapFillTargets.Count * 2,
-                consensusTargets.Count,
-                reconTargets.Count,
-                gapFillTargets.Count,
-                combinedTargets.Count));
 
             // Build the per-file scoring subset: boundary_overrides keyed
             // by entry_id + the subset library RunCoelutionScoring scores.
@@ -719,8 +627,8 @@ namespace pwiz.OspreySharp.Tasks
 
             // Pick the RT calibration: refined (from Stage 6 planning's
             // calibration refit) wins; original first-pass falls back.
-            if (!refinedCalibrations.TryGetValue(fileName, out RTCalibration rtCal))
-                perFileCalibrations.TryGetValue(fileName, out rtCal);
+            if (!inputs.RefinedCalibrations.TryGetValue(fileName, out RTCalibration rtCal))
+                inputs.PerFileCalibrations.TryGetValue(fileName, out rtCal);
 
             // Bisection seam DISABLED (paired with the per-candidate
             // WritePredictRtCall, which was removed from the scoring
@@ -792,24 +700,154 @@ namespace pwiz.OspreySharp.Tasks
                 totalRescored += nGapCwt + nGapForced;
             }
 
-            // PHASE 3 -- reconciled parquet write-back. Read the original
-            // Stage 4 parquet, write a separate .scores-reconciled.parquet
-            // sibling (leaving the original intact). perFileParquetPaths is
-            // non-null here (dereferenced at the resume probe above).
-            if (perFileParquetPaths.TryGetValue(fileName, out string parquetPath) &&
+            // PHASE 3 -- reconciled parquet write-back + sidecar stamp.
+            WriteReconciledAndStamp(fileName, inputFile, fdrEntries, inputs, ctx);
+
+            return (totalRescored, totalGapCwt, totalGapForced);
+        }
+
+        /// <summary>
+        /// Per-file resume probe. When the file's reconciled parquet is already
+        /// on disk with a matching
+        /// <c>&lt;output&gt;.PerFileRescore.osprey.task</c> sidecar, overlays
+        /// the reconciled values back onto the in-memory entries (a partial
+        /// resume must not leave 1st-pass RTs in the buffer a downstream
+        /// MergeNode reads) and returns true so the caller skips re-scoring.
+        /// Pairs with the worker (stage6) crash-resume contract: re-invoking
+        /// the same CLI on the same inputs is a no-op for files whose rescore
+        /// completed. Otherwise clears any stale sidecar so a mid-Run crash
+        /// leaves no false-positive, and returns false.
+        /// </summary>
+        private bool TryResumeRescoredFile(
+            int fileNum, int nTotalFiles, string fileName,
+            List<FdrEntry> fdrEntries, RescorePassInputs inputs, PipelineContext ctx)
+        {
+            // The rescore READS the original Stage 4 parquet and WRITES a
+            // separate <stem>.scores-reconciled.parquet. Resume validity is
+            // keyed on the reconciled output (the task's declared Output),
+            // not on the original read source.
+            bool hasParquetPath = inputs.ParquetPaths.TryGetValue(fileName, out string perFileParquetPath);
+            string reconciledPath = hasParquetPath
+                ? ParquetScoreCache.ReconciledPathFromScoresPath(perFileParquetPath)
+                : null;
+            if (hasParquetPath
+                && PerFileResumeDriver.IsCurrent(reconciledPath, Name, inputs.TaskValidityKey))
+            {
+                ctx.LogInfo(string.Format(
+                    @"[file] {0}/{1} {2}: skipping (outputs valid)",
+                    fileNum + 1, nTotalFiles, fileName));
+
+                // PR-E: a partial resume skips this already-rescored file, but
+                // a downstream consumer (MergeNode, in the full pipeline) reads
+                // ApexRt/StartRt/EndRt/BoundsArea straight off these in-memory
+                // entries. Without overlaying the reconciled values they stay at
+                // the 1st-pass state and the final blib carries 1st-pass RTs.
+                // Reproduce the fresh end state in place from the valid reconciled
+                // parquet we just confirmed on disk + this file's gap-fill targets.
+                IReadOnlyList<GapFillTarget> gapFillForFile = null;
+                if (inputs.GapFill != null &&
+                    inputs.GapFill.TryGetValue(fileName, out var gfList))
+                    gapFillForFile = gfList;
+                OverlayReconciledIntoBuffer(fdrEntries, reconciledPath, gapFillForFile);
+                SortFileEntriesCanonical(fdrEntries);
+                return true;
+            }
+            // About to (re-)rescore this file: clear any stale sidecar
+            // so a mid-Run crash leaves no false-positive pointing at
+            // the partially-written reconciled parquet.
+            if (hasParquetPath)
+                PerFileResumeDriver.ClearStale(reconciledPath, Name);
+            return false;
+        }
+
+        /// <summary>
+        /// Assemble the per-file rescore target set: merge multi-charge
+        /// consensus with reconciliation actions (reconciliation wins on
+        /// conflict -- the inter-replicate peak boundary is more authoritative
+        /// than the multi-charge consensus boundary), collect this file's
+        /// gap-fill targets, and resolve its input mzML path. Logs the
+        /// re-scoring banner + entry breakdown when there is work. Returns
+        /// false -- caller skips the file -- when there is no work to do or the
+        /// file has no input_files entry.
+        /// </summary>
+        private bool TryAssembleRescoreTargets(
+            int fileNum, int nTotalFiles, string fileName, List<FdrEntry> fdrEntries,
+            RescorePassInputs inputs, PipelineContext ctx,
+            out Dictionary<int, (double Apex, double Start, double End)> combinedTargets,
+            out List<GapFillTarget> gapFillTargets,
+            out string inputFile)
+        {
+            combinedTargets = new Dictionary<int, (double Apex, double Start, double End)>();
+            inputFile = null;
+
+            IReadOnlyList<(int Index, double Apex, double Start, double End)> consensusTargets;
+            if (!inputs.ConsensusTargets.TryGetValue(fileName, out consensusTargets))
+                consensusTargets = new List<(int, double, double, double)>();
+
+            List<(int Index, double Apex, double Start, double End)> reconTargets;
+            if (!inputs.ReconTargets.TryGetValue(fileName, out reconTargets))
+                reconTargets = new List<(int, double, double, double)>();
+
+            // PHASE 2 (gap-fill): per-file gap-fill targets land here.
+            if (inputs.GapFill == null ||
+                !inputs.GapFill.TryGetValue(fileName, out gapFillTargets))
+            {
+                gapFillTargets = new List<GapFillTarget>();
+            }
+
+            // Merge consensus + reconciliation into a per-(idx, override) map.
+            foreach (var t in consensusTargets)
+                combinedTargets[t.Index] = (t.Apex, t.Start, t.End);
+            foreach (var t in reconTargets)
+                combinedTargets[t.Index] = (t.Apex, t.Start, t.End);
+
+            // Skip files with no work to do.
+            if (combinedTargets.Count == 0 && gapFillTargets.Count == 0)
+                return false;
+
+            if (!inputs.FileNameToIdx.TryGetValue(fileName, out int inputIdx))
+            {
+                ctx.LogWarning(string.Format(
+                    "Stage 6 rescore: no input_files entry for {0} (skipping)", fileName));
+                return false;
+            }
+            inputFile = inputs.Config.InputFiles[inputIdx];
+
+            ctx.LogInfo(string.Format(
+                "Re-scoring file {0}/{1}: {2}", fileNum + 1, nTotalFiles, fileName));
+            ctx.LogInfo(string.Format(
+                "  {0} entries ({1} consensus, {2} reconciliation, {3} gap-fill, {4} unique after dedup)",
+                combinedTargets.Count + gapFillTargets.Count * 2,
+                consensusTargets.Count,
+                reconTargets.Count,
+                gapFillTargets.Count,
+                combinedTargets.Count));
+            return true;
+        }
+
+        /// <summary>
+        /// PHASE 3 -- reconciled parquet write-back. Reads the original Stage 4
+        /// parquet and writes a separate <c>.scores-reconciled.parquet</c>
+        /// sibling (leaving the original intact), then stamps the per-file
+        /// resume sidecar -- but ONLY on a successful write, so a failed write
+        /// can never mark stale reconciled content valid (which would let
+        /// Stage 7 / a future resume consume old rescored content). On failure
+        /// clears the sidecar and removes the partially-written parquet so the
+        /// next run re-rescores this file from scratch.
+        /// </summary>
+        private void WriteReconciledAndStamp(
+            string fileName, string inputFile, List<FdrEntry> fdrEntries,
+            RescorePassInputs inputs, PipelineContext ctx)
+        {
+            var config = inputs.Config;
+            // ParquetPaths is non-null here (dereferenced at the resume probe).
+            if (inputs.ParquetPaths.TryGetValue(fileName, out string parquetPath) &&
                 File.Exists(parquetPath))
             {
                 string reconciledOutPath = ParquetScoreCache.ReconciledPathFromScoresPath(parquetPath);
                 bool wrote = ReconciledParquetWriter.Write(parquetPath, reconciledOutPath, fdrEntries, fileName,
-                    fullLibrary, config, joinFileStems, ctx.LogInfo, ctx.LogWarning);
+                    inputs.FullLibrary, config, inputs.JoinFileStems, ctx.LogInfo, ctx.LogWarning);
 
-                // Only stamp the per-file resume sidecar when the reconciled
-                // parquet was actually written. Stamping it after a failed
-                // write could mark a STALE reconciled parquet (left from a
-                // prior run with a different validity key) as valid, letting
-                // Stage 7 / a future resume consume old rescored content. On
-                // failure, clear any such stale output + sidecar so the next
-                // run re-rescores this file from scratch.
                 if (wrote)
                 {
                     var perFileInputs = new List<string>
@@ -819,7 +857,7 @@ namespace pwiz.OspreySharp.Tasks
                     if (config.Reconciliation != null && config.Reconciliation.Enabled)
                         perFileInputs.Add(ReconciliationFile.PathForInput(inputFile));
                     PerFileResumeDriver.Stamp(reconciledOutPath, Name, OspreyVersion.Current,
-                        taskValidityKey, perFileInputs, ctx.LogWarning);
+                        inputs.TaskValidityKey, perFileInputs, ctx.LogWarning);
                 }
                 else
                 {
@@ -840,8 +878,6 @@ namespace pwiz.OspreySharp.Tasks
                     }
                 }
             }
-
-            return (totalRescored, totalGapCwt, totalGapForced);
         }
 
         /// <summary>

--- a/pwiz_tools/OspreySharp/OspreySharp.Tasks/PerFileScoringTask.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Tasks/PerFileScoringTask.cs
@@ -577,16 +577,7 @@ namespace pwiz.OspreySharp.Tasks
             bool librarySuppliesDecoys = config.DecoysInLibrary ||
                 config.DecoyMethod == DecoyMethod.FromLibrary;
             if (librarySuppliesDecoys)
-            {
-                LibraryDecoyMarker.ApplyLibraryDecoyMarking(
-                    library, config.DecoyPrefixes, out var markingStats);
-                ctx.LogInfo(string.Format(
-                    @"Library-decoy mode: matched prefixes {0}",
-                    FormatPrefixList(config.DecoyPrefixes)));
-                ctx.LogInfo(string.Format(
-                    @"[COUNT] Library-decoy mode: {0} flagged ({1} via Decoy column, {2} via protein-accession prefix)",
-                    markingStats.NMarked, markingStats.NViaColumn, markingStats.NViaPrefix));
-            }
+                MarkSuppliedDecoys(library, config, ctx);
 
             int nLibraryTargets = 0;
             foreach (var entry in library)
@@ -624,129 +615,8 @@ namespace pwiz.OspreySharp.Tasks
             else
             {
                 decoys = new List<LibraryEntry>();
-
-                // Match Rust pipeline.rs at v26.6.0 (bcd7249): the
-                // "no decoys at all" check runs BEFORE manifest
-                // application. The manifest CAN flip predictor-stripped
-                // entries to IsDecoy=true (the Carafe failure mode commit
-                // d23d496 was built for), so this ordering means a
-                // manifest cannot rescue a load that the prefix scan
-                // misses entirely. TODO(brendanmaclean,maccoss): discuss
-                // with Mike whether this should be relaxed to defer the
-                // check until after manifest application; current C#
-                // ordering matches Rust v26.6.0 for byte parity on the
-                // cross-impl Test-Regression gate.
-                int nLibraryDecoys = library.Count - nLibraryTargets;
-                if (nLibraryDecoys == 0)
-                {
-                    ctx.LogError(string.Format(
-                        @"decoys_in_library mode requested but no library entries match prefixes {0}. " +
-                        @"Check that the library actually contains decoys with one of these prefixes on " +
-                        @"a protein accession, or unset decoys_in_library so Osprey generates decoys.",
-                        FormatPrefixList(config.DecoyPrefixes)));
-                    ctx.ExitCode = 1;
+                if (!TryPairSuppliedDecoys(library, config, nLibraryTargets, ctx))
                     return false;
-                }
-
-                // Pair each decoy with its target so their base_ids match
-                // -- required for SVM target-decoy competition, LDA
-                // calibration, and CV fold grouping. Hybrid path:
-                // manifest first when provided (exact pairs from
-                // FDRBench), composition fallback for whatever the
-                // manifest doesn't cover. Net result on real Carafe-
-                // generated entrapment libraries: ~30% via manifest,
-                // ~70% via composition, >99% total.
-                var pairingState = new PairingState();
-                LibraryDecoyPairing.CountTargetsAndDecoys(library,
-                    out int nTargetsForStats, out int nDecoysForStats);
-                var pairingStats = new PairingStats
-                {
-                    NTargets = nTargetsForStats,
-                    NDecoys = nDecoysForStats,
-                };
-                if (!string.IsNullOrEmpty(config.DecoyPairingManifestPath))
-                {
-                    ctx.LogInfo(string.Format(
-                        @"Loading decoy pairing manifest from {0}",
-                        config.DecoyPairingManifestPath));
-                    DecoyPairingManifest manifest;
-                    try
-                    {
-                        manifest = DecoyPairingManifest.FromTsv(
-                            config.DecoyPairingManifestPath);
-                    }
-                    catch (Exception ex)
-                    {
-                        ctx.LogError(string.Format(
-                            @"Failed to read decoy pairing manifest {0}: {1}",
-                            config.DecoyPairingManifestPath, ex.Message));
-                        ctx.ExitCode = 1;
-                        return false;
-                    }
-                    var manifestStats = manifest.ApplyToLibrary(library, pairingState);
-                    pairingStats.NPairedViaManifest = manifestStats.NPaired;
-                    if (manifestStats.NProteinsReplaced > 0)
-                    {
-                        ctx.LogInfo(string.Format(
-                            @"Library-decoy mode: manifest replaced protein_ids on {0} library " +
-                            @"entries (clean source-protein accessions from the manifest's " +
-                            @"`proteins` column)",
-                            manifestStats.NProteinsReplaced));
-                    }
-                    if (manifestStats.NNewlyMarkedDecoy > 0)
-                    {
-                        // Manifest classified entries as decoy that were
-                        // loaded as targets (the predictor stripped the
-                        // decoy prefix). Update the decoy count so the
-                        // pairing fraction is honest.
-                        ctx.LogInfo(string.Format(
-                            @"Library-decoy mode: manifest classified {0} additional library " +
-                            @"entries as decoys (their protein accessions lacked a decoy prefix)",
-                            manifestStats.NNewlyMarkedDecoy));
-                        LibraryDecoyPairing.CountTargetsAndDecoys(library,
-                            out nTargetsForStats, out nDecoysForStats);
-                        pairingStats.NTargets = nTargetsForStats;
-                        pairingStats.NDecoys = nDecoysForStats;
-                    }
-                }
-                else
-                {
-                    ctx.LogInfo(
-                        @"Pairing library decoys to targets by amino-acid composition " +
-                        @"(no manifest provided).");
-                }
-                pairingStats.NPairedViaComposition =
-                    LibraryDecoyPairing.PairLibraryDecoysByComposition(
-                        library, config.DecoyPrefixes, pairingState);
-                pairingStats.NPaired = pairingStats.NPairedViaManifest +
-                    pairingStats.NPairedViaComposition;
-                // Defense-in-depth saturating subtract (matches Rust's
-                // saturating_sub intent; not load-bearing).
-                pairingStats.NUnpairedDecoys = Math.Max(0,
-                    pairingStats.NDecoys - pairingStats.NPaired);
-                pairingStats.NUnpairedTargets = Math.Max(0,
-                    pairingStats.NTargets - pairingState.ClaimedTargets.Count);
-                ctx.LogInfo(string.Format(
-                    @"Library-decoy pairing: paired {0}/{1} decoys ({2:F1}%); " +
-                    @"manifest={3}, composition={4}; {5} unpaired decoys, {6} unpaired targets",
-                    pairingStats.NPaired, pairingStats.NDecoys,
-                    pairingStats.PairedFraction * 100.0,
-                    pairingStats.NPairedViaManifest, pairingStats.NPairedViaComposition,
-                    pairingStats.NUnpairedDecoys, pairingStats.NUnpairedTargets));
-                if (pairingStats.PairedFraction < config.DecoyPairMinFraction)
-                {
-                    ctx.LogError(string.Format(
-                        @"Library-decoy pairing failed: only {0:F1}% of decoys paired with a target " +
-                        @"(threshold: {1:F0}%). FDR estimates would be unreliable without proper " +
-                        @"target-decoy competition. Either supply a pairing manifest, ensure the " +
-                        @"library uses matching protein accessions with one of `decoy_prefixes` " +
-                        @"({2}), or unset `decoys_in_library` so Osprey generates its own decoys.",
-                        pairingStats.PairedFraction * 100.0,
-                        config.DecoyPairMinFraction * 100.0,
-                        FormatPrefixList(config.DecoyPrefixes)));
-                    ctx.ExitCode = 1;
-                    return false;
-                }
             }
             swLibrary.Stop();
             double totalSec = swLibrary.Elapsed.TotalSeconds;
@@ -787,6 +657,160 @@ namespace pwiz.OspreySharp.Tasks
 
             _fullLibrary = fullLibrary;
             _libraryById = libraryById;
+            return true;
+        }
+
+        /// <summary>
+        /// When the library supplies its own decoys (DIA-NN / EncyclopeDIA
+        /// output with rev_ / DECOY_ prefixes), mark them in place by Decoy
+        /// column / protein-accession prefix. DecoyMethod.FromLibrary is treated
+        /// as a synonym for DecoysInLibrary -- historically it silently fell
+        /// through to Reverse generation, the bug behind v26.5.3's library-decoy
+        /// mode being effectively unusable. Marking runs BEFORE the target count
+        /// is taken so the count reflects post-marking state and matches Rust
+        /// pipeline.rs.
+        /// </summary>
+        private void MarkSuppliedDecoys(List<LibraryEntry> library, OspreyConfig config, PipelineContext ctx)
+        {
+            LibraryDecoyMarker.ApplyLibraryDecoyMarking(
+                library, config.DecoyPrefixes, out var markingStats);
+            ctx.LogInfo(string.Format(
+                @"Library-decoy mode: matched prefixes {0}",
+                FormatPrefixList(config.DecoyPrefixes)));
+            ctx.LogInfo(string.Format(
+                @"[COUNT] Library-decoy mode: {0} flagged ({1} via Decoy column, {2} via protein-accession prefix)",
+                markingStats.NMarked, markingStats.NViaColumn, markingStats.NViaPrefix));
+        }
+
+        /// <summary>
+        /// Library-supplied-decoy path: confirm the library actually contains
+        /// decoys, then pair each decoy with its target so their base_ids match
+        /// -- required for SVM target-decoy competition, LDA calibration, and CV
+        /// fold grouping. Hybrid: manifest first when provided (exact pairs from
+        /// FDRBench), amino-acid composition fallback for the remainder. Returns
+        /// false (with <see cref="PipelineContext.ExitCode"/> set) when there
+        /// are no decoys at all, the pairing manifest is unreadable, or the
+        /// paired fraction is below <c>config.DecoyPairMinFraction</c>.
+        /// </summary>
+        private bool TryPairSuppliedDecoys(
+            List<LibraryEntry> library, OspreyConfig config, int nLibraryTargets, PipelineContext ctx)
+        {
+            // Match Rust pipeline.rs at v26.6.0 (bcd7249): the
+            // "no decoys at all" check runs BEFORE manifest
+            // application. The manifest CAN flip predictor-stripped
+            // entries to IsDecoy=true (the Carafe failure mode commit
+            // d23d496 was built for), so this ordering means a
+            // manifest cannot rescue a load that the prefix scan
+            // misses entirely. TODO(brendanmaclean,maccoss): discuss
+            // with Mike whether this should be relaxed to defer the
+            // check until after manifest application; current C#
+            // ordering matches Rust v26.6.0 for byte parity on the
+            // cross-impl Test-Regression gate.
+            int nLibraryDecoys = library.Count - nLibraryTargets;
+            if (nLibraryDecoys == 0)
+            {
+                ctx.LogError(string.Format(
+                    @"decoys_in_library mode requested but no library entries match prefixes {0}. " +
+                    @"Check that the library actually contains decoys with one of these prefixes on " +
+                    @"a protein accession, or unset decoys_in_library so Osprey generates decoys.",
+                    FormatPrefixList(config.DecoyPrefixes)));
+                ctx.ExitCode = 1;
+                return false;
+            }
+
+            // Hybrid pairing. Net result on real Carafe-generated entrapment
+            // libraries: ~30% via manifest, ~70% via composition, >99% total.
+            var pairingState = new PairingState();
+            LibraryDecoyPairing.CountTargetsAndDecoys(library,
+                out int nTargetsForStats, out int nDecoysForStats);
+            var pairingStats = new PairingStats
+            {
+                NTargets = nTargetsForStats,
+                NDecoys = nDecoysForStats,
+            };
+            if (!string.IsNullOrEmpty(config.DecoyPairingManifestPath))
+            {
+                ctx.LogInfo(string.Format(
+                    @"Loading decoy pairing manifest from {0}",
+                    config.DecoyPairingManifestPath));
+                DecoyPairingManifest manifest;
+                try
+                {
+                    manifest = DecoyPairingManifest.FromTsv(
+                        config.DecoyPairingManifestPath);
+                }
+                catch (Exception ex)
+                {
+                    ctx.LogError(string.Format(
+                        @"Failed to read decoy pairing manifest {0}: {1}",
+                        config.DecoyPairingManifestPath, ex.Message));
+                    ctx.ExitCode = 1;
+                    return false;
+                }
+                var manifestStats = manifest.ApplyToLibrary(library, pairingState);
+                pairingStats.NPairedViaManifest = manifestStats.NPaired;
+                if (manifestStats.NProteinsReplaced > 0)
+                {
+                    ctx.LogInfo(string.Format(
+                        @"Library-decoy mode: manifest replaced protein_ids on {0} library " +
+                        @"entries (clean source-protein accessions from the manifest's " +
+                        @"`proteins` column)",
+                        manifestStats.NProteinsReplaced));
+                }
+                if (manifestStats.NNewlyMarkedDecoy > 0)
+                {
+                    // Manifest classified entries as decoy that were
+                    // loaded as targets (the predictor stripped the
+                    // decoy prefix). Update the decoy count so the
+                    // pairing fraction is honest.
+                    ctx.LogInfo(string.Format(
+                        @"Library-decoy mode: manifest classified {0} additional library " +
+                        @"entries as decoys (their protein accessions lacked a decoy prefix)",
+                        manifestStats.NNewlyMarkedDecoy));
+                    LibraryDecoyPairing.CountTargetsAndDecoys(library,
+                        out nTargetsForStats, out nDecoysForStats);
+                    pairingStats.NTargets = nTargetsForStats;
+                    pairingStats.NDecoys = nDecoysForStats;
+                }
+            }
+            else
+            {
+                ctx.LogInfo(
+                    @"Pairing library decoys to targets by amino-acid composition " +
+                    @"(no manifest provided).");
+            }
+            pairingStats.NPairedViaComposition =
+                LibraryDecoyPairing.PairLibraryDecoysByComposition(
+                    library, config.DecoyPrefixes, pairingState);
+            pairingStats.NPaired = pairingStats.NPairedViaManifest +
+                pairingStats.NPairedViaComposition;
+            // Defense-in-depth saturating subtract (matches Rust's
+            // saturating_sub intent; not load-bearing).
+            pairingStats.NUnpairedDecoys = Math.Max(0,
+                pairingStats.NDecoys - pairingStats.NPaired);
+            pairingStats.NUnpairedTargets = Math.Max(0,
+                pairingStats.NTargets - pairingState.ClaimedTargets.Count);
+            ctx.LogInfo(string.Format(
+                @"Library-decoy pairing: paired {0}/{1} decoys ({2:F1}%); " +
+                @"manifest={3}, composition={4}; {5} unpaired decoys, {6} unpaired targets",
+                pairingStats.NPaired, pairingStats.NDecoys,
+                pairingStats.PairedFraction * 100.0,
+                pairingStats.NPairedViaManifest, pairingStats.NPairedViaComposition,
+                pairingStats.NUnpairedDecoys, pairingStats.NUnpairedTargets));
+            if (pairingStats.PairedFraction < config.DecoyPairMinFraction)
+            {
+                ctx.LogError(string.Format(
+                    @"Library-decoy pairing failed: only {0:F1}% of decoys paired with a target " +
+                    @"(threshold: {1:F0}%). FDR estimates would be unreliable without proper " +
+                    @"target-decoy competition. Either supply a pairing manifest, ensure the " +
+                    @"library uses matching protein accessions with one of `decoy_prefixes` " +
+                    @"({2}), or unset `decoys_in_library` so Osprey generates its own decoys.",
+                    pairingStats.PairedFraction * 100.0,
+                    config.DecoyPairMinFraction * 100.0,
+                    FormatPrefixList(config.DecoyPrefixes)));
+                ctx.ExitCode = 1;
+                return false;
+            }
             return true;
         }
 

--- a/pwiz_tools/OspreySharp/OspreySharp.Tasks/Stage6Planner.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Tasks/Stage6Planner.cs
@@ -1,0 +1,318 @@
+/*
+ * Original author: Brendan MacLean <brendanx .at. uw.edu>,
+ *                  MacCoss Lab, Department of Genome Sciences, UW
+ * AI assistance: Claude Code (Claude Opus 4.8) <noreply .at. anthropic.com>
+ *
+ * Based on osprey (https://github.com/MacCossLab/osprey)
+ *   by Michael J. MacCoss, MacCoss Lab, Department of Genome Sciences, UW
+ *
+ * Copyright 2026 University of Washington - Seattle, WA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
+using System.Collections.Generic;
+using pwiz.OspreySharp.Chromatography;
+using pwiz.OspreySharp.Core;
+using pwiz.OspreySharp.FDR.Reconciliation;
+
+namespace pwiz.OspreySharp.Tasks
+{
+    /// <summary>
+    /// Stage 6 planning subsystem extracted from <see cref="FirstJoinTask"/>.
+    /// Runs the four cross-file planning phases that produce the rescore plan
+    /// <see cref="PerFileRescoreTask"/> executes: multi-charge consensus per
+    /// file, cross-run consensus RTs, per-file calibration refit, and
+    /// reconciliation planning. Mirrors the Stage 6 entry block in
+    /// osprey/src/pipeline.rs ~3208-3273.
+    ///
+    /// Standalone collaborator (does not inherit <see cref="AbstractScoringTask"/>):
+    /// takes the pipeline context for logging, and routes every diagnostic dump
+    /// through the injected <c>_ctx.Diagnostics</c> sink (the *_ONLY abort uses
+    /// <c>OspreyDiagnosticsLog.ExitAfterDump</c>), preserving the Stage-6 dump
+    /// call order bisection relies on. Pure planning -- writing the
+    /// .reconciliation.json envelopes and publishing the typed byproduct slots
+    /// stays in <see cref="FirstJoinTask"/>.
+    /// </summary>
+    internal sealed class Stage6Planner
+    {
+        /// <summary>
+        /// The four cross-file planning byproducts Stage 6 produces. Consumed by
+        /// <see cref="FirstJoinTask"/> to write the reconciliation envelopes and
+        /// to publish the typed byproduct slots <see cref="PerFileRescoreTask"/>
+        /// reads. <see cref="ReconciliationActions"/> is null when reconciliation
+        /// was skipped (single-file / empty consensus).
+        /// </summary>
+        internal sealed class Stage6Plan
+        {
+            public IReadOnlyDictionary<string, IReadOnlyList<(int Index, double Apex, double Start, double End)>> PerFileConsensusTargets;
+            public IReadOnlyList<PeptideConsensusRT> Consensus;
+            // Concrete Dictionary (not IReadOnlyDictionary) to match the
+            // WriteReconciliationFiles parameter the caller forwards it to.
+            public Dictionary<string, RTCalibration> RefinedCalibrations;
+            public IReadOnlyDictionary<(string File, int Index), ReconcileAction> ReconciliationActions;
+        }
+
+        private readonly PipelineContext _ctx;
+
+        internal Stage6Planner(PipelineContext ctx)
+        {
+            _ctx = ctx;
+        }
+
+        /// <summary>
+        /// Run the four Stage 6 planning phases in order and return the plan.
+        /// Phase order matches Rust pipeline.rs:3217 -- multi-charge consensus
+        /// runs first (independent), then cross-run consensus RTs feed the
+        /// calibration refit, which feeds reconciliation planning.
+        /// </summary>
+        internal Stage6Plan Plan(
+            List<KeyValuePair<string, List<FdrEntry>>> perFileEntries,
+            IReadOnlyDictionary<string, RTCalibration> perFileCalibrations,
+            IReadOnlyDictionary<string, string> perFileParquetPaths,
+            OspreyConfig config)
+        {
+            var perFileConsensusTargets = ComputeMultiChargeConsensus(perFileEntries, config);
+            var consensus = ComputeConsensusRts(perFileEntries, perFileCalibrations, config);
+            var refinedCalibrations = RefitCalibrations(perFileEntries, consensus, config);
+            var reconciliationActions = PlanReconciliation(
+                perFileEntries, perFileParquetPaths, refinedCalibrations,
+                perFileCalibrations, consensus, config);
+
+            return new Stage6Plan
+            {
+                PerFileConsensusTargets = perFileConsensusTargets,
+                Consensus = consensus,
+                RefinedCalibrations = refinedCalibrations,
+                ReconciliationActions = reconciliationActions,
+            };
+        }
+
+        /// <summary>
+        /// Phase 1: multi-charge consensus per file (independent -- runs first
+        /// per Rust pipeline.rs:3217, before consensus RT computation).
+        /// </summary>
+        private IReadOnlyDictionary<string, IReadOnlyList<(int Index, double Apex, double Start, double End)>>
+            ComputeMultiChargeConsensus(
+                List<KeyValuePair<string, List<FdrEntry>>> perFileEntries, OspreyConfig config)
+        {
+            var perFileConsensusTargets = new Dictionary<string,
+                IReadOnlyList<(int Index, double Apex, double Start, double End)>>();
+            foreach (var kvp in perFileEntries)
+            {
+                perFileConsensusTargets[kvp.Key] =
+                    MultiChargeConsensus.SelectRescoreTargets(kvp.Value, config.RunFdr);
+            }
+            int totalMulticharge = 0;
+            foreach (var kvp in perFileConsensusTargets)
+                totalMulticharge += kvp.Value.Count;
+            _ctx.LogInfo(string.Format(
+                @"Stage 6 multi-charge consensus: {0} entries need re-scoring across {1} files",
+                totalMulticharge, perFileEntries.Count));
+
+            if (_ctx.Diagnostics?.DumpMulticharge ?? false)
+            {
+                var perFileForDump = new List<KeyValuePair<string,
+                    IReadOnlyList<FdrEntry>>>(perFileEntries.Count);
+                foreach (var kvp in perFileEntries)
+                {
+                    perFileForDump.Add(new KeyValuePair<string,
+                        IReadOnlyList<FdrEntry>>(kvp.Key, kvp.Value));
+                }
+                _ctx.Diagnostics?.WriteStage6MultichargeDump(
+                    perFileForDump, perFileConsensusTargets);
+                if (_ctx.Diagnostics?.MultichargeOnly ?? false)
+                    OspreyDiagnosticsLog.ExitAfterDump(@"OSPREY_MULTICHARGE_ONLY");
+            }
+            return perFileConsensusTargets;
+        }
+
+        /// <summary>
+        /// Phase 2: cross-run consensus RTs (target peptides + paired decoys,
+        /// sigmoid(score)-weighted median, hard run_precursor_qvalue gate).
+        /// Cross-file consensus is only meaningful with &gt; 1 file -- mirrors
+        /// Rust pipeline.rs:4146 where reconciliation_enabled requires
+        /// per_file_entries.len() &gt; 1; single-file runs skip consensus,
+        /// refit, and reconciliation entirely, leaving multi-charge consensus
+        /// rescore as the only Stage 6 work performed.
+        /// </summary>
+        private IReadOnlyList<PeptideConsensusRT> ComputeConsensusRts(
+            List<KeyValuePair<string, List<FdrEntry>>> perFileEntries,
+            IReadOnlyDictionary<string, RTCalibration> perFileCalibrations,
+            OspreyConfig config)
+        {
+            var perFileForRecon = new List<KeyValuePair<string,
+                IReadOnlyList<FdrEntry>>>(perFileEntries.Count);
+            foreach (var kvp in perFileEntries)
+            {
+                perFileForRecon.Add(new KeyValuePair<string,
+                    IReadOnlyList<FdrEntry>>(kvp.Key, kvp.Value));
+            }
+            // Cross-impl bisection trace for InversePredict: if the
+            // OSPREY_DUMP_INV_PREDICT env var is set, ConsensusRts populates
+            // this list with one row per detection. The dump is driven via
+            // OspreyDiagnostics so the FDR project doesn't have to know about
+            // the diagnostic file format.
+            List<InvPredictRecord> invPredictTrace = null;
+            if (_ctx.Diagnostics?.DumpInvPredict ?? false)
+                invPredictTrace = new List<InvPredictRecord>();
+
+            IReadOnlyList<PeptideConsensusRT> consensus =
+                perFileEntries.Count > 1
+                    ? ConsensusRts.Compute(
+                        perFileForRecon, perFileCalibrations,
+                        config.Reconciliation.ConsensusFdr,
+                        config.ProteinFdr ?? 0.0,
+                        invPredictTrace)
+                    : Array.Empty<PeptideConsensusRT>();
+
+            if (invPredictTrace != null)
+            {
+                _ctx.Diagnostics?.WriteStage6InvPredictDump(invPredictTrace);
+                if (_ctx.Diagnostics?.InvPredictOnly ?? false)
+                    OspreyDiagnosticsLog.ExitAfterDump(@"OSPREY_INV_PREDICT_ONLY");
+            }
+            int nTargets = 0, nDecoys = 0;
+            foreach (var c in consensus)
+            {
+                if (c.IsDecoy) nDecoys++;
+                else nTargets++;
+            }
+            _ctx.LogInfo(string.Format(
+                @"Stage 6 consensus: {0} target peptides, {1} decoy peptides",
+                nTargets, nDecoys));
+
+            // Skip the dump on empty consensus to match Rust's
+            // dump_stage6_consensus, which silently elides the file when there
+            // is nothing to write (gated on Some(file) in Rust, derived from
+            // !consensus.is_empty()). Without this gate, C# emits a header-only
+            // cs_stage6_consensus.tsv and Test-Regression sees an
+            // asymmetric-absence FAIL even though both sides agree on empty.
+            if ((_ctx.Diagnostics?.DumpConsensus ?? false) && consensus.Count > 0)
+            {
+                _ctx.Diagnostics?.WriteStage6ConsensusDump(consensus);
+                if (_ctx.Diagnostics?.ConsensusOnly ?? false)
+                    OspreyDiagnosticsLog.ExitAfterDump(@"OSPREY_CONSENSUS_ONLY");
+            }
+            return consensus;
+        }
+
+        /// <summary>
+        /// Phase 3: per-file calibration refit on consensus peptides.
+        /// </summary>
+        private Dictionary<string, RTCalibration> RefitCalibrations(
+            List<KeyValuePair<string, List<FdrEntry>>> perFileEntries,
+            IReadOnlyList<PeptideConsensusRT> consensus,
+            OspreyConfig config)
+        {
+            var refinedCalibrations = new Dictionary<string, RTCalibration>();
+            foreach (var kvp in perFileEntries)
+            {
+                var refined = CalibrationRefit.Refit(consensus, kvp.Value,
+                    config.Reconciliation.ConsensusFdr);
+                if (refined != null)
+                    refinedCalibrations[kvp.Key] = refined;
+            }
+            _ctx.LogInfo(string.Format(
+                @"Stage 6 refit: {0}/{1} files produced refined calibrations",
+                refinedCalibrations.Count, perFileEntries.Count));
+
+            if (_ctx.Diagnostics?.DumpLoessFit ?? false)
+            {
+                _ctx.Diagnostics?.WriteStage6LoessFitDump(refinedCalibrations);
+                if (_ctx.Diagnostics?.LoessFitOnly ?? false)
+                    OspreyDiagnosticsLog.ExitAfterDump(@"OSPREY_LOESS_FIT_ONLY");
+            }
+
+            if (_ctx.Diagnostics?.DumpRefit ?? false)
+            {
+                _ctx.Diagnostics?.WriteStage6RefitDump(refinedCalibrations);
+                if (_ctx.Diagnostics?.RefitOnly ?? false)
+                    OspreyDiagnosticsLog.ExitAfterDump(@"OSPREY_REFIT_ONLY");
+            }
+            return refinedCalibrations;
+        }
+
+        /// <summary>
+        /// Phase 4: reconciliation planning. Reads each file's CWT candidates
+        /// from the parquet cache and asks the planner to choose, per (file,
+        /// entry), whether to keep the existing peak, switch to a stored CWT
+        /// candidate at the consensus RT, or force an integration window.
+        /// Mirrors Rust pipeline.rs reconciliation block at ~3260-3380. Only
+        /// runs when the cross-file consensus is non-empty (Rust
+        /// pipeline.rs:4223): single-file runs (or any case where no peptide had
+        /// enough cross-replicate evidence to form a consensus RT) degenerate to
+        /// zero reconciliation actions. Returns null when skipped.
+        /// </summary>
+        private IReadOnlyDictionary<(string File, int Index), ReconcileAction> PlanReconciliation(
+            List<KeyValuePair<string, List<FdrEntry>>> perFileEntries,
+            IReadOnlyDictionary<string, string> perFileParquetPaths,
+            IReadOnlyDictionary<string, RTCalibration> refinedCalibrations,
+            IReadOnlyDictionary<string, RTCalibration> perFileCalibrations,
+            IReadOnlyList<PeptideConsensusRT> consensus,
+            OspreyConfig config)
+        {
+            IReadOnlyDictionary<(string File, int Index), ReconcileAction> reconciliationActions = null;
+            var perFileCwtCandidates = CwtCandidateLoader.Load(
+                perFileEntries, perFileParquetPaths, _ctx.LogWarning);
+            var perFileForPlan = new List<KeyValuePair<string,
+                IReadOnlyList<FdrEntry>>>(perFileEntries.Count);
+            foreach (var kvp in perFileEntries)
+            {
+                perFileForPlan.Add(new KeyValuePair<string,
+                    IReadOnlyList<FdrEntry>>(kvp.Key, kvp.Value));
+            }
+            if (perFileCwtCandidates.Count == perFileEntries.Count
+                && consensus.Count > 0)
+            {
+                reconciliationActions = ReconciliationPlanner.Plan(
+                    consensus,
+                    perFileForPlan,
+                    perFileCwtCandidates,
+                    refinedCalibrations,
+                    perFileCalibrations,
+                    config.Reconciliation.ConsensusFdr);
+                _ctx.LogInfo(string.Format(
+                    @"Stage 6 reconciliation: {0} per-(file, entry) actions planned",
+                    reconciliationActions.Count));
+            }
+            else if (consensus.Count == 0)
+            {
+                _ctx.LogInfo(@"Stage 6 reconciliation: skipped (empty consensus; single-file or no cross-file evidence)");
+            }
+            else
+            {
+                _ctx.LogInfo(string.Format(
+                    @"Stage 6 reconciliation: skipped (CWT candidates loaded for {0}/{1} files)",
+                    perFileCwtCandidates.Count, perFileEntries.Count));
+            }
+
+            // Stage 6 cross-impl bisection dump for the planner output. Fires
+            // unconditionally when OSPREY_DUMP_RECONCILIATION=1 is set so the
+            // skipped / empty paths still produce a header-only TSV and still
+            // honor OSPREY_RECONCILIATION_ONLY for early exit. Mirrors the Rust
+            // side after the reconciliation block closes.
+            if (_ctx.Diagnostics?.DumpReconciliation ?? false)
+            {
+                var dumpActions = reconciliationActions
+                    ?? new Dictionary<(string File, int Index), ReconcileAction>();
+                _ctx.Diagnostics?.WriteStage6ReconciliationDump(
+                    dumpActions, perFileForPlan);
+                if (_ctx.Diagnostics?.ReconciliationOnly ?? false)
+                    OspreyDiagnosticsLog.ExitAfterDump(@"OSPREY_RECONCILIATION_ONLY");
+            }
+            return reconciliationActions;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Decomposes the three remaining Tasks-layer orchestration monoliths flagged by the 2026-06-18 blind OOP review (Rec 1). Pure code motion, output-locked by the committed golden -- no behavior change. Both the Run and Rehydrate / HPC `--task` paths are preserved intact (the split is a live NextFlow requirement).

* `RescoreOneFile` -> `TryResumeRescoredFile` + `TryAssembleRescoreTargets` + `WriteReconciledAndStamp`; method is now a sequencer with the parity-locked scoring section kept whole.
* New `Stage6Planner` collaborator owns `PlanStage6`'s four phases (multi-charge consensus, cross-run consensus RTs, calibration refit, reconciliation planning), each routing its diagnostic dump through `ctx.Diagnostics`; `PlanStage6` reduced to plan -> write reconciliation envelopes -> publish byproducts.
* `LoadLibraryAndDecoys` -> `MarkSuppliedDecoys` + `TryPairSuppliedDecoys`.

Standing-cadence wiring of the HPC `--task` chain test is deferred to PR 9 (in-process resume is already covered by regression mode 2).

## Test plan

- [x] Build + 390 unit tests + 0-warning ReSharper inspection (per commit)
- [x] `regression.ps1 -Dataset All` -- Stellar + Astral, mode 1 (golden) + mode 2 (resume), 4/4 byte-identical
- [x] `Compare-Stage7-Rehydration-Strict-CSharp -Dataset Stellar` -- bit-parity at every HPC `--task` boundary
- [x] `Compare-StraightThroughResume-CSharp -Dataset Stellar` -- cold == warm blib
- [x] `Compare-CrossImpl-Reference -Dataset Stellar` -- matches frozen Rust at every boundary
- [x] `Test-PerfGate -Dataset Stellar` -- no regression (total median -3.8%)
- [x] `/pw-self-review` -- independent fresh-context agent: behavior-preserving, no concerns

See ai/todos/active/TODO-20260619_ospreysharp_debt_paydown_pr8.md

Co-Authored-By: Claude <noreply@anthropic.com>