### PR TITLE
Hardened TestSpectrumGrid against async grid-population timing flake

### DIFF
--- a/pwiz_tools/Skyline/TestFunctional/SpectrumGridTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/SpectrumGridTest.cs
@@ -57,12 +57,14 @@ namespace pwiz.SkylineTestFunctional
             RunUI(()=>SkylineWindow.SelectedPath = SkylineWindow.DocumentUI.GetPathTo((int) SrmDocument.Level.MoleculeGroups, 0));
             // The grid populates its rows asynchronously, so wait for it to settle at the expected row count
             // rather than asserting the count the instant IsComplete() first returns true.
-            WaitForConditionUI(() => spectrumGrid.IsComplete() && spectrumGrid.DataGridView.RowCount == 3);
+            WaitForConditionUI(() => spectrumGrid.IsComplete() && spectrumGrid.DataGridView.RowCount == 3,
+                () => string.Format("Expected 3 rows but found {0}", spectrumGrid.DataGridView.RowCount));
             RunUI(()=>
             {
                 SkylineWindow.SelectedPath = peptideIdentityPath;
             });
-            WaitForConditionUI(() => spectrumGrid.IsComplete() && spectrumGrid.DataGridView.RowCount == 2);
+            WaitForConditionUI(() => spectrumGrid.IsComplete() && spectrumGrid.DataGridView.RowCount == 2,
+                () => string.Format("Expected 2 rows but found {0}", spectrumGrid.DataGridView.RowCount));
             RunUI(()=>
             {
                 spectrumGrid.SetSpectrumClassColumnCheckState(SpectrumClassColumn.PresetScanConfiguration, CheckState.Unchecked);

--- a/pwiz_tools/Skyline/TestFunctional/SpectrumGridTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/SpectrumGridTest.cs
@@ -55,16 +55,16 @@ namespace pwiz.SkylineTestFunctional
             CollectionAssert.DoesNotContain(initialChromatogramPointCounts, 0);
             var spectrumGrid = ShowDialog<SpectrumGridForm>(() => SkylineWindow.ViewMenu.ShowSpectrumGridForm());
             RunUI(()=>SkylineWindow.SelectedPath = SkylineWindow.DocumentUI.GetPathTo((int) SrmDocument.Level.MoleculeGroups, 0));
-            WaitForCondition(() => spectrumGrid.IsComplete());
+            // The grid populates its rows asynchronously, so wait for it to settle at the expected row count
+            // rather than asserting the count the instant IsComplete() first returns true.
+            WaitForConditionUI(() => spectrumGrid.IsComplete() && spectrumGrid.DataGridView.RowCount == 3);
             RunUI(()=>
             {
-                Assert.AreEqual(3, spectrumGrid.DataGridView.RowCount);
                 SkylineWindow.SelectedPath = peptideIdentityPath;
             });
-            WaitForConditionUI(() => spectrumGrid.IsComplete());
+            WaitForConditionUI(() => spectrumGrid.IsComplete() && spectrumGrid.DataGridView.RowCount == 2);
             RunUI(()=>
             {
-                AssertEx.AreEqual(2, spectrumGrid.DataGridView.RowCount);
                 spectrumGrid.SetSpectrumClassColumnCheckState(SpectrumClassColumn.PresetScanConfiguration, CheckState.Unchecked);
                 spectrumGrid.SetSpectrumClassColumnCheckState(SpectrumClassColumn.Ms2Precursors, CheckState.Unchecked);
                 spectrumGrid.SetSpectrumClassColumnCheckState(SpectrumClassColumn.IsolationWindowWidth, CheckState.Unchecked);


### PR DESCRIPTION
## Summary

* `TestSpectrumGrid` failed once in a nightly run (`Expected:<3>. Actual:<0>` on the row-count assert) — a rare, non-reproducible timing intermittent in the spectrum grid's asynchronous row population.
* Investigation ruled out a locale bug and the async `SpectrumReader`/`SetSpectra` path (the grid populates synchronously from cached document metadata for imported results), and confirmed the cache metadata loads synchronously before the document is considered loaded. No product defect was confirmed.
* Hardened the test to wait for the grid to settle at the expected row count (`WaitForConditionUI(() => spectrumGrid.IsComplete() && DataGridView.RowCount == N)`) instead of asserting the count the instant `IsComplete()` first returns true. The prior first wait used the non-UI-thread `WaitForCondition`, which is the actual flake mechanism (it could read the count before rows materialized). A real regression still fails (the wait times out), and the timeout message reports the actual row count so diagnosability is preserved.
* Removed the now-redundant exact row-count asserts, since the wait conditions carry the expected values.

## Note for the next person

`SpectrumGridForm.IsComplete()` is arguably under-inclusive: it can report complete while the databound grid (`base.IsComplete` / `BindingListSource`) is still materializing rows via `ResetBindings`. This test now works around that, but any other databound-grid test that asserts row counts immediately after `IsComplete()` could hit the same window. A product-side tightening of `IsComplete()` would be the more general fix, but it lives in shared grid infrastructure and is out of scope for this test-only change.

## Test plan

- [x] TestSpectrumGrid - passes (0 failures) after the change; product code is unchanged

Co-Authored-By: Claude <noreply@anthropic.com>
