### PR TITLE
Added %-complete progress to OspreySharp I/O so no step stalls silently

### DIFF
--- a/pwiz_tools/OspreySharp/OspreySharp.Core/ProgressReporter.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Core/ProgressReporter.cs
@@ -52,7 +52,7 @@ namespace pwiz.OspreySharp.Core
     /// </summary>
     public sealed class ProgressReporter : IDisposable
     {
-        private readonly int _total;
+        private readonly long _total;
         private readonly string _indent;
         private readonly double _intervalSeconds;
         private readonly Stopwatch _stopwatch;
@@ -65,11 +65,14 @@ namespace pwiz.OspreySharp.Core
         /// units, printing the "&lt;activity&gt;..." heading immediately.
         /// </summary>
         /// <param name="activity">Heading text printed on construction (without the trailing "...").</param>
-        /// <param name="total">Total number of units; percent is reported as current/total.</param>
+        /// <param name="total">Total number of units; percent is reported as current/total. A
+        /// <see cref="long"/> so byte counts (mzML reads) and row counts (parquet writes) on
+        /// Astral-class data can exceed <see cref="int.MaxValue"/> without overflow; an
+        /// <see cref="int"/> argument widens implicitly.</param>
         /// <param name="indent">Leading whitespace for the heading so it lines up with the
         /// matching completion line; the percent lines are indented one level (2 spaces) deeper.</param>
         /// <param name="intervalSeconds">Minimum seconds between percent lines (timer throttle).</param>
-        public ProgressReporter(string activity, int total, string indent = "", double intervalSeconds = 1.0)
+        public ProgressReporter(string activity, long total, string indent = "", double intervalSeconds = 1.0)
         {
             _total = total;
             _indent = indent;
@@ -83,7 +86,7 @@ namespace pwiz.OspreySharp.Core
         /// parallel workers. Prints a throttled percent only when the percent advances and the
         /// report interval has elapsed.
         /// </summary>
-        public void Report(int current)
+        public void Report(long current)
         {
             lock (_lock)
             {

--- a/pwiz_tools/OspreySharp/OspreySharp.Core/ProgressStream.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Core/ProgressStream.cs
@@ -1,0 +1,99 @@
+/*
+ * Original author: Brendan MacLean <brendanx .at. uw.edu>,
+ *                  MacCoss Lab, Department of Genome Sciences, UW
+ * AI assistance: Claude Code (Claude Opus 4.8) <noreply .at. anthropic.com>
+ *
+ * Based on osprey (https://github.com/MacCossLab/osprey)
+ *   by Michael J. MacCoss, MacCoss Lab, Department of Genome Sciences, UW
+ *
+ * Copyright 2026 University of Washington - Seattle, WA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
+using System.IO;
+
+namespace pwiz.OspreySharp.Core
+{
+    /// <summary>
+    /// A read-only <see cref="Stream"/> decorator that drives a <see cref="ProgressReporter"/>
+    /// by the number of bytes that have passed through it, so a long byte-oriented read (the
+    /// Astral mzML parse, where the file is ~200k MS/MS spectra and the parse runs 40+ seconds
+    /// with no other console output) reports a throttled percent against the total file length.
+    ///
+    /// Mirrors the role of Skyline's <c>pwiz.Common.SystemUtil.ProgressStream</c>, but reports
+    /// through OspreySharp's lightweight <see cref="ProgressReporter"/> rather than the
+    /// IProgressMonitor / ProgressStatus machinery (which OspreySharp deliberately does not yet
+    /// pull into PortableUtil). Counting is the only added work on the hot path -- there are no
+    /// extra buffer copies -- so it does not perturb the read throughput that overlaps with the
+    /// parallel decode in <c>MzmlReader.LoadAllSpectra</c>.
+    ///
+    /// Forward-only: <see cref="CanSeek"/> is false (an <c>XmlReader</c> over the wrapped
+    /// stream reads forward only, exactly as Skyline's ProgressStream is used). The decorator does
+    /// NOT own the inner stream -- the caller keeps the inner stream in its own <c>using</c> and
+    /// disposes it; disposing the ProgressStream is a no-op so an early dispose cannot truncate the
+    /// underlying file handle.
+    /// </summary>
+    public sealed class ProgressStream : Stream
+    {
+        private readonly Stream _inner;
+        private readonly ProgressReporter _reporter;
+        private long _bytesRead;
+
+        public ProgressStream(Stream inner, ProgressReporter reporter)
+        {
+            _inner = inner ?? throw new ArgumentNullException(nameof(inner));
+            _reporter = reporter ?? throw new ArgumentNullException(nameof(reporter));
+        }
+
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            int n = _inner.Read(buffer, offset, count);
+            _bytesRead += n;
+            _reporter.Report(_bytesRead);
+            return n;
+        }
+
+        public override bool CanRead => true;
+        public override bool CanSeek => false;
+        public override bool CanWrite => false;
+        public override long Length => _inner.Length;
+
+        public override long Position
+        {
+            get { return _bytesRead; }
+            set { throw new NotSupportedException(); }
+        }
+
+        public override void Flush()
+        {
+            _inner.Flush();
+        }
+
+        public override long Seek(long offset, SeekOrigin origin)
+        {
+            throw new NotSupportedException();
+        }
+
+        public override void SetLength(long value)
+        {
+            throw new NotSupportedException();
+        }
+
+        public override void Write(byte[] buffer, int offset, int count)
+        {
+            throw new NotSupportedException();
+        }
+    }
+}

--- a/pwiz_tools/OspreySharp/OspreySharp.IO/MzmlReader.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.IO/MzmlReader.cs
@@ -109,7 +109,7 @@ namespace pwiz.OspreySharp.IO
             using (var stream = new FileStream(path, FileMode.Open, FileAccess.Read,
                 FileShare.Read, 16 * 1024 * 1024))
             using (var progress = new ProgressReporter(
-                string.Format("Reading {0}", Path.GetFileName(path)), stream.Length, "  ", 2.0))
+                string.Format("Reading {0}", Path.GetFileName(path)), stream.Length, string.Empty, 2.0))
             using (var progressStream = new ProgressStream(stream, progress))
             {
                 var settings = new XmlReaderSettings { DtdProcessing = DtdProcessing.Ignore };

--- a/pwiz_tools/OspreySharp/OspreySharp.IO/MzmlReader.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.IO/MzmlReader.cs
@@ -99,11 +99,21 @@ namespace pwiz.OspreySharp.IO
             // 16 MB FileStream buffer amortizes per-Read overhead. Do NOT use
             // FileOptions.SequentialScan -- on Windows that hint discards
             // pages after read, defeating OS file cache reuse on repeat runs.
+            //
+            // The parse is byte-driven, so a ProgressStream over the FileStream
+            // reports a throttled percent against the file length -- on Astral
+            // this single read runs 40+ seconds and otherwise emits nothing.
+            // XmlReaderSettings.CloseInput defaults false, so the XmlReader does
+            // not close the FileStream; the ProgressStream does not own it
+            // either, so the FileStream is closed exactly once by its own using.
             using (var stream = new FileStream(path, FileMode.Open, FileAccess.Read,
                 FileShare.Read, 16 * 1024 * 1024))
+            using (var progress = new ProgressReporter(
+                string.Format("Reading {0}", Path.GetFileName(path)), stream.Length, "  ", 2.0))
+            using (var progressStream = new ProgressStream(stream, progress))
             {
                 var settings = new XmlReaderSettings { DtdProcessing = DtdProcessing.Ignore };
-                using (var reader = XmlReader.Create(stream, settings))
+                using (var reader = XmlReader.Create(progressStream, settings))
                 {
                     while (reader.Read())
                     {

--- a/pwiz_tools/OspreySharp/OspreySharp.IO/ParquetScoreCache.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.IO/ParquetScoreCache.cs
@@ -229,27 +229,32 @@ namespace pwiz.OspreySharp.IO
                 .ThenBy(idx => entries[idx].ScanNumber)
                 .ToArray();
 
-            for (int i = 0; i < n; i++)
+            using (var buildProgress = new ProgressReporter(
+                string.Format("Preparing {0} entries", n), n, "  ", 2.0))
             {
-                var entry = entries[sortedIndices[i]];
-                entryIds[i] = entry.EntryId;
-                isDecoys[i] = entry.IsDecoy;
-                sequences[i] = entry.Sequence ?? string.Empty;
-                modifiedSequences[i] = entry.ModifiedSequence ?? string.Empty;
-                charges[i] = entry.Charge;
-                precursorMzs[i] = entry.PrecursorMz;
-                proteinIds[i] = entry.ProteinIds != null
-                    ? string.Join(";", entry.ProteinIds)
-                    : null;
-                scanNumbers[i] = entry.ScanNumber;
-                apexRts[i] = entry.ApexRt;
-                startRts[i] = entry.PeakBounds != null ? entry.PeakBounds.StartRt : 0.0;
-                endRts[i] = entry.PeakBounds != null ? entry.PeakBounds.EndRt : 0.0;
-                boundsAreas[i] = entry.PeakBounds != null ? entry.PeakBounds.Area : 0.0;
-                boundsSnrs[i] = entry.PeakBounds != null ? entry.PeakBounds.SignalToNoise : 0.0;
-                fileNames[i] = entry.FileName ?? string.Empty;
+                for (int i = 0; i < n; i++)
+                {
+                    var entry = entries[sortedIndices[i]];
+                    entryIds[i] = entry.EntryId;
+                    isDecoys[i] = entry.IsDecoy;
+                    sequences[i] = entry.Sequence ?? string.Empty;
+                    modifiedSequences[i] = entry.ModifiedSequence ?? string.Empty;
+                    charges[i] = entry.Charge;
+                    precursorMzs[i] = entry.PrecursorMz;
+                    proteinIds[i] = entry.ProteinIds != null
+                        ? string.Join(";", entry.ProteinIds)
+                        : null;
+                    scanNumbers[i] = entry.ScanNumber;
+                    apexRts[i] = entry.ApexRt;
+                    startRts[i] = entry.PeakBounds != null ? entry.PeakBounds.StartRt : 0.0;
+                    endRts[i] = entry.PeakBounds != null ? entry.PeakBounds.EndRt : 0.0;
+                    boundsAreas[i] = entry.PeakBounds != null ? entry.PeakBounds.Area : 0.0;
+                    boundsSnrs[i] = entry.PeakBounds != null ? entry.PeakBounds.SignalToNoise : 0.0;
+                    fileNames[i] = entry.FileName ?? string.Empty;
 
-                ExtractPinFeatures(entry.Features, featureArrays, i);
+                    ExtractPinFeatures(entry.Features, featureArrays, i);
+                    buildProgress.Report(i + 1);
+                }
             }
 
             // Write to a temp file first, then move to final path (safe NAS writes)
@@ -268,28 +273,13 @@ namespace pwiz.OspreySharp.IO
 
                 using (var group = writer.CreateRowGroup())
                 {
-                    RunSync(group.WriteColumnAsync(new DataColumn(FIELD_ENTRY_ID, entryIds)));
-                    RunSync(group.WriteColumnAsync(new DataColumn(FIELD_IS_DECOY, isDecoys)));
-                    RunSync(group.WriteColumnAsync(new DataColumn(FIELD_SEQUENCE, sequences)));
-                    RunSync(group.WriteColumnAsync(new DataColumn(FIELD_MODIFIED_SEQUENCE, modifiedSequences)));
-                    RunSync(group.WriteColumnAsync(new DataColumn(FIELD_CHARGE, charges)));
-                    RunSync(group.WriteColumnAsync(new DataColumn(FIELD_PRECURSOR_MZ, precursorMzs)));
-                    RunSync(group.WriteColumnAsync(new DataColumn(FIELD_PROTEIN_IDS, proteinIds)));
-                    RunSync(group.WriteColumnAsync(new DataColumn(FIELD_SCAN_NUMBER, scanNumbers)));
-                    RunSync(group.WriteColumnAsync(new DataColumn(FIELD_APEX_RT, apexRts)));
-                    RunSync(group.WriteColumnAsync(new DataColumn(FIELD_START_RT, startRts)));
-                    RunSync(group.WriteColumnAsync(new DataColumn(FIELD_END_RT, endRts)));
-                    RunSync(group.WriteColumnAsync(new DataColumn(FIELD_BOUNDS_AREA, boundsAreas)));
-                    RunSync(group.WriteColumnAsync(new DataColumn(FIELD_BOUNDS_SNR, boundsSnrs)));
-                    RunSync(group.WriteColumnAsync(new DataColumn(FIELD_FILE_NAME, fileNames)));
-                    RunSync(group.WriteColumnAsync(new DataColumn(FIELD_CWT_CANDIDATES, cwtCandidates)));
-                    RunSync(group.WriteColumnAsync(new DataColumn(FIELD_FRAGMENT_MZS, fragmentMzs)));
-                    RunSync(group.WriteColumnAsync(new DataColumn(FIELD_FRAGMENT_INTENSITIES, fragmentIntensities)));
-                    RunSync(group.WriteColumnAsync(new DataColumn(FIELD_REFERENCE_XIC_RTS, refXicRts)));
-                    RunSync(group.WriteColumnAsync(new DataColumn(FIELD_REFERENCE_XIC_INTENSITIES, refXicIntensities)));
-
-                    for (int f = 0; f < NUM_PIN_FEATURES; f++)
-                        RunSync(group.WriteColumnAsync(new DataColumn(featureFields[f], featureArrays[f])));
+                    var columns = BuildRowGroupColumns(
+                        entryIds, isDecoys, sequences, modifiedSequences, charges,
+                        precursorMzs, proteinIds, scanNumbers, apexRts, startRts, endRts,
+                        boundsAreas, boundsSnrs, fileNames, cwtCandidates, fragmentMzs,
+                        fragmentIntensities, refXicRts, refXicIntensities,
+                        featureFields, featureArrays);
+                    WriteRowGroupColumns(group, columns, n);
                 }
             }
 
@@ -365,94 +355,99 @@ namespace pwiz.OspreySharp.IO
                 .ThenBy(idx => entries[idx].ScanNumber)
                 .ToArray();
 
-            for (int i = 0; i < n; i++)
+            using (var buildProgress = new ProgressReporter(
+                string.Format("Preparing {0} entries", n), n, "  ", 2.0))
             {
-                var entry = entries[sortedIndices[i]];
-                // Assign ParquetIndex to match the row position we are
-                // about to write. Mirrors LoadFdrStubsFromParquet, which
-                // assigns ParquetIndex = row on read. Without this
-                // assignment, in-memory entries reach Stage 5
-                // ReconciliationPlanner with ParquetIndex = 0 (FdrEntry
-                // default), and every entry's per-file CWT lookup
-                // (fileCwt[entry.ParquetIndex]) grabs the first row's
-                // CwtCandidate list instead of its own -- the planner
-                // then force-integrates almost every entry because the
-                // wrong CWT list has no candidate near the expected RT.
-                // The HPC chain path was unaffected because its entries
-                // are reloaded via LoadFdrStubsFromParquet, which sets
-                // ParquetIndex correctly. Found by C# in-memory vs
-                // C# HPC-chain strict-rehydration bisection on Stellar
-                // (Stage 5 boundary check: .1st-pass.fdr_scores.bin
-                // byte-identical but reconciliation.json action shape
-                // diverged -- 35K use_cwt actions on HPC side, 814 on
-                // in-memory side, total identical).
-                entry.ParquetIndex = (uint)i;
-                entryIds[i] = entry.EntryId;
-                isDecoys[i] = entry.IsDecoy;
-                charges[i] = entry.Charge;
-                scanNumbers[i] = entry.ScanNumber;
-                modifiedSequences[i] = entry.ModifiedSequence ?? string.Empty;
-                apexRts[i] = entry.ApexRt;
-                startRts[i] = entry.StartRt;
-                endRts[i] = entry.EndRt;
-                boundsAreas[i] = entry.BoundsArea;
-                boundsSnrs[i] = entry.BoundsSnr;
-                fileNames[i] = fileName ?? string.Empty;
-                fragmentMzs[i] = EncodeF64Blob(entry.FragmentMzs);
-                fragmentIntensities[i] = EncodeF32Blob(entry.FragmentIntensities);
-                refXicRts[i] = EncodeF64Blob(entry.ReferenceXicRts);
-                refXicIntensities[i] = EncodeF64Blob(entry.ReferenceXicIntensities);
-
-                // Mirror Rust's invariant: every row carries a cwt_candidates
-                // blob, even when the candidate list is empty. Rust's
-                // pipeline.rs::write_scores_parquet (at the cwt_candidates
-                // serialization site) unconditionally appends a 4-byte
-                // little-endian count prefix, so an entry with zero
-                // candidates becomes a 4-byte zero-length blob, never a
-                // null cell. ~57k post-compaction stubs per Stellar file
-                // had no peaks; without this normalization C# emitted
-                // null cells while Rust emitted empty blobs, producing
-                // a spurious cross-impl parquet diff at end-of-Stage-6.
-                //
-                // TODO(osprey-rust): the proper fix is on the Rust side --
-                // pipeline.rs should write null for empty candidate lists,
-                // which is more parquet-idiomatic and saves 4 bytes per
-                // empty row for downstream consumers. When that lands in
-                // maccoss/osprey, revert this branch to the original
-                // "skip null/empty" form.
-                // Use Array.Empty<>() (not `new List<>()`) on the null
-                // branch so we still emit the 4-byte zero-count blob
-                // without allocating a fresh List per empty row.
-                // CwtCandidateCodec.Encode takes IReadOnlyList<CwtCandidate>
-                // which both List<T> and T[] satisfy.
-                cwtCandidates[i] = CwtCandidateCodec.Encode(
-                    entry.CwtCandidates ?? (IReadOnlyList<CwtCandidate>)Array.Empty<CwtCandidate>());
-
-                LibraryEntry libEntry = null;
-                if (libraryById != null)
-                    libraryById.TryGetValue(entry.EntryId, out libEntry);
-                if (libEntry != null)
+                for (int i = 0; i < n; i++)
                 {
-                    sequences[i] = libEntry.Sequence ?? string.Empty;
-                    precursorMzs[i] = libEntry.PrecursorMz;
-                    proteinIds[i] = libEntry.ProteinIds != null
-                        ? string.Join(";", libEntry.ProteinIds)
-                        : null;
-                }
-                else
-                {
-                    sequences[i] = string.Empty;
-                    precursorMzs[i] = 0.0;
-                    proteinIds[i] = null;
-                }
+                    var entry = entries[sortedIndices[i]];
+                    // Assign ParquetIndex to match the row position we are
+                    // about to write. Mirrors LoadFdrStubsFromParquet, which
+                    // assigns ParquetIndex = row on read. Without this
+                    // assignment, in-memory entries reach Stage 5
+                    // ReconciliationPlanner with ParquetIndex = 0 (FdrEntry
+                    // default), and every entry's per-file CWT lookup
+                    // (fileCwt[entry.ParquetIndex]) grabs the first row's
+                    // CwtCandidate list instead of its own -- the planner
+                    // then force-integrates almost every entry because the
+                    // wrong CWT list has no candidate near the expected RT.
+                    // The HPC chain path was unaffected because its entries
+                    // are reloaded via LoadFdrStubsFromParquet, which sets
+                    // ParquetIndex correctly. Found by C# in-memory vs
+                    // C# HPC-chain strict-rehydration bisection on Stellar
+                    // (Stage 5 boundary check: .1st-pass.fdr_scores.bin
+                    // byte-identical but reconciliation.json action shape
+                    // diverged -- 35K use_cwt actions on HPC side, 814 on
+                    // in-memory side, total identical).
+                    entry.ParquetIndex = (uint)i;
+                    entryIds[i] = entry.EntryId;
+                    isDecoys[i] = entry.IsDecoy;
+                    charges[i] = entry.Charge;
+                    scanNumbers[i] = entry.ScanNumber;
+                    modifiedSequences[i] = entry.ModifiedSequence ?? string.Empty;
+                    apexRts[i] = entry.ApexRt;
+                    startRts[i] = entry.StartRt;
+                    endRts[i] = entry.EndRt;
+                    boundsAreas[i] = entry.BoundsArea;
+                    boundsSnrs[i] = entry.BoundsSnr;
+                    fileNames[i] = fileName ?? string.Empty;
+                    fragmentMzs[i] = EncodeF64Blob(entry.FragmentMzs);
+                    fragmentIntensities[i] = EncodeF32Blob(entry.FragmentIntensities);
+                    refXicRts[i] = EncodeF64Blob(entry.ReferenceXicRts);
+                    refXicIntensities[i] = EncodeF64Blob(entry.ReferenceXicIntensities);
 
-                var featureVec = entry.Features;
-                if (featureVec != null && featureVec.Length == NUM_PIN_FEATURES)
-                {
-                    for (int f = 0; f < NUM_PIN_FEATURES; f++)
-                        featureArrays[f][i] = Finite(featureVec[f]);
+                    // Mirror Rust's invariant: every row carries a cwt_candidates
+                    // blob, even when the candidate list is empty. Rust's
+                    // pipeline.rs::write_scores_parquet (at the cwt_candidates
+                    // serialization site) unconditionally appends a 4-byte
+                    // little-endian count prefix, so an entry with zero
+                    // candidates becomes a 4-byte zero-length blob, never a
+                    // null cell. ~57k post-compaction stubs per Stellar file
+                    // had no peaks; without this normalization C# emitted
+                    // null cells while Rust emitted empty blobs, producing
+                    // a spurious cross-impl parquet diff at end-of-Stage-6.
+                    //
+                    // TODO(osprey-rust): the proper fix is on the Rust side --
+                    // pipeline.rs should write null for empty candidate lists,
+                    // which is more parquet-idiomatic and saves 4 bytes per
+                    // empty row for downstream consumers. When that lands in
+                    // maccoss/osprey, revert this branch to the original
+                    // "skip null/empty" form.
+                    // Use Array.Empty<>() (not `new List<>()`) on the null
+                    // branch so we still emit the 4-byte zero-count blob
+                    // without allocating a fresh List per empty row.
+                    // CwtCandidateCodec.Encode takes IReadOnlyList<CwtCandidate>
+                    // which both List<T> and T[] satisfy.
+                    cwtCandidates[i] = CwtCandidateCodec.Encode(
+                        entry.CwtCandidates ?? (IReadOnlyList<CwtCandidate>)Array.Empty<CwtCandidate>());
+
+                    LibraryEntry libEntry = null;
+                    if (libraryById != null)
+                        libraryById.TryGetValue(entry.EntryId, out libEntry);
+                    if (libEntry != null)
+                    {
+                        sequences[i] = libEntry.Sequence ?? string.Empty;
+                        precursorMzs[i] = libEntry.PrecursorMz;
+                        proteinIds[i] = libEntry.ProteinIds != null
+                            ? string.Join(";", libEntry.ProteinIds)
+                            : null;
+                    }
+                    else
+                    {
+                        sequences[i] = string.Empty;
+                        precursorMzs[i] = 0.0;
+                        proteinIds[i] = null;
+                    }
+
+                    var featureVec = entry.Features;
+                    if (featureVec != null && featureVec.Length == NUM_PIN_FEATURES)
+                    {
+                        for (int f = 0; f < NUM_PIN_FEATURES; f++)
+                            featureArrays[f][i] = Finite(featureVec[f]);
+                    }
+                    // else: leave zeros (entries without features can't drive Stage 5+).
+                    buildProgress.Report(i + 1);
                 }
-                // else: leave zeros (entries without features can't drive Stage 5+).
             }
 
             string tempPath = Path.Combine(Path.GetTempPath(),
@@ -468,34 +463,87 @@ namespace pwiz.OspreySharp.IO
 
                 using (var group = writer.CreateRowGroup())
                 {
-                    RunSync(group.WriteColumnAsync(new DataColumn(FIELD_ENTRY_ID, entryIds)));
-                    RunSync(group.WriteColumnAsync(new DataColumn(FIELD_IS_DECOY, isDecoys)));
-                    RunSync(group.WriteColumnAsync(new DataColumn(FIELD_SEQUENCE, sequences)));
-                    RunSync(group.WriteColumnAsync(new DataColumn(FIELD_MODIFIED_SEQUENCE, modifiedSequences)));
-                    RunSync(group.WriteColumnAsync(new DataColumn(FIELD_CHARGE, charges)));
-                    RunSync(group.WriteColumnAsync(new DataColumn(FIELD_PRECURSOR_MZ, precursorMzs)));
-                    RunSync(group.WriteColumnAsync(new DataColumn(FIELD_PROTEIN_IDS, proteinIds)));
-                    RunSync(group.WriteColumnAsync(new DataColumn(FIELD_SCAN_NUMBER, scanNumbers)));
-                    RunSync(group.WriteColumnAsync(new DataColumn(FIELD_APEX_RT, apexRts)));
-                    RunSync(group.WriteColumnAsync(new DataColumn(FIELD_START_RT, startRts)));
-                    RunSync(group.WriteColumnAsync(new DataColumn(FIELD_END_RT, endRts)));
-                    RunSync(group.WriteColumnAsync(new DataColumn(FIELD_BOUNDS_AREA, boundsAreas)));
-                    RunSync(group.WriteColumnAsync(new DataColumn(FIELD_BOUNDS_SNR, boundsSnrs)));
-                    RunSync(group.WriteColumnAsync(new DataColumn(FIELD_FILE_NAME, fileNames)));
-                    RunSync(group.WriteColumnAsync(new DataColumn(FIELD_CWT_CANDIDATES, cwtCandidates)));
-                    RunSync(group.WriteColumnAsync(new DataColumn(FIELD_FRAGMENT_MZS, fragmentMzs)));
-                    RunSync(group.WriteColumnAsync(new DataColumn(FIELD_FRAGMENT_INTENSITIES, fragmentIntensities)));
-                    RunSync(group.WriteColumnAsync(new DataColumn(FIELD_REFERENCE_XIC_RTS, refXicRts)));
-                    RunSync(group.WriteColumnAsync(new DataColumn(FIELD_REFERENCE_XIC_INTENSITIES, refXicIntensities)));
-
-                    for (int f = 0; f < NUM_PIN_FEATURES; f++)
-                        RunSync(group.WriteColumnAsync(new DataColumn(featureFields[f], featureArrays[f])));
+                    var columns = BuildRowGroupColumns(
+                        entryIds, isDecoys, sequences, modifiedSequences, charges,
+                        precursorMzs, proteinIds, scanNumbers, apexRts, startRts, endRts,
+                        boundsAreas, boundsSnrs, fileNames, cwtCandidates, fragmentMzs,
+                        fragmentIntensities, refXicRts, refXicIntensities,
+                        featureFields, featureArrays);
+                    WriteRowGroupColumns(group, columns, n);
                 }
             }
 
             if (File.Exists(path))
                 File.Delete(path);
             File.Move(tempPath, path);
+        }
+
+        /// <summary>
+        /// Assemble the row-group's <see cref="DataColumn"/> list in the exact physical order
+        /// both <see cref="WriteScoresParquet(string,List{CoelutionScoredEntry},Dictionary{string,string})"/>
+        /// overloads write -- the 19 fixed columns followed by the 21 PIN feature columns.
+        /// Centralizing the order keeps the two overloads identical and lets
+        /// <see cref="WriteRowGroupColumns"/> drive a per-column <see cref="ProgressReporter"/>
+        /// over the write. Parquet is name-indexed, so the order is informational for
+        /// correctness, but it is kept byte-for-byte identical to the prior explicit-call
+        /// sequence so the written parquet is unchanged.
+        /// </summary>
+        private static List<DataColumn> BuildRowGroupColumns(
+            uint[] entryIds, bool[] isDecoys, string[] sequences, string[] modifiedSequences,
+            byte[] charges, double[] precursorMzs, string[] proteinIds, uint[] scanNumbers,
+            double[] apexRts, double[] startRts, double[] endRts, double[] boundsAreas,
+            double[] boundsSnrs, string[] fileNames, byte[][] cwtCandidates, byte[][] fragmentMzs,
+            byte[][] fragmentIntensities, byte[][] refXicRts, byte[][] refXicIntensities,
+            DataField[] featureFields, double[][] featureArrays)
+        {
+            var columns = new List<DataColumn>(19 + NUM_PIN_FEATURES)
+            {
+                new DataColumn(FIELD_ENTRY_ID, entryIds),
+                new DataColumn(FIELD_IS_DECOY, isDecoys),
+                new DataColumn(FIELD_SEQUENCE, sequences),
+                new DataColumn(FIELD_MODIFIED_SEQUENCE, modifiedSequences),
+                new DataColumn(FIELD_CHARGE, charges),
+                new DataColumn(FIELD_PRECURSOR_MZ, precursorMzs),
+                new DataColumn(FIELD_PROTEIN_IDS, proteinIds),
+                new DataColumn(FIELD_SCAN_NUMBER, scanNumbers),
+                new DataColumn(FIELD_APEX_RT, apexRts),
+                new DataColumn(FIELD_START_RT, startRts),
+                new DataColumn(FIELD_END_RT, endRts),
+                new DataColumn(FIELD_BOUNDS_AREA, boundsAreas),
+                new DataColumn(FIELD_BOUNDS_SNR, boundsSnrs),
+                new DataColumn(FIELD_FILE_NAME, fileNames),
+                new DataColumn(FIELD_CWT_CANDIDATES, cwtCandidates),
+                new DataColumn(FIELD_FRAGMENT_MZS, fragmentMzs),
+                new DataColumn(FIELD_FRAGMENT_INTENSITIES, fragmentIntensities),
+                new DataColumn(FIELD_REFERENCE_XIC_RTS, refXicRts),
+                new DataColumn(FIELD_REFERENCE_XIC_INTENSITIES, refXicIntensities),
+            };
+            for (int f = 0; f < NUM_PIN_FEATURES; f++)
+                columns.Add(new DataColumn(featureFields[f], featureArrays[f]));
+            return columns;
+        }
+
+        /// <summary>
+        /// Write the assembled <paramref name="columns"/> to <paramref name="group"/> in order,
+        /// driving a per-column <see cref="ProgressReporter"/> so an Astral-scale parquet write
+        /// (~2.9M rows, 30-47s) reports a throttled percent instead of stalling silently. The
+        /// write order (and therefore the parquet bytes) is exactly the
+        /// <see cref="BuildRowGroupColumns"/> order. <paramref name="rowCount"/> is shown in the
+        /// heading only.
+        /// </summary>
+        private static void WriteRowGroupColumns(ParquetRowGroupWriter group,
+            List<DataColumn> columns, long rowCount)
+        {
+            using (var progress = new ProgressReporter(
+                string.Format("Writing {0} entries", rowCount), columns.Count, "  ", 2.0))
+            {
+                int col = 0;
+                foreach (var column in columns)
+                {
+                    RunSync(group.WriteColumnAsync(column));
+                    progress.Report(++col);
+                }
+            }
         }
 
         /// <summary>

--- a/pwiz_tools/OspreySharp/OspreySharp.IO/ParquetScoreCache.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.IO/ParquetScoreCache.cs
@@ -230,7 +230,7 @@ namespace pwiz.OspreySharp.IO
                 .ToArray();
 
             using (var buildProgress = new ProgressReporter(
-                string.Format("Preparing {0} entries", n), n, "  ", 2.0))
+                string.Format("Preparing {0} entries", n), n, string.Empty, 2.0))
             {
                 for (int i = 0; i < n; i++)
                 {
@@ -356,7 +356,7 @@ namespace pwiz.OspreySharp.IO
                 .ToArray();
 
             using (var buildProgress = new ProgressReporter(
-                string.Format("Preparing {0} entries", n), n, "  ", 2.0))
+                string.Format("Preparing {0} entries", n), n, string.Empty, 2.0))
             {
                 for (int i = 0; i < n; i++)
                 {
@@ -535,7 +535,7 @@ namespace pwiz.OspreySharp.IO
             List<DataColumn> columns, long rowCount)
         {
             using (var progress = new ProgressReporter(
-                string.Format("Writing {0} entries", rowCount), columns.Count, "  ", 2.0))
+                string.Format("Writing {0} entries", rowCount), columns.Count, string.Empty, 2.0))
             {
                 int col = 0;
                 foreach (var column in columns)


### PR DESCRIPTION
## Summary

* Wires OspreySharp's existing `ProgressReporter` to the three large I/O steps that otherwise emit nothing while they run, so an Astral-scale straight-through run no longer stalls silently for 30-47 seconds at a time. Follow-on to PR #4326 (which shipped `ProgressReporter`).
* Widened `ProgressReporter.total`/`Report` from `int` to `long` so byte counts (mzML reads) and row counts (parquet writes) on Astral-class data cannot overflow `int.MaxValue`; existing `int` call sites widen implicitly.
* Added `ProgressStream` (`OspreySharp.Core`): a read-only byte-counting `Stream` decorator that drives a `ProgressReporter`, the OspreySharp analog of Skyline's `pwiz.Common.SystemUtil.ProgressStream`. Adds no buffer copies and does not own the inner stream.
* mzML read (`MzmlReader.LoadAllSpectra`): the producer `FileStream` feeding the `XmlReader` is wrapped in `ProgressStream`, so the 40+ second Astral parse reports a throttled percent against file length.
* Parquet writes (both `ParquetScoreCache.WriteScoresParquet` overloads): a per-row `ProgressReporter` over the column-array build loop, plus a per-column reporter over the row-group write (new `BuildRowGroupColumns` / `WriteRowGroupColumns` helpers shared by both overloads). The column write order is byte-for-byte identical to the prior explicit call sequence, so the written parquet is unchanged.

Output-only change. `regression.ps1` compares the `.blib` + Stage-7 protein-FDR dump at 1e-9, not parquet bytes or stdout, so golden + resume + HPC modes stay byte-identical.

See `ai/todos/active/TODO-20260624_ospreysharp_io_progress.md`.

## Astral acceptance (max silent gap)

Measured on Astral, non-verbose, as the max gap between consecutive `--timestamp` console lines. Logs: `ai/.tmp/osprey-astral-default/run.log` (before/after captures preserved at `ai/.tmp/io-astral-instrumented-run.log`).

* **Before: max gap 47s** (26 gaps >8s). The three biggest spikes were mzML read (40-44s), scored parquet write (32-41s), reconciled parquet write (43-47s).
* **After: max gap 31s** (17 gaps >8s). All three targeted I/O steps dropped out of the >8s list — they now report progress throughout.

### Honest residuals

* **One parquet write still has an ~11s intra-column gap.** The per-column reporter shows steady progress (10% -> 25% -> 37% ...) until the single largest blob column, whose zstd compression has no intra-column progress hook. Down from a 33-47s fully-silent write; fully closing it needs a write-side byte-counting stream wrapper (follow-up).
* **The remaining >8s gaps are compute, out of scope for this I/O TODO:** spectral-library load (~31s), RT calibration (~18-20s), Percolator training iterations (~9-10s each), and post-training FDR math / "Percolator apply" (~24s: TDC competition + PEP KDE + q-values; its per-entry scoring loop is <1s, so there is no clean count denominator to instrument and it is parity-sensitive — left per the TODO).

The TODO's premise that "everything between the I/O spikes is already <8s" does not hold on this run; the harness `Run-OspreyStellar.ps1` runs Astral at `--resolution unit`, which explodes candidates to ~2.9M entries and inflates the compute steps. A proper hram re-measurement plus the compute-step progress are recommended follow-ups.

## Test plan

- [x] `Build-OspreySharp.ps1 -Configuration Debug -RunTests -RunInspection` - build (net472 + net8.0) + unit tests + zero ReSharper warnings
- [x] `regression.ps1 -Dataset Stellar` - mode 1 (golden), mode 3 (HPC 4-task chain), mode 2 (resume) all PASS byte-identical at 1e-9 (output-neutral)
- [x] Astral straight-through max-gap measurement (see above)
- [x] Fresh-context self-review - no CRITICAL/HIGH findings; output-neutral column order confirmed in both overloads

Co-Authored-By: Claude <noreply@anthropic.com>
