### PR TITLE
Routed durable Osprey artifact writes through FileSaver (atomic same-dir rename)

### DIFF
--- a/pwiz_tools/Osprey/Osprey.Chromatography/CalibrationIO.cs
+++ b/pwiz_tools/Osprey/Osprey.Chromatography/CalibrationIO.cs
@@ -24,6 +24,7 @@
 using System;
 using System.IO;
 using Newtonsoft.Json;
+using pwiz.Osprey.Core;
 
 namespace pwiz.Osprey.Chromatography
 {
@@ -46,7 +47,11 @@ namespace pwiz.Osprey.Chromatography
                 throw new ArgumentException("path must not be null or empty", nameof(path));
 
             string json = JsonConvert.SerializeObject(calibration, Formatting.Indented);
-            File.WriteAllText(path, json);
+            using (var saver = new FileSaver(path))
+            {
+                File.WriteAllText(saver.SafeName, json);
+                saver.Commit();
+            }
         }
 
         /// <summary>

--- a/pwiz_tools/Osprey/Osprey.Core/FileSaver.cs
+++ b/pwiz_tools/Osprey/Osprey.Core/FileSaver.cs
@@ -20,7 +20,7 @@
 using System;
 using System.IO;
 
-namespace pwiz.Osprey.IO
+namespace pwiz.Osprey.Core
 {
     /// <summary>
     /// Atomic file write helper. Construct with the final destination

--- a/pwiz_tools/Osprey/Osprey.IO/LibraryCache.cs
+++ b/pwiz_tools/Osprey/Osprey.IO/LibraryCache.cs
@@ -46,74 +46,78 @@ namespace pwiz.Osprey.IO
         /// </summary>
         public static void SaveCache(string path, List<LibraryEntry> entries)
         {
-            using (var stream = new FileStream(path, FileMode.Create, FileAccess.Write))
-            using (var w = new BinaryWriter(stream))
+            using (var saver = new FileSaver(path))
             {
-                w.Write(MAGIC);
-                w.Write(VERSION);
-                w.Write((ulong)entries.Count);
-
-                foreach (var entry in entries)
+                using (var stream = new FileStream(saver.SafeName, FileMode.Create, FileAccess.Write))
+                using (var w = new BinaryWriter(stream))
                 {
-                    w.Write(entry.Id);
-                    WriteString(w, entry.Sequence);
-                    WriteString(w, entry.ModifiedSequence);
-                    w.Write(entry.Charge);
-                    w.Write(entry.PrecursorMz);
-                    w.Write(entry.RetentionTime);
-                    w.Write(entry.RtCalibrated ? (byte)1 : (byte)0);
-                    w.Write(entry.IsDecoy ? (byte)1 : (byte)0);
+                    w.Write(MAGIC);
+                    w.Write(VERSION);
+                    w.Write((ulong)entries.Count);
 
-                    // Modifications
-                    w.Write((uint)entry.Modifications.Count);
-                    foreach (var m in entry.Modifications)
+                    foreach (var entry in entries)
                     {
-                        w.Write((uint)m.Position);
-                        if (m.UnimodId.HasValue)
+                        w.Write(entry.Id);
+                        WriteString(w, entry.Sequence);
+                        WriteString(w, entry.ModifiedSequence);
+                        w.Write(entry.Charge);
+                        w.Write(entry.PrecursorMz);
+                        w.Write(entry.RetentionTime);
+                        w.Write(entry.RtCalibrated ? (byte)1 : (byte)0);
+                        w.Write(entry.IsDecoy ? (byte)1 : (byte)0);
+
+                        // Modifications
+                        w.Write((uint)entry.Modifications.Count);
+                        foreach (var m in entry.Modifications)
                         {
-                            w.Write((byte)1);
-                            w.Write((uint)m.UnimodId.Value);
+                            w.Write((uint)m.Position);
+                            if (m.UnimodId.HasValue)
+                            {
+                                w.Write((byte)1);
+                                w.Write((uint)m.UnimodId.Value);
+                            }
+                            else
+                            {
+                                w.Write((byte)0);
+                            }
+                            w.Write(m.MassDelta);
+                            if (m.Name != null)
+                            {
+                                w.Write((byte)1);
+                                WriteString(w, m.Name);
+                            }
+                            else
+                            {
+                                w.Write((byte)0);
+                            }
                         }
-                        else
+
+                        // Fragments
+                        w.Write((uint)entry.Fragments.Count);
+                        foreach (var frag in entry.Fragments)
                         {
-                            w.Write((byte)0);
+                            w.Write(frag.Mz);
+                            w.Write(frag.RelativeIntensity);
+                            w.Write(IonTypeToByte(frag.Annotation.IonType));
+                            w.Write(frag.Annotation.Ordinal);
+                            w.Write(frag.Annotation.Charge);
+                            WriteNeutralLoss(w, frag.Annotation.NeutralLoss);
                         }
-                        w.Write(m.MassDelta);
-                        if (m.Name != null)
-                        {
-                            w.Write((byte)1);
-                            WriteString(w, m.Name);
-                        }
-                        else
-                        {
-                            w.Write((byte)0);
-                        }
+
+                        // Protein IDs
+                        w.Write((uint)entry.ProteinIds.Count);
+                        foreach (string pid in entry.ProteinIds)
+                            WriteString(w, pid);
+
+                        // Gene names
+                        w.Write((uint)entry.GeneNames.Count);
+                        foreach (string gn in entry.GeneNames)
+                            WriteString(w, gn);
                     }
 
-                    // Fragments
-                    w.Write((uint)entry.Fragments.Count);
-                    foreach (var frag in entry.Fragments)
-                    {
-                        w.Write(frag.Mz);
-                        w.Write(frag.RelativeIntensity);
-                        w.Write(IonTypeToByte(frag.Annotation.IonType));
-                        w.Write(frag.Annotation.Ordinal);
-                        w.Write(frag.Annotation.Charge);
-                        WriteNeutralLoss(w, frag.Annotation.NeutralLoss);
-                    }
-
-                    // Protein IDs
-                    w.Write((uint)entry.ProteinIds.Count);
-                    foreach (string pid in entry.ProteinIds)
-                        WriteString(w, pid);
-
-                    // Gene names
-                    w.Write((uint)entry.GeneNames.Count);
-                    foreach (string gn in entry.GeneNames)
-                        WriteString(w, gn);
+                    w.Flush();
                 }
-
-                w.Flush();
+                saver.Commit();
             }
         }
 

--- a/pwiz_tools/Osprey/Osprey.IO/ParquetScoreCache.cs
+++ b/pwiz_tools/Osprey/Osprey.IO/ParquetScoreCache.cs
@@ -258,36 +258,34 @@ namespace pwiz.Osprey.IO
                 }
             }
 
-            // Write to a temp file first, then move to final path (safe NAS writes)
-            string tempPath = Path.Combine(Path.GetTempPath(),
-                string.Format("osprey_{0}_{1}", System.Diagnostics.Process.GetCurrentProcess().Id,
-                    Path.GetFileName(path)));
-
-            using (var stream = new FileStream(tempPath, FileMode.Create, FileAccess.Write))
-            using (var writer = RunSync(ParquetWriter.CreateAsync(schema, stream)))
+            // Write to a sibling temp file first, then atomically rename into
+            // the final path (safe NAS writes): the temp lives in the SAME
+            // directory as the destination, so the promote is an in-volume
+            // rename rather than a cross-volume copy that could truncate.
+            using (var saver = new FileSaver(path))
             {
-                writer.CompressionMethod = CompressionMethod.Zstd;
-
-                // Set custom metadata if provided
-                if (metadata != null && metadata.Count > 0)
-                    writer.CustomMetadata = metadata;
-
-                using (var group = writer.CreateRowGroup())
+                using (var stream = new FileStream(saver.SafeName, FileMode.Create, FileAccess.Write))
+                using (var writer = RunSync(ParquetWriter.CreateAsync(schema, stream)))
                 {
-                    var columns = BuildRowGroupColumns(
-                        entryIds, isDecoys, sequences, modifiedSequences, charges,
-                        precursorMzs, proteinIds, scanNumbers, apexRts, startRts, endRts,
-                        boundsAreas, boundsSnrs, fileNames, cwtCandidates, fragmentMzs,
-                        fragmentIntensities, refXicRts, refXicIntensities,
-                        featureFields, featureArrays);
-                    WriteRowGroupColumns(group, columns, n);
-                }
-            }
+                    writer.CompressionMethod = CompressionMethod.Zstd;
 
-            // Move temp to final destination
-            if (File.Exists(path))
-                File.Delete(path);
-            File.Move(tempPath, path);
+                    // Set custom metadata if provided
+                    if (metadata != null && metadata.Count > 0)
+                        writer.CustomMetadata = metadata;
+
+                    using (var group = writer.CreateRowGroup())
+                    {
+                        var columns = BuildRowGroupColumns(
+                            entryIds, isDecoys, sequences, modifiedSequences, charges,
+                            precursorMzs, proteinIds, scanNumbers, apexRts, startRts, endRts,
+                            boundsAreas, boundsSnrs, fileNames, cwtCandidates, fragmentMzs,
+                            fragmentIntensities, refXicRts, refXicIntensities,
+                            featureFields, featureArrays);
+                        WriteRowGroupColumns(group, columns, n);
+                    }
+                }
+                saver.Commit();
+            }
         }
 
         /// <summary>
@@ -452,32 +450,32 @@ namespace pwiz.Osprey.IO
                 }
             }
 
-            string tempPath = Path.Combine(Path.GetTempPath(),
-                string.Format("osprey_{0}_{1}", System.Diagnostics.Process.GetCurrentProcess().Id,
-                    Path.GetFileName(path)));
-
-            using (var stream = new FileStream(tempPath, FileMode.Create, FileAccess.Write))
-            using (var writer = RunSync(ParquetWriter.CreateAsync(schema, stream)))
+            // Write to a sibling temp file first, then atomically rename into
+            // the final path (safe NAS writes): the temp lives in the SAME
+            // directory as the destination, so the promote is an in-volume
+            // rename rather than a cross-volume copy that could truncate.
+            using (var saver = new FileSaver(path))
             {
-                writer.CompressionMethod = CompressionMethod.Zstd;
-                if (metadata != null && metadata.Count > 0)
-                    writer.CustomMetadata = metadata;
-
-                using (var group = writer.CreateRowGroup())
+                using (var stream = new FileStream(saver.SafeName, FileMode.Create, FileAccess.Write))
+                using (var writer = RunSync(ParquetWriter.CreateAsync(schema, stream)))
                 {
-                    var columns = BuildRowGroupColumns(
-                        entryIds, isDecoys, sequences, modifiedSequences, charges,
-                        precursorMzs, proteinIds, scanNumbers, apexRts, startRts, endRts,
-                        boundsAreas, boundsSnrs, fileNames, cwtCandidates, fragmentMzs,
-                        fragmentIntensities, refXicRts, refXicIntensities,
-                        featureFields, featureArrays);
-                    WriteRowGroupColumns(group, columns, n);
-                }
-            }
+                    writer.CompressionMethod = CompressionMethod.Zstd;
+                    if (metadata != null && metadata.Count > 0)
+                        writer.CustomMetadata = metadata;
 
-            if (File.Exists(path))
-                File.Delete(path);
-            File.Move(tempPath, path);
+                    using (var group = writer.CreateRowGroup())
+                    {
+                        var columns = BuildRowGroupColumns(
+                            entryIds, isDecoys, sequences, modifiedSequences, charges,
+                            precursorMzs, proteinIds, scanNumbers, apexRts, startRts, endRts,
+                            boundsAreas, boundsSnrs, fileNames, cwtCandidates, fragmentMzs,
+                            fragmentIntensities, refXicRts, refXicIntensities,
+                            featureFields, featureArrays);
+                        WriteRowGroupColumns(group, columns, n);
+                    }
+                }
+                saver.Commit();
+            }
         }
 
         /// <summary>

--- a/pwiz_tools/Osprey/Osprey.IO/ReconciliationFile.cs
+++ b/pwiz_tools/Osprey/Osprey.IO/ReconciliationFile.cs
@@ -199,7 +199,7 @@ namespace pwiz.Osprey.IO
             // promoted to the destination on Commit; on exception, the
             // using-block disposes FileSaver which deletes the temp
             // without touching the destination. See
-            // Osprey.IO.FileSaver for details.
+            // Osprey.Core.FileSaver for details.
             using (var saver = new FileSaver(path))
             {
                 File.WriteAllText(saver.SafeName, json);

--- a/pwiz_tools/Osprey/Osprey.IO/ReconciliationFile.cs
+++ b/pwiz_tools/Osprey/Osprey.IO/ReconciliationFile.cs
@@ -25,6 +25,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using Newtonsoft.Json;
+using pwiz.Osprey.Core;
 
 namespace pwiz.Osprey.IO
 {

--- a/pwiz_tools/Osprey/Osprey.IO/SpectraCache.cs
+++ b/pwiz_tools/Osprey/Osprey.IO/SpectraCache.cs
@@ -82,42 +82,46 @@ namespace pwiz.Osprey.IO
 
             ComputeSourceFingerprint(sourcePath, out long sourceSize, out long sourceMtimeMs);
 
-            using (var fs = new FileStream(path, FileMode.Create, FileAccess.Write))
-            using (var w = new BinaryWriter(fs))
+            using (var saver = new FileSaver(path))
             {
-                // Header
-                w.Write(MAGIC);
-                w.Write(VERSION);
-                w.Write((ulong)sourceSize);
-                w.Write(sourceMtimeMs);
-                w.Write((uint)ms2Spectra.Count);
-                w.Write((uint)ms1Spectra.Count);
-
-                // MS2 spectra
-                foreach (var s in ms2Spectra)
+                using (var fs = new FileStream(saver.SafeName, FileMode.Create, FileAccess.Write))
+                using (var w = new BinaryWriter(fs))
                 {
-                    w.Write(s.ScanNumber);
-                    w.Write(s.RetentionTime);
-                    w.Write(s.PrecursorMz);
-                    w.Write(s.IsolationWindow.Center);
-                    w.Write(s.IsolationWindow.LowerOffset);
-                    w.Write(s.IsolationWindow.UpperOffset);
-                    w.Write((uint)s.Mzs.Length);
-                    WriteDoubleArray(w, s.Mzs);
-                    WriteFloatArray(w, s.Intensities);
-                }
+                    // Header
+                    w.Write(MAGIC);
+                    w.Write(VERSION);
+                    w.Write((ulong)sourceSize);
+                    w.Write(sourceMtimeMs);
+                    w.Write((uint)ms2Spectra.Count);
+                    w.Write((uint)ms1Spectra.Count);
 
-                // MS1 spectra
-                foreach (var s in ms1Spectra)
-                {
-                    w.Write(s.ScanNumber);
-                    w.Write(s.RetentionTime);
-                    w.Write((uint)s.Mzs.Length);
-                    WriteDoubleArray(w, s.Mzs);
-                    WriteFloatArray(w, s.Intensities);
-                }
+                    // MS2 spectra
+                    foreach (var s in ms2Spectra)
+                    {
+                        w.Write(s.ScanNumber);
+                        w.Write(s.RetentionTime);
+                        w.Write(s.PrecursorMz);
+                        w.Write(s.IsolationWindow.Center);
+                        w.Write(s.IsolationWindow.LowerOffset);
+                        w.Write(s.IsolationWindow.UpperOffset);
+                        w.Write((uint)s.Mzs.Length);
+                        WriteDoubleArray(w, s.Mzs);
+                        WriteFloatArray(w, s.Intensities);
+                    }
 
-                w.Flush();
+                    // MS1 spectra
+                    foreach (var s in ms1Spectra)
+                    {
+                        w.Write(s.ScanNumber);
+                        w.Write(s.RetentionTime);
+                        w.Write((uint)s.Mzs.Length);
+                        WriteDoubleArray(w, s.Mzs);
+                        WriteFloatArray(w, s.Intensities);
+                    }
+
+                    w.Flush();
+                }
+                saver.Commit();
             }
         }
 

--- a/pwiz_tools/Osprey/Osprey.Tasks/BlibOutputWriter.cs
+++ b/pwiz_tools/Osprey/Osprey.Tasks/BlibOutputWriter.cs
@@ -60,6 +60,16 @@ namespace pwiz.Osprey.Tasks
             Dictionary<(string, byte), List<KeyValuePair<string, FdrEntry>>> entriesByPrecursor)
         {
             double fdrThreshold = config.RunFdr; // run-level threshold for ID-line semantics
+            // Write the blib to a FileSaver sibling temp, then atomically rename it into
+            // place. This is safe with BlibWriter's WAL journaling ONLY because
+            // FinalizeDatabase() runs PRAGMA wal_checkpoint(TRUNCATE) + journal_mode=DELETE
+            // (BlibWriter.cs:577-578): by the time the inner using disposes BlibWriter -- which
+            // disposes every prepared command before closing the connection, releasing the OS
+            // handle -- the WAL has been merged back and the -wal/-shm sidecars are gone, so
+            // saver.Commit() renames a single self-contained file (no orphaned WAL, no
+            // sharing-violation on the still-open handle). Keep FinalizeDatabase() as the last
+            // BlibWriter call before the connection closes; reordering or dropping it would
+            // leave sidecar files that the rename would not carry.
             using (var saver = new FileSaver(config.OutputBlib))
             {
                 using (var writer = new BlibWriter(saver.SafeName))

--- a/pwiz_tools/Osprey/Osprey.Tasks/BlibOutputWriter.cs
+++ b/pwiz_tools/Osprey/Osprey.Tasks/BlibOutputWriter.cs
@@ -60,25 +60,29 @@ namespace pwiz.Osprey.Tasks
             Dictionary<(string, byte), List<KeyValuePair<string, FdrEntry>>> entriesByPrecursor)
         {
             double fdrThreshold = config.RunFdr; // run-level threshold for ID-line semantics
-            using (var writer = new BlibWriter(config.OutputBlib))
+            using (var saver = new FileSaver(config.OutputBlib))
             {
-                writer.BeginBatch();
+                using (var writer = new BlibWriter(saver.SafeName))
+                {
+                    writer.BeginBatch();
 
-                var sourceFileIds = CreateSourceFiles(writer, config, perFileEntries, fdrThreshold);
+                    var sourceFileIds = CreateSourceFiles(writer, config, perFileEntries, fdrThreshold);
 
-                var blibEntries = bestByPrecursor.Values.ToList();
-                PrecompressSpectra(blibEntries, libraryById, config.NThreads,
-                    out byte[][] blibMzBlobs, out byte[][] blibIntBlobs, out int[] blibNumPeaks);
+                    var blibEntries = bestByPrecursor.Values.ToList();
+                    PrecompressSpectra(blibEntries, libraryById, config.NThreads,
+                        out byte[][] blibMzBlobs, out byte[][] blibIntBlobs, out int[] blibNumPeaks);
 
-                EmitSpectrumRows(writer, blibEntries, blibMzBlobs, blibIntBlobs, blibNumPeaks,
-                    sourceFileIds, libraryById, bestExpPrecursorQ, sharedBounds,
-                    entriesByPrecursor, perFileEntries.Count, fdrThreshold);
+                    EmitSpectrumRows(writer, blibEntries, blibMzBlobs, blibIntBlobs, blibNumPeaks,
+                        sourceFileIds, libraryById, bestExpPrecursorQ, sharedBounds,
+                        entriesByPrecursor, perFileEntries.Count, fdrThreshold);
 
-                writer.Commit();
+                    writer.Commit();
 
-                WriteMetadata(writer, config);
+                    WriteMetadata(writer, config);
 
-                writer.FinalizeDatabase();
+                    writer.FinalizeDatabase();
+                }
+                saver.Commit();
             }
         }
 

--- a/pwiz_tools/Osprey/Osprey.Tasks/FdrBenchInputWriter.cs
+++ b/pwiz_tools/Osprey/Osprey.Tasks/FdrBenchInputWriter.cs
@@ -100,67 +100,71 @@ namespace pwiz.Osprey.Tasks
                 Directory.CreateDirectory(dir);
 
             var result = new Result();
-            using (var writer = new StreamWriter(path, false))
+            using (var saver = new FileSaver(path))
             {
-                writer.NewLine = "\n"; // emit '\n' line endings for the TSV body
-                writer.WriteLine(perRun
-                    ? "peptide\tmod_peptide\tcharge\tq_value\tscore\tprotein\trun"
-                    : "peptide\tmod_peptide\tcharge\tq_value\tscore\tprotein");
-
-                if (perRun)
+                using (var writer = new StreamWriter(saver.SafeName, false))
                 {
-                    foreach (var fileEntries in perFileEntries)
+                    writer.NewLine = "\n"; // emit '\n' line endings for the TSV body
+                    writer.WriteLine(perRun
+                        ? "peptide\tmod_peptide\tcharge\tq_value\tscore\tprotein\trun"
+                        : "peptide\tmod_peptide\tcharge\tq_value\tscore\tprotein");
+
+                    if (perRun)
                     {
-                        string runName = fileEntries.Key;
-                        foreach (var entry in fileEntries.Value)
+                        foreach (var fileEntries in perFileEntries)
                         {
-                            if (entry.IsDecoy)
-                                continue;
-                            var lookup = ResolveLibrary(libraryById, entry.EntryId, ref result);
-                            double q = entry.EffectiveRunQvalue(effectiveLevel);
-                            writer.WriteLine(FormatRow(lookup.Peptide, entry.ModifiedSequence,
-                                entry.Charge, q, entry.Score, lookup.Protein, runName));
+                            string runName = fileEntries.Key;
+                            foreach (var entry in fileEntries.Value)
+                            {
+                                if (entry.IsDecoy)
+                                    continue;
+                                var lookup = ResolveLibrary(libraryById, entry.EntryId, ref result);
+                                double q = entry.EffectiveRunQvalue(effectiveLevel);
+                                writer.WriteLine(FormatRow(lookup.Peptide, entry.ModifiedSequence,
+                                    entry.Charge, q, entry.Score, lookup.Protein, runName));
+                                result.Rows++;
+                            }
+                        }
+                    }
+                    else
+                    {
+                        // Dedup across files: keep best (min q-value, ties by max score) per dedup key.
+                        var best = new Dictionary<string, BestRow>();
+                        foreach (var fileEntries in perFileEntries)
+                        {
+                            foreach (var entry in fileEntries.Value)
+                            {
+                                if (entry.IsDecoy)
+                                    continue;
+                                double q = entry.EffectiveExperimentQvalue(effectiveLevel);
+                                string key = DedupKey(entry, effectiveLevel);
+                                BestRow cur;
+                                if (!best.TryGetValue(key, out cur)
+                                    || q < cur.QValue
+                                    || (q == cur.QValue && entry.Score > cur.Score))
+                                {
+                                    best[key] = new BestRow { QValue = q, Score = entry.Score, Entry = entry };
+                                }
+                            }
+                        }
+
+                        // Dictionary enumeration order is not guaranteed stable across runs / runtimes,
+                        // so sort by the dedup-key components (modified sequence, then charge) before
+                        // writing. The key is unique per surviving row, so this is a total order with no
+                        // ties -- deterministic, diff-friendly output. Ordinal compare avoids any
+                        // culture-dependent sequence ordering.
+                        foreach (var row in best.Values
+                            .OrderBy(r => r.Entry.ModifiedSequence, System.StringComparer.Ordinal)
+                            .ThenBy(r => r.Entry.Charge))
+                        {
+                            var lookup = ResolveLibrary(libraryById, row.Entry.EntryId, ref result);
+                            writer.WriteLine(FormatRow(lookup.Peptide, row.Entry.ModifiedSequence,
+                                row.Entry.Charge, row.QValue, row.Entry.Score, lookup.Protein, null));
                             result.Rows++;
                         }
                     }
                 }
-                else
-                {
-                    // Dedup across files: keep best (min q-value, ties by max score) per dedup key.
-                    var best = new Dictionary<string, BestRow>();
-                    foreach (var fileEntries in perFileEntries)
-                    {
-                        foreach (var entry in fileEntries.Value)
-                        {
-                            if (entry.IsDecoy)
-                                continue;
-                            double q = entry.EffectiveExperimentQvalue(effectiveLevel);
-                            string key = DedupKey(entry, effectiveLevel);
-                            BestRow cur;
-                            if (!best.TryGetValue(key, out cur)
-                                || q < cur.QValue
-                                || (q == cur.QValue && entry.Score > cur.Score))
-                            {
-                                best[key] = new BestRow { QValue = q, Score = entry.Score, Entry = entry };
-                            }
-                        }
-                    }
-
-                    // Dictionary enumeration order is not guaranteed stable across runs / runtimes,
-                    // so sort by the dedup-key components (modified sequence, then charge) before
-                    // writing. The key is unique per surviving row, so this is a total order with no
-                    // ties -- deterministic, diff-friendly output. Ordinal compare avoids any
-                    // culture-dependent sequence ordering.
-                    foreach (var row in best.Values
-                        .OrderBy(r => r.Entry.ModifiedSequence, System.StringComparer.Ordinal)
-                        .ThenBy(r => r.Entry.Charge))
-                    {
-                        var lookup = ResolveLibrary(libraryById, row.Entry.EntryId, ref result);
-                        writer.WriteLine(FormatRow(lookup.Peptide, row.Entry.ModifiedSequence,
-                            row.Entry.Charge, row.QValue, row.Entry.Score, lookup.Protein, null));
-                        result.Rows++;
-                    }
-                }
+                saver.Commit();
             }
             return result;
         }

--- a/pwiz_tools/Osprey/Osprey.Tasks/TaskValiditySidecar.cs
+++ b/pwiz_tools/Osprey/Osprey.Tasks/TaskValiditySidecar.cs
@@ -25,6 +25,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Text;
+using pwiz.Osprey.Core;
 
 namespace pwiz.Osprey.Tasks
 {
@@ -126,7 +127,11 @@ namespace pwiz.Osprey.Tasks
 
             sb.Append('}').Append('\n');
 
-            File.WriteAllText(PathFor(outputPath, taskName), sb.ToString());
+            using (var saver = new FileSaver(PathFor(outputPath, taskName)))
+            {
+                File.WriteAllText(saver.SafeName, sb.ToString());
+                saver.Commit();
+            }
         }
 
         /// <summary>

--- a/pwiz_tools/Osprey/Osprey.Test/FileSaverTest.cs
+++ b/pwiz_tools/Osprey/Osprey.Test/FileSaverTest.cs
@@ -1,0 +1,104 @@
+/*
+ * Original author: Brendan MacLean <brendanx .at. uw.edu>,
+ *                  MacCoss Lab, Department of Genome Sciences, UW
+ * AI assistance: Claude Code (Claude Opus 4.8) <noreply .at. anthropic.com>
+ *
+ * Based on osprey (https://github.com/MacCossLab/osprey)
+ *   by Michael J. MacCoss, MacCoss Lab, Department of Genome Sciences, UW
+ *
+ * Copyright 2026 University of Washington - Seattle, WA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System.IO;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using pwiz.Osprey.Core;
+
+namespace pwiz.Osprey.Test
+{
+    /// <summary>
+    /// Tests for <see cref="FileSaver"/>, the atomic-write primitive every durable
+    /// Osprey artifact writer routes through. Locks the contract those writers rely
+    /// on: the temp is a sibling in the destination directory (so Commit is an
+    /// in-volume rename that cannot truncate on a NAS), Commit promotes it and
+    /// replaces any existing destination, and disposal without Commit discards the
+    /// temp while leaving the destination untouched.
+    /// </summary>
+    [TestClass]
+    public class FileSaverTest
+    {
+        [TestMethod]
+        public void TestFileSaverAtomicContract()
+        {
+            string dir = Path.Combine(Path.GetTempPath(), "osprey_fs_" + Path.GetRandomFileName());
+            Directory.CreateDirectory(dir);
+            try
+            {
+                string dest = Path.Combine(dir, "artifact.bin");
+
+                // Commit promotes the sibling temp into the destination.
+                using (var saver = new FileSaver(dest))
+                {
+                    // The temp lives in the SAME directory as the destination -- the property
+                    // that makes Commit a metadata-only in-volume rename rather than a
+                    // cross-volume copy that could silently truncate on a CIFS/NFS mount.
+                    Assert.AreEqual(Path.GetDirectoryName(Path.GetFullPath(dest)),
+                        Path.GetDirectoryName(saver.SafeName));
+                    Assert.AreNotEqual(Path.GetFullPath(dest), saver.SafeName);
+                    Assert.IsTrue(File.Exists(saver.SafeName)); // ctor claims a 0-byte temp
+
+                    File.WriteAllText(saver.SafeName, "v1");
+                    Assert.IsFalse(File.Exists(dest));          // not promoted until Commit
+                    saver.Commit();
+                }
+                Assert.AreEqual("v1", File.ReadAllText(dest));
+
+                // Commit over an existing destination replaces it.
+                using (var saver = new FileSaver(dest))
+                {
+                    File.WriteAllText(saver.SafeName, "v2");
+                    saver.Commit();
+                }
+                Assert.AreEqual("v2", File.ReadAllText(dest));
+
+                // Disposal without Commit discards the temp and leaves the destination intact.
+                string abandonedTemp;
+                using (var saver = new FileSaver(dest))
+                {
+                    abandonedTemp = saver.SafeName;
+                    File.WriteAllText(saver.SafeName, "discarded on dispose");
+                }
+                Assert.IsFalse(File.Exists(abandonedTemp));     // temp cleaned up
+                Assert.AreEqual("v2", File.ReadAllText(dest));  // destination unchanged
+
+                // FileSaver creates a missing destination directory (a behavior change vs a
+                // bare File.WriteAllText, which throws on a missing parent). Locks it in.
+                string nestedDir = Path.Combine(dir, "created", "on", "demand");
+                string nestedDest = Path.Combine(nestedDir, "artifact.bin");
+                Assert.IsFalse(Directory.Exists(nestedDir));
+                using (var saver = new FileSaver(nestedDest))
+                {
+                    Assert.IsTrue(Directory.Exists(nestedDir));
+                    File.WriteAllText(saver.SafeName, "nested");
+                    saver.Commit();
+                }
+                Assert.AreEqual("nested", File.ReadAllText(nestedDest));
+            }
+            finally
+            {
+                Directory.Delete(dir, true);
+            }
+        }
+    }
+}

--- a/pwiz_tools/Osprey/Osprey.Test/PerFileResumeDriverTest.cs
+++ b/pwiz_tools/Osprey/Osprey.Test/PerFileResumeDriverTest.cs
@@ -84,20 +84,32 @@ namespace pwiz.Osprey.Test
         /// <summary>
         /// A sidecar-write failure is non-fatal: Stamp must route it to the
         /// warning callback and not throw (the output is already on disk; only
-        /// the resume-skip hint is lost). Writing under a non-existent directory
-        /// forces the failure.
+        /// the resume-skip hint is lost). FileSaver creates the destination
+        /// directory, so the failure is forced with a parent path that is an
+        /// existing FILE -- allocating the sibling temp under it throws.
         /// </summary>
         [TestMethod]
         public void TestStampSwallowsWriteFailure()
         {
-            string missingDir = Path.Combine(Path.GetTempPath(),
-                "osprey-resume-driver-missing-dir", "out.parquet");
-            var warnings = new List<string>();
+            string blocker = Path.Combine(Path.GetTempPath(), "osprey-resume-blocker-file");
+            if (File.Exists(blocker))
+                File.Delete(blocker);
+            File.WriteAllText(blocker, "x");
+            try
+            {
+                string badPath = Path.Combine(blocker, "out.parquet"); // parent is a file
+                var warnings = new List<string>();
 
-            PerFileResumeDriver.Stamp(missingDir, TASK, VERSION, "key1",
-                new[] { "input.mzML" }, warnings.Add);
+                PerFileResumeDriver.Stamp(badPath, TASK, VERSION, "key1",
+                    new[] { "input.mzML" }, warnings.Add);
 
-            Assert.AreEqual(1, warnings.Count);
+                Assert.AreEqual(1, warnings.Count);
+            }
+            finally
+            {
+                if (File.Exists(blocker))
+                    File.Delete(blocker);
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary

* Routed every durable Osprey artifact write through `FileSaver` (atomic same-directory temp + rename): `calibration.json`, the `.osprey.task` resume sidecar, the `.spectra.bin` cache, `.libcache`, `.scores.parquet` (both `WriteScoresParquet` overloads), the `.blib`, and the `--fdrbench` TSV input.
* Fixed the actual #4356 truncation risk, which was in our own code: `ParquetScoreCache` staged its temp under the system `%TEMP%` and then `File.Move`d it to the output directory. When those sit on different volumes (the common NAS case — local `%TEMP%` on `C:`, output on a CIFS/NFS mount), `File.Move` degrades to a cross-volume copy+delete that can silently truncate. The temp now lives beside the destination, so the promote is an in-volume rename (metadata-only, no byte copy).
* Moved `FileSaver` from `Osprey.IO` to `Osprey.Core` so durable writers in every assembly can share it.

Reported by Michael.

Fixes #4356

## Test plan

- [x] Osprey.Test unit suite (447 tests) green, including the adjusted `TestStampSwallowsWriteFailure` (now forces the write failure with a file-as-parent path, since `FileSaver` creates the destination directory)
- [x] `regression.ps1 -Dataset Stellar` — golden byte-identical (FileSaver changes *where* the temp sits, not the final bytes)
- [ ] TeamCity Osprey Windows .NET Perf/Regression (Stellar + Astral) — triggered on `pull/<N>`

Co-Authored-By: Claude <noreply@anthropic.com>
