### PR TITLE
Carried the join-wide first-pass base_id set in reconciliation.json (v3); removed the pass-2 protein rescue

### DIFF
--- a/pwiz_tools/Osprey/Osprey.FDR/Reconciliation/ConsensusRts.cs
+++ b/pwiz_tools/Osprey/Osprey.FDR/Reconciliation/ConsensusRts.cs
@@ -53,13 +53,6 @@ namespace pwiz.Osprey.FDR.Reconciliation
         /// <param name="consensusFdr">
         /// FDR threshold for selecting consensus peptides (typically 0.01).
         /// </param>
-        /// <param name="proteinFdrThreshold">
-        /// If &gt; 0, rescue borderline peptides whose first-pass protein
-        /// q-value is &lt;= this threshold. Lets peptides from strong proteins
-        /// contribute to consensus RT computation even if their own peptide
-        /// q-value is borderline. Typically set to <c>config.ProteinFdr</c>.
-        /// Pass 0.0 to disable.
-        /// </param>
         /// <param name="invPredictTrace">
         /// If non-null, populated with one <see cref="InvPredictRecord"/> per
         /// detection contributing to a consensus computation, capturing the
@@ -71,7 +64,6 @@ namespace pwiz.Osprey.FDR.Reconciliation
             IReadOnlyList<KeyValuePair<string, IReadOnlyList<FdrEntry>>> perFileEntries,
             IReadOnlyDictionary<string, RTCalibration> perFileCalibrations,
             double consensusFdr,
-            double proteinFdrThreshold,
             IList<InvPredictRecord> invPredictTrace = null)
         {
             if (perFileEntries == null)
@@ -79,8 +71,7 @@ namespace pwiz.Osprey.FDR.Reconciliation
             if (perFileCalibrations == null)
                 throw new ArgumentNullException(nameof(perFileCalibrations));
 
-            // 1. Collect target peptides passing the run-level hard gate
-            //    (or rescued by protein FDR for peptide-level borderline cases).
+            // 1. Collect target peptides passing the run-level hard gate.
             //    We also record the set of qualifying target *base_ids* so that
             //    paired decoys can be identified by base_id linkage
             //    (entry_id & 0x7FFFFFFF) rather than by stripping a "DECOY_"
@@ -96,7 +87,7 @@ namespace pwiz.Osprey.FDR.Reconciliation
             {
                 foreach (var entry in kvp.Value)
                 {
-                    if (Qualifies(entry, consensusFdr, proteinFdrThreshold))
+                    if (Qualifies(entry, consensusFdr))
                     {
                         targetPeptides.Add(entry.ModifiedSequence);
                         targetBaseIds.Add(entry.EntryId & 0x7FFFFFFFu);
@@ -130,7 +121,7 @@ namespace pwiz.Osprey.FDR.Reconciliation
                     bool include = entry.IsDecoy
                         ? decoyPeptides.Contains(entry.ModifiedSequence)
                         : targetPeptides.Contains(entry.ModifiedSequence) &&
-                          Qualifies(entry, consensusFdr, proteinFdrThreshold);
+                          Qualifies(entry, consensusFdr);
                     if (!include)
                         continue;
 
@@ -237,14 +228,17 @@ namespace pwiz.Osprey.FDR.Reconciliation
             return consensus;
         }
 
-        private static bool Qualifies(FdrEntry entry, double consensusFdr, double proteinFdrThreshold)
+        private static bool Qualifies(FdrEntry entry, double consensusFdr)
         {
             if (entry.IsDecoy)
                 return false;
             if (entry.RunPrecursorQvalue > consensusFdr)
                 return false;
-            return entry.RunPeptideQvalue <= consensusFdr ||
-                   (proteinFdrThreshold > 0.0 && entry.RunProteinQvalue <= proteinFdrThreshold);
+            // Peptide-level gate only. The former protein-FDR rescue
+            // (entry.RunProteinQvalue <= proteinFdrThreshold) was removed as
+            // anti-conservative; see
+            // TODO-20260701_osprey_separate_protein_reporting_from_rescue.md.
+            return entry.RunPeptideQvalue <= consensusFdr;
         }
 
         private static bool IsFinite(double d)

--- a/pwiz_tools/Osprey/Osprey.Tasks/FirstJoinTask.cs
+++ b/pwiz_tools/Osprey/Osprey.Tasks/FirstJoinTask.cs
@@ -227,10 +227,15 @@ namespace pwiz.Osprey.Tasks
 
             // First-pass protein FDR: runs on the full pre-compaction
             // peptide pool so target and decoy proteins compete on a
-            // symmetric set. Sets RunProteinQvalue on every FdrEntry,
-            // which Stage 6 reconciliation reads via the protein-rescue
-            // gate in ConsensusRts.Compute. Mirrors Rust pipeline.rs:3029
-            // ("First-pass protein FDR").
+            // symmetric set. Sets RunProteinQvalue on every FdrEntry, which
+            // is persisted in the 1st-pass fdr_scores sidecars as provenance.
+            // NOTE: as of the protein-rescue removal
+            // (TODO-20260701_osprey_separate_protein_reporting_from_rescue.md)
+            // RunProteinQvalue no longer gates peptide survival (neither
+            // compaction nor ConsensusRts reconciliation), so this first-pass
+            // run is now provenance/reporting only; a future PR may drop it
+            // entirely after measuring the sidecar/golden impact. Mirrors Rust
+            // pipeline.rs:3029 ("First-pass protein FDR").
             if (config.ProteinFdr.HasValue && perFileEntries.Count > 0)
             {
                 ctx.LogInfo(string.Empty);
@@ -523,15 +528,21 @@ namespace pwiz.Osprey.Tasks
                 {
                     var firstPassBaseIds = new HashSet<uint>();
                     double peptideGate = config.RunFdr;
-                    double proteinGate = config.ProteinFdr ?? 0.0;
                     foreach (var kvp in perFileEntries)
                     {
                         foreach (var entry in kvp.Value)
                         {
                             if (entry.IsDecoy)
                                 continue;
-                            if (entry.RunPeptideQvalue <= peptideGate ||
-                                (proteinGate > 0.0 && entry.RunProteinQvalue <= proteinGate))
+                            // Peptide/precursor survival only. The pass-2 protein
+                            // "rescue" (keeping a peptide that FAILED peptide FDR because
+                            // its parent protein PASSED protein FDR) was removed: the
+                            // entrapment oracle showed it admitted false IDs at 6.3x the
+                            // baseline rate (anti-conservative), and pass-2 reconciliation
+                            // can only move a marginal peak to a lower-scoring position,
+                            // so rescuing bad-scoring peptides gained nothing. See
+                            // TODO-20260701_osprey_separate_protein_reporting_from_rescue.md.
+                            if (entry.RunPeptideQvalue <= peptideGate)
                             {
                                 firstPassBaseIds.Add(entry.EntryId & ScoringTaskShared.BASE_ID_MASK);
                             }

--- a/pwiz_tools/Osprey/Osprey.Tasks/RescoreCompaction.cs
+++ b/pwiz_tools/Osprey/Osprey.Tasks/RescoreCompaction.cs
@@ -95,15 +95,18 @@ namespace pwiz.Osprey.Tasks
         /// <see cref="RescoreInputs.ReconciliationActions"/> with
         /// post-compaction <c>vec_idx</c> values.
         ///
-        /// Predicate (mirrors Rust <c>rescore::run_rescore</c>'s
-        /// compaction block): an entry's <c>base_id</c> is retained if
-        /// EITHER <c>RunPeptideQvalue ≤ peptideGate</c> OR
-        /// (<c>--protein-fdr</c> set AND <c>RunProteinQvalue ≤ proteinGate</c>).
-        /// <paramref name="config"/>'s <see cref="OspreyConfig.RunFdr"/>
-        /// supplies the peptide gate (matches the in-process flow's
-        /// <c>peptideGate = config.RunFdr</c> at the same step), and
-        /// <see cref="OspreyConfig.ProteinFdr"/> the protein-rescue
-        /// gate (skipped entirely when null).
+        /// Predicate: an entry's <c>base_id</c> is retained if
+        /// <c>RunPeptideQvalue ≤ peptideGate</c>. <paramref name="config"/>'s
+        /// <see cref="OspreyConfig.RunFdr"/> supplies the peptide gate (matches
+        /// the in-process CompactFirstPass at the same step).
+        ///
+        /// The former protein-FDR "rescue" clause (retain a peptide that failed
+        /// peptide FDR when its parent protein passed <c>--protein-fdr</c>) was
+        /// removed as anti-conservative -- a DELIBERATE divergence from Rust's
+        /// <c>rescore::run_rescore</c>, which still carries the clause; the
+        /// entrapment oracle justifies dropping it (see
+        /// TODO-20260701_osprey_separate_protein_reporting_from_rescue.md). The
+        /// peptide gate still matches Rust.
         /// </summary>
         public static Stats Apply(RescoreInputs inputs, OspreyConfig config)
         {
@@ -111,20 +114,14 @@ namespace pwiz.Osprey.Tasks
             if (config == null) throw new ArgumentNullException(nameof(config));
 
             double peptideGate = config.RunFdr;
-            double? proteinGate = config.ProteinFdr;
 
             // 1. Build the passing base_id set across all files.
             //    Decoys are excluded from the predicate by design: target/decoy
             //    pairs share the same `base_id`, so a passing TARGET retains
             //    its paired decoy automatically via the base_id retain step
-            //    below. Including decoys in the predicate would let a decoy
-            //    peptide whose parent protein passes protein-FDR rescue
-            //    itself via the protein-rescue clause, inflating the base_id
-            //    set beyond what the in-process pipeline's compaction
-            //    produces (AnalysisPipeline.cs:517 has the matching
-            //    `if (entry.IsDecoy) continue;` filter, and
-            //    `pipeline.rs:3879` and `rescore.rs:457` on the Rust side
-            //    have the matching `!e.is_decoy &&` predicate).
+            //    below (AnalysisPipeline.cs's CompactFirstPass has the matching
+            //    `if (entry.IsDecoy) continue;` filter, and `pipeline.rs:3879` /
+            //    `rescore.rs:457` on the Rust side the matching `!e.is_decoy &&`).
             var firstPassBaseIds = new HashSet<uint>();
             int entriesBefore = 0;
             foreach (var kvp in inputs.PerFileEntries)
@@ -134,8 +131,7 @@ namespace pwiz.Osprey.Tasks
                 {
                     if (e.IsDecoy)
                         continue;
-                    if (e.RunPeptideQvalue <= peptideGate ||
-                        (proteinGate.HasValue && e.RunProteinQvalue <= proteinGate.Value))
+                    if (e.RunPeptideQvalue <= peptideGate)
                     {
                         firstPassBaseIds.Add(e.EntryId & BASE_ID_MASK);
                     }

--- a/pwiz_tools/Osprey/Osprey.Tasks/Stage6Planner.cs
+++ b/pwiz_tools/Osprey/Osprey.Tasks/Stage6Planner.cs
@@ -173,7 +173,6 @@ namespace pwiz.Osprey.Tasks
                     ? ConsensusRts.Compute(
                         perFileForRecon, perFileCalibrations,
                         config.Reconciliation.ConsensusFdr,
-                        config.ProteinFdr ?? 0.0,
                         invPredictTrace)
                     : Array.Empty<PeptideConsensusRT>();
 

--- a/pwiz_tools/Osprey/Osprey.Test/IOTest.cs
+++ b/pwiz_tools/Osprey/Osprey.Test/IOTest.cs
@@ -2473,14 +2473,13 @@ namespace pwiz.Osprey.Test
         /// AnalysisPipeline's "First-pass compaction" block.
         ///
         /// Compaction predicate is the UNION of (a) the local-FDR
-        /// predicate (peptide_q OR protein_q pass) AND (b) every
-        /// base_id that has a reconciliation action emitted by the
-        /// planner. The planner runs cross-file consensus rescue
-        /// (ConsensusRts.Compute), so an entry whose own file fails
-        /// local first-pass FDR can still be a reconciliation target
-        /// when its peptide passes FDR in a sibling file. Without the
-        /// union, the local-FDR-only predicate drops those entries and
-        /// their planner actions are silently dropped too -- the
+        /// predicate (peptide_q pass) AND (b) every base_id that has a
+        /// reconciliation action emitted by the planner. The planner runs
+        /// cross-file consensus rescue (ConsensusRts.Compute), so an entry
+        /// whose own file fails local first-pass FDR can still be a
+        /// reconciliation target when its peptide passes FDR in a sibling
+        /// file. Without the union, the local-FDR-only predicate drops those
+        /// entries and their planner actions are silently dropped too -- the
         /// reconciled .scores.parquet ends up with stale Stage 4 apex_rt
         /// / bounds for the rescued entries and the blib output diverges
         /// from the in-memory straight-through pipeline.
@@ -2490,12 +2489,15 @@ namespace pwiz.Osprey.Test
         ///   idx 1: decoy  id=0x80000001, base=1 (retained via target's base_id)
         ///   idx 2: target id=2, peptide_q=0.5  (FAIL local; PLANNER ACTION at (f,2))
         ///   idx 3: decoy  id=0x80000002, base=2 (retained via target's base_id from action)
-        ///   idx 4: target id=3, peptide_q=0.5, protein_q=0.005 (PASS via protein-rescue)
+        ///   idx 4: target id=3, peptide_q=0.5  (FAIL local; PLANNER ACTION at (f,4))
         ///
-        /// With ProteinFdr=0.01 AND the planner-action union:
-        ///   local-FDR pass: base_ids {1, 3}
+        /// With the planner-action union:
+        ///   local-FDR pass: base_ids {1}
         ///   planner action targets: base_ids {1, 2, 3}
         ///   UNION: base_ids {1, 2, 3} — all 5 entries survive compaction.
+        ///
+        /// (The former protein-FDR rescue is gone; id=3 now survives purely
+        /// via its planner action, exercising the union path, not a rescue.)
         ///
         /// Reconciliation actions are seeded at:
         ///   (f, 0) on id=1  → remains at (f, 0) (no compaction shift)
@@ -2514,7 +2516,7 @@ namespace pwiz.Osprey.Test
                     MakeFdrEntryWithProteinQ(0x80000001u,  runPeptideQ: 0.5,   runProteinQ: 1.0),
                     MakeFdrEntryWithProteinQ(2u,           runPeptideQ: 0.5,   runProteinQ: 1.0),
                     MakeFdrEntryWithProteinQ(0x80000002u,  runPeptideQ: 0.5,   runProteinQ: 1.0),
-                    MakeFdrEntryWithProteinQ(3u,           runPeptideQ: 0.5,   runProteinQ: 0.005),
+                    MakeFdrEntryWithProteinQ(3u,           runPeptideQ: 0.5,   runProteinQ: 1.0),
                 }),
             };
 
@@ -2566,14 +2568,18 @@ namespace pwiz.Osprey.Test
         }
 
         /// <summary>
-        /// With ProteinFdr=null (--protein-fdr not passed), the
-        /// protein-rescue branch is skipped entirely. An entry that
-        /// would have been retained via protein rescue (peptide_q
-        /// fails, protein_q passes) gets compacted away, taking any
-        /// action keyed to it with it.
+        /// Rescue lock-out at compaction: a peptide that FAILS peptide FDR
+        /// but whose parent protein PASSES protein FDR (protein_q=0.005) is
+        /// dropped, even with --protein-fdr 0.01 set. The former protein
+        /// rescue is gone
+        /// (TODO-20260701_osprey_separate_protein_reporting_from_rescue.md),
+        /// so a passing protein q-value no longer keeps a failing peptide in
+        /// the compacted set. (Formerly
+        /// TestRescoreCompactionWithoutProteinFdrSkipsRescue, which only
+        /// exercised the ProteinFdr=null path.)
         /// </summary>
         [TestMethod]
-        public void TestRescoreCompactionWithoutProteinFdrSkipsRescue()
+        public void TestRescoreCompactionProteinPassNoLongerRescues()
         {
             const string fileName = "f1";
             var perFile = new List<KeyValuePair<string, List<FdrEntry>>>
@@ -2593,34 +2599,34 @@ namespace pwiz.Osprey.Test
                 PerFileGapFill = new Dictionary<string, List<GapFillTarget>>(),
             };
 
+            // --protein-fdr IS set: exactly the case that used to trigger the rescue.
             var stats = RescoreCompaction.Apply(inputs, new OspreyConfig
             {
                 RunFdr = 0.01,
-                ProteinFdr = null,
+                ProteinFdr = 0.01,
             });
 
-            // Only entry 1 passes; entry 2 dropped (no protein rescue).
+            // Only entry 1 (passing peptide) survives; entry 2's passing
+            // protein no longer rescues its failing peptide.
             Assert.AreEqual(1, stats.EntriesAfter);
             Assert.AreEqual(1, stats.FirstPassBaseIds);
             Assert.AreEqual(1u, inputs.PerFileEntries[0].Value[0].EntryId);
         }
 
         /// <summary>
-        /// Decoys are excluded from the predicate by design: a passing
-        /// target retains its paired decoy automatically via the
-        /// base_id retain step. If decoys WERE allowed in the
-        /// predicate, a decoy peptide whose paired-target's protein
-        /// passes protein-FDR would self-rescue via the protein-rescue
-        /// clause, inflating the base_id set beyond what the
-        /// in-process pipeline produces (AnalysisPipeline.cs:517 has
-        /// the matching `if (entry.IsDecoy) continue;` filter; Rust
+        /// Decoys are excluded from the predicate by design: only TARGETS
+        /// seed base_ids, and a passing target retains its paired decoy via
+        /// the base_id retain step. If decoys WERE allowed into the
+        /// predicate, a lone decoy that passes the peptide gate would seed
+        /// its own base_id and inflate the set beyond what the in-process
+        /// pipeline produces (AnalysisPipeline.cs's CompactFirstPass has the
+        /// matching `if (entry.IsDecoy) continue;` filter; Rust
         /// rescore.rs:457 has the matching `!e.is_decoy &&`).
         ///
-        /// Test layout: a single decoy with a passing protein_q AND a
-        /// failing peptide_q. Without the decoy filter, the decoy's
-        /// base_id would land in firstPassBaseIds via protein-rescue.
-        /// With the filter, the decoy is skipped — and since no target
-        /// shares its base_id, no entries survive at all.
+        /// Test layout: a single decoy that PASSES the peptide gate with no
+        /// paired target. Without the decoy filter its base_id would land in
+        /// firstPassBaseIds; with the filter the decoy is skipped, and since
+        /// no target shares its base_id, no entries survive at all.
         /// </summary>
         [TestMethod]
         public void TestRescoreCompactionSkipsDecoysInPredicate()
@@ -2630,8 +2636,8 @@ namespace pwiz.Osprey.Test
             {
                 new KeyValuePair<string, List<FdrEntry>>(fileName, new List<FdrEntry>
                 {
-                    // Lone decoy with a passing protein_q. No paired target.
-                    MakeFdrEntryWithProteinQ(0x80000007u, runPeptideQ: 0.5, runProteinQ: 0.005),
+                    // Lone decoy that PASSES the peptide gate. No paired target.
+                    MakeFdrEntryWithProteinQ(0x80000007u, runPeptideQ: 0.005, runProteinQ: 1.0),
                 }),
             };
 

--- a/pwiz_tools/Osprey/Osprey.Test/ReconciliationTest.cs
+++ b/pwiz_tools/Osprey/Osprey.Test/ReconciliationTest.cs
@@ -91,8 +91,7 @@ namespace pwiz.Osprey.Test
             var result = ConsensusRts.Compute(
                 new List<KeyValuePair<string, IReadOnlyList<FdrEntry>>>(),
                 new Dictionary<string, RTCalibration>(),
-                consensusFdr: 0.01,
-                proteinFdrThreshold: 0.0);
+                consensusFdr: 0.01);
 
             Assert.AreEqual(0, result.Count);
         }
@@ -117,7 +116,7 @@ namespace pwiz.Osprey.Test
                 Pair(@"f3", PassingTarget(@"PEPTIDE1", apexRt: 9.9,  score: 3.0)),
             };
 
-            var consensus = ConsensusRts.Compute(perFile, cals, 0.01, 0.0);
+            var consensus = ConsensusRts.Compute(perFile, cals, 0.01);
 
             Assert.AreEqual(1, consensus.Count);
             var entry = consensus[0];
@@ -150,7 +149,7 @@ namespace pwiz.Osprey.Test
                 Pair(@"f3", Decoy(@"DECOY_PEPTIDE1", apexRt: 15.0, score: -1.0)),
             };
 
-            var consensus = ConsensusRts.Compute(perFile, cals, 0.01, 0.0);
+            var consensus = ConsensusRts.Compute(perFile, cals, 0.01);
 
             Assert.AreEqual(2, consensus.Count);
             Assert.IsFalse(consensus[0].IsDecoy);
@@ -192,7 +191,7 @@ namespace pwiz.Osprey.Test
                 Pair(@"f3", new[] { libraryDecoy }),
             };
 
-            var consensus = ConsensusRts.Compute(perFile, cals, 0.01, 0.0);
+            var consensus = ConsensusRts.Compute(perFile, cals, 0.01);
 
             Assert.AreEqual(2, consensus.Count,
                 @"target + its no-prefix library decoy (paired by base_id) should both be in consensus");
@@ -204,20 +203,23 @@ namespace pwiz.Osprey.Test
         }
 
         [TestMethod]
-        public void TestComputeRejectsLowPrecursorQvalueDespiteProteinRescue()
+        public void TestComputeProteinEvidenceCannotRescueFailingPeptide()
         {
-            // Mirrors Rust test_consensus_rejects_low_precursor_q_despite_protein_rescue.
-            // Hard precursor-q gate must reject a target even when its protein
-            // q-value would otherwise rescue it. Consensus is driven by the
-            // detection's own apex_rt, so poor precursor-level evidence cannot
-            // be rescued by protein-level aggregate evidence.
+            // Regression lock for the removed protein-FDR rescue
+            // (TODO-20260701_osprey_separate_protein_reporting_from_rescue.md):
+            // a target that fails BOTH the precursor and peptide q-value gates is
+            // rejected even though its parent protein q-value (0.001) would have
+            // triggered the old rescue. Consensus is driven by the detection's own
+            // evidence, not protein-level aggregate evidence. (Formerly
+            // TestComputeRejectsLowPrecursorQvalueDespiteProteinRescue, which
+            // passed proteinFdrThreshold: 0.01; that parameter no longer exists.)
             var cal = IdentityCalibration();
             var cals = new Dictionary<string, RTCalibration>
             {
                 { @"f1", cal }, { @"f2", cal }
             };
 
-            var weakPrecursor = new FdrEntry
+            var strongProteinFailingPeptide = new FdrEntry
             {
                 EntryId = 1,
                 IsDecoy = false,
@@ -229,32 +231,34 @@ namespace pwiz.Osprey.Test
                 Score = 3.0,
                 RunPrecursorQvalue = 0.20,  // fails hard gate
                 RunPeptideQvalue = 0.02,    // fails peptide too
-                RunProteinQvalue = 0.001,   // would rescue if allowed
+                RunProteinQvalue = 0.001,   // strong protein: would have rescued
                 ModifiedSequence = @"PEPTIDE1",
             };
             var goodTarget = PassingTarget(@"PEPTIDE2", apexRt: 20.0, score: 3.0);
 
             var perFile = new List<KeyValuePair<string, IReadOnlyList<FdrEntry>>>
             {
-                Pair(@"f1", new[] { weakPrecursor }),
+                Pair(@"f1", new[] { strongProteinFailingPeptide }),
                 Pair(@"f2", goodTarget),
             };
 
-            var consensus = ConsensusRts.Compute(
-                perFile, cals,
-                consensusFdr: 0.01,
-                proteinFdrThreshold: 0.01);
+            var consensus = ConsensusRts.Compute(perFile, cals, consensusFdr: 0.01);
 
-            Assert.AreEqual(1, consensus.Count);
+            Assert.AreEqual(1, consensus.Count,
+                @"a failing peptide must NOT be rescued by a strong parent protein");
             Assert.AreEqual(@"PEPTIDE2", consensus[0].ModifiedSequence);
         }
 
         [TestMethod]
-        public void TestComputeProteinRescueUpgradesBorderlinePeptideQvalue()
+        public void TestComputeBorderlinePeptideNotRescuedByProtein()
         {
-            // Precursor-q passes the hard gate, peptide-q is borderline but
-            // fails consensus_fdr, protein-q passes protein threshold →
-            // detection should be included.
+            // Regression lock for the removed protein-FDR rescue
+            // (TODO-20260701_osprey_separate_protein_reporting_from_rescue.md):
+            // a detection whose precursor-q passes the hard gate but whose
+            // peptide-q FAILS consensus_fdr is NOT admitted, even though its
+            // protein-q (0.005) would have triggered the old rescue. (Formerly
+            // TestComputeProteinRescueUpgradesBorderlinePeptideQvalue, which
+            // asserted the rescue admitted it.)
             var cal = IdentityCalibration();
             var cals = new Dictionary<string, RTCalibration> { { @"f1", cal } };
 
@@ -269,8 +273,8 @@ namespace pwiz.Osprey.Test
                 CoelutionSum = 1.0,
                 Score = 3.0,
                 RunPrecursorQvalue = 0.005, // passes hard gate
-                RunPeptideQvalue = 0.05,    // fails borderline
-                RunProteinQvalue = 0.005,   // rescues
+                RunPeptideQvalue = 0.05,    // fails borderline peptide gate
+                RunProteinQvalue = 0.005,   // passing protein: would have rescued
                 ModifiedSequence = @"PEPTIDE1",
             };
 
@@ -279,20 +283,10 @@ namespace pwiz.Osprey.Test
                 Pair(@"f1", new[] { borderline }),
             };
 
-            var consensus = ConsensusRts.Compute(
-                perFile, cals,
-                consensusFdr: 0.01,
-                proteinFdrThreshold: 0.01);
+            var consensus = ConsensusRts.Compute(perFile, cals, consensusFdr: 0.01);
 
-            Assert.AreEqual(1, consensus.Count);
-            Assert.AreEqual(@"PEPTIDE1", consensus[0].ModifiedSequence);
-
-            // Repeat with protein rescue disabled — same detection must be rejected.
-            var consensusNoRescue = ConsensusRts.Compute(
-                perFile, cals,
-                consensusFdr: 0.01,
-                proteinFdrThreshold: 0.0);
-            Assert.AreEqual(0, consensusNoRescue.Count);
+            Assert.AreEqual(0, consensus.Count,
+                @"borderline peptide (peptide-q > consensus_fdr) must NOT be rescued by a passing protein");
         }
 
         [TestMethod]
@@ -316,7 +310,7 @@ namespace pwiz.Osprey.Test
                 Pair(@"f3", PassingTarget(@"PEPTIDE1", apexRt: 20.0, score: -4.0)),
             };
 
-            var consensus = ConsensusRts.Compute(perFile, cals, 0.01, 0.0);
+            var consensus = ConsensusRts.Compute(perFile, cals, 0.01);
 
             Assert.AreEqual(1, consensus.Count);
             Assert.AreEqual(10.0, consensus[0].ConsensusLibraryRt, TOLERANCE);
@@ -352,7 +346,7 @@ namespace pwiz.Osprey.Test
                 Pair(@"f2", good),
             };
 
-            var consensus = ConsensusRts.Compute(perFile, cals, 0.01, 0.0);
+            var consensus = ConsensusRts.Compute(perFile, cals, 0.01);
 
             Assert.AreEqual(1, consensus.Count);
             Assert.AreEqual(1, consensus[0].NRunsDetected);
@@ -374,7 +368,7 @@ namespace pwiz.Osprey.Test
                 Pair(@"f2", PassingTarget(@"PEPTIDE1", apexRt: 11.0, score: 3.0)),
             };
 
-            var consensus = ConsensusRts.Compute(perFile, cals, 0.01, 0.0);
+            var consensus = ConsensusRts.Compute(perFile, cals, 0.01);
             Assert.AreEqual(1, consensus.Count);
             Assert.AreEqual(2, consensus[0].NRunsDetected);
             Assert.IsFalse(consensus[0].ApexLibraryRtMad.HasValue);
@@ -399,7 +393,7 @@ namespace pwiz.Osprey.Test
                 }),
             };
 
-            var consensus = ConsensusRts.Compute(perFile, cals, 0.01, 0.0);
+            var consensus = ConsensusRts.Compute(perFile, cals, 0.01);
 
             Assert.AreEqual(3, consensus.Count);
             Assert.AreEqual(@"ALPHA", consensus[0].ModifiedSequence);
@@ -425,7 +419,7 @@ namespace pwiz.Osprey.Test
                 Pair(@"f_no_cal", PassingTarget(@"PEPTIDE1", apexRt: 99.0, score: 3.0)),
             };
 
-            var consensus = ConsensusRts.Compute(perFile, cals, 0.01, 0.0);
+            var consensus = ConsensusRts.Compute(perFile, cals, 0.01);
             Assert.AreEqual(1, consensus.Count);
             Assert.AreEqual(1, consensus[0].NRunsDetected);
             Assert.AreEqual(10.0, consensus[0].ConsensusLibraryRt, TOLERANCE);


### PR DESCRIPTION
## Summary

* Fixed a latent HPC per-file compaction divergence (mode3: HPC chain != straight-through). The per-file rescore worker recomputed a PER-FILE first-pass base_id set instead of the straight-through GLOBAL set; the old `|| protein-q` rescue clause had been masking the gap. FirstJoin now persists the join-wide first-pass base_id set in `reconciliation.json` (bumped to v3, required `first_pass_base_ids`); `RescoreCompaction` compacts to exactly that set and hard-fails if absent.
* Removed the pass-2 protein-FDR rescue (admitting a peptide that failed peptide/precursor FDR because its parent protein passed) from all three survival gates. Matches Mike's intent; `--protein-fdr` becomes reporting-only. Protein-FDR reporting (`proteins.csv` + q-values) is kept.

Scope note: the rescue removal is ~a no-op on final output (golden delta net -3). The anti-conservative `--protein-fdr` behavior is caused by the 2nd-pass Percolator RECALIBRATION on a decoy-depleted null, NOT the rescue; that fix is tracked separately (TODO-osprey_pass2_recalibration_fix). This PR is HPC hardening + cleanup, not the calibration fix.

Cross-impl parity: pairs with maccoss/osprey#48 (`reconciliation.json` v3, byte-identical).

## Test plan

- [x] Build-Osprey -RunTests -RunInspection: 446 tests, 0 warnings
- [x] regression.ps1 Stellar mode3 (HPC chain == straight): PASS on the reconciliation-v3 fix
- [ ] regression.ps1 Stellar + Astral: mode1 golden re-captured after auditing the output diff; mode2/mode3 green
- [ ] /pw-self-review clean; un-draft; land with maccoss/osprey#48

Co-Authored-By: Claude <noreply@anthropic.com>
