### PR TITLE
Added --parallel-files OspreySharp argument with sequential default

### DIFF
--- a/pwiz_tools/OspreySharp/Osprey-workflow.html
+++ b/pwiz_tools/OspreySharp/Osprey-workflow.html
@@ -816,6 +816,12 @@
     files sequentially and is unaffected. A fully fair
     WSL-vs-Windows comparison would set
     <code>OSPREY_MAX_PARALLEL_FILES=1</code> on both sides too.
+    (Historical: as of the <code>--parallel-files</code> work, C# now
+    processes files <em>sequentially by default</em>, so this run's
+    behavior is now the default and no longer needs the env cap;
+    concurrency is opt-in via <code>--parallel-files [N]</code>, and
+    <code>OSPREY_MAX_PARALLEL_FILES</code> remains only as a back-compat
+    cap.)
   </p>
   <p>
     <strong>BLIB writer:</strong> OspreySharp's <code>BlibWriter</code>

--- a/pwiz_tools/OspreySharp/OspreySharp.Core/FileParallelism.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Core/FileParallelism.cs
@@ -1,0 +1,241 @@
+/*
+ * Original author: Brendan MacLean <brendanx .at. uw.edu>,
+ *                  MacCoss Lab, Department of Genome Sciences, UW
+ * AI assistance: Claude Code (Claude Opus 4.8) <noreply .at. anthropic.com>
+ *
+ * Based on osprey (https://github.com/MacCossLab/osprey)
+ *   by Michael J. MacCoss, MacCoss Lab, Department of Genome Sciences, UW
+ *
+ * Copyright 2026 University of Washington - Seattle, WA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+
+namespace pwiz.OspreySharp.Core
+{
+    /// <summary>
+    /// How the user requested outer (across-files) parallelism, from the
+    /// <c>--parallel-files</c> CLI argument. Distinct from <c>--threads</c>,
+    /// which is the INNER per-file main-search thread budget.
+    /// </summary>
+    public enum FileParallelismMode
+    {
+        /// <summary>Argument absent: process input files one at a time (the default).</summary>
+        Sequential = 0,
+
+        /// <summary><c>--parallel-files</c> with no value: pick N from free RAM and cores.</summary>
+        Auto,
+
+        /// <summary><c>--parallel-files N</c>: exactly N concurrent files (clamped to file count).</summary>
+        Explicit
+    }
+
+    /// <summary>
+    /// The parsed <c>--parallel-files</c> request. A value type whose default
+    /// (<c>default(FileParallelism)</c>) is <see cref="FileParallelismMode.Sequential"/>,
+    /// so an un-set <see cref="OspreyConfig.FileParallelism"/> means "one file at
+    /// a time" with no extra wiring. The effective concurrent-file count is
+    /// resolved at run time by <see cref="FileParallelismResolver"/>, which folds
+    /// in file count, cores, free RAM, and the legacy
+    /// <c>OSPREY_MAX_PARALLEL_FILES</c> cap.
+    /// </summary>
+    public readonly struct FileParallelism
+    {
+        private FileParallelism(FileParallelismMode mode, int count)
+        {
+            Mode = mode;
+            Count = count;
+        }
+
+        public FileParallelismMode Mode { get; }
+
+        /// <summary>Explicit file count; only meaningful when <see cref="Mode"/> is
+        /// <see cref="FileParallelismMode.Explicit"/> (0 otherwise).</summary>
+        public int Count { get; }
+
+        /// <summary>Argument absent: one file at a time.</summary>
+        public static readonly FileParallelism Sequential = new FileParallelism(FileParallelismMode.Sequential, 0);
+
+        /// <summary><c>--parallel-files</c> with no value: RAM/CPU-aware auto.</summary>
+        public static readonly FileParallelism Auto = new FileParallelism(FileParallelismMode.Auto, 0);
+
+        /// <summary><c>--parallel-files N</c>: an explicit positive count.</summary>
+        public static FileParallelism Explicit(int count)
+        {
+            return new FileParallelism(FileParallelismMode.Explicit, count);
+        }
+    }
+
+    /// <summary>
+    /// Resolves the parsed <see cref="FileParallelism"/> request into the actual
+    /// number of input files to score concurrently for one run -- the single
+    /// place that owns the precedence between the CLI argument, the
+    /// <c>OSPREY_MAX_PARALLEL_FILES</c> back-compat cap, free RAM, and the core
+    /// count. <c>PerFileScoringTask</c> calls it once per invocation and stores
+    /// the result on <c>RunPlan.EffectiveFileParallelism</c>.
+    ///
+    /// Precedence (highest first):
+    ///   1. explicit <c>--parallel-files N</c>  -> N, clamped to file count only
+    ///                                             (a 500 GB box can force more).
+    ///   2. <c>--parallel-files</c> (auto)      -> RAM/CPU-aware estimate.
+    ///   3. <c>OSPREY_MAX_PARALLEL_FILES</c>    -> legacy cap (only when the
+    ///                                             argument is absent).
+    ///   4. otherwise                           -> 1 (sequential default).
+    /// The argument wins over the env var when both are set.
+    /// </summary>
+    public static class FileParallelismResolver
+    {
+        // Per-file peak working-set estimate = largest input mzML x this factor.
+        // Grounded in the 2026-06-11 Astral (hram) observation: a ~6 GB on-disk
+        // mzML drove a ~14.6 GB per-file working set (~2.4x), rounded up to bias
+        // AUTO toward FEWER concurrent files (over-estimating footprint is the
+        // safe error -- it avoids the OOM this argument exists to prevent).
+        // Coarse by design; explicit --parallel-files N bypasses it entirely.
+        private const double FOOTPRINT_MULTIPLIER = 3.0;
+
+        // Only commit this fraction of free RAM to concurrent files, leaving
+        // headroom for the shared library, GC slack, and OS cache.
+        private const double RAM_BUDGET_FRACTION = 0.8;
+
+        /// <summary>
+        /// Resolve the effective concurrent-file count. <paramref name="availableBytesProbe"/>
+        /// and <paramref name="perFileBytesEstimate"/> are only invoked in auto
+        /// mode, so the common (sequential / explicit) paths do no I/O or system
+        /// probing. <paramref name="log"/> (optional) receives a one-line summary
+        /// of the chosen N and the reason; pass null on the bookkeeping-only paths
+        /// that never actually parallelize.
+        /// </summary>
+        public static int Resolve(
+            FileParallelism request, int nFiles, int envCap, int processorCount,
+            Func<long> availableBytesProbe, Func<long> perFileBytesEstimate,
+            Action<string> log = null)
+        {
+            if (nFiles <= 1)
+                return 1;
+
+            int cores = Math.Max(1, processorCount);
+            int cpuCap = Math.Min(nFiles, cores);
+
+            switch (request.Mode)
+            {
+                case FileParallelismMode.Explicit:
+                    // The argument wins: honor N regardless of RAM/cores, clamped
+                    // only to the file count (more would idle). A box with more
+                    // RAM than this machine reports can force the value it knows
+                    // is safe.
+                    int explicitN = Math.Max(1, Math.Min(request.Count, nFiles));
+                    log?.Invoke(string.Format(
+                        @"File parallelism: {0} (explicit --parallel-files, {1} files)",
+                        explicitN, nFiles));
+                    return explicitN;
+
+                case FileParallelismMode.Auto:
+                    return ResolveAuto(nFiles, cores, cpuCap,
+                        availableBytesProbe, perFileBytesEstimate, log);
+
+                default:
+                    // Sequential default -- unless the legacy env cap is set, in
+                    // which case honor it as a back-compat cap (arg absent here).
+                    if (envCap == 1)
+                    {
+                        log?.Invoke(@"File parallelism: 1 (OSPREY_MAX_PARALLEL_FILES=1)");
+                        return 1;
+                    }
+                    if (envCap > 1)
+                    {
+                        int capped = Math.Min(envCap, nFiles);
+                        log?.Invoke(string.Format(
+                            @"File parallelism: {0} (OSPREY_MAX_PARALLEL_FILES={1} back-compat cap, {2} files)",
+                            capped, envCap, nFiles));
+                        return capped;
+                    }
+                    log?.Invoke(string.Format(
+                        @"File parallelism: 1 (sequential default; pass --parallel-files to score {0} files concurrently)",
+                        nFiles));
+                    return 1;
+            }
+        }
+
+        /// <summary>
+        /// Largest input footprint estimate in bytes (max input file size x
+        /// <see cref="FOOTPRINT_MULTIPLIER"/>), or 0 when no file size can be
+        /// read. Uses the max rather than the mean because the concurrent peak is
+        /// bounded by the biggest files running together.
+        /// </summary>
+        public static long EstimatePerFileBytes(IEnumerable<string> inputFiles)
+        {
+            long maxBytes = 0;
+            if (inputFiles != null)
+            {
+                foreach (var file in inputFiles)
+                {
+                    long len = SafeFileLength(file);
+                    if (len > maxBytes)
+                        maxBytes = len;
+                }
+            }
+            if (maxBytes <= 0)
+                return 0;
+            return (long)(maxBytes * FOOTPRINT_MULTIPLIER);
+        }
+
+        private static int ResolveAuto(
+            int nFiles, int cores, int cpuCap,
+            Func<long> availableBytesProbe, Func<long> perFileBytesEstimate,
+            Action<string> log)
+        {
+            long availableBytes = availableBytesProbe?.Invoke() ?? 0;
+            long perFileBytes = perFileBytesEstimate?.Invoke() ?? 0;
+
+            if (availableBytes <= 0 || perFileBytes <= 0)
+            {
+                // No usable memory signal -- fall back to a CPU-bound cap rather
+                // than guessing. Still safer than the old unbounded default.
+                log?.Invoke(string.Format(
+                    @"File parallelism: {0} (auto, CPU-bound: {1} cores, {2} files; memory estimate unavailable)",
+                    cpuCap, cores, nFiles));
+                return cpuCap;
+            }
+
+            long budget = (long)(availableBytes * RAM_BUDGET_FRACTION);
+            int memFit = (int)Math.Max(1, budget / perFileBytes);
+            int chosen = Math.Max(1, Math.Min(cpuCap, memFit));
+            log?.Invoke(string.Format(
+                @"File parallelism: {0} (auto: {1:F1} GB free x {2:P0} / ~{3:F1} GB est per file -> {4} by RAM, capped to {5} cores / {6} files)",
+                chosen, availableBytes / (double)BYTES_PER_GB, RAM_BUDGET_FRACTION,
+                perFileBytes / (double)BYTES_PER_GB, memFit, cores, nFiles));
+            return chosen;
+        }
+
+        private static long SafeFileLength(string path)
+        {
+            try
+            {
+                if (!string.IsNullOrEmpty(path) && File.Exists(path))
+                    return new FileInfo(path).Length;
+            }
+            catch (Exception)
+            {
+                // Unreadable path -- treat as unknown size (0), never throw from a
+                // sizing hint.
+            }
+            return 0;
+        }
+
+        private const long BYTES_PER_GB = 1024L * 1024L * 1024L;
+    }
+}

--- a/pwiz_tools/OspreySharp/OspreySharp.Core/OspreyConfig.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Core/OspreyConfig.cs
@@ -171,8 +171,22 @@ namespace pwiz.OspreySharp.Core
         /// </summary>
         public FdrLevel FdrLevel { get; set; } = FdrLevel.Precursor;
 
-        /// <summary>Number of threads to use.</summary>
+        /// <summary>
+        /// INNER per-file main-search thread budget. Set by <c>--threads</c>.
+        /// Divided across concurrent files (see <see cref="FileParallelism"/>)
+        /// so total thread demand stays near the core count.
+        /// </summary>
         public int NThreads { get; set; } = Environment.ProcessorCount;
+
+        /// <summary>
+        /// OUTER across-files parallelism request, set by <c>--parallel-files</c>.
+        /// Default <see cref="Core.FileParallelism.Sequential"/> (one file at a
+        /// time) is safe on any machine; <c>--parallel-files</c> opts into
+        /// RAM/CPU-aware auto or an explicit count. Resolved to a concrete
+        /// concurrent-file count at run time by <see cref="FileParallelismResolver"/>;
+        /// not part of any identity / cache hash (a per-run scheduling decision).
+        /// </summary>
+        public FileParallelism FileParallelism { get; set; } = FileParallelism.Sequential;
 
         /// <summary>
         /// Pipeline-membership flag (read by each task's <c>IsIncluded</c>):

--- a/pwiz_tools/OspreySharp/OspreySharp.Core/OspreyEnvironment.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Core/OspreyEnvironment.cs
@@ -39,13 +39,18 @@ namespace pwiz.OspreySharp.Core
     public static class OspreyEnvironment
     {
         /// <summary>
-        /// OSPREY_MAX_PARALLEL_FILES: cap on concurrent file processing in the
-        /// Parallel.For over input files. Values:
-        ///   0 / unset = use .NET default (all files at once)
+        /// OSPREY_MAX_PARALLEL_FILES: legacy back-compat cap on concurrent file
+        /// processing, superseded by the <c>--parallel-files</c> CLI argument
+        /// (which wins when both are set). Consulted by
+        /// <see cref="FileParallelismResolver"/> only when the argument is absent.
+        /// Values:
+        ///   0 / unset = no cap from here (the default is now strictly sequential)
         ///   1        = strictly sequential
         ///   N &gt; 1    = at most N files concurrently
-        /// Useful for memory-bound datasets (Astral HRAM) where three 30 GB
-        /// working sets exceed a 64 GB budget.
+        /// Note the default changed: an unset value used to mean "all files at
+        /// once"; it now means "one file at a time" -- opt into concurrency with
+        /// <c>--parallel-files</c>. Useful historically for memory-bound datasets
+        /// (Astral HRAM) where three large working sets exceed a 64 GB budget.
         /// </summary>
         public static readonly int MaxParallelFiles = ParseIntOrZero(@"OSPREY_MAX_PARALLEL_FILES");
 

--- a/pwiz_tools/OspreySharp/OspreySharp.Core/SystemMemory.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Core/SystemMemory.cs
@@ -1,0 +1,103 @@
+/*
+ * Original author: Brendan MacLean <brendanx .at. uw.edu>,
+ *                  MacCoss Lab, Department of Genome Sciences, UW
+ * AI assistance: Claude Code (Claude Opus 4.8) <noreply .at. anthropic.com>
+ *
+ * Copyright 2026 University of Washington - Seattle, WA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#if NETFRAMEWORK
+using System.Runtime.InteropServices;
+#else
+using System;     // GC.GetGCMemoryInfo (net8.0 only; the net472 path is pure PInvoke)
+#endif
+
+namespace pwiz.OspreySharp.Core
+{
+    /// <summary>
+    /// Best-effort probe of free physical memory, used only by AUTO file
+    /// parallelism (<see cref="FileParallelismResolver"/>) to decide how many
+    /// input files to score concurrently without exhausting RAM. This is a
+    /// sizing hint, never a correctness input, so an unknown value (0) simply
+    /// falls the resolver back to a CPU-bound cap.
+    ///
+    /// net8.0 uses <c>GC.GetGCMemoryInfo()</c>, which is cross-platform and
+    /// respects container / cgroup limits on Linux (the HPC case). net472
+    /// is Windows-only and predates that API, so it falls back to the
+    /// <c>GlobalMemoryStatusEx</c> Win32 call (the same one Skyline's
+    /// MemoryInfo uses). The PInvoke is isolated here per the project's
+    /// "one place for each Win32 API" rule.
+    /// </summary>
+    public static class SystemMemory
+    {
+        /// <summary>
+        /// Free physical memory in bytes, or 0 when it cannot be determined.
+        /// Approximate (the net8.0 path reports the load as of the last GC);
+        /// adequate for a parallelism sizing decision.
+        /// </summary>
+        public static long AvailablePhysicalBytes()
+        {
+#if NETFRAMEWORK
+            var status = new MEMORYSTATUSEX();
+            if (GlobalMemoryStatusEx(status))
+                return (long)status.ullAvailPhys;
+            return 0;
+#else
+            var info = GC.GetGCMemoryInfo();
+            // TotalAvailableMemoryBytes is the GC's view of total physical (or
+            // the cgroup limit); MemoryLoadBytes is how much is currently in
+            // use. Their difference is the free headroom.
+            long total = info.TotalAvailableMemoryBytes;
+            long used = info.MemoryLoadBytes;
+            if (total <= 0)
+                return 0;
+            long available = total - used;
+            return available > 0 ? available : 0;
+#endif
+        }
+
+#if NETFRAMEWORK
+        // Layout must match the Win32 MEMORYSTATUSEX struct exactly; the fields
+        // are populated by GlobalMemoryStatusEx via marshaling (the compiler
+        // cannot see those writes), and only ullAvailPhys is read here.
+        [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Auto)]
+        private class MEMORYSTATUSEX
+        {
+            // ReSharper disable NotAccessedField.Local
+            // ReSharper disable UnassignedField.Compiler
+            public uint dwLength;
+            public uint dwMemoryLoad;
+            public ulong ullTotalPhys;
+            public ulong ullAvailPhys;
+            public ulong ullTotalPageFile;
+            public ulong ullAvailPageFile;
+            public ulong ullTotalVirtual;
+            public ulong ullAvailVirtual;
+            public ulong ullAvailExtendedVirtual;
+            // ReSharper restore UnassignedField.Compiler
+            // ReSharper restore NotAccessedField.Local
+
+            public MEMORYSTATUSEX()
+            {
+                dwLength = (uint)Marshal.SizeOf(typeof(MEMORYSTATUSEX));
+            }
+        }
+
+        [return: MarshalAs(UnmanagedType.Bool)]
+        [DllImport(@"kernel32.dll", CharSet = CharSet.Auto, SetLastError = true)]
+        private static extern bool GlobalMemoryStatusEx([In, Out] MEMORYSTATUSEX lpBuffer);
+#endif
+    }
+}

--- a/pwiz_tools/OspreySharp/OspreySharp.Tasks/PerFileScoringTask.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Tasks/PerFileScoringTask.cs
@@ -198,24 +198,17 @@ namespace pwiz.OspreySharp.Tasks
                 { @"osprey.reconciled", @"false" },
             };
 
-            // File-level parallelism is configurable via
-            // OSPREY_MAX_PARALLEL_FILES. See AnalysisPipeline (and
-            // Osprey-workflow.html) for the policy.
-            int maxParallelFiles = OspreyEnvironment.MaxParallelFiles;
-
-            // Determine how many files will actually run concurrently so
-            // ProcessFile can divide the inner main-search thread budget
-            // and avoid oversubscription. Stored on the per-run RunPlan
-            // (driver-owned run state), not on the parsed OspreyConfig.
-            if (nFiles == 1 || maxParallelFiles == 1)
-                ctx.RunPlan.EffectiveFileParallelism = 1;
-            else if (maxParallelFiles > 1)
-                ctx.RunPlan.EffectiveFileParallelism = Math.Min(maxParallelFiles, nFiles);
-            else
-                ctx.RunPlan.EffectiveFileParallelism = Math.Min(nFiles, Environment.ProcessorCount);
+            // Resolve how many input files run concurrently for this invocation
+            // (--parallel-files, the OSPREY_MAX_PARALLEL_FILES back-compat cap,
+            // free RAM, and core count) in the one shared place. Stored on the
+            // per-run RunPlan (driver-owned run state), not on the parsed
+            // OspreyConfig; ProcessFile reads it to divide the inner main-search
+            // thread budget and avoid oversubscription.
+            int effectiveParallelism = ResolveFileParallelism(config, nFiles, ctx.LogInfo);
+            ctx.RunPlan.EffectiveFileParallelism = effectiveParallelism;
 
             var swAllFiles = Stopwatch.StartNew();
-            if (config.InputFiles.Count == 1)
+            if (nFiles == 1)
             {
                 // Single file: process directly (no parallel overhead)
                 string inputFile = config.InputFiles[0];
@@ -228,15 +221,13 @@ namespace pwiz.OspreySharp.Tasks
                 if (fileResult != null)
                     perFileEntries.Add(new KeyValuePair<string, List<FdrEntry>>(fileName, fileResult));
             }
-            else if (maxParallelFiles == 1)
+            else if (effectiveParallelism == 1)
             {
-                // Strictly sequential: one file at a time. Matches the
-                // memory envelope of the single-file path while still
-                // sharing the library load. Useful for 3-file Astral
-                // runs that would OOM in parallel.
-                ctx.LogInfo(string.Format(
-                    @"[BENCH] OSPREY_MAX_PARALLEL_FILES=1 - processing {0} files sequentially",
-                    config.InputFiles.Count));
+                // Strictly sequential: one file at a time (the default, or an
+                // explicit --parallel-files 1 / OSPREY_MAX_PARALLEL_FILES=1).
+                // Matches the memory envelope of the single-file path while
+                // still sharing the library load -- the safe choice for 3-file
+                // Astral runs that would OOM in parallel.
                 string validityKey = ValidityKey(ctx);
                 for (int fileIdx = 0; fileIdx < config.InputFiles.Count; fileIdx++)
                 {
@@ -252,16 +243,12 @@ namespace pwiz.OspreySharp.Tasks
             }
             else
             {
-                // Multiple files: process in parallel, optionally
-                // capped via OSPREY_MAX_PARALLEL_FILES.
-                var parallelOpts = new ParallelOptions();
-                if (maxParallelFiles > 1)
+                // Multiple files in parallel, bounded by the resolved
+                // concurrent-file count (see ResolveFileParallelism).
+                var parallelOpts = new ParallelOptions
                 {
-                    parallelOpts.MaxDegreeOfParallelism = maxParallelFiles;
-                    ctx.LogInfo(string.Format(
-                        @"[BENCH] OSPREY_MAX_PARALLEL_FILES={0} - capping parallel file count",
-                        maxParallelFiles));
-                }
+                    MaxDegreeOfParallelism = effectiveParallelism
+                };
                 string validityKey = ValidityKey(ctx);
                 var fileResults = new ConcurrentDictionary<int, KeyValuePair<string, List<FdrEntry>>>();
                 Parallel.For(0, config.InputFiles.Count, parallelOpts, fileIdx =>
@@ -350,16 +337,12 @@ namespace pwiz.OspreySharp.Tasks
             // (Stage 6 rescore's fileNameToIdx in particular) already has the
             // synthetic input paths by the time this load runs.
 
-            // Mirror Run's EffectiveFileParallelism bookkeeping (unused by the
-            // disk-load path, which never calls ProcessFile, but kept so the
-            // RunPlan reflects the same per-run state either way).
-            int maxParallelFiles = OspreyEnvironment.MaxParallelFiles;
-            if (nFiles == 1 || maxParallelFiles == 1)
-                ctx.RunPlan.EffectiveFileParallelism = 1;
-            else if (maxParallelFiles > 1)
-                ctx.RunPlan.EffectiveFileParallelism = Math.Min(maxParallelFiles, nFiles);
-            else
-                ctx.RunPlan.EffectiveFileParallelism = Math.Min(nFiles, Environment.ProcessorCount);
+            // Mirror Run's EffectiveFileParallelism bookkeeping via the shared
+            // resolver (unused by the disk-load path, which never calls
+            // ProcessFile, but kept so the RunPlan reflects the same per-run
+            // state either way). No log callback: this path does not parallelize,
+            // so it should not emit a file-parallelism decision line.
+            ctx.RunPlan.EffectiveFileParallelism = ResolveFileParallelism(config, nFiles, null);
 
             var swAllFiles = Stopwatch.StartNew();
             LoadJoinOnlyScores(config, perFileEntries, perFileParquetPaths, perFileCalibrations, ctx);
@@ -429,16 +412,12 @@ namespace pwiz.OspreySharp.Tasks
 
             int nFiles = config.InputFiles?.Count ?? 0;
 
-            // Mirror Run's EffectiveFileParallelism bookkeeping (unused by the
-            // disk-load path, which never calls ProcessFile, but kept so the
-            // RunPlan reflects the same per-run state either way).
-            int maxParallelFiles = OspreyEnvironment.MaxParallelFiles;
-            if (nFiles == 1 || maxParallelFiles == 1)
-                ctx.RunPlan.EffectiveFileParallelism = 1;
-            else if (maxParallelFiles > 1)
-                ctx.RunPlan.EffectiveFileParallelism = Math.Min(maxParallelFiles, nFiles);
-            else
-                ctx.RunPlan.EffectiveFileParallelism = Math.Min(nFiles, Environment.ProcessorCount);
+            // Mirror Run's EffectiveFileParallelism bookkeeping via the shared
+            // resolver (unused by the disk-load path, which never calls
+            // ProcessFile, but kept so the RunPlan reflects the same per-run
+            // state either way). No log callback: this path does not parallelize,
+            // so it should not emit a file-parallelism decision line.
+            ctx.RunPlan.EffectiveFileParallelism = ResolveFileParallelism(config, nFiles, null);
 
             var swAllFiles = Stopwatch.StartNew();
             if (config.InputFiles != null)
@@ -540,6 +519,27 @@ namespace pwiz.OspreySharp.Tasks
             }
 
             return true;
+        }
+
+        /// <summary>
+        /// Resolve the effective concurrent-file count for this invocation via the
+        /// shared <see cref="FileParallelismResolver"/> -- the single owner of the
+        /// precedence between <c>--parallel-files</c>, the
+        /// <c>OSPREY_MAX_PARALLEL_FILES</c> back-compat cap, free RAM, and the core
+        /// count. The memory probe and per-file footprint estimate are evaluated
+        /// lazily (auto mode only), so the common sequential / explicit paths do no
+        /// I/O. <paramref name="log"/> is null on the disk-load bookkeeping paths
+        /// that never actually parallelize, so they compute the same number without
+        /// emitting a misleading decision line.
+        /// </summary>
+        private static int ResolveFileParallelism(OspreyConfig config, int nFiles, Action<string> log)
+        {
+            return FileParallelismResolver.Resolve(
+                config.FileParallelism, nFiles, OspreyEnvironment.MaxParallelFiles,
+                Environment.ProcessorCount,
+                SystemMemory.AvailablePhysicalBytes,
+                () => FileParallelismResolver.EstimatePerFileBytes(config.InputFiles),
+                log);
         }
 
         /// <summary>

--- a/pwiz_tools/OspreySharp/OspreySharp.Test/FileParallelismResolverTests.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Test/FileParallelismResolverTests.cs
@@ -1,0 +1,100 @@
+/*
+ * Original author: Brendan MacLean <brendanx .at. uw.edu>,
+ *                  MacCoss Lab, Department of Genome Sciences, UW
+ * AI assistance: Claude Code (Claude Opus 4.8) <noreply .at. anthropic.com>
+ *
+ * Copyright 2026 University of Washington - Seattle, WA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using pwiz.OspreySharp.Core;
+
+namespace pwiz.OspreySharp.Test
+{
+    /// <summary>
+    /// Tests for <see cref="FileParallelismResolver"/>, the single owner of the
+    /// concurrent-file decision: precedence between the <c>--parallel-files</c>
+    /// argument, the <c>OSPREY_MAX_PARALLEL_FILES</c> back-compat cap, free RAM,
+    /// and the core count. System inputs (free RAM, footprint estimate) are
+    /// injected so the policy is exercised deterministically with no real probing.
+    /// </summary>
+    [TestClass]
+    public class FileParallelismResolverTests
+    {
+        private const long GB = 1024L * 1024L * 1024L;
+
+        // Inject fixed system inputs so the policy is the only thing under test.
+        private static int Resolve(FileParallelism request, int nFiles,
+            int envCap = 0, int cores = 8, long availableBytes = 0, long perFileBytes = 0)
+        {
+            return FileParallelismResolver.Resolve(
+                request, nFiles, envCap, cores,
+                () => availableBytes, () => perFileBytes);
+        }
+
+        [TestMethod]
+        public void TestFileParallelismResolution()
+        {
+            // A single file is always 1, regardless of the request.
+            Assert.AreEqual(1, Resolve(FileParallelism.Auto, 1, cores: 32, availableBytes: 256 * GB, perFileBytes: GB));
+            Assert.AreEqual(1, Resolve(FileParallelism.Explicit(8), 1));
+            Assert.AreEqual(1, Resolve(FileParallelism.Sequential, 0));
+
+            // Sequential default (argument absent, no env cap) = one at a time.
+            Assert.AreEqual(1, Resolve(FileParallelism.Sequential, 3));
+
+            // OSPREY_MAX_PARALLEL_FILES back-compat cap applies ONLY when the
+            // argument is absent (Sequential request). =1 stays sequential;
+            // >1 caps, clamped to the file count.
+            Assert.AreEqual(1, Resolve(FileParallelism.Sequential, 5, envCap: 1));
+            Assert.AreEqual(4, Resolve(FileParallelism.Sequential, 10, envCap: 4));
+            Assert.AreEqual(3, Resolve(FileParallelism.Sequential, 3, envCap: 4)); // clamp to nFiles
+
+            // Explicit N wins regardless of RAM/cores/env -- clamped only to the
+            // file count (a bigger box can force more than this machine fits).
+            Assert.AreEqual(8, Resolve(FileParallelism.Explicit(8), 10, cores: 4, availableBytes: GB, perFileBytes: 100 * GB));
+            Assert.AreEqual(3, Resolve(FileParallelism.Explicit(8), 3)); // clamp to nFiles
+            Assert.AreEqual(2, Resolve(FileParallelism.Explicit(2), 5, envCap: 1)); // env cap ignored when arg present
+            Assert.AreEqual(1, Resolve(FileParallelism.Explicit(0), 5)); // floored at 1
+
+            // Auto, RAM-bound: budget = 80% of free RAM; N = budget / per-file,
+            // then capped by cores and file count.
+            //   51.2 GB budget / 18 GB per file -> 2, capped to min(3 files, 32 cores).
+            Assert.AreEqual(2, Resolve(FileParallelism.Auto, 3, cores: 32, availableBytes: 64 * GB, perFileBytes: 18 * GB));
+            // Plenty of RAM -> CPU/file cap dominates.
+            Assert.AreEqual(3, Resolve(FileParallelism.Auto, 3, cores: 32, availableBytes: 512 * GB, perFileBytes: 6 * GB));
+            // Core-bound even with plenty of RAM.
+            Assert.AreEqual(2, Resolve(FileParallelism.Auto, 8, cores: 2, availableBytes: 512 * GB, perFileBytes: GB));
+            // Tight RAM still yields at least 1 (never 0).
+            Assert.AreEqual(1, Resolve(FileParallelism.Auto, 4, cores: 16, availableBytes: 4 * GB, perFileBytes: 30 * GB));
+
+            // Auto with no usable memory signal falls back to the CPU/file cap
+            // (still bounded, unlike the old unbounded default).
+            Assert.AreEqual(3, Resolve(FileParallelism.Auto, 3, cores: 8, availableBytes: 0, perFileBytes: 6 * GB));
+            Assert.AreEqual(4, Resolve(FileParallelism.Auto, 4, cores: 8, availableBytes: 64 * GB, perFileBytes: 0));
+            Assert.AreEqual(8, Resolve(FileParallelism.Auto, 10, cores: 8, availableBytes: 0, perFileBytes: 0));
+
+            // Auto ignores the env cap entirely (the argument wins when both set).
+            Assert.AreEqual(3, Resolve(FileParallelism.Auto, 3, envCap: 1, cores: 8, availableBytes: 512 * GB, perFileBytes: GB));
+
+            // Footprint estimate: null / empty / unreadable paths -> 0 (unknown),
+            // which routes auto mode to the CPU/file cap rather than throwing.
+            Assert.AreEqual(0, FileParallelismResolver.EstimatePerFileBytes(null));
+            Assert.AreEqual(0, FileParallelismResolver.EstimatePerFileBytes(new string[0]));
+            Assert.AreEqual(0, FileParallelismResolver.EstimatePerFileBytes(
+                new[] { @"C:\does\not\exist\a.mzML", @"C:\does\not\exist\b.mzML" }));
+        }
+    }
+}

--- a/pwiz_tools/OspreySharp/OspreySharp.Test/OspreyCommandArgsTests.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Test/OspreyCommandArgsTests.cs
@@ -98,6 +98,18 @@ namespace pwiz.OspreySharp.Test
             Assert.AreEqual(@"m.tsv", Parse(@"--decoys-in-library", @"--decoy-pairing-manifest", @"m.tsv").DecoyPairingManifestPath);
             Assert.IsTrue(Parse(@"--write-pin").WritePin);
 
+            // Performance: --parallel-files has an OPTIONAL value. Absent =
+            // sequential default; no value = auto; <N> = explicit. The optional
+            // value must not swallow the following flag.
+            Assert.AreEqual(FileParallelismMode.Sequential, Parse(@"-i", @"a.mzML").FileParallelism.Mode);
+            Assert.AreEqual(FileParallelismMode.Auto, Parse(@"--parallel-files").FileParallelism.Mode);
+            var explicitN = Parse(@"--parallel-files", @"4").FileParallelism;
+            Assert.AreEqual(FileParallelismMode.Explicit, explicitN.Mode);
+            Assert.AreEqual(4, explicitN.Count);
+            var autoThenInput = Parse(@"--parallel-files", @"-i", @"a.mzML");
+            Assert.AreEqual(FileParallelismMode.Auto, autoThenInput.FileParallelism.Mode);
+            CollectionAssert.AreEqual(new[] { @"a.mzML" }, autoThenInput.InputFiles.ToArray());
+
             // Diagnostics. --task is resolved in Main, so ParseArgs alone leaves SelectedTask null
             // but must accept both --task forms without throwing.
             Assert.IsTrue(Parse(@"-d").Diagnostics);
@@ -161,9 +173,10 @@ namespace pwiz.OspreySharp.Test
             // representative arg present, and box-drawing borders (not lower-128 ascii).
             string defaultHelp = OspreyCommandArgs.BuildUsage(null);
             foreach (var title in new[] { @"General I/O", @"Scoring & Tolerance", @"FDR & Protein Inference",
-                @"Decoys", @"Distributed / HPC", @"Diagnostics & Info" })
+                @"Decoys", @"Performance", @"Distributed / HPC", @"Diagnostics & Info" })
                 StringAssert.Contains(defaultHelp, title);
             StringAssert.Contains(defaultHelp, @"--input");
+            StringAssert.Contains(defaultHelp, @"--parallel-files");
             StringAssert.Contains(defaultHelp, @"--help");
             StringAssert.Contains(defaultHelp, ArgUsage.Provider.ArgumentHeader);
             Assert.IsTrue(defaultHelp.Contains('│') || defaultHelp.Contains('─'),

--- a/pwiz_tools/OspreySharp/OspreySharp.Test/OspreyCommandArgsTests.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Test/OspreyCommandArgsTests.cs
@@ -106,6 +106,8 @@ namespace pwiz.OspreySharp.Test
             var explicitN = Parse(@"--parallel-files", @"4").FileParallelism;
             Assert.AreEqual(FileParallelismMode.Explicit, explicitN.Mode);
             Assert.AreEqual(4, explicitN.Count);
+            // 0 is the natural "off" -> sequential (consumed as a value, no stray warning).
+            Assert.AreEqual(FileParallelismMode.Sequential, Parse(@"--parallel-files", @"0").FileParallelism.Mode);
             var autoThenInput = Parse(@"--parallel-files", @"-i", @"a.mzML");
             Assert.AreEqual(FileParallelismMode.Auto, autoThenInput.FileParallelism.Mode);
             CollectionAssert.AreEqual(new[] { @"a.mzML" }, autoThenInput.InputFiles.ToArray());

--- a/pwiz_tools/OspreySharp/OspreySharp/OspreyCommandArgs.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/OspreyCommandArgs.cs
@@ -208,12 +208,29 @@ namespace pwiz.OspreySharp
                 c._config.InputScores = Program.ResolveInputScores(scorePaths);
                 return true;
             } };
+        private static readonly ArgumentGroup<OspreyCommandArgs> GROUP_HPC =
+            new ArgumentGroup<OspreyCommandArgs>(() => @"Distributed / HPC", true,
+                ARG_TASK, ARG_INPUT_SCORES);
+
+        // --- Performance ------------------------------------------------------------------
+        // OUTER vs INNER parallelism, kept deliberately separate. --parallel-files is the
+        // number of input files scored at once (each file's Stage 1-4 work is independent);
+        // --threads is the per-file main-search thread budget, divided across whatever files
+        // run concurrently. --parallel-files takes an OPTIONAL value (handled specially in
+        // TokenizeAndDispatch): absent = one file at a time, no value = RAM/CPU-aware auto,
+        // <N> = exactly N. Unlike the rest of OspreySharp's in-process work this is not HPC
+        // (the Rust HPC split fans files across nodes, one file per process), so it gets its
+        // own group rather than sitting under Distributed / HPC.
+        public static readonly OspreyArgument ARG_PARALLEL_FILES = new OspreyArgument(@"parallel-files",
+            () => @"[<N>]", (c, p) => c._config.FileParallelism = string.IsNullOrEmpty(p.Value)
+                ? FileParallelism.Auto
+                : FileParallelism.Explicit(int.Parse(p.Value)));
         public static readonly OspreyArgument ARG_THREADS = new OspreyArgument(@"threads",
             () => @"<count>", (c, p) => c._config.NThreads = int.Parse(p.Value));
 
-        private static readonly ArgumentGroup<OspreyCommandArgs> GROUP_HPC =
-            new ArgumentGroup<OspreyCommandArgs>(() => @"Distributed / HPC", true,
-                ARG_TASK, ARG_INPUT_SCORES, ARG_THREADS);
+        private static readonly ArgumentGroup<OspreyCommandArgs> GROUP_PERFORMANCE =
+            new ArgumentGroup<OspreyCommandArgs>(() => @"Performance", true,
+                ARG_PARALLEL_FILES, ARG_THREADS);
 
         // --- Diagnostics & Info -----------------------------------------------------------
         // -h/--help and -v/--version are terminal: the tokenizer renders help / prints the
@@ -242,6 +259,7 @@ namespace pwiz.OspreySharp
                     GROUP_SCORING,
                     GROUP_FDR,
                     GROUP_DECOYS,
+                    GROUP_PERFORMANCE,
                     GROUP_HPC,
                     GROUP_INFO,
                     new ParaUsageBlock(@"EXAMPLES:"),
@@ -327,6 +345,22 @@ namespace pwiz.OspreySharp
                         throw new ArgumentException(
                             @"--task requires a task name (PerFileScoring, FirstJoin, PerFileRescore, or MergeNode).");
                     i++;
+                    continue;
+                }
+                if (ReferenceEquals(matched, ARG_PARALLEL_FILES))
+                {
+                    // Optional value: consume the next token as the explicit count
+                    // ONLY when it is a non-flag positive integer; otherwise this is
+                    // auto mode and the token is left for normal processing (e.g. a
+                    // trailing positional mzML). Mirrors the --help [fmt] lookahead.
+                    i++;
+                    string parallelValue = null;
+                    if (i < args.Length && IsPositiveInteger(args[i]))
+                    {
+                        parallelValue = args[i];
+                        i++;
+                    }
+                    matched.ProcessValue(this, new NameValuePair(matched.Name, parallelValue));
                     continue;
                 }
 
@@ -458,6 +492,24 @@ namespace pwiz.OspreySharp
             return args[i];
         }
 
+        /// <summary>
+        /// True when <paramref name="token"/> is a plain positive integer (no sign,
+        /// digits only). Used by the <c>--parallel-files</c> optional-value lookahead
+        /// to tell an explicit count from auto-mode-plus-trailing-token; a leading '-'
+        /// is therefore correctly treated as the next flag, not a value.
+        /// </summary>
+        private static bool IsPositiveInteger(string token)
+        {
+            if (string.IsNullOrEmpty(token))
+                return false;
+            foreach (char c in token)
+            {
+                if (c < '0' || c > '9')
+                    return false;
+            }
+            return int.TryParse(token, out int n) && n > 0;
+        }
+
         private static double ParseDouble(string value, string flagName)
         {
             double result;
@@ -575,7 +627,8 @@ namespace pwiz.OspreySharp
                 { @"write-pin", @"Write PIN files for external tools" },
                 { @"task", @"HPC: run exactly one pipeline task (one node = one task). Omit for the full pipeline." },
                 { @"input-scores", @"HPC: one or more .scores.parquet files, or a single directory (non-recursive). Mutex with --input." },
-                { @"threads", @"Number of threads (default: all cores)" },
+                { @"parallel-files", @"Input files scored concurrently (OUTER). Absent: one at a time (default). No value: auto from free RAM and cores. <N>: exactly N regardless of RAM/cores. Distinct from --threads." },
+                { @"threads", @"Per-file main-search threads (INNER; default: all cores), divided across files run concurrently by --parallel-files" },
                 { @"diagnostics", @"Write cross-impl bisection dumps (OSPREY_DUMP_* bundle)" },
                 { @"help", @"Show this help message ([ascii|unicode|sections|html|<Section>])" },
                 { @"version", @"Show version" },

--- a/pwiz_tools/OspreySharp/OspreySharp/OspreyCommandArgs.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/OspreyCommandArgs.cs
@@ -222,9 +222,23 @@ namespace pwiz.OspreySharp
         // (the Rust HPC split fans files across nodes, one file per process), so it gets its
         // own group rather than sitting under Distributed / HPC.
         public static readonly OspreyArgument ARG_PARALLEL_FILES = new OspreyArgument(@"parallel-files",
-            () => @"[<N>]", (c, p) => c._config.FileParallelism = string.IsNullOrEmpty(p.Value)
-                ? FileParallelism.Auto
-                : FileParallelism.Explicit(int.Parse(p.Value)));
+            () => @"[<N>]", (c, p) =>
+            {
+                if (string.IsNullOrEmpty(p.Value))
+                {
+                    c._config.FileParallelism = FileParallelism.Auto;
+                }
+                else
+                {
+                    // 0 is the value a user most naturally types to mean "off" --
+                    // map it to sequential rather than silently falling through to
+                    // auto. Positive N is an explicit concurrent-file count.
+                    int n = int.Parse(p.Value);
+                    c._config.FileParallelism = n <= 0
+                        ? FileParallelism.Sequential
+                        : FileParallelism.Explicit(n);
+                }
+            });
         public static readonly OspreyArgument ARG_THREADS = new OspreyArgument(@"threads",
             () => @"<count>", (c, p) => c._config.NThreads = int.Parse(p.Value));
 
@@ -349,13 +363,14 @@ namespace pwiz.OspreySharp
                 }
                 if (ReferenceEquals(matched, ARG_PARALLEL_FILES))
                 {
-                    // Optional value: consume the next token as the explicit count
-                    // ONLY when it is a non-flag positive integer; otherwise this is
-                    // auto mode and the token is left for normal processing (e.g. a
-                    // trailing positional mzML). Mirrors the --help [fmt] lookahead.
+                    // Optional value: consume the next token as the count ONLY when
+                    // it is a non-flag non-negative integer (0 = sequential, N = N
+                    // files); otherwise this is auto mode and the token is left for
+                    // normal processing (e.g. a trailing positional mzML). Mirrors
+                    // the --help [fmt] lookahead.
                     i++;
                     string parallelValue = null;
-                    if (i < args.Length && IsPositiveInteger(args[i]))
+                    if (i < args.Length && IsNonNegativeInteger(args[i]))
                     {
                         parallelValue = args[i];
                         i++;
@@ -493,12 +508,13 @@ namespace pwiz.OspreySharp
         }
 
         /// <summary>
-        /// True when <paramref name="token"/> is a plain positive integer (no sign,
-        /// digits only). Used by the <c>--parallel-files</c> optional-value lookahead
-        /// to tell an explicit count from auto-mode-plus-trailing-token; a leading '-'
-        /// is therefore correctly treated as the next flag, not a value.
+        /// True when <paramref name="token"/> is a plain non-negative integer (no
+        /// sign, digits only). Used by the <c>--parallel-files</c> optional-value
+        /// lookahead to tell an explicit count (including <c>0</c> = sequential) from
+        /// auto-mode-plus-trailing-token; a leading '-' is therefore correctly treated
+        /// as the next flag, not a value.
         /// </summary>
-        private static bool IsPositiveInteger(string token)
+        private static bool IsNonNegativeInteger(string token)
         {
             if (string.IsNullOrEmpty(token))
                 return false;
@@ -507,7 +523,7 @@ namespace pwiz.OspreySharp
                 if (c < '0' || c > '9')
                     return false;
             }
-            return int.TryParse(token, out int n) && n > 0;
+            return int.TryParse(token, out int n) && n >= 0;
         }
 
         private static double ParseDouble(string value, string flagName)


### PR DESCRIPTION
## Summary

* Changed OspreySharp's default to process input files **strictly sequentially** (one at a time). Multi-file HRAM runs previously processed all files in parallel by default, which could OOM/thrash on smaller boxes and silently competed with the inner scoring threads on larger ones.
* Added a first-class `--parallel-files [<N>]` argument: absent = sequential; no value = **RAM/CPU-aware auto**; `<N>` = explicit concurrent-file count. Deliberately distinct from `--threads` (the inner per-file main-search thread budget). Lives in a new **Performance** help group with `--threads`, OUTER vs INNER spelled out.
* Centralized the decision in one `FileParallelismResolver` (precedence: explicit arg N > auto > `OSPREY_MAX_PARALLEL_FILES` back-compat cap > sequential) routed through all three `PerFileScoringTask` sites. AUTO sizes concurrency from free physical memory (net8.0 `GC.GetGCMemoryInfo`, cgroup-aware; net472 `GlobalMemoryStatusEx`) and core count, biased toward fewer files.
* `OSPREY_MAX_PARALLEL_FILES` is retained as a back-compat cap (the argument wins when both are set); its former "unset = all files at once" default is replaced by sequential.

Requested by Mike.

## Test plan

- [x] `Build-OspreySharp.ps1 -RunTests -RunInspection` - 432 pass / 3 skip, 0 warnings
- [x] `FileParallelismResolverTests` - precedence, clamping, auto (injected RAM/footprint)
- [x] `OspreyCommandArgsTests` - `--parallel-files` absent/auto/explicit, optional-value lookahead does not swallow the next flag, Performance group in help
- [x] `regression.ps1 -Dataset Stellar` - PASS all 3 modes (golden, HPC chain, resume); confirms the new sequential default == the committed golden
- [x] `--parallel-files 3` (explicit) and `--parallel-files` (auto) both == sequential at 1e-9 incl. peaks, via the regression's own `Compare-BlibFull` oracle
- [ ] `Test-PerfGate.ps1 -Dataset Stellar -MaxParallelFiles 1` (both A/B legs pinned sequential) - running
- [ ] `regression.ps1 -Dataset All` (multi-file Astral)

Co-Authored-By: Claude <noreply@anthropic.com>
