### PR TITLE
Fixed reconciliation to pair library-supplied decoys by base_id

### DIFF
--- a/pwiz_tools/Osprey/Osprey.FDR/Reconciliation/ReconciliationPlanner.cs
+++ b/pwiz_tools/Osprey/Osprey.FDR/Reconciliation/ReconciliationPlanner.cs
@@ -36,8 +36,6 @@ namespace pwiz.Osprey.FDR.Reconciliation
     /// </summary>
     public static class ReconciliationPlanner
     {
-        private const string DECOY_PREFIX = @"DECOY_";
-
         // Minimum RT tolerance floor (minutes) accommodates scan-resolution rounding.
         private const double MIN_RT_TOLERANCE = 0.1;
 
@@ -119,13 +117,18 @@ namespace pwiz.Osprey.FDR.Reconciliation
                 }
             }
 
-            // Passing precursors: (base_sequence, charge) where any of the
+            // Passing precursors keyed on (base_id, charge) where any of the
             // four q-values passes at experimentFdr. Rationale at
-            // reconciliation.rs:516-528 — blib admits a precursor if ANY
-            // level passes, so reconciliation must include them in every
-            // file to keep per-file boundaries self-consistent. Decoys are
-            // picked up by the paired-decoy logic below.
-            var passingPrecursors = new HashSet<(string, byte)>();
+            // reconciliation.rs:560-576 — blib admits a precursor if ANY level
+            // passes, so reconciliation must include them in every file to keep
+            // per-file boundaries self-consistent. We key on
+            // base_id = EntryId & 0x7FFFFFFF (plus charge) rather than
+            // modified_sequence so paired decoys are recognised regardless of
+            // whether their modified_sequence carries a DECOY_ prefix: a target
+            // and its library-supplied decoy (Carafe / FDRBench manifest) share
+            // the same base_id by construction. Mirrors Rust plan_reconciliation
+            // and the base_id linkage already used by ConsensusRts.Compute.
+            var passingBaseIds = new HashSet<(uint, byte)>();
             foreach (var fileKvp in perFileEntries)
             {
                 foreach (var entry in fileKvp.Value)
@@ -136,7 +139,7 @@ namespace pwiz.Osprey.FDR.Reconciliation
                         Math.Min(entry.RunPrecursorQvalue, entry.RunPeptideQvalue),
                         Math.Min(entry.ExperimentPrecursorQvalue, entry.ExperimentPeptideQvalue));
                     if (bestQ <= experimentFdr)
-                        passingPrecursors.Add((entry.ModifiedSequence, entry.Charge));
+                        passingBaseIds.Add((entry.EntryId & 0x7FFFFFFFu, entry.Charge));
                 }
             }
 
@@ -198,12 +201,12 @@ namespace pwiz.Osprey.FDR.Reconciliation
                     if (!consensusMap.TryGetValue(key, out var consensusEntry))
                         continue;
 
-                    // Only reconcile precursors that passed experiment-FDR
-                    // (or paired decoys). base_sequence strips DECOY_.
-                    string baseSeq = entry.ModifiedSequence.StartsWith(DECOY_PREFIX, StringComparison.Ordinal)
-                        ? entry.ModifiedSequence.Substring(DECOY_PREFIX.Length)
-                        : entry.ModifiedSequence;
-                    if (!passingPrecursors.Contains((baseSeq, entry.Charge)))
+                    // Only reconcile precursors that passed experiment-FDR (or
+                    // their paired decoys). Pair by base_id (EntryId & 0x7FFFFFFF)
+                    // so a library-supplied decoy whose modified_sequence has no
+                    // DECOY_ prefix is still recognised -- see the passingBaseIds
+                    // rationale above.
+                    if (!passingBaseIds.Contains((entry.EntryId & 0x7FFFFFFFu, entry.Charge)))
                         continue;
 
                     double expectedRt = cal.Predict(consensusEntry.ConsensusLibraryRt);

--- a/pwiz_tools/Osprey/Osprey.Test/CodeInspectionTest.cs
+++ b/pwiz_tools/Osprey/Osprey.Test/CodeInspectionTest.cs
@@ -124,6 +124,63 @@ namespace pwiz.Osprey.Test
         }
 
         /// <summary>
+        /// Reconciliation must pair a target with its decoy by base_id (the
+        /// entry_id low 31 bits), never by stripping a "DECOY_" prefix from the
+        /// modified sequence. Prefix-stripping silently misses library-supplied
+        /// decoys (Carafe / FDRBench manifest) whose modseq carries no prefix, so
+        /// they are dropped from reconciliation and bias second-pass FDR optimistic
+        /// (osprey 0abe0ff). Guard: no "DECOY_" string literal may appear in the
+        /// reconciliation code (comments describing the rationale are fine). If a
+        /// literal is ever genuinely required, add an inline exemption comment
+        /// beginning "// DECOY_ pairing OK:" on the same line.
+        /// </summary>
+        [TestMethod]
+        public void TestReconciliationPairsDecoysByBaseIdNotPrefix()
+        {
+            string sourceRoot = FindOspreySourceRoot();
+            var violations = new List<string>();
+            // A DECOY_ string literal in code (e.g. "DECOY_" or @"DECOY_") is the
+            // fingerprint of prefix-based pairing; the base_id path never needs it.
+            var pattern = new Regex("\"DECOY_");
+            const string exemptionTag = "// DECOY_ pairing OK:";
+            const string reconDir = "Osprey.FDR/Reconciliation/";
+
+            foreach (var file in EnumerateProductionCsFiles(sourceRoot))
+            {
+                string rel = RelativePath(sourceRoot, file).Replace('\\', '/');
+                if (rel.IndexOf(reconDir, StringComparison.OrdinalIgnoreCase) < 0)
+                    continue;
+
+                string[] lines;
+                try { lines = File.ReadAllLines(file); }
+                catch (IOException) { continue; }
+
+                for (int i = 0; i < lines.Length; i++)
+                {
+                    string line = lines[i];
+                    // Only inspect the code part -- comments legitimately mention
+                    // "DECOY_" to explain why base_id pairing is used instead.
+                    int commentIdx = IndexOfLineComment(line);
+                    string codePart = commentIdx >= 0 ? line.Substring(0, commentIdx) : line;
+                    if (!pattern.IsMatch(codePart))
+                        continue;
+                    if (line.Contains(exemptionTag))
+                        continue;
+                    string rel2 = rel;
+                    violations.Add(string.Format("{0}:{1}: {2}", rel2, i + 1, line.TrimEnd()));
+                }
+            }
+
+            Assert.AreEqual(0, violations.Count,
+                "Reconciliation code must pair decoys by base_id (entry_id & 0x7FFFFFFF), not by " +
+                "stripping a \"DECOY_\" prefix from the modified sequence. Prefix-stripping misses " +
+                "library-supplied decoys (no prefix) and biases second-pass FDR optimistic " +
+                "(osprey 0abe0ff). Remove the \"DECOY_\" literal and pair by base_id, or -- if it is " +
+                "truly needed -- add an inline '// DECOY_ pairing OK: <reason>' on the same line.\n" +
+                string.Join("\n", violations));
+        }
+
+        /// <summary>
         /// Find the Osprey source root by walking up from the test
         /// assembly location until we see an Osprey.sln-bearing dir.
         /// </summary>

--- a/pwiz_tools/Osprey/Osprey.Test/ReconciliationTest.cs
+++ b/pwiz_tools/Osprey/Osprey.Test/ReconciliationTest.cs
@@ -742,6 +742,62 @@ namespace pwiz.Osprey.Test
         }
 
         [TestMethod]
+        public void TestPlanLibraryDecoyReconciledByBaseId()
+        {
+            // Library-supplied decoy (Carafe / FDRBench manifest): its modified
+            // sequence is a raw scrambled sequence with NO "DECOY_" prefix, but
+            // it shares the passing target's base_id (EntryId & 0x7FFFFFFF, with
+            // the decoy's high bit set). The planner must pair it by base_id, not
+            // by stripping a DECOY_ prefix from the modseq -- the pre-fix prefix
+            // strip skipped such decoys entirely (0 actions), leaving second-pass
+            // FDR trained on asymmetric target/decoy pools. Mirrors Rust
+            // test_plan_reconciliation_includes_library_decoy_via_base_id.
+            var cal = IdentityCalibration();
+            var cals = new Dictionary<string, RTCalibration> { { @"f1", cal } };
+
+            const uint baseId = 7u;
+
+            var consensus = new[]
+            {
+                new PeptideConsensusRT
+                {
+                    ModifiedSequence = @"PEPTIDEK", IsDecoy = false,
+                    ConsensusLibraryRt = 10.0, MedianPeakWidth = 0.6,
+                    NRunsDetected = 3, ApexLibraryRtMad = 0.02,
+                },
+                new PeptideConsensusRT
+                {
+                    ModifiedSequence = @"EDITPEPK", IsDecoy = true, // no DECOY_ prefix
+                    ConsensusLibraryRt = 10.0, MedianPeakWidth = 0.6,
+                    NRunsDetected = 3, ApexLibraryRtMad = 0.02,
+                },
+            };
+
+            var target = MakeEntry(@"PEPTIDEK", apexRt: 10.0, score: 3.0,
+                isDecoy: false, precursorQ: 0.0, peptideQ: 0.0, entryId: baseId);
+            var libraryDecoy = MakeEntry(@"EDITPEPK", apexRt: 25.0, score: -1.0,
+                isDecoy: true, precursorQ: 1.0, peptideQ: 1.0, entryId: baseId | 0x80000000u);
+
+            var perFile = new List<KeyValuePair<string, IReadOnlyList<FdrEntry>>>
+            {
+                Pair(@"f1", new[] { target, libraryDecoy }),
+            };
+
+            var actions = ReconciliationPlanner.Plan(
+                consensus, perFile,
+                new Dictionary<string, IReadOnlyList<IReadOnlyList<CwtCandidate>>>(),
+                cals, cals, experimentFdr: 0.01);
+
+            // Target at 10.0 is already at consensus -> Keep (absent). The library
+            // decoy at 25.0 is far off consensus 10.0 and, paired to the passing
+            // target by base_id, must be reconciled (ForcedIntegration, no CWT).
+            Assert.AreEqual(1, actions.Count);
+            Assert.IsTrue(actions.ContainsKey((@"f1", 1)));
+            Assert.IsInstanceOfType(
+                actions[(@"f1", 1)], typeof(ReconcileAction.ForcedIntegration));
+        }
+
+        [TestMethod]
         public void TestPlanNonConsensusPeptideSkipped()
         {
             var cal = IdentityCalibration();
@@ -1101,11 +1157,11 @@ namespace pwiz.Osprey.Test
 
         private static FdrEntry MakeEntry(
             string modifiedSequence, double apexRt, double score,
-            bool isDecoy, double precursorQ, double peptideQ)
+            bool isDecoy, double precursorQ, double peptideQ, uint entryId = 1)
         {
             return new FdrEntry
             {
-                EntryId = 1,
+                EntryId = entryId,
                 IsDecoy = isDecoy,
                 Charge = 2,
                 ApexRt = apexRt,

--- a/pwiz_tools/Osprey/Osprey.Test/ReconciliationTest.cs
+++ b/pwiz_tools/Osprey/Osprey.Test/ReconciliationTest.cs
@@ -160,6 +160,50 @@ namespace pwiz.Osprey.Test
         }
 
         [TestMethod]
+        public void TestComputeLibraryDecoyPairedByBaseId()
+        {
+            // A library-supplied decoy (Carafe / FDRBench manifest) carries NO
+            // "DECOY_" prefix on its modified sequence but shares the target's
+            // base_id (entry_id & 0x7FFFFFFF, high bit set). ConsensusRts must
+            // pair it by base_id, not by prefix-stripping, so it lands in the
+            // consensus set -- otherwise its boundaries never get reconciled and
+            // second-pass FDR is biased optimistic (osprey 0abe0ff). Companion to
+            // TestComputePairedDecoyIncludedWhenTargetQualifies, which uses a
+            // prefixed Osprey-generated decoy; this test fails under prefix-strip.
+            var cal = IdentityCalibration();
+            var cals = new Dictionary<string, RTCalibration>
+            {
+                { @"f1", cal }, { @"f2", cal }, { @"f3", cal }
+            };
+
+            const uint baseId = 7u;
+            var target1 = MakeEntry(@"PEPTIDEK", apexRt: 10.0, score: 3.0,
+                isDecoy: false, precursorQ: 0.0, peptideQ: 0.0, entryId: baseId);
+            var target2 = MakeEntry(@"PEPTIDEK", apexRt: 10.1, score: 3.0,
+                isDecoy: false, precursorQ: 0.0, peptideQ: 0.0, entryId: baseId);
+            // Library decoy: no DECOY_ prefix, high bit set, same base_id as target.
+            var libraryDecoy = MakeEntry(@"EDITPEPK", apexRt: 15.0, score: -1.0,
+                isDecoy: true, precursorQ: 1.0, peptideQ: 1.0, entryId: baseId | 0x80000000u);
+
+            var perFile = new List<KeyValuePair<string, IReadOnlyList<FdrEntry>>>
+            {
+                Pair(@"f1", new[] { target1 }),
+                Pair(@"f2", new[] { target2 }),
+                Pair(@"f3", new[] { libraryDecoy }),
+            };
+
+            var consensus = ConsensusRts.Compute(perFile, cals, 0.01, 0.0);
+
+            Assert.AreEqual(2, consensus.Count,
+                @"target + its no-prefix library decoy (paired by base_id) should both be in consensus");
+            Assert.IsFalse(consensus[0].IsDecoy);
+            Assert.AreEqual(@"PEPTIDEK", consensus[0].ModifiedSequence);
+            Assert.IsTrue(consensus[1].IsDecoy);
+            Assert.AreEqual(@"EDITPEPK", consensus[1].ModifiedSequence,
+                @"library decoy with no DECOY_ prefix must be paired by base_id and included");
+        }
+
+        [TestMethod]
         public void TestComputeRejectsLowPrecursorQvalueDespiteProteinRescue()
         {
             // Mirrors Rust test_consensus_rejects_low_precursor_q_despite_protein_rescue.
@@ -795,6 +839,58 @@ namespace pwiz.Osprey.Test
             Assert.IsTrue(actions.ContainsKey((@"f1", 1)));
             Assert.IsInstanceOfType(
                 actions[(@"f1", 1)], typeof(ReconcileAction.ForcedIntegration));
+        }
+
+        [TestMethod]
+        public void TestPlanLibraryDecoyNotReconciledWhenTargetFails()
+        {
+            // Negative companion to TestPlanLibraryDecoyReconciledByBaseId: a
+            // decoy is reconciled only when its PAIRED TARGET passed experiment
+            // FDR. Here the target fails (high q-values), so its base_id is not
+            // in the passing set and the library decoy -- though it shares that
+            // base_id and sits far off consensus RT -- must NOT be reconciled.
+            // Guards the base_id passing-set gate against a naive "reconcile
+            // every decoy" change.
+            var cal = IdentityCalibration();
+            var cals = new Dictionary<string, RTCalibration> { { @"f1", cal } };
+
+            const uint baseId = 9u;
+            var consensus = new[]
+            {
+                new PeptideConsensusRT
+                {
+                    ModifiedSequence = @"PEPTIDEK", IsDecoy = false,
+                    ConsensusLibraryRt = 10.0, MedianPeakWidth = 0.6,
+                    NRunsDetected = 3, ApexLibraryRtMad = 0.02,
+                },
+                new PeptideConsensusRT
+                {
+                    ModifiedSequence = @"EDITPEPK", IsDecoy = true,
+                    ConsensusLibraryRt = 10.0, MedianPeakWidth = 0.6,
+                    NRunsDetected = 3, ApexLibraryRtMad = 0.02,
+                },
+            };
+
+            // Target FAILS experiment-FDR (high q-values); its library decoy is
+            // off consensus RT but must stay unreconciled.
+            var failingTarget = MakeEntry(@"PEPTIDEK", apexRt: 20.0, score: 0.5,
+                isDecoy: false, precursorQ: 0.9, peptideQ: 0.9, entryId: baseId);
+            var libraryDecoy = MakeEntry(@"EDITPEPK", apexRt: 25.0, score: -1.0,
+                isDecoy: true, precursorQ: 1.0, peptideQ: 1.0, entryId: baseId | 0x80000000u);
+
+            var perFile = new List<KeyValuePair<string, IReadOnlyList<FdrEntry>>>
+            {
+                Pair(@"f1", new[] { failingTarget, libraryDecoy }),
+            };
+
+            var actions = ReconciliationPlanner.Plan(
+                consensus, perFile,
+                new Dictionary<string, IReadOnlyList<IReadOnlyList<CwtCandidate>>>(),
+                cals, cals, experimentFdr: 0.01);
+
+            // Target failed FDR -> passing set is empty -> neither the target nor
+            // its paired decoy is reconciled.
+            Assert.AreEqual(0, actions.Count);
         }
 
         [TestMethod]


### PR DESCRIPTION
## Summary

Reconciliation's inter-replicate peak improvement was silently excluding
**library-supplied decoys** (Carafe / FDRBench-manifest, i.e. `--decoys-in-library`
runs), which biased second-pass FDR optimistic. This ports the planner half of the
Rust fix (maccoss/osprey `0abe0ff`) to C#.

**The issue.** Reconciliation lines up each peptide's peak across replicate runs and
improves its boundaries — and it must do this for a target *and its paired decoy*
symmetrically, because decoys drive the second-pass FDR estimate. To find each
decoy's target, `ReconciliationPlanner` matched on the modified sequence: it assumed
every decoy was named `DECOY_<peptide>` and stripped the `DECOY_` prefix. That works
for Osprey-generated (reverse) decoys, but **library-supplied decoys have no `DECOY_`
prefix** (their modseq is either reversed or cycled until obtaining a unique sequence not 
present in the targets), so they never matched a target and were skipped by the planner.

**Impact.** Targets got their peaks reconciled but their library decoys did not — an
asymmetric target/decoy pool that biases the second-pass SVM and makes reported FDR
optimistic (you think you're at 1% when the true FDP is higher). Only affects
`--decoys-in-library` runs; Osprey-generated reverse-decoy runs (e.g. Stellar) were
unaffected.

**The fix.** Pair decoys to targets by the **`base_id` (`EntryId & 0x7FFFFFFF`)** that
Osprey already assigns to every target/decoy pair at library load, instead of by
prefix-stripping the modseq. `ReconciliationPlanner` now keys its passing-precursor
set on `(base_id, charge)` and looks entries up by `base_id` — the same linkage
`ConsensusRts.Compute` already used (the consensus-RT half of `0abe0ff` had been
ported; the planner half had not). Reverse-decoy output is byte-identical.

**Validation (FDRBench).** With the fix, entrapment-based true-FDP tracks at/below the
unity line through the 1% operating point (combined 0.98%, paired 0.88% at q=0.01):

<img width="554" height="479" alt="stellar-FDRBench-post-fix" src="https://github.com/user-attachments/assets/c61fc5ba-8a01-4d2d-93dd-d5276feececa" />

*FDRBench estimated FDP vs FDR threshold, Stellar HeLa entrapment data (27,479
discoveries): both the combined and paired-method curves sit on/below the unity line
through 1% — FDR is properly controlled.*

## Test plan

- [x] `TestPlanLibraryDecoyReconciledByBaseId` — no-prefix library decoy of a passing target is reconciled (fails under the old prefix-strip)
- [x] `TestComputeLibraryDecoyPairedByBaseId` — same at the `ConsensusRts` pairing site
- [x] `TestPlanLibraryDecoyNotReconciledWhenTargetFails` — decoy of a *failing* target is not reconciled (locks the passing-set semantics)
- [x] `TestReconciliationPairsDecoysByBaseIdNotPrefix` — CodeInspection guard forbidding a `"DECOY_"` literal in reconciliation pairing code, so prefix pairing can't return
- [x] Osprey.Test: 443 passed, 0 failed (net472 + net8.0)
- [x] Stellar `regression.ps1`: golden + resume + HPC chain all PASS at 1e-9 (reverse-decoy output unchanged)

Cross-reference: maccoss/osprey `0abe0ff` (fixed both `compute_consensus_rts` and `plan_reconciliation` on the Rust side).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
