### PR TITLE
Carried the join-wide first-pass base_id set in reconciliation.json (v3)

### DIFF
--- a/pwiz_tools/Osprey/Osprey.IO/ReconciliationFile.cs
+++ b/pwiz_tools/Osprey/Osprey.IO/ReconciliationFile.cs
@@ -62,31 +62,46 @@ namespace pwiz.Osprey.IO
         ///     empty <see cref="FileStems"/> list; the worker falls back
         ///     to its <c>OspreyConfig.InputFiles</c> stems in that case,
         ///     preserving v1 behavior.
+        /// v3: added <c>first_pass_base_ids</c>, the JOIN-WIDE set of base_ids
+        ///     that survived first-pass compaction. FirstJoin computes it with
+        ///     every file in memory; a per-file HPC rescore worker uses it to
+        ///     compact to exactly the set the in-memory straight-through pipeline
+        ///     used, instead of recomputing a PER-FILE subset that drops cross-file
+        ///     entries (regression mode3 divergence). Required in v3 (see Load).
+        ///     NOTE: the Rust reconciliation_io.rs needs the matching field to keep
+        ///     cross-impl byte parity.
         /// </summary>
-        public const int CurrentFormatVersion = 2;
+        public const int CurrentFormatVersion = 3;
 
         [JsonProperty("file_stems", Order = 0)]
         public List<string> FileStems { get; set; }
 
-        [JsonProperty("forced_integration_actions", Order = 1)]
+        /// <summary>
+        /// Join-wide first-pass passing base_ids (sorted ascending for
+        /// deterministic, byte-parity output). See v3 note above.
+        /// </summary>
+        [JsonProperty("first_pass_base_ids", Order = 1)]
+        public uint[] FirstPassBaseIds { get; set; }
+
+        [JsonProperty("forced_integration_actions", Order = 2)]
         public List<ForcedIntegrationEntry> ForcedIntegrationActions { get; set; }
 
-        [JsonProperty("format_version", Order = 2)]
+        [JsonProperty("format_version", Order = 3)]
         public int FormatVersion { get; set; }
 
-        [JsonProperty("gap_fill_targets", Order = 3)]
+        [JsonProperty("gap_fill_targets", Order = 4)]
         public List<GapFillEntry> GapFillTargets { get; set; }
 
-        [JsonProperty("library_hash", Order = 4)]
+        [JsonProperty("library_hash", Order = 5)]
         public string LibraryHash { get; set; }
 
-        [JsonProperty("refined_rt_calibration", Order = 5, NullValueHandling = NullValueHandling.Include)]
+        [JsonProperty("refined_rt_calibration", Order = 6, NullValueHandling = NullValueHandling.Include)]
         public RefinedRtCalibrationJson RefinedRtCalibration { get; set; }
 
-        [JsonProperty("search_hash", Order = 6)]
+        [JsonProperty("search_hash", Order = 7)]
         public string SearchHash { get; set; }
 
-        [JsonProperty("use_cwt_peak_actions", Order = 7)]
+        [JsonProperty("use_cwt_peak_actions", Order = 8)]
         public List<UseCwtPeakEntry> UseCwtPeakActions { get; set; }
 
         /// <summary>
@@ -125,6 +140,18 @@ namespace pwiz.Osprey.IO
                     "Reconciliation file {0} has format_version {1} but file_stems is missing " +
                     "or empty; v{1} envelopes are required to carry the planner's full join " +
                     "file set.",
+                    path, CurrentFormatVersion));
+            }
+            // v3 required: the join-wide first-pass base_id set. A per-file HPC
+            // worker MUST have this to compact to the same set as the in-memory
+            // pipeline; without it the worker would recompute a per-file subset
+            // and silently diverge (regression mode3). Fail loudly instead.
+            if (parsed.FirstPassBaseIds == null)
+            {
+                throw new InvalidDataException(string.Format(
+                    "Reconciliation file {0} has format_version {1} but first_pass_base_ids is " +
+                    "missing; v{1} envelopes are required to carry the join-wide first-pass " +
+                    "base_id set.",
                     path, CurrentFormatVersion));
             }
             return parsed;

--- a/pwiz_tools/Osprey/Osprey.Tasks/FirstJoinTask.cs
+++ b/pwiz_tools/Osprey/Osprey.Tasks/FirstJoinTask.cs
@@ -513,7 +513,7 @@ namespace pwiz.Osprey.Tasks
                     // boundaries onto the wrong entries -- the exact
                     // failure the worker's hand-rolled compaction at
                     // RescoreCompaction.Apply was written to avoid.
-                    var stats = RescoreCompaction.Apply(bundle, config);
+                    var stats = RescoreCompaction.Apply(bundle);
                     ctx.LogInfo(string.Format(
                         @"First-pass compaction: {0} -> {1} entries ({2} passing base_ids; {3} action(s) dropped)",
                         stats.EntriesBefore, stats.EntriesAfter,
@@ -811,6 +811,18 @@ namespace pwiz.Osprey.Tasks
                     joinFileStems.RemoveAt(i);
             }
 
+            // The join-wide first-pass passing base_id set. perFileEntries is
+            // already compacted here (a base_id passing peptide-q in ANY file is
+            // kept in ALL files), so the distinct base_ids remaining across all
+            // files ARE that set. Persisted per file (below) so an HPC
+            // PerFileRescore worker -- which only has its own file in memory --
+            // compacts to the same set the in-memory straight-through pipeline
+            // uses, instead of a per-file subset that drops cross-file entries.
+            var globalBaseIds = new HashSet<uint>();
+            foreach (var fEntry in perFileEntries)
+                foreach (var e in fEntry.Value)
+                    globalBaseIds.Add(e.EntryId & ScoringTaskShared.BASE_ID_MASK);
+
             int failures = 0;
             foreach (var kvp in perFileEntries)
             {
@@ -833,7 +845,7 @@ namespace pwiz.Osprey.Tasks
                 var reconFile = BuildReconciliationFile(
                     fileEntries, fileActions, fileGapFill,
                     refinedCalibrations.TryGetValue(fileName, out var fileCal) ? fileCal : null,
-                    searchHash, libraryHash, joinFileStems);
+                    searchHash, libraryHash, joinFileStems, globalBaseIds);
                 try
                 {
                     ReconciliationFile.Save(reconPath, reconFile);
@@ -913,7 +925,8 @@ namespace pwiz.Osprey.Tasks
             RTCalibration refinedCalibration,
             string searchHash,
             string libraryHash,
-            IReadOnlyList<string> joinFileStems)
+            IReadOnlyList<string> joinFileStems,
+            HashSet<uint> globalBaseIds)
         {
             var useCwt = new List<UseCwtPeakEntry>();
             var forced = new List<ForcedIntegrationEntry>();
@@ -990,9 +1003,15 @@ namespace pwiz.Osprey.Tasks
                 ? new List<string>(joinFileStems)
                 : new List<string>();
 
+            // Sorted ascending for deterministic, byte-parity output.
+            var baseIdArray = new uint[globalBaseIds.Count];
+            globalBaseIds.CopyTo(baseIdArray);
+            Array.Sort(baseIdArray); // Array.Sort OK: unique uint base_ids, single primitive array, no ties
+
             return new ReconciliationFile
             {
                 FileStems = fileStems,
+                FirstPassBaseIds = baseIdArray,
                 ForcedIntegrationActions = forced,
                 FormatVersion = ReconciliationFile.CurrentFormatVersion,
                 GapFillTargets = gap,

--- a/pwiz_tools/Osprey/Osprey.Tasks/PerFileRescoreTask.cs
+++ b/pwiz_tools/Osprey/Osprey.Tasks/PerFileRescoreTask.cs
@@ -425,12 +425,16 @@ namespace pwiz.Osprey.Tasks
                 // post-rehydration detected_peptides set + best_peptide_scores
                 // (which differ from the original write-time inputs whenever any
                 // upstream rebuild has nudged peptide q-values or score values
-                // even at the ULP level). Without this matching recompute on the
-                // C# side, the protein-rescue branch of compaction below sees
-                // slightly stale RunProteinQvalue values and the post-compaction
-                // detected_peptides set diverges from Rust by ~19 peptides on
-                // Stellar Single (1 protein delta at Stage 7). Only runs when
-                // protein FDR is enabled. Mirrors Rust pipeline.rs:4292-4358.
+                // even at the ULP level). RescoreCompaction below now retains the
+                // persisted global first-pass base_id set and does NOT consult
+                // RunProteinQvalue, so this recompute no longer affects the
+                // compacted set; it is kept to hold RunProteinQvalue byte-consistent
+                // with the straight-through pipeline for the downstream 2nd-pass
+                // protein FDR and cross-impl parity (before recon-v3 read the
+                // persisted set, omitting it diverged the post-compaction set from
+                // Rust by ~19 peptides / 1 protein at Stage 7 on Stellar Single).
+                // Do not remove without re-checking the 2nd-pass protein-FDR path.
+                // Only runs when protein FDR is enabled. Mirrors Rust pipeline.rs:4292-4358.
                 if (ctx.Config.ProteinFdr.HasValue && bundle.PerFileEntries.Count > 0)
                 {
                     var fullLibrary = ctx.Get<FullLibrary>().Value;

--- a/pwiz_tools/Osprey/Osprey.Tasks/PerFileRescoreTask.cs
+++ b/pwiz_tools/Osprey/Osprey.Tasks/PerFileRescoreTask.cs
@@ -440,7 +440,7 @@ namespace pwiz.Osprey.Tasks
                     ProteinFdrEngine.RunFirstPass(
                         bundle.PerFileEntries, fullLibrary, ctx.Config, null);
                 }
-                var stats = RescoreCompaction.Apply(bundle, ctx.Config);
+                var stats = RescoreCompaction.Apply(bundle);
                 ctx.LogInfo(string.Format(
                     @"--task SecondPassFDR compaction: {0} -> {1} entries ({2} passing base_ids; {3} action(s) dropped)",
                     stats.EntriesBefore, stats.EntriesAfter,

--- a/pwiz_tools/Osprey/Osprey.Tasks/RescoreCompaction.cs
+++ b/pwiz_tools/Osprey/Osprey.Tasks/RescoreCompaction.cs
@@ -95,52 +95,47 @@ namespace pwiz.Osprey.Tasks
         /// <see cref="RescoreInputs.ReconciliationActions"/> with
         /// post-compaction <c>vec_idx</c> values.
         ///
-        /// Predicate (mirrors Rust <c>rescore::run_rescore</c>'s
-        /// compaction block): an entry's <c>base_id</c> is retained if
-        /// EITHER <c>RunPeptideQvalue ≤ peptideGate</c> OR
-        /// (<c>--protein-fdr</c> set AND <c>RunProteinQvalue ≤ proteinGate</c>).
-        /// <paramref name="config"/>'s <see cref="OspreyConfig.RunFdr"/>
-        /// supplies the peptide gate (matches the in-process flow's
-        /// <c>peptideGate = config.RunFdr</c> at the same step), and
-        /// <see cref="OspreyConfig.ProteinFdr"/> the protein-rescue
-        /// gate (skipped entirely when null).
+        /// Retained set: the join-wide first-pass base_id set that FirstJoin
+        /// computed with every file in memory and persisted in the
+        /// <c>reconciliation.json</c> envelope (v3 <c>first_pass_base_ids</c>,
+        /// <see cref="RescoreInputs.GlobalFirstPassBaseIds"/>). Consuming it here
+        /// is what makes a per-file HPC worker compact to the SAME set as the
+        /// in-memory straight-through pipeline. The set is REQUIRED: when it is
+        /// absent this method hard-fails rather than recompute a per-file subset,
+        /// which on a single-file worker would be only a per-file subset and
+        /// silently diverge from the in-memory run (regression mode3).
+        ///
+        /// The survival predicate itself -- the peptide/precursor FDR gate plus
+        /// the protein-FDR rescue -- is applied UPSTREAM by FirstJoin when it
+        /// builds that set (<see cref="FirstJoinTask"/>'s compaction), matching
+        /// Rust's <c>rescore::run_rescore</c>. This method only consumes the set.
         /// </summary>
-        public static Stats Apply(RescoreInputs inputs, OspreyConfig config)
+        public static Stats Apply(RescoreInputs inputs)
         {
             if (inputs == null) throw new ArgumentNullException(nameof(inputs));
-            if (config == null) throw new ArgumentNullException(nameof(config));
 
-            double peptideGate = config.RunFdr;
-            double? proteinGate = config.ProteinFdr;
+            // 1. The join-wide passing base_id set is authoritative: FirstJoin
+            //    computed it with every file in memory and persisted it in the
+            //    reconciliation.json envelope. A worker missing it would have to
+            //    recompute a PER-FILE subset and silently diverge from the
+            //    in-memory pipeline (regression mode3), so fail loudly rather than
+            //    compact to a "close-enough" set.
+            if (inputs.GlobalFirstPassBaseIds == null)
+            {
+                throw new InvalidOperationException(
+                    "RescoreCompaction: RescoreInputs.GlobalFirstPassBaseIds is null. The " +
+                    "reconciliation.json envelope must carry the join-wide first-pass base_id " +
+                    "set (format v3); recomputing per file would diverge from the in-memory run.");
+            }
 
-            // 1. Build the passing base_id set across all files.
-            //    Decoys are excluded from the predicate by design: target/decoy
-            //    pairs share the same `base_id`, so a passing TARGET retains
-            //    its paired decoy automatically via the base_id retain step
-            //    below. Including decoys in the predicate would let a decoy
-            //    peptide whose parent protein passes protein-FDR rescue
-            //    itself via the protein-rescue clause, inflating the base_id
-            //    set beyond what the in-process pipeline's compaction
-            //    produces (AnalysisPipeline.cs:517 has the matching
-            //    `if (entry.IsDecoy) continue;` filter, and
-            //    `pipeline.rs:3879` and `rescore.rs:457` on the Rust side
-            //    have the matching `!e.is_decoy &&` predicate).
-            var firstPassBaseIds = new HashSet<uint>();
             int entriesBefore = 0;
             foreach (var kvp in inputs.PerFileEntries)
-            {
                 entriesBefore += kvp.Value.Count;
-                foreach (var e in kvp.Value)
-                {
-                    if (e.IsDecoy)
-                        continue;
-                    if (e.RunPeptideQvalue <= peptideGate ||
-                        (proteinGate.HasValue && e.RunProteinQvalue <= proteinGate.Value))
-                    {
-                        firstPassBaseIds.Add(e.EntryId & BASE_ID_MASK);
-                    }
-                }
-            }
+
+            // Compact to exactly that set. Decoys need no separate predicate: a
+            // target and its paired decoy share a base_id, so a target in the set
+            // keeps its decoy via the base_id retain step below.
+            var firstPassBaseIds = new HashSet<uint>(inputs.GlobalFirstPassBaseIds);
 
             // 2. Snapshot pre-compaction (file, entry_id) -> action so
             //    the action map can be rebuilt with post-compaction

--- a/pwiz_tools/Osprey/Osprey.Tasks/RescoreCompaction.cs
+++ b/pwiz_tools/Osprey/Osprey.Tasks/RescoreCompaction.cs
@@ -132,9 +132,14 @@ namespace pwiz.Osprey.Tasks
             foreach (var kvp in inputs.PerFileEntries)
                 entriesBefore += kvp.Value.Count;
 
-            // Compact to exactly that set. Decoys need no separate predicate: a
-            // target and its paired decoy share a base_id, so a target in the set
-            // keeps its decoy via the base_id retain step below.
+            // Start from that set. Step 2 below additionally unions in the
+            // base_ids of cross-file reconciliation-action targets, so the
+            // retained set is the global first-pass set PLUS those action targets
+            // -- not the global set alone. Both the worker here and the in-memory
+            // straight-through pipeline apply that same union, so they stay
+            // identical. Decoys need no separate predicate: a target and its
+            // paired decoy share a base_id, so a target in the set keeps its
+            // decoy via the base_id retain step below.
             var firstPassBaseIds = new HashSet<uint>(inputs.GlobalFirstPassBaseIds);
 
             // 2. Snapshot pre-compaction (file, entry_id) -> action so

--- a/pwiz_tools/Osprey/Osprey.Tasks/RescoreHydration.cs
+++ b/pwiz_tools/Osprey/Osprey.Tasks/RescoreHydration.cs
@@ -98,6 +98,16 @@ namespace pwiz.Osprey.Tasks
         /// </summary>
         public List<string> JoinFileStems { get; set; }
 
+        /// <summary>
+        /// Join-wide set of base_ids that survived first-pass compaction, read
+        /// from the <c>reconciliation.json</c> envelope's <c>first_pass_base_ids</c>
+        /// (v3 required field) that FirstJoin wrote with every file in memory.
+        /// <see cref="RescoreCompaction"/> compacts to exactly this set so an HPC
+        /// per-file worker keeps the same cross-file entries the in-memory
+        /// straight-through pipeline keeps.
+        /// </summary>
+        public HashSet<uint> GlobalFirstPassBaseIds { get; set; }
+
         /// <summary>Total non-Keep reconciliation actions across all files.</summary>
         public int TotalActions => ReconciliationActions.Count;
 
@@ -233,6 +243,11 @@ namespace pwiz.Osprey.Tasks
             // worker's join-wide reconciliation hash matches the planner's.
             // Mirrors the consistency check in Rust hydrate_for_rescore.
             List<string> joinFileStems = null;
+            // Join-wide passing base_id set from the reconciliation.json envelope
+            // (v3 required field, identical in every file's envelope). Populated
+            // from the first envelope in the loop below; RescoreCompaction compacts
+            // to exactly this set so a per-file worker matches the in-memory run.
+            HashSet<uint> globalBaseIds = null;
 
             for (int i = 0; i < perFileEntries.Count; i++)
             {
@@ -266,6 +281,12 @@ namespace pwiz.Osprey.Tasks
                         "HydrateReconciliationOverlay: failed to read {0}: {1}",
                         reconPath, ex.Message), ex);
                 }
+
+                // Capture the join-wide passing base_id set from the envelope
+                // (v3 required field; identical in every file's envelope, so the
+                // first one wins). RescoreCompaction compacts to exactly this set.
+                if (globalBaseIds == null)
+                    globalBaseIds = new HashSet<uint>(envelope.FirstPassBaseIds);
 
                 // Capture / validate file_stems across all envelopes.
                 // ReconciliationFile.Load already rejects any envelope whose
@@ -367,6 +388,7 @@ namespace pwiz.Osprey.Tasks
                 PerFileGapFill = perFileGapFill,
                 PerFileConsensusTargets = null,
                 JoinFileStems = joinFileStems ?? new List<string>(),
+                GlobalFirstPassBaseIds = globalBaseIds,
             };
         }
 

--- a/pwiz_tools/Osprey/Osprey.Tasks/RescoreHydration.cs
+++ b/pwiz_tools/Osprey/Osprey.Tasks/RescoreHydration.cs
@@ -306,7 +306,7 @@ namespace pwiz.Osprey.Tasks
 
                 // Capture / validate file_stems across all envelopes.
                 // ReconciliationFile.Load already rejects any envelope whose
-                // format_version != CurrentFormatVersion (currently 2), so by
+                // format_version != CurrentFormatVersion (currently 3), so by
                 // the time we reach here `envelope.FileStems` must be the
                 // planner's full join file set -- a non-empty list, identical
                 // across every envelope produced by a single planner step.

--- a/pwiz_tools/Osprey/Osprey.Tasks/RescoreHydration.cs
+++ b/pwiz_tools/Osprey/Osprey.Tasks/RescoreHydration.cs
@@ -283,10 +283,26 @@ namespace pwiz.Osprey.Tasks
                 }
 
                 // Capture the join-wide passing base_id set from the envelope
-                // (v3 required field; identical in every file's envelope, so the
-                // first one wins). RescoreCompaction compacts to exactly this set.
+                // (v3 required field; identical in every file's envelope by
+                // construction). Validate that every sibling envelope agrees:
+                // a mismatch means the on-disk envelopes were produced by
+                // different planner steps (corrupted hand-off), and silently
+                // taking the first file's set would compact its siblings against
+                // the wrong base_ids. Mirrors the file_stems consistency check
+                // below.
+                var envelopeBaseIds = new HashSet<uint>(envelope.FirstPassBaseIds);
                 if (globalBaseIds == null)
-                    globalBaseIds = new HashSet<uint>(envelope.FirstPassBaseIds);
+                {
+                    globalBaseIds = envelopeBaseIds;
+                }
+                else if (!globalBaseIds.SetEquals(envelopeBaseIds))
+                {
+                    throw new InvalidDataException(string.Format(
+                        "HydrateReconciliationOverlay: reconciliation.json {0} carries a " +
+                        "different first_pass_base_ids set than its siblings (planner " +
+                        "inconsistency): {1} vs {2} base_ids.",
+                        reconPath, globalBaseIds.Count, envelopeBaseIds.Count));
+                }
 
                 // Capture / validate file_stems across all envelopes.
                 // ReconciliationFile.Load already rejects any envelope whose

--- a/pwiz_tools/Osprey/Osprey.Test/IOTest.cs
+++ b/pwiz_tools/Osprey/Osprey.Test/IOTest.cs
@@ -2535,7 +2535,10 @@ namespace pwiz.Osprey.Test
                 RefinedCalibrations = new Dictionary<string, RTCalibration>(),
                 PerFileGapFill = new Dictionary<string, List<GapFillTarget>>(),
                 // FirstJoin's authoritative join-wide set: only base_id 1 passed
-                // first-pass FDR. The planner-action union (below) pulls in 2 and 3.
+                // first-pass FDR. This test deliberately exercises the documented
+                // union semantics: RescoreCompaction retains that set PLUS the
+                // base_ids of reconciliation-action targets (below), pulling in 2
+                // and 3, so the retained set is {1, 2, 3} -- not {1} alone.
                 GlobalFirstPassBaseIds = new HashSet<uint> { 1u },
             };
 

--- a/pwiz_tools/Osprey/Osprey.Test/IOTest.cs
+++ b/pwiz_tools/Osprey/Osprey.Test/IOTest.cs
@@ -2006,6 +2006,7 @@ namespace pwiz.Osprey.Test
                 },
                 FormatVersion = ReconciliationFile.CurrentFormatVersion,
                 FileStems = new List<string> { "round_trip" },
+                FirstPassBaseIds = new[] { 3u, 100u, 101u, 200u, 201u },
                 GapFillTargets = new List<GapFillEntry>
                 {
                     new GapFillEntry
@@ -2293,6 +2294,7 @@ namespace pwiz.Osprey.Test
                 {
                     FormatVersion = ReconciliationFile.CurrentFormatVersion,
                     FileStems = new List<string> { stem },
+                    FirstPassBaseIds = new[] { 100u, 101u, 102u },
                     SearchHash = "abc123",
                     LibraryHash = "lib-h",
                     UseCwtPeakActions = new List<UseCwtPeakEntry>
@@ -2429,6 +2431,7 @@ namespace pwiz.Osprey.Test
                 {
                     FormatVersion = ReconciliationFile.CurrentFormatVersion,
                     FileStems = new List<string> { stem },
+                    FirstPassBaseIds = new[] { 100u, 101u, 102u },
                     SearchHash = "x",
                     LibraryHash = "y",
                     UseCwtPeakActions = new List<UseCwtPeakEntry>
@@ -2531,13 +2534,12 @@ namespace pwiz.Osprey.Test
                 ReconciliationActions = actions,
                 RefinedCalibrations = new Dictionary<string, RTCalibration>(),
                 PerFileGapFill = new Dictionary<string, List<GapFillTarget>>(),
+                // FirstJoin's authoritative join-wide set: only base_id 1 passed
+                // first-pass FDR. The planner-action union (below) pulls in 2 and 3.
+                GlobalFirstPassBaseIds = new HashSet<uint> { 1u },
             };
 
-            var stats = RescoreCompaction.Apply(inputs, new OspreyConfig
-            {
-                RunFdr = 0.01,
-                ProteinFdr = 0.01,
-            });
+            var stats = RescoreCompaction.Apply(inputs);
 
             // Compaction stats: planner-action union keeps base 2 alive.
             Assert.AreEqual(5, stats.EntriesBefore);
@@ -2591,13 +2593,12 @@ namespace pwiz.Osprey.Test
                 ReconciliationActions = new Dictionary<(string, int), ReconcileAction>(),
                 RefinedCalibrations = new Dictionary<string, RTCalibration>(),
                 PerFileGapFill = new Dictionary<string, List<GapFillTarget>>(),
+                // FirstJoin built the passing set WITHOUT the protein rescue, so
+                // entry 2 (failing peptide, passing protein) is not in it.
+                GlobalFirstPassBaseIds = new HashSet<uint> { 1u },
             };
 
-            var stats = RescoreCompaction.Apply(inputs, new OspreyConfig
-            {
-                RunFdr = 0.01,
-                ProteinFdr = null,
-            });
+            var stats = RescoreCompaction.Apply(inputs);
 
             // Only entry 1 passes; entry 2 dropped (no protein rescue).
             Assert.AreEqual(1, stats.EntriesAfter);
@@ -2641,16 +2642,15 @@ namespace pwiz.Osprey.Test
                 ReconciliationActions = new Dictionary<(string, int), ReconcileAction>(),
                 RefinedCalibrations = new Dictionary<string, RTCalibration>(),
                 PerFileGapFill = new Dictionary<string, List<GapFillTarget>>(),
+                // FirstJoin excludes decoys when building the set, so a lone decoy's
+                // base_id is never in it -> empty set here -> decoy dropped.
+                GlobalFirstPassBaseIds = new HashSet<uint>(),
             };
 
-            var stats = RescoreCompaction.Apply(inputs, new OspreyConfig
-            {
-                RunFdr = 0.01,
-                ProteinFdr = 0.01,
-            });
+            var stats = RescoreCompaction.Apply(inputs);
 
-            // Decoy is filtered before predicate; no base_ids passed; the
-            // entry is then dropped by the base_id retain step.
+            // Decoy's base_id is not in the global set; the base_id retain step
+            // drops it.
             Assert.AreEqual(0, stats.FirstPassBaseIds);
             Assert.AreEqual(0, stats.EntriesAfter);
             Assert.AreEqual(0, inputs.PerFileEntries[0].Value.Count);


### PR DESCRIPTION
## Summary

* Fixed a latent HPC per-file compaction divergence (regression mode3: HPC chain != straight-through). The per-file rescore worker recomputed a PER-FILE first-pass base_id set instead of the straight-through GLOBAL set; the old rescue clause had masked the gap. FirstJoin now persists the join-wide set in `reconciliation.json` (bumped to v3, required `first_pass_base_ids`); `RescoreCompaction` compacts to that set (plus the base_ids of cross-file reconciliation-action targets) and hard-fails if it is absent.
* Behavior-neutral on straight-through output: the fix only affects the HPC-worker path, so the committed golden is unchanged.

Cross-impl parity: pairs with maccoss/osprey#48 (identical `reconciliation.json` v3), verified at end-to-end 1e-9 bit-parity on Stellar 3-file.

Note: split from the former #4353. The pass-2 protein-FDR rescue removal and the anti-conservative `--protein-fdr` recalibration fix are tracked separately (backlog TODO-osprey_pass2_recalibration_fix) so this PR stays a clean C#/Rust parity pair.

## Test plan

- [x] Build-Osprey -RunTests -RunInspection: 443 passed, 3 skipped, 0 warnings
- [x] regression.ps1 Stellar: mode1 (vs golden) / mode2 (resume) / mode3 (HPC==straight) all PASS
- [x] Compare-EndToEnd-Crossimpl Stellar 3-file: PASS (C# <-> Rust bit-parity at 1e-9)
- [x] Addressed Copilot review (sibling-envelope validation + wording); threads resolved
- [ ] /pw-self-review

Co-Authored-By: Claude <noreply@anthropic.com>
