### PR TITLE
Tiered scoring peak-data access and a peak-data extractor (OspreySharp)

### DIFF
--- a/pwiz_tools/OspreySharp/OspreySharp.Scoring/ApexMatchCalculators.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Scoring/ApexMatchCalculators.cs
@@ -50,7 +50,7 @@ namespace pwiz.OspreySharp.Scoring
         public double AbsMassErrSum;
         public int NMatched;
 
-        public static ApexFragmentMatchSet GetOrCompute(OspreyScoringContext context, IOspreyDetailedPeakData peakData)
+        public static ApexFragmentMatchSet GetOrCompute(OspreyScoringContext context, IOspreyApexSpectrumPeakData peakData)
         {
             if (context.TryGetInfo(out ApexFragmentMatchSet matchSet))
                 return matchSet;
@@ -59,7 +59,7 @@ namespace pwiz.OspreySharp.Scoring
             return matchSet;
         }
 
-        private static ApexFragmentMatchSet Compute(OspreyScoringContext context, IOspreyDetailedPeakData peakData)
+        private static ApexFragmentMatchSet Compute(OspreyScoringContext context, IOspreyApexSpectrumPeakData peakData)
         {
             var matchSet = new ApexFragmentMatchSet();
 
@@ -143,11 +143,11 @@ namespace pwiz.OspreySharp.Scoring
     /// boolean <see cref="SpectralScorer.HasMatch"/> pass keyed by ion type +
     /// ordinal, with the same closed-both-ends tolerance window.
     /// </summary>
-    internal sealed class ConsecutiveIonsCalc : DetailedOspreyFeatureCalculator
+    internal sealed class ConsecutiveIonsCalc : ApexSpectrumOspreyFeatureCalculator
     {
         public override string Name { get { return "consecutive_ions"; } }
 
-        protected override double Calculate(OspreyScoringContext context, IOspreyDetailedPeakData peakData)
+        protected override double Calculate(OspreyScoringContext context, IOspreyApexSpectrumPeakData peakData)
         {
             var candidate = peakData.Candidate;
             if (candidate.Fragments == null || candidate.Fragments.Count == 0)
@@ -211,11 +211,11 @@ namespace pwiz.OspreySharp.Scoring
     /// (<c>totalIntensity &gt; 1e-12</c>); below it the feature is exactly 0.0
     /// (never NaN/Inf).
     /// </summary>
-    internal sealed class ExplainedIntensityCalc : DetailedOspreyFeatureCalculator
+    internal sealed class ExplainedIntensityCalc : ApexSpectrumOspreyFeatureCalculator
     {
         public override string Name { get { return "explained_intensity"; } }
 
-        protected override double Calculate(OspreyScoringContext context, IOspreyDetailedPeakData peakData)
+        protected override double Calculate(OspreyScoringContext context, IOspreyApexSpectrumPeakData peakData)
         {
             var matchSet = ApexFragmentMatchSet.GetOrCompute(context, peakData);
             return matchSet.TotalIntensity > 1e-12
@@ -229,11 +229,11 @@ namespace pwiz.OspreySharp.Scoring
     /// tolerance unit, typically ppm) over matched fragments. No-match fallback is
     /// exactly 0.0 (Rust returns a 0.0 mean on empty matches).
     /// </summary>
-    internal sealed class MassAccuracyMeanCalc : DetailedOspreyFeatureCalculator
+    internal sealed class MassAccuracyMeanCalc : ApexSpectrumOspreyFeatureCalculator
     {
         public override string Name { get { return "mass_accuracy_deviation_mean"; } }
 
-        protected override double Calculate(OspreyScoringContext context, IOspreyDetailedPeakData peakData)
+        protected override double Calculate(OspreyScoringContext context, IOspreyApexSpectrumPeakData peakData)
         {
             var matchSet = ApexFragmentMatchSet.GetOrCompute(context, peakData);
             return matchSet.NMatched > 0
@@ -250,11 +250,11 @@ namespace pwiz.OspreySharp.Scoring
     /// caused ~65 divergent Astral rows. (Rust compute_mass_accuracy returns
     /// (0.0, tolerance, tolerance) on empty matches, osprey-scoring/src/lib.rs:462.)
     /// </summary>
-    internal sealed class AbsMassAccuracyMeanCalc : DetailedOspreyFeatureCalculator
+    internal sealed class AbsMassAccuracyMeanCalc : ApexSpectrumOspreyFeatureCalculator
     {
         public override string Name { get { return "abs_mass_accuracy_deviation_mean"; } }
 
-        protected override double Calculate(OspreyScoringContext context, IOspreyDetailedPeakData peakData)
+        protected override double Calculate(OspreyScoringContext context, IOspreyApexSpectrumPeakData peakData)
         {
             var matchSet = ApexFragmentMatchSet.GetOrCompute(context, peakData);
             return matchSet.NMatched > 0

--- a/pwiz_tools/OspreySharp/OspreySharp.Scoring/CoelutionScorer.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Scoring/CoelutionScorer.cs
@@ -23,7 +23,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using pwiz.OspreySharp.Chromatography;
 using pwiz.OspreySharp.Core;
@@ -40,16 +39,25 @@ namespace pwiz.OspreySharp.Scoring
     /// invoked null-conditionally). The arithmetic, Parallel usage, CWT / peak /
     /// feature logic, and tie-breaks are unchanged, so cross-impl parity is
     /// unaffected.
+    ///
+    /// Data production (RT window, XICs, peak detection, apex/reference-XIC
+    /// resolution) is delegated to <see cref="PeakDataExtractor"/> -- the producer
+    /// seam mirroring Skyline's results layer. This class composes the extractor,
+    /// then runs the 21-feature calculator pass over the resulting peak-data view
+    /// and assembles the FdrEntry; it no longer interleaves data preparation with
+    /// calculator dispatch.
     /// </summary>
     public class CoelutionScorer
     {
-        private readonly Action<string> _logInfo;
         private readonly IScoringDiagnostics _diagnostics;   // nullable by contract; invoked null-conditionally
+        private readonly PeakDataExtractor _extractor;
 
         public CoelutionScorer(Action<string> logInfo, IScoringDiagnostics diagnostics)
         {
-            _logInfo = logInfo ?? (_ => { });
             _diagnostics = diagnostics;
+            // logInfo is consumed only by the extractor (all detection-side [DIAG]
+            // logging moved there); it is not retained as a field here.
+            _extractor = new PeakDataExtractor(logInfo, diagnostics);
         }
 
 
@@ -126,7 +134,6 @@ namespace pwiz.OspreySharp.Scoring
             var ospreyContext = new OspreyScoringContext(config);
             ospreyContext.SetWindow(context.Resolution, preprocessedXcorr, scorer,
                 context.XcorrScratchPool);
-            ospreyContext.SetMs1Machinery(context.Resolution.HasMs1Features, ms1Spectra, ms1Calibration);
             var ospreyPeakData = new OspreyPeakData();
 
             try
@@ -138,7 +145,8 @@ namespace pwiz.OspreySharp.Scoring
                         candidate, windowSpectra, windowRts,
                         rtCalibration,
                         globalRtTolerance, rtSigma,
-                        scorer, context,
+                        ms1Spectra, ms1Calibration,
+                        context,
                         ospreyContext, ospreyPeakData);
 
                     if (fdrEntry != null)
@@ -154,6 +162,16 @@ namespace pwiz.OspreySharp.Scoring
         }
 
 
+        /// <summary>
+        /// Score one candidate: ask the <see cref="PeakDataExtractor"/> for the
+        /// per-candidate peak-data view (RT window, XICs, winning peak, apex), then
+        /// publish the median-polish fit, run the 21 PIN feature calculators over
+        /// that view, and assemble the <see cref="FdrEntry"/>. Returns null when
+        /// the extractor found no scorable peak. The detection arithmetic and its
+        /// diagnostics live in the extractor; only the median-polish publish (which
+        /// is harness-owned because its bisection dump is exe-layer) and the
+        /// calculator pass remain here.
+        /// </summary>
         private FdrEntry ScoreCandidate(
             LibraryEntry candidate,
             List<Spectrum> windowSpectra,
@@ -161,488 +179,35 @@ namespace pwiz.OspreySharp.Scoring
             RTCalibration rtCalibration,
             double globalRtTolerance,
             double rtSigma,
-            SpectralScorer scorer,
+            List<MS1Spectrum> ms1Spectra,
+            MzCalibrationResult ms1Calibration,
             ScoringContext context,
             OspreyScoringContext ospreyContext,
             OspreyPeakData ospreyPeakData)
         {
-            var config = context.Config;
-            var resolution = context.Resolution;
-            bool diag = !candidate.IsDecoy && candidate.ModifiedSequence == DIAG_PEPTIDE
-                && candidate.Charge == 2;
-            int nScans = windowSpectra.Count;
-            if (nScans < 5)
+            if (!_extractor.TryExtract(
+                    candidate, windowSpectra, windowRts, rtCalibration,
+                    globalRtTolerance, rtSigma, ms1Spectra, ms1Calibration,
+                    context, ospreyPeakData, out var ext))
                 return null;
 
-            // Stage 6 boundary override (post-FDR re-scoring): when set,
-            // peak detection + the signal pre-filter are skipped and
-            // scoring uses the supplied (apex, start, end) RT triple.
-            // Mirrors the boundary_overrides path in run_search at
-            // osprey/crates/osprey/src/pipeline.rs:6453-6664.
-            (double Apex, double Start, double End)? overrideBounds = null;
-            if (context.BoundaryOverrides != null &&
-                context.BoundaryOverrides.TryGetValue(candidate.Id, out var bnd))
-            {
-                overrideBounds = bnd;
-            }
+            var bestPeak = ext.BestPeak;
+            var xics = ext.Xics;
+            var apexSpectrum = ext.ApexSpectrum;
 
-            // Determine RT search window.
-            // Use the global tolerance passed from RunCoelutionScoring (matches
-            // Rust's single rt_tolerance for all entries in run_search).
-            double expectedRt = rtCalibration != null
-                ? rtCalibration.Predict(candidate.RetentionTime)
-                : candidate.RetentionTime;
-            // Bisection seam DISABLED (perf hotspot): this dumped
-            // (entry_id, library_rt -> expected_rt) for every per-window
-            // candidate. In the per-candidate inner loop even the gated-off
-            // call cost a call + branch each candidate, so it is commented
-            // out rather than routed through the diagnostics sink. To
-            // restore, re-enable this and the paired WritePredictRtArrays /
-            // ClosePredictRtDump in PerFileRescoreTask, and remove the
-            // OSPREY_DUMP_PREDICT_RT guard (NotImplementedException) in
-            // OspreyFileDiagnostics's constructor. Mirrors Rust's
-            // dump_predict_rt_call at pipeline.rs ~7014. See
-            // ai/todos/active/TODO-20260606_ospreysharp_diagnostics_di.md.
-            // OspreyDiagnostics.WritePredictRtCall(
-            //     candidate.Id, candidate.RetentionTime, expectedRt);
-            double rtTolerance = globalRtTolerance;
-
-            if (diag)
-            {
-                _logInfo(string.Format(
-                    "[DIAG] {0} charge {1}: library_rt={2:F3}, expected_rt={3:F3}, tolerance={4:F3}",
-                    candidate.ModifiedSequence, candidate.Charge,
-                    candidate.RetentionTime, expectedRt, rtTolerance));
-                _logInfo(string.Format(
-                    "[DIAG] {0}: window m/z={1:F3}, fragments={2}, window_spectra={3}",
-                    candidate.ModifiedSequence, candidate.PrecursorMz,
-                    candidate.Fragments.Count, nScans));
-            }
-
-            // Find scan range for XIC extraction. Extracted to FindScanRange
-            // (override-bounds vs normal-search filter shapes).
-            FindScanRange(overrideBounds, windowRts, nScans, expectedRt, rtTolerance,
-                out int startScan, out int endScan);
-
-            if (diag)
-            {
-                if (startScan >= 0 && endScan >= 0)
-                {
-                    _logInfo(string.Format(
-                        "[DIAG] {0}: scan range [{1}..{2}] RT [{3:F3}..{4:F3}] ({5} scans)",
-                        candidate.ModifiedSequence, startScan, endScan,
-                        windowRts[startScan], windowRts[endScan],
-                        endScan - startScan + 1));
-                    _logInfo(string.Format(
-                        "[DIAG] {0}: spectrum scan_numbers in range: first={1}, last={2}",
-                        candidate.ModifiedSequence,
-                        windowSpectra[startScan].ScanNumber,
-                        windowSpectra[endScan].ScanNumber));
-                }
-                else
-                {
-                    _logInfo(string.Format(
-                        "[DIAG] {0}: no scans in RT window around expected_rt={1:F3}",
-                        candidate.ModifiedSequence, expectedRt));
-                }
-            }
-
-            if (startScan < 0 || endScan < 0 || endScan - startScan + 1 < 5)
-                return null;
-
-            int rangeLen = endScan - startScan + 1;
-
-            // Signal pre-filter: require at least 2 of top 6 fragments present
-            // in at least 3 of 4 consecutive scans. Matches Rust pipeline.rs:6032-6066.
-            // Skips noise-only candidates before the expensive XIC extraction.
-            // Skipped for boundary overrides — caller has already decided to
-            // score here.
-            if (config.PrefilterEnabled && !overrideBounds.HasValue)
-            {
-                const int WIN = 4;
-                const int MIN_PASS = 3;
-                bool[] window = new bool[WIN];
-                int winSum = 0;
-                bool hasSignal = false;
-
-                for (int i = startScan; i <= endScan; i++)
-                {
-                    bool passes = FragmentMath.HasTopNFragmentMatch(
-                        candidate, windowSpectra[i].Mzs, config.FragmentTolerance);
-                    int slot = (i - startScan) % WIN;
-                    if (window[slot])
-                        winSum--;
-                    window[slot] = passes;
-                    if (passes)
-                        winSum++;
-                    if (i - startScan + 1 >= WIN && winSum >= MIN_PASS)
-                    {
-                        hasSignal = true;
-                        break;
-                    }
-                }
-                if (!hasSignal)
-                    return null;
-            }
-
-            // Extract fragment XICs within the RT range
-            var xics = TopFragmentExtractor.ExtractFragmentXics(
-                candidate, windowSpectra, windowRts, startScan, endScan, config);
-
-            // Per-entry search XIC diagnostic. Fires for every scoring
-            // path; if the entry is scored twice (consensus + override)
-            // the LAST call wins on disk. Caller can isolate by
-            // limiting OSPREY_DIAG_SEARCH_ENTRY_IDS to the right
-            // entries, or by tagging the dump filename with the path.
-            if (_diagnostics?.ShouldDumpSearchXicFor(candidate.Id) ?? false)
-            {
-                _diagnostics?.WriteSearchXicDump(
-                    candidate, expectedRt, rtTolerance,
-                    startScan, endScan, rangeLen,
-                    windowSpectra, xics);
-            }
-
-            if (xics.Count < 2)
-                return null;
-
-            // Detect candidate peaks (3-tier CWT/fallback, or a synthetic peak
-            // from override bounds). Extracted to DetectCandidatePeaks; returns
-            // null ONLY when an override produced a degenerate index range
-            // (the original override `if (peaks == null) return null`).
-            List<XICPeakBounds> peaks = DetectCandidatePeaks(
-                overrideBounds, xics, out int diagNCwtPeaks);
-            if (peaks == null)
-                return null;
-
-            if (diag)
-            {
-                _logInfo(string.Format(
-                    "[DIAG] {0}: xics extracted={1}, peaks={2}",
-                    candidate.ModifiedSequence, xics.Count, peaks.Count));
-                for (int i = 0; i < peaks.Count; i++)
-                {
-                    var p = peaks[i];
-                    int apexAbsIdx = startScan + p.ApexIndex;
-                    double apexRt = windowRts[apexAbsIdx];
-                    uint apexScanNum = windowSpectra[apexAbsIdx].ScanNumber;
-                    _logInfo(string.Format(
-                        "[DIAG] {0}: peak[{1}] apex_local={2} apex_rt={3:F3} scan#={4} range=[{5}..{6}]",
-                        candidate.ModifiedSequence, i, p.ApexIndex,
-                        apexRt, apexScanNum, p.StartIndex, p.EndIndex));
-                }
-            }
-            if (peaks.Count == 0)
-            {
-                if (!overrideBounds.HasValue)
-                {
-                    _diagnostics?.WriteCwtPathRow(
-                        context.FileName, candidate.Id,
-                        diagNCwtPeaks, 0, 0, false, xics);
-                }
-                return null;
-            }
-
-            // Rust scores each candidate peak by mean pairwise fragment
-            // correlation weighted by a Gaussian RT penalty and an intensity
-            // tiebreaker, then picks the highest-ranked peak. The RT penalty
-            // prevents strong interferers at the wrong RT from beating the
-            // correct peak on coelution alone; the intensity tiebreaker
-            // ensures the main peak wins over its own shoulder when coelution
-            // scores are nearly identical. Matches Rust pipeline.rs:6685-6760.
-            //   rank_score = coelution * exp(-dt^2 / (2 * sigma^2)) * ln(1 + apex_intensity)
-            // where dt = |peak_apex_rt - expected_rt|. Peak at expected
-            // position gets RT penalty=1.0; 5-sigma away gets ~0.01.
-
-            // Reference XIC = highest total-intensity fragment. Matches Rust
-            // run_search at pipeline.rs:7140-7148 which uses
-            // `xics.max_by(|a, b| sum_a.total_cmp(&sum_b))`. Rust's
-            // `Iterator::max_by` returns the LAST equal element on ties
-            // (per std doc), so use `>=` here, NOT `>`. Without this,
-            // ~33k Stellar entries pick the first tied fragment as ref_xic
-            // while Rust picks the last, producing divergent
-            // peak_apex / peak_sharpness in the reconciled parquet.
-            int refXicIdx = 0;
-            double refXicBestTotal = -1.0;
-            for (int f = 0; f < xics.Count; f++)
-            {
-                double total = 0.0;
-                for (int i = 0; i < xics[f].Intensities.Length; i++)
-                    total += xics[f].Intensities[i];
-                if (total >= refXicBestTotal) { refXicBestTotal = total; refXicIdx = f; }
-            }
-            double[] refXicIntensities = xics[refXicIdx].Intensities;
-
-            XICPeakBounds bestPeak = null;
-            double bestRankScore = double.MinValue;
-            int bestPeakIdx = -1;
-            int diagNScored = 0; // peaks that pass apex-acceptance
-            double twoSigmaSq = 2.0 * rtSigma * rtSigma;
-            // Capture every scored peak with its raw coelution score
-            // and rank score for the top-N CwtCandidate list assigned
-            // below (Stage 6 reconciliation input). Mirrors Rust
-            // run_search's scored_candidates collection at
-            // pipeline.rs:7261-7327, which fires for the non-override
-            // path -- the override branch (pipeline.rs:7155-7223)
-            // returns at line 7223 BEFORE reaching the cwt_top_n
-            // code, so override entries leave cwt_candidates as the
-            // default empty `Vec::new()` on the rescored
-            // CoelutionScoredEntry.
-            //
-            // Build for CWT-OR-FALLBACK paths (anything reaching the
-            // rank-scoring loop without an override). Earlier C#
-            // versions gated this on `peaksFromCwt` (CWT-consensus
-            // success only) which left fallback-path entries with
-            // empty cwt_candidates blobs while Rust still populated
-            // them; that produced the last 5 / 3 / 2 cwt_candidates
-            // divergent rows per Stellar file.
-            var capturedPeaks = !overrideBounds.HasValue
-                ? new List<(XICPeakBounds peak, double coelutionScore, double rankScore)>(peaks.Count)
-                : null;
-            for (int pi = 0; pi < peaks.Count; pi++)
-            {
-                var p = peaks[pi];
-                int pLen = p.EndIndex - p.StartIndex + 1;
-                if (pLen < 3)
-                    continue;
-
-                // Apex-acceptance filter (Rust pipeline.rs commit 885339b):
-                // the XIC extraction window above is wider than rtTolerance so
-                // CWT can extend peak boundaries past the acceptance edge, but
-                // the detected apex itself must fall within rtTolerance of
-                // expectedRt. Preserves first-pass selectivity -- only
-                // boundaries are allowed to extend past rtTolerance; apex
-                // locations still have to be within it. Bypassed for
-                // boundary overrides (caller has already chosen the apex).
-                double peakApexRt = windowRts[startScan + p.ApexIndex];
-                double rtResidual = Math.Abs(peakApexRt - expectedRt);
-                if (!overrideBounds.HasValue && rtResidual > rtTolerance)
-                    continue;
-                diagNScored++;
-
-                double sum = 0.0;
-                int count = 0;
-                for (int ii = 0; ii < xics.Count; ii++)
-                {
-                    for (int jj = ii + 1; jj < xics.Count; jj++)
-                    {
-                        double corr = ScoringMath.PearsonCorrelationInRange(
-                            xics[ii].Intensities, xics[jj].Intensities,
-                            p.StartIndex, p.EndIndex);
-                        if (!double.IsNaN(corr))
-                        {
-                            sum += corr;
-                            count++;
-                        }
-                    }
-                }
-                double coelutionScore = count > 0 ? sum / count : 0.0;
-
-                double rtPenalty = Math.Exp(-(rtResidual * rtResidual) / twoSigmaSq);
-
-                // Intensity tiebreaker (Rust pipeline.rs:6753-6758, added in
-                // v26.3.1 commit 4d0119d): log(1 + apex_intensity) breaks ties
-                // between main peak and shoulder without dominating the
-                // coelution ranking.
-                double apexIntensity = refXicIntensities[p.ApexIndex];
-                double intensityWeight = Math.Log(1.0 + apexIntensity);
-
-                double rankScore = coelutionScore * rtPenalty * intensityWeight;
-
-                if (diag)
-                {
-                    _logInfo(string.Format(
-                        "[DIAG] {0}: peak[{1}] pairwise_corr_mean={2:F4} rt_penalty={3:F4} int_weight={4:F2} rank={5:F4}",
-                        candidate.ModifiedSequence, pi, coelutionScore, rtPenalty, intensityWeight, rankScore));
-                }
-                // Tie-break via IEEE 754-2008 total order (matches Rust's
-                // f64::total_cmp used in run_search's scored_candidates
-                // sort). When intensityWeight is 0 (ref_xic intensity at
-                // apex is 0), rankScore is -0.0 or +0.0 depending on
-                // coelutionScore sign. Standard '>' treats -0.0 == +0.0, so
-                // without total-order compare the tie falls back to
-                // iteration order, producing divergent peak picks vs Rust
-                // for the handful of entries where all in-tolerance peaks
-                // have zero reference intensity.
-                if (TotalOrder.Greater(rankScore, bestRankScore))
-                {
-                    bestRankScore = rankScore;
-                    bestPeak = p;
-                    bestPeakIdx = pi;
-                }
-
-                if (capturedPeaks != null)
-                    capturedPeaks.Add((p, coelutionScore, rankScore));
-            }
-
-            if (diag && bestPeak != null)
-            {
-                int apexAbsIdx = startScan + bestPeak.ApexIndex;
-                _logInfo(string.Format(
-                    "[DIAG] {0}: WINNER peak[{1}] apex_rt={2:F3} scan#={3}",
-                    candidate.ModifiedSequence, bestPeakIdx,
-                    windowRts[apexAbsIdx], windowSpectra[apexAbsIdx].ScanNumber));
-            }
-
-            // Append peak boundaries to search XIC diagnostic dump
-            if (_diagnostics?.ShouldDumpSearchXicFor(candidate.Id) ?? false)
-            {
-                string peakDumpPath = "cs_search_xic_entry_" + candidate.Id + ".txt";
-                using (var dw = new StreamWriter(peakDumpPath, true))
-                {
-                    dw.WriteLine(string.Format(System.Globalization.CultureInfo.InvariantCulture,
-                        "# CWT PEAKS: {0} candidates", peaks.Count));
-                    dw.WriteLine("peak\tidx\tstart\tapex\tend\tcorr_score");
-                    for (int pi = 0; pi < peaks.Count; pi++)
-                    {
-                        var p = peaks[pi];
-                        int pLen = p.EndIndex - p.StartIndex + 1;
-                        double corrScore = 0.0;
-                        if (pLen >= 3)
-                        {
-                            double psum = 0.0; int pcnt = 0;
-                            for (int ii = 0; ii < xics.Count; ii++)
-                                for (int jj = ii + 1; jj < xics.Count; jj++)
-                                {
-                                    double c = ScoringMath.PearsonCorrelationInRange(xics[ii].Intensities, xics[jj].Intensities,
-                                        p.StartIndex, p.EndIndex);
-                                    if (!double.IsNaN(c)) { psum += c; pcnt++; }
-                                }
-                            corrScore = pcnt > 0 ? psum / pcnt : 0.0;
-                        }
-                        dw.WriteLine(string.Format(System.Globalization.CultureInfo.InvariantCulture,
-                            "peak\t{0}\t{1}\t{2}\t{3}\t{4:F10}",
-                            pi, p.StartIndex, p.ApexIndex, p.EndIndex, corrScore));
-                    }
-                    dw.WriteLine(string.Format(System.Globalization.CultureInfo.InvariantCulture,
-                        "# BEST PEAK: idx={0} start={1} apex={2} end={3}",
-                        bestPeakIdx,
-                        bestPeak != null ? bestPeak.StartIndex : -1,
-                        bestPeak != null ? bestPeak.ApexIndex : -1,
-                        bestPeak != null ? bestPeak.EndIndex : -1));
-                }
-            }
-
-            if (bestPeak == null)
-            {
-                if (!overrideBounds.HasValue)
-                {
-                    _diagnostics?.WriteCwtPathRow(
-                        context.FileName, candidate.Id,
-                        diagNCwtPeaks, peaks.Count, diagNScored, false, xics);
-                }
-                return null;
-            }
-
-            // For CWT-path entries (no override), Rust pipeline.rs:7406-7424
-            // RECOMPUTES the peak's apex_index / apex_intensity using
-            // ref_xic[si..=ei] (the highest-total-intensity single
-            // fragment), discarding the apex_index that came out of
-            // detect_cwt_consensus_peaks (which used ref_signal -- the
-            // SUM of all fragment intensities). When a peak's max in
-            // the summed signal sits at a different scan than the max
-            // in the single ref_xic, leaving the consensus apex_index
-            // in place produces divergent peak_apex / peak_sharpness
-            // vs Rust on the reconciled .scores.parquet (~32k rows on
-            // Stellar before this fix). Override entries are excluded
-            // because Rust's override branch (pipeline.rs:7155-7223)
-            // uses the override-supplied apex_index directly without
-            // refining it -- match by skipping the recompute.
-            if (!overrideBounds.HasValue)
-            {
-                int si = bestPeak.StartIndex;
-                int ei = bestPeak.EndIndex;
-                int newApexIdx = si;
-                double newApexVal = refXicIntensities[si];
-                for (int i = si + 1; i <= ei; i++)
-                {
-                    // Use `>=` to match Rust's `max_by` last-on-tie.
-                    if (refXicIntensities[i] >= newApexVal)
-                    {
-                        newApexVal = refXicIntensities[i];
-                        newApexIdx = i;
-                    }
-                }
-                // Rust pipeline.rs:7433-7444 RECOMPUTES `peak.area` and
-                // `peak.signal_to_noise` from `ref_xic[si..=ei]` here, NOT
-                // preserving the original CWT detection's values. The
-                // original area/SNR came from the consensus signal's
-                // boundary (which can differ from the CWT apex's
-                // [start..end] in the ref_xic). Preserving them produces
-                // ~560 bounds_area / ~546 bounds_snr divergent rows on
-                // Stellar where the parquet reports the WRONG (consensus-
-                // boundary) area for the WINNING (ref_xic-boundary) peak.
-                // peak_area / peak_sharpness as PIN features already
-                // recompute correctly via ComputePeakShapeFeatures; this
-                // recompute keeps the parquet's bounds_area / bounds_snr
-                // consistent with that.
-                double[] refRtsAll = xics[refXicIdx].RetentionTimes;
-                double newArea = PeakDetector.TrapezoidalArea(
-                    refRtsAll, refXicIntensities, si, ei);
-                double newSnr = PeakDetector.ComputeSnr(
-                    refXicIntensities, newApexIdx, si, ei);
-                bestPeak = new XICPeakBounds
-                {
-                    ApexRt = refRtsAll[newApexIdx],
-                    ApexIntensity = newApexVal,
-                    ApexIndex = newApexIdx,
-                    StartRt = refRtsAll[si],
-                    EndRt = refRtsAll[ei],
-                    StartIndex = si,
-                    EndIndex = ei,
-                    Area = newArea,
-                    SignalToNoise = newSnr,
-                };
-            }
-
-            int apexGlobalIdx = startScan + bestPeak.ApexIndex;
-
-            // Score at the apex spectrum
-            if (apexGlobalIdx < 0 || apexGlobalIdx >= windowSpectra.Count)
-            {
-                if (!overrideBounds.HasValue)
-                {
-                    _diagnostics?.WriteCwtPathRow(
-                        context.FileName, candidate.Id,
-                        diagNCwtPeaks, peaks.Count, diagNScored, false, xics);
-                }
-                return null;
-            }
-
-            var apexSpectrum = windowSpectra[apexGlobalIdx];
-
-            // LibCosine at apex
-            double libCosine = scorer.LibCosine(apexSpectrum, candidate, config.FragmentTolerance);
-
-            // Count fragment matches (top-6 dedup byproduct, NOT a PIN feature;
-            // stays inline). consecutive_ions / explained_intensity / mass-accuracy
-            // (features 7-10) moved to the apex-match calculators below.
-            byte top6Matches = TopFragmentExtractor.CountTop6Matches(candidate, apexSpectrum, config);
-
-            // MS1 features (precursor coelution, isotope cosine) are computed by the
-            // MS1 calculators (features 13, 14) below from the published per-window
-            // MS1 machinery (ospreyContext.SetMs1Machinery) and the window RT axis
-            // (windowRts) passed to ospreyPeakData.Set. The HRAM gate (Rust
-            // pipeline.rs:5362 is_hram) lives in the calculators.
-
-            // Per-candidate state for the modular feature calculators. Reused
-            // window-local instances (see RunCoelutionScoring); ClearByproducts
-            // resets the per-candidate byproduct cache. Done BEFORE the
-            // median-polish publish below so that byproduct survives to the
-            // calculators. Calculator-backed features mirror Skyline's
-            // IPeakFeatureCalculator; the rest stay inline until extracted.
-            // windowRts is passed by reference (no per-candidate copy); the MS1
-            // family maps an XIC index i to an absolute RT via windowRts[startScan + i]
-            // (= WindowRetentionTimes[WindowStartIndex + i]).
+            // The extractor has populated ospreyPeakData via Set. Reset the
+            // per-candidate byproduct cache (carried over from the previous
+            // candidate) BEFORE the median-polish publish below so that byproduct
+            // survives to the calculators. Calculator-backed features mirror
+            // Skyline's IPeakFeatureCalculator.
             ospreyContext.ClearByproducts();
-            ospreyPeakData.Set(candidate, bestPeak, xics, apexSpectrum.RetentionTime, expectedRt, apexSpectrum,
-                apexGlobalIdx, bestPeak.ApexIndex, startScan, rangeLen, windowSpectra, windowRts);
 
             // Tukey median-polish inputs + fit (features 15, 16, 19, 20). The crop,
             // WriteMpInputsRow, and Compute stay here because the bisection
-            // diagnostics live in the exe layer that OspreySharp.Scoring cannot
-            // reference; the four feature values are computed by the calculators
-            // from the published MedianPolishByproduct, and the optional
-            // WriteMpDump fires after the feature vector below.
+            // diagnostics (OspreyDiagnostics) live in the exe layer that
+            // OspreySharp.Scoring cannot reference; the four feature values are
+            // computed by the calculators from the published MedianPolishByproduct,
+            // and the optional WriteMpDump fires after the feature vector below.
             // Crop XICs to the peak range so the polish operates only on signal,
             // not the wider RT search window. Matches Rust pipeline.rs:5198-5212.
             int peakLen = bestPeak.EndIndex - bestPeak.StartIndex + 1;
@@ -727,75 +292,15 @@ namespace pwiz.OspreySharp.Scoring
             // penalized rank score) -- reconciliation has its own RT
             // tolerance logic via consensus RT comparison.
             List<CwtCandidate> cwtCandidatesOut = CaptureCwtCandidates(
-                capturedPeaks, xics, refXicIdx, refXicIntensities, context);
+                ext.CapturedPeaks, xics, ext.RefXicIdx, ext.RefXicIntensities, context);
 
             // Build FdrEntry from the winning peak + feature vector (frag
             // blobs, reference-XIC slice, bounds). Extracted to BuildFdrEntry.
             var entry = BuildFdrEntry(
                 candidate, bestPeak, features, cwtCandidatesOut,
-                xics, refXicIdx, refXicIntensities, windowRts, startScan, apexSpectrum);
+                xics, ext.RefXicIdx, ext.RefXicIntensities, windowRts, ext.StartScan, apexSpectrum);
 
-            if (!overrideBounds.HasValue)
-            {
-                _diagnostics?.WriteCwtPathRow(
-                    context.FileName, candidate.Id,
-                    diagNCwtPeaks, peaks.Count, diagNScored, true, xics);
-            }
             return entry;
-        }
-
-
-        /// <summary>
-        /// Find the [startScan..endScan] range for XIC extraction. For boundary
-        /// overrides: the given boundaries plus margin for SNR context (peak_width
-        /// each side, 0.2 min floor; run_search pipeline.rs:6473-6477). For normal
-        /// search (Rust commit 885339b): a window wider than rtTolerance so CWT has
-        /// context on both sides of any in-tolerance apex; half-width is
-        /// rtTolerance + max(rtTolerance, 0.1). Both yield -1/-1 when no scan
-        /// matches. The normal branch uses the abs-diff form |rt - expectedRt| &lt;=
-        /// xicHalfWidth (NOT a precomputed rtHi compare): the two arithmetic chains
-        /// round differently in the last bit, and ~1k entries per Stellar file pick
-        /// a different best apex if a single boundary spectrum slips in/out of the
-        /// window (cascades through CWT peak detection). Mirrors pipeline.rs:7031-7065.
-        /// </summary>
-        private static void FindScanRange(
-            (double Apex, double Start, double End)? overrideBounds,
-            double[] windowRts, int nScans,
-            double expectedRt, double rtTolerance,
-            out int startScan, out int endScan)
-        {
-            startScan = -1;
-            endScan = -1;
-            if (overrideBounds.HasValue)
-            {
-                var ob = overrideBounds.Value;
-                double peakWidth = Math.Max(0.1, ob.End - ob.Start);
-                double margin = Math.Max(0.2, peakWidth);
-                double rtLo = ob.Start - margin;
-                double rtHi = ob.End + margin;
-                for (int i = 0; i < nScans; i++)
-                {
-                    if (windowRts[i] >= rtLo && windowRts[i] <= rtHi)
-                    {
-                        if (startScan < 0)
-                            startScan = i;
-                        endScan = i;
-                    }
-                }
-            }
-            else
-            {
-                double xicHalfWidth = rtTolerance + Math.Max(rtTolerance, 0.1);
-                for (int i = 0; i < nScans; i++)
-                {
-                    if (Math.Abs(windowRts[i] - expectedRt) <= xicHalfWidth)
-                    {
-                        if (startScan < 0)
-                            startScan = i;
-                        endScan = i;
-                    }
-                }
-            }
         }
 
 
@@ -869,83 +374,6 @@ namespace pwiz.OspreySharp.Scoring
                 });
             }
             return cwtCandidatesOut;
-        }
-
-
-        /// <summary>
-        /// Detect candidate peaks with a three-tier fallback (matches Rust
-        /// pipeline.rs:6244-6259): (1) CWT consensus, (2) peak detection on the
-        /// median-polish elution profile, (3) peak detection on the reference
-        /// XIC (highest total intensity). For boundary overrides (Stage 6
-        /// re-scoring) peak detection is skipped and a single synthetic
-        /// <see cref="XICPeakBounds"/> is built from the supplied (apex, start,
-        /// end); mirrors run_search at pipeline.rs:6596-6664. Returns null ONLY
-        /// when an override produced a degenerate index range; otherwise a
-        /// (possibly empty) peak list. <paramref name="diagNCwtPeaks"/> snapshots
-        /// the CWT consensus peak count for the OSPREY_DUMP_CWT_PATH dump.
-        /// </summary>
-        private static List<XICPeakBounds> DetectCandidatePeaks(
-            (double Apex, double Start, double End)? overrideBounds,
-            List<XicData> xics,
-            out int diagNCwtPeaks)
-        {
-            List<XICPeakBounds> peaks;
-            if (overrideBounds.HasValue)
-            {
-                peaks = BuildOverridePeaks(overrideBounds.Value, xics);
-                if (peaks == null)
-                {
-                    diagNCwtPeaks = 0;
-                    return null;
-                }
-            }
-            else
-            {
-                peaks = CwtPeakDetector.DetectConsensusPeaks(xics, 0.0);
-            }
-            diagNCwtPeaks = peaks.Count;
-
-            if (peaks.Count == 0)
-            {
-                // Fallback 1: detect peaks on the median polish elution profile.
-                // Rust: detect_all_xic_peaks(&mp.elution_profile, 0.01, 5.0)
-                var polishXics = new List<KeyValuePair<int, double[]>>();
-                for (int f = 0; f < xics.Count; f++)
-                    polishXics.Add(new KeyValuePair<int, double[]>(
-                        xics[f].FragmentIndex, xics[f].Intensities));
-                double[] polishRts = xics[0].RetentionTimes;
-
-                var fullPolish = TukeyMedianPolish.Compute(polishXics, polishRts, 10, 0.01);
-                if (fullPolish != null && fullPolish.ElutionProfileRts != null &&
-                    fullPolish.ElutionProfileIntensities != null)
-                {
-                    peaks = PeakDetector.DetectAllXicPeaks(
-                        fullPolish.ElutionProfileRts,
-                        fullPolish.ElutionProfileIntensities,
-                        0.01, 5.0);
-                }
-            }
-
-            if (peaks.Count == 0)
-            {
-                // Fallback 2: detect peaks on the reference XIC (highest total intensity).
-                // Rust: detect_all_xic_peaks(ref_xic, 0.01, 5.0)
-                int refIdx = 0;
-                double bestTotal = 0.0;
-                for (int f = 0; f < xics.Count; f++)
-                {
-                    double total = 0.0;
-                    for (int i = 0; i < xics[f].Intensities.Length; i++)
-                        total += xics[f].Intensities[i];
-                    if (total > bestTotal) { bestTotal = total; refIdx = f; }
-                }
-                peaks = PeakDetector.DetectAllXicPeaks(
-                    xics[refIdx].RetentionTimes,
-                    xics[refIdx].Intensities,
-                    0.01, 5.0);
-            }
-
-            return peaks;
         }
 
 
@@ -1039,89 +467,6 @@ namespace pwiz.OspreySharp.Scoring
                 ReferenceXicIntensities = refXicInts,
                 BoundsArea = bestPeak.Area,
                 BoundsSnr = bestPeak.SignalToNoise,
-            };
-        }
-
-
-        // Diagnostic: log detailed trace for a specific peptide. Set this to a
-        // peptide modified sequence to dump its RT window, XICs, CWT peaks, and
-        // winning peak selection. Used for bisecting divergences with Rust.
-        private const string DIAG_PEPTIDE = "AAAAAAAAAAAAAAAGAGAGAK";
-
-
-        /// <summary>
-        /// Build a one-element peak list at the supplied (apex, start, end)
-        /// RT triple, mapped onto the reference XIC's RT axis. Returns null
-        /// when the resulting index range is degenerate. Mirrors the
-        /// boundary_overrides peak-construction path in run_search at
-        /// osprey/crates/osprey/src/pipeline.rs:6596-6644.
-        /// </summary>
-        private static List<XICPeakBounds> BuildOverridePeaks(
-            (double Apex, double Start, double End) ob,
-            List<XicData> xics)
-        {
-            // Reference XIC = highest total-intensity fragment, matching
-            // Rust run_search at pipeline.rs:7140-7148 which uses
-            // `xics.max_by(|a, b| sum_a.total_cmp(&sum_b))` (returns
-            // the LAST equal element on ties). Use `>=` to match -- a
-            // strict `>` would keep the FIRST equal element here while
-            // every other ref_xic selection in this file (including
-            // the rank-scoring loop further down) uses `>=`, so an
-            // override entry whose top two fragments tie on total
-            // intensity would have BuildOverridePeaks pick a different
-            // ref than the rank loop expects. That mismatch shows up
-            // as ~32k peak_apex divergent rows in the reconciled
-            // parquet vs the Rust output.
-            int refIdx = 0;
-            double refTotal = -1.0;
-            for (int f = 0; f < xics.Count; f++)
-            {
-                double total = 0.0;
-                var ints = xics[f].Intensities;
-                for (int j = 0; j < ints.Length; j++)
-                    total += ints[j];
-                if (total >= refTotal) { refTotal = total; refIdx = f; }
-            }
-            var rtArr = xics[refIdx].RetentionTimes;
-            var intArr = xics[refIdx].Intensities;
-            int last = rtArr.Length - 1;
-            if (last < 2)
-                return null;
-
-            // Map override RTs to indices via Rust partition_point semantics:
-            // first index where rt >= target. start_index then saturating_sub(1).
-            int startIdx = ScoringMath.BinarySearchLowerBound(rtArr, ob.Start);
-            if (startIdx > 0) startIdx--;
-            if (startIdx > last) startIdx = last;
-
-            int endIdx = ScoringMath.BinarySearchLowerBound(rtArr, ob.End);
-            if (endIdx > last) endIdx = last;
-
-            int apexIdx = ScoringMath.BinarySearchLowerBound(rtArr, ob.Apex);
-            if (apexIdx > last) apexIdx = last;
-            if (apexIdx > 0 &&
-                Math.Abs(rtArr[apexIdx - 1] - ob.Apex) < Math.Abs(rtArr[apexIdx] - ob.Apex))
-                apexIdx--;
-            if (apexIdx < startIdx) apexIdx = startIdx;
-            if (apexIdx > endIdx) apexIdx = endIdx;
-
-            if (endIdx <= startIdx + 1)
-                return null;
-
-            return new List<XICPeakBounds>
-            {
-                new XICPeakBounds
-                {
-                    ApexRt = rtArr[apexIdx],
-                    ApexIntensity = intArr[apexIdx],
-                    ApexIndex = apexIdx,
-                    StartRt = rtArr[startIdx],
-                    EndRt = rtArr[endIdx],
-                    StartIndex = startIdx,
-                    EndIndex = endIdx,
-                    Area = PeakDetector.TrapezoidalArea(rtArr, intArr, startIdx, endIdx),
-                    SignalToNoise = PeakDetector.ComputeSnr(intArr, apexIdx, startIdx, endIdx),
-                },
             };
         }
     }

--- a/pwiz_tools/OspreySharp/OspreySharp.Scoring/IOspreyFeatureCalculator.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Scoring/IOspreyFeatureCalculator.cs
@@ -1,7 +1,7 @@
 /*
  * Original author: Brendan MacLean <brendanx .at. uw.edu>,
  *                  MacCoss Lab, Department of Genome Sciences, UW
- * AI assistance: Claude Code (Claude Opus 4) <noreply .at. anthropic.com>
+ * AI assistance: Claude Code (Claude Opus 4.8) <noreply .at. anthropic.com>
  *
  * Based on osprey (https://github.com/MacCossLab/osprey)
  *   by Michael J. MacCoss, MacCoss Lab, Department of Genome Sciences, UW
@@ -32,6 +32,12 @@ namespace pwiz.OspreySharp.Scoring
     /// the shared scoring context. The parity-critical order and identity of the
     /// 21 features lives in <see cref="OspreyFeatureCalculators"/>, not on the
     /// calculator.
+    ///
+    /// The SPI is typed to the least-specific peak-data tier
+    /// (<see cref="IOspreySummaryPeakData"/>); each abstract base below narrows it to
+    /// the tier its family needs, so a calculator declares its data dependency in the
+    /// type system and the harness presents no more data than the score reads. See the
+    /// tier hierarchy in <c>IOspreyPeakData.cs</c>.
     /// </summary>
     public interface IOspreyFeatureCalculator
     {
@@ -44,35 +50,85 @@ namespace pwiz.OspreySharp.Scoring
         /// <summary>
         /// Compute this feature's value for one candidate peak.
         /// </summary>
-        double Calculate(OspreyScoringContext context, IOspreyPeakData peakData);
+        double Calculate(OspreyScoringContext context, IOspreySummaryPeakData peakData);
     }
 
     /// <summary>
-    /// Base for OspreySharp scoring calculators, mirroring Skyline's
-    /// <c>DetailedPeakFeatureCalculator</c> (it narrows the peak data to the
-    /// detailed view). Every current Osprey feature reads detailed
-    /// (chromatogram/spectrum) data, so -- unlike Skyline -- there is no
-    /// summary-only calculator base. The data-interface split
-    /// (<see cref="IOspreyPeakData"/> / <see cref="IOspreyDetailedPeakData"/>)
-    /// still mirrors <c>ISummaryPeakData</c> / <c>IDetailedPeakData</c>.
+    /// Base for scores that read only summary peak data (identity + chosen peak
+    /// location), mirroring Skyline's <c>SummaryPeakFeatureCalculator</c>. The
+    /// rt-deviation family is the only Osprey family at this tier.
+    /// </summary>
+    public abstract class SummaryOspreyFeatureCalculator : IOspreyFeatureCalculator
+    {
+        public abstract string Name { get; }
+
+        public abstract double Calculate(OspreyScoringContext context, IOspreySummaryPeakData peakData);
+    }
+
+    /// <summary>
+    /// Base for scores that read per-fragment XICs, mirroring Skyline's
+    /// <c>DetailedPeakFeatureCalculator</c>. Narrows the SPI's summary peak data to
+    /// <see cref="IOspreyDetailedPeakData"/>; throws a clear error rather than a raw
+    /// <see cref="InvalidCastException"/> if a narrower view is supplied. The
+    /// coelution, peak-shape, and median-polish families ride this tier.
     /// </summary>
     public abstract class DetailedOspreyFeatureCalculator : IOspreyFeatureCalculator
     {
         public abstract string Name { get; }
 
-        public double Calculate(OspreyScoringContext context, IOspreyPeakData peakData)
+        public double Calculate(OspreyScoringContext context, IOspreySummaryPeakData peakData)
         {
-            // Every Osprey calculator reads detailed (chromatogram/spectrum) data, so
-            // the SPI accepts the summary base for Skyline-shape parity but narrows
-            // here. Throw a clear error rather than a raw InvalidCastException if a
-            // caller passes a summary-only implementation.
             var detailed = peakData as IOspreyDetailedPeakData;
             if (detailed == null)
                 throw new InvalidOperationException(
-                    @"OspreySharp feature calculators require IOspreyDetailedPeakData; a summary-only IOspreyPeakData was provided.");
+                    @"This OspreySharp feature calculator requires IOspreyDetailedPeakData; a narrower peak-data tier was provided.");
             return Calculate(context, detailed);
         }
 
         protected abstract double Calculate(OspreyScoringContext context, IOspreyDetailedPeakData peakData);
+    }
+
+    /// <summary>
+    /// Base for scores that read the single apex MS2 spectrum -- the first tier above
+    /// what Skyline's results layer can supply. Narrows the SPI's summary peak data to
+    /// <see cref="IOspreyApexSpectrumPeakData"/>. The xcorr feature and the apex-match
+    /// family ride this tier.
+    /// </summary>
+    public abstract class ApexSpectrumOspreyFeatureCalculator : IOspreyFeatureCalculator
+    {
+        public abstract string Name { get; }
+
+        public double Calculate(OspreyScoringContext context, IOspreySummaryPeakData peakData)
+        {
+            var apex = peakData as IOspreyApexSpectrumPeakData;
+            if (apex == null)
+                throw new InvalidOperationException(
+                    @"This OspreySharp feature calculator requires IOspreyApexSpectrumPeakData; a narrower peak-data tier was provided.");
+            return Calculate(context, apex);
+        }
+
+        protected abstract double Calculate(OspreyScoringContext context, IOspreyApexSpectrumPeakData peakData);
+    }
+
+    /// <summary>
+    /// Base for scores that read the apex +/- 2 MS2 spectra -- the widest tier, two
+    /// levels above Skyline. Narrows the SPI's summary peak data to
+    /// <see cref="IOspreyApexSpectraPeakData"/>. The Savitzky-Golay sweep rides this
+    /// tier (and the MS1 family until its data is produced upstream).
+    /// </summary>
+    public abstract class ApexSpectraOspreyFeatureCalculator : IOspreyFeatureCalculator
+    {
+        public abstract string Name { get; }
+
+        public double Calculate(OspreyScoringContext context, IOspreySummaryPeakData peakData)
+        {
+            var spectra = peakData as IOspreyApexSpectraPeakData;
+            if (spectra == null)
+                throw new InvalidOperationException(
+                    @"This OspreySharp feature calculator requires IOspreyApexSpectraPeakData; a narrower peak-data tier was provided.");
+            return Calculate(context, spectra);
+        }
+
+        protected abstract double Calculate(OspreyScoringContext context, IOspreyApexSpectraPeakData peakData);
     }
 }

--- a/pwiz_tools/OspreySharp/OspreySharp.Scoring/IOspreyFeatureCalculator.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Scoring/IOspreyFeatureCalculator.cs
@@ -113,8 +113,10 @@ namespace pwiz.OspreySharp.Scoring
     /// <summary>
     /// Base for scores that read the apex +/- 2 MS2 spectra -- the widest tier, two
     /// levels above Skyline. Narrows the SPI's summary peak data to
-    /// <see cref="IOspreyApexSpectraPeakData"/>. The Savitzky-Golay sweep rides this
-    /// tier (and the MS1 family until its data is produced upstream).
+    /// <see cref="IOspreyApexSpectraPeakData"/>. The Savitzky-Golay sweep is the only
+    /// family that rides this tier; the MS1 family does NOT (its precursor XIC +
+    /// isotope envelope are produced upstream and exposed on
+    /// <see cref="IOspreyDetailedPeakData"/>).
     /// </summary>
     public abstract class ApexSpectraOspreyFeatureCalculator : IOspreyFeatureCalculator
     {

--- a/pwiz_tools/OspreySharp/OspreySharp.Scoring/IOspreyPeakData.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Scoring/IOspreyPeakData.cs
@@ -87,6 +87,35 @@ namespace pwiz.OspreySharp.Scoring
         /// shared scan axis. The full set is iterated to select the reference XIC.
         /// </summary>
         IReadOnlyList<XicData> Xics { get; }
+
+        /// <summary>
+        /// The MS1 precursor-intensity chromatogram the harness produced for this
+        /// candidate: the precursor m/z sampled at the nearest MS1 scan along the
+        /// peak (missing MS1 scans skipped, so its length is the number of present
+        /// MS1 scans, not the peak width). <c>null</c> for unit-resolution runs / no
+        /// MS1 / a too-short peak. The ms1_precursor_coelution feature correlates it
+        /// against <see cref="Ms1ReferenceXic"/>. Mirrors how Skyline produces MS1
+        /// chromatograms upstream so the score is a pure consumer.
+        /// </summary>
+        XicData Ms1PrecursorXic { get; }
+
+        /// <summary>
+        /// The reference fragment XIC co-sampled at the SAME retained MS1 scans as
+        /// <see cref="Ms1PrecursorXic"/> (the MS1-specific reference selection:
+        /// highest-total-intensity fragment, last-on-tie). The partner the
+        /// ms1_precursor_coelution Pearson correlation runs against. <c>null</c>
+        /// whenever <see cref="Ms1PrecursorXic"/> is.
+        /// </summary>
+        XicData Ms1ReferenceXic { get; }
+
+        /// <summary>
+        /// The observed isotope-envelope intensities at the apex MS1 scan (the
+        /// <see cref="IsotopeEnvelope"/> extraction the harness ran for this
+        /// candidate). <c>null</c> when there is no apex MS1 scan. The
+        /// ms1_isotope_cosine feature applies the M0 gate and cosines it against the
+        /// theoretical envelope. This part has no Skyline analog yet.
+        /// </summary>
+        double[] ApexIsotopeEnvelope { get; }
     }
 
     /// <summary>

--- a/pwiz_tools/OspreySharp/OspreySharp.Scoring/IOspreyPeakData.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Scoring/IOspreyPeakData.cs
@@ -1,7 +1,7 @@
 /*
  * Original author: Brendan MacLean <brendanx .at. uw.edu>,
  *                  MacCoss Lab, Department of Genome Sciences, UW
- * AI assistance: Claude Code (Claude Opus 4) <noreply .at. anthropic.com>
+ * AI assistance: Claude Code (Claude Opus 4.8) <noreply .at. anthropic.com>
  *
  * Based on osprey (https://github.com/MacCossLab/osprey)
  *   by Michael J. MacCoss, MacCoss Lab, Department of Genome Sciences, UW
@@ -27,14 +27,29 @@ using pwiz.OspreySharp.Core;
 
 namespace pwiz.OspreySharp.Scoring
 {
+    // Per-candidate peak data presented to the feature calculators, as a four-level
+    // tier hierarchy of increasing data access. A calculator implements against the
+    // narrowest tier it needs, so the type system records each score's data
+    // dependency and the harness presents each score with no more than it requires.
+    //
+    // The first two tiers mirror Skyline's ISummaryPeakData / IDetailedPeakData; the
+    // top two expose spectral data Skyline's chromatogram-centric results layer does
+    // NOT provide at scoring time, in two honest levels:
+    //
+    //   IOspreySummaryPeakData       identity + chosen peak location (stats only)
+    //   IOspreyDetailedPeakData      + per-fragment XICs                          (Skyline-achievable)
+    //   IOspreyApexSpectrumPeakData  + the single apex MS2 spectrum               (one level above Skyline)
+    //   IOspreyApexSpectraPeakData   + the apex +/- 2 MS2 spectra                 (two levels above Skyline)
+
     /// <summary>
-    /// Per-candidate peak data, mirroring Skyline's <c>ISummaryPeakData</c>: the
-    /// identity and the chosen peak location a feature scores against. Osprey's
+    /// Summary per-candidate peak data, mirroring Skyline's <c>ISummaryPeakData</c>:
+    /// the identity and the chosen peak location a feature scores against. Osprey's
     /// scoring is flat -- one precursor (<see cref="Candidate"/>) at its best peak
     /// (<see cref="PeakBounds"/>) within one isolation window -- so this is a flat
-    /// view, not Skyline's peptide/group/transition tree.
+    /// view, not Skyline's peptide/group/transition tree. The rt-deviation family
+    /// (rt_deviation / abs_rt_deviation) reads only this tier.
     /// </summary>
-    public interface IOspreyPeakData
+    public interface IOspreySummaryPeakData
     {
         /// <summary>The candidate library entry: precursor plus theoretical fragments.</summary>
         LibraryEntry Candidate { get; }
@@ -59,39 +74,61 @@ namespace pwiz.OspreySharp.Scoring
     }
 
     /// <summary>
-    /// Detailed per-candidate peak data, mirroring Skyline's
-    /// <c>IDetailedPeakData</c>: adds the per-fragment extracted-ion chromatograms
-    /// on the shared scan axis. Spectral accessors (apex / MS1 spectra) -- the part
-    /// Skyline's chromatogram-centric results layer cannot supply -- are added by
-    /// the feature families that read them.
+    /// Detailed per-candidate peak data, mirroring Skyline's <c>IDetailedPeakData</c>:
+    /// adds the per-fragment extracted-ion chromatograms on the shared scan axis. The
+    /// coelution, peak-shape, and median-polish families read this tier (the
+    /// median-polish fit is an XIC-derived byproduct the harness publishes). This is
+    /// the richest tier Skyline's results layer can currently supply.
     /// </summary>
-    public interface IOspreyDetailedPeakData : IOspreyPeakData
+    public interface IOspreyDetailedPeakData : IOspreySummaryPeakData
     {
         /// <summary>
         /// Per-fragment XICs (FragmentIndex, RetentionTimes, Intensities) on the
         /// shared scan axis. The full set is iterated to select the reference XIC.
         /// </summary>
         IReadOnlyList<XicData> Xics { get; }
+    }
 
+    /// <summary>
+    /// Apex-spectrum per-candidate peak data: adds the single MS2 spectrum at the
+    /// chosen peak apex. This is the first tier beyond what Skyline's
+    /// chromatogram-centric results layer can supply -- a Skyline implementation
+    /// would throw on <see cref="ApexSpectrum"/>. The xcorr feature and the
+    /// apex-match family (consecutive_ions, explained_intensity, the two
+    /// mass-accuracy means) read this tier: they match the candidate's theoretical
+    /// fragments against the apex spectrum's sorted m/z and index-aligned intensity
+    /// arrays.
+    /// </summary>
+    public interface IOspreyApexSpectrumPeakData : IOspreyDetailedPeakData
+    {
         /// <summary>
         /// The MS2 spectrum at the chosen peak apex
-        /// (windowSpectra[startScan + bestPeak.ApexIndex]). This is the spectral
-        /// surface Skyline's chromatogram-centric results layer cannot supply -- a
-        /// Skyline implementation of this interface would throw here. The
-        /// apex-match family matches the candidate's theoretical fragments against
-        /// this spectrum's sorted m/z and index-aligned intensity arrays.
+        /// (windowSpectra[startScan + bestPeak.ApexIndex]). The spectral surface
+        /// Skyline's chromatogram-centric results layer cannot supply.
         /// </summary>
         Spectrum ApexSpectrum { get; }
 
         /// <summary>
         /// Window-global spectrum index of the chosen apex
-        /// (= <see cref="WindowStartIndex"/> + <see cref="ApexLocalIndex"/>). The
-        /// xcorr feature indexes the preprocessed cache HERE. INDEX TRAP: this is a
-        /// distinct index space from the Savitzky-Golay sweep's candidate-local
-        /// index -- see <see cref="ApexLocalIndex"/> / <see cref="WindowLength"/>.
+        /// (= WindowStartIndex + candidate-local apex). The xcorr feature indexes the
+        /// preprocessed cache HERE. INDEX TRAP: this is a distinct index space from
+        /// the Savitzky-Golay sweep's candidate-local index -- see
+        /// <see cref="IOspreyApexSpectraPeakData"/>.
         /// </summary>
         int ApexGlobalIndex { get; }
+    }
 
+    /// <summary>
+    /// Apex-spectra per-candidate peak data: adds the apex +/- 2 MS2 spectra (five
+    /// scans). This is the widest spectral access -- two levels beyond Skyline -- and
+    /// is read only by the Savitzky-Golay sweep (sg_weighted_xcorr / sg_weighted_cosine),
+    /// which weights the per-scan xcorr / cosine over the apex and its two neighbors on
+    /// each side. (The MS1 family also rides this tier today because it reads the window
+    /// RT axis; it drops to <see cref="IOspreyDetailedPeakData"/> once its MS1 precursor
+    /// XIC + isotope envelope are produced upstream.)
+    /// </summary>
+    public interface IOspreyApexSpectraPeakData : IOspreyApexSpectrumPeakData
+    {
         /// <summary>
         /// Candidate-local apex index within the scoring range
         /// (= bestPeak.ApexIndex). The SG sweep builds candIdx = ApexLocalIndex +
@@ -102,7 +139,8 @@ namespace pwiz.OspreySharp.Scoring
         /// <summary>
         /// startScan: the offset mapping a candidate-local index to a window-global
         /// index (globalIdx = WindowStartIndex + candIdx). Kept distinct from
-        /// <see cref="ApexGlobalIndex"/>; at offset 0 they coincide by construction.
+        /// <see cref="IOspreyApexSpectrumPeakData.ApexGlobalIndex"/>; at offset 0 they
+        /// coincide by construction.
         /// </summary>
         int WindowStartIndex { get; }
 
@@ -121,10 +159,9 @@ namespace pwiz.OspreySharp.Scoring
         /// <summary>
         /// The window's per-scan retention-time axis (the shared <c>windowRts</c>
         /// reference, a per-window value -- not a per-candidate copy). The MS1 family
-        /// (features 13, 14) maps an XIC scan index i to an absolute RT via
+        /// maps an XIC scan index i to an absolute RT via
         /// WindowRetentionTimes[<see cref="WindowStartIndex"/> + i] to find the nearest
-        /// MS1 scan. Just RT, not a spectral surface, so unlike
-        /// <see cref="ApexSpectrum"/> a chromatogram-centric implementation can supply it.
+        /// MS1 scan. Just RT, not a spectral surface.
         /// </summary>
         IReadOnlyList<double> WindowRetentionTimes { get; }
     }

--- a/pwiz_tools/OspreySharp/OspreySharp.Scoring/IOspreyPeakData.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Scoring/IOspreyPeakData.cs
@@ -148,13 +148,13 @@ namespace pwiz.OspreySharp.Scoring
     }
 
     /// <summary>
-    /// Apex-spectra per-candidate peak data: adds the apex +/- 2 MS2 spectra (five
-    /// scans). This is the widest spectral access -- two levels beyond Skyline -- and
-    /// is read only by the Savitzky-Golay sweep (sg_weighted_xcorr / sg_weighted_cosine),
-    /// which weights the per-scan xcorr / cosine over the apex and its two neighbors on
-    /// each side. (The MS1 family also rides this tier today because it reads the window
-    /// RT axis; it drops to <see cref="IOspreyDetailedPeakData"/> once its MS1 precursor
-    /// XIC + isotope envelope are produced upstream.)
+    /// Apex-spectra per-candidate peak data: adds bounded access to the apex +/- 2 MS2
+    /// spectra (five scans) via <see cref="TryGetApexOffsetSpectrum"/>. This is the
+    /// widest spectral access -- two levels beyond Skyline -- and is read only by the
+    /// Savitzky-Golay sweep (sg_weighted_xcorr / sg_weighted_cosine), which weights the
+    /// per-scan xcorr / cosine over the apex and its two neighbors on each side. (The
+    /// MS1 family does NOT ride this tier: its precursor XIC + isotope envelope are
+    /// produced upstream and exposed on <see cref="IOspreyDetailedPeakData"/>.)
     /// </summary>
     public interface IOspreyApexSpectraPeakData : IOspreyApexSpectrumPeakData
     {

--- a/pwiz_tools/OspreySharp/OspreySharp.Scoring/IOspreyPeakData.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Scoring/IOspreyPeakData.cs
@@ -159,39 +159,22 @@ namespace pwiz.OspreySharp.Scoring
     public interface IOspreyApexSpectraPeakData : IOspreyApexSpectrumPeakData
     {
         /// <summary>
-        /// Candidate-local apex index within the scoring range
-        /// (= bestPeak.ApexIndex). The SG sweep builds candIdx = ApexLocalIndex +
-        /// offset and bound-checks it against [0, <see cref="WindowLength"/>).
+        /// Get the MS2 spectrum at the given offset from the peak apex. The
+        /// Savitzky-Golay sweep reads offsets -2..+2; this bounded accessor is the
+        /// ONLY spectral reach beyond the apex the scoring contract grants (it
+        /// replaces direct exposure of the whole window spectrum list, so a
+        /// calculator cannot read an arbitrary scan).
+        ///
+        /// Returns <c>false</c> at a window edge -- where the candidate-local index
+        /// (apex + <paramref name="offset"/>) falls outside [0, scoring-range) -- which
+        /// is the asymmetric boundary skip the sweep relies on (out-of-range offsets
+        /// contribute nothing, with no renormalization). On success
+        /// <paramref name="cacheIndex"/> is the window-global spectrum index the
+        /// preprocessed-xcorr cache is indexed by; at offset 0 it equals
+        /// <see cref="IOspreyApexSpectrumPeakData.ApexGlobalIndex"/> by construction.
+        /// The accessor owns the candidate-local/window-global index mapping (the
+        /// former "index trap"), so calculators no longer juggle the two index spaces.
         /// </summary>
-        int ApexLocalIndex { get; }
-
-        /// <summary>
-        /// startScan: the offset mapping a candidate-local index to a window-global
-        /// index (globalIdx = WindowStartIndex + candIdx). Kept distinct from
-        /// <see cref="IOspreyApexSpectrumPeakData.ApexGlobalIndex"/>; at offset 0 they
-        /// coincide by construction.
-        /// </summary>
-        int WindowStartIndex { get; }
-
-        /// <summary>
-        /// rangeLen = endScan - startScan + 1. The SG sweep bounds the
-        /// candidate-local index against THIS, NOT <see cref="WindowSpectra"/>.Count.
-        /// </summary>
-        int WindowLength { get; }
-
-        /// <summary>
-        /// The window's MS2 spectra (sorted by RT). The SG sweep reads
-        /// WindowSpectra[globalIdx] for each apex+/-2 offset.
-        /// </summary>
-        IReadOnlyList<Spectrum> WindowSpectra { get; }
-
-        /// <summary>
-        /// The window's per-scan retention-time axis (the shared <c>windowRts</c>
-        /// reference, a per-window value -- not a per-candidate copy). The MS1 family
-        /// maps an XIC scan index i to an absolute RT via
-        /// WindowRetentionTimes[<see cref="WindowStartIndex"/> + i] to find the nearest
-        /// MS1 scan. Just RT, not a spectral surface.
-        /// </summary>
-        IReadOnlyList<double> WindowRetentionTimes { get; }
+        bool TryGetApexOffsetSpectrum(int offset, out Spectrum spectrum, out int cacheIndex);
     }
 }

--- a/pwiz_tools/OspreySharp/OspreySharp.Scoring/Ms1Calculators.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Scoring/Ms1Calculators.cs
@@ -64,7 +64,7 @@ namespace pwiz.OspreySharp.Scoring
         public double PrecursorCoelution;
         public double IsotopeCosine;
 
-        public static Ms1ScoringByproduct GetOrCompute(OspreyScoringContext context, IOspreyDetailedPeakData peakData)
+        public static Ms1ScoringByproduct GetOrCompute(OspreyScoringContext context, IOspreyApexSpectraPeakData peakData)
         {
             if (context.TryGetInfo(out Ms1ScoringByproduct byproduct))
                 return byproduct;
@@ -73,7 +73,7 @@ namespace pwiz.OspreySharp.Scoring
             return byproduct;
         }
 
-        private static Ms1ScoringByproduct Compute(OspreyScoringContext context, IOspreyDetailedPeakData peakData)
+        private static Ms1ScoringByproduct Compute(OspreyScoringContext context, IOspreyApexSpectraPeakData peakData)
         {
             // Both feature values default to 0.0 (mirrors the inline
             // ms1PrecursorCoelution / ms1IsotopeCosine seeds). Inner early-returns
@@ -198,11 +198,11 @@ namespace pwiz.OspreySharp.Scoring
     /// parity traps (seed-0.0 / '&gt;=' reference-XIC pick, skip-not-zerofill sampling,
     /// the &lt; 1e-10 Pearson denominator guard with feature-side NaN-&gt;0.0).
     /// </summary>
-    internal sealed class Ms1PrecursorCoelutionCalc : DetailedOspreyFeatureCalculator
+    internal sealed class Ms1PrecursorCoelutionCalc : ApexSpectraOspreyFeatureCalculator
     {
         public override string Name { get { return "ms1_precursor_coelution"; } }
 
-        protected override double Calculate(OspreyScoringContext context, IOspreyDetailedPeakData peakData)
+        protected override double Calculate(OspreyScoringContext context, IOspreyApexSpectraPeakData peakData)
         {
             // HRAM gate: no MS1 features -> exactly 0.0, do not even build the byproduct.
             if (!context.HasMs1Features || context.Ms1Spectra == null || context.Ms1Spectra.Count == 0)
@@ -222,11 +222,11 @@ namespace pwiz.OspreySharp.Scoring
     /// a negative score there, so the feature stays 0.0). Uses the UNMODIFIED
     /// Candidate.Sequence.
     /// </summary>
-    internal sealed class Ms1IsotopeCosineCalc : DetailedOspreyFeatureCalculator
+    internal sealed class Ms1IsotopeCosineCalc : ApexSpectraOspreyFeatureCalculator
     {
         public override string Name { get { return "ms1_isotope_cosine"; } }
 
-        protected override double Calculate(OspreyScoringContext context, IOspreyDetailedPeakData peakData)
+        protected override double Calculate(OspreyScoringContext context, IOspreyApexSpectraPeakData peakData)
         {
             // Same HRAM gate as feature 13.
             if (!context.HasMs1Features || context.Ms1Spectra == null || context.Ms1Spectra.Count == 0)

--- a/pwiz_tools/OspreySharp/OspreySharp.Scoring/Ms1Calculators.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Scoring/Ms1Calculators.cs
@@ -1,7 +1,7 @@
 /*
  * Original author: Brendan MacLean <brendanx .at. uw.edu>,
  *                  MacCoss Lab, Department of Genome Sciences, UW
- * AI assistance: Claude Code (Claude Opus 4) <noreply .at. anthropic.com>
+ * AI assistance: Claude Code (Claude Opus 4.8) <noreply .at. anthropic.com>
  *
  * Based on osprey (https://github.com/MacCossLab/osprey)
  *   by Michael J. MacCoss, MacCoss Lab, Department of Genome Sciences, UW
@@ -21,218 +21,67 @@
  * limitations under the License.
  */
 
-using System;
-using System.Collections.Generic;
 using pwiz.OspreySharp.Core;
 
 namespace pwiz.OspreySharp.Scoring
 {
     /// <summary>
-    /// Shared MS1-family scoring pass for ms1_precursor_coelution (feature 13) and
-    /// ms1_isotope_cosine (feature 14). Both features come from ONE pass that
-    /// reverse-calibrates the precursor search m/z, selects the reference XIC, samples
-    /// the MS1 precursor intensity along the peak, and reads the apex isotope envelope
-    /// -- the inline <c>ComputeMs1Features</c>. The producer runs it once and the two
-    /// calculators read its fields, so the calibration math, the reference-XIC pick,
-    /// and the nearest-MS1 lookups happen exactly once and identically. Published per
-    /// candidate to the <see cref="OspreyScoringContext"/> byproduct cache.
-    ///
-    /// PARITY TRAPS preserved here (byte-faithful to AbstractScoringTask.cs
-    /// ComputeMs1Features, Rust pipeline.rs:5362-5404):
-    ///  * HRAM GATE: both features are exactly 0.0 unless the run has MS1 features and a
-    ///    non-empty MS1 spectrum list. Enforced by the calculators (which short-circuit
-    ///    to 0.0 before GetOrCompute) AND mirrored by the inner guards here.
-    ///  * REFERENCE-XIC SELECTION is MS1-SPECIFIC: seed total 0.0, '&gt;=' tie-break
-    ///    (LAST fragment achieving the running max wins). This is DISTINCT from the
-    ///    peak-shape family's selection (seed -1.0 / different tie-break) and from the
-    ///    harness fallback ('&gt;' / seed 0.0). It is computed INSIDE this byproduct and is
-    ///    NOT shared with peak-shape -- do not route it through any shared ref-XIC info.
-    ///  * MISSING MS1 scans are SKIPPED, not zero-filled, so the Pearson sample count is
-    ///    the number of present MS1 scans, not the peak width.
-    ///  * Every observed intensity is a single float-&gt;double widen (MzIntensityPair.Intensity
-    ///    is float). Do not cache as double end-to-end.
-    ///  * Pearson uses ScoringMath.PearsonCorrelationInRange (denom guard &lt; 1e-10),
-    ///    NOT the &lt; 1e-30 overload; NaN-&gt;0.0 is applied feature-side.
-    ///  * Calibration branch uses plain string equality Unit == "Th" (matches inline).
-    ///  * baseTolPpm = 10.0 is hardcoded (NOT promoted to Config) to preserve parity.
-    ///  * The nearest-MS1 search is the single Core implementation
-    ///    <see cref="MS1Spectrum.FindNearest"/> (binary search RetentionTime &lt; rt,
-    ///    '&lt;=' tie-break) shared with the harness so the tie-break cannot drift.
-    /// </summary>
-    internal sealed class Ms1ScoringByproduct
-    {
-        public double PrecursorCoelution;
-        public double IsotopeCosine;
-
-        public static Ms1ScoringByproduct GetOrCompute(OspreyScoringContext context, IOspreyApexSpectraPeakData peakData)
-        {
-            if (context.TryGetInfo(out Ms1ScoringByproduct byproduct))
-                return byproduct;
-            byproduct = Compute(context, peakData);
-            context.AddInfo(byproduct);
-            return byproduct;
-        }
-
-        private static Ms1ScoringByproduct Compute(OspreyScoringContext context, IOspreyApexSpectraPeakData peakData)
-        {
-            // Both feature values default to 0.0 (mirrors the inline
-            // ms1PrecursorCoelution / ms1IsotopeCosine seeds). Inner early-returns
-            // below leave them at 0.0.
-            var result = new Ms1ScoringByproduct();
-
-            var ms1Spectra = context.Ms1Spectra;
-            var xics = peakData.Xics;
-
-            // Inner guards. The outer HRAM gate is applied by the calculators; this
-            // re-checks the data guards so a direct GetOrCompute is still safe.
-            if (ms1Spectra == null || ms1Spectra.Count == 0 || xics.Count == 0)
-                return result;
-
-            int len = xics[0].Intensities.Length;
-            if (len == 0)
-                return result;
-
-            var peak = peakData.PeakBounds;
-            int start = Math.Max(0, peak.StartIndex);
-            int end = Math.Min(len - 1, peak.EndIndex);
-            if (end - start + 1 < 3)
-                return result;
-
-            // Reference XIC (highest total intensity). MS1-SPECIFIC selection: seed 0.0,
-            // '>=' last-wins.
-            int refXicIdx = 0;
-            double bestTotal = 0.0;
-            for (int f = 0; f < xics.Count; f++)
-            {
-                double total = 0.0;
-                double[] inten = xics[f].Intensities;
-                for (int k = 0; k < inten.Length; k++)
-                    total += inten[k];
-                if (total >= bestTotal) { bestTotal = total; refXicIdx = f; }
-            }
-
-            // MS1 calibration: reverse-calibrate search m/z and use calibrated tolerance.
-            // Matches Rust pipeline.rs:5363-5370 (reverse_calibrate_mz + calibrated_tolerance_ppm).
-            double baseTolPpm = 10.0;
-            double ms1TolPpm = baseTolPpm;
-            double searchMz = peakData.Candidate.PrecursorMz;
-            var ms1Calibration = context.Ms1Calibration;
-            if (ms1Calibration != null && ms1Calibration.Calibrated)
-            {
-                // calibrated_tolerance_ppm: max(3*SD, 1.0) ppm
-                ms1TolPpm = Math.Max(3.0 * ms1Calibration.SD, 1.0);
-                // reverse_calibrate_mz: observed ~ theoretical + offset
-                if (ms1Calibration.Unit == "Th")
-                    searchMz = peakData.Candidate.PrecursorMz + ms1Calibration.Mean;
-                else
-                    searchMz = peakData.Candidate.PrecursorMz * (1.0 + ms1Calibration.Mean / 1e6);
-            }
-
-            // Map an XIC scan index i to its absolute RT via the window axis:
-            // windowRts[startScan + i]. Reproduces the inline ComputeMs1Features
-            // indexing exactly (no per-candidate slice copy).
-            var windowRts = peakData.WindowRetentionTimes;
-            int startScan = peakData.WindowStartIndex;
-
-            // Correlate MS1 precursor intensity with reference XIC (not summed fragment).
-            // Rust pipeline.rs:5373-5389: uses ref_xic[start..=end], skips missing MS1.
-            double[] refIntensities = xics[refXicIdx].Intensities;
-            var ms1Intensities = new List<double>();
-            var refValues = new List<double>();
-
-            for (int i = start; i <= end; i++)
-            {
-                double rt = windowRts[startScan + i];
-                var ms1 = MS1Spectrum.FindNearest(ms1Spectra, rt);
-                if (ms1 != null)
-                {
-                    var peakInfo = ms1.FindPeakPpm(searchMz, ms1TolPpm);
-                    double intensity = peakInfo.HasValue ? peakInfo.Value.Intensity : 0.0;
-                    ms1Intensities.Add(intensity);
-                    refValues.Add(i < refIntensities.Length ? refIntensities[i] : 0.0);
-                }
-            }
-
-            if (ms1Intensities.Count >= 3)
-            {
-                double[] ms1Arr = ms1Intensities.ToArray();
-                double[] refArr = refValues.ToArray();
-                double coelution = ScoringMath.PearsonCorrelationInRange(ms1Arr, refArr, 0, ms1Arr.Length - 1);
-                if (double.IsNaN(coelution))
-                    coelution = 0.0;
-                result.PrecursorCoelution = coelution;
-            }
-
-            // Isotope cosine at apex MS1 scan.
-            // Rust pipeline.rs:5393-5404: gates on envelope.has_m0().
-            int apex = Math.Max(start, Math.Min(end, peak.ApexIndex));
-            double apexRt = windowRts[startScan + apex];
-            var apexMs1 = MS1Spectrum.FindNearest(ms1Spectra, apexRt);
-            if (apexMs1 != null)
-            {
-                int charge = peakData.Candidate.Charge > 0 ? peakData.Candidate.Charge : 1;
-                var envelope = IsotopeEnvelope.Extract(apexMs1, searchMz, charge, ms1TolPpm);
-
-                // Gate: skip if M0 peak is missing (matches Rust envelope.has_m0()).
-                if (envelope.Intensities != null && envelope.Intensities.Length > 1
-                    && envelope.Intensities[1] > 0.0) // index 1 = M0 (M-1 at 0)
-                {
-                    // Sequence-based isotope distribution, matching Rust
-                    // pipeline.rs:5400 peptide_isotope_cosine. Uses the UNMODIFIED Sequence.
-                    double score = IsotopeDistribution.PeptideIsotopeCosine(
-                        peakData.Candidate.Sequence, envelope.Intensities);
-                    if (score >= 0.0)
-                        result.IsotopeCosine = score;
-                }
-            }
-
-            return result;
-        }
-    }
-
-    /// <summary>
     /// ms1_precursor_coelution (feature 13): Pearson correlation between the MS1
-    /// precursor-intensity trace (sampled at the nearest MS1 scan along the peak) and
-    /// the reference fragment XIC. HRAM-only -- exactly 0.0 for unit-resolution runs or
-    /// when no MS1 spectra are present. See <see cref="Ms1ScoringByproduct"/> for the
-    /// parity traps (seed-0.0 / '&gt;=' reference-XIC pick, skip-not-zerofill sampling,
-    /// the &lt; 1e-10 Pearson denominator guard with feature-side NaN-&gt;0.0).
+    /// precursor-intensity trace and the reference fragment XIC, sampled at the
+    /// nearest MS1 scan along the peak. Both chromatograms are produced upstream by
+    /// <see cref="PeakDataExtractor"/> (<see cref="IOspreyDetailedPeakData.Ms1PrecursorXic"/>
+    /// / <see cref="IOspreyDetailedPeakData.Ms1ReferenceXic"/>), so this calculator
+    /// is a pure consumer -- the MS1-specific reference selection, reverse
+    /// calibration, and skip-not-zerofill sampling live in the producer. HRAM-only:
+    /// for unit-resolution runs (or no MS1) the producer emits no chromatogram and
+    /// this is exactly 0.0. The &lt; 3-sample gate and the &lt; 1e-10 Pearson
+    /// denominator guard (with feature-side NaN-&gt;0.0) are preserved here.
     /// </summary>
-    internal sealed class Ms1PrecursorCoelutionCalc : ApexSpectraOspreyFeatureCalculator
+    internal sealed class Ms1PrecursorCoelutionCalc : DetailedOspreyFeatureCalculator
     {
         public override string Name { get { return "ms1_precursor_coelution"; } }
 
-        protected override double Calculate(OspreyScoringContext context, IOspreyApexSpectraPeakData peakData)
+        protected override double Calculate(OspreyScoringContext context, IOspreyDetailedPeakData peakData)
         {
-            // HRAM gate: no MS1 features -> exactly 0.0, do not even build the byproduct.
-            if (!context.HasMs1Features || context.Ms1Spectra == null || context.Ms1Spectra.Count == 0)
+            var precursor = peakData.Ms1PrecursorXic;
+            var reference = peakData.Ms1ReferenceXic;
+            if (precursor == null || reference == null || precursor.Intensities.Length < 3)
                 return 0.0;
 
-            return Ms1ScoringByproduct.GetOrCompute(context, peakData).PrecursorCoelution;
+            double coelution = ScoringMath.PearsonCorrelationInRange(
+                precursor.Intensities, reference.Intensities, 0, precursor.Intensities.Length - 1);
+            return double.IsNaN(coelution) ? 0.0 : coelution;
         }
     }
 
     /// <summary>
-    /// ms1_isotope_cosine (feature 14): cosine similarity between the observed isotope
-    /// envelope at the apex MS1 scan and the theoretical averagine envelope for the
-    /// candidate sequence. HRAM-only -- exactly 0.0 for unit-resolution runs or when no
-    /// MS1 spectra are present. The M0 gate (Intensities[1] &gt; 0.0) and the
-    /// PeptideIsotopeCosine score &gt;= 0.0 acceptance are preserved in
-    /// <see cref="Ms1ScoringByproduct"/> (a composition failure or zero-norm returns
-    /// a negative score there, so the feature stays 0.0). Uses the UNMODIFIED
-    /// Candidate.Sequence.
+    /// ms1_isotope_cosine (feature 14): cosine similarity between the observed
+    /// isotope envelope at the apex MS1 scan and the theoretical averagine envelope
+    /// for the candidate sequence. The observed envelope is produced upstream
+    /// (<see cref="IOspreyDetailedPeakData.ApexIsotopeEnvelope"/>); this calculator
+    /// applies the M0 gate (Intensities[1] &gt; 0.0) and the PeptideIsotopeCosine
+    /// score &gt;= 0.0 acceptance, returning 0.0 otherwise. HRAM-only -- exactly 0.0
+    /// for unit-resolution runs or when no apex MS1 scan was found. Uses the
+    /// UNMODIFIED Candidate.Sequence.
     /// </summary>
-    internal sealed class Ms1IsotopeCosineCalc : ApexSpectraOspreyFeatureCalculator
+    internal sealed class Ms1IsotopeCosineCalc : DetailedOspreyFeatureCalculator
     {
         public override string Name { get { return "ms1_isotope_cosine"; } }
 
-        protected override double Calculate(OspreyScoringContext context, IOspreyApexSpectraPeakData peakData)
+        protected override double Calculate(OspreyScoringContext context, IOspreyDetailedPeakData peakData)
         {
-            // Same HRAM gate as feature 13.
-            if (!context.HasMs1Features || context.Ms1Spectra == null || context.Ms1Spectra.Count == 0)
+            double[] envelope = peakData.ApexIsotopeEnvelope;
+            // Gate: skip if M0 peak is missing (matches Rust envelope.has_m0()).
+            // index 1 = M0 (M-1 at 0).
+            if (envelope == null || envelope.Length <= 1 || envelope[1] <= 0.0)
                 return 0.0;
 
-            return Ms1ScoringByproduct.GetOrCompute(context, peakData).IsotopeCosine;
+            // Sequence-based isotope distribution, matching Rust pipeline.rs:5400
+            // peptide_isotope_cosine. A composition failure or zero-norm returns a
+            // negative score, which stays 0.0.
+            double score = IsotopeDistribution.PeptideIsotopeCosine(
+                peakData.Candidate.Sequence, envelope);
+            return score >= 0.0 ? score : 0.0;
         }
     }
 }

--- a/pwiz_tools/OspreySharp/OspreySharp.Scoring/OspreyPeakData.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Scoring/OspreyPeakData.cs
@@ -53,7 +53,6 @@ namespace pwiz.OspreySharp.Scoring
         private int _windowStartIndex;
         private int _windowLength;
         private IReadOnlyList<Spectrum> _windowSpectra;
-        private IReadOnlyList<double> _windowRetentionTimes;
         private XicData _ms1PrecursorXic;
         private XicData _ms1ReferenceXic;
         private double[] _apexIsotopeEnvelope;
@@ -61,7 +60,7 @@ namespace pwiz.OspreySharp.Scoring
         public void Set(LibraryEntry candidate, XICPeakBounds peakBounds, IReadOnlyList<XicData> xics,
             double apexRetentionTime, double expectedRt, Spectrum apexSpectrum,
             int apexGlobalIndex, int apexLocalIndex, int windowStartIndex, int windowLength,
-            IReadOnlyList<Spectrum> windowSpectra, IReadOnlyList<double> windowRetentionTimes)
+            IReadOnlyList<Spectrum> windowSpectra)
         {
             _candidate = candidate;
             _peakBounds = peakBounds;
@@ -74,7 +73,6 @@ namespace pwiz.OspreySharp.Scoring
             _windowStartIndex = windowStartIndex;
             _windowLength = windowLength;
             _windowSpectra = windowSpectra;
-            _windowRetentionTimes = windowRetentionTimes;
             // Reset the produced MS1 data each candidate; SetMs1 overrides it when
             // the extractor produced it (HRAM + MS1 present). Without this reset the
             // reused instance would leak the previous candidate's MS1 chromatograms.
@@ -104,11 +102,24 @@ namespace pwiz.OspreySharp.Scoring
         public IReadOnlyList<XicData> Xics { get { return _xics; } }
         public Spectrum ApexSpectrum { get { return _apexSpectrum; } }
         public int ApexGlobalIndex { get { return _apexGlobalIndex; } }
-        public int ApexLocalIndex { get { return _apexLocalIndex; } }
-        public int WindowStartIndex { get { return _windowStartIndex; } }
-        public int WindowLength { get { return _windowLength; } }
-        public IReadOnlyList<Spectrum> WindowSpectra { get { return _windowSpectra; } }
-        public IReadOnlyList<double> WindowRetentionTimes { get { return _windowRetentionTimes; } }
+
+        public bool TryGetApexOffsetSpectrum(int offset, out Spectrum spectrum, out int cacheIndex)
+        {
+            // candidate-local index within the scoring range; the window-spectrum
+            // list and the start/length come from the per-candidate Set. Out-of-range
+            // offsets (window edges) return false -- the asymmetric boundary skip.
+            int candIdx = _apexLocalIndex + offset;
+            if (candIdx < 0 || candIdx >= _windowLength)
+            {
+                spectrum = null;
+                cacheIndex = -1;
+                return false;
+            }
+            cacheIndex = _windowStartIndex + candIdx;
+            spectrum = _windowSpectra[cacheIndex];
+            return true;
+        }
+
         public XicData Ms1PrecursorXic { get { return _ms1PrecursorXic; } }
         public XicData Ms1ReferenceXic { get { return _ms1ReferenceXic; } }
         public double[] ApexIsotopeEnvelope { get { return _apexIsotopeEnvelope; } }

--- a/pwiz_tools/OspreySharp/OspreySharp.Scoring/OspreyPeakData.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Scoring/OspreyPeakData.cs
@@ -54,6 +54,9 @@ namespace pwiz.OspreySharp.Scoring
         private int _windowLength;
         private IReadOnlyList<Spectrum> _windowSpectra;
         private IReadOnlyList<double> _windowRetentionTimes;
+        private XicData _ms1PrecursorXic;
+        private XicData _ms1ReferenceXic;
+        private double[] _apexIsotopeEnvelope;
 
         public void Set(LibraryEntry candidate, XICPeakBounds peakBounds, IReadOnlyList<XicData> xics,
             double apexRetentionTime, double expectedRt, Spectrum apexSpectrum,
@@ -72,6 +75,26 @@ namespace pwiz.OspreySharp.Scoring
             _windowLength = windowLength;
             _windowSpectra = windowSpectra;
             _windowRetentionTimes = windowRetentionTimes;
+            // Reset the produced MS1 data each candidate; SetMs1 overrides it when
+            // the extractor produced it (HRAM + MS1 present). Without this reset the
+            // reused instance would leak the previous candidate's MS1 chromatograms.
+            _ms1PrecursorXic = null;
+            _ms1ReferenceXic = null;
+            _apexIsotopeEnvelope = null;
+        }
+
+        /// <summary>
+        /// Publish the MS1 data the extractor produced for this candidate (the
+        /// precursor chromatogram, its co-sampled reference fragment chromatogram,
+        /// and the apex isotope envelope). Called only when the run has MS1 features
+        /// and an MS1 scan was found; otherwise the <see cref="Set"/> reset leaves
+        /// all three null and the MS1 features evaluate to 0.0.
+        /// </summary>
+        public void SetMs1(XicData ms1PrecursorXic, XicData ms1ReferenceXic, double[] apexIsotopeEnvelope)
+        {
+            _ms1PrecursorXic = ms1PrecursorXic;
+            _ms1ReferenceXic = ms1ReferenceXic;
+            _apexIsotopeEnvelope = apexIsotopeEnvelope;
         }
 
         public LibraryEntry Candidate { get { return _candidate; } }
@@ -86,5 +109,8 @@ namespace pwiz.OspreySharp.Scoring
         public int WindowLength { get { return _windowLength; } }
         public IReadOnlyList<Spectrum> WindowSpectra { get { return _windowSpectra; } }
         public IReadOnlyList<double> WindowRetentionTimes { get { return _windowRetentionTimes; } }
+        public XicData Ms1PrecursorXic { get { return _ms1PrecursorXic; } }
+        public XicData Ms1ReferenceXic { get { return _ms1ReferenceXic; } }
+        public double[] ApexIsotopeEnvelope { get { return _apexIsotopeEnvelope; } }
     }
 }

--- a/pwiz_tools/OspreySharp/OspreySharp.Scoring/OspreyPeakData.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Scoring/OspreyPeakData.cs
@@ -28,18 +28,19 @@ using pwiz.OspreySharp.Core;
 namespace pwiz.OspreySharp.Scoring
 {
     /// <summary>
-    /// Reusable <see cref="IOspreyDetailedPeakData"/> adapter over the harness's
-    /// per-candidate scoring state. One instance is created per window and
-    /// <see cref="Set"/> is called for each candidate, so the per-candidate
-    /// scoring loop allocates no peak-data objects. Windows are scored on separate
-    /// threads, so each window owns its own instance -- this is never shared task
-    /// state.
+    /// Reusable <see cref="IOspreyApexSpectraPeakData"/> adapter over the harness's
+    /// per-candidate scoring state. It implements the widest peak-data tier; each
+    /// calculator receives it narrowed to the tier its family declares. One instance
+    /// is created per window and <see cref="Set"/> is called for each candidate, so the
+    /// per-candidate scoring loop allocates no peak-data objects. Windows are scored on
+    /// separate threads, so each window owns its own instance -- this is never shared
+    /// task state.
     ///
-    /// Lives in Scoring (alongside the <see cref="IOspreyDetailedPeakData"/> seam it
-    /// implements and the feature calculators that consume it); relocated out of the
-    /// Tasks layer so the coelution scorer can move down here too.
+    /// Lives in Scoring (alongside the peak-data tier seam it implements and the
+    /// feature calculators that consume it); relocated out of the Tasks layer so the
+    /// coelution scorer can move down here too.
     /// </summary>
-    public sealed class OspreyPeakData : IOspreyDetailedPeakData
+    public sealed class OspreyPeakData : IOspreyApexSpectraPeakData
     {
         private LibraryEntry _candidate;
         private XICPeakBounds _peakBounds;

--- a/pwiz_tools/OspreySharp/OspreySharp.Scoring/OspreyScoringContext.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Scoring/OspreyScoringContext.cs
@@ -23,7 +23,6 @@
 
 using System;
 using System.Collections.Generic;
-using pwiz.OspreySharp.Chromatography;
 using pwiz.OspreySharp.Core;
 
 namespace pwiz.OspreySharp.Scoring
@@ -95,40 +94,12 @@ namespace pwiz.OspreySharp.Scoring
             XcorrScratchPool = xcorrScratchPool;
         }
 
-        /// <summary>
-        /// True when the run has MS1 features (HRAM). The MS1 family (features 13,
-        /// 14) is exactly 0.0 for unit-resolution runs; the calculators gate on this
-        /// before doing any work. Window-level -- set via <see cref="SetMs1Machinery"/>.
-        /// </summary>
-        public bool HasMs1Features { get; private set; }
-
-        /// <summary>
-        /// The window's MS1 full-scan spectra (sorted by RT), used by the MS1 family
-        /// to sample the precursor-intensity trace and the apex isotope envelope.
-        /// Window-level -- set via <see cref="SetMs1Machinery"/>.
-        /// </summary>
-        public IReadOnlyList<MS1Spectrum> Ms1Spectra { get; private set; }
-
-        /// <summary>
-        /// The m/z calibration result used to reverse-calibrate the precursor search
-        /// m/z and derive the MS1 tolerance. Per-run; null when uncalibrated.
-        /// Window-level -- set via <see cref="SetMs1Machinery"/>.
-        /// </summary>
-        public MzCalibrationResult Ms1Calibration { get; private set; }
-
-        /// <summary>
-        /// Set the per-window MS1 machinery the MS1 family (features 13, 14) reads.
-        /// Called once per window after construction. These are window-level and
-        /// deliberately survive <see cref="ClearByproducts"/> (which only resets the
-        /// per-candidate byproduct cache).
-        /// </summary>
-        public void SetMs1Machinery(bool hasMs1Features, IReadOnlyList<MS1Spectrum> ms1Spectra,
-            MzCalibrationResult ms1Calibration)
-        {
-            HasMs1Features = hasMs1Features;
-            Ms1Spectra = ms1Spectra;
-            Ms1Calibration = ms1Calibration;
-        }
+        // NOTE: the per-window MS1 machinery (HasMs1Features / Ms1Spectra /
+        // Ms1Calibration + SetMs1Machinery) was removed when MS1 production moved
+        // upstream: the extractor now produces the MS1 precursor XIC + isotope
+        // envelope and the ms1 features read them from the peak-data view, so the
+        // context no longer carries MS1 state. The HRAM gate is the resolution
+        // strategy (IResolutionStrategy.HasMs1Features), read by the extractor.
 
         /// <summary>
         /// Publish a byproduct keyed by its type for sibling calculators to read.

--- a/pwiz_tools/OspreySharp/OspreySharp.Scoring/PeakDataExtractor.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Scoring/PeakDataExtractor.cs
@@ -516,7 +516,7 @@ namespace pwiz.OspreySharp.Scoring
             // and range length carry the index machinery the xcorr / SG family
             // reads; windowRts is shared by reference (no per-candidate copy).
             peakData.Set(candidate, bestPeak, xics, apexSpectrum.RetentionTime, expectedRt, apexSpectrum,
-                apexGlobalIdx, bestPeak.ApexIndex, startScan, rangeLen, windowSpectra, windowRts);
+                apexGlobalIdx, bestPeak.ApexIndex, startScan, rangeLen, windowSpectra);
 
             // Produce the MS1 data the ms1_precursor_coelution / ms1_isotope_cosine
             // features consume (HRAM only) -- the precursor chromatogram, its

--- a/pwiz_tools/OspreySharp/OspreySharp.Scoring/PeakDataExtractor.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Scoring/PeakDataExtractor.cs
@@ -1,0 +1,902 @@
+/*
+ * Original author: Brendan MacLean <brendanx .at. uw.edu>,
+ *                  MacCoss Lab, Department of Genome Sciences, UW
+ * AI assistance: Claude Code (Claude Opus 4.8) <noreply .at. anthropic.com>
+ *
+ * Based on osprey (https://github.com/MacCossLab/osprey)
+ *   by Michael J. MacCoss, MacCoss Lab, Department of Genome Sciences, UW
+ *
+ * Copyright 2026 University of Washington - Seattle, WA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using pwiz.OspreySharp.Chromatography;
+using pwiz.OspreySharp.Core;
+
+namespace pwiz.OspreySharp.Scoring
+{
+    /// <summary>
+    /// Produces the per-candidate peak data the feature calculators consume:
+    /// selects the RT scan range, extracts the fragment XICs, detects and
+    /// rank-scores candidate peaks, resolves the winning peak's apex / area / SNR
+    /// over the reference XIC, and populates an <see cref="OspreyPeakData"/> view.
+    ///
+    /// This is the producer seam mirroring Skyline's results layer: the scorer
+    /// (<see cref="CoelutionScorer"/>) composes an extractor and consumes its
+    /// output, rather than interleaving data preparation with calculator dispatch.
+    /// All detection-side diagnostics (search-XIC dump, CWT-path row, [DIAG] trace)
+    /// live here with the logic they describe; the median-polish publish and the
+    /// 21-calculator pass stay in the scorer.
+    /// </summary>
+    internal sealed class PeakDataExtractor
+    {
+        // Diagnostic: log detailed trace for a specific peptide. Set this to a
+        // peptide modified sequence to dump its RT window, XICs, CWT peaks, and
+        // winning peak selection. Used for bisecting divergences with Rust.
+        private const string DIAG_PEPTIDE = "AAAAAAAAAAAAAAAGAGAGAK";
+
+        private readonly Action<string> _logInfo;
+        private readonly IScoringDiagnostics _diagnostics;
+
+        public PeakDataExtractor(Action<string> logInfo, IScoringDiagnostics diagnostics)
+        {
+            _logInfo = logInfo ?? (_ => { });
+            _diagnostics = diagnostics;
+        }
+
+        /// <summary>
+        /// Build the per-candidate peak data. Returns <c>true</c> and populates
+        /// <paramref name="peakData"/> (via <see cref="OspreyPeakData.Set"/>) plus
+        /// the <paramref name="extracted"/> side artifacts the scorer needs for
+        /// CWT-candidate capture and FdrEntry assembly; returns <c>false</c> when
+        /// the candidate has no scorable peak (the scorer then drops it). Mirrors
+        /// the detection half of Rust run_search; the arithmetic is byte-identical
+        /// to the former inline block in <c>CoelutionScorer.ScoreCandidate</c>.
+        /// </summary>
+        public bool TryExtract(
+            LibraryEntry candidate,
+            List<Spectrum> windowSpectra,
+            double[] windowRts,
+            RTCalibration rtCalibration,
+            double globalRtTolerance,
+            double rtSigma,
+            List<MS1Spectrum> ms1Spectra,
+            MzCalibrationResult ms1Calibration,
+            ScoringContext context,
+            OspreyPeakData peakData,
+            out ExtractedPeak extracted)
+        {
+            extracted = default;
+            var config = context.Config;
+            bool diag = !candidate.IsDecoy && candidate.ModifiedSequence == DIAG_PEPTIDE
+                && candidate.Charge == 2;
+            int nScans = windowSpectra.Count;
+            if (nScans < 5)
+                return false;
+
+            // Stage 6 boundary override (post-FDR re-scoring): when set,
+            // peak detection + the signal pre-filter are skipped and
+            // scoring uses the supplied (apex, start, end) RT triple.
+            // Mirrors the boundary_overrides path in run_search at
+            // osprey/crates/osprey/src/pipeline.rs:6453-6664.
+            (double Apex, double Start, double End)? overrideBounds = null;
+            if (context.BoundaryOverrides != null &&
+                context.BoundaryOverrides.TryGetValue(candidate.Id, out var bnd))
+            {
+                overrideBounds = bnd;
+            }
+
+            // Determine RT search window.
+            // Use the global tolerance passed from RunCoelutionScoring (matches
+            // Rust's single rt_tolerance for all entries in run_search).
+            double expectedRt = rtCalibration != null
+                ? rtCalibration.Predict(candidate.RetentionTime)
+                : candidate.RetentionTime;
+            double rtTolerance = globalRtTolerance;
+
+            if (diag)
+            {
+                _logInfo(string.Format(
+                    "[DIAG] {0} charge {1}: library_rt={2:F3}, expected_rt={3:F3}, tolerance={4:F3}",
+                    candidate.ModifiedSequence, candidate.Charge,
+                    candidate.RetentionTime, expectedRt, rtTolerance));
+                _logInfo(string.Format(
+                    "[DIAG] {0}: window m/z={1:F3}, fragments={2}, window_spectra={3}",
+                    candidate.ModifiedSequence, candidate.PrecursorMz,
+                    candidate.Fragments.Count, nScans));
+            }
+
+            // Find scan range for XIC extraction. Extracted to FindScanRange
+            // (override-bounds vs normal-search filter shapes).
+            FindScanRange(overrideBounds, windowRts, nScans, expectedRt, rtTolerance,
+                out int startScan, out int endScan);
+
+            if (diag)
+            {
+                if (startScan >= 0 && endScan >= 0)
+                {
+                    _logInfo(string.Format(
+                        "[DIAG] {0}: scan range [{1}..{2}] RT [{3:F3}..{4:F3}] ({5} scans)",
+                        candidate.ModifiedSequence, startScan, endScan,
+                        windowRts[startScan], windowRts[endScan],
+                        endScan - startScan + 1));
+                    _logInfo(string.Format(
+                        "[DIAG] {0}: spectrum scan_numbers in range: first={1}, last={2}",
+                        candidate.ModifiedSequence,
+                        windowSpectra[startScan].ScanNumber,
+                        windowSpectra[endScan].ScanNumber));
+                }
+                else
+                {
+                    _logInfo(string.Format(
+                        "[DIAG] {0}: no scans in RT window around expected_rt={1:F3}",
+                        candidate.ModifiedSequence, expectedRt));
+                }
+            }
+
+            if (startScan < 0 || endScan < 0 || endScan - startScan + 1 < 5)
+                return false;
+
+            int rangeLen = endScan - startScan + 1;
+
+            // Signal pre-filter: require at least 2 of top 6 fragments present
+            // in at least 3 of 4 consecutive scans. Matches Rust pipeline.rs:6032-6066.
+            // Skips noise-only candidates before the expensive XIC extraction.
+            // Skipped for boundary overrides — caller has already decided to
+            // score here.
+            if (config.PrefilterEnabled && !overrideBounds.HasValue)
+            {
+                const int WIN = 4;
+                const int MIN_PASS = 3;
+                bool[] window = new bool[WIN];
+                int winSum = 0;
+                bool hasSignal = false;
+
+                for (int i = startScan; i <= endScan; i++)
+                {
+                    bool passes = FragmentMath.HasTopNFragmentMatch(
+                        candidate, windowSpectra[i].Mzs, config.FragmentTolerance);
+                    int slot = (i - startScan) % WIN;
+                    if (window[slot])
+                        winSum--;
+                    window[slot] = passes;
+                    if (passes)
+                        winSum++;
+                    if (i - startScan + 1 >= WIN && winSum >= MIN_PASS)
+                    {
+                        hasSignal = true;
+                        break;
+                    }
+                }
+                if (!hasSignal)
+                    return false;
+            }
+
+            // Extract fragment XICs within the RT range
+            var xics = TopFragmentExtractor.ExtractFragmentXics(
+                candidate, windowSpectra, windowRts, startScan, endScan, config);
+
+            // Per-entry search XIC diagnostic. Fires for every scoring
+            // path; if the entry is scored twice (consensus + override)
+            // the LAST call wins on disk. Caller can isolate by
+            // limiting OSPREY_DIAG_SEARCH_ENTRY_IDS to the right
+            // entries, or by tagging the dump filename with the path.
+            if (_diagnostics?.ShouldDumpSearchXicFor(candidate.Id) ?? false)
+            {
+                _diagnostics?.WriteSearchXicDump(
+                    candidate, expectedRt, rtTolerance,
+                    startScan, endScan, rangeLen,
+                    windowSpectra, xics);
+            }
+
+            if (xics.Count < 2)
+                return false;
+
+            // Detect candidate peaks (3-tier CWT/fallback, or a synthetic peak
+            // from override bounds). Extracted to DetectCandidatePeaks; returns
+            // null ONLY when an override produced a degenerate index range
+            // (the original override `if (peaks == null) return null`).
+            List<XICPeakBounds> peaks = DetectCandidatePeaks(
+                overrideBounds, xics, out int diagNCwtPeaks);
+            if (peaks == null)
+                return false;
+
+            if (diag)
+            {
+                _logInfo(string.Format(
+                    "[DIAG] {0}: xics extracted={1}, peaks={2}",
+                    candidate.ModifiedSequence, xics.Count, peaks.Count));
+                for (int i = 0; i < peaks.Count; i++)
+                {
+                    var p = peaks[i];
+                    int apexAbsIdx = startScan + p.ApexIndex;
+                    double apexRt = windowRts[apexAbsIdx];
+                    uint apexScanNum = windowSpectra[apexAbsIdx].ScanNumber;
+                    _logInfo(string.Format(
+                        "[DIAG] {0}: peak[{1}] apex_local={2} apex_rt={3:F3} scan#={4} range=[{5}..{6}]",
+                        candidate.ModifiedSequence, i, p.ApexIndex,
+                        apexRt, apexScanNum, p.StartIndex, p.EndIndex));
+                }
+            }
+            if (peaks.Count == 0)
+            {
+                if (!overrideBounds.HasValue)
+                {
+                    _diagnostics?.WriteCwtPathRow(
+                        context.FileName, candidate.Id,
+                        diagNCwtPeaks, 0, 0, false, xics);
+                }
+                return false;
+            }
+
+            // Rust scores each candidate peak by mean pairwise fragment
+            // correlation weighted by a Gaussian RT penalty and an intensity
+            // tiebreaker, then picks the highest-ranked peak. The RT penalty
+            // prevents strong interferers at the wrong RT from beating the
+            // correct peak on coelution alone; the intensity tiebreaker
+            // ensures the main peak wins over its own shoulder when coelution
+            // scores are nearly identical. Matches Rust pipeline.rs:6685-6760.
+            //   rank_score = coelution * exp(-dt^2 / (2 * sigma^2)) * ln(1 + apex_intensity)
+            // where dt = |peak_apex_rt - expected_rt|. Peak at expected
+            // position gets RT penalty=1.0; 5-sigma away gets ~0.01.
+
+            // Reference XIC = highest total-intensity fragment. Matches Rust
+            // run_search at pipeline.rs:7140-7148 which uses
+            // `xics.max_by(|a, b| sum_a.total_cmp(&sum_b))`. Rust's
+            // `Iterator::max_by` returns the LAST equal element on ties
+            // (per std doc), so use `>=` here, NOT `>`. Without this,
+            // ~33k Stellar entries pick the first tied fragment as ref_xic
+            // while Rust picks the last, producing divergent
+            // peak_apex / peak_sharpness in the reconciled parquet.
+            int refXicIdx = 0;
+            double refXicBestTotal = -1.0;
+            for (int f = 0; f < xics.Count; f++)
+            {
+                double total = 0.0;
+                for (int i = 0; i < xics[f].Intensities.Length; i++)
+                    total += xics[f].Intensities[i];
+                if (total >= refXicBestTotal) { refXicBestTotal = total; refXicIdx = f; }
+            }
+            double[] refXicIntensities = xics[refXicIdx].Intensities;
+
+            XICPeakBounds bestPeak = null;
+            double bestRankScore = double.MinValue;
+            int bestPeakIdx = -1;
+            int diagNScored = 0; // peaks that pass apex-acceptance
+            double twoSigmaSq = 2.0 * rtSigma * rtSigma;
+            // Capture every scored peak with its raw coelution score
+            // and rank score for the top-N CwtCandidate list assigned
+            // by the scorer (Stage 6 reconciliation input). Mirrors Rust
+            // run_search's scored_candidates collection at
+            // pipeline.rs:7261-7327, which fires for the non-override
+            // path -- the override branch (pipeline.rs:7155-7223)
+            // returns at line 7223 BEFORE reaching the cwt_top_n
+            // code, so override entries leave cwt_candidates as the
+            // default empty `Vec::new()` on the rescored
+            // CoelutionScoredEntry.
+            //
+            // Build for CWT-OR-FALLBACK paths (anything reaching the
+            // rank-scoring loop without an override). Earlier C#
+            // versions gated this on `peaksFromCwt` (CWT-consensus
+            // success only) which left fallback-path entries with
+            // empty cwt_candidates blobs while Rust still populated
+            // them; that produced the last 5 / 3 / 2 cwt_candidates
+            // divergent rows per Stellar file.
+            var capturedPeaks = !overrideBounds.HasValue
+                ? new List<(XICPeakBounds peak, double coelutionScore, double rankScore)>(peaks.Count)
+                : null;
+            for (int pi = 0; pi < peaks.Count; pi++)
+            {
+                var p = peaks[pi];
+                int pLen = p.EndIndex - p.StartIndex + 1;
+                if (pLen < 3)
+                    continue;
+
+                // Apex-acceptance filter (Rust pipeline.rs commit 885339b):
+                // the XIC extraction window above is wider than rtTolerance so
+                // CWT can extend peak boundaries past the acceptance edge, but
+                // the detected apex itself must fall within rtTolerance of
+                // expectedRt. Preserves first-pass selectivity -- only
+                // boundaries are allowed to extend past rtTolerance; apex
+                // locations still have to be within it. Bypassed for
+                // boundary overrides (caller has already chosen the apex).
+                double peakApexRt = windowRts[startScan + p.ApexIndex];
+                double rtResidual = Math.Abs(peakApexRt - expectedRt);
+                if (!overrideBounds.HasValue && rtResidual > rtTolerance)
+                    continue;
+                diagNScored++;
+
+                double sum = 0.0;
+                int count = 0;
+                for (int ii = 0; ii < xics.Count; ii++)
+                {
+                    for (int jj = ii + 1; jj < xics.Count; jj++)
+                    {
+                        double corr = ScoringMath.PearsonCorrelationInRange(
+                            xics[ii].Intensities, xics[jj].Intensities,
+                            p.StartIndex, p.EndIndex);
+                        if (!double.IsNaN(corr))
+                        {
+                            sum += corr;
+                            count++;
+                        }
+                    }
+                }
+                double coelutionScore = count > 0 ? sum / count : 0.0;
+
+                double rtPenalty = Math.Exp(-(rtResidual * rtResidual) / twoSigmaSq);
+
+                // Intensity tiebreaker (Rust pipeline.rs:6753-6758, added in
+                // v26.3.1 commit 4d0119d): log(1 + apex_intensity) breaks ties
+                // between main peak and shoulder without dominating the
+                // coelution ranking.
+                double apexIntensity = refXicIntensities[p.ApexIndex];
+                double intensityWeight = Math.Log(1.0 + apexIntensity);
+
+                double rankScore = coelutionScore * rtPenalty * intensityWeight;
+
+                if (diag)
+                {
+                    _logInfo(string.Format(
+                        "[DIAG] {0}: peak[{1}] pairwise_corr_mean={2:F4} rt_penalty={3:F4} int_weight={4:F2} rank={5:F4}",
+                        candidate.ModifiedSequence, pi, coelutionScore, rtPenalty, intensityWeight, rankScore));
+                }
+                // Tie-break via IEEE 754-2008 total order (matches Rust's
+                // f64::total_cmp used in run_search's scored_candidates
+                // sort). When intensityWeight is 0 (ref_xic intensity at
+                // apex is 0), rankScore is -0.0 or +0.0 depending on
+                // coelutionScore sign. Standard '>' treats -0.0 == +0.0, so
+                // without total-order compare the tie falls back to
+                // iteration order, producing divergent peak picks vs Rust
+                // for the handful of entries where all in-tolerance peaks
+                // have zero reference intensity.
+                if (TotalOrder.Greater(rankScore, bestRankScore))
+                {
+                    bestRankScore = rankScore;
+                    bestPeak = p;
+                    bestPeakIdx = pi;
+                }
+
+                if (capturedPeaks != null)
+                    capturedPeaks.Add((p, coelutionScore, rankScore));
+            }
+
+            if (diag && bestPeak != null)
+            {
+                int apexAbsIdx = startScan + bestPeak.ApexIndex;
+                _logInfo(string.Format(
+                    "[DIAG] {0}: WINNER peak[{1}] apex_rt={2:F3} scan#={3}",
+                    candidate.ModifiedSequence, bestPeakIdx,
+                    windowRts[apexAbsIdx], windowSpectra[apexAbsIdx].ScanNumber));
+            }
+
+            // Append peak boundaries to search XIC diagnostic dump
+            if (_diagnostics?.ShouldDumpSearchXicFor(candidate.Id) ?? false)
+            {
+                string peakDumpPath = "cs_search_xic_entry_" + candidate.Id + ".txt";
+                using (var dw = new StreamWriter(peakDumpPath, true))
+                {
+                    dw.WriteLine(string.Format(System.Globalization.CultureInfo.InvariantCulture,
+                        "# CWT PEAKS: {0} candidates", peaks.Count));
+                    dw.WriteLine("peak\tidx\tstart\tapex\tend\tcorr_score");
+                    for (int pi = 0; pi < peaks.Count; pi++)
+                    {
+                        var p = peaks[pi];
+                        int pLen = p.EndIndex - p.StartIndex + 1;
+                        double corrScore = 0.0;
+                        if (pLen >= 3)
+                        {
+                            double psum = 0.0; int pcnt = 0;
+                            for (int ii = 0; ii < xics.Count; ii++)
+                                for (int jj = ii + 1; jj < xics.Count; jj++)
+                                {
+                                    double c = ScoringMath.PearsonCorrelationInRange(xics[ii].Intensities, xics[jj].Intensities,
+                                        p.StartIndex, p.EndIndex);
+                                    if (!double.IsNaN(c)) { psum += c; pcnt++; }
+                                }
+                            corrScore = pcnt > 0 ? psum / pcnt : 0.0;
+                        }
+                        dw.WriteLine(string.Format(System.Globalization.CultureInfo.InvariantCulture,
+                            "peak\t{0}\t{1}\t{2}\t{3}\t{4:F10}",
+                            pi, p.StartIndex, p.ApexIndex, p.EndIndex, corrScore));
+                    }
+                    dw.WriteLine(string.Format(System.Globalization.CultureInfo.InvariantCulture,
+                        "# BEST PEAK: idx={0} start={1} apex={2} end={3}",
+                        bestPeakIdx,
+                        bestPeak != null ? bestPeak.StartIndex : -1,
+                        bestPeak != null ? bestPeak.ApexIndex : -1,
+                        bestPeak != null ? bestPeak.EndIndex : -1));
+                }
+            }
+
+            if (bestPeak == null)
+            {
+                if (!overrideBounds.HasValue)
+                {
+                    _diagnostics?.WriteCwtPathRow(
+                        context.FileName, candidate.Id,
+                        diagNCwtPeaks, peaks.Count, diagNScored, false, xics);
+                }
+                return false;
+            }
+
+            // For CWT-path entries (no override), Rust pipeline.rs:7406-7424
+            // RECOMPUTES the peak's apex_index / apex_intensity using
+            // ref_xic[si..=ei] (the highest-total-intensity single
+            // fragment), discarding the apex_index that came out of
+            // detect_cwt_consensus_peaks (which used ref_signal -- the
+            // SUM of all fragment intensities). When a peak's max in
+            // the summed signal sits at a different scan than the max
+            // in the single ref_xic, leaving the consensus apex_index
+            // in place produces divergent peak_apex / peak_sharpness
+            // vs Rust on the reconciled .scores.parquet (~32k rows on
+            // Stellar before this fix). Override entries are excluded
+            // because Rust's override branch (pipeline.rs:7155-7223)
+            // uses the override-supplied apex_index directly without
+            // refining it -- match by skipping the recompute.
+            if (!overrideBounds.HasValue)
+            {
+                int si = bestPeak.StartIndex;
+                int ei = bestPeak.EndIndex;
+                int newApexIdx = si;
+                double newApexVal = refXicIntensities[si];
+                for (int i = si + 1; i <= ei; i++)
+                {
+                    // Use `>=` to match Rust's `max_by` last-on-tie.
+                    if (refXicIntensities[i] >= newApexVal)
+                    {
+                        newApexVal = refXicIntensities[i];
+                        newApexIdx = i;
+                    }
+                }
+                // Rust pipeline.rs:7433-7444 RECOMPUTES `peak.area` and
+                // `peak.signal_to_noise` from `ref_xic[si..=ei]` here, NOT
+                // preserving the original CWT detection's values. The
+                // original area/SNR came from the consensus signal's
+                // boundary (which can differ from the CWT apex's
+                // [start..end] in the ref_xic). Preserving them produces
+                // ~560 bounds_area / ~546 bounds_snr divergent rows on
+                // Stellar where the parquet reports the WRONG (consensus-
+                // boundary) area for the WINNING (ref_xic-boundary) peak.
+                // peak_area / peak_sharpness as PIN features already
+                // recompute correctly via the peak-shape calculators; this
+                // recompute keeps the parquet's bounds_area / bounds_snr
+                // consistent with that.
+                double[] refRtsAll = xics[refXicIdx].RetentionTimes;
+                double newArea = PeakDetector.TrapezoidalArea(
+                    refRtsAll, refXicIntensities, si, ei);
+                double newSnr = PeakDetector.ComputeSnr(
+                    refXicIntensities, newApexIdx, si, ei);
+                bestPeak = new XICPeakBounds
+                {
+                    ApexRt = refRtsAll[newApexIdx],
+                    ApexIntensity = newApexVal,
+                    ApexIndex = newApexIdx,
+                    StartRt = refRtsAll[si],
+                    EndRt = refRtsAll[ei],
+                    StartIndex = si,
+                    EndIndex = ei,
+                    Area = newArea,
+                    SignalToNoise = newSnr,
+                };
+            }
+
+            int apexGlobalIdx = startScan + bestPeak.ApexIndex;
+
+            // Score at the apex spectrum
+            if (apexGlobalIdx < 0 || apexGlobalIdx >= windowSpectra.Count)
+            {
+                if (!overrideBounds.HasValue)
+                {
+                    _diagnostics?.WriteCwtPathRow(
+                        context.FileName, candidate.Id,
+                        diagNCwtPeaks, peaks.Count, diagNScored, false, xics);
+                }
+                return false;
+            }
+
+            var apexSpectrum = windowSpectra[apexGlobalIdx];
+
+            // Publish the per-candidate peak-data view for the calculators. The
+            // window-global apex index, candidate-local apex index, window start,
+            // and range length carry the index machinery the xcorr / SG family
+            // reads; windowRts is shared by reference (no per-candidate copy).
+            peakData.Set(candidate, bestPeak, xics, apexSpectrum.RetentionTime, expectedRt, apexSpectrum,
+                apexGlobalIdx, bestPeak.ApexIndex, startScan, rangeLen, windowSpectra, windowRts);
+
+            // Produce the MS1 data the ms1_precursor_coelution / ms1_isotope_cosine
+            // features consume (HRAM only) -- the precursor chromatogram, its
+            // co-sampled reference fragment chromatogram, and the apex isotope
+            // envelope. Lifting this here makes those scores pure consumers (they
+            // drop to the Detailed tier) and mirrors how Skyline produces MS1
+            // chromatograms upstream. The HRAM gate is the resolution strategy; on
+            // unit-resolution runs no MS1 data is produced (the Set reset leaves the
+            // accessors null) and both features evaluate to 0.0, as before.
+            if (context.Resolution.HasMs1Features)
+            {
+                ProduceMs1Data(candidate, xics, bestPeak, startScan, windowRts,
+                    ms1Spectra, ms1Calibration,
+                    out XicData ms1PrecursorXic, out XicData ms1ReferenceXic, out double[] apexEnvelope);
+                if (ms1PrecursorXic != null)
+                    peakData.SetMs1(ms1PrecursorXic, ms1ReferenceXic, apexEnvelope);
+            }
+
+            // Detection-side CWT-path dump for the winning candidate (success
+            // row). Content depends only on detection counters, not on the
+            // built FdrEntry, so it is emitted here next to the logic it
+            // describes; the scorer's downstream feature pass adds no rows.
+            if (!overrideBounds.HasValue)
+            {
+                _diagnostics?.WriteCwtPathRow(
+                    context.FileName, candidate.Id,
+                    diagNCwtPeaks, peaks.Count, diagNScored, true, xics);
+            }
+
+            extracted = new ExtractedPeak(
+                xics, refXicIdx, refXicIntensities, bestPeak, startScan, apexSpectrum, capturedPeaks);
+            return true;
+        }
+
+        /// <summary>
+        /// Find the [startScan..endScan] range for XIC extraction. For boundary
+        /// overrides: the given boundaries plus margin for SNR context (peak_width
+        /// each side, 0.2 min floor; run_search pipeline.rs:6473-6477). For normal
+        /// search (Rust commit 885339b): a window wider than rtTolerance so CWT has
+        /// context on both sides of any in-tolerance apex; half-width is
+        /// rtTolerance + max(rtTolerance, 0.1). Both yield -1/-1 when no scan
+        /// matches. The normal branch uses the abs-diff form |rt - expectedRt| &lt;=
+        /// xicHalfWidth (NOT a precomputed rtHi compare): the two arithmetic chains
+        /// round differently in the last bit, and ~1k entries per Stellar file pick
+        /// a different best apex if a single boundary spectrum slips in/out of the
+        /// window (cascades through CWT peak detection). Mirrors pipeline.rs:7031-7065.
+        /// </summary>
+        private static void FindScanRange(
+            (double Apex, double Start, double End)? overrideBounds,
+            double[] windowRts, int nScans,
+            double expectedRt, double rtTolerance,
+            out int startScan, out int endScan)
+        {
+            startScan = -1;
+            endScan = -1;
+            if (overrideBounds.HasValue)
+            {
+                var ob = overrideBounds.Value;
+                double peakWidth = Math.Max(0.1, ob.End - ob.Start);
+                double margin = Math.Max(0.2, peakWidth);
+                double rtLo = ob.Start - margin;
+                double rtHi = ob.End + margin;
+                for (int i = 0; i < nScans; i++)
+                {
+                    if (windowRts[i] >= rtLo && windowRts[i] <= rtHi)
+                    {
+                        if (startScan < 0)
+                            startScan = i;
+                        endScan = i;
+                    }
+                }
+            }
+            else
+            {
+                double xicHalfWidth = rtTolerance + Math.Max(rtTolerance, 0.1);
+                for (int i = 0; i < nScans; i++)
+                {
+                    if (Math.Abs(windowRts[i] - expectedRt) <= xicHalfWidth)
+                    {
+                        if (startScan < 0)
+                            startScan = i;
+                        endScan = i;
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Detect candidate peaks with a three-tier fallback (matches Rust
+        /// pipeline.rs:6244-6259): (1) CWT consensus, (2) peak detection on the
+        /// median-polish elution profile, (3) peak detection on the reference
+        /// XIC (highest total intensity). For boundary overrides (Stage 6
+        /// re-scoring) peak detection is skipped and a single synthetic
+        /// <see cref="XICPeakBounds"/> is built from the supplied (apex, start,
+        /// end); mirrors run_search at pipeline.rs:6596-6664. Returns null ONLY
+        /// when an override produced a degenerate index range; otherwise a
+        /// (possibly empty) peak list. <paramref name="diagNCwtPeaks"/> snapshots
+        /// the CWT consensus peak count for the OSPREY_DUMP_CWT_PATH dump.
+        /// </summary>
+        private static List<XICPeakBounds> DetectCandidatePeaks(
+            (double Apex, double Start, double End)? overrideBounds,
+            List<XicData> xics,
+            out int diagNCwtPeaks)
+        {
+            List<XICPeakBounds> peaks;
+            if (overrideBounds.HasValue)
+            {
+                peaks = BuildOverridePeaks(overrideBounds.Value, xics);
+                if (peaks == null)
+                {
+                    diagNCwtPeaks = 0;
+                    return null;
+                }
+            }
+            else
+            {
+                peaks = CwtPeakDetector.DetectConsensusPeaks(xics, 0.0);
+            }
+            diagNCwtPeaks = peaks.Count;
+
+            if (peaks.Count == 0)
+            {
+                // Fallback 1: detect peaks on the median polish elution profile.
+                // Rust: detect_all_xic_peaks(&mp.elution_profile, 0.01, 5.0)
+                var polishXics = new List<KeyValuePair<int, double[]>>();
+                for (int f = 0; f < xics.Count; f++)
+                    polishXics.Add(new KeyValuePair<int, double[]>(
+                        xics[f].FragmentIndex, xics[f].Intensities));
+                double[] polishRts = xics[0].RetentionTimes;
+
+                var fullPolish = TukeyMedianPolish.Compute(polishXics, polishRts, 10, 0.01);
+                if (fullPolish != null && fullPolish.ElutionProfileRts != null &&
+                    fullPolish.ElutionProfileIntensities != null)
+                {
+                    peaks = PeakDetector.DetectAllXicPeaks(
+                        fullPolish.ElutionProfileRts,
+                        fullPolish.ElutionProfileIntensities,
+                        0.01, 5.0);
+                }
+            }
+
+            if (peaks.Count == 0)
+            {
+                // Fallback 2: detect peaks on the reference XIC (highest total intensity).
+                // Rust: detect_all_xic_peaks(ref_xic, 0.01, 5.0)
+                int refIdx = 0;
+                double bestTotal = 0.0;
+                for (int f = 0; f < xics.Count; f++)
+                {
+                    double total = 0.0;
+                    for (int i = 0; i < xics[f].Intensities.Length; i++)
+                        total += xics[f].Intensities[i];
+                    if (total > bestTotal) { bestTotal = total; refIdx = f; }
+                }
+                peaks = PeakDetector.DetectAllXicPeaks(
+                    xics[refIdx].RetentionTimes,
+                    xics[refIdx].Intensities,
+                    0.01, 5.0);
+            }
+
+            return peaks;
+        }
+
+        /// <summary>
+        /// Build a one-element peak list at the supplied (apex, start, end)
+        /// RT triple, mapped onto the reference XIC's RT axis. Returns null
+        /// when the resulting index range is degenerate. Mirrors the
+        /// boundary_overrides peak-construction path in run_search at
+        /// osprey/crates/osprey/src/pipeline.rs:6596-6644.
+        /// </summary>
+        private static List<XICPeakBounds> BuildOverridePeaks(
+            (double Apex, double Start, double End) ob,
+            List<XicData> xics)
+        {
+            // Reference XIC = highest total-intensity fragment, matching
+            // Rust run_search at pipeline.rs:7140-7148 which uses
+            // `xics.max_by(|a, b| sum_a.total_cmp(&sum_b))` (returns
+            // the LAST equal element on ties). Use `>=` to match -- a
+            // strict `>` would keep the FIRST equal element here while
+            // every other ref_xic selection in this file (including
+            // the rank-scoring loop further down) uses `>=`, so an
+            // override entry whose top two fragments tie on total
+            // intensity would have BuildOverridePeaks pick a different
+            // ref than the rank loop expects. That mismatch shows up
+            // as ~32k peak_apex divergent rows in the reconciled
+            // parquet vs the Rust output.
+            int refIdx = 0;
+            double refTotal = -1.0;
+            for (int f = 0; f < xics.Count; f++)
+            {
+                double total = 0.0;
+                var ints = xics[f].Intensities;
+                for (int j = 0; j < ints.Length; j++)
+                    total += ints[j];
+                if (total >= refTotal) { refTotal = total; refIdx = f; }
+            }
+            var rtArr = xics[refIdx].RetentionTimes;
+            var intArr = xics[refIdx].Intensities;
+            int last = rtArr.Length - 1;
+            if (last < 2)
+                return null;
+
+            // Map override RTs to indices via Rust partition_point semantics:
+            // first index where rt >= target. start_index then saturating_sub(1).
+            int startIdx = ScoringMath.BinarySearchLowerBound(rtArr, ob.Start);
+            if (startIdx > 0) startIdx--;
+            if (startIdx > last) startIdx = last;
+
+            int endIdx = ScoringMath.BinarySearchLowerBound(rtArr, ob.End);
+            if (endIdx > last) endIdx = last;
+
+            int apexIdx = ScoringMath.BinarySearchLowerBound(rtArr, ob.Apex);
+            if (apexIdx > last) apexIdx = last;
+            if (apexIdx > 0 &&
+                Math.Abs(rtArr[apexIdx - 1] - ob.Apex) < Math.Abs(rtArr[apexIdx] - ob.Apex))
+                apexIdx--;
+            if (apexIdx < startIdx) apexIdx = startIdx;
+            if (apexIdx > endIdx) apexIdx = endIdx;
+
+            if (endIdx <= startIdx + 1)
+                return null;
+
+            return new List<XICPeakBounds>
+            {
+                new XICPeakBounds
+                {
+                    ApexRt = rtArr[apexIdx],
+                    ApexIntensity = intArr[apexIdx],
+                    ApexIndex = apexIdx,
+                    StartRt = rtArr[startIdx],
+                    EndRt = rtArr[endIdx],
+                    StartIndex = startIdx,
+                    EndIndex = endIdx,
+                    Area = PeakDetector.TrapezoidalArea(rtArr, intArr, startIdx, endIdx),
+                    SignalToNoise = PeakDetector.ComputeSnr(intArr, apexIdx, startIdx, endIdx),
+                },
+            };
+        }
+
+        /// <summary>
+        /// Produce the MS1 data for one candidate (HRAM path): the precursor
+        /// chromatogram sampled at the nearest MS1 scan along the peak, the
+        /// co-sampled reference fragment chromatogram it is correlated against, and
+        /// the apex isotope-envelope intensities. Reproduces the former
+        /// <c>Ms1ScoringByproduct.Compute</c> sampling exactly (MS1-specific
+        /// reference selection seed-0.0 / '&gt;=' last-wins, reverse calibration,
+        /// skip-not-zerofill nearest-MS1 sampling, apex isotope envelope), so the
+        /// ms1_precursor_coelution / ms1_isotope_cosine features stay byte-identical
+        /// -- they now just Pearson / cosine the produced vectors. Outputs are all
+        /// null for the degenerate cases (no MS1 spectra, empty XICs, too-short peak)
+        /// in which both features are 0.0; <paramref name="apexEnvelope"/> is null
+        /// when there is no apex MS1 scan.
+        /// </summary>
+        private static void ProduceMs1Data(
+            LibraryEntry candidate, List<XicData> xics, XICPeakBounds peak,
+            int startScan, double[] windowRts,
+            List<MS1Spectrum> ms1Spectra, MzCalibrationResult ms1Calibration,
+            out XicData precursorXic, out XicData referenceXic, out double[] apexEnvelope)
+        {
+            precursorXic = null;
+            referenceXic = null;
+            apexEnvelope = null;
+
+            if (ms1Spectra == null || ms1Spectra.Count == 0 || xics.Count == 0)
+                return;
+            int len = xics[0].Intensities.Length;
+            if (len == 0)
+                return;
+            int start = Math.Max(0, peak.StartIndex);
+            int end = Math.Min(len - 1, peak.EndIndex);
+            if (end - start + 1 < 3)
+                return;
+
+            // Reference XIC (highest total intensity). MS1-SPECIFIC selection: seed
+            // 0.0, '>=' last-wins -- distinct from the peak-shape selection (seed
+            // -1.0) and the harness fallback ('>'). Do not unify.
+            int refXicIdx = 0;
+            double bestTotal = 0.0;
+            for (int f = 0; f < xics.Count; f++)
+            {
+                double total = 0.0;
+                double[] inten = xics[f].Intensities;
+                for (int k = 0; k < inten.Length; k++)
+                    total += inten[k];
+                if (total >= bestTotal) { bestTotal = total; refXicIdx = f; }
+            }
+
+            // MS1 calibration: reverse-calibrate search m/z and use calibrated tolerance.
+            // Matches Rust pipeline.rs:5363-5370 (reverse_calibrate_mz + calibrated_tolerance_ppm).
+            double baseTolPpm = 10.0;
+            double ms1TolPpm = baseTolPpm;
+            double searchMz = candidate.PrecursorMz;
+            if (ms1Calibration != null && ms1Calibration.Calibrated)
+            {
+                // calibrated_tolerance_ppm: max(3*SD, 1.0) ppm
+                ms1TolPpm = Math.Max(3.0 * ms1Calibration.SD, 1.0);
+                // reverse_calibrate_mz: observed ~ theoretical + offset
+                if (ms1Calibration.Unit == "Th")
+                    searchMz = candidate.PrecursorMz + ms1Calibration.Mean;
+                else
+                    searchMz = candidate.PrecursorMz * (1.0 + ms1Calibration.Mean / 1e6);
+            }
+
+            // Sample the MS1 precursor intensity along the peak at the nearest MS1
+            // scan, skipping (not zero-filling) scans with no MS1, alongside the
+            // reference fragment XIC value at the same scan. Rust pipeline.rs:5373-5389
+            // (ref_xic[start..=end], skip missing MS1). Every observed intensity is a
+            // single float->double widen.
+            double[] refIntensities = xics[refXicIdx].Intensities;
+            var retainedRts = new List<double>();
+            var ms1Intensities = new List<double>();
+            var refValues = new List<double>();
+            for (int i = start; i <= end; i++)
+            {
+                double rt = windowRts[startScan + i];
+                var ms1 = MS1Spectrum.FindNearest(ms1Spectra, rt);
+                if (ms1 != null)
+                {
+                    var peakInfo = ms1.FindPeakPpm(searchMz, ms1TolPpm);
+                    double intensity = peakInfo.HasValue ? peakInfo.Value.Intensity : 0.0;
+                    retainedRts.Add(rt);
+                    ms1Intensities.Add(intensity);
+                    refValues.Add(i < refIntensities.Length ? refIntensities[i] : 0.0);
+                }
+            }
+
+            // The precursor chromatogram and its co-sampled reference companion share
+            // the retained-scan RT axis; the ms1_precursor_coelution Pearson runs over
+            // their intensities (the RT axis is the chromatogram's, not used by the
+            // correlation). Always produced when the guards pass; the feature applies
+            // the >= 3 sample count gate.
+            double[] retainedRtArr = retainedRts.ToArray();
+            precursorXic = new XicData(-1, retainedRtArr, ms1Intensities.ToArray());
+            referenceXic = new XicData(xics[refXicIdx].FragmentIndex, retainedRtArr, refValues.ToArray());
+
+            // Isotope envelope at apex MS1 scan. Rust pipeline.rs:5393-5404 gates on
+            // envelope.has_m0(); the feature applies that gate. Computed independently
+            // of the precursor sample count, matching the original.
+            int apex = Math.Max(start, Math.Min(end, peak.ApexIndex));
+            double apexRt = windowRts[startScan + apex];
+            var apexMs1 = MS1Spectrum.FindNearest(ms1Spectra, apexRt);
+            if (apexMs1 != null)
+            {
+                int charge = candidate.Charge > 0 ? candidate.Charge : 1;
+                var envelope = IsotopeEnvelope.Extract(apexMs1, searchMz, charge, ms1TolPpm);
+                apexEnvelope = envelope.Intensities;
+            }
+        }
+    }
+
+    /// <summary>
+    /// The side artifacts a successful <see cref="PeakDataExtractor.TryExtract"/>
+    /// hands back to the scorer: the extracted XICs, the reference-XIC selection,
+    /// the winning peak, the window start offset, the apex spectrum, and the
+    /// per-peak captures for the Stage 6 CWT-candidate list. The populated
+    /// per-candidate <see cref="OspreyPeakData"/> view is set separately on the
+    /// reused instance the scorer passes in.
+    /// </summary>
+    internal sealed class ExtractedPeak
+    {
+        public List<XicData> Xics { get; }
+        public int RefXicIdx { get; }
+        public double[] RefXicIntensities { get; }
+        public XICPeakBounds BestPeak { get; }
+        public int StartScan { get; }
+        public Spectrum ApexSpectrum { get; }
+        public List<(XICPeakBounds peak, double coelutionScore, double rankScore)> CapturedPeaks { get; }
+
+        public ExtractedPeak(
+            List<XicData> xics, int refXicIdx, double[] refXicIntensities,
+            XICPeakBounds bestPeak, int startScan, Spectrum apexSpectrum,
+            List<(XICPeakBounds peak, double coelutionScore, double rankScore)> capturedPeaks)
+        {
+            Xics = xics;
+            RefXicIdx = refXicIdx;
+            RefXicIntensities = refXicIntensities;
+            BestPeak = bestPeak;
+            StartScan = startScan;
+            ApexSpectrum = apexSpectrum;
+            CapturedPeaks = capturedPeaks;
+        }
+    }
+}

--- a/pwiz_tools/OspreySharp/OspreySharp.Scoring/RtDeviationCalculators.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Scoring/RtDeviationCalculators.cs
@@ -30,22 +30,22 @@ namespace pwiz.OspreySharp.Scoring
     /// predicted) retention time. NaN propagates by design; there is no no-score
     /// fallback here.
     /// </summary>
-    internal sealed class RtDeviationCalc : DetailedOspreyFeatureCalculator
+    internal sealed class RtDeviationCalc : SummaryOspreyFeatureCalculator
     {
         public override string Name { get { return "rt_deviation"; } }
 
-        protected override double Calculate(OspreyScoringContext context, IOspreyDetailedPeakData peakData)
+        public override double Calculate(OspreyScoringContext context, IOspreySummaryPeakData peakData)
         {
             return peakData.ApexRetentionTime - peakData.ExpectedRt;
         }
     }
 
     /// <summary>abs_rt_deviation: the absolute value of rt_deviation.</summary>
-    internal sealed class AbsRtDeviationCalc : DetailedOspreyFeatureCalculator
+    internal sealed class AbsRtDeviationCalc : SummaryOspreyFeatureCalculator
     {
         public override string Name { get { return "abs_rt_deviation"; } }
 
-        protected override double Calculate(OspreyScoringContext context, IOspreyDetailedPeakData peakData)
+        public override double Calculate(OspreyScoringContext context, IOspreySummaryPeakData peakData)
         {
             return Math.Abs(peakData.ApexRetentionTime - peakData.ExpectedRt);
         }

--- a/pwiz_tools/OspreySharp/OspreySharp.Scoring/XcorrCalculators.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Scoring/XcorrCalculators.cs
@@ -34,7 +34,7 @@ namespace pwiz.OspreySharp.Scoring
     /// no Savitzky-Golay sweep, no shared byproduct.
     ///
     /// INDEX TRAP: this feature indexes the preprocessed cache at the WINDOW-GLOBAL
-    /// apex index (<see cref="IOspreyDetailedPeakData.ApexGlobalIndex"/> =
+    /// apex index (<see cref="IOspreyApexSpectraPeakData.ApexGlobalIndex"/> =
     /// WindowStartIndex + candidate-local apex). It is a DIFFERENT index space from
     /// the SG sweep (features 17/18), which bound-checks a candidate-local index
     /// against WindowLength before mapping to global. Do not unify the two.
@@ -50,11 +50,11 @@ namespace pwiz.OspreySharp.Scoring
     /// allocation. This family is the perf gate -- keep the pool on the call.
     /// Mirrors inline AbstractScoringTask.cs apex xcorr.
     /// </summary>
-    internal sealed class XcorrCalc : DetailedOspreyFeatureCalculator
+    internal sealed class XcorrCalc : ApexSpectrumOspreyFeatureCalculator
     {
         public override string Name { get { return "xcorr"; } }
 
-        protected override double Calculate(OspreyScoringContext context, IOspreyDetailedPeakData peakData)
+        protected override double Calculate(OspreyScoringContext context, IOspreyApexSpectrumPeakData peakData)
         {
             // Single apex-spectrum xcorr via the resolution strategy. The Spectrum
             // arg is passed for fidelity with the inline call; the Unit/HRAM cache
@@ -114,7 +114,7 @@ namespace pwiz.OspreySharp.Scoring
         public double SgXcorr;   // feature 17
         public double SgCosine;  // feature 18
 
-        public static SgWeightedSweep GetOrCompute(OspreyScoringContext context, IOspreyDetailedPeakData peakData)
+        public static SgWeightedSweep GetOrCompute(OspreyScoringContext context, IOspreyApexSpectraPeakData peakData)
         {
             if (context.TryGetInfo(out SgWeightedSweep sweep))
                 return sweep;
@@ -123,7 +123,7 @@ namespace pwiz.OspreySharp.Scoring
             return sweep;
         }
 
-        private static SgWeightedSweep Compute(OspreyScoringContext context, IOspreyDetailedPeakData peakData)
+        private static SgWeightedSweep Compute(OspreyScoringContext context, IOspreyApexSpectraPeakData peakData)
         {
             var sweep = new SgWeightedSweep();
 
@@ -241,11 +241,11 @@ namespace pwiz.OspreySharp.Scoring
     /// the apex+/-2 spectra are scanned once. See <see cref="SgWeightedSweep"/> for
     /// the index trap, asymmetric boundary skip, and accumulation-order hazards.
     /// </summary>
-    internal sealed class SgXcorrCalc : DetailedOspreyFeatureCalculator
+    internal sealed class SgXcorrCalc : ApexSpectraOspreyFeatureCalculator
     {
         public override string Name { get { return "sg_weighted_xcorr"; } }
 
-        protected override double Calculate(OspreyScoringContext context, IOspreyDetailedPeakData peakData)
+        protected override double Calculate(OspreyScoringContext context, IOspreyApexSpectraPeakData peakData)
         {
             return SgWeightedSweep.GetOrCompute(context, peakData).SgXcorr;
         }
@@ -259,11 +259,11 @@ namespace pwiz.OspreySharp.Scoring
     /// byproduct. See <see cref="SgWeightedSweep"/> for the index trap, asymmetric
     /// boundary skip, accumulation-order, and tie-break hazards.
     /// </summary>
-    internal sealed class SgCosineCalc : DetailedOspreyFeatureCalculator
+    internal sealed class SgCosineCalc : ApexSpectraOspreyFeatureCalculator
     {
         public override string Name { get { return "sg_weighted_cosine"; } }
 
-        protected override double Calculate(OspreyScoringContext context, IOspreyDetailedPeakData peakData)
+        protected override double Calculate(OspreyScoringContext context, IOspreyApexSpectraPeakData peakData)
         {
             return SgWeightedSweep.GetOrCompute(context, peakData).SgCosine;
         }

--- a/pwiz_tools/OspreySharp/OspreySharp.Scoring/XcorrCalculators.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Scoring/XcorrCalculators.cs
@@ -34,7 +34,7 @@ namespace pwiz.OspreySharp.Scoring
     /// no Savitzky-Golay sweep, no shared byproduct.
     ///
     /// INDEX TRAP: this feature indexes the preprocessed cache at the WINDOW-GLOBAL
-    /// apex index (<see cref="IOspreyApexSpectraPeakData.ApexGlobalIndex"/> =
+    /// apex index (<see cref="IOspreyApexSpectrumPeakData.ApexGlobalIndex"/> =
     /// WindowStartIndex + candidate-local apex). It is a DIFFERENT index space from
     /// the SG sweep (features 17/18), which bound-checks a candidate-local index
     /// against WindowLength before mapping to global. Do not unify the two.

--- a/pwiz_tools/OspreySharp/OspreySharp.Scoring/XcorrCalculators.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Scoring/XcorrCalculators.cs
@@ -133,21 +133,18 @@ namespace pwiz.OspreySharp.Scoring
             var pool = context.XcorrScratchPool;
             var config = context.Config;
             var candidate = peakData.Candidate;
-            var windowSpectra = peakData.WindowSpectra;
-            int startScan = peakData.WindowStartIndex;
-            int rangeLen = peakData.WindowLength;
-            int apexLocal = peakData.ApexLocalIndex;
 
             double sgXcorr = 0.0;
             double sgCosine = 0.0;
             for (int offset = -2; offset <= 2; offset++)
             {
                 double weight = SG_WEIGHTS[offset + 2];
-                int candIdx = apexLocal + offset;
-                if (candIdx < 0 || candIdx >= rangeLen)
+                // The bounded apex+/-N accessor owns the candidate-local ->
+                // window-global index mapping and the asymmetric edge skip: it
+                // returns false when apex+offset falls outside the scoring range, so
+                // out-of-range offsets contribute nothing (no renormalization).
+                if (!peakData.TryGetApexOffsetSpectrum(offset, out var s, out int globalIdx))
                     continue;
-                int globalIdx = startScan + candIdx;
-                var s = windowSpectra[globalIdx];
                 sgXcorr += resolution.ScoreXcorr(preprocessedXcorr, globalIdx, s, candidate, scorer,
                     pool) * weight;
                 sgCosine += ComputeCosineAtScan(candidate, s, config) * weight;

--- a/pwiz_tools/OspreySharp/OspreySharp.Test/OspreyFeatureCalculatorsTest.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Test/OspreyFeatureCalculatorsTest.cs
@@ -347,6 +347,60 @@ namespace pwiz.OspreySharp.Test
             Assert.AreEqual(266.0 / 35.0, OspreyFeatureCalculators.Get(17).Calculate(edgeContext, edge), TOLERANCE);
         }
 
+        /// <summary>
+        /// The production <see cref="OspreyPeakData.TryGetApexOffsetSpectrum"/> bounded
+        /// accessor (tested directly, not via the fake's copy): interior offsets map
+        /// candidate-local to window-global (cacheIndex = windowStartIndex +
+        /// apexLocalIndex + offset) and return the window spectrum there; offsets that
+        /// fall outside [0, windowLength) at a window edge return false -- the
+        /// asymmetric skip the Savitzky-Golay sweep relies on.
+        /// </summary>
+        [TestMethod]
+        public void TestApexOffsetSpectrumAccessor()
+        {
+            var windowSpectra = new List<Spectrum>();
+            for (int i = 0; i < 20; i++)
+                windowSpectra.Add(new Spectrum { Mzs = new double[0], Intensities = new float[0] });
+
+            // startScan=10, apexLocal=5, rangeLen=8 -> candIdx 3..7 valid (globalIdx 13..17).
+            var peakData = new OspreyPeakData();
+            peakData.Set(null, new XICPeakBounds(), new List<XicData>(),
+                0.0, 0.0, windowSpectra[15],
+                apexGlobalIndex: 15, apexLocalIndex: 5, windowStartIndex: 10, windowLength: 8,
+                windowSpectra: windowSpectra);
+            for (int offset = -2; offset <= 2; offset++)
+            {
+                Assert.IsTrue(peakData.TryGetApexOffsetSpectrum(offset, out var s, out int idx),
+                    string.Format("offset {0} should be in range", offset));
+                Assert.AreEqual(15 + offset, idx);
+                Assert.AreSame(windowSpectra[15 + offset], s);
+            }
+
+            // Lower edge: apexLocal=0 -> offsets -2,-1 fall below 0 and are skipped;
+            // 0,1,2 resolve to globalIdx 10,11,12.
+            var edge = new OspreyPeakData();
+            edge.Set(null, new XICPeakBounds(), new List<XicData>(),
+                0.0, 0.0, windowSpectra[10],
+                apexGlobalIndex: 10, apexLocalIndex: 0, windowStartIndex: 10, windowLength: 8,
+                windowSpectra: windowSpectra);
+            Assert.IsFalse(edge.TryGetApexOffsetSpectrum(-2, out _, out _));
+            Assert.IsFalse(edge.TryGetApexOffsetSpectrum(-1, out _, out _));
+            Assert.IsTrue(edge.TryGetApexOffsetSpectrum(0, out _, out int i0));
+            Assert.AreEqual(10, i0);
+            Assert.IsTrue(edge.TryGetApexOffsetSpectrum(2, out _, out int i2));
+            Assert.AreEqual(12, i2);
+
+            // Upper edge: apexLocal=7 at the top of an 8-wide range -> candIdx 8 (offset
+            // +1) equals windowLength and is skipped.
+            var upper = new OspreyPeakData();
+            upper.Set(null, new XICPeakBounds(), new List<XicData>(),
+                0.0, 0.0, windowSpectra[17],
+                apexGlobalIndex: 17, apexLocalIndex: 7, windowStartIndex: 10, windowLength: 8,
+                windowSpectra: windowSpectra);
+            Assert.IsTrue(upper.TryGetApexOffsetSpectrum(0, out _, out _));
+            Assert.IsFalse(upper.TryGetApexOffsetSpectrum(1, out _, out _));
+        }
+
         private static LibraryFragment Frag(double mz, IonType ionType, byte ordinal)
         {
             return new LibraryFragment

--- a/pwiz_tools/OspreySharp/OspreySharp.Test/OspreyFeatureCalculatorsTest.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Test/OspreyFeatureCalculatorsTest.cs
@@ -211,8 +211,7 @@ namespace pwiz.OspreySharp.Test
             var peakData = new FakePeakData(
                 new List<XicData> { new XicData(0, rts, frag0) },
                 new XICPeakBounds { StartIndex = 0, EndIndex = 4, ApexIndex = 2 },
-                candidate: new LibraryEntry(1, "PEPTIDE", "PEPTIDE", 2, 500.0, 10.0),
-                windowRetentionTimes: rts);
+                candidate: new LibraryEntry(1, "PEPTIDE", "PEPTIDE", 2, 500.0, 10.0));
 
             // The fake supplies no MS1 data (Ms1PrecursorXic / ApexIsotopeEnvelope
             // null), so both features return 0.0 without any MS1 work.
@@ -370,14 +369,12 @@ namespace pwiz.OspreySharp.Test
             private readonly int _windowStartIndex;
             private readonly int _windowLength;
             private readonly IReadOnlyList<Spectrum> _windowSpectra;
-            private readonly IReadOnlyList<double> _windowRetentionTimes;
 
             public FakePeakData(IReadOnlyList<XicData> xics, XICPeakBounds peakBounds,
                 double apexRetentionTime = 0.0, double expectedRt = 0.0,
                 LibraryEntry candidate = null, Spectrum apexSpectrum = null,
                 int apexGlobalIndex = 0, int apexLocalIndex = 0, int windowStartIndex = 0,
-                int windowLength = 0, IReadOnlyList<Spectrum> windowSpectra = null,
-                IReadOnlyList<double> windowRetentionTimes = null)
+                int windowLength = 0, IReadOnlyList<Spectrum> windowSpectra = null)
             {
                 _xics = xics;
                 _peakBounds = peakBounds;
@@ -390,7 +387,6 @@ namespace pwiz.OspreySharp.Test
                 _windowStartIndex = windowStartIndex;
                 _windowLength = windowLength;
                 _windowSpectra = windowSpectra;
-                _windowRetentionTimes = windowRetentionTimes;
             }
 
             public LibraryEntry Candidate { get { return _candidate; } }
@@ -400,11 +396,21 @@ namespace pwiz.OspreySharp.Test
             public IReadOnlyList<XicData> Xics { get { return _xics; } }
             public Spectrum ApexSpectrum { get { return _apexSpectrum; } }
             public int ApexGlobalIndex { get { return _apexGlobalIndex; } }
-            public int ApexLocalIndex { get { return _apexLocalIndex; } }
-            public int WindowStartIndex { get { return _windowStartIndex; } }
-            public int WindowLength { get { return _windowLength; } }
-            public IReadOnlyList<Spectrum> WindowSpectra { get { return _windowSpectra; } }
-            public IReadOnlyList<double> WindowRetentionTimes { get { return _windowRetentionTimes; } }
+
+            public bool TryGetApexOffsetSpectrum(int offset, out Spectrum spectrum, out int cacheIndex)
+            {
+                int candIdx = _apexLocalIndex + offset;
+                if (candIdx < 0 || candIdx >= _windowLength)
+                {
+                    spectrum = null;
+                    cacheIndex = -1;
+                    return false;
+                }
+                cacheIndex = _windowStartIndex + candIdx;
+                spectrum = _windowSpectra[cacheIndex];
+                return true;
+            }
+
             // MS1 data is produced upstream by the extractor; the fake supplies none,
             // so the MS1 features evaluate to 0.0 (the HRAM-off path under test).
             public XicData Ms1PrecursorXic { get { return null; } }

--- a/pwiz_tools/OspreySharp/OspreySharp.Test/OspreyFeatureCalculatorsTest.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Test/OspreyFeatureCalculatorsTest.cs
@@ -61,7 +61,7 @@ namespace pwiz.OspreySharp.Test
                 new XicData(1, rts, frag1),
             };
             var bounds = new XICPeakBounds { StartIndex = 1, EndIndex = 5, ApexIndex = 3 };
-            var peakData = new FakeDetailedPeakData(xics, bounds);
+            var peakData = new FakePeakData(xics, bounds);
 
             var context = new OspreyScoringContext(null);
             context.ClearByproducts();
@@ -84,7 +84,7 @@ namespace pwiz.OspreySharp.Test
             Assert.AreEqual("peak_sharpness", OspreyFeatureCalculators.Get(5).Name);
 
             // Degenerate peak data (no XICs) yields 0.0 for every peak-shape feature.
-            var empty = new FakeDetailedPeakData(new List<XicData>(), bounds);
+            var empty = new FakePeakData(new List<XicData>(), bounds);
             context.ClearByproducts();
             Assert.AreEqual(0.0, OspreyFeatureCalculators.Get(3).Calculate(context, empty), TOLERANCE);
             Assert.AreEqual(0.0, OspreyFeatureCalculators.Get(4).Calculate(context, empty), TOLERANCE);
@@ -110,7 +110,7 @@ namespace pwiz.OspreySharp.Test
                 new XicData(1, rts, frag1),
             };
             var bounds = new XICPeakBounds { StartIndex = 0, EndIndex = 4, ApexIndex = 2 };
-            var peakData = new FakeDetailedPeakData(xics, bounds);
+            var peakData = new FakePeakData(xics, bounds);
 
             double expectedCorr = ScoringMath.PearsonCorrelationInRange(frag0, frag1, 0, 4);
             Assert.IsTrue(expectedCorr > 0.0, "fixture fragments should positively correlate");
@@ -132,7 +132,7 @@ namespace pwiz.OspreySharp.Test
             Assert.AreEqual("n_coeluting_fragments", OspreyFeatureCalculators.Get(2).Name);
 
             // Fewer than two fragments -> all coelution features 0.
-            var single = new FakeDetailedPeakData(
+            var single = new FakePeakData(
                 new List<XicData> { new XicData(0, rts, frag0) }, bounds);
             context.ClearByproducts();
             Assert.AreEqual(0.0, OspreyFeatureCalculators.Get(0).Calculate(context, single), TOLERANCE);
@@ -151,7 +151,7 @@ namespace pwiz.OspreySharp.Test
         {
             var rts = new double[] { 0, 1, 2 };
             var frag0 = new double[] { 1, 2, 1 };
-            var peakData = new FakeDetailedPeakData(
+            var peakData = new FakePeakData(
                 new List<XicData> { new XicData(0, rts, frag0) },
                 new XICPeakBounds { StartIndex = 0, EndIndex = 2, ApexIndex = 1 });
 
@@ -179,13 +179,13 @@ namespace pwiz.OspreySharp.Test
             var context = new OspreyScoringContext(null);
             context.ClearByproducts();
 
-            var late = new FakeDetailedPeakData(new List<XicData>(), new XICPeakBounds(),
+            var late = new FakePeakData(new List<XicData>(), new XICPeakBounds(),
                 apexRetentionTime: 12.5, expectedRt: 10.0);
             Assert.AreEqual(2.5, OspreyFeatureCalculators.Get(11).Calculate(context, late), TOLERANCE);
             Assert.AreEqual(2.5, OspreyFeatureCalculators.Get(12).Calculate(context, late), TOLERANCE);
 
             // Earlier-than-expected apex -> negative deviation, positive absolute.
-            var early = new FakeDetailedPeakData(new List<XicData>(), new XICPeakBounds(),
+            var early = new FakePeakData(new List<XicData>(), new XICPeakBounds(),
                 apexRetentionTime: 8.0, expectedRt: 10.0);
             Assert.AreEqual(-2.0, OspreyFeatureCalculators.Get(11).Calculate(context, early), TOLERANCE);
             Assert.AreEqual(2.0, OspreyFeatureCalculators.Get(12).Calculate(context, early), TOLERANCE);
@@ -208,7 +208,7 @@ namespace pwiz.OspreySharp.Test
         {
             var rts = new double[] { 0, 1, 2, 3, 4 };
             var frag0 = new double[] { 1, 2, 3, 2, 1 };
-            var peakData = new FakeDetailedPeakData(
+            var peakData = new FakePeakData(
                 new List<XicData> { new XicData(0, rts, frag0) },
                 new XICPeakBounds { StartIndex = 0, EndIndex = 4, ApexIndex = 2 },
                 candidate: new LibraryEntry(1, "PEPTIDE", "PEPTIDE", 2, 500.0, 10.0),
@@ -256,7 +256,7 @@ namespace pwiz.OspreySharp.Test
                     Frag(999.0, IonType.Y, 2),
                 },
             };
-            var peakData = new FakeDetailedPeakData(new List<XicData>(), new XICPeakBounds(),
+            var peakData = new FakePeakData(new List<XicData>(), new XICPeakBounds(),
                 candidate: candidate, apexSpectrum: apex);
 
             var context = new OspreyScoringContext(config);
@@ -282,7 +282,7 @@ namespace pwiz.OspreySharp.Test
             {
                 Fragments = new List<LibraryFragment> { Frag(999.0, IonType.B, 1) },
             };
-            var noMatchData = new FakeDetailedPeakData(new List<XicData>(), new XICPeakBounds(),
+            var noMatchData = new FakePeakData(new List<XicData>(), new XICPeakBounds(),
                 candidate: noMatch, apexSpectrum: apex);
             var noMatchContext = new OspreyScoringContext(config);
             noMatchContext.ClearByproducts();
@@ -318,7 +318,7 @@ namespace pwiz.OspreySharp.Test
 
             // Interior apex: startScan=10, apexLocal=5, rangeLen=8 -> candIdx 3..7 all
             // in range, globalIdx 13..17. ScoreXcorr echoes the index.
-            var interior = new FakeDetailedPeakData(new List<XicData>(), new XICPeakBounds(),
+            var interior = new FakePeakData(new List<XicData>(), new XICPeakBounds(),
                 candidate: candidate, apexSpectrum: windowSpectra[15],
                 apexGlobalIndex: 15, apexLocalIndex: 5, windowStartIndex: 10,
                 windowLength: 8, windowSpectra: windowSpectra);
@@ -339,7 +339,7 @@ namespace pwiz.OspreySharp.Test
             // Edge apex: apexLocal=0 -> offsets -2,-1 skip (candIdx<0); offsets 0,1,2
             // -> globalIdx 10,11,12. NO renormalization: only those weights apply.
             // 10*(17/35) + 11*(12/35) + 12*(-3/35) = 266/35 = 7.6.
-            var edge = new FakeDetailedPeakData(new List<XicData>(), new XICPeakBounds(),
+            var edge = new FakePeakData(new List<XicData>(), new XICPeakBounds(),
                 candidate: candidate, apexSpectrum: windowSpectra[10],
                 apexGlobalIndex: 10, apexLocalIndex: 0, windowStartIndex: 10,
                 windowLength: 8, windowSpectra: windowSpectra);
@@ -358,7 +358,7 @@ namespace pwiz.OspreySharp.Test
             };
         }
 
-        private sealed class FakeDetailedPeakData : IOspreyDetailedPeakData
+        private sealed class FakePeakData : IOspreyApexSpectraPeakData
         {
             private readonly IReadOnlyList<XicData> _xics;
             private readonly XICPeakBounds _peakBounds;
@@ -373,7 +373,7 @@ namespace pwiz.OspreySharp.Test
             private readonly IReadOnlyList<Spectrum> _windowSpectra;
             private readonly IReadOnlyList<double> _windowRetentionTimes;
 
-            public FakeDetailedPeakData(IReadOnlyList<XicData> xics, XICPeakBounds peakBounds,
+            public FakePeakData(IReadOnlyList<XicData> xics, XICPeakBounds peakBounds,
                 double apexRetentionTime = 0.0, double expectedRt = 0.0,
                 LibraryEntry candidate = null, Spectrum apexSpectrum = null,
                 int apexGlobalIndex = 0, int apexLocalIndex = 0, int windowStartIndex = 0,

--- a/pwiz_tools/OspreySharp/OspreySharp.Test/OspreyFeatureCalculatorsTest.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Test/OspreyFeatureCalculatorsTest.cs
@@ -196,12 +196,12 @@ namespace pwiz.OspreySharp.Test
 
         /// <summary>
         /// MS1 family (ms1_precursor_coelution / ms1_isotope_cosine): both features
-        /// are HRAM-only. The HRAM gate is on the context -- when SetMs1Machinery was
-        /// never called (so HasMs1Features stays false and Ms1Spectra is null), both
-        /// calculators short-circuit to exactly 0.0 before any byproduct work. The
+        /// are HRAM-only and now pure consumers of MS1 data produced upstream by the
+        /// extractor. When no MS1 data is supplied (the peak-data accessors are null,
+        /// i.e. a unit-resolution run or no MS1 scan), both return exactly 0.0. The
         /// numeric path (calibration, reference-XIC pick, nearest-MS1 sampling,
-        /// isotope envelope) is covered by the end-to-end 1e-9 cross-impl parity gate
-        /// against the Rust reference on the HRAM datasets.
+        /// isotope envelope) lives in the extractor and is covered by the end-to-end
+        /// 1e-9 cross-impl parity gate against the Rust reference on the HRAM datasets.
         /// </summary>
         [TestMethod]
         public void TestMs1Calculators()
@@ -214,11 +214,10 @@ namespace pwiz.OspreySharp.Test
                 candidate: new LibraryEntry(1, "PEPTIDE", "PEPTIDE", 2, 500.0, 10.0),
                 windowRetentionTimes: rts);
 
-            // No SetMs1Machinery -> HasMs1Features is false -> HRAM gate returns 0.0
-            // for both features, without touching the (null) MS1 spectra.
+            // The fake supplies no MS1 data (Ms1PrecursorXic / ApexIsotopeEnvelope
+            // null), so both features return 0.0 without any MS1 work.
             var context = new OspreyScoringContext(null);
             context.ClearByproducts();
-            Assert.IsFalse(context.HasMs1Features);
             Assert.AreEqual(0.0, OspreyFeatureCalculators.Get(13).Calculate(context, peakData), TOLERANCE);
             Assert.AreEqual(0.0, OspreyFeatureCalculators.Get(14).Calculate(context, peakData), TOLERANCE);
 
@@ -406,6 +405,11 @@ namespace pwiz.OspreySharp.Test
             public int WindowLength { get { return _windowLength; } }
             public IReadOnlyList<Spectrum> WindowSpectra { get { return _windowSpectra; } }
             public IReadOnlyList<double> WindowRetentionTimes { get { return _windowRetentionTimes; } }
+            // MS1 data is produced upstream by the extractor; the fake supplies none,
+            // so the MS1 features evaluate to 0.0 (the HRAM-off path under test).
+            public XicData Ms1PrecursorXic { get { return null; } }
+            public XicData Ms1ReferenceXic { get { return null; } }
+            public double[] ApexIsotopeEnvelope { get { return null; } }
         }
 
         /// <summary>

--- a/pwiz_tools/OspreySharp/regression.ps1
+++ b/pwiz_tools/OspreySharp/regression.ps1
@@ -72,10 +72,20 @@
     Skip the OspreySharp build step (use the existing Release binary).
 
 .PARAMETER KeepRunDirs
-    Number of most-recent TestResults\regression-* run dirs to keep; older ones are
-    pruned at startup (before the build) to reclaim disk (default 2). Each run dir
-    holds multi-GB spectra caches and is gitignored scratch that nothing else cleans
-    up. On a long-lived build agent these otherwise accumulate until the disk fills.
+    Number of most-recent TestResults\regression-* run dirs to keep when pruning
+    ORPHANS at startup (default 0 -- keep none). A normal run now removes its own
+    output when it finishes (see -KeepOutput), so this only clears dirs left behind
+    by a previously killed run (TeamCity timeout / OOM). Raise it to retain old run
+    dirs on a roomy local disk.
+
+.PARAMETER KeepOutput
+    Keep this run's TestResults\regression-<stamp> output instead of deleting it. By
+    default the run deletes its scratch as it goes -- each HPC-chain phase and each
+    dataset as soon as it is consumed, then the whole run root at the end -- so it
+    leaves no multi-GB output behind to starve the next run on a shared build agent.
+    The raw input data (downloaded mzML/library) is NEVER touched. Pass this locally
+    to retain output for post-mortem; a red CI gate's diagnosis lives in the build
+    log, not these files.
 
 .EXAMPLE
     # Local: run Stellar straight-through + resume against the committed golden
@@ -99,7 +109,8 @@ param(
     [switch]$TeamCity,
     [switch]$NoBuild,
     [ValidateRange(0, [int]::MaxValue)]
-    [int]$KeepRunDirs = 2,
+    [int]$KeepRunDirs = 0,
+    [switch]$KeepOutput,
     [double]$Tolerance = 1e-9
 )
 
@@ -148,16 +159,17 @@ function Write-Problem-Tc([string]$msg) {
     Write-Host "ERROR: $msg" -ForegroundColor Red
 }
 
-# --- Reclaim disk: prune stale TestResults run dirs ---------------------------
-# Each invocation writes a timestamped TestResults\regression-<stamp> dir holding
-# multi-GB .spectra.bin caches (via --work-dir). They are gitignored scratch and
-# nothing else cleans them, so on a long-lived build agent they accumulate until
-# the disk fills (the Astral straight-through leg alone needs ~26 GB). Prune here,
+# --- Reclaim disk: prune orphaned TestResults run dirs ------------------------
+# A normal run now removes its OWN TestResults\regression-<stamp> dir as it goes
+# (each HPC-chain phase + dataset when consumed, then the run root at the end --
+# see the cleanup below and -KeepOutput), so between runs there is normally nothing
+# here. This startup prune is the safety net for ORPHANS: a dir left by a run that
+# was killed (TeamCity timeout / OOM) before it reached its own cleanup. Run here
 # FIRST -- before the build, data acquisition, and the new run dir -- so even a
-# near-full disk can run it (deleting needs ~no free space) and the rest of the
-# run has the reclaimed space. Keeps the most recent $KeepRunDirs dirs (the latest
-# is useful for post-mortem on a red gate). The dir names sort chronologically
-# (regression-YYYYMMDD_HHMMSS), so a Name sort orders oldest-first.
+# near-full disk can run it (deleting needs ~no free space) and the rest of the run
+# has the reclaimed space. Keeps the most recent $KeepRunDirs (default 0 = keep
+# none). The dir names sort chronologically (regression-YYYYMMDD_HHMMSS), so a Name
+# sort orders oldest-first.
 function Remove-StaleRunDirs([string]$TestResultsDir, [int]$Keep) {
     if (-not (Test-Path $TestResultsDir)) { return }
     $runDirs = @(Get-ChildItem -Path $TestResultsDir -Directory -Filter 'regression-*' `
@@ -175,6 +187,15 @@ function Remove-StaleRunDirs([string]$TestResultsDir, [int]$Keep) {
     }
 }
 Remove-StaleRunDirs (Join-Path $scriptRoot 'TestResults') $KeepRunDirs
+
+# Best-effort recursive delete of a scratch path (a run/phase/dataset output dir or
+# a single dead-weight input copy). Swallows errors -- reclaiming disk must never
+# fail the gate. Honors -KeepOutput so a local post-mortem can retain everything.
+function Remove-Scratch([string]$Path) {
+    if ($KeepOutput) { return }
+    if ([string]::IsNullOrEmpty($Path) -or -not (Test-Path -LiteralPath $Path)) { return }
+    Remove-Item -LiteralPath $Path -Recurse -Force -ErrorAction SilentlyContinue
+}
 
 # --- Build (unless -NoBuild) --------------------------------------------------
 if (-not $NoBuild) {
@@ -334,6 +355,13 @@ function Invoke-HpcChain {
     $a1 += @('-l', $libName, '-o', 'output.blib', '--resolution', $Resolution,
              '--protein-fdr', '0.01', '--threads', $Threads.ToString(), '--task', 'PerFileScoring')
     Invoke-OspreyTaskRun -WorkDir $ph1 -CliArgs $a1 -LogName 'phase1.log'
+    # Phase 1's copied mzMLs are dead weight once it has run: phase 2/3 read its
+    # parquets + calibration, never its mzML (phase 3 re-copies the mzML from the
+    # data dir). Drop them so they don't sit on disk through the per-file rescore loop.
+    if (-not $KeepOutput) {
+        Get-ChildItem -Path $ph1 -Filter '*.mzML' -File -ErrorAction SilentlyContinue |
+            Remove-Item -Force -ErrorAction SilentlyContinue
+    }
 
     # Phase 2: 1st-join (Stage 5). Consumes the per-file parquets, writes the
     # <stem>.1st-pass.fdr_scores.bin + <stem>.reconciliation.json sidecar pair. A
@@ -370,7 +398,24 @@ function Invoke-HpcChain {
                 '-l', $libName, '-o', 'output.blib', '--resolution', $Resolution,
                 '--protein-fdr', '0.01', '--threads', $Threads.ToString())
         Invoke-OspreyTaskRun -WorkDir $ph3 -CliArgs $a3 -LogName 'phase3.log'
+        # This worker has written its reconciled parquet + 2nd-pass bin; phase 4
+        # consumes only those plus the calibration / reconciliation / 1st-pass
+        # sidecars copied above -- never this worker's mzML, input scores.parquet,
+        # or library. Drop those big inputs now so at most one worker's mzML +
+        # library copy is on disk at a time (the out-of-disk failure was several of
+        # them coexisting with the straight-through leg's spectra caches).
+        if (-not $KeepOutput) {
+            Remove-Item (Join-Path $ph3 (Split-Path -Leaf $mzmlByStem[$s])) -Force -ErrorAction SilentlyContinue
+            Remove-Item (Join-Path $ph3 "$s.scores.parquet") -Force -ErrorAction SilentlyContinue
+            Remove-Item (Join-Path $ph3 $libName) -Force -ErrorAction SilentlyContinue
+            Remove-Item (Join-Path $ph3 ($libName + '.libcache')) -Force -ErrorAction SilentlyContinue
+        }
     }
+
+    # Phases 1 and 2 are fully consumed once every rescore worker has copied its
+    # inputs (phase 4 reads only phase-3 outputs). Free them before the merge node.
+    Remove-Scratch $ph1
+    Remove-Scratch $ph2
 
     # Phase 4: 2nd-join merge node (Stage 7 + blib). Consumes each worker's
     # reconciled parquet + sidecars (never the original Stage 4 parquet, and never
@@ -387,6 +432,9 @@ function Invoke-HpcChain {
         if (Test-Path $pass2) { Copy-Item $pass2 (Join-Path $ph4 "$s.2nd-pass.fdr_scores.bin") }
         New-Item -ItemType File -Path (Join-Path $ph4 "$s.mzML") -Force | Out-Null
     }
+    # The merge node now has every worker's reconciled output copied in; the phase-3
+    # worker dirs are done.
+    foreach ($d in $ph3Dirs.Values) { Remove-Scratch $d }
     Copy-LibraryInto -Library $Library -Dir $ph4
     $a4 = @('--task', 'MergeNode')
     foreach ($s in $stemList) { $a4 += @('--input-scores', "$s.scores-reconciled.parquet") }
@@ -401,6 +449,11 @@ function Invoke-HpcChain {
 $overallFail = $false
 $summaryLines = [System.Collections.Generic.List[string]]::new()
 
+# Self-cleaning: each dataset's scratch is removed as soon as its legs finish, and
+# the whole run root in the finally below -- so the run leaves no multi-GB output
+# behind to starve the next run on a shared agent. -KeepOutput (honored by
+# Remove-Scratch) opts out for local post-mortem.
+try {
 foreach ($name in $selected) {
     $cfg = $datasets[$name]
     Write-Progress-Tc "Dataset $name"
@@ -488,16 +541,27 @@ foreach ($name in $selected) {
             $summaryLines.Add("$name mode2 (resume==straight): FAIL ($($m2.Issues.Count) issues)")
         }
     }
+
+    # All legs for this dataset are done -- free its scratch now so peak disk stays
+    # at ~one dataset (the next dataset / the perf-gate step gets the space back).
+    Remove-Scratch (Join-Path $runRoot $name)
+}
+}
+finally {
+    # Safety net for a dataset that threw before its own cleanup -- drop the whole
+    # run root. Raw input data lives outside $runRoot and is untouched.
+    Remove-Scratch $runRoot
 }
 
 # --- Summary + exit -----------------------------------------------------------
 Write-Host ""
 Write-Host "=== OspreySharp regression summary ===" -ForegroundColor Cyan
 $summaryLines | ForEach-Object { Write-Host "  $_" }
-# No artifacts are published. The diagnosis on a red gate lives in the build log
-# (every per-file log is Tee'd to the console TeamCity captures) and the
-# buildProblem line (which names the failing dataset + leg + first divergent
-# columns); the run outputs stay on the agent under the gitignored TestResults.
+# No artifacts are published, and the run's scratch under TestResults is deleted on
+# completion (the downloaded raw input data is kept). A red gate's diagnosis lives in
+# the build log (every per-file log is Tee'd to the console TeamCity captures) and
+# the buildProblem line (which names the failing dataset + leg + first divergent
+# columns), NOT in the run output files. Pass -KeepOutput to retain them locally.
 if ($overallFail) {
     Write-Problem-Tc 'OspreySharp regression FAILED'
     exit 1


### PR DESCRIPTION
## Summary

* Tightens the OspreySharp scoring SPI per the 2026-06-20 OOP review: gives each score class least-privilege access to per-candidate data and adds the missing producer seam, moving the score classes materially closer to Skyline-portable.
* Draft, landing as 3 byte-parity-gated commits on one branch:
  * (1) four-tier peak-data hierarchy — Summary / Detailed / ApexSpectrum / ApexSpectra — and reclassification of all 21 PIN calculators to the narrowest tier each reads. **Done.**
  * (2) PeakDataExtractor that owns all data production (scan-range, XICs, peak detection, apex/ref resolution, and the MS1 precursor XIC + isotope envelope), collapsing ScoreCandidate to extract -> score -> assemble; MS1 scores drop to Detailed. _Pending._
  * (3) N=2 bounded apex-spectrum accessor replacing raw window exposure. _Pending._

See ai/todos/active/TODO-20260620_ospreysharp_scoring_peakdata_tiers.md

## Test plan

- [x] Build + 389 tests + zero-warning inspection (Debug)
- [x] Stellar regression byte-identical — mode1 (vs golden), mode2 (resume), mode3 (HPC chain)
- [ ] Dataset All regression before marking ready
- [ ] Test-PerfGate (commit 3)

Co-Authored-By: Claude <noreply@anthropic.com>