### PR TITLE
Improved OspreySharp parallel-file console output and parallelized the Stage 6 rescore

### DIFF
--- a/pwiz_tools/OspreySharp/OspreySharp.Core/MultiProgressReporter.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Core/MultiProgressReporter.cs
@@ -135,10 +135,10 @@ namespace pwiz.OspreySharp.Core
         /// equal-weight phases the file's percent is divided into. Returns a handle
         /// whose disposal flushes the file's buffered block and drops its slot.
         /// </summary>
-        public FileScope BeginFile(int index, string displayName, int segmentCount)
+        public FileScope BeginFile(int index, int segmentCount)
         {
             var buffer = new StringWriter();
-            var slot = new FileSlot(index, displayName);
+            var slot = new FileSlot(index);
             var scope = new FileScope(this, slot, buffer, segmentCount);
             lock (_renderLock)
             {
@@ -217,17 +217,16 @@ namespace pwiz.OspreySharp.Core
         }
 
         /// <summary>One concurrently-processing file's aggregate-line state: its
-        /// display index and current composite percent.</summary>
+        /// 0-based slot index (shown as <c>[index+1]</c>) and current composite
+        /// percent.</summary>
         internal sealed class FileSlot
         {
-            internal FileSlot(int index, string displayName)
+            internal FileSlot(int index)
             {
                 Index = index;
-                DisplayName = displayName;
             }
 
             internal int Index { get; }
-            internal string DisplayName { get; }
             internal int Percent { get; set; }
         }
 
@@ -245,7 +244,6 @@ namespace pwiz.OspreySharp.Core
             private readonly StringWriter _buffer;
             private readonly TextWriter _syncBuffer;
             private readonly int _segmentCount;
-            private readonly object _segmentLock = new object();
             // Segments fully behind the cursor (each contributes its full slice).
             private int _completedSegments;
             private SegmentSink _currentSegmentSink;
@@ -280,15 +278,15 @@ namespace pwiz.OspreySharp.Core
             // The cookie that restores the prior OspreyOutput.Out on dispose.
             internal IDisposable OutCookie { get; set; }
 
-            // Snapshot of the buffered narrative, read once on completion after the
-            // file's work (and its inner threads) have finished writing.
+            // Snapshot of the buffered narrative. No lock by design: this runs only
+            // from CompleteFile -> FileScope.Dispose, i.e. AFTER the file's `using`
+            // body and its inner scoring Parallel.For have fully joined, so no
+            // narrative writer is live to race the read. Safety is from that
+            // lifecycle, not a lock -- a future change that flushed a block mid-file
+            // would have to synchronize on the _syncBuffer monitor the writers use.
             internal string BufferContents
             {
-                get
-                {
-                    lock (_segmentLock)
-                        return _buffer.ToString();
-                }
+                get { return _buffer.ToString(); }
             }
 
             /// <summary>
@@ -300,12 +298,14 @@ namespace pwiz.OspreySharp.Core
             /// </summary>
             public void BeginSegment()
             {
-                lock (_segmentLock)
-                {
-                    if (_currentSegmentSink != null && _completedSegments < _segmentCount)
-                        _completedSegments++;
-                    _currentSegmentSink = new SegmentSink(this, _completedSegments);
-                }
+                // No lock: a file's segments are advanced only from its own single
+                // phase thread (ProcessFile / RescoreOneFile call this sequentially at
+                // phase boundaries). The inner scoring Parallel.For never calls this --
+                // it drives the captured SegmentSink, whose cross-thread report path is
+                // synchronized by the owner's render lock.
+                if (_currentSegmentSink != null && _completedSegments < _segmentCount)
+                    _completedSegments++;
+                _currentSegmentSink = new SegmentSink(this, _completedSegments);
                 UpdateFilePercent(_completedSegments, 0);
             }
 

--- a/pwiz_tools/OspreySharp/OspreySharp.Core/MultiProgressReporter.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Core/MultiProgressReporter.cs
@@ -1,0 +1,370 @@
+/*
+ * Original author: Brendan MacLean <brendanx .at. uw.edu>,
+ *                  MacCoss Lab, Department of Genome Sciences, UW
+ * AI assistance: Claude Code (Claude Opus 4.8) <noreply .at. anthropic.com>
+ *
+ * Based on osprey (https://github.com/MacCossLab/osprey)
+ *   by Michael J. MacCoss, MacCoss Lab, Department of Genome Sciences, UW
+ *
+ * Copyright 2026 University of Washington - Seattle, WA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Text;
+using System.Threading;
+
+namespace pwiz.OspreySharp.Core
+{
+    /// <summary>
+    /// Where a <see cref="ProgressReporter"/> sends its 0..100 percent when it runs
+    /// inside a <see cref="MultiProgressReporter"/> per-file scope, instead of
+    /// printing a "&lt;pct&gt;%" line. The single segment-scoped implementation
+    /// (<c>MultiProgressReporter.FileScope</c>'s segment sink) maps that percent
+    /// into the file's composite percent; the aggregate <c>[i] p%</c> line shows the
+    /// motion. A null sink (the common sequential / single-file path) means the
+    /// reporter prints inline as before -- so this seam is inert outside
+    /// <c>--parallel-files</c>.
+    /// </summary>
+    public interface IProgressSink
+    {
+        /// <summary>Report <paramref name="percent"/> (0..100) of the current
+        /// segment's work done.</summary>
+        void Report(int percent);
+    }
+
+    /// <summary>
+    /// Collapses concurrent per-file progress (<c>--parallel-files</c>) into
+    /// Skyline's MultiProgressStatus look: a single throttled
+    /// <c>[1] 42%  [2] 38%  [3] 51%</c> line while files run at once, plus each
+    /// file's narrative buffered and flushed as one contiguous block when the file
+    /// finishes (Boost-Build per-action buffering) so blocks never interleave. A
+    /// thin wrapper over <see cref="ProgressReporter"/>'s stopwatch throttle and the
+    /// <see cref="OspreyOutput"/> seam -- deliberately NOT a port of Skyline's
+    /// IProgressMonitor / ProgressStatus / MultiProgressStatus machinery.
+    ///
+    /// Per-file percent uses the ProgressStatus *segments* model (mimicked, not the
+    /// class): one file's work is N equal-weight segments (read, calibrate, score,
+    /// write), each counting its own 0..100 via a segment sink, combined into one
+    /// 0..100 for the file. Two combine levels then exist: segments -&gt; one file's
+    /// percent (the segment sink), and N files' percents -&gt; the <c>[i] p%</c> line
+    /// (this class). Equal weight is the simple ProgressStatus default; weighted
+    /// segment ends can come later if one phase dominates wall-clock.
+    ///
+    /// A file is entered with <see cref="BeginFile"/>, which redirects that async
+    /// flow's narrative into the file's own buffer and makes the file the ambient
+    /// <see cref="Current"/> scope (flowing into the inner scoring
+    /// <c>Parallel.For</c> via ExecutionContext). The phase code advances segments
+    /// through <see cref="FileScope.BeginSegment"/>; <see cref="ProgressReporter"/> finds the
+    /// active segment sink through <see cref="CurrentSink"/> with no signature
+    /// changes through the IO / scoring stack. Disposing the file handle flushes its
+    /// block and drops it from the aggregate line.
+    /// </summary>
+    public sealed class MultiProgressReporter
+    {
+        // The active per-file scope for THIS async flow. Set by BeginFile and flowed
+        // into the inner scoring Parallel.For (ExecutionContext copy-on-write per
+        // iteration isolates one file's scope from its siblings), so ProcessFile can
+        // advance segments and ProgressReporter can read the active segment sink
+        // without any per-file argument threaded through the scoring stack.
+        private static readonly AsyncLocal<FileScope> _current = new AsyncLocal<FileScope>();
+
+        /// <summary>The per-file scope active on the current async flow, or null when
+        /// not inside one (sequential / single-file paths). Phase code advances the
+        /// active file's segment via <c>Current?.BeginSegment()</c>, a no-op off the
+        /// parallel path.</summary>
+        public static FileScope Current
+        {
+            get { return _current.Value; }
+        }
+
+        /// <summary>The active file segment's percent sink for this async flow, or
+        /// null when not inside a per-file scope -- the seam <see cref="ProgressReporter"/>
+        /// reads to decide whether to route its percent or print it.</summary>
+        internal static IProgressSink CurrentSink
+        {
+            get { return _current.Value?.CurrentSegmentSink; }
+        }
+
+        // The real, unscoped process writer the aggregate line + completion blocks
+        // render to (bypassing the per-file buffer redirect). Captured once at
+        // construction, before any file scope is pushed.
+        private readonly TextWriter _out;
+        private readonly double _intervalSeconds;
+        private readonly Stopwatch _stopwatch;
+
+        // Guards the slot set, the last-rendered state, and every write to _out
+        // (aggregate line + block flush), so concurrent files serialize their output.
+        private readonly object _renderLock = new object();
+        private readonly SortedDictionary<int, FileSlot> _slots = new SortedDictionary<int, FileSlot>();
+        private double _lastRenderSeconds = double.NegativeInfinity;
+        private string _lastRendered;
+
+        /// <summary>
+        /// Start an aggregator that renders the <c>[i] p%</c> line no more than once
+        /// per <paramref name="intervalSeconds"/> (the same I/O cadence the per-file
+        /// reporters use by default). Captures the current process writer as the
+        /// render target.
+        /// </summary>
+        public MultiProgressReporter(double intervalSeconds = ProgressReporter.IO_INTERVAL_SECONDS)
+        {
+            _out = OspreyOutput.RealOut;
+            _intervalSeconds = intervalSeconds;
+            _stopwatch = Stopwatch.StartNew();
+        }
+
+        /// <summary>
+        /// Enter a per-file scope for file <paramref name="index"/> (0-based; shown
+        /// as <c>[index+1]</c>): register its slot, redirect this async flow's
+        /// narrative into the file's own buffer, and make the scope the ambient
+        /// <see cref="Current"/>. <paramref name="segmentCount"/> is the number of
+        /// equal-weight phases the file's percent is divided into. Returns a handle
+        /// whose disposal flushes the file's buffered block and drops its slot.
+        /// </summary>
+        public FileScope BeginFile(int index, string displayName, int segmentCount)
+        {
+            var buffer = new StringWriter();
+            var slot = new FileSlot(index, displayName);
+            var scope = new FileScope(this, slot, buffer, segmentCount);
+            lock (_renderLock)
+            {
+                _slots[index] = slot;
+                RenderLocked(force: true);
+            }
+            // Redirect narrative (ctx.LogInfo, ProgressReporter headings, WARN) for
+            // this async flow -- and the inner scoring Parallel.For it spawns -- into
+            // the file buffer until the scope is disposed, then publish the scope.
+            // Wrap the buffer in a StatFilteringTextWriter so the machine-parseable
+            // [COUNT]/[TIMING]/[BENCH]/[STAGE-WALL] lines are dropped as they are
+            // buffered (unless --perf-stats), exactly as the unbuffered Out does --
+            // otherwise a file's buffered block would leak the stat lines the default
+            // log suppresses, making a normal run look like perf mode.
+            scope.OutCookie = OspreyOutput.PushScopedOut(
+                new StatFilteringTextWriter(scope.ScopedWriter));
+            _current.Value = scope;
+            return scope;
+        }
+
+        // Raise file <paramref name="slot"/> to <paramref name="filePercent"/> and
+        // re-render on the throttle. Monotonic: a lower value (e.g. a later segment's
+        // reporter restarting at 0) never pulls the line backward.
+        internal void ReportFilePercent(FileSlot slot, int filePercent)
+        {
+            lock (_renderLock)
+            {
+                if (filePercent <= slot.Percent)
+                    return;
+                slot.Percent = filePercent;
+                RenderLocked(force: false);
+            }
+        }
+
+        // Flush the file's buffered narrative as one contiguous block, then drop its
+        // slot and re-render so the finished file leaves the aggregate line.
+        internal void CompleteFile(FileScope scope)
+        {
+            lock (_renderLock)
+            {
+                string block = scope.BufferContents;
+                if (!string.IsNullOrEmpty(block))
+                    _out.Write(block);
+                _slots.Remove(scope.Slot.Index);
+                RenderLocked(force: true);
+            }
+        }
+
+        // Render the "[i] p%" line for the currently-active slots, throttled unless
+        // forced (a file entering or completing forces it so the set is current).
+        // Caller holds _renderLock.
+        private void RenderLocked(bool force)
+        {
+            if (_slots.Count == 0)
+                return;
+            double now = _stopwatch.Elapsed.TotalSeconds;
+            if (!force && now - _lastRenderSeconds < _intervalSeconds)
+                return;
+
+            var sb = new StringBuilder();
+            bool first = true;
+            foreach (var kv in _slots)
+            {
+                if (!first)
+                    sb.Append(@"  ");
+                first = false;
+                sb.AppendFormat(@"[{0}] {1}%", kv.Key + 1, kv.Value.Percent);
+            }
+            string line = sb.ToString();
+            // Suppress an identical repeat (no advance since the last render).
+            if (string.Equals(line, _lastRendered, StringComparison.Ordinal))
+                return;
+            _out.WriteLine(line);
+            _lastRendered = line;
+            _lastRenderSeconds = now;
+        }
+
+        /// <summary>One concurrently-processing file's aggregate-line state: its
+        /// display index and current composite percent.</summary>
+        internal sealed class FileSlot
+        {
+            internal FileSlot(int index, string displayName)
+            {
+                Index = index;
+                DisplayName = displayName;
+            }
+
+            internal int Index { get; }
+            internal string DisplayName { get; }
+            internal int Percent { get; set; }
+        }
+
+        /// <summary>
+        /// A live per-file scope: owns the file's narrative buffer and its segment
+        /// cursor. Phase code advances segments with <see cref="BeginSegment"/>; the
+        /// active segment's <see cref="IProgressSink"/> maps an inner reporter's
+        /// 0..100 into that segment's equal-weight slice of the file's 0..100.
+        /// Disposing flushes the buffered block and removes the file from the
+        /// aggregate line.
+        /// </summary>
+        public sealed class FileScope : IDisposable
+        {
+            private readonly MultiProgressReporter _owner;
+            private readonly StringWriter _buffer;
+            private readonly TextWriter _syncBuffer;
+            private readonly int _segmentCount;
+            private readonly object _segmentLock = new object();
+            // Segments fully behind the cursor (each contributes its full slice).
+            private int _completedSegments;
+            private SegmentSink _currentSegmentSink;
+            private bool _disposed;
+
+            internal FileScope(MultiProgressReporter owner, FileSlot slot,
+                StringWriter buffer, int segmentCount)
+            {
+                _owner = owner;
+                Slot = slot;
+                _buffer = buffer;
+                // The inner scoring Parallel.For can write narrative from several
+                // threads at once into this one buffer; serialize those writes.
+                _syncBuffer = TextWriter.Synchronized(buffer);
+                _segmentCount = Math.Max(1, segmentCount);
+            }
+
+            internal FileSlot Slot { get; }
+
+            /// <summary>The writer the per-file scope redirects narrative into (a
+            /// thread-safe wrapper over the file's buffer).</summary>
+            internal TextWriter ScopedWriter
+            {
+                get { return _syncBuffer; }
+            }
+
+            internal IProgressSink CurrentSegmentSink
+            {
+                get { return _currentSegmentSink; }
+            }
+
+            // The cookie that restores the prior OspreyOutput.Out on dispose.
+            internal IDisposable OutCookie { get; set; }
+
+            // Snapshot of the buffered narrative, read once on completion after the
+            // file's work (and its inner threads) have finished writing.
+            internal string BufferContents
+            {
+                get
+                {
+                    lock (_segmentLock)
+                        return _buffer.ToString();
+                }
+            }
+
+            /// <summary>
+            /// Advance to the next equal-weight segment: bank the previous segment at
+            /// its full slice end, then open a fresh segment whose 0..100 maps into
+            /// the next slice. Bumps the file percent to the new segment's start
+            /// boundary so a phase that emits no reporter (e.g. calibration) still
+            /// carries the file forward.
+            /// </summary>
+            public void BeginSegment()
+            {
+                lock (_segmentLock)
+                {
+                    if (_currentSegmentSink != null && _completedSegments < _segmentCount)
+                        _completedSegments++;
+                    _currentSegmentSink = new SegmentSink(this, _completedSegments);
+                }
+                UpdateFilePercent(_completedSegments, 0);
+            }
+
+            // Combine (completedSegments + segPercent/100) / segmentCount into the
+            // file's 0..100 and report it to the aggregator.
+            internal void UpdateFilePercent(int completedSegments, int segPercent)
+            {
+                if (segPercent < 0)
+                    segPercent = 0;
+                else if (segPercent > 100)
+                    segPercent = 100;
+                long composite = (completedSegments * 100L + segPercent) / _segmentCount;
+                if (composite > 100)
+                    composite = 100;
+                _owner.ReportFilePercent(Slot, (int)composite);
+            }
+
+            public void Dispose()
+            {
+                if (_disposed)
+                    return;
+                _disposed = true;
+                // Restore the prior Out and clear the ambient scope BEFORE flushing,
+                // so the block flush (and aggregate render) write to the real writer.
+                OutCookie?.Dispose();
+                _current.Value = null;
+                _owner.CompleteFile(this);
+            }
+
+            /// <summary>
+            /// One segment's percent sink: maps an inner reporter's 0..100 into this
+            /// segment's slice of the file's percent. Monotonic within the segment so
+            /// a phase with more than one reporter (e.g. parquet "Preparing" then
+            /// "Writing") never regresses the file percent; the slice fills and holds.
+            /// </summary>
+            private sealed class SegmentSink : IProgressSink
+            {
+                private readonly FileScope _scope;
+                private readonly int _baseSegment;
+                private int _maxPercent = -1;
+
+                internal SegmentSink(FileScope scope, int baseSegment)
+                {
+                    _scope = scope;
+                    _baseSegment = baseSegment;
+                }
+
+                public void Report(int percent)
+                {
+                    if (percent < 0)
+                        percent = 0;
+                    else if (percent > 100)
+                        percent = 100;
+                    if (percent <= _maxPercent)
+                        return;
+                    _maxPercent = percent;
+                    _scope.UpdateFilePercent(_baseSegment, percent);
+                }
+            }
+        }
+    }
+}

--- a/pwiz_tools/OspreySharp/OspreySharp.Core/OspreyOutput.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Core/OspreyOutput.cs
@@ -23,6 +23,7 @@
 
 using System;
 using System.IO;
+using System.Threading;
 
 namespace pwiz.OspreySharp.Core
 {
@@ -41,12 +42,79 @@ namespace pwiz.OspreySharp.Core
     /// </summary>
     public static class OspreyOutput
     {
-        public static TextWriter Out { get; set; } = Console.Error;
+        private static TextWriter _out = Console.Error;
 
         /// <summary>
-        /// When false (default), the machine-parseable [COUNT]/[TIMING]/[STAGE-WALL] lines
-        /// are suppressed so the human log stays clean (each has a human-readable plain twin
-        /// that remains). The --perf-stats flag sets this true so the perf tools
+        /// The process-wide output writer, with one twist for <c>--parallel-files</c>:
+        /// while a file runs inside a <see cref="MultiProgressReporter"/> per-file
+        /// scope (entered on this async flow via <see cref="PushScopedOut"/>), the
+        /// getter returns that file's private buffer instead, so the file's
+        /// narrative (ctx.LogInfo, ProgressReporter headings, WARN) accumulates in
+        /// its own block rather than interleaving with other files'. The setter
+        /// always targets the real process writer; <c>Program</c> points it at its
+        /// single <c>CommandStatusWriter</c>. The scoped redirect flows into the
+        /// inner scoring <c>Parallel.For</c> (ExecutionContext capture), so a file's
+        /// nested-thread output is attributed to that file.
+        /// </summary>
+        public static TextWriter Out
+        {
+            get { return _scopedOut.Value ?? _out; }
+            set { _out = value; }
+        }
+
+        /// <summary>
+        /// The real process writer, ignoring any per-file scoped redirect. The
+        /// <see cref="MultiProgressReporter"/> renders its cross-file <c>[i] p%</c>
+        /// aggregate line and flushes each completed file's buffered block here, so
+        /// those bypass the per-file buffer (which would otherwise swallow the
+        /// aggregate line into whichever file's block is active on the rendering thread).
+        /// </summary>
+        internal static TextWriter RealOut
+        {
+            get { return _out; }
+        }
+
+        // Per-async-flow output override for a MultiProgressReporter file scope.
+        // Null on the common (sequential / single-file) paths, where Out is just
+        // the process writer and ProgressReporter prints its percent lines inline.
+        private static readonly AsyncLocal<TextWriter> _scopedOut = new AsyncLocal<TextWriter>();
+
+        /// <summary>
+        /// Redirect <see cref="Out"/> to <paramref name="writer"/> for the current
+        /// async flow (and any work it spawns) until the returned cookie is
+        /// disposed. Used by <see cref="MultiProgressReporter.BeginFile"/> to buffer
+        /// one file's narrative; nesting restores the prior writer on dispose.
+        /// </summary>
+        internal static IDisposable PushScopedOut(TextWriter writer)
+        {
+            var previous = _scopedOut.Value;
+            _scopedOut.Value = writer;
+            return new ScopedOutCookie(previous);
+        }
+
+        private sealed class ScopedOutCookie : IDisposable
+        {
+            private readonly TextWriter _previous;
+            private bool _disposed;
+
+            public ScopedOutCookie(TextWriter previous)
+            {
+                _previous = previous;
+            }
+
+            public void Dispose()
+            {
+                if (_disposed)
+                    return;
+                _disposed = true;
+                _scopedOut.Value = _previous;
+            }
+        }
+
+        /// <summary>
+        /// When false (default), the machine-parseable [COUNT]/[TIMING]/[BENCH]/[STAGE-WALL]
+        /// lines are suppressed so the human log stays clean (each has a human-readable plain
+        /// twin that remains). The --perf-stats flag sets this true so the perf tools
         /// (Test-PerfGate.ps1, Measure-Pipeline.ps1, Osprey-workflow.html) get the tagged lines.
         /// </summary>
         public static bool PerfStats { get; set; }
@@ -70,8 +138,9 @@ namespace pwiz.OspreySharp.Core
         }
 
         /// <summary>
-        /// True if a line is a machine-parseable stat line (leading [COUNT]/[TIMING]/[STAGE-WALL],
-        /// ignoring leading spaces) gated by <see cref="PerfStats"/>.
+        /// True if a line is a machine-parseable stat line (leading
+        /// [COUNT]/[TIMING]/[BENCH]/[STAGE-WALL], ignoring leading spaces) gated by
+        /// <see cref="PerfStats"/>.
         /// </summary>
         public static bool IsStatLine(string line)
         {
@@ -82,6 +151,7 @@ namespace pwiz.OspreySharp.Core
                 i++;
             return string.CompareOrdinal(line, i, "[COUNT]", 0, 7) == 0
                 || string.CompareOrdinal(line, i, "[TIMING]", 0, 8) == 0
+                || string.CompareOrdinal(line, i, "[BENCH]", 0, 7) == 0
                 || string.CompareOrdinal(line, i, "[STAGE-WALL]", 0, 12) == 0;
         }
     }

--- a/pwiz_tools/OspreySharp/OspreySharp.Core/ProgressReporter.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Core/ProgressReporter.cs
@@ -52,6 +52,14 @@ namespace pwiz.OspreySharp.Core
     /// </summary>
     public sealed class ProgressReporter : IDisposable
     {
+        /// <summary>
+        /// Throttle interval for the large I/O steps (mzML read, parquet writes). Wider
+        /// than the compute loops' cadence because on HRAM/Astral-class data these steps
+        /// run for tens of seconds and a 2s cadence emits a long string of percent lines;
+        /// 5s still reassures a watching user the run is alive without cluttering the log.
+        /// </summary>
+        public const double IO_INTERVAL_SECONDS = 5.0;
+
         private readonly long _total;
         private readonly string _indent;
         private readonly double _intervalSeconds;

--- a/pwiz_tools/OspreySharp/OspreySharp.Core/ProgressReporter.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Core/ProgressReporter.cs
@@ -65,6 +65,12 @@ namespace pwiz.OspreySharp.Core
         private readonly double _intervalSeconds;
         private readonly Stopwatch _stopwatch;
         private readonly object _lock = new object();
+        // Non-null only inside a MultiProgressReporter per-file scope (--parallel-files):
+        // captured at construction so this reporter feeds the file's active segment
+        // instead of printing "<pct>%" lines. The aggregate "[i] p%" line shows the
+        // motion; the heading still buffers into the file's narrative block. Null on
+        // the common sequential / single-file paths -- inline percent printing then.
+        private readonly IProgressSink _sink;
         private int _lastPercent = -1;
         private double _lastReportSeconds;
 
@@ -85,6 +91,7 @@ namespace pwiz.OspreySharp.Core
             _total = total;
             _indent = indent;
             _intervalSeconds = intervalSeconds;
+            _sink = MultiProgressReporter.CurrentSink;
             _stopwatch = Stopwatch.StartNew();
             OspreyOutput.Out.WriteLine("{0}{1}...", indent, activity);
         }
@@ -99,6 +106,19 @@ namespace pwiz.OspreySharp.Core
             lock (_lock)
             {
                 int percent = _total > 0 ? (int)(100L * current / _total) : 100;
+                if (_sink != null)
+                {
+                    // Multi-file mode: feed the file's active segment (which maps it
+                    // into the "[i] p%" aggregate line) rather than printing a percent
+                    // line. The MultiProgressReporter owns the display throttle, so we
+                    // forward every advance; the segment sink is monotonic.
+                    if (percent > _lastPercent)
+                    {
+                        _lastPercent = percent;
+                        _sink.Report(percent);
+                    }
+                    return;
+                }
                 double now = _stopwatch.Elapsed.TotalSeconds;
                 if (percent > _lastPercent && now - _lastReportSeconds >= _intervalSeconds)
                 {
@@ -114,6 +134,13 @@ namespace pwiz.OspreySharp.Core
         {
             lock (_lock)
             {
+                if (_sink != null)
+                {
+                    // Bank this segment at 100% so the file percent reaches the
+                    // segment boundary even on a sub-second phase; no percent line.
+                    _sink.Report(100);
+                    return;
+                }
                 if (_lastPercent < 100)
                     OspreyOutput.Out.WriteLine("{0}  100%", _indent);
             }

--- a/pwiz_tools/OspreySharp/OspreySharp.IO/MzmlReader.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.IO/MzmlReader.cs
@@ -109,7 +109,8 @@ namespace pwiz.OspreySharp.IO
             using (var stream = new FileStream(path, FileMode.Open, FileAccess.Read,
                 FileShare.Read, 16 * 1024 * 1024))
             using (var progress = new ProgressReporter(
-                string.Format("Reading {0}", Path.GetFileName(path)), stream.Length, string.Empty, 2.0))
+                string.Format("Reading {0}", Path.GetFileName(path)), stream.Length, string.Empty,
+                ProgressReporter.IO_INTERVAL_SECONDS))
             using (var progressStream = new ProgressStream(stream, progress))
             {
                 var settings = new XmlReaderSettings { DtdProcessing = DtdProcessing.Ignore };

--- a/pwiz_tools/OspreySharp/OspreySharp.IO/ParquetScoreCache.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.IO/ParquetScoreCache.cs
@@ -230,7 +230,8 @@ namespace pwiz.OspreySharp.IO
                 .ToArray();
 
             using (var buildProgress = new ProgressReporter(
-                string.Format("Preparing {0} entries", n), n, string.Empty, 2.0))
+                string.Format("Preparing {0} entries", n), n, string.Empty,
+                ProgressReporter.IO_INTERVAL_SECONDS))
             {
                 for (int i = 0; i < n; i++)
                 {
@@ -356,7 +357,8 @@ namespace pwiz.OspreySharp.IO
                 .ToArray();
 
             using (var buildProgress = new ProgressReporter(
-                string.Format("Preparing {0} entries", n), n, string.Empty, 2.0))
+                string.Format("Preparing {0} entries", n), n, string.Empty,
+                ProgressReporter.IO_INTERVAL_SECONDS))
             {
                 for (int i = 0; i < n; i++)
                 {
@@ -535,7 +537,8 @@ namespace pwiz.OspreySharp.IO
             List<DataColumn> columns, long rowCount)
         {
             using (var progress = new ProgressReporter(
-                string.Format("Writing {0} entries", rowCount), columns.Count, string.Empty, 2.0))
+                string.Format("Writing {0} entries", rowCount), columns.Count, string.Empty,
+                ProgressReporter.IO_INTERVAL_SECONDS))
             {
                 int col = 0;
                 foreach (var column in columns)

--- a/pwiz_tools/OspreySharp/OspreySharp.Tasks/PerFileRescoreTask.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Tasks/PerFileRescoreTask.cs
@@ -25,6 +25,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using System.Threading.Tasks;
 using pwiz.OspreySharp.Chromatography;
 using pwiz.OspreySharp.Core;
 using pwiz.OspreySharp.FDR;
@@ -94,6 +95,13 @@ namespace pwiz.OspreySharp.Tasks
     /// </summary>
     internal sealed class PerFileRescoreTask : OspreyTask
     {
+        // Equal-weight progress segments one file's Stage 6 rescore is divided into
+        // for the --parallel-files "[i] p%" aggregate line: reload spectra, re-score
+        // the subset, write the reconciled parquet. RescoreOneFile advances them via
+        // MultiProgressReporter.Current?.BeginSegment(); off the parallel path those
+        // are no-ops.
+        private const int RESCORE_FILE_SEGMENTS = 3;
+
         // Captured during Run so MergeNodeTask (downstream) can reach
         // the post-rescore version. Per the ownership-transfer semantics
         // of the pipeline: this task is the producer of the post-rescore
@@ -514,20 +522,62 @@ namespace pwiz.OspreySharp.Tasks
                 JoinFileStems = joinFileStems,
             };
 
+            int nTotalFiles = perFileEntries.Count;
+            // The Stage 6 rescore is the "second per-file fan-out": each file's rescore
+            // is independent (its own entry list + its own .scores-reconciled.parquet),
+            // and it reuses the same RunCoelutionScoring the Stage 1-4 fan-out already
+            // runs concurrently. So run files in parallel under the SAME
+            // EffectiveFileParallelism the scoring phase resolved (set on RunPlan by
+            // PerFileScoringTask). Output is byte-identical to the sequential loop --
+            // gated by regression.ps1 -- because the per-file work shares no mutable
+            // state. Per-file results land by index so the accumulation is order-free.
+            int parallelism = Math.Max(1, ctx.RunPlan.EffectiveFileParallelism);
+            var counts = new (int Rescored, int GapCwt, int GapForced)[nTotalFiles];
+
+            if (nTotalFiles == 1 || parallelism == 1)
+            {
+                for (int fileNum = 0; fileNum < nTotalFiles; fileNum++)
+                    counts[fileNum] = RescoreOneFile(
+                        fileNum, nTotalFiles,
+                        perFileEntries[fileNum].Key, perFileEntries[fileNum].Value,
+                        inputs, ctx);
+            }
+            else
+            {
+                // Legend mapping each aggregate-line slot to its file, then the
+                // concurrent rescore collapsed onto the throttled "[i] p%" line +
+                // per-file buffered blocks (same MultiProgressReporter as scoring).
+                ctx.LogInfo(string.Format(@"Re-scoring {0} files in parallel:", nTotalFiles));
+                for (int i = 0; i < nTotalFiles; i++)
+                {
+                    string key = perFileEntries[i].Key;
+                    string label =
+                        inputs.FileNameToIdx.TryGetValue(key, out int inputIdx)
+                        && inputIdx < inputs.Config.InputFiles.Count
+                            ? inputs.Config.InputFiles[inputIdx]
+                            : key;
+                    ctx.LogInfo(string.Format(@"  {0}. {1}", i + 1, label));
+                }
+                var multi = new MultiProgressReporter();
+                var parallelOpts = new ParallelOptions { MaxDegreeOfParallelism = parallelism };
+                Parallel.For(0, nTotalFiles, parallelOpts, fileNum =>
+                {
+                    using (multi.BeginFile(fileNum, perFileEntries[fileNum].Key, RESCORE_FILE_SEGMENTS))
+                        counts[fileNum] = RescoreOneFile(
+                            fileNum, nTotalFiles,
+                            perFileEntries[fileNum].Key, perFileEntries[fileNum].Value,
+                            inputs, ctx);
+                });
+            }
+
             int totalRescored = 0;
             int totalGapCwt = 0;
             int totalGapForced = 0;
-            int nTotalFiles = perFileEntries.Count;
-
-            for (int fileNum = 0; fileNum < nTotalFiles; fileNum++)
+            foreach (var c in counts)
             {
-                var counts = RescoreOneFile(
-                    fileNum, nTotalFiles,
-                    perFileEntries[fileNum].Key, perFileEntries[fileNum].Value,
-                    inputs, ctx);
-                totalRescored += counts.Rescored;
-                totalGapCwt += counts.GapCwt;
-                totalGapForced += counts.GapForced;
+                totalRescored += c.Rescored;
+                totalGapCwt += c.GapCwt;
+                totalGapForced += c.GapForced;
             }
 
             return new RescoreStats
@@ -604,11 +654,21 @@ namespace pwiz.OspreySharp.Tasks
             // the per-file clone pattern in ProcessFile.
             var fileConfig = config.ShallowClone();
 
+            // Divide the inner main-search thread budget across concurrently rescored
+            // files so total demand stays near core count (mirrors ProcessFile under
+            // --parallel-files). The subset rescore is light, but this still avoids
+            // thread oversubscription when several files re-score at once.
+            if (ctx.RunPlan.EffectiveFileParallelism > 1)
+                fileConfig.NThreads = Math.Max(1, config.NThreads / ctx.RunPlan.EffectiveFileParallelism);
+
             // Build the per-file scoring subset: boundary_overrides keyed
             // by entry_id + the subset library RunCoelutionScoring scores.
             var (boundaryOverrides, subsetLibrary) =
                 BuildScoringSubset(combinedTargets, fdrEntries, fullLibrary);
 
+            // Segment 1/3 (read): reload this file's spectra -- the file's first
+            // progress slice on the --parallel-files "[i] p%" aggregate line.
+            MultiProgressReporter.Current?.BeginSegment();
             // Load spectra: prefer the .spectra.bin cache the original
             // Stage 1 wrote; fall back to mzML if the cache is missing
             // or unreadable.
@@ -655,6 +715,9 @@ namespace pwiz.OspreySharp.Tasks
             // the first-pass ProcessFile path).
             var isolationWindows = ScoringTaskShared.ExtractIsolationWindows(spectra);
 
+            // Segment 2/3 (score): the subset re-score; its "Re-scoring isolation
+            // windows" reporter feeds this slice (the bulk of the file's motion).
+            MultiProgressReporter.Current?.BeginSegment();
             // Re-score the subset.
             var swRescore = Stopwatch.StartNew();
             List<FdrEntry> rescored;
@@ -700,6 +763,8 @@ namespace pwiz.OspreySharp.Tasks
                 totalRescored += nGapCwt + nGapForced;
             }
 
+            // Segment 3/3 (write): the reconciled parquet write-back.
+            MultiProgressReporter.Current?.BeginSegment();
             // PHASE 3 -- reconciled parquet write-back + sidecar stamp.
             WriteReconciledAndStamp(fileName, inputFile, fdrEntries, inputs, ctx);
 

--- a/pwiz_tools/OspreySharp/OspreySharp.Tasks/PerFileRescoreTask.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Tasks/PerFileRescoreTask.cs
@@ -562,7 +562,7 @@ namespace pwiz.OspreySharp.Tasks
                 var parallelOpts = new ParallelOptions { MaxDegreeOfParallelism = parallelism };
                 Parallel.For(0, nTotalFiles, parallelOpts, fileNum =>
                 {
-                    using (multi.BeginFile(fileNum, perFileEntries[fileNum].Key, RESCORE_FILE_SEGMENTS))
+                    using (multi.BeginFile(fileNum, RESCORE_FILE_SEGMENTS))
                         counts[fileNum] = RescoreOneFile(
                             fileNum, nTotalFiles,
                             perFileEntries[fileNum].Key, perFileEntries[fileNum].Value,

--- a/pwiz_tools/OspreySharp/OspreySharp.Tasks/PerFileScoringTask.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Tasks/PerFileScoringTask.cs
@@ -64,6 +64,12 @@ namespace pwiz.OspreySharp.Tasks
     /// </summary>
     internal sealed class PerFileScoringTask : OspreyTask
     {
+        // Equal-weight progress segments one input file's work is divided into for
+        // the --parallel-files "[i] p%" aggregate line: read spectra, calibrate RT/
+        // mass, score, write the scores parquet. ProcessFile advances them through
+        // MultiProgressReporter.BeginSegment at each phase boundary; off the parallel
+        // path those calls are no-ops.
+        private const int PROCESS_FILE_SEGMENTS = 4;
 
         public override string Name => @"PerFileScoring";
 
@@ -251,16 +257,33 @@ namespace pwiz.OspreySharp.Tasks
                 };
                 string validityKey = ValidityKey(ctx);
                 var fileResults = new ConcurrentDictionary<int, KeyValuePair<string, List<FdrEntry>>>();
+                // Legend mapping each aggregate-line slot to its input file, printed once
+                // before the concurrent "[i] p%" line starts -- mirrors Skyline's numbered
+                // file list above its multi-file import progress, so a reader can tell which
+                // file each [i] is. Uses the same [i] token as the aggregate line.
+                ctx.LogInfo(string.Format(@"Scoring {0} files in parallel:", config.InputFiles.Count));
+                for (int legendIdx = 0; legendIdx < config.InputFiles.Count; legendIdx++)
+                    ctx.LogInfo(string.Format(@"  {0}. {1}", legendIdx + 1, config.InputFiles[legendIdx]));
+
+                // Collapse the concurrent per-file progress onto a single throttled
+                // "[i] p%" aggregate line, and buffer each file's narrative so its
+                // block flushes contiguously on completion rather than interleaving
+                // with the other files' lines. Each file is one BeginFile scope; the
+                // PROCESS_FILE_SEGMENTS phases inside ProcessFile drive its percent.
+                var multi = new MultiProgressReporter();
                 Parallel.For(0, config.InputFiles.Count, parallelOpts, fileIdx =>
                 {
                     string inputFile = config.InputFiles[fileIdx];
                     string fileName = Path.GetFileNameWithoutExtension(inputFile);
-                    var fileResult = ScoreOrLoadForFile(
-                        inputFile, fileName, fileIdx, config.InputFiles.Count,
-                        fullLibrary, config, parquetFooterMetadata,
-                        perFileCalibrations, validityKey, ctx);
-                    if (fileResult != null)
-                        fileResults[fileIdx] = new KeyValuePair<string, List<FdrEntry>>(fileName, fileResult);
+                    using (multi.BeginFile(fileIdx, fileName, PROCESS_FILE_SEGMENTS))
+                    {
+                        var fileResult = ScoreOrLoadForFile(
+                            inputFile, fileName, fileIdx, config.InputFiles.Count,
+                            fullLibrary, config, parquetFooterMetadata,
+                            perFileCalibrations, validityKey, ctx);
+                        if (fileResult != null)
+                            fileResults[fileIdx] = new KeyValuePair<string, List<FdrEntry>>(fileName, fileResult);
+                    }
                 });
                 // Collect in original order
                 for (int i = 0; i < config.InputFiles.Count; i++)
@@ -1030,8 +1053,7 @@ namespace pwiz.OspreySharp.Tasks
                 // load failed -- fall through and rescore the file.
             }
 
-            ctx.LogInfo(string.Empty);
-            ctx.LogInfo(string.Format(@"===== Processing file {0}/{1}: {2} =====",
+            ctx.LogInfo(string.Format(@"Scoring file {0}/{1}: {2}",
                 fileIdx + 1, totalFiles, inputFile));
             // Clear stale sidecar so a mid-ProcessFile crash leaves no
             // false-positive sidecar on the next invocation.
@@ -1166,6 +1188,9 @@ namespace pwiz.OspreySharp.Tasks
             var context = new ScoringContext(config, fileName);
 
             // Load spectra (from mzML or .spectra.bin cache)
+            // Segment 1/4 (read): the mzML/cache read reporter inside LoadSpectra
+            // feeds this file's first progress slice under --parallel-files.
+            MultiProgressReporter.Current?.BeginSegment();
             List<Spectrum> spectra;
             List<MS1Spectrum> ms1Spectra;
             var swParse = Stopwatch.StartNew();
@@ -1217,6 +1242,9 @@ namespace pwiz.OspreySharp.Tasks
 
             // Resolve the per-file calibration (load a cached/Rust JSON or
             // compute via Calibrator) and persist the calibration JSON.
+            // Segment 2/4 (calibrate): no inner reporter today, so this slice
+            // carries the file forward as a step when scoring begins.
+            MultiProgressReporter.Current?.BeginSegment();
             RTCalibration rtCalibration = ResolveCalibration(
                 inputFile, fileName, fullLibrary, spectra, ms1Spectra,
                 context, config, out MzCalibrationResult ms2Cal, out MzCalibrationResult ms1Cal, ctx);
@@ -1240,6 +1268,10 @@ namespace pwiz.OspreySharp.Tasks
             // Run coelution scoring, then drop double-counted features and
             // deduplicate target/decoy pairs per base_id. Extracted to
             // ScoreAndDeduplicate so ProcessFile reads as a sequencer.
+            // Segment 3/4 (score): the inner isolation-window Parallel.For reporter
+            // in ScoringPipeline feeds this slice -- the long phase that shows the
+            // bulk of a file's motion on the aggregate line.
+            MultiProgressReporter.Current?.BeginSegment();
             var scoredEntries = ScoreAndDeduplicate(
                 fullLibrary, spectra, ms1Spectra, isolationWindows,
                 rtCalibration, ms2Cal, ms1Cal, context, config, fileName, ctx);
@@ -1260,6 +1292,9 @@ namespace pwiz.OspreySharp.Tasks
             // in Run() against the original (un-mutated) outer config — see
             // Run() for why. Skipped only in --task FirstPassFDR mode (no Stages 1-4
             // ran here, so there is nothing fresh to persist).
+            // Segment 4/4 (write): the parquet build/write reporters in
+            // ParquetScoreCache feed this final slice.
+            MultiProgressReporter.Current?.BeginSegment();
             if (parquetFooterMetadata != null)
             {
                 string parquetPath = ParquetScoreCache.GetScoresPath(inputFile);

--- a/pwiz_tools/OspreySharp/OspreySharp.Tasks/PerFileScoringTask.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Tasks/PerFileScoringTask.cs
@@ -275,7 +275,7 @@ namespace pwiz.OspreySharp.Tasks
                 {
                     string inputFile = config.InputFiles[fileIdx];
                     string fileName = Path.GetFileNameWithoutExtension(inputFile);
-                    using (multi.BeginFile(fileIdx, fileName, PROCESS_FILE_SEGMENTS))
+                    using (multi.BeginFile(fileIdx, PROCESS_FILE_SEGMENTS))
                     {
                         var fileResult = ScoreOrLoadForFile(
                             inputFile, fileName, fileIdx, config.InputFiles.Count,

--- a/pwiz_tools/OspreySharp/OspreySharp.Test/MultiProgressReporterTest.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Test/MultiProgressReporterTest.cs
@@ -76,7 +76,7 @@ namespace pwiz.OspreySharp.Test
             var multi = new MultiProgressReporter(0.0);
             var percents = new List<int>();
             string fileBlock;
-            using (var file = multi.BeginFile(0, @"fileA", 4))
+            using (var file = multi.BeginFile(0, 4))
             {
                 // Segment 1/4 (read): a reporter inside the scope feeds the slice.
                 file.BeginSegment();
@@ -138,9 +138,9 @@ namespace pwiz.OspreySharp.Test
             OspreyOutput.Out = capture;
 
             var multi = new MultiProgressReporter(0.0);
-            var fileA = multi.BeginFile(0, @"fileA", 4);
+            var fileA = multi.BeginFile(0, 4);
             OspreyOutput.Out.WriteLine(@"AAA narrative line");   // -> fileA buffer
-            var fileB = multi.BeginFile(1, @"fileB", 4);
+            var fileB = multi.BeginFile(1, 4);
             OspreyOutput.Out.WriteLine(@"BBB narrative line");   // -> fileB buffer
 
             fileA.BeginSegment();

--- a/pwiz_tools/OspreySharp/OspreySharp.Test/MultiProgressReporterTest.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Test/MultiProgressReporterTest.cs
@@ -1,0 +1,186 @@
+/*
+ * Original author: Brendan MacLean <brendanx .at. uw.edu>,
+ *                  MacCoss Lab, Department of Genome Sciences, UW
+ * AI assistance: Claude Code (Claude Opus 4.8) <noreply .at. anthropic.com>
+ *
+ * Based on osprey (https://github.com/MacCossLab/osprey)
+ *   by Michael J. MacCoss, MacCoss Lab, Department of Genome Sciences, UW
+ *
+ * Copyright 2026 University of Washington - Seattle, WA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using pwiz.OspreySharp.Core;
+
+namespace pwiz.OspreySharp.Test
+{
+    /// <summary>
+    /// Unit tests for the <c>--parallel-files</c> progress aggregator
+    /// (<see cref="MultiProgressReporter"/>) and its seams on
+    /// <see cref="OspreyOutput"/> + <see cref="ProgressReporter"/>:
+    /// the throttled <c>[i] p%</c> aggregate line, the equal-weight segment
+    /// model that composes one file's percent, per-file narrative buffering
+    /// flushed contiguously on completion, and the inert-off-the-parallel-path
+    /// behavior (a ProgressReporter with no active scope still prints inline).
+    ///
+    /// Drives the API synchronously through the (internals-visible) handle
+    /// surface rather than a real <c>Parallel.For</c>, so the assertions are
+    /// deterministic; the cross-thread ExecutionContext flow is exercised by the
+    /// end-to-end Stellar/Astral runs. Interval 0 disables the render throttle so
+    /// every advance is observable.
+    /// </summary>
+    [TestClass]
+    public class MultiProgressReporterTest
+    {
+        [TestMethod]
+        public void TestMultiProgressReporter()
+        {
+            var savedOut = OspreyOutput.Out;
+            try
+            {
+                ValidateSegmentCompositeAndRouting();
+                ValidateAggregateLineAndBuffering();
+                ValidateInertWhenNoScope();
+            }
+            finally
+            {
+                OspreyOutput.Out = savedOut;
+            }
+        }
+
+        // One file, four equal-weight segments: each segment's 0..100 maps into its
+        // 25% slice, and a ProgressReporter constructed inside the scope routes its
+        // percent to the active segment (no inline "<pct>%" line) while its heading
+        // still buffers into the file's block.
+        private static void ValidateSegmentCompositeAndRouting()
+        {
+            var capture = new StringWriter();
+            OspreyOutput.Out = capture;
+            OspreyOutput.PerfStats = false;   // default: machine stat lines suppressed
+
+            var multi = new MultiProgressReporter(0.0);
+            var percents = new List<int>();
+            string fileBlock;
+            using (var file = multi.BeginFile(0, @"fileA", 4))
+            {
+                // Segment 1/4 (read): a reporter inside the scope feeds the slice.
+                file.BeginSegment();
+                using (var reader = new ProgressReporter(@"Reading fileA", 100))
+                {
+                    reader.Report(50);                 // (0*100 + 50) / 4 = 12
+                    percents.Add(file.Slot.Percent);
+                }                                       // Dispose banks segment at 100 -> 25
+                percents.Add(file.Slot.Percent);
+
+                // Segment 2/4 (calibrate): no reporter -- BeginSegment alone carries
+                // the file to the slice boundary (50%) when segment 3 opens.
+                file.BeginSegment();
+                file.BeginSegment();                    // open segment 3 -> floor at 50
+                percents.Add(file.Slot.Percent);
+                file.CurrentSegmentSink.Report(100);    // (2*100 + 100) / 4 = 75
+                percents.Add(file.Slot.Percent);
+
+                // Machine stat lines must be filtered OUT of the buffered block (default
+                // PerfStats=false) exactly as the unbuffered Out filters them -- otherwise a
+                // buffered run leaks [COUNT]/[BENCH]/etc. and looks like perf mode. A plain
+                // narrative line survives.
+                OspreyOutput.Out.WriteLine(@"[COUNT] suppressed count line");
+                OspreyOutput.Out.WriteLine(@"[BENCH] suppressed bench line");
+                OspreyOutput.Out.WriteLine(@"[TIMING] suppressed timing line");
+                OspreyOutput.Out.WriteLine(@"plain narrative survives");
+
+                // Read the file's OWN buffer (not the full capture, which also holds
+                // the aggregate "[i] p%" lines) to check what the narrative block got.
+                fileBlock = file.BufferContents;
+            }
+
+            Assert.AreEqual(12, percents[0], @"segment 1 at 50% should compose to 12%");
+            Assert.AreEqual(25, percents[1], @"segment 1 disposed should bank the slice at 25%");
+            Assert.AreEqual(50, percents[2], @"two segments behind should floor the file at 50%");
+            Assert.AreEqual(75, percents[3], @"segment 3 at 100% should compose to 75%");
+
+            StringAssert.Contains(fileBlock, @"Reading fileA...",
+                @"the reporter heading must buffer into the file block");
+            Assert.IsFalse(fileBlock.Contains(@"%"),
+                @"inside a scope the reporter must route its percent, not print a '%' line into the block");
+            StringAssert.Contains(fileBlock, @"plain narrative survives",
+                @"a non-stat narrative line must remain in the buffered block");
+            Assert.IsFalse(fileBlock.Contains(@"[COUNT]"),
+                @"[COUNT] stat lines must be filtered out of the buffered block (default PerfStats)");
+            Assert.IsFalse(fileBlock.Contains(@"[BENCH]"),
+                @"[BENCH] stat lines must be filtered out of the buffered block (default PerfStats)");
+            Assert.IsFalse(fileBlock.Contains(@"[TIMING]"),
+                @"[TIMING] stat lines must be filtered out of the buffered block (default PerfStats)");
+        }
+
+        // Two concurrent files: the aggregate line shows both active slots, each
+        // file's narrative is buffered and flushed as one contiguous block on
+        // completion (LIFO here to respect the synthetic single-thread scope stack),
+        // and a completed file drops off the line.
+        private static void ValidateAggregateLineAndBuffering()
+        {
+            var capture = new StringWriter();
+            OspreyOutput.Out = capture;
+
+            var multi = new MultiProgressReporter(0.0);
+            var fileA = multi.BeginFile(0, @"fileA", 4);
+            OspreyOutput.Out.WriteLine(@"AAA narrative line");   // -> fileA buffer
+            var fileB = multi.BeginFile(1, @"fileB", 4);
+            OspreyOutput.Out.WriteLine(@"BBB narrative line");   // -> fileB buffer
+
+            fileA.BeginSegment();
+            fileA.CurrentSegmentSink.Report(40);                 // fileA -> 10%
+            fileB.BeginSegment();
+            fileB.CurrentSegmentSink.Report(80);                 // fileB -> 20%
+
+            fileB.Dispose();                                     // flush B, drop slot 2
+            fileA.Dispose();                                     // flush A, drop slot 1
+
+            string output = capture.ToString();
+            StringAssert.Contains(output, @"[1] 10%  [2] 20%",
+                @"the aggregate line must show both active files with 0-based index shown as [i+1]");
+
+            // Each file's narrative must appear as one contiguous block (its single
+            // line here), not interleaved into the other file's block.
+            StringAssert.Contains(output, @"AAA narrative line");
+            StringAssert.Contains(output, @"BBB narrative line");
+            // fileB completed first (LIFO), so its block flushes before fileA's.
+            Assert.IsTrue(
+                output.IndexOf(@"BBB narrative line", StringComparison.Ordinal)
+                    < output.IndexOf(@"AAA narrative line", StringComparison.Ordinal),
+                @"the first-completed file's block should flush first");
+        }
+
+        // Off the parallel path (no per-file scope), a ProgressReporter prints its
+        // percent inline exactly as before -- the seam is inert.
+        private static void ValidateInertWhenNoScope()
+        {
+            var capture = new StringWriter();
+            OspreyOutput.Out = capture;
+
+            Assert.IsNull(MultiProgressReporter.Current,
+                @"no per-file scope should be active outside BeginFile");
+            using (var progress = new ProgressReporter(@"Standalone", 100, string.Empty, 0.0))
+                progress.Report(50);
+
+            string output = capture.ToString();
+            StringAssert.Contains(output, @"Standalone...");
+            StringAssert.Contains(output, @"50%");
+        }
+    }
+}

--- a/pwiz_tools/OspreySharp/OspreySharp/Program.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/Program.cs
@@ -186,16 +186,11 @@ namespace pwiz.OspreySharp
                 // differently from per-file scoring.
                 bool fromInputScores = config.InputScores != null && config.InputScores.Count > 0;
 
-                // Non-fatal warning: --task PerFileScoring with --output
-                // supplied — that Stage 1-4 worker mode ignores --output. The
-                // rescore worker (--task PerFileRescoring, identified by
-                // --input-scores) requires --output, so the warning would be
-                // incorrect/confusing there.
-                if (config.NoJoin && !fromInputScores && !string.IsNullOrEmpty(config.OutputBlib))
-                {
-                    LogWarning("--task PerFileScoring: --output is ignored (no blib is written). " +
-                               "Per-file `.scores.parquet` files will be written next to each input mzML.");
-                }
+                // --task PerFileScoring ignores --output (it writes per-file
+                // .scores.parquet, not a blib), but that is expected single-task /
+                // HPC-worker behavior -- wrapper scripts routinely pass a placeholder
+                // --output -- so it is NOT warned about. The settings block below
+                // reports the real per-file parquet output for this task instead.
 
                 // Validate input files exist on disk (skip when consuming
                 // --input-scores, where there are no mzML inputs; --input-scores
@@ -224,7 +219,19 @@ namespace pwiz.OspreySharp
                 LogInfo(string.Format("Library: {0} ({1})",
                     config.LibrarySource?.Path ?? "(none)",
                     config.LibrarySource?.Format.ToString() ?? "?"));
-                LogInfo(string.Format("Output: {0}", config.OutputBlib));
+                // A --task run executes one HPC stage rather than the full pipeline;
+                // name it so the log says which single task ran (no --task = full
+                // pipeline, no line).
+                if (config.SelectedTask.HasValue)
+                    LogInfo(string.Format("Task: {0} (single-task run)",
+                        TaskCliName(config.SelectedTask.Value)));
+                // --task PerFileScoring writes per-file .scores.parquet next to each
+                // input mzML, not a blib -- report the real output rather than the
+                // ignored --output blib path. (PerFileRescoring still writes --output.)
+                if (config.NoJoin && !fromInputScores)
+                    LogInfo("Output: per-file .scores.parquet (next to each input mzML)");
+                else
+                    LogInfo(string.Format("Output: {0}", config.OutputBlib));
                 LogInfo(string.Format("Resolution: {0}", config.ResolutionMode));
                 LogInfo(string.Format("Fragment tolerance: {0} {1}",
                     config.FragmentTolerance.Tolerance,
@@ -308,6 +315,25 @@ namespace pwiz.OspreySharp
             return string.Format(
                 "--task: unknown task '{0}'. Valid tasks: PerFileScoring, FirstPassFDR, PerFileRescoring, SecondPassFDR.",
                 taskName);
+        }
+
+        /// <summary>
+        /// The CLI <c>--task</c> name for an <see cref="HpcTask"/> -- the inverse of
+        /// <see cref="ResolveTask"/>, used to echo the selected task in the startup
+        /// settings block. The enum members and CLI spellings differ
+        /// (FirstJoin/FirstPassFDR, PerFileRescore/PerFileRescoring,
+        /// MergeNode/SecondPassFDR), so this maps back to what the user typed.
+        /// </summary>
+        private static string TaskCliName(HpcTask task)
+        {
+            switch (task)
+            {
+                case HpcTask.PerFileScoring: return "PerFileScoring";
+                case HpcTask.FirstJoin: return "FirstPassFDR";
+                case HpcTask.PerFileRescore: return "PerFileRescoring";
+                case HpcTask.MergeNode: return "SecondPassFDR";
+                default: return task.ToString();
+            }
         }
 
         /// <summary>
@@ -464,11 +490,20 @@ namespace pwiz.OspreySharp
 
         internal static void LogWarning(string message)
         {
-            _out.WriteLine("[WARN] {0}", message);
+            // Through OspreyOutput.Out (not _out directly) so a warning emitted
+            // while a file runs in a MultiProgressReporter per-file scope
+            // (--parallel-files) lands in that file's buffered block, in context,
+            // instead of interleaving with the live "[i] p%" aggregate line. Off
+            // the parallel path OspreyOutput.Out is the same CommandStatusWriter
+            // (wrapped for stat-filtering), so the output is unchanged.
+            OspreyOutput.Out.WriteLine("[WARN] {0}", message);
         }
 
         internal static void LogError(string message)
         {
+            // Errors go straight to the process writer (NOT the per-file buffer):
+            // surface immediately rather than waiting for the file's block to flush
+            // on completion, so a failing run reports the cause right away.
             _out.WriteLine("[ERROR] {0}", message);
         }
     }


### PR DESCRIPTION
## Summary

* Added a MultiProgressReporter that collapses concurrent `--parallel-files` progress onto one throttled `[i] p%` line with a numbered file legend, buffering each file's narrative into a block flushed on completion (Skyline MultiProgressStatus + Boost-Build style)
* Kept default logs clean: machine stat lines (incl. `[BENCH]`) gate behind `--perf-stats`, dropped the `--task`/`--output` warning, report `Task:` + the real per-file parquet output, and renamed the per-file scoring banner to `Scoring file N/M`
* Widened the I/O progress reporting interval to 5s
* Parallelized the Stage 6 per-file rescore (`Parallel.For` bounded by `EffectiveFileParallelism`); each file's rescore is independent, so output stays byte-identical

See ai/todos/active/TODO-20260625_ospreysharp_output_progress.md

## Test plan

- [x] TestMultiProgressReporter - segment compositing, `[i] p%` aggregate, per-file buffering, stat-line filtering
- [x] regression.ps1 -Dataset All - all 6 legs PASS at parallelism 3 (byte-identical vs golden, resume, HPC 4-task chain)
- [x] Test-PerfGate.ps1 -Dataset Stellar - PASS, total wall -5.5% (rescore -51%, scoring flat)

Co-Authored-By: Claude <noreply@anthropic.com>
