### PR TITLE
Fixed 32-bit (address-model=32) build and installer on VS 2026

### DIFF
--- a/Jamroot.jam
+++ b/Jamroot.jam
@@ -1268,7 +1268,17 @@ rule msparser-path ( properties * )
     }
     else if <toolset>msvc in $(properties)
     {
-        if [ feature.get-values <toolset-msvc:version> : $(properties) ] in "14.0" "14.1" "14.2" "14.3" "14.5"
+        if <address-model>32 in $(properties)
+        {
+            # Only a 64-bit Mascot Parser library is bundled, so disable Mascot support in 32-bit builds.
+            if ! $(.warn-once-mascot32)
+            {
+                .warn-once-mascot32 = true ;
+                echo "Note: Not using Mascot Parser in 32-bit builds (only a 64-bit msparser library is bundled)." ;
+            }
+            lib-location = "" ;
+        }
+        else if [ feature.get-values <toolset-msvc:version> : $(properties) ] in "14.0" "14.1" "14.2" "14.3" "14.5"
         {
             lib-location = "$(PWIZ_LIBRARIES_PATH)\\msparser_3_1_0_x86_win64\\vs2015" ;
         }

--- a/libraries/boost-build/src/tools/stage.jam
+++ b/libraries/boost-build/src/tools/stage.jam
@@ -444,6 +444,52 @@ class install-target-class : basic-target
             }
         }
 
+        # Under <install-dependencies>on the recursively-collected graph can
+        # contain a raw *source* file whose basename matches the *generated*
+        # copy of the same name -- e.g. a vendor .dll fed to a 'make' copy, or a
+        # <manifest-dependency> DLL referenced only so its version can be read.
+        # Staging both to one location is a fatal "Name clash ... none/none".
+        # The generated artifact is the one meant to be installed, so on such a
+        # collision drop the raw source (a target with no creating action).
+        # Genuine conflicts -- two generated, or two source, targets sharing a
+        # name -- are left untouched so they still error as before.
+        if [ $(property-set).get <install-dependencies> ] = "on"
+        {
+            local deduped ;
+            for local r in $(result)
+            {
+                local rn = [ $(r).name ] ;
+                local rdest = $(rn:BS) ;
+                local conflict ;
+                for local k in $(deduped)
+                {
+                    local kn = [ $(k).name ] ;
+                    if $(kn:BS) = $(rdest) { conflict = $(k) ; }
+                }
+                if ! $(conflict)
+                {
+                    deduped += $(r) ;
+                }
+                else if [ $(r).action ] && ! [ $(conflict).action ]
+                {
+                    # r is generated, the kept one is a raw source: replace it.
+                    local rebuilt ;
+                    for local k in $(deduped) { if $(k) != $(conflict) { rebuilt += $(k) ; } }
+                    deduped = $(rebuilt) $(r) ;
+                }
+                else if [ $(conflict).action ] && ! [ $(r).action ]
+                {
+                    # r is a raw source and the kept one is generated: drop r.
+                }
+                else
+                {
+                    # Ambiguous: keep both and let the existing clash check run.
+                    deduped += $(r) ;
+                }
+            }
+            result = $(deduped) ;
+        }
+
         return $(result) ;
     }
 

--- a/libraries/boost-build/src/tools/stage.jam
+++ b/libraries/boost-build/src/tools/stage.jam
@@ -449,42 +449,47 @@ class install-target-class : basic-target
         # copy of the same name -- e.g. a vendor .dll fed to a 'make' copy, or a
         # <manifest-dependency> DLL referenced only so its version can be read.
         # Staging both to one location is a fatal "Name clash ... none/none".
-        # The generated artifact is the one meant to be installed, so on such a
-        # collision drop the raw source (a target with no creating action).
-        # Genuine conflicts -- two generated, or two source, targets sharing a
-        # name -- are left untouched so they still error as before.
+        # The generated artifact is the one meant to be installed, so drop the
+        # raw source (a target with no creating action) that it shadows.
+        #
+        # This deliberately resolves -- rather than errors on -- that specific
+        # collision, but only for a *flat* install: when <install-source-root>
+        # is set the destination preserves sub-directories, so a basename is no
+        # longer the full destination and two same-basename files in different
+        # sub-dirs are distinct (must not be collapsed). Skipping source-root
+        # installs keeps "basename == destination", so this fires only where the
+        # copies would truly land on one path and b2 would otherwise abort.
+        # Every generated target is kept, so a genuine two-generated (or two
+        # raw-source) same-name conflict still reaches the clash check.
         if [ $(property-set).get <install-dependencies> ] = "on"
+            && ! [ $(property-set).get <install-source-root> ]
         {
+            # Basenames produced by a generated (action-bearing) target.
+            local generated-dests ;
+            for local r in $(result)
+            {
+                if [ $(r).action ]
+                {
+                    local rn = [ $(r).name ] ;
+                    generated-dests += $(rn:BS) ;
+                }
+            }
             local deduped ;
             for local r in $(result)
             {
-                local rn = [ $(r).name ] ;
-                local rdest = $(rn:BS) ;
-                local conflict ;
-                for local k in $(deduped)
+                if [ $(r).action ]
                 {
-                    local kn = [ $(k).name ] ;
-                    if $(kn:BS) = $(rdest) { conflict = $(k) ; }
-                }
-                if ! $(conflict)
-                {
-                    deduped += $(r) ;
-                }
-                else if [ $(r).action ] && ! [ $(conflict).action ]
-                {
-                    # r is generated, the kept one is a raw source: replace it.
-                    local rebuilt ;
-                    for local k in $(deduped) { if $(k) != $(conflict) { rebuilt += $(k) ; } }
-                    deduped = $(rebuilt) $(r) ;
-                }
-                else if [ $(conflict).action ] && ! [ $(r).action ]
-                {
-                    # r is a raw source and the kept one is generated: drop r.
+                    deduped += $(r) ;  # always keep generated artifacts
                 }
                 else
                 {
-                    # Ambiguous: keep both and let the existing clash check run.
-                    deduped += $(r) ;
+                    local rn = [ $(r).name ] ;
+                    if ! $(rn:BS) in $(generated-dests)
+                    {
+                        deduped += $(r) ;  # raw source not shadowed by a generated copy
+                    }
+                    # else: raw source shadowed by a generated copy of the same
+                    # name -- drop it (it would otherwise clash on install).
                 }
             }
             result = $(deduped) ;

--- a/pwiz_tools/BiblioSpec/Jamfile.jam
+++ b/pwiz_tools/BiblioSpec/Jamfile.jam
@@ -20,9 +20,12 @@
 # limitations under the License.
 # 
 
-project 
+project
   : requirements
     <toolset>darwin:<build>no
+    # Arrow (a BiblioSpec dependency) uses x64-only MSVC intrinsics (__popcnt64,
+    # _BitScan{Reverse,Forward}64), so BiblioSpec is not built for 32-bit.
+    <address-model>32:<build>no
 ;
 
 build-project-if-exists src ;

--- a/pwiz_tools/MSConvertGUI/MSConvertGUI.csproj
+++ b/pwiz_tools/MSConvertGUI/MSConvertGUI.csproj
@@ -11,6 +11,7 @@
     <RootNamespace>MSConvertGUI</RootNamespace>
     <AssemblyName>MSConvertGUI</AssemblyName>
     <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <RuntimeIdentifiers>win;win-x64;win-x86</RuntimeIdentifiers>
     <FileAlignment>512</FileAlignment>
     <FileUpgradeFlags>
     </FileUpgradeFlags>

--- a/pwiz_tools/SeeMS/seems.csproj
+++ b/pwiz_tools/SeeMS/seems.csproj
@@ -12,6 +12,7 @@
     <AssemblyName>seems</AssemblyName>
     <ApplicationIcon>Misc\SpectrumIcon.ico</ApplicationIcon>
     <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <RuntimeIdentifiers>win;win-x64;win-x86</RuntimeIdentifiers>
     <FileAlignment>512</FileAlignment>
     <FileUpgradeFlags>
     </FileUpgradeFlags>

--- a/pwiz_tools/Shared/CommonFileDialogs/CommonFileDialogs.csproj
+++ b/pwiz_tools/Shared/CommonFileDialogs/CommonFileDialogs.csproj
@@ -10,6 +10,7 @@
     <RootNamespace>pwiz.CommonFileDialogs</RootNamespace>
     <AssemblyName>pwiz.CommonFileDialogs</AssemblyName>
     <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <RuntimeIdentifiers>win;win-x64;win-x86</RuntimeIdentifiers>
     <FileAlignment>512</FileAlignment>
     <Deterministic>true</Deterministic>
   </PropertyGroup>

--- a/pwiz_tools/Shared/CommonMsData/CommonMsData.csproj
+++ b/pwiz_tools/Shared/CommonMsData/CommonMsData.csproj
@@ -12,7 +12,7 @@
     <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <Deterministic>true</Deterministic>
-    <RuntimeIdentifiers>win;win-x64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win;win-x64;win-x86</RuntimeIdentifiers>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
     <DebugSymbols>true</DebugSymbols>

--- a/pwiz_tools/Shared/CommonUtil/CommonUtil.csproj
+++ b/pwiz_tools/Shared/CommonUtil/CommonUtil.csproj
@@ -11,6 +11,7 @@
     <RootNamespace>pwiz.Common</RootNamespace>
     <AssemblyName>pwiz.CommonUtil</AssemblyName>
     <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <RuntimeIdentifiers>win;win-x64;win-x86</RuntimeIdentifiers>
     <FileAlignment>512</FileAlignment>
     <FileUpgradeFlags>
     </FileUpgradeFlags>

--- a/pwiz_tools/Shared/MSGraph/MSGraph.csproj
+++ b/pwiz_tools/Shared/MSGraph/MSGraph.csproj
@@ -16,6 +16,7 @@
     </FileUpgradeFlags>
     <OldToolsVersion>3.5</OldToolsVersion>
     <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <RuntimeIdentifiers>win;win-x64;win-x86</RuntimeIdentifiers>
     <UpgradeBackupLocation>
     </UpgradeBackupLocation>
     <TargetFrameworkProfile />

--- a/pwiz_tools/Shared/ProteowizardWrapper/ProteowizardWrapper.csproj
+++ b/pwiz_tools/Shared/ProteowizardWrapper/ProteowizardWrapper.csproj
@@ -11,6 +11,7 @@
     <RootNamespace>pwiz.ProteowizardWrapper</RootNamespace>
     <AssemblyName>ProteowizardWrapper</AssemblyName>
     <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <RuntimeIdentifiers>win;win-x64;win-x86</RuntimeIdentifiers>
     <FileAlignment>512</FileAlignment>
     <FileUpgradeFlags>
     </FileUpgradeFlags>

--- a/pwiz_tools/Shared/zedgraph/ZedGraph.csproj
+++ b/pwiz_tools/Shared/zedgraph/ZedGraph.csproj
@@ -18,6 +18,7 @@
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>ZedGraph.snk</AssemblyOriginatorKeyFile>
     <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <RuntimeIdentifiers>win;win-x64;win-x86</RuntimeIdentifiers>
     <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">


### PR DESCRIPTION
## Summary

Restores the 32-bit (`address-model=32`) build under Visual Studio 2026 (msvc-14.5), through to the WiX installer and the TeamCity target set (`pwiz`, `pwiz_aux`, `pwiz_tools/commandline`, `pwiz_tools/examples`, `pwiz_tools/sld`, `pwiz_tools/SeeMS`, `pwiz_tools/MSConvertGUI`, `pwiz_tools/BiblioSpec`, `scripts/wix`, `pwiz-bin.tar.bz2`).

* **Mascot Parser (`Jamroot.jam`)** — gated off for `address-model=32`. Only a 64-bit `msparser` is bundled, so 32-bit builds were linking it and failing with `__thiscall` unresolved externals in `MascotReader`. 32-bit now cleanly disables Mascot, matching the existing gcc / unsupported-MSVC path.
* **Boost.Build install clash (`stage.jam`)** — fixed a fatal `Name clash ... none/none` under `<install-dependencies>on`. The recursive collector staged both a generated DLL copy *and* its raw `.dll` source input (the Thermo `fileio` / `fregistry` / `MSFileReader.XRawfile2` DLLs). On a flat install it now keeps the generated artifact and drops the raw source it shadows; skips source-root installs (subdirs) and keeps every generated target, so genuine conflicts still error. Verified a no-op for 64-bit. Latent since #4099.
* **VS 2026 NuGet RIDs (8 `.csproj`)** — added `win-x86` to `<RuntimeIdentifiers>` across the MSConvertGUI and SeeMS project trees (`CommonUtil`, `CommonFileDialogs`, `CommonMsData`, `ProteowizardWrapper`, `MSConvertGUI`, `seems`, `MSGraph`, `ZedGraph`). MSBuild 18 requires the RID for x86-platform restore; matches the existing `Common.csproj` / `Skyline.csproj` convention.
* **BiblioSpec excluded for 32-bit (`BiblioSpec/Jamfile.jam`)** — its Arrow dependency uses x64-only MSVC intrinsics (`__popcnt64`, `_BitScan{Reverse,Forward}64`). Gated off with `<address-model>32:<build>no`, mirroring the existing `<toolset>darwin:<build>no`.

Requested by Matt.

## Test plan

- [x] 32-bit core C++ libraries, `msconvert` / `msdiff`, `pwiz_bindings_cli` — clean
- [x] 32-bit `MSConvertGUI.exe` and `SeeMS.exe` build and stage to `msvc-release`
- [x] Full TeamCity target set compiles/links/packages in 32-bit (`pwiz`, `pwiz_aux`, `commandline`, `examples`, `sld`, `SeeMS`, `MSConvertGUI`, `BiblioSpec` (excluded), `scripts/wix`, `pwiz-bin.tar.bz2`)
- [x] `scripts/wix//Test` — installs the MSI, runs `SeeMS.exe --test` on a Thermo `.RAW` (exercising the 32-bit legacy MSFileReader path), then uninstalls: **Deployment test passed**
- [x] 64-bit `install-native-dependencies` re-verified as a non-regression of the `stage.jam` change

### Known 32-bit limitations (pre-existing, not introduced here)
- `Reader_Thermo_Test` / `Reader_Shimadzu_Test` produce vendor-reader output diffs in 32-bit (legacy MSFileReader vs. the .NET RawFileReader reference; Shimadzu SDK `E_INVALIDARG`). These are reader-parity issues independent of the build fixes and are out of scope for this PR.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
