### PR TITLE
Support non-1:1 (partial) entrapment in Osprey --model-diagnostics

### DIFF
--- a/pwiz_tools/Osprey/Osprey.FDR/ModelDiagnostics/ModelDiagnosticsData.cs
+++ b/pwiz_tools/Osprey/Osprey.FDR/ModelDiagnostics/ModelDiagnosticsData.cs
@@ -189,9 +189,10 @@ namespace pwiz.Osprey.FDR.ModelDiagnostics
             /// OR when the entrapment library is not ~1:1 (see <see cref="PairedSuppressedPartial"/>).</summary>
             public double[] Paired { get; set; }
             /// <summary>True when the paired estimator was suppressed because the entrapment
-            /// library is not ~1:1 (r != 1). The paired estimator is a 1-fold method
-            /// (FDRBench / Wen et al. 2025): it is only valid when every target has exactly
-            /// one entrapment twin. Combined and lower-bound remain valid at any ratio.</summary>
+            /// library is not ~1:1 (|r - 1| exceeds <see cref="PairedRatioTolerance"/>). The
+            /// paired estimator is a 1-fold method (FDRBench / Wen et al. 2025): it is only
+            /// valid when every target has exactly one entrapment twin. Combined and
+            /// lower-bound remain valid at any ratio.</summary>
             public bool PairedSuppressedPartial { get; set; }
             public int[] NTargetAccepted { get; set; }
         }

--- a/pwiz_tools/Osprey/Osprey.FDR/ModelDiagnostics/ModelDiagnosticsData.cs
+++ b/pwiz_tools/Osprey/Osprey.FDR/ModelDiagnostics/ModelDiagnosticsData.cs
@@ -185,8 +185,14 @@ namespace pwiz.Osprey.FDR.ModelDiagnostics
             public double[] Q { get; set; }
             public double[] LowerBound { get; set; }
             public double[] Combined { get; set; }
-            /// <summary>FDRBench paired estimator, or null when no pair_index was supplied.</summary>
+            /// <summary>FDRBench paired estimator, or null when no pair_index was supplied
+            /// OR when the entrapment library is not ~1:1 (see <see cref="PairedSuppressedPartial"/>).</summary>
             public double[] Paired { get; set; }
+            /// <summary>True when the paired estimator was suppressed because the entrapment
+            /// library is not ~1:1 (r != 1). The paired estimator is a 1-fold method
+            /// (FDRBench / Wen et al. 2025): it is only valid when every target has exactly
+            /// one entrapment twin. Combined and lower-bound remain valid at any ratio.</summary>
+            public bool PairedSuppressedPartial { get; set; }
             public int[] NTargetAccepted { get; set; }
         }
 
@@ -785,6 +791,13 @@ namespace pwiz.Osprey.FDR.ModelDiagnostics
             return tot > 0 ? (double)win / tot : double.NaN;
         }
 
+        // The paired estimator (FDRBench / Wen et al. 2025) is a strictly 1-fold
+        // method: it is only valid when every target carries exactly one entrapment
+        // twin (r = 1). Beyond this tolerance the paired curve is suppressed; combined
+        // and lower-bound carry the r term and stay valid at any ratio (e.g. a routine
+        // 10% entrapment overlay, r = 0.1).
+        private const double PairedRatioTolerance = 0.05;
+
         // Build one calibration view: entrapment FDP estimators vs the selected
         // Osprey q-value axis, best-per-precursor, walked down the score ranking.
         // Reproduces FDRBench's fdp.csv when qSel is the experiment-precursor q
@@ -906,6 +919,10 @@ namespace pwiz.Osprey.FDR.ModelDiagnostics
             // (so the plotted curve and the 1%-q metrics stay faithful to the
             // per-precursor FDRBench values) and subsample only the long tail.
             var idx = ThinFdpIndices(qs);
+            // The paired estimator is 1-fold only; suppress it for partial (r != 1)
+            // entrapment libraries so a nonsensical paired curve is never shown. The
+            // template surfaces PairedSuppressedPartial as a note.
+            bool pairedOk = anyPair && Math.Abs(r - 1.0) <= PairedRatioTolerance;
             return new FdpView
             {
                 Label = label,
@@ -916,7 +933,8 @@ namespace pwiz.Osprey.FDR.ModelDiagnostics
                 Q = Pick(qs, idx),
                 LowerBound = Pick(lb, idx),
                 Combined = Pick(comb, idx),
-                Paired = anyPair ? Pick(paired, idx) : null,
+                Paired = pairedOk ? Pick(paired, idx) : null,
+                PairedSuppressedPartial = anyPair && !pairedOk,
                 NTargetAccepted = Pick(ntAcc, idx),
             };
         }

--- a/pwiz_tools/Osprey/Osprey.Tasks/ModelDiagnostics/model-diagnostics-template.html
+++ b/pwiz_tools/Osprey/Osprey.Tasks/ModelDiagnostics/model-diagnostics-template.html
@@ -588,7 +588,7 @@ if(D.fdpViews && D.fdpViews.length){
         ? "<b>Reproduces the FDRBench plot</b> — x is Osprey's <b>experiment-wide precursor</b> q, the exact value <code>--fdrbench</code> hands to FDRBench (which only counts entrapment on it). No FDRBench install needed. "
         : "<b>Per-run view</b> (new) — x is Osprey's <b>per-run precursor</b> q; FDRBench collapses runs so it can't show this. ")
       + "The dashed line is y=x (perfect calibration); the curve above it means the reported q is anti-conservative there. Entrapment DB ratio r = "+fmt(f.entrapmentRatio,2)+"."
-      + (f.pairedSuppressedPartial ? " <b>Paired FDP omitted</b> — it is a 1-fold estimator that needs a ~1:1 entrapment library (r near 1); combined and lower-bound remain valid at this ratio." : "");
+      + (f.pairedSuppressedPartial ? " <b>Paired FDP omitted</b> — it is a 1-fold estimator that needs a ~1:1 entrapment library (r near 1); combined and lower-bound remain valid at this ratio (<a href='https://raw.githack.com/ProteoWizard/pwiz/master/pwiz_tools/Osprey/docs/fractional-entrapment.md' target='_blank' rel='noopener'>why non-1:1 is valid</a>)." : "");
   }
   sel.innerHTML="";
   views.forEach((v,k)=>{const b=H(sel,"button",{class:"vbtn"+(k===0?" on":"")},v.label+(v.matchesFdrBench?"  (= FDRBench)":""));

--- a/pwiz_tools/Osprey/Osprey.Tasks/ModelDiagnostics/model-diagnostics-template.html
+++ b/pwiz_tools/Osprey/Osprey.Tasks/ModelDiagnostics/model-diagnostics-template.html
@@ -588,7 +588,7 @@ if(D.fdpViews && D.fdpViews.length){
         ? "<b>Reproduces the FDRBench plot</b> — x is Osprey's <b>experiment-wide precursor</b> q, the exact value <code>--fdrbench</code> hands to FDRBench (which only counts entrapment on it). No FDRBench install needed. "
         : "<b>Per-run view</b> (new) — x is Osprey's <b>per-run precursor</b> q; FDRBench collapses runs so it can't show this. ")
       + "The dashed line is y=x (perfect calibration); the curve above it means the reported q is anti-conservative there. Entrapment DB ratio r = "+fmt(f.entrapmentRatio,2)+"."
-      + (f.pairedSuppressedPartial ? " <b>Paired FDP omitted</b> — it is a 1-fold estimator that needs a ~1:1 entrapment library (r near 1); combined and lower-bound remain valid at this ratio (<a href='https://raw.githack.com/ProteoWizard/pwiz/master/pwiz_tools/Osprey/docs/fractional-entrapment.md' target='_blank' rel='noopener'>why non-1:1 is valid</a>)." : "");
+      + (f.pairedSuppressedPartial ? " <b>Paired FDP omitted</b> — it is a 1-fold estimator that needs a ~1:1 entrapment library (r near 1); combined and lower-bound remain valid at this ratio (<a href='https://github.com/ProteoWizard/pwiz/blob/master/pwiz_tools/Osprey/docs/fractional-entrapment.md' target='_blank' rel='noopener'>why non-1:1 is valid</a>)." : "");
   }
   sel.innerHTML="";
   views.forEach((v,k)=>{const b=H(sel,"button",{class:"vbtn"+(k===0?" on":"")},v.label+(v.matchesFdrBench?"  (= FDRBench)":""));

--- a/pwiz_tools/Osprey/Osprey.Tasks/ModelDiagnostics/model-diagnostics-template.html
+++ b/pwiz_tools/Osprey/Osprey.Tasks/ModelDiagnostics/model-diagnostics-template.html
@@ -587,12 +587,13 @@ if(D.fdpViews && D.fdpViews.length){
       (f.matchesFdrBench
         ? "<b>Reproduces the FDRBench plot</b> — x is Osprey's <b>experiment-wide precursor</b> q, the exact value <code>--fdrbench</code> hands to FDRBench (which only counts entrapment on it). No FDRBench install needed. "
         : "<b>Per-run view</b> (new) — x is Osprey's <b>per-run precursor</b> q; FDRBench collapses runs so it can't show this. ")
-      + "The dashed line is y=x (perfect calibration); the curve above it means the reported q is anti-conservative there. Entrapment DB ratio r = "+fmt(f.entrapmentRatio,2)+".";
+      + "The dashed line is y=x (perfect calibration); the curve above it means the reported q is anti-conservative there. Entrapment DB ratio r = "+fmt(f.entrapmentRatio,2)+"."
+      + (f.pairedSuppressedPartial ? " <b>Paired FDP omitted</b> — it is a 1-fold estimator that needs a ~1:1 entrapment library (r near 1); combined and lower-bound remain valid at this ratio." : "");
   }
   sel.innerHTML="";
   views.forEach((v,k)=>{const b=H(sel,"button",{class:"vbtn"+(k===0?" on":"")},v.label+(v.matchesFdrBench?"  (= FDRBench)":""));
     b.onclick=()=>{vi=k;sel.querySelectorAll("button").forEach(x=>x.classList.remove("on"));b.classList.add("on");render();};});
-  legend(document.getElementById("fdpLegend"),series.map(se=>({name:se.name,color:se.color,toggle:o=>{off[se.k]=o;render();}})));
+  legend(document.getElementById("fdpLegend"),series.filter(se=>views.some(v=>v[se.key])).map(se=>({name:se.name,color:se.color,toggle:o=>{off[se.k]=o;render();}})));
   render();
   // Print-only: render ALL views so the PDF captures every FDR plot, not just the
   // one selected on screen. Reuses drawPanel; a per-view title + 1%-q summary line.

--- a/pwiz_tools/Osprey/Osprey.Test/ModelDiagnosticsDataTest.cs
+++ b/pwiz_tools/Osprey/Osprey.Test/ModelDiagnosticsDataTest.cs
@@ -45,6 +45,7 @@ namespace pwiz.Osprey.Test
         {
             TestFdpMatchesFdrBenchFormula();
             TestPairedEstimator();
+            TestPairedSuppressedForPartialEntrapment();
             TestClassCountsAndDegrade();
             TestWinFractionCoinVsSignal();
             TestFeatureTableContributions();
@@ -250,6 +251,44 @@ namespace pwiz.Osprey.Test
             Assert.AreEqual(2.0 / 6.0, fdp.LowerBound[last], 1e-9);
             // Paired sits at or above lower-bound once an entrapment ranks above its pair.
             Assert.IsTrue(fdp.Paired[last] >= fdp.LowerBound[last]);
+            // r == 1 (balanced 1-fold library): paired is shown, not suppressed.
+            Assert.IsFalse(fdp.PairedSuppressedPartial);
+        }
+
+        // A partial (non-1:1) entrapment library -- e.g. a routine 10% overlay,
+        // r != 1 -- must SUPPRESS the paired estimator (it is 1-fold only) while
+        // combined and lower-bound stay valid and r-aware. Same fixture as
+        // TestPairedEstimator, built with r = 0.1.
+        private static void TestPairedSuppressedForPartialEntrapment()
+        {
+            var entries = new List<FdrEntry>();
+            var cls = new Dictionary<uint, EntrapmentClass>();
+            var pair = new Dictionary<uint, uint>();
+            double[] tscores = { 8, 6, 4, 2 };
+            for (int i = 0; i < 4; i++)
+            {
+                entries.Add(Entry((uint)(10 + i), false, tscores[i], 0.001 * (i + 1), "T" + i, 2));
+                cls[(uint)(10 + i)] = EntrapmentClass.Target;
+                pair[(uint)(10 + i)] = (uint)i;
+            }
+            entries.Add(Entry(20, false, 5.0, 0.002, "Pa", 2));
+            cls[20] = EntrapmentClass.PTarget; pair[20] = 100;
+            entries.Add(Entry(21, false, 3.0, 0.003, "Pb", 2));
+            cls[21] = EntrapmentClass.PTarget; pair[21] = 0;
+
+            const double r = 0.1;
+            var data = ModelDiagnosticsData.Build(Wrap(entries), null, cls, pair, r, 0.01, "peptide");
+            var fdp = data.FdpViews.Single(v => v.Scope == "experiment");
+            // Paired is a 1-fold estimator: suppressed (null) and flagged for r != 1.
+            Assert.IsNull(fdp.Paired);
+            Assert.IsTrue(fdp.PairedSuppressedPartial);
+            // Combined and lower-bound stay populated and r-aware. At the last target
+            // n_t = 4, n_p = 2: combined = (1 + 1/r)*2/(4+2), lower = 2/(r*(4+2)).
+            Assert.IsNotNull(fdp.Combined);
+            Assert.IsNotNull(fdp.LowerBound);
+            int last = fdp.Combined.Length - 1;
+            Assert.AreEqual((1.0 + 1.0 / r) * 2.0 / 6.0, fdp.Combined[last], 1e-9);
+            Assert.AreEqual(2.0 / (r * 6.0), fdp.LowerBound[last], 1e-9);
         }
 
         // combined = (1 + 1/r) * n_p / (n_t + n_p); lower = n_p / (r*(n_t+n_p)).

--- a/pwiz_tools/Osprey/docs/fractional-entrapment.md
+++ b/pwiz_tools/Osprey/docs/fractional-entrapment.md
@@ -1,0 +1,126 @@
+# Fractional entrapment for FDR-accuracy diagnostics
+
+Osprey's `--model-diagnostics` report estimates the true false-discovery proportion
+(FDP) of a search from an *entrapment* set — known-absent sequences (e.g. peptides
+from a foreign species) mixed into the searched library, whose reported hits reveal
+how well the reported q-values control the real error rate.
+
+The entrapment set does **not** have to be the same size as the target set. Osprey
+supports a *fractional* entrapment ratio — for example a routine **10% overlay**
+(entrapment:target ratio `r ≈ 0.1`) — which measures the FDP at a fraction of the
+detection cost of a full 1:1 (`r = 1`) entrapment library. This note explains why a
+non-1:1 ratio still yields a valid estimate, so the calibration curve in the report
+can be trusted (and cited) when `r ≠ 1`.
+
+## The estimator is ratio-corrected, so any ratio is valid
+
+Entrapment error estimation counts how often a known-false marker is reported above a
+score threshold and scales that count by the marker-to-target database-size ratio.
+The ratio is carried explicitly in the estimator, so any ratio is admissible as long
+as it is accounted for. With `N_T`, `N_E` the target and entrapment discoveries and
+`r = |E| / |T|` the entrapment:target size ratio, the **combined** upper-bound
+estimator is
+
+    FDP = (1 + 1/r) · N_E / (N_T + N_E)
+
+`r` is a free parameter; the `1/r` term is the ratio correction. Its only assumption
+is the ratio-aware *equal-chance* condition — that an incorrect match lands on a
+target or a marker in proportion to their database sizes — which does not depend on
+`r`. The **lower-bound** estimator, `N_E / (N_T + N_E)`, is likewise valid at any
+ratio (it can only demonstrate a failure of FDR control, never confirm it).
+
+A 1:1 ratio is required **only** for the **paired** estimator, a distinct refinement
+that pairs each target with one unique entrapment twin (so `r = 1`) *and* requires
+that twin be a shuffle or reversal of the target. Foreign-species entrapment has no
+such twin, so the paired estimator does not apply to it at any ratio. Osprey's report
+therefore shows the combined and lower-bound curves at any ratio and suppresses the
+paired curve when the library is not ~1:1.
+
+## Published basis
+
+This is a long-standing, peer-reviewed result, not a new relaxation.
+
+**Fitzgibbon, Li & McIntosh (2008)** derived the ratio-corrected estimator and
+demonstrated the fractional case directly. Writing `k = |target| / |decoy|`:
+
+> "when not of equal size, the fundamental assumption of both PeptideProphet and the
+> classic FIR approach can be stated as: an incorrect hit will match either the decoy
+> or target database in proportion to their size. Specifically, when the relative
+> size of the target to decoy database is k to 1 then
+> **FIR = (k + 1)(no. decoy > x)/(no. total > x)**, which defaults to a more standard
+> calculation when k = 1."
+
+With `k = 1/r`, this is `(1 + 1/r) · N_E / (N_T + N_E)` — algebraically identical to
+the combined estimator above. Their Figure 1D plots yield versus error rate for
+decoy databases at **1/2, 1/4, and 1/10** of the target size (`r` = 0.5, 0.25, 0.1)
+and one 10× larger, and concludes:
+
+> "For decoy databases which are smaller or equal to the target, the overall
+> performance is not highly distinguishable. For the larger database, the yield
+> declines dramatically …"
+
+and that "using equally sized databases … is not a strict requirement," so "using
+smaller ones in situations where [the error rate] can be estimated sufficiently with
+them would be preferred," because larger databases buy precision "with the cost of …
+fewer identifications."
+
+The equal-size *requirement* that is sometimes assumed universal belongs specifically
+to the separate-search q-value formulation of **Käll, Storey, MacCoss & Noble
+(2008)** — the lineage of the *paired* estimator — not to the ratio-corrected
+combined estimator. **Wen et al. (2025)** carry the same split into the entrapment
+setting: their combined estimator is valid at any `r` (the classic-FIR lineage),
+while their paired estimator requires `r = 1` and shuffled twins.
+
+## Validation on the Stellar test dataset
+
+Measuring the combined estimate over a matched foreign-species (*Arabidopsis*)
+entrapment set at several ratios (reported precursor pool, 1% reported q):
+
+| r (entrapment:target) | combined FDP | target detections |
+|---|---|---|
+| 1.00 | 1.05% | 27,931 |
+| 0.50 | 1.14% | 29,536 |
+| 0.25 | 1.09% | 30,141 |
+| 0.10 | 1.15% | 30,654 |
+
+- The estimate is essentially **invariant (~1.1%) across a 10× change in `r`** — the
+  ratio correction behaving exactly as the theory predicts.
+- **Detections are recovered as `r` shrinks** (target detections rise from 27,931 to
+  30,654): at `r = 1` a 50%-marker library perturbs the search and suppresses
+  detections; near `r ≈ 0.1` the analysis is close to native. This is the
+  precision-versus-yield trade-off Fitzgibbon et al. describe, in reverse.
+
+The estimate is also sensitive to marker *realism* independently of ratio: at
+`r = 1`, target-anagram shuffled entrapment reads ~1.6% versus ~1.05% for real
+foreign-species peptides, because shuffled anagrams share the target's amino-acid
+composition and are over-identified. Foreign-species entrapment is the more faithful
+model of the sequences that cause real false identifications.
+
+## Recommendation and caveats
+
+A **~10% foreign-species entrapment overlay**, read through the combined and
+lower-bound estimators, is a low-cost, valid check on the accuracy of Osprey's
+reported FDR: it preserves detections (near-native search) and avoids the doubling of
+a full 1:1 library.
+
+- **Power versus cost.** Smaller `r` means fewer entrapment hits and a noisier
+  estimate; 10% is a pragmatic operating point, not a proven optimum. Read the value
+  as an interval, not a third significant figure.
+- **Marker choice.** The entrapment species must be genuinely absent from the sample
+  (e.g. *Arabidopsis* for human/mammalian samples), homology-filtered against the
+  targets, and matched on precursor m/z so it samples the same difficulty regime.
+
+## References
+
+1. Elias JE, Gygi SP. Target-decoy search strategy for increased confidence in
+   large-scale protein identifications by mass spectrometry. *Nat. Methods* 2007;
+   4(3):207–214.
+2. Fitzgibbon M, Li Q, McIntosh M. Modes of inference for evaluating the confidence
+   of peptide identifications. *J. Proteome Res.* 2008; 7(1):35–39.
+   doi:10.1021/pr7007303.
+3. Käll L, Storey JD, MacCoss MJ, Noble WS. Assigning significance to peptides
+   identified by tandem mass spectrometry using decoy databases. *J. Proteome Res.*
+   2008; 7(1):29–34.
+4. Wen B, Freestone J, Riffle M, et al. Assessment of false discovery rate control in
+   tandem mass spectrometry analysis using entrapment. *Nat. Methods* 2025;
+   22:1454–1463.

--- a/pwiz_tools/Osprey/docs/fractional-entrapment.md
+++ b/pwiz_tools/Osprey/docs/fractional-entrapment.md
@@ -122,6 +122,6 @@ a full 1:1 library.
 3. Käll L, Storey JD, MacCoss MJ, Noble WS. Assigning significance to peptides
    identified by tandem mass spectrometry using decoy databases. *J. Proteome Res.*
    2008; 7(1):29–34.
-4. Wen B, Freestone J, Riffle M, et al. Assessment of false discovery rate control in
-   tandem mass spectrometry analysis using entrapment. *Nat. Methods* 2025;
-   22:1454–1463.
+4. Wen B, Freestone J, Riffle M, MacCoss MJ, Noble WS, Keich U. Assessment of false
+   discovery rate control in tandem mass spectrometry analysis using entrapment.
+   *Nat. Methods* 2025; 22:1454–1463.

--- a/pwiz_tools/Osprey/docs/fractional-entrapment.md
+++ b/pwiz_tools/Osprey/docs/fractional-entrapment.md
@@ -99,6 +99,30 @@ composition (and therefore many fragment masses) and are over-identified.
 Foreign-species entrapment is the more faithful model of the sequences that cause
 real false identifications.
 
+## Why entrapment, and how to read it
+
+Entrapment is an *external* check: unlike the decoys (which are also the null the
+q-values are built on), a foreign-species marker set is an independent estimate of the
+real false-positive population, so it can catch a decoy model that is silently wrong.
+Bernhardt et al. (2016) established this methodology on high-resolution DIA — using a
+foreign proteome (*E. coli*) as a ground-truth negative control, they showed that a
+composition-preserving (scrambled/inverted) decoy matches the control and gives an
+accurate, slightly conservative FDR, whereas an m/z-shifted decoy underestimates the
+FDR while returning the *most* identifications — a mirage. Their lesson is the reason
+this report exists: the number of identifications alone is not evidence a change was
+good; only an independent false-signal control is.
+
+Read the combined estimate **comparatively**, following Wen et al. (2025) and the
+diagFDR reporting framework (Chion et al. 2026):
+
+- `FDP_entrap(α) ≫ α` at the operating cutoff is strong evidence of **anti-conservative**
+  error control — the reported q is optimistic.
+- `FDP_entrap(α) ≈ α` is *consistent with* valid control but is **not proof** of it: an
+  optimistic decoy and a pessimistic entrapment can coincidentally cancel. (In
+  particular, if the entrapment shares whatever manipulation makes the decoys unusual —
+  e.g. both shifted off the target m/z — the two agree while both mis-model real false
+  targets. Keep the entrapment representative and independent of the decoy construction.)
+
 ## Recommendation and caveats
 
 A **~10% foreign-species entrapment overlay**, read through the combined and
@@ -109,9 +133,15 @@ a full 1:1 library.
 - **Power versus cost.** Smaller `r` means fewer entrapment hits and a noisier
   estimate; 10% is a pragmatic operating point, not a proven optimum. Read the value
   as an interval, not a third significant figure.
-- **Marker choice.** The entrapment species must be genuinely absent from the sample
-  (e.g. *Arabidopsis* for human/mammalian samples), homology-filtered against the
-  targets, and matched on precursor m/z so it samples the same difficulty regime.
+- **Marker choice.** The entrapment proteome must be genuinely absent from the sample
+  (e.g. *Arabidopsis* for human/mammalian samples), sufficiently large to yield
+  measurable hits at the operating cutoff, and phylogenetically distant enough to be
+  homology-filtered cleanly against the targets (the three criteria of Chion et al.
+  2026). It should also **model the sequences that cause real false identifications**:
+  match the target precursor-m/z distribution so it samples the same difficulty regime,
+  and — on high-resolution data, where MS1 precursor features carry weight — sit at
+  physically plausible, occupied precursor m/z rather than being shifted off it, so its
+  MS1 behaviour mirrors a true false target rather than an easily-rejected artifact.
 
 ## References
 
@@ -127,3 +157,11 @@ a full 1:1 library.
 4. Wen B, Freestone J, Riffle M, MacCoss MJ, Noble WS, Keich U. Assessment of false
    discovery rate control in tandem mass spectrometry analysis using entrapment.
    *Nat. Methods* 2025; 22:1454–1463.
+5. Bernhardt OM, Bruderer R, Gandhi T, Miladinović SM, Bober M, Ehrenberger T, Rinner O,
+   Reiter L. General guidelines for validation of decoy models for HRM/DIA/SWATH as
+   exemplified using Spectronaut. *Proteomics* 2016 (poster/methods) — foreign-organism
+   (*E. coli*) negative-control validation of decoy models on high-resolution DIA.
+6. Chion M, Godmer A, Douché T, Matondo M, Giai Gianetto Q. diagFDR: verifiable FDR
+   reporting in proteomics via scope, calibration, and stability diagnostics. *bioRxiv*
+   2026; doi:10.64898/2026.04.16.718468. (Formalizes the equal-chance assumption and the
+   comparative interpretation of entrapment-based FDP.)

--- a/pwiz_tools/Osprey/docs/fractional-entrapment.md
+++ b/pwiz_tools/Osprey/docs/fractional-entrapment.md
@@ -78,23 +78,24 @@ entrapment set at several ratios (reported precursor pool, 1% reported q):
 
 | r (entrapment:target) | combined FDP | target detections |
 |---|---|---|
-| 1.00 | 1.05% | 27,931 |
-| 0.50 | 1.14% | 29,536 |
-| 0.25 | 1.09% | 30,141 |
-| 0.10 | 1.15% | 30,654 |
+| 1.00 | 0.96% | 27,112 |
+| 0.50 | 1.05% | 28,595 |
+| 0.25 | 0.96% | 29,116 |
+| 0.10 | 1.09% | 29,576 |
 
-- The estimate is essentially **invariant (~1.1%) across a 10× change in `r`** — the
+- The estimate is essentially **invariant (~1.0%) across a 10× change in `r`** — the
   ratio correction behaving exactly as the theory predicts.
-- **Detections are recovered as `r` shrinks** (target detections rise from 27,931 to
-  30,654): at `r = 1` a 50%-marker library perturbs the search and suppresses
+- **Detections are recovered as `r` shrinks** (target detections rise from 27,112 to
+  29,576): at `r = 1` a 50%-marker library perturbs the search and suppresses
   detections; near `r ≈ 0.1` the analysis is close to native. This is the
   precision-versus-yield trade-off Fitzgibbon et al. describe, in reverse.
 
-The estimate is also sensitive to marker *realism* independently of ratio: at
-`r = 1`, target-anagram shuffled entrapment reads ~1.6% versus ~1.05% for real
+The estimate is also sensitive to marker *realism* independently of ratio:
+target-anagram shuffled entrapment reads meaningfully higher than real
 foreign-species peptides, because shuffled anagrams share the target's amino-acid
-composition and are over-identified. Foreign-species entrapment is the more faithful
-model of the sequences that cause real false identifications.
+composition (and therefore many fragment masses) and are over-identified.
+Foreign-species entrapment is the more faithful model of the sequences that cause
+real false identifications.
 
 ## Recommendation and caveats
 

--- a/pwiz_tools/Osprey/docs/fractional-entrapment.md
+++ b/pwiz_tools/Osprey/docs/fractional-entrapment.md
@@ -26,8 +26,10 @@ estimator is
 `r` is a free parameter; the `1/r` term is the ratio correction. Its only assumption
 is the ratio-aware *equal-chance* condition — that an incorrect match lands on a
 target or a marker in proportion to their database sizes — which does not depend on
-`r`. The **lower-bound** estimator, `N_E / (N_T + N_E)`, is likewise valid at any
-ratio (it can only demonstrate a failure of FDR control, never confirm it).
+`r`. The **lower-bound** estimator, `N_E / (r·(N_T + N_E))`, is likewise ratio-aware
+and valid at any ratio (it can only demonstrate a failure of FDR control, never
+confirm it); note `combined = lower-bound + N_E/(N_T + N_E)`, so at `r = 1` the
+combined value is exactly twice the lower bound.
 
 A 1:1 ratio is required **only** for the **paired** estimator, a distinct refinement
 that pairs each target with one unique entrapment twin (so `r = 1`) *and* requires


### PR DESCRIPTION
## Summary

* Made the `--model-diagnostics` FDR-calibration report correct for non-1:1 (partial) entrapment libraries, e.g. a routine ~10% foreign-species entrapment overlay for FDR-accuracy visibility at a fraction of the detection cost of a full 1:1 doubling.
* The combined and lower-bound estimators already computed the entrapment:target ratio `r` and applied it, so they were already valid at any ratio. The paired estimator is 1-fold only (FDRBench / Wen et al.), so it is now suppressed when the ratio is not ~1:1, where it previously read nonsensically low.
* Added `FdpView.PairedSuppressedPartial` + `PairedRatioTolerance`; `BuildFdpView` nulls `Paired` and sets the flag when `|r - 1| > 0.05` (both passes, both scopes). Combined/lower-bound untouched.
* The FDR-tab note explains the omission and links to a new justification doc when the ratio is not ~1:1; the legend drops the now-dead paired toggle.
* Added `docs/fractional-entrapment.md`: why a non-1:1 ratio still yields a valid FDP estimate (ratio-corrected combined estimator; Fitzgibbon, Li and McIntosh 2008; Wen et al. 2025).

See ai/todos/active/TODO-20260706_osprey_model_diagnostics_partial_entrapment.md

## Test plan

- [x] TestPairedSuppressedForPartialEntrapment - paired null + flagged, combined/lower r-aware at r=0.1
- [x] TestPairedEstimator - paired shown (not suppressed) at r=1
- [x] Build-Osprey.ps1 -RunTests -RunInspection - 453 passed, 0 failed, inspection clean
- [x] End-to-end 10% Stellar run - paired suppressed with note, combined ~1.1%, pass-1 combined byte-identical pre/post (no computation change)

Co-Authored-By: Claude <noreply@anthropic.com>