### PR TITLE
Fixed intermittent DDA search test failures (RT alignment race + Tide percolator handle leak)

### DIFF
--- a/pwiz_tools/Skyline/Model/DdaSearch/TideSearchEngine.cs
+++ b/pwiz_tools/Skyline/Model/DdaSearch/TideSearchEngine.cs
@@ -480,7 +480,12 @@ namespace pwiz.Skyline.Model.DdaSearch
 
         private void GetPercolatorScores(string percolatorTsvFilepath, Dictionary<string, double> qvalueByPsmId)
         {
-            var percolatorTargetPsmsReader = new DsvFileReader(percolatorTsvFilepath, TextUtil.SEPARATOR_TSV);
+            // Dispose the reader so the file handle is released before the next search's
+            // percolator run, which writes to the same output directory; a leaked
+            // StreamReader holds the .psms.txt read-locked and makes the next percolator
+            // fail with "Could not open the file for writing" (seen intermittently under
+            // code coverage, where GC frees the handle too late).
+            using var percolatorTargetPsmsReader = new DsvFileReader(percolatorTsvFilepath, TextUtil.SEPARATOR_TSV);
             int psmIdColumn = percolatorTargetPsmsReader.GetFieldIndex(@"PSMId");
             int qvalueColumn = percolatorTargetPsmsReader.GetFieldIndex(@"q-value");
             int filenameColumn = percolatorTargetPsmsReader.GetFieldIndex(@"filename");

--- a/pwiz_tools/Skyline/TestFunctional/DdaSearchTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/DdaSearchTest.cs
@@ -1444,6 +1444,17 @@ namespace pwiz.SkylineTestFunctional
             var preset = Settings.Default.SearchSettingsPresets.FirstOrDefault(p => p.Name == presetName);
             Assert.IsNotNull(preset, $"Preset '{presetName}' should exist in settings");
 
+            // The DDA search just imported results, which kicks off background retention-time
+            // alignment (ResultFileAlignments). ShowRunPeptideSearchDlg refuses to open until
+            // Document.IsLoaded, and that alignment can still be settling on the committed
+            // document here: the earlier WaitForDocumentLoaded() only checks DocumentUI, which
+            // can report loaded before the committed Document finishes aligning. Wait on the
+            // committed Document so reopening the wizard doesn't intermittently hit the
+            // "document must be fully loaded" error on slower/contended nightly agents.
+            WaitForConditionUI(() => SkylineWindow.Document.IsLoaded,
+                () => TextUtil.LineSeparate("Document not loaded before reopening Run Peptide Search wizard:",
+                    TextUtil.LineSeparate(SkylineWindow.Document.NonLoadedStateDescriptions)));
+
             var importPeptideSearchDlg2 = ShowDialog<ImportPeptideSearchDlg>(SkylineWindow.ShowRunPeptideSearchDlg);
 
             RunUI(() =>


### PR DESCRIPTION
Two intermittent DDA-search test failures seen on nightly / code-coverage CI but green on the standard PR build.

## Summary

**1. RT-alignment race (TestDdaSearch, TestDdaSearchComet)**
* `TestSearch` reopens the Run Peptide Search wizard via `VerifyPresetInNewWizard` (added in #3819) right after importing result files. The import kicks off background retention-time alignment (`ResultFileAlignments`), briefly leaving the committed `Document.IsLoaded` false; `ShowRunPeptideSearchDlg` then rejects the reopen with a modal "document must be fully loaded" error → timeout.
* The existing `WaitForDocumentLoaded()` didn't protect this: it waits on `DocumentUI.IsLoaded` (UI snapshot), while the dialog guard checks the committed `Document.IsLoaded`, and the alignment loader settles those non-atomically.
* Fixed by waiting on the committed `Document.IsLoaded` before reopening the wizard. Test-only.

**2. Tide percolator file-handle leak (TestDdaSearchTide)**
* `TideSearchEngine.GetPercolatorScores` opened the percolator `.psms.txt` files via `DsvFileReader` but never disposed them, leaking the read-locked handle. `DdaSearchTest` runs two Tide searches into the same output directory, so the second search's `crux percolator` failed to open `percolator.target.psms.txt` for writing → "Could not open the file for writing" → timeout.
* Intermittent / coverage-specific: the handle is only freed when GC finalizes the reader; under dotCover (bt210) it lingers, so it failed there but passed on bt209.
* Fixed by disposing the reader (`using`).

## Test plan

- [x] TestDdaSearch - 25x loop, 0 failures (was ~1-in-5)
- [x] TestDdaSearchComet - 6x loop, 0 failures
- [x] TestDdaSearchTide - 4x loop, 0 failures, 0 percolator write errors (dotCover not available locally; validated functionally + by code inspection)

Co-Authored-By: Claude <noreply@anthropic.com>