### PR TITLE
Hardened the .libcache staleness guard with the library identity hash

### DIFF
--- a/pwiz_tools/Osprey/Osprey.IO/LibraryCache.cs
+++ b/pwiz_tools/Osprey/Osprey.IO/LibraryCache.cs
@@ -38,13 +38,41 @@ namespace pwiz.Osprey.IO
         /// <summary>Magic bytes at the start of every cache file.</summary>
         private static readonly byte[] MAGIC = Encoding.ASCII.GetBytes("OSPRLBR\0");
 
-        /// <summary>Current cache format version.</summary>
-        private const uint VERSION = 1;
+        /// <summary>
+        /// Current cache format version. v2 stamps the source library's
+        /// identity hash (<see cref="pwiz.Osprey.Core.SearchIdentity.LibraryIdentityHash"/>)
+        /// into the header immediately after the version, so a cache built from
+        /// a different build of the same library path is detected and rebuilt.
+        /// v1 had no identity and a different header layout, so it reads as
+        /// <see cref="LibraryCacheStatus.Invalid"/> and is rebuilt once.
+        /// </summary>
+        private const uint VERSION = 2;
 
         /// <summary>
-        /// Save library entries to a binary cache file.
+        /// Outcome of a <see cref="LoadCache(string,string,out LibraryCacheStatus)"/>
+        /// attempt.
         /// </summary>
-        public static void SaveCache(string path, List<LibraryEntry> entries)
+        public enum LibraryCacheStatus
+        {
+            /// <summary>Cache was valid and its entries were read.</summary>
+            Loaded,
+            /// <summary>
+            /// Cache was structurally valid but was built from a different
+            /// version of the source library (stored identity hash mismatch).
+            /// Its entries were NOT read, so the caller should rebuild.
+            /// </summary>
+            IdentityMismatch,
+            /// <summary>
+            /// Cache was unreadable: bad magic bytes or an unsupported version.
+            /// </summary>
+            Invalid
+        }
+
+        /// <summary>
+        /// Save library entries to a binary cache file, stamping the source
+        /// library's identity hash into the header.
+        /// </summary>
+        public static void SaveCache(string path, List<LibraryEntry> entries, string libraryHash)
         {
             using (var saver = new FileSaver(path))
             {
@@ -53,6 +81,7 @@ namespace pwiz.Osprey.IO
                 {
                     w.Write(MAGIC);
                     w.Write(VERSION);
+                    WriteString(w, libraryHash ?? string.Empty);
                     w.Write((ulong)entries.Count);
 
                     foreach (var entry in entries)
@@ -122,10 +151,30 @@ namespace pwiz.Osprey.IO
         }
 
         /// <summary>
-        /// Load library entries from a binary cache file.
+        /// Load library entries from a binary cache file, identity-agnostic.
         /// Returns null if the file is invalid or has an unsupported version.
+        /// Thin overload of <see cref="LoadCache(string,string,out LibraryCacheStatus)"/>
+        /// with no expected identity hash (used by round-trip tests and the
+        /// source-missing fallback, where the cache is the only copy available).
         /// </summary>
         public static List<LibraryEntry> LoadCache(string path)
+        {
+            return LoadCache(path, null, out _);
+        }
+
+        /// <summary>
+        /// Load library entries from a binary cache file, validating the source
+        /// library's identity hash against <paramref name="expectedLibraryHash"/>.
+        /// On bad magic or an unsupported version, returns null with
+        /// <paramref name="status"/> = <see cref="LibraryCacheStatus.Invalid"/>.
+        /// When <paramref name="expectedLibraryHash"/> is non-empty and the
+        /// stored hash differs, returns null with
+        /// <see cref="LibraryCacheStatus.IdentityMismatch"/> WITHOUT reading the
+        /// entries (skips a multi-GB read on a stale cache). Otherwise reads the
+        /// entries and returns <see cref="LibraryCacheStatus.Loaded"/>.
+        /// </summary>
+        public static List<LibraryEntry> LoadCache(string path, string expectedLibraryHash,
+            out LibraryCacheStatus status)
         {
             using (var stream = new FileStream(path, FileMode.Open, FileAccess.Read))
             using (var r = new BinaryReader(stream))
@@ -133,11 +182,29 @@ namespace pwiz.Osprey.IO
                 // Validate magic
                 byte[] magic = r.ReadBytes(8);
                 if (magic.Length != 8 || !BytesEqual(magic, MAGIC))
+                {
+                    status = LibraryCacheStatus.Invalid;
                     return null;
+                }
 
                 uint version = r.ReadUInt32();
                 if (version != VERSION)
+                {
+                    status = LibraryCacheStatus.Invalid;
                     return null;
+                }
+
+                // Identity hash stamped at write time (v2). When the caller
+                // supplies a non-empty expected hash and it disagrees, the cache
+                // was built from a different version of the source library at
+                // this path -- treat it as stale and skip reading the entries.
+                string storedLibraryHash = ReadString(r);
+                if (!string.IsNullOrEmpty(expectedLibraryHash) &&
+                    !string.Equals(storedLibraryHash, expectedLibraryHash, StringComparison.Ordinal))
+                {
+                    status = LibraryCacheStatus.IdentityMismatch;
+                    return null;
+                }
 
                 ulong count = r.ReadUInt64();
                 var entries = new List<LibraryEntry>((int)count);
@@ -224,6 +291,7 @@ namespace pwiz.Osprey.IO
                     entries.Add(entry);
                 }
 
+                status = LibraryCacheStatus.Loaded;
                 return entries;
             }
         }

--- a/pwiz_tools/Osprey/Osprey.IO/LibraryLoader.cs
+++ b/pwiz_tools/Osprey/Osprey.IO/LibraryLoader.cs
@@ -62,16 +62,25 @@ namespace pwiz.Osprey.IO
                 ArtifactPaths.ResolveCacheDir(path),
                 Path.GetFileName(path) + ".libcache");
 
-            // Try loading from binary cache first, but only when it is at least
-            // as new as the source library. A cache older than its source is
-            // stale -- the library was rebuilt in place without clearing the
-            // cache -- and using it would silently load the PREVIOUS build,
-            // whose decoys and pairing no longer match the current manifest.
-            if (IsCacheFresh(cachePath, path))
+            // Reuse the binary cache only when it was built from the SAME
+            // version of the source library. The library's identity hash
+            // (file name + size + mtime, the same recipe .scores.parquet uses)
+            // is stamped into the cache header on write and checked here on
+            // read. A cache built from a different build at this path -- an
+            // in-place rebuild, or a timestamp-preserving swap that a mtime
+            // check would miss -- is ignored and rebuilt, since its decoys and
+            // pairing no longer match the current manifest. Compute the hash
+            // once and reuse it for both the read check and the save below.
+            // A null hash (source missing) skips the check and trusts the
+            // cache, since it is then the only copy available.
+            bool sourceExists = !string.IsNullOrEmpty(path) && File.Exists(path);
+            string libraryHash = sourceExists ? config.Identity.LibraryIdentityHash() : null;
+            if (File.Exists(cachePath))
             {
                 try
                 {
-                    var cached = LibraryCache.LoadCache(cachePath);
+                    LibraryCache.LibraryCacheStatus status;
+                    var cached = LibraryCache.LoadCache(cachePath, libraryHash, out status);
                     if (cached != null && cached.Count > 0)
                     {
                         logInfo(string.Format(
@@ -79,19 +88,19 @@ namespace pwiz.Osprey.IO
                             cached.Count, cachePath));
                         return cached;
                     }
+                    if (status == LibraryCache.LibraryCacheStatus.IdentityMismatch)
+                    {
+                        logInfo(string.Format(
+                            "Library cache '{0}' was built from a different version of the " +
+                            "source library; ignoring the stale cache and rebuilding from source.",
+                            cachePath));
+                    }
                 }
                 catch (Exception ex)
                 {
                     logWarning(string.Format(
                         "Failed to load library cache: {0}. Falling back to source.", ex.Message));
                 }
-            }
-            else if (File.Exists(cachePath))
-            {
-                logInfo(string.Format(
-                    "Library cache '{0}' is older than the source library; " +
-                    "ignoring the stale cache and rebuilding from source.",
-                    cachePath));
             }
 
             // Parse from source
@@ -124,7 +133,8 @@ namespace pwiz.Osprey.IO
             // Save binary cache for next run
             try
             {
-                LibraryCache.SaveCache(cachePath, entries);
+                // libraryHash is non-null here: the source existed to parse.
+                LibraryCache.SaveCache(cachePath, entries, libraryHash);
                 logInfo(string.Format(
                     "Saved library cache ({0} entries) to '{1}'",
                     entries.Count, cachePath));
@@ -135,23 +145,6 @@ namespace pwiz.Osprey.IO
             }
 
             return entries;
-        }
-
-        /// <summary>
-        /// True when the binary cache at <paramref name="cachePath"/> exists and is
-        /// at least as new as the source library at <paramref name="sourcePath"/>.
-        /// A cache older than its source is stale: the library was rebuilt in place,
-        /// so the cache holds the previous build and must be ignored. When the source
-        /// cannot be located the cache is trusted, since it is then the only copy
-        /// available (the historical behavior before this check existed).
-        /// </summary>
-        public static bool IsCacheFresh(string cachePath, string sourcePath)
-        {
-            if (!File.Exists(cachePath))
-                return false;
-            if (string.IsNullOrEmpty(sourcePath) || !File.Exists(sourcePath))
-                return true;
-            return File.GetLastWriteTimeUtc(cachePath) >= File.GetLastWriteTimeUtc(sourcePath);
         }
     }
 }

--- a/pwiz_tools/Osprey/Osprey.Test/IOTest.cs
+++ b/pwiz_tools/Osprey/Osprey.Test/IOTest.cs
@@ -946,6 +946,43 @@ namespace pwiz.Osprey.Test
         }
 
         [TestMethod]
+        public void TestLibraryCacheStaleVersionInvalid()
+        {
+            // A cache whose header carries an unsupported version -- e.g. a pre-v2
+            // cache left on disk from an older build -- reads as Invalid and is
+            // rebuilt; its body is never reinterpreted under the current layout.
+            // Poke the version field (the uint32 immediately after the 8-byte
+            // magic) down to v1 to simulate that, and confirm both the
+            // identity-checked and the no-check load report Invalid rather than
+            // misparsing the body.
+            var entries = new List<LibraryEntry> { MakeTestEntry(0) };
+            string tempPath = Path.Combine(Path.GetTempPath(),
+                "osprey_test_version_" + Guid.NewGuid().ToString("N") + ".libcache");
+            try
+            {
+                LibraryCache.SaveCache(tempPath, entries, "hash-A");
+
+                byte[] bytes = File.ReadAllBytes(tempPath);
+                BitConverter.GetBytes((uint)1).CopyTo(bytes, 8); // version at offset 8
+                File.WriteAllBytes(tempPath, bytes);
+
+                LibraryCache.LibraryCacheStatus status;
+                var loaded = LibraryCache.LoadCache(tempPath, "hash-A", out status);
+                Assert.AreEqual(LibraryCache.LibraryCacheStatus.Invalid, status);
+                Assert.IsNull(loaded);
+
+                // The version gate precedes the identity check, so the identity-
+                // agnostic overload is Invalid too, not silently accepted.
+                Assert.IsNull(LibraryCache.LoadCache(tempPath));
+            }
+            finally
+            {
+                if (File.Exists(tempPath))
+                    File.Delete(tempPath);
+            }
+        }
+
+        [TestMethod]
         public void TestLibraryCacheEmpty()
         {
             var entries = new List<LibraryEntry>();

--- a/pwiz_tools/Osprey/Osprey.Test/IOTest.cs
+++ b/pwiz_tools/Osprey/Osprey.Test/IOTest.cs
@@ -779,7 +779,7 @@ namespace pwiz.Osprey.Test
 
             try
             {
-                LibraryCache.SaveCache(tempPath, entries);
+                LibraryCache.SaveCache(tempPath, entries, "round-trip-hash");
                 var loaded = LibraryCache.LoadCache(tempPath);
 
                 Assert.IsNotNull(loaded);
@@ -849,52 +849,95 @@ namespace pwiz.Osprey.Test
         }
 
         [TestMethod]
-        public void TestLibraryLoaderIgnoresStaleCache()
+        public void TestLibraryCacheIdentityHash()
         {
-            // IsCacheFresh guards against loading a .libcache that predates the
-            // source library (the library was rebuilt in place without clearing
-            // the cache). A stale cache would otherwise be loaded silently and
-            // yield the previous build, whose decoys/pairing no longer match the
-            // current run.
-            string dir = Path.Combine(Path.GetTempPath(),
-                "osprey_cache_fresh_" + Guid.NewGuid().ToString("N"));
-            Directory.CreateDirectory(dir);
-            string source = Path.Combine(dir, "lib.tsv");
-            string cache = Path.Combine(dir, "lib.tsv.libcache");
+            // The .libcache stamps the source library's identity hash into its
+            // header (v2). A cache is reused only when the caller-supplied
+            // expected hash matches the stored one; a mismatch reports
+            // IdentityMismatch and does NOT read the entries (so a stale cache
+            // from a rebuilt-in-place library, whose decoys/pairing no longer
+            // match the current run, is rebuilt from source rather than loaded).
+            var entries = new List<LibraryEntry>
+            {
+                MakeTestEntry(0),
+                MakeTestEntry(1)
+            };
+
+            string tempPath = Path.Combine(Path.GetTempPath(),
+                "osprey_test_identity_" + Guid.NewGuid().ToString("N") + ".libcache");
+
             try
             {
-                File.WriteAllText(source, "source");
-                File.WriteAllText(cache, "cache");
+                LibraryCache.SaveCache(tempPath, entries, "hash-A");
 
-                var t0 = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+                // Matching hash -> loaded with entries.
+                LibraryCache.LibraryCacheStatus status;
+                var loadedMatch = LibraryCache.LoadCache(tempPath, "hash-A", out status);
+                Assert.AreEqual(LibraryCache.LibraryCacheStatus.Loaded, status);
+                Assert.IsNotNull(loadedMatch);
+                Assert.AreEqual(2, loadedMatch.Count);
 
-                // Cache older than source -> stale -> not fresh.
-                File.SetLastWriteTimeUtc(source, t0.AddHours(1));
-                File.SetLastWriteTimeUtc(cache, t0);
-                Assert.IsFalse(LibraryLoader.IsCacheFresh(cache, source),
-                    "a cache older than its source must be treated as stale");
+                // Different hash -> identity mismatch, no entries read.
+                var loadedMismatch = LibraryCache.LoadCache(tempPath, "hash-B", out status);
+                Assert.AreEqual(LibraryCache.LibraryCacheStatus.IdentityMismatch, status);
+                Assert.IsNull(loadedMismatch);
 
-                // Cache newer than source -> fresh.
-                File.SetLastWriteTimeUtc(cache, t0.AddHours(2));
-                Assert.IsTrue(LibraryLoader.IsCacheFresh(cache, source),
-                    "a cache newer than its source must be usable");
+                // Null expected hash -> identity check skipped, entries loaded.
+                var loadedNoCheck = LibraryCache.LoadCache(tempPath, null, out status);
+                Assert.AreEqual(LibraryCache.LibraryCacheStatus.Loaded, status);
+                Assert.IsNotNull(loadedNoCheck);
+                Assert.AreEqual(2, loadedNoCheck.Count);
+            }
+            finally
+            {
+                if (File.Exists(tempPath))
+                    File.Delete(tempPath);
+            }
+        }
 
-                // Equal timestamps -> fresh (the comparison is >=).
-                File.SetLastWriteTimeUtc(source, t0);
-                File.SetLastWriteTimeUtc(cache, t0);
-                Assert.IsTrue(LibraryLoader.IsCacheFresh(cache, source),
-                    "a cache as new as its source must be usable");
+        [TestMethod]
+        public void TestLibraryCacheRealIdentityHash()
+        {
+            // End-to-end: stamp a cache with the REAL LibraryIdentityHash of a
+            // temp library file, then change the file's size and mtime and
+            // confirm the recomputed hash no longer matches the stored one, so
+            // the cache reports IdentityMismatch. This locks the size+mtime
+            // sensitivity of SearchIdentity.LibraryIdentityHash to the actual
+            // file, catching even a timestamp-preserving swap that the old
+            // mtime-ordering check would have missed.
+            string dir = Path.Combine(Path.GetTempPath(),
+                "osprey_cache_identity_" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(dir);
+            string source = Path.Combine(dir, "lib.tsv");
+            string cachePath = Path.Combine(dir, "lib.tsv.libcache");
+            try
+            {
+                File.WriteAllText(source, "original library contents");
+                var config = new OspreyConfig { LibrarySource = LibrarySource.FromPath(source) };
+                string hashBefore = config.Identity.LibraryIdentityHash();
 
-                // Missing cache -> not fresh (nothing to load).
-                File.Delete(cache);
-                Assert.IsFalse(LibraryLoader.IsCacheFresh(cache, source),
-                    "an absent cache cannot be fresh");
+                var entries = new List<LibraryEntry> { MakeTestEntry(0) };
+                LibraryCache.SaveCache(cachePath, entries, hashBefore);
 
-                // Missing source -> trust the cache (it is the only copy).
-                File.WriteAllText(cache, "cache");
-                File.Delete(source);
-                Assert.IsTrue(LibraryLoader.IsCacheFresh(cache, source),
-                    "with no source to compare against, the cache is trusted");
+                // The cache is reused while the file identity is unchanged.
+                LibraryCache.LibraryCacheStatus status;
+                var loaded = LibraryCache.LoadCache(cachePath, hashBefore, out status);
+                Assert.AreEqual(LibraryCache.LibraryCacheStatus.Loaded, status);
+                Assert.IsNotNull(loaded);
+                Assert.AreEqual(1, loaded.Count);
+
+                // Rebuild the library in place with a different size and mtime.
+                File.WriteAllText(source, "a rebuilt library with different contents and length");
+                File.SetLastWriteTimeUtc(source,
+                    File.GetLastWriteTimeUtc(source).AddHours(1));
+                string hashAfter = config.Identity.LibraryIdentityHash();
+                Assert.AreNotEqual(hashBefore, hashAfter,
+                    "changing the library's size and mtime must change its identity hash");
+
+                // The stale cache is now detected and rebuilt from source.
+                var stale = LibraryCache.LoadCache(cachePath, hashAfter, out status);
+                Assert.AreEqual(LibraryCache.LibraryCacheStatus.IdentityMismatch, status);
+                Assert.IsNull(stale);
             }
             finally
             {
@@ -912,7 +955,7 @@ namespace pwiz.Osprey.Test
 
             try
             {
-                LibraryCache.SaveCache(tempPath, entries);
+                LibraryCache.SaveCache(tempPath, entries, "empty-hash");
                 var loaded = LibraryCache.LoadCache(tempPath);
 
                 Assert.IsNotNull(loaded);


### PR DESCRIPTION
## Summary

* Stamped the source library's identity hash (`SearchIdentity.LibraryIdentityHash` — file name + size + mtime, the same recipe `.scores.parquet` uses) into the `.libcache` header (format **v2**). `LibraryLoader` now reuses a cache only when the stored hash matches the current library and rebuilds on mismatch — replacing the mtime-ordering `IsCacheFresh` check #4338 added.
* Added `LibraryCacheStatus` and a `LoadCache(path, expectedLibraryHash, out status)` overload that reports `IdentityMismatch` and skips reading the entries on a stale cache (avoids a multi-GB read); kept the thin identity-agnostic `LoadCache(path)` overload for round-trip tests and the source-missing fallback.
* A pre-existing v1 `.libcache` reads as `Invalid` and is rebuilt once (desired).

Tightens #4338: identity over mtime-ordering is symmetric, size-aware, and catches a timestamp-preserving swap (git checkout / `rsync --times` / `cp -p` / timestamp-preserving unzip) that the mtime check would pass as "fresh".

Fixes #4365

## Test plan

- [x] Osprey.Test (449 pass) incl. `TestLibraryCacheIdentityHash` (match → Loaded / mismatch → IdentityMismatch, no entry read / null → no-check) and `TestLibraryCacheRealIdentityHash` (real `LibraryIdentityHash`, size+mtime change → hash differs → IdentityMismatch)
- [x] Build + ReSharper inspection: 0 new warnings in changed files
- [ ] TeamCity Osprey Windows .NET Perf/Regression (Stellar + Astral) — triggered on `pull/<N>`; cache-validity change only, golden expected byte-identical

**Stacked on #4366** (PR 0 rewrote `LibraryCache.SaveCache` to write through `FileSaver`); this PR's base is that branch. Retarget to `master` after #4366 merges.

Co-Authored-By: Claude <noreply@anthropic.com>
