### PR TITLE
Sped up protein parsimony subset elimination with a rarest-peptide candidate scan

### DIFF
--- a/pwiz_tools/Osprey/Osprey.FDR/ProteinFdr.cs
+++ b/pwiz_tools/Osprey/Osprey.FDR/ProteinFdr.cs
@@ -280,21 +280,93 @@ namespace pwiz.Osprey.FDR
             }
             groups.Sort((a, b) => b.Key.Count.CompareTo(a.Key.Count));
 
-            // Step 3: Subset elimination
-            var retained = new List<KeyValuePair<HashSet<string>, List<string>>>();
+            // Step 3: Subset elimination — rarest-peptide candidate scan (issue #4357).
+            //
+            // The naive form scanned every already-retained group for each group,
+            // which is O(groups^2 x peptides) — tens of seconds to minutes at
+            // SEA-AD scale (tens of thousands of protein groups). A proper superset
+            // of group A must contain ALL of A's peptides, hence A's rarest peptide.
+            // So we index peptide -> retained-group indices INCREMENTALLY (only
+            // groups already appended to retained), and for each A test only the
+            // retained groups sharing A's rarest peptide. This prunes only groups
+            // that provably cannot be supersets, so it drops exactly the same
+            // groups in exactly the same order as the pairwise scan — byte-identical
+            // protein grouping — while running near-linearly.
+            //
+            // Invariants (see issue #4357): the DESCENDING sort above is left
+            // untouched (its unstable tie order is part of the golden output);
+            // groups are iterated in that order and non-subsets appended to
+            // retained in that same order (retained order == gid in Step 4); and
+            // the drop test is the identical proper-subset predicate against
+            // already-retained groups only.
+
+            // Global peptide -> group-count over ALL groups, used only to pick each
+            // group's rarest peptide (the pivot minimizing the candidate set). This
+            // choice does not affect correctness, only which peptide's candidate
+            // list is scanned.
+            var peptideGroupCount = new Dictionary<string, int>(StringComparer.Ordinal);
             foreach (var group in groups)
             {
-                bool isSubset = false;
-                foreach (var larger in retained)
+                foreach (string peptide in group.Key)
                 {
-                    if (group.Key.Count < larger.Key.Count && group.Key.IsSubsetOf(larger.Key))
+                    int count;
+                    peptideGroupCount.TryGetValue(peptide, out count);
+                    peptideGroupCount[peptide] = count + 1;
+                }
+            }
+
+            var retained = new List<KeyValuePair<HashSet<string>, List<string>>>();
+            // peptide -> indices into retained of groups (already appended) containing it.
+            var peptideToRetained = new Dictionary<string, List<int>>(StringComparer.Ordinal);
+            foreach (var group in groups)
+            {
+                var peptideSet = group.Key;
+
+                // Pick the rarest peptide of this group as the pivot: any proper
+                // superset must contain it, so its (typically short) candidate list
+                // is sufficient to find every possible superset.
+                string pivot = null;
+                int pivotCount = int.MaxValue;
+                foreach (string peptide in peptideSet)
+                {
+                    int count = peptideGroupCount[peptide];
+                    if (count < pivotCount)
                     {
-                        isSubset = true;
-                        break;
+                        pivotCount = count;
+                        pivot = peptide;
                     }
                 }
+
+                bool isSubset = false;
+                List<int> candidates;
+                if (pivot != null && peptideToRetained.TryGetValue(pivot, out candidates))
+                {
+                    foreach (int candidateIdx in candidates)
+                    {
+                        var larger = retained[candidateIdx];
+                        if (peptideSet.Count < larger.Key.Count && peptideSet.IsSubsetOf(larger.Key))
+                        {
+                            isSubset = true;
+                            break;
+                        }
+                    }
+                }
+
                 if (!isSubset)
+                {
+                    int idx = retained.Count;
                     retained.Add(group);
+                    foreach (string peptide in peptideSet)
+                    {
+                        List<int> list;
+                        if (!peptideToRetained.TryGetValue(peptide, out list))
+                        {
+                            list = new List<int>();
+                            peptideToRetained[peptide] = list;
+                        }
+                        list.Add(idx);
+                    }
+                }
             }
 
             // Step 4: Assign group IDs and build peptide -> group mapping


### PR DESCRIPTION
## Summary

* Replaced the O(groups²) pairwise subset-elimination scan in `ProteinFdr.BuildProteinParsimony` Step 3 with a near-linear rarest-peptide candidate scan: index peptide → already-retained group indices, and for each group test only the retained groups sharing its **rarest** peptide. A proper superset must contain the group's rarest peptide, so no candidate is ever missed — the drop set **and order** (hence the Step-4 group IDs) are byte-identical to the pairwise scan.
* Near-linear scaling matters at SEA-AD scale (tens of thousands of protein groups), where the pairwise scan ran tens of seconds to minutes; on Stellar's ~5K groups the delta is negligible but the output is unchanged.

The unstable `Count`-descending sort is left untouched (its tie order is part of the golden output), and the drop predicate (`group.Count < larger.Count && group ⊆ larger`, against already-retained groups only) is unchanged.

Reported by Michael.

Fixes #4357

## Test plan

- [x] Osprey.Test (447 pass) + ReSharper inspection: 0 new warnings in `ProteinFdr.cs`
- [x] `regression.ps1 -Dataset Stellar` — mode1 (vs golden) / mode2 (resume) / mode3 (HPC chain) all **PASS**; protein grouping byte-identical (blib 52,514,816 bytes, unchanged)
- [ ] TeamCity Osprey Windows .NET Perf/Regression (Stellar + Astral) — triggered on `pull/<N>`

The Rust mirror (`crates/osprey-fdr/src/protein.rs`) is a **companion PR in maccoss/osprey** (keeps the two algorithms aligned and gives Rust the same speedup). Cross-impl output parity holds regardless, since this change is output-preserving on the C# side.

Co-Authored-By: Claude <noreply@anthropic.com>
