### PR TITLE
Fixed intermittent TestDdaSearch RT-alignment race by waiting for auto-train

### DIFF
--- a/pwiz_tools/Skyline/TestFunctional/DdaSearchTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/DdaSearchTest.cs
@@ -1444,16 +1444,29 @@ namespace pwiz.SkylineTestFunctional
             var preset = Settings.Default.SearchSettingsPresets.FirstOrDefault(p => p.Name == presetName);
             Assert.IsNotNull(preset, $"Preset '{presetName}' should exist in settings");
 
-            // The DDA search just imported results, which kicks off background retention-time
-            // alignment (ResultFileAlignments). ShowRunPeptideSearchDlg refuses to open until
-            // Document.IsLoaded, and that alignment can still be settling on the committed
-            // document here: the earlier WaitForDocumentLoaded() only checks DocumentUI, which
-            // can report loaded before the committed Document finishes aligning. Wait on the
-            // committed Document so reopening the wizard doesn't intermittently hit the
-            // "document must be fully loaded" error on slower/contended nightly agents.
-            WaitForConditionUI(() => SkylineWindow.Document.IsLoaded,
-                () => TextUtil.LineSeparate("Document not loaded before reopening Run Peptide Search wizard:",
+            // The DDA search just imported results. That makes the document briefly report
+            // IsLoaded==true while mProphet auto-training is still pending (IsAutoTrain==true):
+            // AutoTrainManager only starts training once the document first becomes loaded, then
+            // commits a retrained document that re-triggers background retention-time alignment
+            // (ResultFileAlignments), making the document not-loaded again for a moment.
+            // ShowRunPeptideSearchDlg refuses to open unless the *committed* Document.IsLoaded, so
+            // waiting only on IsLoaded (or WaitForDocumentLoaded, which checks DocumentUI) returns
+            // too early and lets the wizard reopen race that not-loaded window - the intermittent
+            // "document must be fully loaded before running a peptide search" failure seen on
+            // slower/contended nightly agents. Wait for the document to be fully settled: loaded
+            // AND auto-train complete.
+            WaitForConditionUI(() => SkylineWindow.Document.IsLoaded &&
+                                     !SkylineWindow.Document.Settings.PeptideSettings.Integration.IsAutoTrain,
+                () => TextUtil.LineSeparate("Document not fully settled before reopening Run Peptide Search wizard:",
+                    "IsAutoTrain=" + SkylineWindow.Document.Settings.PeptideSettings.Integration.IsAutoTrain,
                     TextUtil.LineSeparate(SkylineWindow.Document.NonLoadedStateDescriptions)));
+
+            // Regression tripwire for the race above: at this point auto-train must be finished. If
+            // the wait is ever weakened back to a plain IsLoaded/WaitForDocumentLoaded check this
+            // fails deterministically, because auto-train is still pending the instant such a wait
+            // returns (it needs ~tens of ms after the document first loads to commit).
+            RunUI(() => Assert.IsFalse(SkylineWindow.Document.Settings.PeptideSettings.Integration.IsAutoTrain,
+                "Document not fully settled before reopening wizard - mProphet auto-train still pending"));
 
             var importPeptideSearchDlg2 = ShowDialog<ImportPeptideSearchDlg>(SkylineWindow.ShowRunPeptideSearchDlg);
 


### PR DESCRIPTION
## Summary

* Follow-up to #4342, whose wait on the committed `Document.IsLoaded` turned out to be insufficient. Instrumenting the committed document (16s repro on `TestDdaSearch`/MSAmanda) revealed a **chained-loader race**: after the search imports results the document becomes loaded (first RT alignment done) while mProphet auto-train is still pending; `AutoTrainManager` then commits a retrained document that re-triggers `ResultFileAlignments`, so `Document.IsLoaded` bounces `true -> false -> true`. A single `IsLoaded` wait catches the premature `true`, and on slow/contended nightly agents the wizard reopen lands in the not-loaded window -> "The document must be fully loaded before running a peptide search."
* `VerifyPresetInNewWizard` now waits for `Document.IsLoaded && !PeptideSettings.Integration.IsAutoTrain` (fully settled). Added a `RunUI(Assert.IsFalse(...IsAutoTrain))` tripwire immediately after the wait: auto-train is always still pending the instant a plain `IsLoaded` wait returns, so this fails **deterministically** if the wait is ever weakened back.

This is the exact `TestDdaSearch*` cluster that failed on the 2026-07-02 master nightly (build already contained #4342).

## Test plan

- [x] TestDdaSearch (MSAmanda) - passes; reproduced the failure deterministically via the tripwire before the fix
- [x] TestDdaSearchComet - passes (end-to-end, real engine)
- [x] TestDdaSearchTide - passes (end-to-end, real engine)
- [x] TestDdaSearchMsFragger - passes (end-to-end, real engine)
- [x] TestDdaSearchMsgfPlus - passes (end-to-end, real engine)

Co-Authored-By: Claude <noreply@anthropic.com>