### PR TITLE
Stamped Osprey version with git hash on every build path

### DIFF
--- a/pwiz_tools/Osprey/Directory.Build.props
+++ b/pwiz_tools/Osprey/Directory.Build.props
@@ -26,6 +26,10 @@
          Assembly.GetName().Version, which OspreyVersion.Current reads as the
          logical osprey version. -->
     <Version>26.1.1.0</Version>
+    <!-- Directory.Build.targets stamps AssemblyInformationalVersion itself as
+         "<numeric>-<githash>[-dirty]"; keep the SDK from appending its own
+         "+<sha>" source-revision metadata so OspreyVersion parses one clean form. -->
+    <IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
     <!-- Server GC on .NET 8 is driven by runtimeconfig.json auto-generated
          from these MSBuild properties. net472 ignores these and uses the
          app.config gcServer/gcConcurrent settings instead. -->

--- a/pwiz_tools/Osprey/Directory.Build.targets
+++ b/pwiz_tools/Osprey/Directory.Build.targets
@@ -37,8 +37,8 @@
        a Carafe/redistribution `dotnet publish` all bypass those scripts and
        would otherwise ship the Directory.Build.props placeholder
        (26.1.1.0: DOY 0, no hash): an untraceable binary, the exact defect that
-       made a build-vs-build FDRBench attribution impossible (see
-       TODO-osprey_version_git_hash.md). This target runs stamp-version.ps1, which
+       made a build-vs-build FDRBench attribution impossible. This target runs
+       stamp-version.ps1, which
        dot-sources version.ps1 (the single source of the YEAR.ORDINAL.BRANCH.DOY +
        hash formula shared with build.ps1 / package.ps1), and sets:
 
@@ -64,7 +64,7 @@
       <Output TaskParameter="ConsoleOutput" PropertyName="_OspreyStamp" />
       <Output TaskParameter="ExitCode" PropertyName="_OspreyStampExit" />
     </Exec>
-    <PropertyGroup Condition="'$(_OspreyStampExit)' == '0' and '$(_OspreyStamp)' != ''">
+    <PropertyGroup Condition="'$(_OspreyStampExit)' == '0' and '$(_OspreyStamp.Trim())' != ''">
       <InformationalVersion>$(_OspreyStamp.Trim())</InformationalVersion>
       <Version Condition="'$(Version)' == '' or '$(Version)' == '26.1.1.0'">$(InformationalVersion.Split('-')[0])</Version>
     </PropertyGroup>

--- a/pwiz_tools/Osprey/Directory.Build.targets
+++ b/pwiz_tools/Osprey/Directory.Build.targets
@@ -32,4 +32,42 @@
           Condition="Exists('$(_ResolvedParquetTarget)') and Exists('$(_PatchedParquetSource)')" />
   </Target>
 
+  <!-- Stamp the Osprey version + git short hash on EVERY build path, not just
+       build.ps1 / package.ps1. A plain `dotnet build`, a Debug build in VS, and
+       a Carafe/redistribution `dotnet publish` all bypass those scripts and
+       would otherwise ship the Directory.Build.props placeholder
+       (26.1.1.0: DOY 0, no hash): an untraceable binary, the exact defect that
+       made a build-vs-build FDRBench attribution impossible (see
+       TODO-osprey_version_git_hash.md). This target runs stamp-version.ps1, which
+       dot-sources version.ps1 (the single source of the YEAR.ORDINAL.BRANCH.DOY +
+       hash formula shared with build.ps1 / package.ps1), and sets:
+
+         * InformationalVersion = numeric-shorthash[-dirty]  (Skyline scheme,
+           mirrors pwiz_tools/Skyline AssemblyInformationalVersion; OspreyVersion
+           parses it back for the version display). Set on every path.
+         * Version = numeric  only while it is still the props placeholder, so an
+           explicit /p:Version from build.ps1 / package.ps1 / the Boost build (a
+           global property) still wins and this only fills the script-less gap.
+
+       pwsh is a hard project prerequisite (pwiz_tools/Osprey/tcbuild.bat), so the
+       Exec is reliable on every build agent and dev shell. If git or pwsh is
+       genuinely absent the Exec is non-fatal (ContinueOnError) and the build keeps
+       the placeholder: a visibly-unstamped binary rather than a failed build.
+       Set OspreyDisableGitStamp=true to skip stamping (e.g. a hermetic build). -->
+  <Target Name="StampOspreyInformationalVersion"
+          BeforeTargets="GetAssemblyVersion;CoreGenerateAssemblyInfo"
+          Condition="'$(OspreyDisableGitStamp)' != 'true'">
+    <Exec Command="pwsh -NoProfile -ExecutionPolicy Bypass -File &quot;$(MSBuildThisFileDirectory)stamp-version.ps1&quot;"
+          ConsoleToMSBuild="true"
+          StandardOutputImportance="low"
+          ContinueOnError="true">
+      <Output TaskParameter="ConsoleOutput" PropertyName="_OspreyStamp" />
+      <Output TaskParameter="ExitCode" PropertyName="_OspreyStampExit" />
+    </Exec>
+    <PropertyGroup Condition="'$(_OspreyStampExit)' == '0' and '$(_OspreyStamp)' != ''">
+      <InformationalVersion>$(_OspreyStamp.Trim())</InformationalVersion>
+      <Version Condition="'$(Version)' == '' or '$(Version)' == '26.1.1.0'">$(InformationalVersion.Split('-')[0])</Version>
+    </PropertyGroup>
+  </Target>
+
 </Project>

--- a/pwiz_tools/Osprey/Osprey.Core/OspreyVersion.cs
+++ b/pwiz_tools/Osprey/Osprey.Core/OspreyVersion.cs
@@ -19,6 +19,9 @@
  */
 
 using System;
+using System.Linq;
+using System.Reflection;
+using System.Text.RegularExpressions;
 
 namespace pwiz.Osprey.Core
 {
@@ -58,6 +61,33 @@ namespace pwiz.Osprey.Core
         /// </summary>
         public static readonly string Current = ResolveVersion();
 
+        /// <summary>
+        /// The full informational version stamped by the build:
+        /// <c>YEAR.ORDINAL.BRANCH.DOY-&lt;shorthash&gt;[-dirty]</c>. Mirrors the
+        /// Skyline <c>AssemblyInformationalVersion</c> scheme (see
+        /// pwiz_tools/Skyline/Util/Install.cs) so a binary is always traceable to
+        /// its source commit -- the defect that made a build-vs-build FDRBench
+        /// attribution impossible (TODO-osprey_version_git_hash.md). The hash is
+        /// stamped on every build path by pwiz_tools/Osprey/Directory.Build.targets;
+        /// falls back to the bare numeric <see cref="Current"/> for a non-git build
+        /// or under the bit-parity <c>OSPREY_VERSION_OVERRIDE</c>.
+        /// </summary>
+        public static readonly string InformationalVersion = ResolveInformationalVersion();
+
+        /// <summary>
+        /// Git short hash parsed from <see cref="InformationalVersion"/> (empty for
+        /// a non-git build). Follows the Skyline split convention: the token after
+        /// the numeric version, without any trailing <c>-dirty</c> marker.
+        /// </summary>
+        public static string GitHash => ExtractGitHash(InformationalVersion);
+
+        /// <summary>
+        /// Human-facing version, Skyline-style <c>26.1.1.182 (b2373f9f9c)</c> (or
+        /// <c>... (b2373f9f9c-dirty)</c>); the plain numeric version when no hash
+        /// is stamped. Used by <c>--version</c> and the startup log.
+        /// </summary>
+        public static string DisplayVersion => FormatDisplay(InformationalVersion);
+
         private static string ResolveVersion()
         {
             string overrideValue = Environment.GetEnvironmentVariable(@"OSPREY_VERSION_OVERRIDE");
@@ -67,6 +97,55 @@ namespace pwiz.Osprey.Core
             // stamped by the build; Version.ToString() renders all four components.
             var version = typeof(OspreyVersion).Assembly.GetName().Version;
             return version != null ? version.ToString() : @"0.0.0.0";
+        }
+
+        private static string ResolveInformationalVersion()
+        {
+            // Honor the bit-parity pin so --version and provenance stay
+            // deterministic under the regression harness (the override string
+            // carries no hash; DisplayVersion then renders it as-is).
+            string overrideValue = Environment.GetEnvironmentVariable(@"OSPREY_VERSION_OVERRIDE");
+            if (!string.IsNullOrEmpty(overrideValue))
+                return overrideValue;
+            var attr = typeof(OspreyVersion).Assembly
+                .GetCustomAttributes(typeof(AssemblyInformationalVersionAttribute), false)
+                .OfType<AssemblyInformationalVersionAttribute>().FirstOrDefault();
+            string info = attr?.InformationalVersion;
+            if (string.IsNullOrEmpty(info))
+                return Current;
+            // Defensive: strip any SDK-appended source-revision metadata ("+<sha>").
+            // We stamp the hash ourselves as a "-<hash>" suffix and disable the SDK
+            // append (IncludeSourceRevisionInInformationalVersion=false).
+            int plus = info.IndexOf('+');
+            return plus >= 0 ? info.Substring(0, plus) : info;
+        }
+
+        /// <summary>
+        /// Extracts the git short hash from an informational version such as
+        /// <c>26.1.1.182-b2373f9f9c</c> or <c>26.1.1.182-b2373f9f9c-dirty</c>.
+        /// Returns the empty string for a bare numeric version (no hash stamped).
+        /// </summary>
+        internal static string ExtractGitHash(string informational)
+        {
+            if (string.IsNullOrEmpty(informational))
+                return string.Empty;
+            // "26.1.1.182-b2373f9f9c[-dirty]".Split('-') -> the hash is element [1]
+            // (Skyline Install.GitHash convention); a trailing "dirty" is element [2].
+            var parts = informational.Split('-');
+            return parts.Length > 1 ? parts[1] : string.Empty;
+        }
+
+        /// <summary>
+        /// Renders an informational version Skyline-style: the numeric version
+        /// followed by the hash (and any <c>-dirty</c> marker) in parentheses.
+        /// A bare numeric version is returned unchanged.
+        /// </summary>
+        internal static string FormatDisplay(string informational)
+        {
+            if (string.IsNullOrEmpty(informational))
+                return informational;
+            // "26.1.1.182-b2373f9f9c[-dirty]" -> "26.1.1.182 (b2373f9f9c[-dirty])"
+            return Regex.Replace(informational, @"^(\d+\.\d+\.\d+\.\d+)-(.+)$", @"$1 ($2)");
         }
     }
 }

--- a/pwiz_tools/Osprey/Osprey.Core/OspreyVersion.cs
+++ b/pwiz_tools/Osprey/Osprey.Core/OspreyVersion.cs
@@ -67,7 +67,7 @@ namespace pwiz.Osprey.Core
         /// Skyline <c>AssemblyInformationalVersion</c> scheme (see
         /// pwiz_tools/Skyline/Util/Install.cs) so a binary is always traceable to
         /// its source commit -- the defect that made a build-vs-build FDRBench
-        /// attribution impossible (TODO-osprey_version_git_hash.md). The hash is
+        /// attribution impossible. The hash is
         /// stamped on every build path by pwiz_tools/Osprey/Directory.Build.targets;
         /// falls back to the bare numeric <see cref="Current"/> for a non-git build
         /// or under the bit-parity <c>OSPREY_VERSION_OVERRIDE</c>.

--- a/pwiz_tools/Osprey/Osprey.Test/OspreyVersionTest.cs
+++ b/pwiz_tools/Osprey/Osprey.Test/OspreyVersionTest.cs
@@ -1,0 +1,97 @@
+/*
+ * Original author: Brendan MacLean <brendanx .at. uw.edu>,
+ *                  MacCoss Lab, Department of Genome Sciences, UW
+ * AI assistance: Claude Code (Claude Opus 4.8) <noreply .at. anthropic.com>
+ *
+ * Copyright 2026 University of Washington - Seattle, WA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
+using System.Globalization;
+using System.Text.RegularExpressions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using pwiz.Osprey.Core;
+
+namespace pwiz.Osprey.Test
+{
+    /// <summary>
+    /// Tests for <see cref="OspreyVersion"/> git-hash version stamping
+    /// (TODO-osprey_version_git_hash.md). The Skyline-style informational
+    /// version (<c>YEAR.ORDINAL.BRANCH.DOY-&lt;hash&gt;[-dirty]</c>) parses and
+    /// renders correctly, and an in-checkout build stamps a real commit hash and
+    /// a nonzero commit day-of-year so every Osprey binary is traceable to its
+    /// source -- the defect this change closes.
+    /// </summary>
+    [TestClass]
+    public class OspreyVersionTest
+    {
+        [TestMethod]
+        public void TestFormatDisplayRendersHashInParentheses()
+        {
+            Assert.AreEqual(@"26.1.1.182 (b2373f9f9c)",
+                OspreyVersion.FormatDisplay(@"26.1.1.182-b2373f9f9c"));
+            // A dirty marker stays inside the parentheses with the hash.
+            Assert.AreEqual(@"26.1.1.182 (b2373f9f9c-dirty)",
+                OspreyVersion.FormatDisplay(@"26.1.1.182-b2373f9f9c-dirty"));
+        }
+
+        [TestMethod]
+        public void TestFormatDisplayLeavesBareNumericVersionUnchanged()
+        {
+            // The non-git / OSPREY_VERSION_OVERRIDE fallback carries no hash.
+            Assert.AreEqual(@"26.1.1.0", OspreyVersion.FormatDisplay(@"26.1.1.0"));
+            Assert.AreEqual(@"26.1.1.182", OspreyVersion.FormatDisplay(@"26.1.1.182"));
+            Assert.AreEqual(string.Empty, OspreyVersion.FormatDisplay(string.Empty));
+            Assert.IsNull(OspreyVersion.FormatDisplay(null));
+        }
+
+        [TestMethod]
+        public void TestExtractGitHashTakesHashWithoutDirtyMarker()
+        {
+            Assert.AreEqual(@"b2373f9f9c", OspreyVersion.ExtractGitHash(@"26.1.1.182-b2373f9f9c"));
+            Assert.AreEqual(@"b2373f9f9c", OspreyVersion.ExtractGitHash(@"26.1.1.182-b2373f9f9c-dirty"));
+            Assert.AreEqual(string.Empty, OspreyVersion.ExtractGitHash(@"26.1.1.0"));
+            Assert.AreEqual(string.Empty, OspreyVersion.ExtractGitHash(string.Empty));
+        }
+
+        [TestMethod]
+        public void TestInCheckoutBuildStampsHashAndNonzeroDoy()
+        {
+            // The bit-parity regression harness pins OSPREY_VERSION_OVERRIDE to a
+            // hash-free constant; skip the stamp assertion under it. Every other
+            // in-checkout build (this test build, CI, a release build) must carry
+            // a real hash + nonzero DOY so the binary is traceable to its commit.
+            if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable(@"OSPREY_VERSION_OVERRIDE")))
+            {
+                Assert.Inconclusive(@"OSPREY_VERSION_OVERRIDE pins a hash-free version.");
+                return;
+            }
+
+            string hash = OspreyVersion.GitHash;
+            Assert.IsTrue(Regex.IsMatch(hash, @"^[0-9a-f]{7,}$"),
+                string.Format(@"Expected a 7+ hex-char git hash, got '{0}' (informational '{1}'). " +
+                    @"An in-checkout build must stamp the commit hash via Directory.Build.targets.",
+                    hash, OspreyVersion.InformationalVersion));
+
+            string[] parts = OspreyVersion.Current.Split('.');
+            Assert.AreEqual(4, parts.Length,
+                string.Format(@"Version should be YEAR.ORDINAL.BRANCH.DOY, got '{0}'", OspreyVersion.Current));
+            int doy = int.Parse(parts[3], CultureInfo.InvariantCulture);
+            Assert.IsTrue(doy > 0,
+                string.Format(@"DOY must be the nonzero commit day-of-year, got {0} (version '{1}')",
+                    doy, OspreyVersion.Current));
+        }
+    }
+}

--- a/pwiz_tools/Osprey/Osprey.Test/OspreyVersionTest.cs
+++ b/pwiz_tools/Osprey/Osprey.Test/OspreyVersionTest.cs
@@ -27,8 +27,8 @@ using pwiz.Osprey.Core;
 namespace pwiz.Osprey.Test
 {
     /// <summary>
-    /// Tests for <see cref="OspreyVersion"/> git-hash version stamping
-    /// (TODO-osprey_version_git_hash.md). The Skyline-style informational
+    /// Tests for <see cref="OspreyVersion"/> git-hash version stamping. The
+    /// Skyline-style informational
     /// version (<c>YEAR.ORDINAL.BRANCH.DOY-&lt;hash&gt;[-dirty]</c>) parses and
     /// renders correctly, and an in-checkout build stamps a real commit hash and
     /// a nonzero commit day-of-year so every Osprey binary is traceable to its

--- a/pwiz_tools/Osprey/Osprey/OspreyCommandArgs.cs
+++ b/pwiz_tools/Osprey/Osprey/OspreyCommandArgs.cs
@@ -374,7 +374,7 @@ namespace pwiz.Osprey
                 }
                 if (ReferenceEquals(matched, ARG_VERSION))
                 {
-                    Console.WriteLine(@"Osprey v{0}", OspreyVersion.Current);
+                    Console.WriteLine(@"Osprey v{0}", OspreyVersion.DisplayVersion);
                     Environment.Exit(0);
                     return;
                 }

--- a/pwiz_tools/Osprey/Osprey/Program.cs
+++ b/pwiz_tools/Osprey/Osprey/Program.cs
@@ -213,7 +213,7 @@ namespace pwiz.Osprey
                 }
 
                 // Log startup info
-                LogInfo(string.Format("Osprey v{0}", OspreyVersion.Current));
+                LogInfo(string.Format("Osprey v{0}", OspreyVersion.DisplayVersion));
                 LogInfo(string.Format("Command: {0}", string.Join(" ", args)));
                 LogInfo(string.Format("Input files: {0}", config.InputFiles.Count));
                 LogInfo(string.Format("Library: {0} ({1})",

--- a/pwiz_tools/Osprey/stamp-version.ps1
+++ b/pwiz_tools/Osprey/stamp-version.ps1
@@ -1,0 +1,15 @@
+<#
+.SYNOPSIS
+    Prints the Osprey informational version (YEAR.ORDINAL.BRANCH.DOY-<hash>[-dirty])
+    to stdout for the Directory.Build.targets stamping target.
+
+.DESCRIPTION
+    Directory.Build.targets invokes this on every build path (a plain
+    `dotnet build`, a Debug build in VS, a Carafe/redistribution `dotnet
+    publish`) so those binaries carry the same commit-derived version + git hash
+    that build.ps1 / package.ps1 stamp. Dot-sources version.ps1 -- the single
+    source of the version formula -- so the stamp can never drift from the
+    binary the release scripts produce.
+#>
+. (Join-Path $PSScriptRoot 'version.ps1')
+Write-Output (Get-OspreyInformationalVersion -RepoPath $PSScriptRoot)

--- a/pwiz_tools/Osprey/stamp-version.ps1
+++ b/pwiz_tools/Osprey/stamp-version.ps1
@@ -12,4 +12,7 @@
     binary the release scripts produce.
 #>
 . (Join-Path $PSScriptRoot 'version.ps1')
-Write-Output (Get-OspreyInformationalVersion -RepoPath $PSScriptRoot)
+# Emit exactly ONE line: the Directory.Build.targets Exec captures all stdout via
+# ConsoleToMSBuild, so guard against a future edit to version.ps1 leaking a stray
+# line onto the pipeline (Select-Object -Last 1 keeps only the version string).
+Get-OspreyInformationalVersion -RepoPath $PSScriptRoot | Select-Object -Last 1

--- a/pwiz_tools/Osprey/version.ps1
+++ b/pwiz_tools/Osprey/version.ps1
@@ -38,3 +38,39 @@ function Get-OspreyVersion {
     $doy = (([int]$verDate.ToString('yy')) - $OSPREY_YEAR) * 365 + $verDate.DayOfYear
     return "$OSPREY_YEAR.$OSPREY_ORDINAL.$OSPREY_BRANCH.$doy"
 }
+
+function Get-OspreyInformationalVersion {
+    <#
+    .SYNOPSIS
+        The numeric version plus the git short hash (and a -dirty marker for a
+        modified tree): YEAR.ORDINAL.BRANCH.DOY-<shorthash>[-dirty].
+    .DESCRIPTION
+        Mirrors the Skyline AssemblyInformationalVersion scheme
+        (pwiz_tools/Skyline/Util/Install.cs parses the "<numeric>-<hash>" form).
+        OspreyVersion.DisplayVersion renders it Skyline-style as
+        "26.1.1.182 (b2373f9f9c)". This is the single source of the hash stamp:
+        build.ps1 (binary), package.ps1 (redistributable), and the
+        Directory.Build.targets stamping target for every other build path all
+        derive from it, so the hash can never drift across build paths. Falls
+        back to the bare numeric version outside a git checkout.
+    #>
+    param(
+        [Parameter(Mandatory = $true)] [string]$RepoPath
+    )
+
+    $numeric = Get-OspreyVersion -RepoPath $RepoPath
+
+    $shortHash = & git -C $RepoPath rev-parse --short=10 HEAD 2>$null
+    if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($shortHash)) {
+        return $numeric   # not a git checkout (e.g. an extracted source tree)
+    }
+    $shortHash = $shortHash.Trim()
+
+    # A -dirty marker so a modified build can never masquerade as a clean commit.
+    # Untracked files (build artifacts, .tmp scratch) are ignored -- only tracked
+    # modifications change what compiles.
+    $dirty = & git -C $RepoPath status --porcelain --untracked-files=no 2>$null
+    $suffix = if ([string]::IsNullOrWhiteSpace($dirty)) { '' } else { '-dirty' }
+
+    return "$numeric-$shortHash$suffix"
+}

--- a/pwiz_tools/Osprey/version.ps1
+++ b/pwiz_tools/Osprey/version.ps1
@@ -74,7 +74,9 @@ function Get-OspreyInformationalVersion {
     # Untracked files (build artifacts, .tmp scratch) are ignored -- only tracked
     # modifications change what compiles.
     $dirty = & git -C $RepoPath status --porcelain --untracked-files=no 2>$null
-    $suffix = if ([string]::IsNullOrWhiteSpace($dirty)) { '' } else { '-dirty' }
+    # A git-status failure (nonzero exit) leaves the tree state unknown; mark
+    # -dirty rather than let an unverifiable tree masquerade as a clean commit.
+    $suffix = if ($LASTEXITCODE -eq 0 -and [string]::IsNullOrWhiteSpace($dirty)) { '' } else { '-dirty' }
 
     return "$numeric-$shortHash$suffix"
 }

--- a/pwiz_tools/Osprey/version.ps1
+++ b/pwiz_tools/Osprey/version.ps1
@@ -60,6 +60,10 @@ function Get-OspreyInformationalVersion {
 
     $numeric = Get-OspreyVersion -RepoPath $RepoPath
 
+    # --short=10 is a MINIMUM width: git lengthens the abbreviation when 10 chars
+    # would be ambiguous in a given clone, so the hash LENGTH (not identity) can
+    # differ across machines. It still resolves to the same commit; the numeric
+    # version (the parquet-cache key) is fully deterministic regardless.
     $shortHash = & git -C $RepoPath rev-parse --short=10 HEAD 2>$null
     if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($shortHash)) {
         return $numeric   # not a git checkout (e.g. an extracted source tree)


### PR DESCRIPTION
## Summary

* Osprey binaries now carry the **git commit short hash** and the commit-date
  **day-of-year** on **every** build path. Previously only `build.ps1` /
  `package.ps1` stamped a real version; a plain `dotnet build`, a Debug/VS
  build, and a Carafe/redistribution `dotnet publish` shipped the
  `Directory.Build.props` placeholder `26.1.1.0` (DOY 0, no hash) — an
  untraceable binary. That is exactly what made a build-vs-build FDRBench
  attribution impossible while reproducing PR #4347.
* Added `pwiz_tools/Osprey/Directory.Build.targets` to stamp
  `AssemblyInformationalVersion = YEAR.ORDINAL.BRANCH.DOY-<shorthash>[-dirty]`
  (Skyline scheme, mirrors `pwiz_tools/Skyline/Util/Install.cs`). It runs on
  every MSBuild invocation, so a bare `dotnet build`/`publish` and VS builds
  are stamped too; an explicit `/p:Version` from the release scripts still wins
  for the numeric version.
* A modified working tree appends a `-dirty` marker so a dev build can never
  masquerade as a clean commit.
* `OspreyVersion` gains `InformationalVersion` / `GitHash` / `DisplayVersion`;
  `--version` and the startup log now print Skyline-style
  `Osprey v26.1.1.182 (8c0be655c8)`. `OspreyVersion.Current` (the cache-compat
  and blib/sidecar provenance value) stays the bare numeric version, so the
  regression golden and cache-compatibility semantics are unchanged.
* `version.ps1` gains `Get-OspreyInformationalVersion`, the single source of the
  hash+DOY formula shared by the release scripts and the MSBuild stamp
  (`stamp-version.ps1`), so the stamp can never drift across build paths.

Deferred (follow-up): embedding the hash in the blib `osprey_version` /
`.osprey.task` sidecar provenance cells — that would change golden-compared
artifacts and needs a golden re-capture, out of scope for a versioning-only PR.

See ai/todos/active/TODO-20260701_osprey_version_git_hash.md

## Test plan

- [x] `OspreyVersionTest` — display/hash parsing (synthetic) + an in-checkout
      build stamps a 7+ hex-char hash and nonzero DOY (skips under
      `OSPREY_VERSION_OVERRIDE`).
- [x] `Build-Osprey.ps1 -Configuration Debug -RunTests -RunInspection` — green
      (450 tests, 447 passed / 3 skipped, 0 inspection warnings).
- [x] Plain `dotnet build` (the former DOY-0 path) → `26.1.1.182 (b2373f9f9c-dirty)`.
- [x] Clean-tree Release build via `Build-Osprey.ps1` → `26.1.1.182 (8c0be655c8)`
      (no `-dirty`); version derives only from commit date + hash + tree state,
      so builds of the same commit are byte-identical.

Co-Authored-By: Claude <noreply@anthropic.com>
