### PR TITLE
Restored the calibration + SVM C summary to the default Osprey console; gated the feature table behind --verbose

### DIFF
--- a/pwiz_tools/Osprey/Osprey.Chromatography/CalibrationParams.cs
+++ b/pwiz_tools/Osprey/Osprey.Chromatography/CalibrationParams.cs
@@ -289,6 +289,16 @@ namespace pwiz.Osprey.Chromatography
         [JsonProperty("mad", NullValueHandling = NullValueHandling.Ignore)]
         public double? MAD { get; set; }
 
+        /// <summary>
+        /// Final RT search-window half-width (minutes) the main search uses:
+        /// <c>3 * MAD * 1.4826</c> clamped to the configured [min, max] RT tolerance.
+        /// Persisted so the JSON records the value the console highlights (issue
+        /// #4364) -- the "how narrow / how fast" number, previously only recomputed
+        /// at scoring time. Optional (absent for uncalibrated / legacy JSON).
+        /// </summary>
+        [JsonProperty("rt_search_window_halfwidth", NullValueHandling = NullValueHandling.Ignore)]
+        public double? RtSearchWindowHalfWidth { get; set; }
+
         /// <summary>Check if RT was calibrated.</summary>
         [JsonIgnore]
         public bool IsCalibrated
@@ -315,13 +325,21 @@ namespace pwiz.Osprey.Chromatography
         /// Build a JSON DTO from an in-memory RTCalibration.
         /// Returns Uncalibrated() when <paramref name="rt"/> is null.
         /// ModelParams is populated so SaveCalibration+LoadCalibration
-        /// round-trips the LOESS fit exactly.
+        /// round-trips the LOESS fit exactly. When <paramref name="minRtTolerance"/> /
+        /// <paramref name="maxRtTolerance"/> are supplied (the search RT-tolerance
+        /// clamps), the final RT search-window half-width is persisted too so the
+        /// JSON records the value the console highlights (issue #4364).
         /// </summary>
-        public static RTCalibrationJson FromRTCalibration(RTCalibration rt)
+        public static RTCalibrationJson FromRTCalibration(RTCalibration rt,
+            double? minRtTolerance = null, double? maxRtTolerance = null)
         {
             if (rt == null)
                 return Uncalibrated();
             var stats = rt.Stats();
+            double? windowHalfWidth = null;
+            if (minRtTolerance.HasValue && maxRtTolerance.HasValue)
+                windowHalfWidth = RTCalibration.SearchWindowHalfWidth(
+                    stats.MAD, minRtTolerance.Value, maxRtTolerance.Value);
             return new RTCalibrationJson
             {
                 Method = RTCalibrationMethod.LOESS,
@@ -330,6 +348,7 @@ namespace pwiz.Osprey.Chromatography
                 RSquared = stats.RSquared,
                 P20AbsResidual = stats.P20AbsResidual,
                 MAD = stats.MAD,
+                RtSearchWindowHalfWidth = windowHalfWidth,
                 ModelParams = new RTModelParamsJson
                 {
                     LibraryRts = rt.LibraryRts,

--- a/pwiz_tools/Osprey/Osprey.Chromatography/RTCalibration.cs
+++ b/pwiz_tools/Osprey/Osprey.Chromatography/RTCalibration.cs
@@ -306,6 +306,22 @@ namespace pwiz.Osprey.Chromatography
             };
         }
 
+        /// <summary>
+        /// The final RT search-window half-width (minutes) actually used by the
+        /// main search for a given robust-spread MAD: <c>3 * MAD * 1.4826</c>
+        /// clamped to <c>[minTolerance, maxTolerance]</c>. This is the single
+        /// definition shared by the scoring path (<c>ScoringPipeline</c>), the
+        /// persisted calibration JSON (<c>RTCalibrationJson</c>), and the console
+        /// calibration summary, so all three report the same number. MAD*1.4826
+        /// approximates a robust SD; 3x covers ~99.7% of a normal spread.
+        /// </summary>
+        public static double SearchWindowHalfWidth(double mad, double minTolerance, double maxTolerance)
+        {
+            double robustSd = mad * 1.4826;
+            double window = robustSd * 3.0;
+            return Math.Max(minTolerance, Math.Min(maxTolerance, window));
+        }
+
         /// <summary>Get the library RT range used for calibration.</summary>
         public void LibraryRtRange(out double min, out double max)
         {

--- a/pwiz_tools/Osprey/Osprey.FDR/FeatureContributions.cs
+++ b/pwiz_tools/Osprey/Osprey.FDR/FeatureContributions.cs
@@ -292,8 +292,16 @@ namespace pwiz.Osprey.FDR
         /// </summary>
         public IEnumerable<string> ToReportLines()
         {
-            yield return "  Feature weight contributions (trained linear model, coefficients standardized):";
-            yield return string.Format("    {0,-36} {1,12} {2,9}", "feature", "coefficient", "percent");
+            // Framed as a model sanity check, NOT feature importance: the percent is
+            // each feature's share of the target-decoy separation (a mean-difference
+            // decomposition), not a ranking of predictive value. A near-zero share on
+            // a score expected to matter (e.g. library dot-product, RT difference), or
+            // a large share weighted opposite its expected direction, is a flag to
+            // investigate the library / calibration -- the analog of Skyline's mProphet
+            // model view. The raw standardized coefficient is kept alongside for the
+            // Compare-Peaks-style read of how the composite score was built.
+            yield return "  Model sanity check -- feature share of target-decoy separation (trained linear model, coefficients standardized):";
+            yield return string.Format("    {0,-36} {1,12} {2,9}", "feature", "coefficient", "share");
             foreach (var f in Features
                 .OrderByDescending(f => IsDegenerate ? 0.0 : Math.Abs(f.Percent))
                 .ThenBy(f => f.Index))

--- a/pwiz_tools/Osprey/Osprey.FDR/FeatureContributions.cs
+++ b/pwiz_tools/Osprey/Osprey.FDR/FeatureContributions.cs
@@ -301,7 +301,7 @@ namespace pwiz.Osprey.FDR
             // model view. The raw standardized coefficient is kept alongside for the
             // Compare-Peaks-style read of how the composite score was built.
             yield return "  Model sanity check -- feature share of target-decoy separation (trained linear model, coefficients standardized):";
-            yield return string.Format("    {0,-36} {1,12} {2,9}", "feature", "coefficient", "share");
+            yield return string.Format("    {0,-36} {1,12} {2,9}", "feature", "coefficient", "share (%)");
             foreach (var f in Features
                 .OrderByDescending(f => IsDegenerate ? 0.0 : Math.Abs(f.Percent))
                 .ThenBy(f => f.Index))

--- a/pwiz_tools/Osprey/Osprey.FDR/PercolatorFdr.cs
+++ b/pwiz_tools/Osprey/Osprey.FDR/PercolatorFdr.cs
@@ -419,6 +419,10 @@ namespace pwiz.Osprey.FDR
             var foldModels = new LinearSvmClassifier[config.NFolds];
             var foldIterations = new int[config.NFolds];
             var foldElapsed = new double[config.NFolds];
+            // Selected SVM cost C per fold (chosen by inner CV over config.CValues,
+            // the log-scale sweep grid). Reported on the default console after
+            // training so the coefficients above have context (issue #4364).
+            var foldBestC = new double[config.NFolds];
 
             // Pre-compute training indices for each fold (cheap, single-threaded).
             var foldTrainIndices = new int[config.NFolds][];
@@ -462,11 +466,13 @@ namespace pwiz.Osprey.FDR
             {
                 var swFold = Stopwatch.StartNew();
                 int iters;
+                double foldC;
                 foldModels[fold] = TrainFold(
                     subFeatures, subLabels, subEntryIds, subPeptides,
                     foldTrainIndices[fold], initialScores, config, trainFdr,
-                    svmScratchPool, fold, trainProgress, out iters);
+                    svmScratchPool, fold, trainProgress, out iters, out foldC);
                 foldIterations[fold] = iters;
+                foldBestC[fold] = foldC;
                 swFold.Stop();
                 foldElapsed[fold] = swFold.Elapsed.TotalSeconds;
             });
@@ -479,6 +485,18 @@ namespace pwiz.Osprey.FDR
             }
             OspreyOutput.Out.WriteLine("[TIMING]   Percolator train all folds (parallel): {0:F1}s",
                 swTrain.Elapsed.TotalSeconds);
+
+            // Selected SVM regularization C per fold, on the default console (issue
+            // #4364): C controls the SVM margin, so the trained coefficients above are
+            // only interpretable with it. C is chosen per fold by inner cross-validation
+            // from a log-scale sweep grid; report the grid and each fold's pick.
+            OspreyOutput.Out.WriteLine("  SVM regularization C (swept over {0}, chosen by cross-validation per fold):",
+                FormatCGrid(config.CValues));
+            for (int fold = 0; fold < config.NFolds; fold++)
+            {
+                OspreyOutput.Out.WriteLine("    fold {0}/{1}: C = {2}",
+                    fold + 1, config.NFolds, FormatC(foldBestC[fold]));
+            }
 
             // Stage 5 SVM-internals dump. Gated by OSPREY_DUMP_SVM_WEIGHTS;
             // a *Only request returns the abort sentinel. Captures per-fold
@@ -977,10 +995,17 @@ namespace pwiz.Osprey.FDR
             SvmTrainScratchPool svmScratchPool,
             int foldIndex,
             TrainProgressReporter progress,
-            out int bestIteration)
+            out int bestIteration,
+            out double bestC)
         {
             int nFeatures = stdFeatures.Cols;
             var currentScores = (double[])initialScores.Clone();
+            // The C (SVM cost / margin) of the winning iteration's model. Tracked
+            // alongside bestModel so Stage 5 can report the selected regularization
+            // on the default console (issue #4364): C is swept in log steps per
+            // GridSearchC and chosen by inner CV each iteration, so the fold's C is
+            // whichever iteration's model became bestModel below.
+            bestC = 1.0;
 
             // Rent one scratch for this outer fold's sequential Train calls
             // (the final per-iteration Train at the bottom of the loop). The
@@ -1061,14 +1086,14 @@ namespace pwiz.Osprey.FDR
                 var svmFoldAssignments = CreateStratifiedFoldsByPeptide(
                     svmLabels, svmPeptides, svmEntryIds, config.NFolds);
 
-                double bestC = GridSearchC(
+                double bestC1 = GridSearchC(
                     svmFeatures, svmLabels, svmEntryIds,
                     config.CValues, svmFoldAssignments, config.NFolds,
                     config.Seed, trainFdr, svmScratchPool);
 
                 // iii. Train SVM with best C
                 var model = LinearSvmClassifier.Train(
-                    svmFeatures, svmLabels, bestC, config.Seed, foldScratch);
+                    svmFeatures, svmLabels, bestC1, config.Seed, foldScratch);
 
                 // iv. Score ALL training set entries with new model
                 // trainFeatures is live just for the DecisionFunction call;
@@ -1105,6 +1130,7 @@ namespace pwiz.Osprey.FDR
                     bestModel = model;
                     bestPassing = nPassing;
                     bestIteration = iteration + 1;
+                    bestC = bestC1;
                     consecutiveNoImprove = 0;
                 }
                 else
@@ -2406,12 +2432,41 @@ namespace pwiz.Osprey.FDR
         }
 
         /// <summary>
+        /// Format a single SVM cost C for the console using the invariant culture
+        /// (a numeric value, not localizable text), with the general "R" round-trip
+        /// so grid values like 0.001 / 100 print exactly rather than as 1E-03.
+        /// </summary>
+        private static string FormatC(double c)
+        {
+            return c.ToString("R", CultureInfo.InvariantCulture);
+        }
+
+        /// <summary>
+        /// Format the log-scale C sweep grid as "{a, b, c}" for the console header.
+        /// </summary>
+        private static string FormatCGrid(double[] cValues)
+        {
+            if (cValues == null || cValues.Length == 0)
+                return "{}";
+            var parts = new string[cValues.Length];
+            for (int i = 0; i < cValues.Length; i++)
+                parts[i] = FormatC(cValues[i]);
+            return "{" + string.Join(", ", parts) + "}";
+        }
+
+        /// <summary>
         /// Writes the feature-contribution table (<see cref="FeatureContributions.ToReportLines"/>)
         /// to <c>OspreyOutput.Out</c> after Stage 5 training -- one row per line so each
         /// keeps its own log timestamp prefix. Pure reporting; never moves q-values.
+        /// Gated behind <c>--verbose</c> (<see cref="OspreyOutput.Verbose"/>): the table is
+        /// a model sanity check for implementers, not default-console output (per issue
+        /// #4364 -- the raw coefficients aren't comparable on magnitude alone and the L2
+        /// SVM splits signal across correlated scores, so it should not be emphasized).
         /// </summary>
         private static void EmitFeatureContributions(FeatureContributions contributions)
         {
+            if (!OspreyOutput.Verbose)
+                return;
             foreach (string line in contributions.ToReportLines())
                 OspreyOutput.Out.WriteLine(line);
         }

--- a/pwiz_tools/Osprey/Osprey.Scoring/ScoringPipeline.cs
+++ b/pwiz_tools/Osprey/Osprey.Scoring/ScoringPipeline.cs
@@ -169,10 +169,11 @@ namespace pwiz.Osprey.Scoring
                 // best-peak picks per Stellar file.
                 double mad = context.OriginalRtMad ?? rtCalibration.Stats().MAD;
                 double robustSd = mad * 1.4826;
-                double rtToleranceMad = robustSd * 3.0;
-                rtToleranceGlobal = Math.Max(
-                    config.RtCalibration.MinRtTolerance,
-                    Math.Min(config.RtCalibration.MaxRtTolerance, rtToleranceMad));
+                // Shared definition of the final search-window half-width so the
+                // scoring path, the persisted calibration JSON, and the console
+                // calibration summary all report the same number (issue #4364).
+                rtToleranceGlobal = RTCalibration.SearchWindowHalfWidth(
+                    mad, config.RtCalibration.MinRtTolerance, config.RtCalibration.MaxRtTolerance);
                 rtSigmaGlobal = Math.Max(robustSd * 5.0, 0.1);
                 if (OspreyOutput.Verbose) _logInfo(string.Format(
                     "Coelution search RT tolerance: {0:F2} min (3*MAD*1.4826, MAD={1:F3}{2})",

--- a/pwiz_tools/Osprey/Osprey.Tasks/Calibrator.cs
+++ b/pwiz_tools/Osprey/Osprey.Tasks/Calibrator.cs
@@ -129,8 +129,12 @@ namespace pwiz.Osprey.Tasks
             // metadata caller in a known state. Overwritten on success.
             numSampledPrecursors = 0;
             // The wide pre-calibration RT tolerance (the "before" number in the
-            // console summary's before-vs-after RT window). Set once initialTolerance
-            // is computed below; 0 on the no-target early return.
+            // console summary's before-vs-after RT window). Defaults to 0 to keep the
+            // out-parameter assigned on any early exit before the initial tolerance is
+            // computed below; every return path that runs past that point carries the
+            // computed value (the no-target return happens after it is set, and the
+            // caller ignores it then since RunCalibration returns null and emits no
+            // summary).
             initialRtTolerance = 0.0;
             _ctx.LogInfo("Running RT calibration...");
 

--- a/pwiz_tools/Osprey/Osprey.Tasks/Calibrator.cs
+++ b/pwiz_tools/Osprey/Osprey.Tasks/Calibrator.cs
@@ -121,12 +121,17 @@ namespace pwiz.Osprey.Tasks
             ScoringContext context,
             out MzCalibrationResult ms1Calibration,
             out MzCalibrationResult ms2Calibration,
-            out int numSampledPrecursors)
+            out int numSampledPrecursors,
+            out double initialRtTolerance)
         {
             var config = context.Config;
             // Default to 0 so early returns / exception paths leave the
             // metadata caller in a known state. Overwritten on success.
             numSampledPrecursors = 0;
+            // The wide pre-calibration RT tolerance (the "before" number in the
+            // console summary's before-vs-after RT window). Set once initialTolerance
+            // is computed below; 0 on the no-target early return.
+            initialRtTolerance = 0.0;
             _ctx.LogInfo("Running RT calibration...");
 
             // Calculate library and mzML RT ranges
@@ -176,6 +181,7 @@ namespace pwiz.Osprey.Tasks
 
             double toleranceFraction = rangesSimilar ? 0.2 : 0.5;
             double initialTolerance = mzmlRtRange * toleranceFraction;
+            initialRtTolerance = initialTolerance;
 
             _ctx.LogVerbose(string.Format("Initial RT tolerance: {0:F1} min", initialTolerance));
 

--- a/pwiz_tools/Osprey/Osprey.Tasks/PerFileScoringTask.cs
+++ b/pwiz_tools/Osprey/Osprey.Tasks/PerFileScoringTask.cs
@@ -25,6 +25,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
@@ -1397,6 +1398,10 @@ namespace pwiz.Osprey.Tasks
             RTCalibration rtCalibration = null;
             ms2Cal = MzCalibrationResult.Uncalibrated();
             ms1Cal = MzCalibrationResult.Uncalibrated();
+            // The wide pre-calibration RT tolerance (the "before" number in the
+            // console calibration summary). Set by the compute path below; stays 0
+            // when calibration is loaded from a cached JSON (no summary emitted then).
+            double calInitialRtTolerance = 0.0;
             // Total matches scored during pass 1 of calibration; threaded
             // into CalibrationMetadata.NumSampledPrecursors to match Rust's
             // accumulated_matches.len() (Stellar Single: 192289). Stays 0
@@ -1456,12 +1461,21 @@ namespace pwiz.Osprey.Tasks
                 var swCal = Stopwatch.StartNew();
                 rtCalibration = new Calibrator(ctx).RunCalibration(
                     fullLibrary, spectra, ms1Spectra, context,
-                    out ms1Cal, out ms2Cal, out numSampledPrecursorsForMetadata);
+                    out ms1Cal, out ms2Cal, out numSampledPrecursorsForMetadata,
+                    out calInitialRtTolerance);
                 swCal.Stop();
                 int nPoints = rtCalibration != null ? rtCalibration.Stats().NPoints : 0;
                 ctx.LogInfo(string.Format(
                     "[TIMING] RT calibration: {0:F1}s ({1} calibration points)",
                     swCal.Elapsed.TotalSeconds, nPoints));
+
+                // Curated calibration summary on the DEFAULT console (issue #4364):
+                // the RT window before vs. after, the final search-window half-width
+                // (and how fast/usable that makes the search), and the MS1/MS2 mass
+                // corrections + applied tolerances. The detailed per-pass lines stay
+                // at --verbose inside the Calibrator.
+                EmitCalibrationSummary(ctx, config, fileName,
+                    rtCalibration, ms1Cal, ms2Cal, calInitialRtTolerance);
             }
 
             // Dump 11 calibration summary scalars (MS1/MS2 mean/sd/count/
@@ -1495,7 +1509,11 @@ namespace pwiz.Osprey.Tasks
                     },
                     Ms1Calibration = MzCalibrationJson.FromResult(ms1Cal),
                     Ms2Calibration = MzCalibrationJson.FromResult(ms2Cal),
-                    RtCalibration = RTCalibrationJson.FromRTCalibration(rtCalibration),
+                    // Persist the final RT search-window half-width too (issue #4364)
+                    // so the JSON records the value the console highlights; pass the
+                    // config's RT-tolerance clamps used at scoring time.
+                    RtCalibration = RTCalibrationJson.FromRTCalibration(rtCalibration,
+                        config.RtCalibration.MinRtTolerance, config.RtCalibration.MaxRtTolerance),
                     SecondPassRt = null
                 };
                 // ArtifactPaths.ResolveOutputDir routes the calibration JSON to
@@ -1511,6 +1529,69 @@ namespace pwiz.Osprey.Tasks
             }
 
             return rtCalibration;
+        }
+
+        /// <summary>
+        /// Emit the curated per-file calibration summary on the DEFAULT console
+        /// (issue #4364). One compact block flagging the RT window before vs. after
+        /// calibration (initial wide tolerance -> final search-window half-width),
+        /// a fit-quality number (MAD / residual SD / R^2 / n), and the MS1/MS2
+        /// systematic mass corrections with their applied tolerance windows and
+        /// units. This is Mike's "is the AI library usable / how fast will the
+        /// search be" sanity check. The detailed per-pass lines stay at --verbose
+        /// inside the Calibrator; this promotes only the summary. Numeric values are
+        /// formatted with the invariant culture (fixed decimals), not localizable
+        /// text. Called only on the compute path (a loaded cal JSON is silent).
+        /// </summary>
+        private static void EmitCalibrationSummary(
+            PipelineContext ctx, OspreyConfig config, string fileName,
+            RTCalibration rtCalibration,
+            MzCalibrationResult ms1Cal, MzCalibrationResult ms2Cal,
+            double initialRtTolerance)
+        {
+            var ic = CultureInfo.InvariantCulture;
+            ctx.LogInfo(string.Format(ic, "Calibration summary [{0}]:", fileName));
+
+            if (rtCalibration == null)
+            {
+                ctx.LogInfo("  RT: calibration failed - using fallback RT tolerance");
+            }
+            else
+            {
+                var stats = rtCalibration.Stats();
+                double finalHalfWidth = RTCalibration.SearchWindowHalfWidth(
+                    stats.MAD, config.RtCalibration.MinRtTolerance, config.RtCalibration.MaxRtTolerance);
+                ctx.LogInfo(string.Format(ic,
+                    "  RT window: {0:F2} min before -> {1:F2} min (+/-) search half-width after calibration",
+                    initialRtTolerance, finalHalfWidth));
+                ctx.LogInfo(string.Format(ic,
+                    "  RT fit: MAD={0:F3} min, residual SD={1:F3} min, R^2={2:F4}, n={3} points",
+                    stats.MAD, stats.ResidualSD, stats.RSquared, stats.NPoints));
+            }
+
+            EmitMassCalibrationLine(ctx, "MS1", ms1Cal);
+            EmitMassCalibrationLine(ctx, "MS2", ms2Cal);
+        }
+
+        /// <summary>
+        /// One console line for an MS1/MS2 mass calibration in the summary block:
+        /// systematic correction (mean offset), SD, and the applied tolerance window
+        /// (|mean| + 3*SD), all in the calibration's unit. Reports "not calibrated"
+        /// when the level had no usable errors.
+        /// </summary>
+        private static void EmitMassCalibrationLine(
+            PipelineContext ctx, string level, MzCalibrationResult cal)
+        {
+            var ic = CultureInfo.InvariantCulture;
+            if (cal == null || !cal.Calibrated)
+            {
+                ctx.LogInfo(string.Format(ic, "  {0} mass: not calibrated", level));
+                return;
+            }
+            double tolerance = cal.AdjustedTolerance ?? (Math.Abs(cal.Mean) + 3.0 * cal.SD);
+            ctx.LogInfo(string.Format(ic,
+                "  {0} mass: correction={1:F2} {2}, SD={3:F2} {2}, tolerance=+/-{4:F2} {2} ({5} errors)",
+                level, cal.Mean, cal.Unit, cal.SD, tolerance, cal.Count));
         }
 
         /// <summary>

--- a/pwiz_tools/Osprey/Osprey.Test/CalibrationTest.cs
+++ b/pwiz_tools/Osprey/Osprey.Test/CalibrationTest.cs
@@ -470,7 +470,9 @@ namespace pwiz.Osprey.Test
                         AbsResiduals = new[] { 0.1, 0.2, 0.3, 0.4 }
                     },
                     P20AbsResidual = 0.15,
-                    MAD = 0.12
+                    MAD = 0.12,
+                    // Final RT search-window half-width persisted per issue #4364.
+                    RtSearchWindowHalfWidth = 1.5
                 }
             };
 
@@ -480,6 +482,7 @@ namespace pwiz.Osprey.Test
 
             Assert.IsTrue(json.Contains("\"ms1_calibration\""));
             Assert.IsTrue(json.Contains("-2.5"));
+            Assert.IsTrue(json.Contains("\"rt_search_window_halfwidth\""));
 
             // Deserialize back
             var loaded = Newtonsoft.Json.JsonConvert.DeserializeObject<CalibrationParams>(json);
@@ -488,6 +491,55 @@ namespace pwiz.Osprey.Test
             Assert.AreEqual(RTCalibrationMethod.LOESS, loaded.RtCalibration.Method);
             Assert.IsNotNull(loaded.RtCalibration.ModelParams);
             Assert.AreEqual(4, loaded.RtCalibration.ModelParams.LibraryRts.Length);
+            Assert.IsTrue(loaded.RtCalibration.RtSearchWindowHalfWidth.HasValue);
+            Assert.AreEqual(1.5, loaded.RtCalibration.RtSearchWindowHalfWidth.Value, TOLERANCE);
+        }
+
+        /// <summary>
+        /// The final RT search-window half-width is the single shared definition
+        /// <c>clamp(3 * MAD * 1.4826, [min, max])</c> used by the scoring path, the
+        /// persisted JSON, and the console summary (issue #4364). Verifies the clamp
+        /// and that FromRTCalibration only persists the field when the clamps are
+        /// supplied.
+        /// </summary>
+        [TestMethod]
+        public void TestRtSearchWindowHalfWidth()
+        {
+            // 3 * 1.4826 * MAD, unclamped when inside [min, max].
+            double mad = 0.30;
+            double expected = 3.0 * mad * 1.4826; // ~1.334
+            Assert.AreEqual(expected,
+                RTCalibration.SearchWindowHalfWidth(mad, 0.5, 3.0), TOLERANCE);
+
+            // Clamped up to the min floor for a tiny MAD.
+            Assert.AreEqual(0.5,
+                RTCalibration.SearchWindowHalfWidth(0.001, 0.5, 3.0), TOLERANCE);
+
+            // Clamped down to the max ceiling for a large MAD.
+            Assert.AreEqual(3.0,
+                RTCalibration.SearchWindowHalfWidth(5.0, 0.5, 3.0), TOLERANCE);
+
+            // Fit a small calibration and confirm FromRTCalibration persists the
+            // window only when the clamps are supplied.
+            double[] libraryRts = new double[50];
+            double[] measuredRts = new double[50];
+            for (int i = 0; i < 50; i++)
+            {
+                libraryRts[i] = i;
+                measuredRts[i] = 2.0 * i + 5.0;
+            }
+            var cal = new RTCalibrator(
+                new RTCalibratorConfig { Bandwidth = 0.3, OutlierRetention = 1.0 })
+                .Fit(libraryRts, measuredRts);
+
+            var withoutClamps = RTCalibrationJson.FromRTCalibration(cal);
+            Assert.IsFalse(withoutClamps.RtSearchWindowHalfWidth.HasValue);
+
+            var withClamps = RTCalibrationJson.FromRTCalibration(cal, 0.5, 3.0);
+            Assert.IsTrue(withClamps.RtSearchWindowHalfWidth.HasValue);
+            Assert.AreEqual(
+                RTCalibration.SearchWindowHalfWidth(cal.Stats().MAD, 0.5, 3.0),
+                withClamps.RtSearchWindowHalfWidth.Value, TOLERANCE);
         }
 
         /// <summary>

--- a/pwiz_tools/Osprey/Osprey.Test/FdrTest.cs
+++ b/pwiz_tools/Osprey/Osprey.Test/FdrTest.cs
@@ -406,28 +406,45 @@ namespace pwiz.Osprey.Test
             };
 
             string report;
+            string defaultReport;
             PercolatorResults results;
             var savedOut = OspreyOutput.Out;
+            bool savedVerbose = OspreyOutput.Verbose;
             try
             {
+                // Default console (verbose off): the model sanity-check table must NOT
+                // appear -- it is gated behind --verbose (issue #4364).
+                var defaultCapture = new StringWriter();
+                OspreyOutput.Out = defaultCapture;
+                OspreyOutput.Verbose = false;
+                PercolatorFdr.RunPercolator(entries, config);
+                defaultReport = defaultCapture.ToString();
+
+                // Verbose console: the table is emitted.
                 var capture = new StringWriter();
                 OspreyOutput.Out = capture;
+                OspreyOutput.Verbose = true;
                 results = PercolatorFdr.RunPercolator(entries, config);
                 report = capture.ToString();
             }
             finally
             {
                 OspreyOutput.Out = savedOut;
+                OspreyOutput.Verbose = savedVerbose;
             }
 
-            // The contribution decomposition is surfaced on the results.
+            // The contribution decomposition is surfaced on the results regardless of
+            // the verbose gate (the gate only controls the printed table).
             Assert.IsNotNull(results.FeatureContributions);
             var features = results.FeatureContributions.Features;
             Assert.AreEqual(3, features.Count);
 
-            // The human-readable block is present.
+            // The model sanity-check block appears only under --verbose, reframed away
+            // from importance/weight wording (issue #4364).
             StringAssert.Contains(report,
-                "Feature weight contributions (trained linear model");
+                "Model sanity check -- feature share of target-decoy separation");
+            Assert.IsFalse(defaultReport.Contains("Model sanity check"),
+                "the feature share table must be gated behind --verbose");
 
             // Parse the percent column from the three feature rows. The table rows
             // are "<4 spaces><label><coefficient F4><percent F1>%"; match on the


### PR DESCRIPTION
## Summary

* Promoted a curated per-file calibration summary to the **default** console: the RT window before vs after calibration (initial wide tolerance → final search-window half-width), a fit-quality line (MAD / residual SD / R² / n), and the MS1/MS2 systematic mass corrections with their applied tolerance windows and units. The detailed per-pass lines stay at `--verbose`. (Mike's "is the AI library usable / how fast will the search be" sanity check.)
* Restored the selected **per-fold SVM regularization `C`** (and the log-scale sweep grid it was chosen from) to the default console after Stage 5 training — the standardized coefficients aren't interpretable without it.
* **Gated the Percolator feature-contribution table behind `--verbose`** and reframed it as a *model sanity check* (each feature's share of target-decoy separation), keeping both the coefficient and signed-percent columns and the unexpected-direction flag.
* **Closed the RT-window JSON gap**: the final RT search-window half-width is now persisted in the calibration JSON via a single shared `RTCalibration.SearchWindowHalfWidth` definition used by the scoring path, the JSON, and the console, so all three report the same number. The scoring-path refactor to that helper is value-preserving (identical clamp of `3·MAD·1.4826`).

Item 5 (correlated-score diagnostics) is intentionally deferred (open design).

Requested by Michael.

Fixes #4364

## Test plan

- [x] Osprey.Test (448 pass) incl. `TestRtSearchWindowHalfWidth` (clamp + JSON persistence) and the updated feature-contribution test (verbose gate + reframed heading); ReSharper inspection 0 new warnings
- [x] `regression.ps1 -Dataset Stellar` — mode1 (vs golden) / mode2 / mode3 all PASS; blib byte-identical (52,514,816 bytes) — reporting-only, no scored-output change
- [ ] TeamCity Osprey Windows .NET Perf/Regression (Stellar + Astral) — triggered on `pull/<N>`

Note: Osprey has no `.resx`/localization today (all console text is plain literals — a deliberate future swap noted in `OspreyCommandArgs`); new numeric output uses `InvariantCulture`, so there is no `Func<string>` static-capture risk and `-Language all` does not apply to the Osprey MSTest suite.

Co-Authored-By: Claude <noreply@anthropic.com>
