### PR TITLE
Shrank the resident spectral library with value-struct fragments and string interning

### DIFF
--- a/pwiz_tools/Osprey/Osprey.Core/FragmentAnnotation.cs
+++ b/pwiz_tools/Osprey/Osprey.Core/FragmentAnnotation.cs
@@ -25,6 +25,10 @@ namespace pwiz.Osprey.Core
 {
     /// <summary>
     /// Annotation metadata for a library fragment peak. Maps to osprey-core/src/types.rs FragmentAnnotation.
+    /// This is a value type: an initializer that omits a field gets the zero default
+    /// (<see cref="IonType.B"/> = 0, <see cref="Charge"/> = 0), NOT the former
+    /// reference-type ctor defaults (<see cref="IonType.Unknown"/>, Charge = 1). Set
+    /// <see cref="IonType"/> and <see cref="Charge"/> explicitly at every construction site.
     /// </summary>
     public struct FragmentAnnotation
     {

--- a/pwiz_tools/Osprey/Osprey.Core/FragmentAnnotation.cs
+++ b/pwiz_tools/Osprey/Osprey.Core/FragmentAnnotation.cs
@@ -26,18 +26,29 @@ namespace pwiz.Osprey.Core
     /// <summary>
     /// Annotation metadata for a library fragment peak. Maps to osprey-core/src/types.rs FragmentAnnotation.
     /// </summary>
-    public class FragmentAnnotation
+    public struct FragmentAnnotation
     {
         public IonType IonType { get; set; }
         public byte Ordinal { get; set; }
         public byte Charge { get; set; }
-        public NeutralLoss NeutralLoss { get; set; }
+        public NeutralLossCode NeutralLoss { get; set; }
 
-        public FragmentAnnotation()
+        /// <summary>
+        /// Custom neutral-loss mass; meaningful only when <see cref="NeutralLoss"/>
+        /// is <see cref="NeutralLossCode.Custom"/>.
+        /// </summary>
+        public double CustomLossMass { get; set; }
+
+        /// <summary>True when this fragment carries any neutral loss.</summary>
+        public bool HasNeutralLoss
         {
-            IonType = IonType.Unknown;
-            Ordinal = 0;
-            Charge = 1;
+            get { return NeutralLoss != NeutralLossCode.None; }
+        }
+
+        /// <summary>Mass of the neutral loss (0 when there is none).</summary>
+        public double NeutralLossMass
+        {
+            get { return pwiz.Osprey.Core.NeutralLoss.MassFor(NeutralLoss, CustomLossMass); }
         }
     }
 

--- a/pwiz_tools/Osprey/Osprey.Core/LibraryFragment.cs
+++ b/pwiz_tools/Osprey/Osprey.Core/LibraryFragment.cs
@@ -26,7 +26,7 @@ namespace pwiz.Osprey.Core
     /// <summary>
     /// A single fragment peak from a spectral library. Maps to osprey-core/src/types.rs LibraryFragment.
     /// </summary>
-    public class LibraryFragment
+    public struct LibraryFragment
     {
         public double Mz { get; set; }
         public float RelativeIntensity { get; set; }

--- a/pwiz_tools/Osprey/Osprey.Core/NeutralLoss.cs
+++ b/pwiz_tools/Osprey/Osprey.Core/NeutralLoss.cs
@@ -26,56 +26,78 @@ using System.Globalization;
 namespace pwiz.Osprey.Core
 {
     /// <summary>
-    /// Represents a neutral loss from a fragment ion.
-    /// Maps to osprey-core/src/types.rs NeutralLoss enum.
+    /// Neutral loss kind, carried inline on a <see cref="FragmentAnnotation"/> as
+    /// a compact value code rather than a per-fragment heap reference. The values
+    /// match the on-disk tags written by the library cache, so serialization needs
+    /// no translation table. Maps to osprey-core/src/types.rs NeutralLoss enum.
     /// </summary>
-    public class NeutralLoss
+    public enum NeutralLossCode : byte
     {
-        public static readonly NeutralLoss H2O = new NeutralLoss(18.010565);
-        public static readonly NeutralLoss NH3 = new NeutralLoss(17.026549);
-        public static readonly NeutralLoss H3PO4 = new NeutralLoss(97.976896);
+        None = 0,
+        H2O = 1,
+        NH3 = 2,
+        H3PO4 = 3,
+        Custom = 4
+    }
 
-        public double Mass { get; private set; }
+    /// <summary>
+    /// Neutral loss masses and parsing. Formerly a per-fragment reference type;
+    /// now a static helper so a <see cref="FragmentAnnotation"/> can hold a
+    /// <see cref="NeutralLossCode"/> plus a custom mass entirely by value.
+    /// </summary>
+    public static class NeutralLoss
+    {
+        public const double H2OMass = 18.010565;
+        public const double NH3Mass = 17.026549;
+        public const double H3PO4Mass = 97.976896;
 
-        private NeutralLoss(double mass)
+        /// <summary>
+        /// Mass of the neutral loss for the given code, using
+        /// <paramref name="customMass"/> only when the code is
+        /// <see cref="NeutralLossCode.Custom"/>. Returns 0 for
+        /// <see cref="NeutralLossCode.None"/>.
+        /// </summary>
+        public static double MassFor(NeutralLossCode code, double customMass)
         {
-            Mass = mass;
+            switch (code)
+            {
+                case NeutralLossCode.H2O: return H2OMass;
+                case NeutralLossCode.NH3: return NH3Mass;
+                case NeutralLossCode.H3PO4: return H3PO4Mass;
+                case NeutralLossCode.Custom: return customMass;
+                default: return 0.0;
+            }
         }
 
         /// <summary>
-        /// Creates a custom neutral loss with the specified mass.
+        /// Parses a string to a neutral loss. Returns
+        /// (<see cref="NeutralLossCode.None"/>, 0) for empty, "NOLOSS", or
+        /// unrecognized input; a named code for known losses; and
+        /// (<see cref="NeutralLossCode.Custom"/>, mass) for a numeric mass.
         /// </summary>
-        public static NeutralLoss Custom(double mass)
-        {
-            return new NeutralLoss(mass);
-        }
-
-        /// <summary>
-        /// Parses a string to a <see cref="NeutralLoss"/>. Returns null for empty, "NOLOSS", or unrecognized input.
-        /// </summary>
-        public static NeutralLoss Parse(string s)
+        public static (NeutralLossCode Code, double CustomMass) Parse(string s)
         {
             if (string.IsNullOrEmpty(s))
-                return null;
+                return (NeutralLossCode.None, 0.0);
 
             switch (s.ToUpperInvariant())
             {
                 case "H2O":
                 case "WATER":
-                    return H2O;
+                    return (NeutralLossCode.H2O, 0.0);
                 case "NH3":
                 case "AMMONIA":
-                    return NH3;
+                    return (NeutralLossCode.NH3, 0.0);
                 case "H3PO4":
                 case "PHOSPHO":
-                    return H3PO4;
+                    return (NeutralLossCode.H3PO4, 0.0);
                 case "NOLOSS":
-                    return null;
+                    return (NeutralLossCode.None, 0.0);
                 default:
                     double mass;
                     if (double.TryParse(s, NumberStyles.Float, CultureInfo.InvariantCulture, out mass))
-                        return Custom(mass);
-                    return null;
+                        return (NeutralLossCode.Custom, mass);
+                    return (NeutralLossCode.None, 0.0);
             }
         }
     }

--- a/pwiz_tools/Osprey/Osprey.IO/BlibLoader.cs
+++ b/pwiz_tools/Osprey/Osprey.IO/BlibLoader.cs
@@ -375,8 +375,12 @@ namespace pwiz.Osprey.IO
 
             if (maxIntensity > 0f)
             {
-                foreach (var f in fragments)
+                for (int i = 0; i < fragments.Count; i++)
+                {
+                    var f = fragments[i];
                     f.RelativeIntensity /= maxIntensity;
+                    fragments[i] = f;
+                }
             }
 
             return fragments;

--- a/pwiz_tools/Osprey/Osprey.IO/DiannTsvLoader.cs
+++ b/pwiz_tools/Osprey/Osprey.IO/DiannTsvLoader.cs
@@ -150,17 +150,19 @@ namespace pwiz.Osprey.IO
             if (!string.IsNullOrEmpty(fragChargeStr))
                 byte.TryParse(fragChargeStr, out fragmentCharge);
 
-            NeutralLoss neutralLoss = null;
+            NeutralLossCode lossCode = NeutralLossCode.None;
+            double lossMass = 0.0;
             string lossStr = GetFieldOrNull(fields, cols.FragmentLossType);
             if (!string.IsNullOrEmpty(lossStr))
-                neutralLoss = NeutralLoss.Parse(lossStr);
+                (lossCode, lossMass) = NeutralLoss.Parse(lossStr);
 
             var annotation = new FragmentAnnotation
             {
                 IonType = ionType,
                 Ordinal = ordinal,
                 Charge = fragmentCharge,
-                NeutralLoss = neutralLoss
+                NeutralLoss = lossCode,
+                CustomLossMass = lossMass
             };
 
             // Protein and gene info

--- a/pwiz_tools/Osprey/Osprey.IO/LibraryCache.cs
+++ b/pwiz_tools/Osprey/Osprey.IO/LibraryCache.cs
@@ -130,7 +130,7 @@ namespace pwiz.Osprey.IO
                             w.Write(IonTypeToByte(frag.Annotation.IonType));
                             w.Write(frag.Annotation.Ordinal);
                             w.Write(frag.Annotation.Charge);
-                            WriteNeutralLoss(w, frag.Annotation.NeutralLoss);
+                            WriteNeutralLoss(w, frag.Annotation.NeutralLoss, frag.Annotation.CustomLossMass);
                         }
 
                         // Protein IDs
@@ -251,7 +251,7 @@ namespace pwiz.Osprey.IO
                         IonType ionType = ByteToIonType(r.ReadByte());
                         byte ordinal = r.ReadByte();
                         byte fragCharge = r.ReadByte();
-                        NeutralLoss neutralLoss = ReadNeutralLoss(r);
+                        var (lossCode, lossMass) = ReadNeutralLoss(r);
 
                         fragments.Add(new LibraryFragment
                         {
@@ -262,7 +262,8 @@ namespace pwiz.Osprey.IO
                                 IonType = ionType,
                                 Ordinal = ordinal,
                                 Charge = fragCharge,
-                                NeutralLoss = neutralLoss
+                                NeutralLoss = lossCode,
+                                CustomLossMass = lossMass
                             }
                         });
                     }
@@ -346,46 +347,59 @@ namespace pwiz.Osprey.IO
             }
         }
 
-        private static void WriteNeutralLoss(BinaryWriter w, NeutralLoss nl)
+        private static void WriteNeutralLoss(BinaryWriter w, NeutralLossCode code, double customMass)
         {
-            if (nl == null)
+            switch (code)
             {
-                w.Write((byte)0);
-            }
-            else if (ReferenceEquals(nl, NeutralLoss.H2O) ||
-                     Math.Abs(nl.Mass - NeutralLoss.H2O.Mass) < 1e-6)
-            {
-                w.Write((byte)1);
-            }
-            else if (ReferenceEquals(nl, NeutralLoss.NH3) ||
-                     Math.Abs(nl.Mass - NeutralLoss.NH3.Mass) < 1e-6)
-            {
-                w.Write((byte)2);
-            }
-            else if (ReferenceEquals(nl, NeutralLoss.H3PO4) ||
-                     Math.Abs(nl.Mass - NeutralLoss.H3PO4.Mass) < 1e-6)
-            {
-                w.Write((byte)3);
-            }
-            else
-            {
-                w.Write((byte)4);
-                w.Write(nl.Mass);
+                case NeutralLossCode.None:
+                    w.Write((byte)0);
+                    break;
+                case NeutralLossCode.H2O:
+                    w.Write((byte)1);
+                    break;
+                case NeutralLossCode.NH3:
+                    w.Write((byte)2);
+                    break;
+                case NeutralLossCode.H3PO4:
+                    w.Write((byte)3);
+                    break;
+                default:
+                    // Custom -- collapse to a named tag when the mass matches one
+                    // within 1e-6, matching the legacy reference-type writer so the
+                    // on-disk bytes are unchanged.
+                    if (Math.Abs(customMass - NeutralLoss.H2OMass) < 1e-6)
+                    {
+                        w.Write((byte)1);
+                    }
+                    else if (Math.Abs(customMass - NeutralLoss.NH3Mass) < 1e-6)
+                    {
+                        w.Write((byte)2);
+                    }
+                    else if (Math.Abs(customMass - NeutralLoss.H3PO4Mass) < 1e-6)
+                    {
+                        w.Write((byte)3);
+                    }
+                    else
+                    {
+                        w.Write((byte)4);
+                        w.Write(customMass);
+                    }
+                    break;
             }
         }
 
-        private static NeutralLoss ReadNeutralLoss(BinaryReader r)
+        private static (NeutralLossCode Code, double CustomMass) ReadNeutralLoss(BinaryReader r)
         {
             byte tag = r.ReadByte();
             switch (tag)
             {
-                case 0: return null;
-                case 1: return NeutralLoss.H2O;
-                case 2: return NeutralLoss.NH3;
-                case 3: return NeutralLoss.H3PO4;
+                case 0: return (NeutralLossCode.None, 0.0);
+                case 1: return (NeutralLossCode.H2O, 0.0);
+                case 2: return (NeutralLossCode.NH3, 0.0);
+                case 3: return (NeutralLossCode.H3PO4, 0.0);
                 case 4:
                     double mass = r.ReadDouble();
-                    return NeutralLoss.Custom(mass);
+                    return (NeutralLossCode.Custom, mass);
                 default:
                     throw new InvalidDataException(string.Format(
                         "Unknown neutral loss tag: {0}", tag));

--- a/pwiz_tools/Osprey/Osprey.IO/LibraryLoader.cs
+++ b/pwiz_tools/Osprey/Osprey.IO/LibraryLoader.cs
@@ -86,6 +86,7 @@ namespace pwiz.Osprey.IO
                         logInfo(string.Format(
                             "Loaded {0} library entries from cache '{1}'",
                             cached.Count, cachePath));
+                        LibraryStringInterner.InternInPlace(cached, logInfo);
                         return cached;
                     }
                     if (status == LibraryCache.LibraryCacheStatus.IdentityMismatch)
@@ -143,6 +144,11 @@ namespace pwiz.Osprey.IO
             {
                 logWarning(string.Format("Failed to save library cache: {0}", ex.Message));
             }
+
+            // Intern after the cache is written (the cache bytes are identical
+            // either way) so the resident set shares one instance per distinct
+            // string.
+            LibraryStringInterner.InternInPlace(entries, logInfo);
 
             return entries;
         }

--- a/pwiz_tools/Osprey/Osprey.IO/LibraryStringInterner.cs
+++ b/pwiz_tools/Osprey/Osprey.IO/LibraryStringInterner.cs
@@ -1,0 +1,111 @@
+/*
+ * Original author: Brendan MacLean <brendanx .at. uw.edu>,
+ *                  MacCoss Lab, Department of Genome Sciences, UW
+ * AI assistance: Claude Code (Claude Opus 4.8) <noreply .at. anthropic.com>
+ *
+ * Based on osprey (https://github.com/MacCossLab/osprey)
+ *   by Michael J. MacCoss, MacCoss Lab, Department of Genome Sciences, UW
+ *
+ * Copyright 2026 University of Washington - Seattle, WA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
+using System.Collections.Generic;
+using pwiz.Osprey.Core;
+
+namespace pwiz.Osprey.IO
+{
+    /// <summary>
+    /// Collapses duplicate per-entry strings of a resident spectral library to
+    /// a single shared instance. A large library repeats the same protein
+    /// accessions, gene names, stripped sequences, and modification names across
+    /// millions of entries (one protein maps to many peptides; one stripped
+    /// sequence spans many charge/modification states), so the distinct string
+    /// count is far smaller than the total. Sharing one instance per distinct
+    /// value drops the per-duplicate string object (header + chars) from the
+    /// resident set.
+    ///
+    /// The intern pool is a plain (single-threaded) dictionary built and
+    /// released within one load call -- unlike the concurrent per-observation
+    /// interning that was a net loss on the FDR path, this runs once over the
+    /// library and only the shared instances survive. Values are unchanged
+    /// (only object identity), so output stays byte-identical.
+    /// </summary>
+    public static class LibraryStringInterner
+    {
+        /// <summary>
+        /// Intern the repeated string fields of every entry in place. Logs a
+        /// one-line distinct/total summary when <paramref name="logInfo"/> is set.
+        /// </summary>
+        public static void InternInPlace(IList<LibraryEntry> entries, Action<string> logInfo = null)
+        {
+            if (entries == null || entries.Count == 0)
+                return;
+
+            var pool = new Dictionary<string, string>(StringComparer.Ordinal);
+            long totalRefs = 0;
+
+            foreach (var entry in entries)
+            {
+                if (entry == null)
+                    continue;
+                entry.Sequence = Intern(pool, entry.Sequence, ref totalRefs);
+                entry.ModifiedSequence = Intern(pool, entry.ModifiedSequence, ref totalRefs);
+                InternList(pool, entry.ProteinIds, ref totalRefs);
+                InternList(pool, entry.GeneNames, ref totalRefs);
+
+                var mods = entry.Modifications;
+                if (mods != null)
+                {
+                    for (int i = 0; i < mods.Count; i++)
+                    {
+                        var m = mods[i];
+                        if (m != null && m.Name != null)
+                            m.Name = Intern(pool, m.Name, ref totalRefs);
+                    }
+                }
+            }
+
+            if (logInfo != null)
+            {
+                long collapsed = totalRefs - pool.Count;
+                double pct = totalRefs > 0 ? 100.0 * collapsed / totalRefs : 0.0;
+                logInfo(string.Format(
+                    "Interned library strings: {0} distinct / {1} total ({2:F1}% collapsed)",
+                    pool.Count, totalRefs, pct));
+            }
+        }
+
+        private static string Intern(Dictionary<string, string> pool, string s, ref long totalRefs)
+        {
+            if (s == null)
+                return null;
+            totalRefs++;
+            string existing;
+            if (pool.TryGetValue(s, out existing))
+                return existing;
+            pool[s] = s;
+            return s;
+        }
+
+        private static void InternList(Dictionary<string, string> pool, List<string> list, ref long totalRefs)
+        {
+            if (list == null)
+                return;
+            for (int i = 0; i < list.Count; i++)
+                list[i] = Intern(pool, list[i], ref totalRefs);
+        }
+    }
+}

--- a/pwiz_tools/Osprey/Osprey.Scoring/DecoyGenerator.cs
+++ b/pwiz_tools/Osprey/Osprey.Scoring/DecoyGenerator.cs
@@ -479,18 +479,12 @@ namespace pwiz.Osprey.Scoring
                 }
                 else
                 {
-                    // For other ion types, keep as-is
+                    // For other ion types, keep as-is (annotation copied by value).
                     result.Add(new LibraryFragment
                     {
                         Mz = frag.Mz,
                         RelativeIntensity = frag.RelativeIntensity,
-                        Annotation = new FragmentAnnotation
-                        {
-                            IonType = annotation.IonType,
-                            Ordinal = annotation.Ordinal,
-                            Charge = annotation.Charge,
-                            NeutralLoss = annotation.NeutralLoss
-                        }
+                        Annotation = annotation
                     });
                     continue;
                 }
@@ -501,21 +495,20 @@ namespace pwiz.Osprey.Scoring
                 double? mz = CalculateFragmentMz(
                     newIonType, newOrdinal, annotation.Charge,
                     decoySequence, modMasses,
-                    annotation.NeutralLoss != null ? annotation.NeutralLoss.Mass : null);
+                    annotation.HasNeutralLoss ? annotation.NeutralLossMass : null);
 
                 if (mz.HasValue)
                 {
+                    // Swap b<->y ion type and ordinal; charge and neutral loss
+                    // (code + custom mass) carry over from the target fragment.
+                    var newAnnotation = annotation;
+                    newAnnotation.IonType = newIonType;
+                    newAnnotation.Ordinal = (byte)newOrdinal;
                     result.Add(new LibraryFragment
                     {
                         Mz = mz.Value,
                         RelativeIntensity = frag.RelativeIntensity,
-                        Annotation = new FragmentAnnotation
-                        {
-                            IonType = newIonType,
-                            Ordinal = (byte)newOrdinal,
-                            Charge = annotation.Charge,
-                            NeutralLoss = annotation.NeutralLoss
-                        }
+                        Annotation = newAnnotation
                     });
                 }
             }

--- a/pwiz_tools/Osprey/Osprey.Tasks/PerFileScoringTask.cs
+++ b/pwiz_tools/Osprey/Osprey.Tasks/PerFileScoringTask.cs
@@ -720,17 +720,19 @@ namespace pwiz.Osprey.Tasks
             _fullLibrary = fullLibrary;
             _libraryById = libraryById;
 
-            // Diagnostic: the true resident-library managed heap after a full GC.
-            // The working set at this point still holds the one-time TSV/cache
-            // read buffers and freed load garbage, so GC.GetTotalMemory(true) is
-            // the clean resident number. Zero-cost when OSPREY_LOG_MEMORY is unset.
+            // Diagnostic: the true resident-library managed heap. The working set
+            // at this point still holds the one-time TSV/cache read buffers and freed
+            // load garbage, so the settled managed heap is the clean resident number.
+            // Collect/WaitForPendingFinalizers/Collect settles finalizable objects,
+            // then GetTotalMemory(false) reads the result WITHOUT forcing a further
+            // collection. Zero-cost when OSPREY_LOG_MEMORY is unset.
             if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable(@"OSPREY_LOG_MEMORY")))
             {
                 GC.Collect();
                 GC.WaitForPendingFinalizers();
                 GC.Collect();
-                long managedBytes = GC.GetTotalMemory(true);
-                ctx.LogInfo(string.Format(
+                long managedBytes = GC.GetTotalMemory(false);
+                ctx.LogInfo(string.Format(System.Globalization.CultureInfo.InvariantCulture,
                     @"[MEM library-resident] managed_heap={0:F2} GB ({1} entries)",
                     managedBytes / (1024.0 * 1024.0 * 1024.0), fullLibrary.Count));
             }

--- a/pwiz_tools/Osprey/Osprey.Tasks/PerFileScoringTask.cs
+++ b/pwiz_tools/Osprey/Osprey.Tasks/PerFileScoringTask.cs
@@ -719,6 +719,22 @@ namespace pwiz.Osprey.Tasks
 
             _fullLibrary = fullLibrary;
             _libraryById = libraryById;
+
+            // Diagnostic: the true resident-library managed heap after a full GC.
+            // The working set at this point still holds the one-time TSV/cache
+            // read buffers and freed load garbage, so GC.GetTotalMemory(true) is
+            // the clean resident number. Zero-cost when OSPREY_LOG_MEMORY is unset.
+            if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable(@"OSPREY_LOG_MEMORY")))
+            {
+                GC.Collect();
+                GC.WaitForPendingFinalizers();
+                GC.Collect();
+                long managedBytes = GC.GetTotalMemory(true);
+                ctx.LogInfo(string.Format(
+                    @"[MEM library-resident] managed_heap={0:F2} GB ({1} entries)",
+                    managedBytes / (1024.0 * 1024.0 * 1024.0), fullLibrary.Count));
+            }
+
             return true;
         }
 

--- a/pwiz_tools/Osprey/Osprey.Test/CoreTypesTest.cs
+++ b/pwiz_tools/Osprey/Osprey.Test/CoreTypesTest.cs
@@ -69,31 +69,31 @@ namespace pwiz.Osprey.Test
         [TestMethod]
         public void TestNeutralLossMass()
         {
-            Assert.AreEqual(18.010565, NeutralLoss.H2O.Mass, TOLERANCE);
-            Assert.AreEqual(17.026549, NeutralLoss.NH3.Mass, TOLERANCE);
-            Assert.AreEqual(97.976896, NeutralLoss.H3PO4.Mass, TOLERANCE);
+            Assert.AreEqual(18.010565, NeutralLoss.H2OMass, TOLERANCE);
+            Assert.AreEqual(17.026549, NeutralLoss.NH3Mass, TOLERANCE);
+            Assert.AreEqual(97.976896, NeutralLoss.H3PO4Mass, TOLERANCE);
         }
 
         [TestMethod]
         public void TestNeutralLossParse()
         {
             // Named losses
-            AssertNeutralLossEqual(NeutralLoss.H2O, NeutralLoss.Parse("H2O"));
-            AssertNeutralLossEqual(NeutralLoss.H2O, NeutralLoss.Parse("WATER"));
-            AssertNeutralLossEqual(NeutralLoss.NH3, NeutralLoss.Parse("NH3"));
-            AssertNeutralLossEqual(NeutralLoss.NH3, NeutralLoss.Parse("AMMONIA"));
-            AssertNeutralLossEqual(NeutralLoss.H3PO4, NeutralLoss.Parse("H3PO4"));
-            AssertNeutralLossEqual(NeutralLoss.H3PO4, NeutralLoss.Parse("PHOSPHO"));
+            AssertNeutralLossEqual(NeutralLossCode.H2O, NeutralLoss.Parse("H2O"));
+            AssertNeutralLossEqual(NeutralLossCode.H2O, NeutralLoss.Parse("WATER"));
+            AssertNeutralLossEqual(NeutralLossCode.NH3, NeutralLoss.Parse("NH3"));
+            AssertNeutralLossEqual(NeutralLossCode.NH3, NeutralLoss.Parse("AMMONIA"));
+            AssertNeutralLossEqual(NeutralLossCode.H3PO4, NeutralLoss.Parse("H3PO4"));
+            AssertNeutralLossEqual(NeutralLossCode.H3PO4, NeutralLoss.Parse("PHOSPHO"));
 
-            // Null returns
-            Assert.IsNull(NeutralLoss.Parse(""));
-            Assert.IsNull(NeutralLoss.Parse("NOLOSS"));
-            Assert.IsNull(NeutralLoss.Parse(null));
+            // None returns
+            Assert.AreEqual(NeutralLossCode.None, NeutralLoss.Parse("").Code);
+            Assert.AreEqual(NeutralLossCode.None, NeutralLoss.Parse("NOLOSS").Code);
+            Assert.AreEqual(NeutralLossCode.None, NeutralLoss.Parse(null).Code);
 
             // Custom numeric
             var custom = NeutralLoss.Parse("18.5");
-            Assert.IsNotNull(custom);
-            Assert.AreEqual(18.5, custom.Mass, TOLERANCE);
+            Assert.AreEqual(NeutralLossCode.Custom, custom.Code);
+            Assert.AreEqual(18.5, custom.CustomMass, TOLERANCE);
         }
 
         #endregion
@@ -622,10 +622,10 @@ namespace pwiz.Osprey.Test
             };
         }
 
-        private static void AssertNeutralLossEqual(NeutralLoss expected, NeutralLoss actual)
+        private static void AssertNeutralLossEqual(NeutralLossCode expected,
+            (NeutralLossCode Code, double CustomMass) actual)
         {
-            Assert.IsNotNull(actual);
-            Assert.AreEqual(expected.Mass, actual.Mass, TOLERANCE);
+            Assert.AreEqual(expected, actual.Code);
         }
 
         #endregion

--- a/pwiz_tools/Osprey/Osprey.Test/IOTest.cs
+++ b/pwiz_tools/Osprey/Osprey.Test/IOTest.cs
@@ -1020,6 +1020,71 @@ namespace pwiz.Osprey.Test
             }
         }
 
+        [TestMethod]
+        public void TestLibraryStringInterning()
+        {
+            // Two entries repeat the same values across every interned field.
+            var e0 = MakeInternEntry(1, "PEPTIDER", "M[16]PEPTIDER", "P12345", "GENEA", "Oxidation");
+            var e1 = MakeInternEntry(2, "PEPTIDER", "M[16]PEPTIDER", "P12345", "GENEA", "Oxidation");
+
+            // A third entry with a null protein list, an empty gene list, and a
+            // null modification name -- interning must leave these untouched, not throw.
+            var e2 = new LibraryEntry(3, FreshCopy("PEPTIDEK"), FreshCopy("PEPTIDEK"), 2, 600.0, 8.0);
+            e2.ProteinIds = null;
+            e2.GeneNames = new List<string>();
+            e2.Modifications = new List<Modification> { new Modification { Position = 0, Name = null } };
+
+            var entries = new List<LibraryEntry> { e0, e1, e2 };
+
+            // Pre-condition: the repeated values are DISTINCT instances (the char-array
+            // copies defeat the compiler's literal interning), so AreSame below proves
+            // LibraryStringInterner shared them -- not the CLR string pool.
+            Assert.AreNotSame(e0.Sequence, e1.Sequence);
+            Assert.AreNotSame(e0.ProteinIds[0], e1.ProteinIds[0]);
+
+            LibraryStringInterner.InternInPlace(entries);
+
+            // Values are unchanged on every interned field...
+            Assert.AreEqual("PEPTIDER", e0.Sequence);
+            Assert.AreEqual("M[16]PEPTIDER", e0.ModifiedSequence);
+            Assert.AreEqual("P12345", e0.ProteinIds[0]);
+            Assert.AreEqual("GENEA", e0.GeneNames[0]);
+            Assert.AreEqual("Oxidation", e0.Modifications[0].Name);
+
+            // ...but duplicates now share one instance, for each interned field.
+            Assert.AreSame(e0.Sequence, e1.Sequence);
+            Assert.AreSame(e0.ModifiedSequence, e1.ModifiedSequence);
+            Assert.AreSame(e0.ProteinIds[0], e1.ProteinIds[0]);
+            Assert.AreSame(e0.GeneNames[0], e1.GeneNames[0]);
+            Assert.AreSame(e0.Modifications[0].Name, e1.Modifications[0].Name);
+
+            // The null/empty entry is untouched (no NRE).
+            Assert.IsNull(e2.ProteinIds);
+            Assert.AreEqual(0, e2.GeneNames.Count);
+            Assert.IsNull(e2.Modifications[0].Name);
+            Assert.AreEqual("PEPTIDEK", e2.Sequence);
+        }
+
+        // Fresh instance with the same characters, so the compiler's literal
+        // interning does not pre-share it before LibraryStringInterner runs.
+        private static string FreshCopy(string s)
+        {
+            return new string(s.ToCharArray());
+        }
+
+        private static LibraryEntry MakeInternEntry(uint id, string seq, string modSeq,
+            string protein, string gene, string modName)
+        {
+            var e = new LibraryEntry(id, FreshCopy(seq), FreshCopy(modSeq), 2, 500.0, 10.0);
+            e.ProteinIds = new List<string> { FreshCopy(protein) };
+            e.GeneNames = new List<string> { FreshCopy(gene) };
+            e.Modifications = new List<Modification>
+            {
+                new Modification { Position = 1, Name = FreshCopy(modName) }
+            };
+            return e;
+        }
+
         #endregion
 
         #region Blob Compression Tests

--- a/pwiz_tools/Osprey/Osprey.Test/IOTest.cs
+++ b/pwiz_tools/Osprey/Osprey.Test/IOTest.cs
@@ -1021,6 +1021,49 @@ namespace pwiz.Osprey.Test
         }
 
         [TestMethod]
+        public void TestLibraryCacheNeutralLossCollapse()
+        {
+            // A Custom neutral-loss mass within 1e-6 of a named loss must serialize
+            // to the named tag (byte-identity with the legacy reference-type writer)
+            // and read back as the named code -- the most byte-sensitive
+            // WriteNeutralLoss branch, which the round-trip test does not exercise.
+            var entry = new LibraryEntry(1, "PEPTIDER", "PEPTIDER", 2, 500.0, 10.0);
+            entry.Fragments = new List<LibraryFragment>
+            {
+                new LibraryFragment
+                {
+                    Mz = 200.0,
+                    RelativeIntensity = 1.0f,
+                    Annotation = new FragmentAnnotation
+                    {
+                        IonType = IonType.B,
+                        Ordinal = 1,
+                        Charge = 1,
+                        NeutralLoss = NeutralLossCode.Custom,
+                        CustomLossMass = NeutralLoss.H2OMass
+                    }
+                }
+            };
+
+            string tempPath = Path.Combine(Path.GetTempPath(),
+                "osprey_nl_" + Guid.NewGuid().ToString("N") + ".libcache");
+            try
+            {
+                LibraryCache.SaveCache(tempPath, new List<LibraryEntry> { entry }, "hash");
+                var loaded = LibraryCache.LoadCache(tempPath);
+                Assert.AreEqual(1, loaded.Count);
+                var ann = loaded[0].Fragments[0].Annotation;
+                Assert.AreEqual(NeutralLossCode.H2O, ann.NeutralLoss);
+                Assert.AreEqual(NeutralLoss.H2OMass, ann.NeutralLossMass, 1e-10);
+            }
+            finally
+            {
+                if (File.Exists(tempPath))
+                    File.Delete(tempPath);
+            }
+        }
+
+        [TestMethod]
         public void TestLibraryStringInterning()
         {
             // Two entries repeat the same values across every interned field.

--- a/pwiz_tools/Osprey/Osprey.Test/IOTest.cs
+++ b/pwiz_tools/Osprey/Osprey.Test/IOTest.cs
@@ -816,15 +816,10 @@ namespace pwiz.Osprey.Test
                         Assert.AreEqual(orig.Fragments[f].Annotation.Charge,
                             copy.Fragments[f].Annotation.Charge);
 
-                        var origNl = orig.Fragments[f].Annotation.NeutralLoss;
-                        var copyNl = copy.Fragments[f].Annotation.NeutralLoss;
-                        if (origNl == null)
-                            Assert.IsNull(copyNl);
-                        else
-                        {
-                            Assert.IsNotNull(copyNl);
-                            Assert.AreEqual(origNl.Mass, copyNl.Mass, 1e-10);
-                        }
+                        Assert.AreEqual(orig.Fragments[f].Annotation.HasNeutralLoss,
+                            copy.Fragments[f].Annotation.HasNeutralLoss);
+                        Assert.AreEqual(orig.Fragments[f].Annotation.NeutralLossMass,
+                            copy.Fragments[f].Annotation.NeutralLossMass, 1e-10);
                     }
 
                     // Check modification details
@@ -1825,7 +1820,7 @@ namespace pwiz.Osprey.Test
                         IonType = IonType.B,
                         Ordinal = 3,
                         Charge = 1,
-                        NeutralLoss = NeutralLoss.H2O
+                        NeutralLoss = NeutralLossCode.H2O
                     }
                 },
                 new LibraryFragment
@@ -1837,7 +1832,8 @@ namespace pwiz.Osprey.Test
                         IonType = IonType.Y,
                         Ordinal = 5,
                         Charge = 2,
-                        NeutralLoss = NeutralLoss.Custom(98.0)
+                        NeutralLoss = NeutralLossCode.Custom,
+                        CustomLossMass = 98.0
                     }
                 }
             };

--- a/pwiz_tools/Osprey/Osprey.Test/OspreyFeatureCalculatorsTest.cs
+++ b/pwiz_tools/Osprey/Osprey.Test/OspreyFeatureCalculatorsTest.cs
@@ -437,7 +437,7 @@ namespace pwiz.Osprey.Test
             return new LibraryFragment
             {
                 Mz = mz,
-                Annotation = new FragmentAnnotation { IonType = ionType, Ordinal = ordinal },
+                Annotation = new FragmentAnnotation { IonType = ionType, Ordinal = ordinal, Charge = 1 },
             };
         }
 

--- a/pwiz_tools/Osprey/Osprey.Test/ScoringTest.cs
+++ b/pwiz_tools/Osprey/Osprey.Test/ScoringTest.cs
@@ -288,9 +288,9 @@ namespace pwiz.Osprey.Test
             var entry = new LibraryEntry(1, "PEPTIDE", "PEPTIDE", 2, 500.0, 10.0);
             entry.Fragments = new List<LibraryFragment>
             {
-                new LibraryFragment { Mz = 300.0, RelativeIntensity = 100.0f, Annotation = new FragmentAnnotation() },
-                new LibraryFragment { Mz = 400.0, RelativeIntensity = 50.0f, Annotation = new FragmentAnnotation() },
-                new LibraryFragment { Mz = 500.0, RelativeIntensity = 75.0f, Annotation = new FragmentAnnotation() }
+                new LibraryFragment { Mz = 300.0, RelativeIntensity = 100.0f, Annotation = new FragmentAnnotation { Charge = 1 } },
+                new LibraryFragment { Mz = 400.0, RelativeIntensity = 50.0f, Annotation = new FragmentAnnotation { Charge = 1 } },
+                new LibraryFragment { Mz = 500.0, RelativeIntensity = 75.0f, Annotation = new FragmentAnnotation { Charge = 1 } }
             };
 
             var spectrum = new Spectrum

--- a/pwiz_tools/Osprey/Osprey.Test/ScoringTest.cs
+++ b/pwiz_tools/Osprey/Osprey.Test/ScoringTest.cs
@@ -288,9 +288,9 @@ namespace pwiz.Osprey.Test
             var entry = new LibraryEntry(1, "PEPTIDE", "PEPTIDE", 2, 500.0, 10.0);
             entry.Fragments = new List<LibraryFragment>
             {
-                new LibraryFragment { Mz = 300.0, RelativeIntensity = 100.0f, Annotation = new FragmentAnnotation { Charge = 1 } },
-                new LibraryFragment { Mz = 400.0, RelativeIntensity = 50.0f, Annotation = new FragmentAnnotation { Charge = 1 } },
-                new LibraryFragment { Mz = 500.0, RelativeIntensity = 75.0f, Annotation = new FragmentAnnotation { Charge = 1 } }
+                new LibraryFragment { Mz = 300.0, RelativeIntensity = 100.0f, Annotation = new FragmentAnnotation { IonType = IonType.Unknown, Charge = 1 } },
+                new LibraryFragment { Mz = 400.0, RelativeIntensity = 50.0f, Annotation = new FragmentAnnotation { IonType = IonType.Unknown, Charge = 1 } },
+                new LibraryFragment { Mz = 500.0, RelativeIntensity = 75.0f, Annotation = new FragmentAnnotation { IonType = IonType.Unknown, Charge = 1 } }
             };
 
             var spectrum = new Spectrum


### PR DESCRIPTION
## Summary

* Shrank the resident spectral library **~35%** (~4.9 -> **3.2 GB** managed heap on the 3.17M-entry Carafe library) with two output-preserving changes:
  * **Fragment value structs (~1.5 GB):** `LibraryFragment` and `FragmentAnnotation` are now value structs, and the per-fragment `NeutralLoss` heap reference becomes a `NeutralLossCode` byte + inline custom mass. Removes tens of millions of tiny heap objects; the fragment array is now contiguous/blittable. The `.libcache` on-disk format is unchanged (VERSION 2), so existing caches still load.
  * **String interning (~0.2 GB here, much more on PTM-rich libraries):** one shared instance per distinct sequence / protein / gene / mod-name at load (~50% of string references collapse on Carafe). This scales sharply with PTMs -- modified forms multiply the entry count but not the distinct-string count (mod names are a few dozen values referenced by millions of entries), so the collapse ratio climbs on large modified libraries.
* Also ~4% faster end-to-end (n=1, 8-file Astral) from fewer allocations / less GC pressure. Adds a `[MEM library-resident]` post-GC managed-heap probe behind `OSPREY_LOG_MEMORY`.

**Scope note (honest):** the resident library was *not* the ~18-20 GB "floor" the issue estimated -- that figure was working set, inflated by the one-time 5.3 GB TSV read buffer during load. The true library is ~3-5 GB (post-GC managed heap). In a full run the ~80 GB peak is dominated by stage6 reconciliation (#4376) and per-file scoring (#4355/#4378), not the library. This PR is a clean, independent library reduction; the larger memory levers are tracked separately.

Reported by Michael.

Fixes #4372

## Test plan

- [x] `regression.ps1 -Dataset Stellar` -- mode1 (vs golden) / mode2 (resume) / mode3 (HPC chain) byte-identical (blib 52,514,816 bytes)
- [x] `Osprey.Test` 454 pass incl. new `TestLibraryStringInterning` (distinct-but-equal strings share one instance across every interned field; null/empty safe) and the `IOTest` libcache round-trip (format gate)
- [x] 8-file Astral Carafe A/B (master vs branch): resident library 4.9 -> 3.2 GB; blib byte-identical except the per-run LSID GUID + creation timestamp; all stage walls slightly faster
- [ ] TeamCity Osprey Windows .NET Perf/Regression (Astral) -- triggered on `pull/<N>`

Co-Authored-By: Claude <noreply@anthropic.com>
