### PR TITLE
Extract the declarative CLI-argument framework into a new shared PortableUtil DLL

### DIFF
--- a/pwiz_tools/Shared/PortableUtil/CommandLine/ArgUsage.cs
+++ b/pwiz_tools/Shared/PortableUtil/CommandLine/ArgUsage.cs
@@ -1,0 +1,104 @@
+/*
+ * Original author: Brendan MacLean <brendanx .at. u.washington.edu>,
+ *                  MacCoss Lab, Department of Genome Sciences, UW
+ *
+ * Copyright 2026 University of Washington - Seattle, WA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+using System;
+using System.Net;
+
+namespace pwiz.Common.CommandLine
+{
+    /// <summary>
+    /// Supplies the host-application text the framework cannot carry itself: localized
+    /// argument descriptions, the usage-table column headers, and the localized error
+    /// messages for the framework's value exceptions. A host (e.g. Skyline) installs an
+    /// implementation on <see cref="ArgUsage.Provider"/> so PortableUtil needs no .resx.
+    /// </summary>
+    public interface IArgUsageProvider
+    {
+        string GetDescription(string argName);
+        string AppliesToHeader { get; }
+        string ArgumentHeader { get; }
+        string DescriptionHeader { get; }
+
+        string ValueMissingMessage(string argText);
+        string ValueUnexpectedMessage(string argText);
+        string ValueInvalidMessage(string argText, string value, string[] argValues);
+        string ValueInvalidBoolMessage(string argText, string value);
+        string ValueInvalidIntMessage(string argText, string value);
+        string ValueOutOfRangeIntMessage(string argText, int value, int minVal, int maxVal);
+        string ValueInvalidDoubleMessage(string argText, string value);
+        string ValueOutOfRangeDoubleMessage(string argText, double value, double minVal, double maxVal);
+        string ValueInvalidDateMessage(string argText, string value);
+        string ValueInvalidPathMessage(string argText, string value);
+    }
+
+    /// <summary>
+    /// Static seams that decouple the generic CLI-argument framework from its host
+    /// application. Defaults keep PortableUtil a pure-BCL leaf usable on its own; a host
+    /// overrides them at startup (Skyline does so in the CommandArgs static constructor).
+    /// </summary>
+    public static class ArgUsage
+    {
+        // Usage rendering format identifiers (also surfaced to users via Skyline's --help values).
+        public const string FORMAT_ASCII = "ascii";
+        public const string FORMAT_NO_BORDERS = "no-borders";
+
+        /// <summary>
+        /// Host-supplied descriptions, headers and value-error messages. Defaults to a
+        /// no-op provider (empty strings/null descriptions) so the framework never NREs
+        /// before a host installs its own.
+        /// </summary>
+        public static IArgUsageProvider Provider { get; set; } = new NullArgUsageProvider();
+
+        /// <summary>
+        /// Classifies a value as a remote URL (left untouched by <see cref="NameValuePair.ValueFullPath"/>
+        /// instead of being run through <see cref="System.IO.Path.GetFullPath(string)"/>). Default: never remote.
+        /// </summary>
+        public static Func<string, bool> IsRemoteUrl { get; set; } = _ => false;
+
+        /// <summary>
+        /// Identifies value-example delegates whose argument text should be allowed to wrap
+        /// in HTML output (spaces left as-is rather than replaced with &amp;nbsp;). Default: none.
+        /// </summary>
+        public static Func<Func<string>, bool> IsWrappableListType { get; set; } = _ => false;
+
+        /// <summary>
+        /// HTML-encodes a string fragment. Defaults to <see cref="WebUtility.HtmlEncode(string)"/> (BCL on
+        /// all targets); a host may override to match a specific encoder's byte-for-byte output.
+        /// </summary>
+        public static Func<string, string> HtmlEncode { get; set; } = WebUtility.HtmlEncode;
+
+        private class NullArgUsageProvider : IArgUsageProvider
+        {
+            public string GetDescription(string argName) { return null; }
+            public string AppliesToHeader { get { return string.Empty; } }
+            public string ArgumentHeader { get { return string.Empty; } }
+            public string DescriptionHeader { get { return string.Empty; } }
+
+            public string ValueMissingMessage(string argText) { return string.Empty; }
+            public string ValueUnexpectedMessage(string argText) { return string.Empty; }
+            public string ValueInvalidMessage(string argText, string value, string[] argValues) { return string.Empty; }
+            public string ValueInvalidBoolMessage(string argText, string value) { return string.Empty; }
+            public string ValueInvalidIntMessage(string argText, string value) { return string.Empty; }
+            public string ValueOutOfRangeIntMessage(string argText, int value, int minVal, int maxVal) { return string.Empty; }
+            public string ValueInvalidDoubleMessage(string argText, string value) { return string.Empty; }
+            public string ValueOutOfRangeDoubleMessage(string argText, double value, double minVal, double maxVal) { return string.Empty; }
+            public string ValueInvalidDateMessage(string argText, string value) { return string.Empty; }
+            public string ValueInvalidPathMessage(string argText, string value) { return string.Empty; }
+        }
+    }
+}

--- a/pwiz_tools/Shared/PortableUtil/CommandLine/ArgUsage.cs
+++ b/pwiz_tools/Shared/PortableUtil/CommandLine/ArgUsage.cs
@@ -58,11 +58,13 @@ namespace pwiz.Common.CommandLine
         public const string FORMAT_NO_BORDERS = "no-borders";
 
         /// <summary>
-        /// Host-supplied descriptions, headers and value-error messages. Defaults to a
-        /// no-op provider (empty strings/null descriptions) so the framework never NREs
-        /// before a host installs its own.
+        /// Host-supplied descriptions, headers and value-error messages. Defaults to a provider
+        /// that throws: descriptions/headers/error text are inherently host-specific, so a host
+        /// that renders usage or reports a value error MUST install one. Failing loudly here turns
+        /// a "seam not installed" bug into an immediate exception instead of silently emitting
+        /// empty/mis-encoded output the byte-identical golden HTML test cannot catch.
         /// </summary>
-        public static IArgUsageProvider Provider { get; set; } = new NullArgUsageProvider();
+        public static IArgUsageProvider Provider { get; set; } = new NotInstalledArgUsageProvider();
 
         /// <summary>
         /// Classifies a value as a remote URL (left untouched by <see cref="NameValuePair.ValueFullPath"/>
@@ -82,23 +84,29 @@ namespace pwiz.Common.CommandLine
         /// </summary>
         public static Func<string, string> HtmlEncode { get; set; } = WebUtility.HtmlEncode;
 
-        private class NullArgUsageProvider : IArgUsageProvider
+        private class NotInstalledArgUsageProvider : IArgUsageProvider
         {
-            public string GetDescription(string argName) { return null; }
-            public string AppliesToHeader { get { return string.Empty; } }
-            public string ArgumentHeader { get { return string.Empty; } }
-            public string DescriptionHeader { get { return string.Empty; } }
+            private static InvalidOperationException NotInstalled()
+            {
+                return new InvalidOperationException(
+                    @"No IArgUsageProvider has been installed on ArgUsage.Provider. The host application must install one before rendering usage or reporting a command-line value error.");
+            }
 
-            public string ValueMissingMessage(string argText) { return string.Empty; }
-            public string ValueUnexpectedMessage(string argText) { return string.Empty; }
-            public string ValueInvalidMessage(string argText, string value, string[] argValues) { return string.Empty; }
-            public string ValueInvalidBoolMessage(string argText, string value) { return string.Empty; }
-            public string ValueInvalidIntMessage(string argText, string value) { return string.Empty; }
-            public string ValueOutOfRangeIntMessage(string argText, int value, int minVal, int maxVal) { return string.Empty; }
-            public string ValueInvalidDoubleMessage(string argText, string value) { return string.Empty; }
-            public string ValueOutOfRangeDoubleMessage(string argText, double value, double minVal, double maxVal) { return string.Empty; }
-            public string ValueInvalidDateMessage(string argText, string value) { return string.Empty; }
-            public string ValueInvalidPathMessage(string argText, string value) { return string.Empty; }
+            public string GetDescription(string argName) { throw NotInstalled(); }
+            public string AppliesToHeader { get { throw NotInstalled(); } }
+            public string ArgumentHeader { get { throw NotInstalled(); } }
+            public string DescriptionHeader { get { throw NotInstalled(); } }
+
+            public string ValueMissingMessage(string argText) { throw NotInstalled(); }
+            public string ValueUnexpectedMessage(string argText) { throw NotInstalled(); }
+            public string ValueInvalidMessage(string argText, string value, string[] argValues) { throw NotInstalled(); }
+            public string ValueInvalidBoolMessage(string argText, string value) { throw NotInstalled(); }
+            public string ValueInvalidIntMessage(string argText, string value) { throw NotInstalled(); }
+            public string ValueOutOfRangeIntMessage(string argText, int value, int minVal, int maxVal) { throw NotInstalled(); }
+            public string ValueInvalidDoubleMessage(string argText, string value) { throw NotInstalled(); }
+            public string ValueOutOfRangeDoubleMessage(string argText, double value, double minVal, double maxVal) { throw NotInstalled(); }
+            public string ValueInvalidDateMessage(string argText, string value) { throw NotInstalled(); }
+            public string ValueInvalidPathMessage(string argText, string value) { throw NotInstalled(); }
         }
     }
 }

--- a/pwiz_tools/Shared/PortableUtil/CommandLine/Argument.cs
+++ b/pwiz_tools/Shared/PortableUtil/CommandLine/Argument.cs
@@ -1,0 +1,92 @@
+/*
+ * Original author: Brendan MacLean <brendanx .at. u.washington.edu>,
+ *                  MacCoss Lab, Department of Genome Sciences, UW
+ *
+ * Copyright 2026 University of Washington - Seattle, WA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+using System;
+
+namespace pwiz.Common.CommandLine
+{
+    /// <summary>
+    /// A declarative command-line argument that processes its value against a host
+    /// controller of type <typeparamref name="TContext"/>. The host registers one of
+    /// these per recognized argument, embedding the parse/apply logic in <see cref="ProcessValue"/>.
+    /// </summary>
+    public class Argument<TContext> : ArgumentBase
+    {
+        public Argument(string name, Func<TContext, NameValuePair, bool> processValue)
+            : base(name, null, null, null)
+        {
+            ProcessValue = processValue;
+        }
+
+        public Argument(string name, Action<TContext, NameValuePair> processValue)
+            : this(name, (c, p) =>
+            {
+                processValue(c, p);
+                return true;
+            })
+        {
+        }
+
+        public Argument(string name, Func<string> valueExample, Func<TContext, NameValuePair, bool> processValue)
+            : base(name, valueExample, null, null)
+        {
+            ProcessValue = processValue;
+        }
+
+        public Argument(string name, Func<string> valueExample, Action<TContext, NameValuePair> processValue)
+            : this(name, valueExample, (c, p) =>
+            {
+                processValue(c, p);
+                return true;
+            })
+        {
+        }
+
+        public Argument(string name, string[] values, Func<TContext, NameValuePair, bool> processValue)
+            : base(name, () => ValuesToExample(values), values, null)
+        {
+            ProcessValue = processValue;
+        }
+
+        public Argument(string name, string[] values, Action<TContext, NameValuePair> processValue)
+            : this(name, values, (c, p) =>
+            {
+                processValue(c, p);
+                return true;
+            })
+        {
+        }
+
+        public Argument(string name, Func<string[]> values, Func<TContext, NameValuePair, bool> processValue)
+            : base(name, () => ValuesToExample(values()), null, values)
+        {
+            ProcessValue = processValue;
+        }
+
+        public Argument(string name, Func<string[]> values, Action<TContext, NameValuePair> processValue)
+            : this(name, values, (c, p) =>
+            {
+                processValue(c, p);
+                return true;
+            })
+        {
+        }
+
+        public Func<TContext, NameValuePair, bool> ProcessValue;
+    }
+}

--- a/pwiz_tools/Shared/PortableUtil/CommandLine/ArgumentBase.cs
+++ b/pwiz_tools/Shared/PortableUtil/CommandLine/ArgumentBase.cs
@@ -1,0 +1,150 @@
+/*
+ * Original author: Brendan MacLean <brendanx .at. u.washington.edu>,
+ *                  MacCoss Lab, Department of Genome Sciences, UW
+ *
+ * Copyright 2026 University of Washington - Seattle, WA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace pwiz.Common.CommandLine
+{
+    /// <summary>
+    /// The non-generic core of a declarative command-line argument: its name, the value
+    /// example/allowed values used to render help, and the flags controlling display and
+    /// validation. The strongly-typed value processor lives on <see cref="Argument{TContext}"/>.
+    /// </summary>
+    public abstract class ArgumentBase
+    {
+        public const string ARG_PREFIX = "--";
+
+        protected ArgumentBase(string name, Func<string> valueExample, string[] fixedValues, Func<string[]> dynamicValues)
+        {
+            Name = name;
+            ValueExample = valueExample;
+            _fixedValues = fixedValues;
+            _dynamicValues = dynamicValues;
+        }
+
+        private readonly string[] _fixedValues;
+        private readonly Func<string[]> _dynamicValues;
+
+        public string Name { get; private set; }
+        public string AppliesTo { get; set; }
+        public string Description
+        {
+            get { return ArgUsage.Provider.GetDescription(Name); }
+        }
+        public Func<string> ValueExample { get; private set; }
+        public string[] Values
+        {
+            get
+            {
+                return _dynamicValues?.Invoke() ?? _fixedValues;
+            }
+        }
+        public bool WrapValue { get; set; }
+        public bool OptionalValue { get; set; }
+        public bool InternalUse { get; set; }
+        public bool HasValueChecking { get; set; }  // Set to avoid default checking against values listed for documentation
+
+        public string ArgumentText
+        {
+            get { return ARG_PREFIX + Name; }
+        }
+
+        public string GetArgumentTextWithValue(string value)
+        {
+            if (ValueExample == null)
+                throw new ValueUnexpectedException(this);
+            else if (Values != null && !Values.Any(v => v.Equals(value, StringComparison.CurrentCultureIgnoreCase)))
+                throw new ValueInvalidException(this, value, Values);
+
+            return ArgumentText + '=' + value;
+        }
+
+        public static string operator +(ArgumentBase arg, string value)
+        {
+            return arg.GetArgumentTextWithValue(value);
+        }
+
+        public static implicit operator string(ArgumentBase arg)
+        {
+            return arg.ArgumentText;
+        }
+
+        public string ArgumentDescription
+        {
+            get
+            {
+                var retValue = ArgumentText;
+                if (ValueExample != null)
+                {
+                    var valueText = '=' + (WrapValue ? Environment.NewLine : string.Empty) + ValueExample();
+                    if (OptionalValue)
+                        valueText = '[' + valueText + ']';
+                    retValue += valueText;
+                }
+                return retValue;
+            }
+        }
+
+        public override string ToString()
+        {
+            return ArgumentDescription;
+        }
+
+        public static string ValuesToExample(IEnumerable<string> options)
+        {
+            var sb = new StringBuilder();
+            sb.Append('<');
+            foreach (var o in options)
+            {
+                if (sb.Length > 1)
+                    sb.Append(@" | ");
+                sb.Append(o);
+            }
+            sb.Append('>');
+            return sb.ToString();
+        }
+
+        public static string ValuesToExample(params string[] options)
+        {
+            return ValuesToExample((IEnumerable<string>) options);
+        }
+
+        public static NameValuePair Parse(string arg)
+        {
+            if (!arg.StartsWith(ARG_PREFIX))
+                return NameValuePair.EMPTY;
+
+            string name, value = null;
+            arg = arg.Substring(2);
+            int indexEqualsSign = arg.IndexOf('=');
+            if (indexEqualsSign >= 0)
+            {
+                name = arg.Substring(0, indexEqualsSign);
+                value = arg.Substring(indexEqualsSign + 1);
+            }
+            else
+            {
+                name = arg;
+            }
+            return new NameValuePair(name, value);
+        }
+    }
+}

--- a/pwiz_tools/Shared/PortableUtil/CommandLine/ArgumentGroup.cs
+++ b/pwiz_tools/Shared/PortableUtil/CommandLine/ArgumentGroup.cs
@@ -1,0 +1,224 @@
+/*
+ * Original author: Brendan MacLean <brendanx .at. u.washington.edu>,
+ *                  MacCoss Lab, Department of Genome Sciences, UW
+ *
+ * Copyright 2026 University of Washington - Seattle, WA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace pwiz.Common.CommandLine
+{
+    /// <summary>
+    /// A named, renderable group of related <see cref="Argument{TContext}"/> declarations.
+    /// Renders itself as an ascii/unicode table or HTML, and carries optional group-level
+    /// validation and inter-argument dependencies evaluated by the host controller.
+    /// </summary>
+    public class ArgumentGroup<TContext> : IUsageBlock
+    {
+        private readonly Func<string> _getTitle;
+
+        public ArgumentGroup(Func<string> getTitle, bool showHeaders, params Argument<TContext>[] args)
+        {
+            _getTitle = getTitle;
+            Args = args;
+            ShowHeaders = showHeaders;
+            Dependencies = new Dictionary<Argument<TContext>, Argument<TContext>>();
+        }
+
+        public string Title { get { return _getTitle(); } }
+        public Func<string> Preamble { get; set; }
+        public Func<string> Postamble { get; set; }
+        public IList<Argument<TContext>> Args { get; private set; }
+        public bool ShowHeaders { get; private set; }
+
+        public IDictionary<Argument<TContext>, Argument<TContext>> Dependencies { get; set; }
+
+        public Func<TContext, bool> Validate { get; set; }
+
+        public int? LeftColumnWidth { get; set; }
+
+        public bool IncludeInUsage
+        {
+            get { return !Args.All(a => a.InternalUse); }
+        }
+
+        public override string ToString()
+        {
+            return ToString(78, null, true);
+        }
+
+        public string ToString(int width, string formatType)
+        {
+            return ToString(width, formatType, false);
+        }
+
+        private string ToString(int width, string formatType, bool forDebugging)
+        {
+            if (!IncludeInUsage && !forDebugging)
+                return string.Empty;
+
+            var ct = new ConsoleTable
+            {
+                Title = Title,
+                Borders = formatType != ArgUsage.FORMAT_NO_BORDERS,
+                Ascii = formatType == ArgUsage.FORMAT_ASCII
+            };
+            if (Preamble != null)
+                ct.Preamble = Preamble();
+            if (Postamble != null)
+                ct.Postamble = Postamble();
+            ct.Width = width;
+
+            bool hasAppliesTo = Args.Any(a => a.AppliesTo != null);
+            if (ShowHeaders)
+            {
+                if (hasAppliesTo)
+                    ct.SetHeaders(ArgUsage.Provider.AppliesToHeader,
+                        ArgUsage.Provider.ArgumentHeader,
+                        ArgUsage.Provider.DescriptionHeader);
+                else
+                    ct.SetHeaders(ArgUsage.Provider.ArgumentHeader,
+                        ArgUsage.Provider.DescriptionHeader);
+            }
+
+            var usageArgs = Args.Where(a => !a.InternalUse).ToList();
+            foreach (var commandArg in usageArgs)
+            {
+                if (hasAppliesTo)
+                    ct.AddRow(commandArg.AppliesTo ?? string.Empty, commandArg.ArgumentDescription, commandArg.Description);
+                else
+                    ct.AddRow(commandArg.ArgumentDescription, commandArg.Description);
+            }
+
+            int GetIdealArgumentWidth(Argument<TContext> a)
+            {
+                int maxWidth = width / 2;
+
+                // if value is on a separate line or the argument by itself is over the max width, just use argument plus =
+                if (a.WrapValue || a.ArgumentText.Length + 2 > maxWidth)
+                    return a.ArgumentText.Length + 2;
+
+                // if value is included on single line, set a reasonable limit
+                return Math.Min(maxWidth, a.ArgumentDescription.Length);
+            }
+
+            if (!hasAppliesTo)
+            {
+                int minLines = int.MaxValue;
+                int bestWidth = 0;
+                for (int leftColumnWidth = usageArgs.Max(GetIdealArgumentWidth); leftColumnWidth < width - 10; leftColumnWidth += 5)
+                {
+                    ct.Widths = new[] { leftColumnWidth, width - leftColumnWidth - 3 };   // 3 borders
+                    int numLines = ct.ToString().Split(new [] { Environment.NewLine }, StringSplitOptions.None).Length;
+                    if (bestWidth == 0 || numLines <= minLines)
+                    {
+                        minLines = numLines;
+                        bestWidth = leftColumnWidth;
+                    }
+                }
+                ct.Widths = new[] { bestWidth, width - bestWidth - 3 };   // 3 borders
+            }
+
+            return ct.ToString();
+        }
+
+        public string ToHtmlString()
+        {
+            if (!IncludeInUsage)
+                return string.Empty;
+
+            // ReSharper disable LocalizableElement
+            var sb = new StringBuilder();
+            sb.AppendLine("<div class=\"RowType\">" + UsageHtmlEncoder.Encode(Title) + "</div>");
+            if (Preamble != null)
+                sb.AppendLine("<p>" + Preamble() + "</p>");
+            sb.AppendLine("<table>");
+            bool hasAppliesTo = Args.Any(a => a.AppliesTo != null);
+            if (ShowHeaders)
+            {
+                sb.Append("<tr>");
+
+                if (hasAppliesTo)
+                    sb.Append("<th>").Append(ArgUsage.Provider.AppliesToHeader).Append("</th>");
+                sb.Append("<th>").Append(ArgUsage.Provider.ArgumentHeader).Append("</th>");
+                sb.Append("<th>").Append(ArgUsage.Provider.DescriptionHeader).Append("</th>");
+
+                sb.AppendLine("</tr>");
+            }
+            foreach (var commandArg in Args.Where(a => !a.InternalUse))
+            {
+                sb.Append("<tr>");
+
+                if (hasAppliesTo)
+                    sb.Append("<td>").Append(commandArg.AppliesTo != null ? UsageHtmlEncoder.Encode(commandArg.AppliesTo) : "&nbsp;").Append("</td>");
+                string argDescription = UsageHtmlEncoder.Encode(commandArg.ArgumentDescription);
+                if (!argDescription.Contains('|') && !ArgUsage.IsWrappableListType(commandArg.ValueExample))
+                    argDescription = argDescription.Replace(" ", "&nbsp;");
+                argDescription = argDescription.Replace(Environment.NewLine, "<br/>");
+                sb.Append("<td>").Append(argDescription).Append("</td>");
+                sb.Append("<td>").Append(UsageHtmlEncoder.Encode(commandArg.Description)).Append("</td>");
+
+                sb.AppendLine("</tr>");
+            }
+            sb.AppendLine("</table>");
+            if (Postamble != null)
+                sb.AppendLine("<p>" + Postamble() + "</p>");
+
+            return sb.ToString();
+            // ReSharper restore LocalizableElement
+        }
+    }
+
+    /// <summary>
+    /// Non-generic helper for argument-table HTML encoding. Kept out of the generic
+    /// <see cref="ArgumentGroup{TContext}"/> so its compiled regex is shared across all
+    /// context types rather than duplicated per generic instantiation.
+    /// </summary>
+    internal static class UsageHtmlEncoder
+    {
+        // Regular expression for an argument: a hyphen surrounded by zero or more word characters
+        // (i.e. letters, numbers or UnicodeCategory.ConnectorPunctuation) or hyphens
+        private static readonly Regex REGEX_ARGUMENT = new Regex(@"[\w-]*-[\w-]*",
+            RegexOptions.Compiled | RegexOptions.CultureInvariant);
+        /// <summary>
+        /// HTML encodes the string.
+        /// Also, puts &lt;nobr> tags around everything that contains a hyphen so that argument names do not get broken across lines.
+        /// </summary>
+        public static string Encode(string str)
+        {
+            str = str ?? string.Empty;
+            var result = new StringBuilder();
+            int charIndex = 0;
+            var matchCollection = REGEX_ARGUMENT.Matches(str);
+            foreach (Match match in matchCollection)
+            {
+                result.Append(ArgUsage.HtmlEncode(str.Substring(charIndex, match.Index - charIndex)));
+                // ReSharper disable LocalizableElement
+                result.Append("<nobr>");
+                result.Append(ArgUsage.HtmlEncode(match.Value));
+                result.Append("</nobr>");
+                // ReSharper restore LocalizableElement
+                charIndex = match.Index + match.Length;
+            }
+
+            result.Append(ArgUsage.HtmlEncode(str.Substring(charIndex)));
+            return result.ToString();
+        }
+    }
+}

--- a/pwiz_tools/Shared/PortableUtil/CommandLine/ConsoleTable.cs
+++ b/pwiz_tools/Shared/PortableUtil/CommandLine/ConsoleTable.cs
@@ -20,11 +20,10 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
-using pwiz.Common.SystemUtil;
 
-namespace pwiz.Skyline.Util
+namespace pwiz.Common.CommandLine
 {
-    class ConsoleTable
+    public class ConsoleTable
     {
         /// <summary>
         /// This will hold the header of the table.
@@ -316,7 +315,12 @@ namespace pwiz.Skyline.Util
                                                         - (widths.Length - 1) // cell separators
                                                         - (Borders ? 2 : 0);  // outside borders if applicable
             }
-            Assume.IsTrue(widths.All(w => w > 0));
+            // Was Assume.IsTrue(widths.All(w => w > 0)) when this lived in Skyline. Inlined as a
+            // throw to keep PortableUtil a pure-BCL leaf (no CommonUtil dependency). Skyline's
+            // ExceptionUtil.IsProgrammingDefect classifies InvalidOperationException as a coding
+            // defect, so the failure is still treated like the old assertion.
+            if (!widths.All(w => w > 0))
+                throw new InvalidOperationException(@"ConsoleTable column widths must all be greater than zero.");
 
             return widths;
         }

--- a/pwiz_tools/Shared/PortableUtil/CommandLine/IUsageBlock.cs
+++ b/pwiz_tools/Shared/PortableUtil/CommandLine/IUsageBlock.cs
@@ -1,0 +1,31 @@
+/*
+ * Original author: Brendan MacLean <brendanx .at. u.washington.edu>,
+ *                  MacCoss Lab, Department of Genome Sciences, UW
+ *
+ * Copyright 2026 University of Washington - Seattle, WA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace pwiz.Common.CommandLine
+{
+    /// <summary>
+    /// A renderable section of command-line usage output (an argument group or a
+    /// paragraph). Rendered as plain text (ascii/unicode tables) or as HTML.
+    /// </summary>
+    public interface IUsageBlock
+    {
+        string ToString(int width, string formatType);
+        string ToHtmlString();
+    }
+}

--- a/pwiz_tools/Shared/PortableUtil/CommandLine/NameValuePair.cs
+++ b/pwiz_tools/Shared/PortableUtil/CommandLine/NameValuePair.cs
@@ -1,0 +1,187 @@
+/*
+ * Original author: Brendan MacLean <brendanx .at. u.washington.edu>,
+ *                  MacCoss Lab, Department of Genome Sciences, UW
+ *
+ * Copyright 2026 University of Washington - Seattle, WA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+using System;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+
+namespace pwiz.Common.CommandLine
+{
+    /// <summary>
+    /// A parsed "--name[=value]" token, matched against a declared <see cref="ArgumentBase"/>
+    /// and exposing strongly-typed coercions (bool/int/double/date/path) that throw the
+    /// framework's value exceptions on malformed input.
+    /// </summary>
+    public class NameValuePair
+    {
+        public static NameValuePair EMPTY = new NameValuePair(null, null);
+
+        public NameValuePair(string name, string value)
+        {
+            Name = name;
+            Value = value;
+        }
+
+        public string Name { get; private set; }
+        public string Value { get; private set; }
+
+        public ArgumentBase Match { get; private set; }
+
+        public bool ValueBool
+        {
+            get
+            {
+                if (IsNameOnly)
+                    return true;
+                if (bool.TryParse(Value, out var result))
+                    return result;
+                throw new ValueInvalidBoolException(Match, Value);
+            }
+        }
+
+        public int ValueInt
+        {
+            get
+            {
+                AssertMatched();
+                try
+                {
+                    return int.Parse(Value);
+                }
+                catch (FormatException)
+                {
+                    throw new ValueInvalidIntException(Match, Value);
+                }
+            }
+        }
+
+        public int GetValueInt(int minVal, int maxVal)
+        {
+            int v = ValueInt;
+            if (minVal > v || v > maxVal)
+                throw new ValueOutOfRangeIntException(Match, v, minVal, maxVal);
+            return v;
+        }
+
+        public double ValueDouble
+        {
+            get
+            {
+                AssertMatched();
+                double valueDouble;
+                // Try both local and invariant formats to make batch files more portable
+                if (!double.TryParse(Value, out valueDouble) && !double.TryParse(Value, NumberStyles.Float, CultureInfo.InvariantCulture, out valueDouble))
+                    throw new ValueInvalidDoubleException(Match, Value);
+                return valueDouble;
+            }
+        }
+
+        public double GetValueDouble(double minVal, double maxVal)
+        {
+            double v = ValueDouble;
+            if (minVal > v || v > maxVal)
+                throw new ValueOutOfRangeDoubleException(Match, v, minVal, maxVal);
+            return v;
+        }
+
+        public DateTime ValueDate
+        {
+            get
+            {
+                AssertMatched();
+                try
+                {
+                    // Try local format
+                    return Convert.ToDateTime(Value);
+                }
+                catch (Exception)
+                {
+                    try
+                    {
+                        // Try invariant format to make command-line batch files more portable
+                        return Convert.ToDateTime(Value, CultureInfo.InvariantCulture);
+                    }
+                    catch (Exception)
+                    {
+                        throw new ValueInvalidDateException(Match, Value);
+                    }
+                }
+            }
+        }
+
+        public string ValueFullPath
+        {
+            get
+            {
+                try
+                {
+                    if (ArgUsage.IsRemoteUrl(Value))
+                        return Value;
+                    return Path.GetFullPath(Value);
+                }
+                catch (Exception)
+                {
+                    throw new ValueInvalidPathException(Match, Value);
+                }
+            }
+        }
+
+        public bool IsEmpty { get { return string.IsNullOrEmpty(Name); } }
+        public bool IsNameOnly { get { return string.IsNullOrEmpty(Value); } }
+
+        public bool IsMatch(ArgumentBase arg)
+        {
+            if (!Name.Equals(arg.Name))
+                return false;
+            if (arg.ValueExample == null && !IsNameOnly)
+                throw new ValueUnexpectedException(arg);
+            if (arg.ValueExample != null)
+            {
+                if (IsNameOnly)
+                {
+                    if (!arg.OptionalValue)
+                        throw new ValueMissingException(arg);
+                }
+                else
+                {
+                    var val = Value;
+                    if (arg.Values != null && !arg.HasValueChecking && !arg.Values.Any(v => v.Equals(val, StringComparison.CurrentCultureIgnoreCase)))
+                        throw new ValueInvalidException(arg, Value, arg.Values);
+                }
+            }
+
+            Match = arg;
+            return true;
+        }
+
+        public bool IsValue(string value)
+        {
+            return value.Equals(Value, StringComparison.CurrentCultureIgnoreCase);
+        }
+
+        private void AssertMatched()
+        {
+            // Was Assume.IsNotNull(Match) in Skyline. Inlined as a throw to keep PortableUtil
+            // a pure-BCL leaf. Indicates a coding defect: a coercion was read before the pair
+            // was matched to a declared argument.
+            if (Match == null)
+                throw new InvalidOperationException(@"NameValuePair value accessed before being matched to an argument.");
+        }
+    }
+}

--- a/pwiz_tools/Shared/PortableUtil/CommandLine/NameValuePair.cs
+++ b/pwiz_tools/Shared/PortableUtil/CommandLine/NameValuePair.cs
@@ -30,7 +30,7 @@ namespace pwiz.Common.CommandLine
     /// </summary>
     public class NameValuePair
     {
-        public static NameValuePair EMPTY = new NameValuePair(null, null);
+        public static readonly NameValuePair EMPTY = new NameValuePair(null, null);
 
         public NameValuePair(string name, string value)
         {

--- a/pwiz_tools/Shared/PortableUtil/CommandLine/ParaUsageBlock.cs
+++ b/pwiz_tools/Shared/PortableUtil/CommandLine/ParaUsageBlock.cs
@@ -1,0 +1,45 @@
+/*
+ * Original author: Brendan MacLean <brendanx .at. u.washington.edu>,
+ *                  MacCoss Lab, Department of Genome Sciences, UW
+ *
+ * Copyright 2026 University of Washington - Seattle, WA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace pwiz.Common.CommandLine
+{
+    /// <summary>
+    /// A free-text paragraph in usage output (intro/section prose), rendered as a
+    /// borderless wrapped block in plain text and a &lt;p&gt; element in HTML.
+    /// </summary>
+    public class ParaUsageBlock : IUsageBlock
+    {
+        public ParaUsageBlock(string text)
+        {
+            Text = text;
+        }
+
+        public string Text { get; private set; }
+
+        public string ToString(int width, string formatType)
+        {
+            return ConsoleTable.ParaToString(width, Text, true);
+        }
+
+        public string ToHtmlString()
+        {
+            return @"<p>" + Text + @"</p>";
+        }
+    }
+}

--- a/pwiz_tools/Shared/PortableUtil/CommandLine/UsageException.cs
+++ b/pwiz_tools/Shared/PortableUtil/CommandLine/UsageException.cs
@@ -1,0 +1,115 @@
+/*
+ * Original author: Brendan MacLean <brendanx .at. u.washington.edu>,
+ *                  MacCoss Lab, Department of Genome Sciences, UW
+ *
+ * Copyright 2026 University of Washington - Seattle, WA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+using System;
+
+namespace pwiz.Common.CommandLine
+{
+    /// <summary>
+    /// Base for all command-line usage errors (a bad or missing argument value). The
+    /// message is supplied pre-formatted/localized; the context-free value exceptions
+    /// below build theirs through <see cref="ArgUsage.Provider"/>. Host applications
+    /// subclass this for domain-specific value errors.
+    /// </summary>
+    public class UsageException : ArgumentException
+    {
+        protected UsageException(string message) : base(message)
+        {
+        }
+    }
+
+    public class ValueMissingException : UsageException
+    {
+        public ValueMissingException(ArgumentBase arg)
+            : base(ArgUsage.Provider.ValueMissingMessage(arg.ArgumentText))
+        {
+        }
+    }
+
+    public class ValueUnexpectedException : UsageException
+    {
+        public ValueUnexpectedException(ArgumentBase arg)
+            : base(ArgUsage.Provider.ValueUnexpectedMessage(arg.ArgumentText))
+        {
+        }
+    }
+
+    public class ValueInvalidException : UsageException
+    {
+        public ValueInvalidException(ArgumentBase arg, string value, string[] argValues)
+            : base(ArgUsage.Provider.ValueInvalidMessage(arg.ArgumentText, value, argValues))
+        {
+        }
+    }
+
+    public class ValueInvalidBoolException : UsageException
+    {
+        public ValueInvalidBoolException(ArgumentBase arg, string value)
+            : base(ArgUsage.Provider.ValueInvalidBoolMessage(arg.ArgumentText, value))
+        {
+        }
+    }
+
+    public class ValueInvalidDoubleException : UsageException
+    {
+        public ValueInvalidDoubleException(ArgumentBase arg, string value)
+            : base(ArgUsage.Provider.ValueInvalidDoubleMessage(arg.ArgumentText, value))
+        {
+        }
+    }
+
+    public class ValueOutOfRangeDoubleException : UsageException
+    {
+        public ValueOutOfRangeDoubleException(ArgumentBase arg, double value, double minVal, double maxVal)
+            : base(ArgUsage.Provider.ValueOutOfRangeDoubleMessage(arg.ArgumentText, value, minVal, maxVal))
+        {
+        }
+    }
+
+    public class ValueInvalidIntException : UsageException
+    {
+        public ValueInvalidIntException(ArgumentBase arg, string value)
+            : base(ArgUsage.Provider.ValueInvalidIntMessage(arg.ArgumentText, value))
+        {
+        }
+    }
+
+    public class ValueOutOfRangeIntException : UsageException
+    {
+        public ValueOutOfRangeIntException(ArgumentBase arg, int value, int minVal, int maxVal)
+            : base(ArgUsage.Provider.ValueOutOfRangeIntMessage(arg.ArgumentText, value, minVal, maxVal))
+        {
+        }
+    }
+
+    public class ValueInvalidDateException : UsageException
+    {
+        public ValueInvalidDateException(ArgumentBase arg, string value)
+            : base(ArgUsage.Provider.ValueInvalidDateMessage(arg.ArgumentText, value))
+        {
+        }
+    }
+
+    public class ValueInvalidPathException : UsageException
+    {
+        public ValueInvalidPathException(ArgumentBase arg, string value)
+            : base(ArgUsage.Provider.ValueInvalidPathMessage(arg.ArgumentText, value))
+        {
+        }
+    }
+}

--- a/pwiz_tools/Shared/PortableUtil/PortableUtil.csproj
+++ b/pwiz_tools/Shared/PortableUtil/PortableUtil.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <!-- PortableUtil is a pure-BCL, SDK-style leaf assembly: the net8.0-capable
+       staging ground for portable pieces of CommonUtil (which is net472-only,
+       non-SDK, and GUI/web-laden). It must NOT reference CommonUtil or any other
+       pwiz assembly. Props are inlined here on purpose - a Directory.Build.props
+       under Shared/ would leak into the sibling non-SDK projects. -->
+  <PropertyGroup>
+    <TargetFrameworks>net472;net8.0</TargetFrameworks>
+    <!-- SDK-style csproj defaults to AnyCPU, but Skyline.sln/OspreySharp.sln use
+         x64 configurations. Declare both so the x64 sln configs map cleanly and
+         the net8.0 target can still build AnyCPU on other hosts. The sln maps its
+         x86 config rows to this project's AnyCPU (the slns have no AnyCPU). -->
+    <Platforms>AnyCPU;x64</Platforms>
+    <LangVersion>latest</LangVersion>
+    <Nullable>disable</Nullable>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <RootNamespace>pwiz.Common</RootNamespace>
+    <AssemblyName>pwiz.PortableUtil</AssemblyName>
+    <Company>University of Washington</Company>
+    <Copyright>Copyright (c) University of Washington 2026</Copyright>
+  </PropertyGroup>
+
+</Project>

--- a/pwiz_tools/Skyline/CommandArgs.cs
+++ b/pwiz_tools/Skyline/CommandArgs.cs
@@ -29,6 +29,7 @@ using System.Web;
 using System.Xml.Serialization;
 using pwiz.Common.Chemistry;
 using pwiz.Common.Collections;
+using pwiz.Common.CommandLine;
 using pwiz.Common.DataBinding.Documentation;
 using pwiz.Common.SystemUtil;
 using pwiz.CommonMsData;

--- a/pwiz_tools/Skyline/CommandArgs.cs
+++ b/pwiz_tools/Skyline/CommandArgs.cs
@@ -52,11 +52,30 @@ using pwiz.Skyline.Properties;
 using pwiz.Skyline.Util;
 using pwiz.Skyline.Util.Extensions;
 using static pwiz.Skyline.Model.Proteome.ProteinAssociation;
+// The generic CLI-argument framework now lives in PortableUtil. These file-scoped aliases
+// keep the 100+ argument declarations below (and DocArgument/RefineArgument/ToolArgument)
+// compiling unchanged against the Skyline-typed instantiations.
+using Argument = pwiz.Common.CommandLine.Argument<pwiz.Skyline.CommandArgs>;
+using ArgumentGroup = pwiz.Common.CommandLine.ArgumentGroup<pwiz.Skyline.CommandArgs>;
 
 namespace pwiz.Skyline
 {
     public class CommandArgs
     {
+        // Installs Skyline's text and behavior into the PortableUtil CLI-argument framework
+        // seams. Runs before any argument parsing, usage rendering, or value-exception is
+        // thrown (the first access to any CommandArgs static member triggers this, and every
+        // such path touches a static member first).
+        static CommandArgs()
+        {
+            ArgUsage.Provider = new SkylineArgUsageProvider();
+            ArgUsage.IsRemoteUrl = IsRemoteUrl;
+            ArgUsage.IsWrappableListType = ve => WRAPPABLE_LIST_TYPE_VALUES.Contains(ve);
+            // Keep Skyline's usage HTML byte-identical to the committed goldens by using the
+            // same encoder it always has (HttpUtility); PortableUtil defaults to WebUtility.
+            ArgUsage.HtmlEncode = HttpUtility.HtmlEncode;
+        }
+
         // Argument value descriptions
         private static readonly Func<string> PATH_TO_FILE = () => CommandArgUsage.CommandArgs_PATH_TO_FILE_path_to_file;
 
@@ -252,8 +271,8 @@ namespace pwiz.Skyline
         public static readonly Argument ARG_HELP = new Argument(@"help",
             new[] { ARG_VALUE_ASCII, ARG_VALUE_NO_BORDERS, ARG_VALUE_SECTIONS },
             (c, p) => c.Usage(p.Value)) {OptionalValue = true, HasValueChecking = true};
-        public const string ARG_VALUE_ASCII = "ascii";
-        public const string ARG_VALUE_NO_BORDERS = "no-borders";
+        public const string ARG_VALUE_ASCII = ArgUsage.FORMAT_ASCII;
+        public const string ARG_VALUE_NO_BORDERS = ArgUsage.FORMAT_NO_BORDERS;
         public const string ARG_VALUE_SECTIONS = "sections";
         public static readonly Argument ARG_VERSION = new Argument(@"version", (c, p) => c.Version());
         public static readonly Argument ARG_VERBOSE_ERRORS =
@@ -1596,7 +1615,7 @@ namespace pwiz.Skyline
             (c, p) => c.FullScanProductMassAnalyzerType = p);
         public static readonly Argument ARG_FULL_SCAN_PRODUCT_ISOLATION_SCHEME = new DocArgument(
                 @"full-scan-isolation-scheme",
-                () => Argument.ValuesToExample(GetDisplayNames(Settings.Default.IsolationSchemeList)
+                () => ArgumentBase.ValuesToExample(GetDisplayNames(Settings.Default.IsolationSchemeList)
                     .Append(CommandArgUsage.CommandArgs_ARG_FULL_SCAN_PRODUCT_ISOLATION_SCHEME_path_to_result_file_to_import_the_isolation_scheme)),
                 (c, p) => c.FullScanProductIsolationScheme = p.Value)
             { WrapValue = true };
@@ -1632,7 +1651,7 @@ namespace pwiz.Skyline
         public static readonly Argument ARG_PEPTIDE_UNIQUE_BY = DocArgument.FromEnumType<PeptideFilter.PeptideUniquenessConstraint>(@"pep-unique-by",
             (c, p) => c.PeptideDigestUniquenessConstraint = p);
         public static readonly Argument ARG_BGPROTEOME_NAME = new DocArgument(@"background-proteome-name",
-                () => Argument.ValuesToExample(Settings.Default.BackgroundProteomeList.Select(p => p.Name)
+                () => ArgumentBase.ValuesToExample(Settings.Default.BackgroundProteomeList.Select(p => p.Name)
                     .Append(SkylineResources.CommandArgs_ARG_BGPROTEOME_NAME_name_to_give_protdb_imported_by___background_proteome_file)),
                 (c, p) => c.BackgroundProteomeName = p.Value)
             { WrapValue = true };
@@ -2424,26 +2443,6 @@ namespace pwiz.Skyline
             }
         }
 
-        private class ParaUsageBlock : IUsageBlock
-        {
-            public ParaUsageBlock(string text)
-            {
-                Text = text;
-            }
-
-            public string Text { get; private set; }
-
-            public string ToString(int width, string formatType)
-            {
-                return ConsoleTable.ParaToString(width, Text, true);
-            }
-
-            public string ToHtmlString()
-            {
-                return @"<p>" + Text + @"</p>";
-            }
-        }
-
         public static IEnumerable<IUsageBlock> UsageBlocks
         {
             get
@@ -2628,7 +2627,7 @@ namespace pwiz.Skyline
 
             foreach (string s in args)
             {
-                var pair = Argument.Parse(s);
+                var pair = ArgumentBase.Parse(s);
                 if (!ProcessArgument(pair))
                     return false;
             }
@@ -2716,180 +2715,6 @@ namespace pwiz.Skyline
         private void ErrorArgsExclusive(Argument arg1, Argument arg2)
         {
             WriteLine(ErrorArgsExclusiveText(arg1, arg2));
-        }
-
-        public class Argument
-        {
-            private const string ARG_PREFIX = "--";
-
-            public Argument(string name, Func<CommandArgs, NameValuePair, bool> processValue)
-            {
-                Name = name;
-                ProcessValue = processValue;
-            }
-
-            public Argument(string name, Action<CommandArgs, NameValuePair> processValue)
-                : this(name, (c, p) =>
-                {
-                    processValue(c, p);
-                    return true;
-                })
-            {
-            }
-
-            public Argument(string name, Func<string> valueExample, Func<CommandArgs, NameValuePair, bool> processValue)
-                : this(name, processValue)
-            {
-                ValueExample = valueExample;
-            }
-
-            public Argument(string name, Func<string> valueExample, Action<CommandArgs, NameValuePair> processValue)
-                : this(name, valueExample, (c, p) =>
-                {
-                    processValue(c, p);
-                    return true;
-                })
-            {
-            }
-
-            public Argument(string name, string[] values, Func<CommandArgs, NameValuePair, bool> processValue)
-                : this(name, () => ValuesToExample(values), processValue)
-            {
-                _fixedValues = values;
-            }
-
-            public Argument(string name, string[] values, Action<CommandArgs, NameValuePair> processValue)
-                : this(name, values, (c, p) =>
-                {
-                    processValue(c, p);
-                    return true;
-                })
-            {
-            }
-
-            public Argument(string name, Func<string[]> values, Func<CommandArgs, NameValuePair, bool> processValue)
-                : this(name, () => ValuesToExample(values()), processValue)
-            {
-                _dynamicValues = values;
-            }
-
-            public Argument(string name, Func<string[]> values, Action<CommandArgs, NameValuePair> processValue)
-                : this(name, values, (c, p) =>
-                {
-                    processValue(c, p);
-                    return true;
-                })
-            {
-            }
-
-            private string[] _fixedValues;
-            private Func<string[]> _dynamicValues;
-
-            public Func<CommandArgs, NameValuePair, bool> ProcessValue;
-
-            public string Name { get; private set; }
-            public string AppliesTo { get; set; }
-            public string Description
-            {
-                get { return CommandArgUsage.ResourceManager.GetString(@"_" + Name.Replace('-', '_')); }
-            }
-            public Func<string> ValueExample { get; private set; }
-            public string[] Values
-            {
-                get
-                {
-                    return _dynamicValues?.Invoke() ?? _fixedValues;
-                }
-            }
-            public bool WrapValue { get; set; }
-            public bool OptionalValue { get; set; }
-            public bool InternalUse { get; set; }
-            public bool HasValueChecking { get; set; }  // Set to avoid default checking against values listed for documentation
-
-            public string ArgumentText
-            {
-                get { return ARG_PREFIX + Name; }
-            }
-
-            public string GetArgumentTextWithValue(string value)
-            {
-                if (ValueExample == null)
-                    throw new ValueUnexpectedException(this);
-                else if (Values != null && !Values.Any(v => v.Equals(value, StringComparison.CurrentCultureIgnoreCase)))
-                    throw new ValueInvalidException(this, value, Values);
-
-                return ArgumentText + '=' + value;
-            }
-
-            public static string operator +(Argument arg, string value)
-            {
-                return arg.GetArgumentTextWithValue(value);
-            }
-
-            public static implicit operator string(Argument arg)
-            {
-                return arg.ArgumentText;
-            }
-
-            public string ArgumentDescription
-            {
-                get
-                {
-                    var retValue = ArgumentText;
-                    if (ValueExample != null)
-                    {
-                        var valueText = '=' + (WrapValue ? Environment.NewLine : string.Empty) + ValueExample();
-                        if (OptionalValue)
-                            valueText = '[' + valueText + ']';
-                        retValue += valueText;
-                    }
-                    return retValue;
-                }
-            }
-
-            public override string ToString()
-            {
-                return ArgumentDescription;
-            }
-
-            public static string ValuesToExample(IEnumerable<string> options)
-            {
-                var sb = new StringBuilder();
-                sb.Append('<');
-                foreach (var o in options)
-                {
-                    if (sb.Length > 1)
-                        sb.Append(@" | ");
-                    sb.Append(o);
-                }
-                sb.Append('>');
-                return sb.ToString();
-            }
-
-            public static string ValuesToExample(params string[] options)
-            {
-                return ValuesToExample((IEnumerable<string>) options);
-            }
-
-            public static NameValuePair Parse(string arg)
-            {
-                if (!arg.StartsWith(ARG_PREFIX))
-                    return NameValuePair.EMPTY;
-
-                string name, value = null;
-                arg = arg.Substring(2);
-                int indexEqualsSign = arg.IndexOf('=');
-                if (indexEqualsSign >= 0)
-                {
-                    name = arg.Substring(0, indexEqualsSign);
-                    value = arg.Substring(indexEqualsSign + 1);
-                }
-                else
-                {
-                    name = arg;
-                }
-                return new NameValuePair(name, value);
-            }
         }
 
         /// <summary>
@@ -3047,405 +2872,76 @@ namespace pwiz.Skyline
             }
         }
 
-        public class NameValuePair
+        /// <summary>
+        /// Supplies Skyline's localized descriptions, usage-table headers, and value-error
+        /// messages to the PortableUtil CLI-argument framework. Message templates are copied
+        /// verbatim from the former nested value exceptions to keep output byte-identical.
+        /// </summary>
+        private class SkylineArgUsageProvider : IArgUsageProvider
         {
-            public static NameValuePair EMPTY = new NameValuePair(null, null);
-
-            public NameValuePair(string name, string value)
+            public string GetDescription(string argName)
             {
-                Name = name;
-                Value = value;
+                return CommandArgUsage.ResourceManager.GetString(@"_" + argName.Replace('-', '_'));
             }
 
-            public string Name { get; private set; }
-            public string Value { get; private set; }
+            public string AppliesToHeader => CommandArgUsage.CommandArgGroup_ToString_Applies_To;
+            public string ArgumentHeader => CommandArgUsage.CommandArgGroup_ToString_Argument;
+            public string DescriptionHeader => CommandArgUsage.CommandArgGroup_ToString_Description;
 
-            public Argument Match { get; private set; }
-
-            public bool ValueBool
+            public string ValueMissingMessage(string argText)
             {
-                get
-                {
-                    if (IsNameOnly)
-                        return true;
-                    if (bool.TryParse(Value, out var result))
-                        return result;
-                    throw new ValueInvalidBoolException(Match, Value);
-                }
+                return string.Format(Resources.ValueMissingException_ValueMissingException_, argText);
             }
 
-            public int ValueInt
+            public string ValueUnexpectedMessage(string argText)
             {
-                get
-                {
-                    Assume.IsNotNull(Match); // Must be matched before accessing this
-                    try
-                    {
-                        return int.Parse(Value);
-                    }
-                    catch (FormatException)
-                    {
-                        throw new ValueInvalidIntException(Match, Value);
-                    }
-                }
+                return string.Format(Resources.ValueUnexpectedException_ValueUnexpectedException_The_argument__0__should_not_have_a_value_specified, argText);
             }
 
-            public int GetValueInt(int minVal, int maxVal)
+            public string ValueInvalidMessage(string argText, string value, string[] argValues)
             {
-                int v = ValueInt;
-                if (minVal > v || v > maxVal)
-                    throw new ValueOutOfRangeIntException(Match, v, minVal, maxVal);
-                return v;
+                return string.Format(CommandArgUsage.ValueInvalidException_ValueInvalidException_The_value___0___is_not_valid_for_the_argument__1___Use_one_of__2_, value, argText, string.Join(@", ", argValues));
             }
 
-            public double ValueDouble
+            public string ValueInvalidBoolMessage(string argText, string value)
             {
-                get
-                {
-                    Assume.IsNotNull(Match); // Must be matched before accessing this
-                    double valueDouble;
-                    // Try both local and invariant formats to make batch files more portable
-                    if (!double.TryParse(Value, out valueDouble) && !double.TryParse(Value, NumberStyles.Float, CultureInfo.InvariantCulture, out valueDouble))
-                        throw new ValueInvalidDoubleException(Match, Value);
-                    return valueDouble;
-                }
+                return string.Format(CommandArgUsage.ValueInvalidBoolException_ValueInvalidBoolException_The_value___0___is_not_valid_for_the_argument___1____it_must_be__2_, value, argText, BOOL_VALUE());
             }
 
-            public double GetValueDouble(double minVal, double maxVal)
+            public string ValueInvalidIntMessage(string argText, string value)
             {
-                double v = ValueDouble;
-                if (minVal > v || v > maxVal)
-                    throw new ValueOutOfRangeDoubleException(Match, v, minVal, maxVal);
-                return v;
+                return string.Format(Resources.ValueInvalidIntException_ValueInvalidIntException_The_value___0___is_not_valid_for_the_argument__1__which_requires_an_integer_, value, argText);
             }
 
-            public DateTime ValueDate
+            public string ValueOutOfRangeIntMessage(string argText, int value, int minVal, int maxVal)
             {
-                get
-                {
-                    Assume.IsNotNull(Match); // Must be matched before accessing this
-                    try
-                    {
-                        // Try local format
-                        return Convert.ToDateTime(Value);
-                    }
-                    catch (Exception)
-                    {
-                        try
-                        {
-                            // Try invariant format to make command-line batch files more portable
-                            return Convert.ToDateTime(Value, CultureInfo.InvariantCulture);
-                        }
-                        catch (Exception)
-                        {
-                            throw new ValueInvalidDateException(Match, Value);
-                        }
-                    }
-                }
+                return string.Format(Resources.ValueOutOfRangeDoubleException_ValueOutOfRangeException_The_value___0___for_the_argument__1__must_be_between__2__and__3__, value, argText, minVal, maxVal);
             }
 
-            public string ValueFullPath
+            public string ValueInvalidDoubleMessage(string argText, string value)
             {
-                get
-                {
-                    try
-                    {
-                        if (IsRemoteUrl(Value))
-                            return Value;
-                        return Path.GetFullPath(Value);
-                    }
-                    catch (Exception)
-                    {
-                        throw new ValueInvalidPathException(Match, Value);
-                    }
-                }
+                return string.Format(Resources.ValueInvalidDoubleException_ValueInvalidDoubleException_The_value___0___is_not_valid_for_the_argument__1__which_requires_a_decimal_number_, value, argText);
             }
 
-            public bool IsEmpty { get { return string.IsNullOrEmpty(Name); } }
-            public bool IsNameOnly { get { return string.IsNullOrEmpty(Value); } }
-
-            public bool IsMatch(Argument arg)
+            public string ValueOutOfRangeDoubleMessage(string argText, double value, double minVal, double maxVal)
             {
-                if (!Name.Equals(arg.Name))
-                    return false;
-                if (arg.ValueExample == null && !IsNameOnly)
-                    throw new ValueUnexpectedException(arg);
-                if (arg.ValueExample != null)
-                {
-                    if (IsNameOnly)
-                    {
-                        if (!arg.OptionalValue)
-                            throw new ValueMissingException(arg);
-                    }
-                    else
-                    {
-                        var val = Value;
-                        if (arg.Values != null && !arg.HasValueChecking && !arg.Values.Any(v => v.Equals(val, StringComparison.CurrentCultureIgnoreCase)))
-                            throw new ValueInvalidException(arg, Value, arg.Values);
-                    }
-                }
-
-                Match = arg;
-                return true;
+                return string.Format(Resources.ValueOutOfRangeDoubleException_ValueOutOfRangeException_The_value___0___for_the_argument__1__must_be_between__2__and__3__, value, argText, minVal, maxVal);
             }
 
-            public bool IsValue(string value)
+            public string ValueInvalidDateMessage(string argText, string value)
             {
-                return value.Equals(Value, StringComparison.CurrentCultureIgnoreCase);
-            }
-        }
-
-        public class ArgumentGroup : IUsageBlock
-        {
-            private readonly Func<string> _getTitle;
-
-            public ArgumentGroup(Func<string> getTitle, bool showHeaders, params Argument[] args)
-            {
-                _getTitle = getTitle;
-                Args = args;
-                ShowHeaders = showHeaders;
-                Dependencies = new Dictionary<Argument, Argument>();
+                return string.Format(Resources.ValueInvalidDateException_ValueInvalidDateException_The_value___0___is_not_valid_for_the_argument__1__which_requires_a_date_time_value_, value, argText);
             }
 
-            public string Title { get { return _getTitle(); } }
-            public Func<string> Preamble { get; set; }
-            public Func<string> Postamble { get; set; }
-            public IList<Argument> Args { get; private set; }
-            public bool ShowHeaders { get; private set; }
-
-            public IDictionary<Argument, Argument> Dependencies { get; set; }
-
-            public Func<CommandArgs, bool> Validate { get; set; }
-
-            public int? LeftColumnWidth { get; set; }
-
-            public bool IncludeInUsage
+            public string ValueInvalidPathMessage(string argText, string value)
             {
-                get { return !Args.All(a => a.InternalUse); }
-            }
-
-            public override string ToString()
-            {
-                return ToString(78, null, true);
-            }
-
-            public string ToString(int width, string formatType)
-            {
-                return ToString(width, formatType, false);
-            }
-
-            private string ToString(int width, string formatType, bool forDebugging)
-            {
-                if (!IncludeInUsage && !forDebugging)
-                    return string.Empty;
-
-                var ct = new ConsoleTable
-                {
-                    Title = Title,
-                    Borders = formatType != ARG_VALUE_NO_BORDERS,
-                    Ascii = formatType == ARG_VALUE_ASCII
-                };
-                if (Preamble != null)
-                    ct.Preamble = Preamble();
-                if (Postamble != null)
-                    ct.Postamble = Postamble();
-                ct.Width = width;
-
-                bool hasAppliesTo = Args.Any(a => a.AppliesTo != null);
-                if (ShowHeaders)
-                {
-                    if (hasAppliesTo)
-                        ct.SetHeaders(CommandArgUsage.CommandArgGroup_ToString_Applies_To,
-                            CommandArgUsage.CommandArgGroup_ToString_Argument,
-                            CommandArgUsage.CommandArgGroup_ToString_Description);
-                    else
-                        ct.SetHeaders(CommandArgUsage.CommandArgGroup_ToString_Argument,
-                            CommandArgUsage.CommandArgGroup_ToString_Description);
-                }
-
-                var usageArgs = Args.Where(a => !a.InternalUse).ToList();
-                foreach (var commandArg in usageArgs)
-                {
-                    if (hasAppliesTo)
-                        ct.AddRow(commandArg.AppliesTo ?? string.Empty, commandArg.ArgumentDescription, commandArg.Description);
-                    else
-                        ct.AddRow(commandArg.ArgumentDescription, commandArg.Description);
-                }
-
-                int GetIdealArgumentWidth(Argument a)
-                {
-                    int maxWidth = width / 2;
-
-                    // if value is on a separate line or the argument by itself is over the max width, just use argument plus =
-                    if (a.WrapValue || a.ArgumentText.Length + 2 > maxWidth)
-                        return a.ArgumentText.Length + 2;
-
-                    // if value is included on single line, set a reasonable limit
-                    return Math.Min(maxWidth, a.ArgumentDescription.Length);
-                }
-
-                if (!hasAppliesTo)
-                {
-                    int minLines = int.MaxValue;
-                    int bestWidth = 0;
-                    for (int leftColumnWidth = usageArgs.Max(GetIdealArgumentWidth); leftColumnWidth < width - 10; leftColumnWidth += 5)
-                    {
-                        ct.Widths = new[] { leftColumnWidth, width - leftColumnWidth - 3 };   // 3 borders
-                        int numLines = ct.ToString().Split(new [] { Environment.NewLine }, StringSplitOptions.None).Length;
-                        if (bestWidth == 0 || numLines <= minLines)
-                        {
-                            minLines = numLines;
-                            bestWidth = leftColumnWidth;
-                        }
-                    }
-                    ct.Widths = new[] { bestWidth, width - bestWidth - 3 };   // 3 borders
-                }
-
-                return ct.ToString();
-            }
-
-            public string ToHtmlString()
-            {
-                if (!IncludeInUsage)
-                    return string.Empty;
-
-                // ReSharper disable LocalizableElement
-                var sb = new StringBuilder();
-                sb.AppendLine("<div class=\"RowType\">" + HtmlEncode(Title) + "</div>");
-                if (Preamble != null)
-                    sb.AppendLine("<p>" + Preamble() + "</p>");
-                sb.AppendLine("<table>");
-                bool hasAppliesTo = Args.Any(a => a.AppliesTo != null);
-                if (ShowHeaders)
-                {
-                    sb.Append("<tr>");
-
-                    if (hasAppliesTo)
-                        sb.Append("<th>").Append(CommandArgUsage.CommandArgGroup_ToString_Applies_To).Append("</th>");
-                    sb.Append("<th>").Append(CommandArgUsage.CommandArgGroup_ToString_Argument).Append("</th>");
-                    sb.Append("<th>").Append(CommandArgUsage.CommandArgGroup_ToString_Description).Append("</th>");
-
-                    sb.AppendLine("</tr>");
-                }
-                foreach (var commandArg in Args.Where(a => !a.InternalUse))
-                {
-                    sb.Append("<tr>");
-
-                    if (hasAppliesTo)
-                        sb.Append("<td>").Append(commandArg.AppliesTo != null ? HtmlEncode(commandArg.AppliesTo) : "&nbsp;").Append("</td>");
-                    string argDescription = HtmlEncode(commandArg.ArgumentDescription);
-                    if (!argDescription.Contains('|') && !WRAPPABLE_LIST_TYPE_VALUES.Contains(commandArg.ValueExample))
-                        argDescription = argDescription.Replace(" ", "&nbsp;");
-                    argDescription = argDescription.Replace(Environment.NewLine, "<br/>");
-                    sb.Append("<td>").Append(argDescription).Append("</td>");
-                    sb.Append("<td>").Append(HtmlEncode(commandArg.Description)).Append("</td>");
-
-                    sb.AppendLine("</tr>");
-                }
-                sb.AppendLine("</table>");
-                if (Postamble != null)
-                    sb.AppendLine("<p>" + Postamble() + "</p>");
-
-                return sb.ToString();
-                // ReSharper restore LocalizableElement
-            }
-
-            // Regular expression for an argument: a hyphen surrounded by zero or more word characters
-            // (i.e. letters, numbers or UnicodeCategory.ConnectorPunctuation) or hyphens
-            private static readonly Regex REGEX_ARGUMENT = new Regex(@"[\w-]*-[\w-]*",
-                RegexOptions.Compiled | RegexOptions.CultureInvariant);
-            /// <summary>
-            /// HTML encodes the string.
-            /// Also, puts &lt;nobr> tags around everything that contains a hyphen so that argument names do not get broken across lines.
-            /// </summary>
-            private static string HtmlEncode(string str)
-            {
-                str = str ?? string.Empty;
-                var result = new StringBuilder();
-                int charIndex = 0;
-                var matchCollection = REGEX_ARGUMENT.Matches(str);
-                foreach (Match match in matchCollection)
-                {
-                    result.Append(HttpUtility.HtmlEncode(str.Substring(charIndex, match.Index - charIndex)));
-                    // ReSharper disable LocalizableElement
-                    result.Append("<nobr>");
-                    result.Append(HttpUtility.HtmlEncode(match.Value));
-                    result.Append("</nobr>");
-                    // ReSharper restore LocalizableElement
-                    charIndex = match.Index + match.Length;
-                }
-
-                result.Append(HttpUtility.HtmlEncode(str.Substring(charIndex)));
-                return result.ToString();
-            }
-        }
-
-        public interface IUsageBlock
-        {
-            string ToString(int width, string formatType);
-            string ToHtmlString();
-        }
-
-
-        public class ValueMissingException : UsageException
-        {
-            public ValueMissingException(Argument arg)
-                : base(string.Format(Resources.ValueMissingException_ValueMissingException_, arg.ArgumentText))
-            {
-            }
-        }
-
-        public class ValueUnexpectedException : UsageException
-        {
-            public ValueUnexpectedException(Argument arg)
-                : base(string.Format(Resources.ValueUnexpectedException_ValueUnexpectedException_The_argument__0__should_not_have_a_value_specified, arg.ArgumentText))
-            {
-            }
-        }
-
-        public class ValueInvalidException : UsageException
-        {
-            public ValueInvalidException(Argument arg, string value, string[] argValues)
-                : base(string.Format(CommandArgUsage.ValueInvalidException_ValueInvalidException_The_value___0___is_not_valid_for_the_argument__1___Use_one_of__2_, value, arg.ArgumentText, string.Join(@", ", argValues)))
-            {
-            }
-        }
-
-        public class ValueInvalidBoolException : UsageException
-        {
-            public ValueInvalidBoolException(Argument arg, string value)
-                : base(string.Format(CommandArgUsage.ValueInvalidBoolException_ValueInvalidBoolException_The_value___0___is_not_valid_for_the_argument___1____it_must_be__2_, value, arg.ArgumentText, BOOL_VALUE()))
-            {
-            }
-        }
-
-        public class ValueInvalidDoubleException : UsageException
-        {
-            public ValueInvalidDoubleException(Argument arg, string value)
-                : base(string.Format(Resources.ValueInvalidDoubleException_ValueInvalidDoubleException_The_value___0___is_not_valid_for_the_argument__1__which_requires_a_decimal_number_, value, arg.ArgumentText))
-            {
-            }
-        }
-
-        public class ValueOutOfRangeDoubleException : UsageException
-        {
-            public ValueOutOfRangeDoubleException(Argument arg, double value, double minVal, double maxVal)
-                : base(string.Format(Resources.ValueOutOfRangeDoubleException_ValueOutOfRangeException_The_value___0___for_the_argument__1__must_be_between__2__and__3__, value, arg.ArgumentText, minVal, maxVal))
-            {
-            }
-        }
-
-        public class ValueInvalidIntException : UsageException
-        {
-            public ValueInvalidIntException(Argument arg, string value)
-                : base(string.Format(Resources.ValueInvalidIntException_ValueInvalidIntException_The_value___0___is_not_valid_for_the_argument__1__which_requires_an_integer_, value, arg.ArgumentText))
-            {
+                return string.Format(Resources.ValueInvalidPathException_ValueInvalidPathException_The_value___0___is_not_valid_for_the_argument__1__failed_attempting_to_convert_it_to_a_full_file_path_, value, argText);
             }
         }
 
         public class ValueInvalidNumberListException : UsageException
         {
-            public ValueInvalidNumberListException(Argument arg, string value)
+            public ValueInvalidNumberListException(ArgumentBase arg, string value)
                 : base(string.Format(Resources.ValueInvalidNumberListException_ValueInvalidNumberListException_The_value__0__is_not_valid_for_the_argument__1__which_requires_a_list_of_decimal_numbers_, value, arg.ArgumentText))
             {
             }
@@ -3453,7 +2949,7 @@ namespace pwiz.Skyline
 
         public class ValueInvalidChargeListException : UsageException
         {
-            public ValueInvalidChargeListException(Argument arg, string value)
+            public ValueInvalidChargeListException(ArgumentBase arg, string value)
                 : base(string.Format(Resources.ValueInvalidChargeListException_ValueInvalidChargeListException_The_value___0___is_not_valid_for_the_argument__1__which_requires_an_comma_separated_list_of_integers_, value, arg.ArgumentText))
             {
             }
@@ -3461,7 +2957,7 @@ namespace pwiz.Skyline
 
         public class ValueInvalidIonTypeListException : UsageException
         {
-            public ValueInvalidIonTypeListException(Argument arg, string value)
+            public ValueInvalidIonTypeListException(ArgumentBase arg, string value)
                 : base(string.Format(Resources.ValueInvalidIonTypeListException_ValueInvalidIonTypeListException_The_value___0___is_not_valid_for_the_argument__1__which_requires_an_comma_separated_list_of_fragment_ion_types__a__b__c__x__y__z__p__, value, arg.ArgumentText))
             {
             }
@@ -3469,7 +2965,7 @@ namespace pwiz.Skyline
 
         public class ValueInvalidAnnotationTargetListException : UsageException
         {
-            public ValueInvalidAnnotationTargetListException(Argument arg, string value, string annotationTargets)
+            public ValueInvalidAnnotationTargetListException(ArgumentBase arg, string value, string annotationTargets)
                 : base(string.Format(SkylineResources.ValueInvalidAnnotationTargetListException_ValueInvalidAnnotationTargetListException_The_value__0___is_not_valid_for_the_argument___1___which_requires_a_comma_separated_list_of_annotation_targets___2___, value, arg.ArgumentText, annotationTargets))
             {
             }
@@ -3477,7 +2973,7 @@ namespace pwiz.Skyline
 
         public class ValueInvalidModTerminusException : ValueInvalidException
         {
-            public ValueInvalidModTerminusException(Argument arg, string value)
+            public ValueInvalidModTerminusException(ArgumentBase arg, string value)
                 : base(arg, value, new []{ ModTerminus.N.ToString(), ModTerminus.C.ToString() })
             {
             }
@@ -3485,7 +2981,7 @@ namespace pwiz.Skyline
 
         public class ValueInvalidAminoAcidException : UsageException
         {
-            public ValueInvalidAminoAcidException(Argument arg, string value)
+            public ValueInvalidAminoAcidException(ArgumentBase arg, string value)
                 : base(string.Format(
                     CommandArgUsage.ValueInvalidException_ValueInvalidException_The_value___0___is_not_valid_for_the_argument__1___Use_one_of__2_,
                     value, arg.ArgumentText, MOD_AA_VALUE()))
@@ -3495,7 +2991,7 @@ namespace pwiz.Skyline
 
         public class ValueInvalidModException : UsageException
         {
-            public ValueInvalidModException(Argument arg, string mod, ArgumentException ex)
+            public ValueInvalidModException(ArgumentBase arg, string mod, ArgumentException ex)
                 : base(string.Format(CommandArgUsage.ValueInvalidModException_ValueInvalidModException_Unable_to_add_peptide_modification___0_____1_, mod, ex.Message))
             {
             }
@@ -3503,41 +2999,11 @@ namespace pwiz.Skyline
 
         public class ValueInvalidMzToleranceException : UsageException
         {
-            public ValueInvalidMzToleranceException(Argument arg, string value)
+            public ValueInvalidMzToleranceException(ArgumentBase arg, string value)
                 : base(string.Format(Resources.ValueInvalidMzToleranceException_ValueInvalidMzToleranceException_The_value__0__is_not_valid_for_the_argument__1__which_requires_a_value_and_a_unit__For_example___2__, value, arg.ArgumentText, arg.ValueExample()))
             {
             }
         }
 
-        public class ValueOutOfRangeIntException : UsageException
-        {
-            public ValueOutOfRangeIntException(Argument arg, int value, int minVal, int maxVal)
-                : base(string.Format(Resources.ValueOutOfRangeDoubleException_ValueOutOfRangeException_The_value___0___for_the_argument__1__must_be_between__2__and__3__, value, arg.ArgumentText, minVal, maxVal))
-            {
-            }
-        }
-
-        public class ValueInvalidDateException : UsageException
-        {
-            public ValueInvalidDateException(Argument arg, string value)
-                : base(string.Format(Resources.ValueInvalidDateException_ValueInvalidDateException_The_value___0___is_not_valid_for_the_argument__1__which_requires_a_date_time_value_, value, arg.ArgumentText))
-            {
-            }
-        }
-
-        public class ValueInvalidPathException : UsageException
-        {
-            public ValueInvalidPathException(Argument arg, string value)
-                : base(string.Format(Resources.ValueInvalidPathException_ValueInvalidPathException_The_value___0___is_not_valid_for_the_argument__1__failed_attempting_to_convert_it_to_a_full_file_path_, value, arg.ArgumentText))
-            {
-            }
-        }
-
-        public class UsageException : ArgumentException
-        {
-            protected UsageException(string message) : base(message)
-            {
-            }
-        }
     }
 }

--- a/pwiz_tools/Skyline/CommandLine.cs
+++ b/pwiz_tools/Skyline/CommandLine.cs
@@ -29,6 +29,7 @@ using System.Xml;
 using System.Xml.Serialization;
 using pwiz.PanoramaClient;
 using pwiz.Common.Collections;
+using pwiz.Common.CommandLine;
 using pwiz.Common.DataBinding;
 using pwiz.Common.SystemUtil;
 using pwiz.CommonMsData;
@@ -4824,7 +4825,7 @@ namespace pwiz.Skyline
             if (skylineFile == null)
             {
                 // Mimic the usage error before --new was allowed inside running Skyline UI
-                _out.WriteLine(Resources.Error___0_, new CommandArgs.ValueMissingException(CommandArgs.ARG_NEW).Message);
+                _out.WriteLine(Resources.Error___0_, new ValueMissingException(CommandArgs.ARG_NEW).Message);
                 return null;
             }
             return NewSkyFile(skylineFile, overwrite) ? _doc : null;

--- a/pwiz_tools/Skyline/Executables/Installer/FileList64-template.txt
+++ b/pwiz_tools/Skyline/Executables/Installer/FileList64-template.txt
@@ -251,6 +251,8 @@ pwiz.CommonMsData.dll
 pwiz.CommonMsData.pdb
 pwiz.CommonUtil.dll
 pwiz.CommonUtil.pdb
+pwiz.PortableUtil.dll
+pwiz.PortableUtil.pdb
 pwiz_data_cli.dll
 PanoramaClient.dll
 PanoramaClient.pdb

--- a/pwiz_tools/Skyline/Executables/Installer/Product-template.wxs
+++ b/pwiz_tools/Skyline/Executables/Installer/Product-template.wxs
@@ -330,6 +330,12 @@
       <Component Id="pwiz.CommonUtil.pdb">
         <File Source="$(var.Skyline.TargetDir)/pwiz.CommonUtil.pdb" KeyPath="yes"/>
       </Component>
+      <Component Id="pwiz.PortableUtil.dll">
+        <File Source="$(var.Skyline.TargetDir)/pwiz.PortableUtil.dll" KeyPath="yes"/>
+      </Component>
+      <Component Id="pwiz.PortableUtil.pdb">
+        <File Source="$(var.Skyline.TargetDir)/pwiz.PortableUtil.pdb" KeyPath="yes"/>
+      </Component>
       <Component Id="pwiz_data_cli.dll">
         <File Source="$(var.Skyline.TargetDir)/pwiz_data_cli.dll" KeyPath="yes"/>
       </Component>

--- a/pwiz_tools/Skyline/Skyline.csproj
+++ b/pwiz_tools/Skyline/Skyline.csproj
@@ -5363,7 +5363,6 @@
     <Compile Include="Util\AxisLabelScaler.cs" />
     <Compile Include="Util\BackgroundEventThreads.cs" />
     <Compile Include="Util\BioMassCalc.cs" />
-    <Compile Include="Util\ConsoleTable.cs" />
     <Compile Include="Util\CreateHandleDebugBase.cs">
       <SubType>Form</SubType>
     </Compile>
@@ -7197,6 +7196,10 @@
     <ProjectReference Include="..\Shared\MSGraph\MSGraph.csproj">
       <Project>{26CFD1FF-F4F7-4F66-B5B4-E686BDB9B34E}</Project>
       <Name>MSGraph</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\Shared\PortableUtil\PortableUtil.csproj">
+      <Project>{97ECF0B4-0AAA-4593-ADE0-9E8740973AC2}</Project>
+      <Name>PortableUtil</Name>
     </ProjectReference>
     <ProjectReference Include="..\Shared\PanoramaClient\PanoramaClient.csproj">
       <Project>{bf849cf8-25d7-4619-b001-9ed8e3771c44}</Project>

--- a/pwiz_tools/Skyline/Skyline.sln
+++ b/pwiz_tools/Skyline/Skyline.sln
@@ -35,6 +35,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Common", "..\Shared\Common\
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CommonUtil", "..\Shared\CommonUtil\CommonUtil.csproj", "{13BF2FFB-50A1-4AB1-83A4-5733E36905CE}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PortableUtil", "..\Shared\PortableUtil\PortableUtil.csproj", "{97ECF0B4-0AAA-4593-ADE0-9E8740973AC2}"
+EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BiblioSpec", "..\Shared\BiblioSpec\BiblioSpec.csproj", "{32CC9B1A-9442-4B56-AF34-FB47595278A1}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TestRunner", "TestRunner\TestRunner.csproj", "{B92CA24E-0867-4B99-88F8-EF542A4AFE87}"
@@ -177,6 +179,14 @@ Global
 		{13BF2FFB-50A1-4AB1-83A4-5733E36905CE}.Release|x64.Build.0 = Release|x64
 		{13BF2FFB-50A1-4AB1-83A4-5733E36905CE}.Release|x86.ActiveCfg = Release|x86
 		{13BF2FFB-50A1-4AB1-83A4-5733E36905CE}.Release|x86.Build.0 = Release|x86
+		{97ECF0B4-0AAA-4593-ADE0-9E8740973AC2}.Debug|x64.ActiveCfg = Debug|x64
+		{97ECF0B4-0AAA-4593-ADE0-9E8740973AC2}.Debug|x64.Build.0 = Debug|x64
+		{97ECF0B4-0AAA-4593-ADE0-9E8740973AC2}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{97ECF0B4-0AAA-4593-ADE0-9E8740973AC2}.Debug|x86.Build.0 = Debug|Any CPU
+		{97ECF0B4-0AAA-4593-ADE0-9E8740973AC2}.Release|x64.ActiveCfg = Release|x64
+		{97ECF0B4-0AAA-4593-ADE0-9E8740973AC2}.Release|x64.Build.0 = Release|x64
+		{97ECF0B4-0AAA-4593-ADE0-9E8740973AC2}.Release|x86.ActiveCfg = Release|Any CPU
+		{97ECF0B4-0AAA-4593-ADE0-9E8740973AC2}.Release|x86.Build.0 = Release|Any CPU
 		{32CC9B1A-9442-4B56-AF34-FB47595278A1}.Debug|x64.ActiveCfg = Debug|x64
 		{32CC9B1A-9442-4B56-AF34-FB47595278A1}.Debug|x64.Build.0 = Debug|x64
 		{32CC9B1A-9442-4B56-AF34-FB47595278A1}.Debug|x86.ActiveCfg = Debug|x86

--- a/pwiz_tools/Skyline/Test/Test.csproj
+++ b/pwiz_tools/Skyline/Test/Test.csproj
@@ -331,6 +331,10 @@
       <Project>{13BF2FFB-50A1-4AB1-83A4-5733E36905CE}</Project>
       <Name>CommonUtil</Name>
     </ProjectReference>
+    <ProjectReference Include="..\..\Shared\PortableUtil\PortableUtil.csproj">
+      <Project>{97ECF0B4-0AAA-4593-ADE0-9E8740973AC2}</Project>
+      <Name>PortableUtil</Name>
+    </ProjectReference>
     <ProjectReference Include="..\..\Shared\PanoramaClient\PanoramaClient.csproj">
       <Project>{bf849cf8-25d7-4619-b001-9ed8e3771c44}</Project>
       <Name>PanoramaClient</Name>

--- a/pwiz_tools/Skyline/TestData/CommandLineImportTest.cs
+++ b/pwiz_tools/Skyline/TestData/CommandLineImportTest.cs
@@ -23,6 +23,7 @@ using System.Linq;
 using System.Text.RegularExpressions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using pwiz.Skyline;
+using pwiz.Common.CommandLine;
 using pwiz.Skyline.Model;
 using pwiz.Skyline.Model.DocSettings;
 using pwiz.Skyline.Model.Irt;
@@ -61,7 +62,7 @@ namespace pwiz.SkylineTestData
             };
             var output = RunCommand(args);
 
-            AssertEx.Contains(output, new CommandArgs.ValueOutOfRangeDoubleException(CommandArgs.ARG_IMPORT_PEPTIDE_SEARCH_CUTOFF, badCutoff, 0, 1).Message);
+            AssertEx.Contains(output, new ValueOutOfRangeDoubleException(CommandArgs.ARG_IMPORT_PEPTIDE_SEARCH_CUTOFF, badCutoff, 0, 1).Message);
 
             args[3] = "--import-search-cutoff-score=" + Settings.Default.LibraryResultCutOff;
             output = RunCommand(args);

--- a/pwiz_tools/Skyline/TestData/CommandLineRefineTest.cs
+++ b/pwiz_tools/Skyline/TestData/CommandLineRefineTest.cs
@@ -24,6 +24,8 @@ using System.IO;
 using System.Linq;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using pwiz.Skyline;
+using pwiz.Common.CommandLine;
+using Argument = pwiz.Common.CommandLine.Argument<pwiz.Skyline.CommandArgs>;
 using pwiz.Skyline.Model;
 using pwiz.Skyline.Model.AuditLog;
 using pwiz.Skyline.Model.GroupComparison;
@@ -433,7 +435,7 @@ namespace pwiz.SkylineTestData
         [TestMethod]
         public void ConsoleArgumentInvalidValuesTest()
         {
-            var testedArguments = new HashSet<CommandArgs.Argument>
+            var testedArguments = new HashSet<Argument>
             {
                 CommandArgs.ARG_PANORAMA_FOLDER,
                 CommandArgs.ARG_TOOL_INITIAL_DIR,
@@ -443,7 +445,7 @@ namespace pwiz.SkylineTestData
                 CommandArgs.ARG_PEPTIDE_ADD_MOD_AA, // tested in ConsoleModsTest
                 CommandArgs.ARG_PEPTIDE_ADD_MOD_TERM, // tested in ConsoleModsTest
             };
-            var allArgumentsSet = new HashSet<CommandArgs.Argument>(
+            var allArgumentsSet = new HashSet<Argument>(
                 CommandArgs.AllArguments.Where(a => !a.InternalUse && !testedArguments.Contains(a)));
 
             TestFilesDir = new TestFilesDir(TestContext, @"TestData\CommandLineRefine.zip");
@@ -468,18 +470,18 @@ namespace pwiz.SkylineTestData
             Assert.AreEqual(0, allArgumentsSet.Count, string.Join(", ", allArgumentsSet.Select(a => a.Name)));
         }
 
-        private void ValidateInvalidValue(CommandArgs.Argument arg, HashSet<CommandArgs.Argument> testedArguments)
+        private void ValidateInvalidValue(Argument arg, HashSet<Argument> testedArguments)
         {
             const string NO_VALUE = "NO VALUE";
             string expected = string.Format(
                 CommandArgUsage.ValueInvalidException_ValueInvalidException_The_value___0___is_not_valid_for_the_argument__1___Use_one_of__2_,
                 NO_VALUE, arg.ArgumentText, arg.ValueExample());
             expected = expected.Substring(0, expected.IndexOf(@"None, ", StringComparison.Ordinal) + 6);
-            AssertEx.ThrowsException<CommandArgs.ValueInvalidException>(() => arg.GetArgumentTextWithValue(NO_VALUE), expected);
+            AssertEx.ThrowsException<ValueInvalidException>(() => arg.GetArgumentTextWithValue(NO_VALUE), expected);
             testedArguments.Add(arg);
         }
 
-        private void ValidateInvalidValueNumeric(CommandArgs.Argument arg, HashSet<CommandArgs.Argument> testedArguments)
+        private void ValidateInvalidValueNumeric(Argument arg, HashSet<Argument> testedArguments)
         {
 
             const string BAD_VALUE = "-1a";
@@ -509,10 +511,10 @@ namespace pwiz.SkylineTestData
             testedArguments.Add(arg);
         }
 
-        private void ValidateInvalidValueBool(CommandArgs.Argument arg, HashSet<CommandArgs.Argument> testedArguments)
+        private void ValidateInvalidValueBool(Argument arg, HashSet<Argument> testedArguments)
         {
             const string BAD_VALUE = "-1a";
-            AssertEx.ThrowsException<CommandArgs.ValueUnexpectedException>(() => arg.GetArgumentTextWithValue(BAD_VALUE), arg.ArgumentText);
+            AssertEx.ThrowsException<ValueUnexpectedException>(() => arg.GetArgumentTextWithValue(BAD_VALUE), arg.ArgumentText);
             var args = new[] { "--in=" + DocumentPath, "--overwrite", arg.ArgumentText + "=BAD_VALUE" };
             string output = RunCommand(args);
             string expected = string.Format(Resources.ValueUnexpectedException_ValueUnexpectedException_The_argument__0__should_not_have_a_value_specified, arg.ArgumentText);
@@ -520,7 +522,7 @@ namespace pwiz.SkylineTestData
             testedArguments.Add(arg);
         }
 
-        private void ValidateInvalidValueString(CommandArgs.Argument arg, HashSet<CommandArgs.Argument> testedArguments)
+        private void ValidateInvalidValueString(Argument arg, HashSet<Argument> testedArguments)
         {
             var args = new[] { "--in=" + DocumentPath, "--overwrite", arg.ArgumentText /* no value */ };
             string output = RunCommand(args);
@@ -529,7 +531,7 @@ namespace pwiz.SkylineTestData
             testedArguments.Add(arg);
         }
 
-        private void ValidateInvalidValuePath(CommandArgs.Argument arg, HashSet<CommandArgs.Argument> testedArguments)
+        private void ValidateInvalidValuePath(Argument arg, HashSet<Argument> testedArguments)
         {
             const string BAD_VALUE = "Bad:\\Path\\Value";
             string argText = arg.GetArgumentTextWithValue(BAD_VALUE);
@@ -583,11 +585,11 @@ namespace pwiz.SkylineTestData
             AssertEx.Contains(output, new CommandArgs.ValueInvalidIonTypeListException(CommandArgs.ARG_TRAN_FRAGMENT_ION_TYPES, typesWithError).Message);
             const int outOfRangeCharge = Transition.MAX_PRODUCT_CHARGE + 1;
             output = Run(CommandArgs.ARG_TRAN_FRAGMENT_ION_CHARGES.GetArgumentTextWithValue(outOfRangeCharge.ToString()));
-            AssertEx.Contains(output, new CommandArgs.ValueOutOfRangeIntException(CommandArgs.ARG_TRAN_FRAGMENT_ION_CHARGES, outOfRangeCharge,
+            AssertEx.Contains(output, new ValueOutOfRangeIntException(CommandArgs.ARG_TRAN_FRAGMENT_ION_CHARGES, outOfRangeCharge,
                 Transition.MIN_PRODUCT_CHARGE, Transition.MAX_PRODUCT_CHARGE).Message);
             const int outOfRangePrecursorCharge = TransitionGroup.MAX_PRECURSOR_CHARGE + 1;
             output = Run(CommandArgs.ARG_TRAN_PRECURSOR_ION_CHARGES.GetArgumentTextWithValue("1, 2, " + outOfRangePrecursorCharge));
-            AssertEx.Contains(output, new CommandArgs.ValueOutOfRangeIntException(CommandArgs.ARG_TRAN_PRECURSOR_ION_CHARGES, outOfRangePrecursorCharge,
+            AssertEx.Contains(output, new ValueOutOfRangeIntException(CommandArgs.ARG_TRAN_PRECURSOR_ION_CHARGES, outOfRangePrecursorCharge,
                 TransitionGroup.MIN_PRECURSOR_CHARGE, TransitionGroup.MAX_PRECURSOR_CHARGE).Message);
             const string chargesWithError = "2, 3, p, 5";
             output = Run(CommandArgs.ARG_TRAN_PRECURSOR_ION_CHARGES.GetArgumentTextWithValue(chargesWithError));

--- a/pwiz_tools/Skyline/TestData/CommandLineTest.cs
+++ b/pwiz_tools/Skyline/TestData/CommandLineTest.cs
@@ -33,6 +33,9 @@ using pwiz.Common.DataBinding;
 using pwiz.Common.SystemUtil;
 using pwiz.CommonMsData;
 using pwiz.Skyline;
+using pwiz.Common.CommandLine;
+using Argument = pwiz.Common.CommandLine.Argument<pwiz.Skyline.CommandArgs>;
+using ArgumentGroup = pwiz.Common.CommandLine.ArgumentGroup<pwiz.Skyline.CommandArgs>;
 using pwiz.Skyline.Controls.Databinding;
 using pwiz.Skyline.Model;
 using pwiz.Skyline.Model.AuditLog;
@@ -829,7 +832,7 @@ namespace pwiz.SkylineTestData
                     Resources.PeptideMod_SetVariable_A_peptide_modification_must_be_added_before_assigning_its_variable_status_, printErrors);
 
                 RunCommandAndValidateError(new[] { "--pep-add-mod=Oxi", "--pep-add-mod-variable=X" },
-                    new CommandArgs.ValueInvalidBoolException(CommandArgs.ARG_PEPTIDE_ADD_MOD_VARIABLE, "X").Message, printErrors);
+                    new ValueInvalidBoolException(CommandArgs.ARG_PEPTIDE_ADD_MOD_VARIABLE, "X").Message, printErrors);
 
                 // Variable failure on loss-only modification
                 RunCommandAndValidateError(new[] { "--pep-add-mod=Water Loss (D, E, S, T)", "--pep-add-mod-variable=true" },
@@ -1234,7 +1237,7 @@ namespace pwiz.SkylineTestData
             output = RunCommand("--in=" + docPath,
                                        "--decoys-add=" + badDecoyMethod);
             var arg = CommandArgs.ARG_DECOYS_ADD;
-            AssertEx.Contains(output, new CommandArgs.ValueInvalidException(arg, badDecoyMethod, arg.Values).Message);
+            AssertEx.Contains(output, new ValueInvalidException(arg, badDecoyMethod, arg.Values).Message);
 
             output = RunCommand("--in=" + outPath,
                                        "--decoys-add");
@@ -1564,7 +1567,7 @@ namespace pwiz.SkylineTestData
             };
             string output = RunCommand(args);
 
-            AssertEx.Contains(output, new CommandArgs.ValueInvalidIntException(CommandArgs.ARG_EXP_PRIMARY_COUNT, "x").Message);
+            AssertEx.Contains(output, new ValueInvalidIntException(CommandArgs.ARG_EXP_PRIMARY_COUNT, "x").Message);
             args[args.Length - 1] = "--exp-primary-count=1";
             output = RunCommand(args);
 
@@ -1824,7 +1827,7 @@ namespace pwiz.SkylineTestData
 
             //Test value lists for failing values
             const string bogusValue = "BOGUS";
-            CommandArgs.Argument[] valueListArgs = 
+            Argument[] valueListArgs = 
             {
                 CommandArgs.ARG_REPORT_FORMAT,
                 CommandArgs.ARG_EXP_STRATEGY,
@@ -1836,7 +1839,7 @@ namespace pwiz.SkylineTestData
             {
                 args[3] = valueListArg.ArgumentText + "=" + bogusValue;
                 output = RunCommand(args);
-                AssertEx.Contains(output, new CommandArgs.ValueInvalidException(valueListArg, bogusValue, valueListArg.Values).Message);
+                AssertEx.Contains(output, new ValueInvalidException(valueListArg, bogusValue, valueListArg.Values).Message);
             }
 
             // Transition list, isolation list, and method export
@@ -1862,7 +1865,7 @@ namespace pwiz.SkylineTestData
                 TextUtil.LineSeparate(ExportInstrumentType.METHOD_TYPES),
                 SkylineResources.CommandArgs_ParseArgsInternal_No_method_will_be_exported_);
 
-            CommandArgs.Argument[] valueIntArguments =
+            Argument[] valueIntArguments =
             {
                 CommandArgs.ARG_EXP_MAX_TRANS,
                 CommandArgs.ARG_EXP_DWELL_TIME
@@ -1871,10 +1874,10 @@ namespace pwiz.SkylineTestData
             {
                 args[3] = valueIntArg.ArgumentText + "=" + bogusValue;
                 output = RunCommand(args);
-                AssertEx.Contains(output, new CommandArgs.ValueInvalidIntException(valueIntArg, bogusValue).Message);
+                AssertEx.Contains(output, new ValueInvalidIntException(valueIntArg, bogusValue).Message);
             }
 
-            CommandArgs.Argument[] valueDoubleArguments =
+            Argument[] valueDoubleArguments =
             {
                 CommandArgs.ARG_EXP_RUN_LENGTH,
                 CommandArgs.ARG_IMPORT_LOCKMASS_POSITIVE,
@@ -1885,16 +1888,16 @@ namespace pwiz.SkylineTestData
             {
                 args[3] = valueDoubleArg.ArgumentText + "=" + bogusValue;
                 output = RunCommand(args);
-                AssertEx.Contains(output, new CommandArgs.ValueInvalidDoubleException(valueDoubleArg, bogusValue).Message);
+                AssertEx.Contains(output, new ValueInvalidDoubleException(valueDoubleArg, bogusValue).Message);
             }
             const int bigValue = 100000000;
             args[3] = "--exp-dwell-time=" + bigValue;
             output = RunCommand(args);
-            AssertEx.Contains(output, new CommandArgs.ValueOutOfRangeIntException(CommandArgs.ARG_EXP_DWELL_TIME, bigValue,
+            AssertEx.Contains(output, new ValueOutOfRangeIntException(CommandArgs.ARG_EXP_DWELL_TIME, bigValue,
                 AbstractMassListExporter.DWELL_TIME_MIN, AbstractMassListExporter.DWELL_TIME_MAX).Message);
             args[3] = "--exp-run-length=" + bigValue;
             output = RunCommand(args);
-            AssertEx.Contains(output, new CommandArgs.ValueOutOfRangeIntException(CommandArgs.ARG_EXP_RUN_LENGTH, bigValue,
+            AssertEx.Contains(output, new ValueOutOfRangeIntException(CommandArgs.ARG_EXP_RUN_LENGTH, bigValue,
                 AbstractMassListExporter.RUN_LENGTH_MIN, AbstractMassListExporter.RUN_LENGTH_MAX).Message);
 
 
@@ -3811,7 +3814,7 @@ namespace pwiz.SkylineTestData
 
         private static void CheckUsageOutput(string output)
         {
-            foreach (CommandArgs.ArgumentGroup group in CommandArgs.UsageBlocks.Where(b => b is CommandArgs.ArgumentGroup))
+            foreach (ArgumentGroup group in CommandArgs.UsageBlocks.Where(b => b is ArgumentGroup))
             {
                 if (group.IncludeInUsage)
                 {
@@ -3969,7 +3972,7 @@ namespace pwiz.SkylineTestData
             // --new without a path should fail in CLI mode.
             // The DocArgument validation catches it as "no document specified".
             string output = AbstractUnitTestEx.RunCommand(false, CommandArgs.ARG_NEW);
-            AssertEx.Contains(output, new CommandArgs.ValueMissingException(CommandArgs.ARG_NEW).Message);
+            AssertEx.Contains(output, new ValueMissingException(CommandArgs.ARG_NEW).Message);
         }
 
         [TestMethod]

--- a/pwiz_tools/Skyline/TestData/TestData.csproj
+++ b/pwiz_tools/Skyline/TestData/TestData.csproj
@@ -224,6 +224,10 @@
       <Project>{13BF2FFB-50A1-4AB1-83A4-5733E36905CE}</Project>
       <Name>CommonUtil</Name>
     </ProjectReference>
+    <ProjectReference Include="..\..\Shared\PortableUtil\PortableUtil.csproj">
+      <Project>{97ECF0B4-0AAA-4593-ADE0-9E8740973AC2}</Project>
+      <Name>PortableUtil</Name>
+    </ProjectReference>
     <ProjectReference Include="..\..\Shared\MSGraph\MSGraph.csproj">
       <Project>{26CFD1FF-F4F7-4F66-B5B4-E686BDB9B34E}</Project>
       <Name>MSGraph</Name>

--- a/pwiz_tools/Skyline/TestFunctional/TestFunctional.csproj
+++ b/pwiz_tools/Skyline/TestFunctional/TestFunctional.csproj
@@ -548,6 +548,10 @@
       <Project>{13BF2FFB-50A1-4AB1-83A4-5733E36905CE}</Project>
       <Name>CommonUtil</Name>
     </ProjectReference>
+    <ProjectReference Include="..\..\Shared\PortableUtil\PortableUtil.csproj">
+      <Project>{97ECF0B4-0AAA-4593-ADE0-9E8740973AC2}</Project>
+      <Name>PortableUtil</Name>
+    </ProjectReference>
     <ProjectReference Include="..\..\Shared\MSGraph\MSGraph.csproj">
       <Project>{26CFD1FF-F4F7-4F66-B5B4-E686BDB9B34E}</Project>
       <Name>MSGraph</Name>

--- a/pwiz_tools/Skyline/TestPerf/PerfCommandlineCreateImsDbTest.cs
+++ b/pwiz_tools/Skyline/TestPerf/PerfCommandlineCreateImsDbTest.cs
@@ -23,6 +23,7 @@ using System.Linq;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using pwiz.Common.Chemistry;
 using pwiz.Skyline;
+using Argument = pwiz.Common.CommandLine.Argument<pwiz.Skyline.CommandArgs>;
 using pwiz.Skyline.Model;
 using pwiz.Skyline.Properties;
 using pwiz.SkylineTestUtil;
@@ -177,17 +178,17 @@ namespace TestPerf // Note: tests in the "TestPerf" namespace only run when the 
             return output;
         }
 
-        private string GetArg(CommandArgs.Argument arg, string value)
+        private string GetArg(Argument arg, string value)
         {
             return arg.GetArgumentTextWithValue(value);
         }
 
-        private string GetOptionalArg(CommandArgs.Argument arg, string value)
+        private string GetOptionalArg(Argument arg, string value)
         {
             return string.IsNullOrEmpty(value) ? string.Empty : GetArg(arg, value);
         }
 
-        private string GetPathArg(CommandArgs.Argument arg, string value)
+        private string GetPathArg(Argument arg, string value)
         {
             return GetArg(arg, GetTestPath(value));
         }

--- a/pwiz_tools/Skyline/TestPerf/TestPerf.csproj
+++ b/pwiz_tools/Skyline/TestPerf/TestPerf.csproj
@@ -217,6 +217,10 @@
       <Project>{13BF2FFB-50A1-4AB1-83A4-5733E36905CE}</Project>
       <Name>CommonUtil</Name>
     </ProjectReference>
+    <ProjectReference Include="..\..\Shared\PortableUtil\PortableUtil.csproj">
+      <Project>{97ECF0B4-0AAA-4593-ADE0-9E8740973AC2}</Project>
+      <Name>PortableUtil</Name>
+    </ProjectReference>
     <ProjectReference Include="..\..\Shared\MSGraph\MSGraph.csproj">
       <Project>{26CFD1FF-F4F7-4F66-B5B4-E686BDB9B34E}</Project>
       <Name>MSGraph</Name>


### PR DESCRIPTION
## Summary

* Created `pwiz_tools/Shared/PortableUtil` - a new SDK-style, multi-target (`net472;net8.0`), pure-BCL leaf assembly (namespace `pwiz.Common.CommandLine`) as the net8.0-capable home for portable pieces of CommonUtil.
* Moved the generic CLI-argument framework out of `CommandArgs.cs` into it: `ConsoleTable`, `ArgumentBase`, `Argument<TContext>`, `NameValuePair`, `ArgumentGroup<TContext>`, `IUsageBlock`, `ParaUsageBlock`, base `UsageException`, and the 10 context-free value exceptions - generified on `TContext`.
* Broke host coupling via static `ArgUsage` seams (`IArgUsageProvider` for localized descriptions/headers/value-error messages, plus `IsRemoteUrl`/`IsWrappableListType`/`HtmlEncode` and the format constants). Skyline installs them in the `CommandArgs` static ctor; the default provider throws so a missing install fails loudly.
* Skyline consumes the moved types via file-scoped `using` aliases (the 100+ argument declarations compile unchanged); domain value exceptions remain nested in `CommandArgs`, subclassing the moved bases. `Assume` and `CommonUtil.csproj` are untouched.
* Kept Skyline's usage HTML byte-identical by routing the encoder through the seam (Skyline keeps `HttpUtility.HtmlEncode`; PortableUtil defaults to `WebUtility`).

This is Phase A of a two-phase sprint; Phase B adopts the framework in OspreySharp and depends on this.

## Test plan

- [x] TestCommandLineHelpDocumentation - byte-identical `CommandLine.html` in en/ja/zh-CHS
- [x] CommandLineUsageTest / CommandLineUsageDescriptionsTest
- [x] CommandLineImportTest / CommandLineRefineTest / ConsoleAddAnnotationsTest / ConsoleVerboseExceptionsTest / SkylineCmdTest
- [x] CommandLineTest
- [x] Full ReSharper inspection - zero warnings
- [x] All Skyline non-perf tests passed locally in en/ja/zh-CHS

Co-Authored-By: Claude <noreply@anthropic.com>