### PR TITLE
Cleared Full Scan mobilogram along with the heatmap

### DIFF
--- a/pwiz_tools/Skyline/Controls/Graphs/GraphFullScan.cs
+++ b/pwiz_tools/Skyline/Controls/Graphs/GraphFullScan.cs
@@ -2144,6 +2144,13 @@ namespace pwiz.Skyline.Controls.Graphs
             comboBoxScanType.Enabled = false;
             lblScanId.Text = string.Empty;
             leftButton.Enabled = rightButton.Enabled = false;
+            // The mobilogram lives in its own pane separate from the heatmap, so clear it here
+            // on every clear path or a stale mobilogram lingers after the heatmap is emptied.
+            if (_mobilogramPane != null)
+            {
+                _mobilogramPane.CurveList.Clear();
+                _mobilogramPane.GraphObjList.Clear();
+            }
             graphControl.MasterPane.Title.Text = _msDataFileScanHelper.FileName;
             graphControl.MasterPane.Title.IsVisible = true;
         }


### PR DESCRIPTION
## Summary

* In the Full Scan graph for ion-mobility data with the mobilogram pane visible, clearing the displayed scan (navigating to a state with no scan to show) emptied the heatmap (m/z vs drift time) but left the mobilogram (intensity vs drift time) showing its stale trace.
* Root cause: `GraphFullScan.ClearGraph()` reset the combo/labels/title but never touched `_mobilogramPane`, which is a separate pane from the heatmap (`GraphPane => _heatMapPane`). Both clear paths route through `ClearGraph()` — `LoadScan` when `scanId < 0`, and `ShowSpectrum` with a null scan provider — so only the heatmap's curves were cleared.
* Fix: `ClearGraph()` now clears `_mobilogramPane.CurveList` / `GraphObjList` (guarded on the pane being present), covering every clear path in one place.

Not applicable to the 26.1 release branch: the mobilogram feature (#4152/#4166) landed after the release branch was created, so no cherry-pick.

## Test plan

- [x] CrosslinkImsTest - ran on-screen; confirmed the mobilogram clears together with the heatmap
- [x] CodeInspection + ReSharper full-solution inspection - 0 errors / 0 warnings

Co-Authored-By: Claude <noreply@anthropic.com>
