### PR TITLE
Added Osprey redistribution packaging (ZIP + WiX MSI)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -389,6 +389,7 @@ Version.cpp
 /pwiz_tools/SeeMS/**/AssemblyInfo.cs
 /pwiz_tools/MSConvertGUI/**/AssemblyInfo.cs
 /pwiz_tools/Osprey/**/AssemblyInfo.cs
+/pwiz_tools/Osprey/dist/
 /pwiz_tools/Bumbershoot/**/*Version.cpp
 /pwiz_tools/Bumbershoot/**/AssemblyInfo.cpp
 /pwiz_tools/Bumbershoot/**/AssemblyInfo.cs

--- a/pwiz_tools/Osprey/Installer/Osprey.wxs
+++ b/pwiz_tools/Osprey/Installer/Osprey.wxs
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Osprey per-machine Windows installer (modern WiX v5 toolset).
+
+  Built by ../package.ps1 -Msi, which dotnet-publishes a self-contained
+  win-x64 Osprey and then invokes `wix build` passing:
+    -d PublishDir=<self-contained win-x64 publish folder>
+    -d ProductVersion=<YEAR.ORDINAL.DOY>           (MSI upgrade-significant)
+    -d InformationalVersion=<YEAR.ORDINAL.BRANCH.DOY>  (full Osprey version)
+    -d LicenseRtf=<generated License.rtf>
+
+  Requirements: the WiX v5 dotnet tool plus the matching v5 UI extension
+  (package.ps1 and the ai/.tmp TeamCity plan document the exact commands).
+  WiX v5 is the last release under the free MS-RL license (v6+ require the
+  paid Open Source Maintenance Fee), matching the project's existing WiX 3
+  Skyline installer policy of not taking on installer-tool license costs.
+
+  Installs to C:\Program Files\Osprey (per-machine), adds an Add/Remove
+  Programs entry, and puts the install dir on the system PATH so `osprey`
+  resolves in any shell. The UpgradeCode is fixed so each new version cleanly
+  replaces the prior per-machine install.
+-->
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs"
+     xmlns:ui="http://wixtoolset.org/schemas/v4/wxs/ui">
+
+  <Package
+      Name="Osprey"
+      Manufacturer="University of Washington"
+      Version="$(ProductVersion)"
+      UpgradeCode="7B0D9C2A-4E6F-4A1B-8C3D-2F5E6A7B8C9D"
+      Scope="perMachine"
+      Compressed="yes">
+
+    <SummaryInformation Description="Osprey $(InformationalVersion) - peptide-centric DIA search engine" />
+
+    <MajorUpgrade DowngradeErrorMessage="A newer version of Osprey is already installed. Setup will now exit." />
+
+    <MediaTemplate EmbedCab="yes" />
+
+    <!-- C:\Program Files\Osprey -->
+    <StandardDirectory Id="ProgramFiles64Folder">
+      <Directory Id="INSTALLFOLDER" Name="Osprey" />
+    </StandardDirectory>
+
+    <!-- Harvest the whole self-contained publish tree. The WiX v4+ Files
+         element auto-creates one component per file, preserving the layout
+         under INSTALLFOLDER. -->
+    <ComponentGroup Id="OspreyFiles" Directory="INSTALLFOLDER">
+      <Files Include="$(PublishDir)\**" />
+    </ComponentGroup>
+
+    <!-- Put the install dir on the system PATH so `osprey` works everywhere. -->
+    <ComponentGroup Id="OspreyPath" Directory="INSTALLFOLDER">
+      <Component Id="OspreyPathEntry" Guid="A1C4E8D2-6F3B-4A90-B17E-2D5C9E0F4A66">
+        <Environment Id="OspreyPathEnv" Name="PATH" Value="[INSTALLFOLDER]"
+                     Part="last" Action="set" System="yes" Permanent="no" />
+        <RegistryValue Root="HKLM" Key="Software\University of Washington\Osprey"
+                       Name="InstallPath" Type="string" Value="[INSTALLFOLDER]" KeyPath="yes" />
+      </Component>
+    </ComponentGroup>
+
+    <Feature Id="Main" Title="Osprey" Level="1">
+      <ComponentGroupRef Id="OspreyFiles" />
+      <ComponentGroupRef Id="OspreyPath" />
+    </Feature>
+
+    <!-- Standard install-dir wizard with the license shown. -->
+    <ui:WixUI Id="WixUI_InstallDir" InstallDirectory="INSTALLFOLDER" />
+    <WixVariable Id="WixUILicenseRtf" Value="$(LicenseRtf)" />
+  </Package>
+</Wix>

--- a/pwiz_tools/Osprey/Installer/Osprey.wxs
+++ b/pwiz_tools/Osprey/Installer/Osprey.wxs
@@ -44,7 +44,9 @@
 
     <!-- Harvest the whole self-contained publish tree. The WiX v4+ Files
          element auto-creates one component per file, preserving the layout
-         under INSTALLFOLDER. -->
+         under INSTALLFOLDER. PublishDir is a Windows path with a backslash
+         glob; that is fine because the .msi is win-x64 only and package.ps1
+         always feeds New-OspreyMsi the win-x64 stage. -->
     <ComponentGroup Id="OspreyFiles" Directory="INSTALLFOLDER">
       <Files Include="$(PublishDir)\**" />
     </ComponentGroup>

--- a/pwiz_tools/Osprey/README.md
+++ b/pwiz_tools/Osprey/README.md
@@ -185,6 +185,36 @@ with MSBuild directly against `Osprey/Osprey.csproj`. The
 assembly name is `Osprey`, so the produced binary is `Osprey`
 (Linux) / `Osprey.exe` (Windows).
 
+## Redistribution (ZIP / .msi)
+
+`package.ps1` produces the canonical redistributable artifacts on top of the
+build above. Each is a self-contained `net8.0` publish (no system .NET needed),
+laid out under one versioned top-level folder so multiple versions coexist when
+unzipped side by side -- important for pinning an exact Osprey per HPC analysis.
+
+```powershell
+# Per-RID ZIPs into dist/ (win-x64 + linux-x64 by default)
+pwsh -File ./package.ps1
+
+# Windows ZIP + the per-machine .msi installer
+pwsh -File ./package.ps1 -Rid win-x64 -Msi
+```
+
+Artifacts (gitignored `dist/`):
+
+```
+Osprey-<version>-win-x64.zip      Osprey.exe + runtime DLLs + Documentation/ + README + LICENSE
+Osprey-<version>-linux-x64.zip    same layout, Linux self-contained
+Osprey-<version>-win-x64.msi      installs to C:\Program Files\Osprey (per-machine), adds PATH
+```
+
+The version is the Skyline scheme `YEAR.ORDINAL.BRANCH.DOY` shared with the
+build via `version.ps1`. The `.msi` is built with the WiX v5 dotnet tool (see
+`Installer/Osprey.wxs`); Authenticode signing is available behind `-Sign`
+(off by default -- see the script header for the `OSPREY_SIGN*` env vars). CI
+runs this via `tcpackage.bat`. This is the official artifact downstream tools
+(e.g. Carafe) should consume rather than building their own Osprey publish.
+
 ## Running against test data
 
 The reference test datasets are not in this repo. They live on the

--- a/pwiz_tools/Osprey/build.ps1
+++ b/pwiz_tools/Osprey/build.ps1
@@ -153,21 +153,12 @@ foreach ($f in $staleAsmInfo) {
 # --- Version (Skyline scheme YEAR.ORDINAL.BRANCH.DOY) -------------------
 # Mirrors pwiz_tools/Skyline/Jamfile.jam so a standalone dev/CI build stamps
 # the same versioning the Boost build does (rather than the Directory.Build.props
-# placeholder). YEAR/ORDINAL/BRANCH are the release-line constants; DOY is the
-# day-of-year of the git commit date (reproducible), offset by 365 per year past
-# YEAR. The stamped version becomes OspreyVersion.Current at runtime. The
+# placeholder). The stamped version becomes OspreyVersion.Current at runtime. The
 # regression harness pins OSPREY_VERSION_OVERRIDE on top of this for bit parity.
-$OSPREY_YEAR = 26
-$OSPREY_ORDINAL = 1
-$OSPREY_BRANCH = 1
-$gitDate = & git -C $scriptRoot log -1 --format=%cs HEAD 2>$null
-if ($LASTEXITCODE -eq 0 -and $gitDate -match '^\d{4}-\d{2}-\d{2}$') {
-    $verDate = [datetime]::ParseExact($gitDate.Trim(), 'yyyy-MM-dd', [cultureinfo]::InvariantCulture)
-} else {
-    $verDate = Get-Date
-}
-$doy = (([int]$verDate.ToString('yy')) - $OSPREY_YEAR) * 365 + $verDate.DayOfYear
-$ospreyVersion = "$OSPREY_YEAR.$OSPREY_ORDINAL.$OSPREY_BRANCH.$doy"
+# The formula lives in version.ps1 so build.ps1 (stamps the binary) and
+# package.ps1 (names the redistributable) can never disagree.
+. (Join-Path $scriptRoot 'version.ps1')
+$ospreyVersion = Get-OspreyVersion -RepoPath $scriptRoot
 
 # --- Build --------------------------------------------------------------
 Write-Progress-Tc "Building Osprey.sln ($Configuration|$platform) v$ospreyVersion"

--- a/pwiz_tools/Osprey/package.ps1
+++ b/pwiz_tools/Osprey/package.ps1
@@ -1,0 +1,335 @@
+<#
+.SYNOPSIS
+    Package Osprey for redistribution: a self-contained, per-RID ZIP for each
+    target platform and (optionally) a Windows .msi installer.
+
+.DESCRIPTION
+    Produces the canonical Osprey redistributable artifacts described in
+    ai/todos/active/TODO-20260627_osprey_redistribution.md:
+
+      * For each RID, a `dotnet publish -c Release -f net8.0 -r <rid>
+        --self-contained` is laid out under a single versioned top-level
+        folder (Osprey.exe + runtime/dependency DLLs + Documentation/ +
+        README + LICENSE) and zipped to `Osprey-<version>-<rid>.zip`. The
+        single containing folder means multiple versions coexist when
+        unzipped side by side, and extraction never explodes ~200 files into
+        the user's download dir.
+
+      * With -Msi, the win-x64 publish is additionally packaged into a
+        per-machine `C:\Program Files\Osprey` WiX installer
+        (Osprey-<version>-win-x64.msi) with an Add/Remove-Programs entry.
+
+    Self-contained means ZERO system-.NET dependency: copy the folder to an
+    HPC node and run it. net8.0 is the canonical distribution runtime; net472
+    is intentionally not packaged.
+
+    This script is standalone (build.ps1 / Osprey.sln are the dev+CI build;
+    this is the redistribution step on top of them). It is NOT wired into
+    Boost.Build / the ProteoWizard release -- Osprey ships as its own tool.
+
+.PARAMETER Rid
+    Runtime identifiers to package. Default: win-x64, linux-x64. linux-x64
+    cross-builds fine from Windows (the binaries just can't be run here).
+
+.PARAMETER Configuration
+    Debug or Release. Default Release.
+
+.PARAMETER OutputDir
+    Where the .zip/.msi artifacts land. Default <scriptRoot>/dist (gitignored).
+    The per-RID publish trees are staged under <OutputDir>/_staging.
+
+.PARAMETER Msi
+    Also build the win-x64 .msi (requires the `wix` dotnet tool and that
+    win-x64 is among -Rid). See Installer/Osprey.wxs.
+
+.PARAMETER NoZip
+    Skip the .zip step (e.g. -Msi -NoZip to produce only the installer).
+
+.PARAMETER IncludePdb
+    Keep *.pdb files in the package. Default: stripped (leaner release artifact).
+
+.PARAMETER Sign
+    Authenticode-sign Osprey.exe and the .msi. OFF by default. Also enabled by
+    setting OSPREY_SIGN=1. Requires signtool on PATH (or OSPREY_SIGNTOOL) and a
+    cert: either OSPREY_SIGN_PFX (+ OSPREY_SIGN_PFX_PASSWORD) or, with no PFX,
+    signtool's machine-store auto-select (/a). If signing is requested but the
+    tool or cert is unavailable this script HARD-FAILS rather than shipping an
+    unsigned artifact that looks signed.
+
+.PARAMETER TeamCity
+    Emit TeamCity service messages (progress + publishArtifacts) so a CI config
+    can collect the artifacts.
+
+.EXAMPLE
+    # Local: both platform zips into dist/
+    .\package.ps1
+
+.EXAMPLE
+    # Windows zip + msi only
+    .\package.ps1 -Rid win-x64 -Msi
+
+.EXAMPLE
+    # CI
+    .\package.ps1 -TeamCity -Msi
+#>
+param(
+    [string[]]$Rid = @('win-x64','linux-x64'),
+    [ValidateSet('Debug','Release')] [string]$Configuration = 'Release',
+    [string]$OutputDir,
+    [switch]$Msi,
+    [switch]$NoZip,
+    [switch]$IncludePdb,
+    [switch]$Sign,
+    [switch]$TeamCity
+)
+
+$ErrorActionPreference = 'Stop'
+[Console]::OutputEncoding = [System.Text.Encoding]::UTF8
+
+$scriptRoot = Split-Path -Parent $PSCommandPath
+$repoRoot   = (Resolve-Path (Join-Path $scriptRoot '..\..')).Path
+$ospreyCsproj = Join-Path $scriptRoot 'Osprey\Osprey.csproj'
+if (-not (Test-Path $ospreyCsproj)) {
+    Write-Error "Osprey.csproj not found at $ospreyCsproj"
+    exit 2
+}
+
+. (Join-Path $scriptRoot 'version.ps1')
+$version = Get-OspreyVersion -RepoPath $scriptRoot
+
+if (-not $OutputDir) { $OutputDir = Join-Path $scriptRoot 'dist' }
+$stagingRoot = Join-Path $OutputDir '_staging'
+
+# --- TeamCity service-message helpers (mirror build.ps1) ----------------
+function Format-TcMessage([string]$s) {
+    if ($null -eq $s) { return '' }
+    return $s.Replace('|', '||').Replace("'", "|'").Replace("`n", '|n').Replace("`r", '|r').Replace('[', '|[').Replace(']', '|]')
+}
+function Write-Progress-Tc([string]$msg) {
+    if ($TeamCity) {
+        Write-Host ("##teamcity[progressMessage '{0}']" -f (Format-TcMessage $msg))
+    } else {
+        Write-Host "==> $msg" -ForegroundColor Cyan
+    }
+}
+function Publish-Artifact-Tc([string]$path) {
+    if ($TeamCity) {
+        Write-Host ("##teamcity[publishArtifacts '{0}']" -f (Format-TcMessage $path))
+    }
+}
+
+# --- Signing (env-gated, hard-fail when requested-but-unavailable) -------
+function Invoke-OspreySign {
+    param([string]$Path)
+    $enabled = $Sign -or ($env:OSPREY_SIGN -eq '1')
+    if (-not $enabled) { return }
+
+    $signtool = $env:OSPREY_SIGNTOOL
+    if (-not $signtool) {
+        $cmd = Get-Command signtool.exe -ErrorAction SilentlyContinue
+        if ($cmd) { $signtool = $cmd.Source }
+    }
+    if (-not $signtool -or -not (Test-Path $signtool)) {
+        Write-Error "Signing requested but signtool.exe not found (set OSPREY_SIGNTOOL or add it to PATH). Refusing to ship an unsigned artifact."
+        exit 3
+    }
+
+    $timestampUrl = if ($env:OSPREY_SIGN_TIMESTAMP_URL) { $env:OSPREY_SIGN_TIMESTAMP_URL } else { 'http://timestamp.digicert.com' }
+    $signArgs = @('sign', '/fd', 'SHA256', '/tr', $timestampUrl, '/td', 'SHA256')
+    if ($env:OSPREY_SIGN_PFX) {
+        if (-not (Test-Path $env:OSPREY_SIGN_PFX)) {
+            Write-Error "OSPREY_SIGN_PFX points to a missing file: $($env:OSPREY_SIGN_PFX)"
+            exit 3
+        }
+        $signArgs += @('/f', $env:OSPREY_SIGN_PFX)
+        if ($env:OSPREY_SIGN_PFX_PASSWORD) { $signArgs += @('/p', $env:OSPREY_SIGN_PFX_PASSWORD) }
+    } else {
+        # No PFX: let signtool auto-select a suitable cert from the machine store.
+        $signArgs += '/a'
+    }
+    $signArgs += $Path
+
+    Write-Progress-Tc "Signing $(Split-Path -Leaf $Path)"
+    & $signtool @signArgs | Out-Host
+    if ($LASTEXITCODE -ne 0) {
+        Write-Error "signtool failed (exit $LASTEXITCODE) for $Path"
+        exit 3
+    }
+}
+
+# --- Per-RID publish + stage --------------------------------------------
+function New-OspreyStage {
+    param([string]$Rid)
+
+    $folderName = "Osprey-$version-$Rid"
+    $stageDir = Join-Path $stagingRoot $folderName
+    if (Test-Path $stageDir) { Remove-Item $stageDir -Recurse -Force }
+    New-Item -ItemType Directory -Force -Path $stageDir | Out-Null
+
+    Write-Progress-Tc "Publishing $folderName ($Configuration, self-contained net8.0)"
+    $publishArgs = @(
+        'publish', $ospreyCsproj,
+        '-c', $Configuration,
+        '-f', 'net8.0',
+        '-r', $Rid,
+        '--self-contained', 'true',
+        '-p:PublishSingleFile=false',
+        '-p:Platform=x64',
+        "-p:Version=$version",
+        '-o', $stageDir,
+        '-v', 'minimal', '--nologo'
+    )
+    # Out-Host keeps publish output visible/logged without it leaking into this
+    # function's return value (PowerShell returns the whole success stream).
+    & dotnet @publishArgs | Out-Host
+    if ($LASTEXITCODE -ne 0) {
+        Write-Error "dotnet publish failed for $Rid (exit $LASTEXITCODE)"
+        exit $LASTEXITCODE
+    }
+
+    if (-not $IncludePdb) {
+        Get-ChildItem -Path $stageDir -Filter *.pdb -Recurse -ErrorAction SilentlyContinue | Remove-Item -Force
+    }
+
+    Add-OspreyDocs -StageDir $stageDir
+
+    # Sign the Windows exe inside the stage before zipping/MSI packaging.
+    if ($Rid -like 'win-*') {
+        Invoke-OspreySign -Path (Join-Path $stageDir 'Osprey.exe')
+    }
+
+    return $stageDir
+}
+
+# --- Documentation + README + LICENSE -----------------------------------
+function Add-OspreyDocs {
+    param([string]$StageDir)
+
+    $docOut = Join-Path $StageDir 'Documentation'
+    New-Item -ItemType Directory -Force -Path $docOut | Out-Null
+
+    $cmdHelp = Join-Path $scriptRoot 'Documentation\Help\en\CommandLine.html'
+    $workflow = Join-Path $scriptRoot 'Osprey-workflow.html'
+    Copy-Item $cmdHelp (Join-Path $docOut 'CommandLine.html') -Force
+    Copy-Item $workflow (Join-Path $docOut 'Osprey-workflow.html') -Force
+
+    # The in-repo CommandLine.html cross-links to the workflow page via a
+    # raw.githack master URL (good for the website). In the offline bundle,
+    # both files sit side by side, so retarget that link to the local copy so
+    # the docs work with no network. Operates on the COPY, never the source.
+    $staged = Join-Path $docOut 'CommandLine.html'
+    $html = Get-Content $staged -Raw
+    $html = [regex]::Replace($html, 'https?://raw\.githack\.com/ProteoWizard/pwiz/[^"'' ]*Osprey-workflow\.html', 'Osprey-workflow.html')
+    Set-Content -Path $staged -Value $html -NoNewline
+
+    Copy-Item (Join-Path $scriptRoot 'README.md') (Join-Path $StageDir 'README.md') -Force
+    Copy-Item (Join-Path $repoRoot 'LICENSE') (Join-Path $StageDir 'LICENSE') -Force
+}
+
+# --- License.rtf for the MSI UI (generated from the plain-text LICENSE) --
+function Write-LicenseRtf {
+    param([string]$Source, [string]$Destination)
+    # WiX's license dialog requires RTF. Generate it from the canonical
+    # plain-text LICENSE at build time so the installer license never drifts
+    # from the repo. (LICENSE is ASCII, so no \uN escaping is needed.)
+    $text = (Get-Content $Source -Raw).Replace('\', '\\').Replace('{', '\{').Replace('}', '\}')
+    $body = ($text -split "`r?`n") -join '\par '
+    $rtf = '{\rtf1\ansi\deff0{\fonttbl{\f0\fmodern Courier New;}}\fs16 ' + $body + '}'
+    Set-Content -Path $Destination -Value $rtf -NoNewline -Encoding ascii
+}
+
+# --- Zip (single versioned top-level folder) ----------------------------
+function New-OspreyZip {
+    param([string]$StageDir, [string]$Rid)
+    $zipPath = Join-Path $OutputDir "Osprey-$version-$Rid.zip"
+    if (Test-Path $zipPath) { Remove-Item $zipPath -Force }
+    Write-Progress-Tc "Zipping $(Split-Path -Leaf $zipPath)"
+    Add-Type -AssemblyName System.IO.Compression.FileSystem
+    # includeBaseDirectory=$true -> the archive contains the single
+    # "Osprey-<version>-<rid>/" folder, never root-exploded files.
+    [System.IO.Compression.ZipFile]::CreateFromDirectory(
+        $StageDir, $zipPath,
+        [System.IO.Compression.CompressionLevel]::Optimal, $true)
+    Publish-Artifact-Tc $zipPath
+    return $zipPath
+}
+
+# --- MSI (delegates layout to Installer/Osprey.wxs) ---------------------
+function New-OspreyMsi {
+    param([string]$StageDir)
+
+    $wxs = Join-Path $scriptRoot 'Installer\Osprey.wxs'
+    if (-not (Test-Path $wxs)) {
+        Write-Error "Installer/Osprey.wxs not found at $wxs"
+        exit 2
+    }
+    $wix = Get-Command wix -ErrorAction SilentlyContinue
+    if (-not $wix) {
+        Write-Error "The 'wix' tool is not installed (dotnet tool install --global wix). Cannot build the .msi."
+        exit 2
+    }
+
+    # MSI ProductVersion only compares major.minor.build for upgrades (the 4th
+    # field is ignored). Map the Osprey version YEAR.ORDINAL.BRANCH.DOY ->
+    # YEAR.ORDINAL.DOY so each dated build is upgrade-significant.
+    $parts = $version.Split('.')
+    $msiVersion = "$($parts[0]).$($parts[1]).$($parts[3])"
+
+    $msiPath = Join-Path $OutputDir "Osprey-$version-win-x64.msi"
+    if (Test-Path $msiPath) { Remove-Item $msiPath -Force }
+
+    $licenseRtf = Join-Path $stagingRoot 'License.rtf'
+    Write-LicenseRtf -Source (Join-Path $repoRoot 'LICENSE') -Destination $licenseRtf
+
+    Write-Progress-Tc "Building $(Split-Path -Leaf $msiPath) (WiX, per-machine)"
+    & wix build $wxs `
+        -arch x64 `
+        -d "PublishDir=$StageDir" `
+        -d "ProductVersion=$msiVersion" `
+        -d "InformationalVersion=$version" `
+        -d "LicenseRtf=$licenseRtf" `
+        -ext WixToolset.UI.wixext `
+        -o $msiPath | Out-Host
+    if ($LASTEXITCODE -ne 0) {
+        Write-Error "wix build failed (exit $LASTEXITCODE)"
+        exit $LASTEXITCODE
+    }
+
+    Invoke-OspreySign -Path $msiPath
+    Publish-Artifact-Tc $msiPath
+    return $msiPath
+}
+
+# --- Main ---------------------------------------------------------------
+New-Item -ItemType Directory -Force -Path $OutputDir | Out-Null
+New-Item -ItemType Directory -Force -Path $stagingRoot | Out-Null
+
+Write-Host "Osprey package version $version" -ForegroundColor Green
+Write-Host "  RIDs:       $($Rid -join ', ')" -ForegroundColor Green
+Write-Host "  Output:     $OutputDir" -ForegroundColor Green
+Write-Host "  Zip:        $(-not $NoZip)   Msi: $Msi   Sign: $($Sign -or ($env:OSPREY_SIGN -eq '1'))" -ForegroundColor Green
+
+$artifacts = @()
+$winStage = $null
+foreach ($r in $Rid) {
+    $stage = New-OspreyStage -Rid $r
+    if ($r -eq 'win-x64') { $winStage = $stage }
+    if (-not $NoZip) {
+        $artifacts += (New-OspreyZip -StageDir $stage -Rid $r)
+    }
+}
+
+if ($Msi) {
+    if (-not $winStage) {
+        Write-Error "-Msi requires win-x64 in -Rid (got: $($Rid -join ', '))"
+        exit 2
+    }
+    $artifacts += (New-OspreyMsi -StageDir $winStage)
+}
+
+Write-Host "`nArtifacts:" -ForegroundColor Green
+foreach ($a in $artifacts) {
+    $sizeMb = [math]::Round((Get-Item $a).Length / 1MB, 1)
+    Write-Host ("  {0}  ({1} MB)" -f $a, $sizeMb) -ForegroundColor Green
+}
+exit 0

--- a/pwiz_tools/Osprey/package.ps1
+++ b/pwiz_tools/Osprey/package.ps1
@@ -220,7 +220,7 @@ function Add-OspreyDocs {
     $staged = Join-Path $docOut 'CommandLine.html'
     $html = Get-Content $staged -Raw
     $html = [regex]::Replace($html, 'https?://raw\.githack\.com/ProteoWizard/pwiz/[^"'' ]*Osprey-workflow\.html', 'Osprey-workflow.html')
-    Set-Content -Path $staged -Value $html -NoNewline
+    Set-Content -Path $staged -Value $html -NoNewline -Encoding utf8
 
     Copy-Item (Join-Path $scriptRoot 'README.md') (Join-Path $StageDir 'README.md') -Force
     Copy-Item (Join-Path $repoRoot 'LICENSE') (Join-Path $StageDir 'LICENSE') -Force

--- a/pwiz_tools/Osprey/tcbuild.bat
+++ b/pwiz_tools/Osprey/tcbuild.bat
@@ -1,7 +1,9 @@
 @echo off
-REM TeamCity entry point: build + test Osprey with dotCover
-REM and TeamCity service messages.  TeamCity invokes this batch
-REM directly as the build step; smart-build trigger wiring for
+REM TeamCity entry point: build + test Osprey with dotCover and TeamCity service
+REM messages, then package the unsigned redistributable installers so they are
+REM published as artifacts of this per-commit config (the Tier-C "testing"
+REM installers a collaborator can grab before an official release). TeamCity
+REM invokes this batch directly as the build step; smart-build trigger wiring for
 REM pwiz_tools/Osprey/** is in scripts/misc/vcs_trigger_and_paths_config.py.
 REM
 REM Pre-requisites on the build agent:
@@ -9,14 +11,24 @@ REM   * pwsh (PowerShell 7+) on PATH (project standard; no powershell.exe fallba
 REM   * Visual Studio Build Tools (MSBuild + vstest.console.exe)
 REM   * .NET 8 SDK
 REM   * JetBrains.dotCover.GlobalTools (dotnet tool install -g)
+REM   * wix v5 dotnet tool + matching v5 UI extension (for the .msi step):
+REM       dotnet tool install --global wix --version 5.0.2
+REM       wix extension add -g WixToolset.UI.wixext/5.0.2
+REM     WiX v5 is the last MS-RL-licensed release (v6+ require the paid OSMF EULA).
+REM     If wix is absent the package step fails the build (by design, like dotCover).
 REM
-REM Outputs consumed by TeamCity (all emitted via service messages in build.ps1):
+REM Outputs consumed by TeamCity:
 REM   * pwiz_tools/Osprey/TestResults/*.trx                  (vstest importData)
 REM   * pwiz_tools/Osprey/TestResults/*.dcvr                 (dotCover importData)
-REM   * pwiz_tools/Osprey/Osprey/bin/x64/Release/net8.0 (publishArtifacts)
-REM   * pwiz_tools/Osprey/Osprey/bin/x64/Release/net472 (publishArtifacts)
-REM   * pwiz_tools/Osprey/TestResults                        (publishArtifacts)
+REM   * pwiz_tools/Osprey/dist/Osprey-<ver>-win-x64.zip      (publishArtifacts)
+REM   * pwiz_tools/Osprey/dist/Osprey-<ver>-win-x64.msi      (publishArtifacts)
+REM   The installers are unsigned here; signing is a later CI step. The
+REM   publishArtifacts service messages are emitted by package.ps1 -TeamCity, so
+REM   no server-side artifact-path configuration is required.
 
 setlocal
 pwsh -NoProfile -File "%~dp0build.ps1" -TeamCity -Coverage -Configuration Release -Framework net8.0
+if %ERRORLEVEL% NEQ 0 exit /b %ERRORLEVEL%
+
+pwsh -NoProfile -File "%~dp0package.ps1" -TeamCity -Rid win-x64 -Msi
 exit /b %ERRORLEVEL%

--- a/pwiz_tools/Osprey/tcbuild.bat
+++ b/pwiz_tools/Osprey/tcbuild.bat
@@ -11,11 +11,8 @@ REM   * pwsh (PowerShell 7+) on PATH (project standard; no powershell.exe fallba
 REM   * Visual Studio Build Tools (MSBuild + vstest.console.exe)
 REM   * .NET 8 SDK
 REM   * JetBrains.dotCover.GlobalTools (dotnet tool install -g)
-REM   * wix v5 dotnet tool + matching v5 UI extension (for the .msi step):
-REM       dotnet tool install --global wix --version 5.0.2
-REM       wix extension add -g WixToolset.UI.wixext/5.0.2
-REM     WiX v5 is the last MS-RL-licensed release (v6+ require the paid OSMF EULA).
-REM     If wix is absent the package step fails the build (by design, like dotCover).
+REM   The wix v5 tool (for the .msi) is self-provisioned below if absent, so no
+REM   manual agent step is needed; this can be replaced by explicit provisioning.
 REM
 REM Outputs consumed by TeamCity:
 REM   * pwiz_tools/Osprey/TestResults/*.trx                  (vstest importData)
@@ -27,7 +24,18 @@ REM   publishArtifacts service messages are emitted by package.ps1 -TeamCity, so
 REM   no server-side artifact-path configuration is required.
 
 setlocal
+REM Make dotnet global tools (wix, etc.) resolvable in this build's environment.
+set "PATH=%PATH%;%USERPROFILE%\.dotnet\tools"
+
 pwsh -NoProfile -File "%~dp0build.ps1" -TeamCity -Coverage -Configuration Release -Framework net8.0
+if %ERRORLEVEL% NEQ 0 exit /b %ERRORLEVEL%
+
+REM Bootstrap the wix v5 tool + matching v5 UI extension if the agent lacks them
+REM (idempotent: first build on a fresh agent installs, later builds skip). WiX v5
+REM is the last MS-RL-licensed release; v6+ require the paid OSMF EULA.
+where wix >nul 2>nul || dotnet tool install --global wix --version 5.0.2
+if %ERRORLEVEL% NEQ 0 exit /b %ERRORLEVEL%
+wix extension list -g 2>nul | findstr /i "WixToolset.UI.wixext" >nul || wix extension add -g WixToolset.UI.wixext/5.0.2
 if %ERRORLEVEL% NEQ 0 exit /b %ERRORLEVEL%
 
 pwsh -NoProfile -File "%~dp0package.ps1" -TeamCity -Rid win-x64 -Msi

--- a/pwiz_tools/Osprey/tcpackage.bat
+++ b/pwiz_tools/Osprey/tcpackage.bat
@@ -1,0 +1,28 @@
+@echo off
+REM TeamCity entry point: build the redistributable Osprey artifacts
+REM (per-RID self-contained ZIPs + the win-x64 .msi) and publish them.
+REM
+REM Intended for a dedicated packaging build config (trigger on master and/or
+REM release tags), SEPARATE from the per-commit ProteoWizard_OspreyWindowsNet
+REM build so day-to-day commits are not slowed by a full self-contained publish.
+REM package.ps1 emits ##teamcity[publishArtifacts ...] for each artifact, so no
+REM server-side artifact-path configuration is required -- only a build config
+REM that runs this batch on an agent with the prerequisites below.
+REM
+REM Pre-requisites on the build agent (in addition to tcbuild.bat's):
+REM   * .NET 8 runtime packs (restored automatically by `dotnet publish`;
+REM     needs outbound NuGet on first run)
+REM   * The wix v5 dotnet tool + the matching v5 UI extension for the .msi:
+REM       dotnet tool install --global wix --version 5.0.2
+REM       wix extension add -g WixToolset.UI.wixext/5.0.2
+REM     WiX v5 is the last release under the free MS-RL license; v6+ require the
+REM     paid Open Source Maintenance Fee EULA.
+REM
+REM Artifacts (published via service messages from package.ps1):
+REM   * pwiz_tools/Osprey/dist/Osprey-<version>-win-x64.zip
+REM   * pwiz_tools/Osprey/dist/Osprey-<version>-linux-x64.zip
+REM   * pwiz_tools/Osprey/dist/Osprey-<version>-win-x64.msi
+
+setlocal
+pwsh -NoProfile -File "%~dp0package.ps1" -TeamCity -Msi
+exit /b %ERRORLEVEL%

--- a/pwiz_tools/Osprey/version.ps1
+++ b/pwiz_tools/Osprey/version.ps1
@@ -16,8 +16,12 @@
 
 function Get-OspreyVersion {
     param(
-        # Repo path used to read the committed date. Defaults to this script's folder.
-        [string]$RepoPath = (Split-Path -Parent $PSCommandPath)
+        # Repo path used to read the committed date. Mandatory by design: a
+        # dot-sourced function cannot reliably derive its own script directory
+        # at call time ($PSScriptRoot / $PSCommandPath resolve to the CALLER's
+        # scope, not version.ps1), so each caller (build.ps1 / package.ps1)
+        # passes its own $scriptRoot explicitly.
+        [Parameter(Mandatory = $true)] [string]$RepoPath
     )
 
     $OSPREY_YEAR = 26

--- a/pwiz_tools/Osprey/version.ps1
+++ b/pwiz_tools/Osprey/version.ps1
@@ -1,0 +1,36 @@
+<#
+.SYNOPSIS
+    Shared Osprey version computation (Skyline scheme YEAR.ORDINAL.BRANCH.DOY).
+
+.DESCRIPTION
+    Dot-sourced by build.ps1 (stamps the assembly via /p:Version) and by
+    package.ps1 (names the redistributable artifacts). Keeping the formula in
+    one place means the version baked into Osprey.exe and the version in the
+    ZIP/.msi file names can never drift.
+
+    Mirrors pwiz_tools/Skyline/Jamfile.jam: YEAR/ORDINAL/BRANCH are the
+    release-line constants; DOY is the day-of-year of the git commit date
+    (reproducible across rebuilds of the same commit), offset by 365 per year
+    past YEAR. Falls back to the current date outside a git checkout.
+#>
+
+function Get-OspreyVersion {
+    param(
+        # Repo path used to read the committed date. Defaults to this script's folder.
+        [string]$RepoPath = (Split-Path -Parent $PSCommandPath)
+    )
+
+    $OSPREY_YEAR = 26
+    $OSPREY_ORDINAL = 1
+    $OSPREY_BRANCH = 1
+
+    $gitDate = & git -C $RepoPath log -1 --format=%cs HEAD 2>$null
+    if ($LASTEXITCODE -eq 0 -and $gitDate -match '^\d{4}-\d{2}-\d{2}$') {
+        $verDate = [datetime]::ParseExact($gitDate.Trim(), 'yyyy-MM-dd', [cultureinfo]::InvariantCulture)
+    } else {
+        $verDate = Get-Date
+    }
+
+    $doy = (([int]$verDate.ToString('yy')) - $OSPREY_YEAR) * 365 + $verDate.DayOfYear
+    return "$OSPREY_YEAR.$OSPREY_ORDINAL.$OSPREY_BRANCH.$doy"
+}


### PR DESCRIPTION
## Summary

First-class redistribution for Osprey (the C# DIA search tool), implementing
**Phase 2 + Phase 3** of `TODO-20260627_osprey_redistribution.md`:

- **Standalone per-RID ZIPs** (`package.ps1`): a self-contained `net8.0`
  publish laid out under a single versioned top-level folder
  (`Osprey.exe` + runtime/dependency DLLs + `Documentation/` + `README` +
  `LICENSE`), zipped as `Osprey-<version>-win-x64.zip` and
  `Osprey-<version>-linux-x64.zip`. Self-contained = zero system-.NET
  dependency (copy a folder to an HPC node and run); the single containing
  folder lets versions coexist side by side and never explodes ~200 files into
  a download dir.
- **WiX MSI** (`Installer/Osprey.wxs`, `package.ps1 -Msi`): per-machine
  `C:\Program Files\Osprey` install with an Add/Remove-Programs entry and a
  system `PATH` entry. Built with the WiX **v5** dotnet tool.
- **Shared versioning** (`version.ps1`): the Skyline `YEAR.ORDINAL.BRANCH.DOY`
  formula is now in one place; `build.ps1` (stamps the binary) and
  `package.ps1` (names the artifact) both use it so they can't drift.
- **TeamCity entry point** (`tcpackage.bat`): runs `package.ps1 -TeamCity -Msi`,
  which self-publishes the artifacts via `##teamcity[publishArtifacts]`.

This produces the **canonical Osprey artifact** that downstream tools (Carafe
today) should consume instead of building their own publish.

## Decisions (confirmed with Brendan before the session)

- Scope = Phase 2 + 3 + TC wiring. **Phase 4 (bundling Osprey inside the
  Skyline install) is deferred** to a follow-up PR: Skyline is net472, Osprey
  net8.0, so they can't share a runtime, forcing a ~150 MB self-contained copy
  plus WiX-template edits inside the Skyline installer -- too much CI risk for
  one PR.
- Platforms v1 = Windows + Linux. Distribution runtime = net8.0 only,
  self-contained. MSI = per-machine. Signing = unsigned draft with an
  env-gated `signtool` hook (`-Sign` / `OSPREY_SIGN*`), off by default.
- Packaging lives in a standalone `package.ps1`, NOT wired into Boost.Build /
  the ProteoWizard release -- Osprey ships as its own tool with its own
  sln / TC configs / versioning.

## Local verification

- `package.ps1` (both RIDs): win-x64.zip (38 MB) + linux-x64.zip produced; each
  has one top-level folder, `Osprey.exe` at its root, `Documentation/` with the
  CLI + workflow HTML (the in-bundle CommandLine.html cross-link is rewritten
  from the githack URL to the local file), README, LICENSE, no `.pdb`.
- Published `Osprey.exe --help` runs and prints usage.
- `package.ps1 -Msi`: MSI built and validated via the Windows Installer DB --
  ProductName `Osprey`, version `26.1.178`, `ALLUSERS=1` (per-machine), 219
  files incl. `Osprey.exe`, install dir `Osprey`, PATH entry present.
- All three PowerShell scripts parse clean; `build.ps1`'s `version.ps1`
  refactor produces the same version it did inline.

## What still needs you (server-side / follow-ups)

1. **Add a TeamCity packaging config** (or a build step) that runs
   `pwiz_tools/Osprey/tcpackage.bat` on master/release tags. Artifacts publish
   via service messages, so **no artifact-path config is needed** -- but the
   agent needs the WiX v5 dotnet tool + the matching v5 UI extension installed
   (the batch header and the ai/.tmp TeamCity plan list the exact commands).
2. **Code signing**: provide a cert and flip `-Sign` (or set `OSPREY_SIGN*`).
3. **Doc hosting + the skyline.ms landing page** (Phase 5) and **Skyline
   bundling** (Phase 4) are separate follow-ups.
4. **Carafe**: retarget Mike's PRs #9/#10 to consume this official artifact
   (plan in `ai/.tmp/osprey-carafe-adoption-plan.md`).

Draft from an autonomous night session. Per-commit TeamCity (build + tests)
runs via the existing Osprey smart trigger; the packaging config above is the
only new CI wiring.

See `ai/todos/active/TODO-20260627_osprey_redistribution.md`.

Co-Authored-By: Claude <noreply@anthropic.com>
