### PR TITLE
Improved Osprey calibration summary console wording

### DIFF
--- a/pwiz_tools/Osprey/Osprey.Chromatography/RTCalibration.cs
+++ b/pwiz_tools/Osprey/Osprey.Chromatography/RTCalibration.cs
@@ -317,9 +317,20 @@ namespace pwiz.Osprey.Chromatography
         /// </summary>
         public static double SearchWindowHalfWidth(double mad, double minTolerance, double maxTolerance)
         {
+            return Math.Max(minTolerance, Math.Min(maxTolerance, SearchWindowRaw(mad)));
+        }
+
+        /// <summary>
+        /// The unclamped RT search tolerance (minutes) for a given robust-spread
+        /// MAD: <c>3 * MAD * 1.4826</c>, before the <c>[minTolerance, maxTolerance]</c>
+        /// clamp in <see cref="SearchWindowHalfWidth"/> is applied. Shared so the
+        /// console summary can report the computed tolerance alongside the clamped
+        /// one (e.g. when the fit is tighter than the floor).
+        /// </summary>
+        public static double SearchWindowRaw(double mad)
+        {
             double robustSd = mad * 1.4826;
-            double window = robustSd * 3.0;
-            return Math.Max(minTolerance, Math.Min(maxTolerance, window));
+            return robustSd * 3.0;
         }
 
         /// <summary>Get the library RT range used for calibration.</summary>

--- a/pwiz_tools/Osprey/Osprey.Tasks/Calibrator.cs
+++ b/pwiz_tools/Osprey/Osprey.Tasks/Calibrator.cs
@@ -738,10 +738,10 @@ namespace pwiz.Osprey.Tasks
             ms1Calibration = MzCalibration.CalculateSingleLevel(allMs1Errors.ToArray(), unitStr);
             ms2Calibration = MzCalibration.CalculateSingleLevel(allMs2Errors.ToArray(), unitStr);
             _ctx.LogVerbose(string.Format(
-                "MS1 calibration (pass {0}): mean={1:F4} {2}, SD={3:F4} {2}, 3*SD={4:F4} {2} ({5} errors)",
+                "MS1 calibration (pass {0}): mean={1:F4} {2}, SD={3:F4} {2}, 3*SD={4:F4} {2} (n={5} precursor matches)",
                 passNumber, ms1Calibration.Mean, unitStr, ms1Calibration.SD, 3.0 * ms1Calibration.SD, allMs1Errors.Count));
             _ctx.LogVerbose(string.Format(
-                "MS2 calibration (pass {0}): mean={1:F4} {2}, SD={3:F4} {2}, 3*SD={4:F4} {2} ({5} errors)",
+                "MS2 calibration (pass {0}): mean={1:F4} {2}, SD={3:F4} {2}, 3*SD={4:F4} {2} (n={5} fragment matches)",
                 passNumber, ms2Calibration.Mean, unitStr, ms2Calibration.SD, 3.0 * ms2Calibration.SD, allMs2Errors.Count));
         }
 

--- a/pwiz_tools/Osprey/Osprey.Tasks/PerFileScoringTask.cs
+++ b/pwiz_tools/Osprey/Osprey.Tasks/PerFileScoringTask.cs
@@ -1633,18 +1633,40 @@ namespace pwiz.Osprey.Tasks
             else
             {
                 var stats = rtCalibration.Stats();
-                double finalHalfWidth = RTCalibration.SearchWindowHalfWidth(
+                double rawTolerance = RTCalibration.SearchWindowRaw(stats.MAD);
+                double finalTolerance = RTCalibration.SearchWindowHalfWidth(
                     stats.MAD, config.RtCalibration.MinRtTolerance, config.RtCalibration.MaxRtTolerance);
-                ctx.LogInfo(string.Format(ic,
-                    "  RT window: {0:F2} min before -> {1:F2} min (+/-) search half-width after calibration",
-                    initialRtTolerance, finalHalfWidth));
+                string rtToleranceLine;
+                if (finalTolerance > rawTolerance)
+                {
+                    // The computed 3*SD was tighter than the floor: show the real
+                    // computed tolerance and the floor actually in use.
+                    rtToleranceLine = string.Format(ic,
+                        "  RT tolerance: +/-{0:F2} min before -> +/-{1:F2} min computed (3xSD), using +/-{2:F2} min floor, after calibration",
+                        initialRtTolerance, rawTolerance, finalTolerance);
+                }
+                else if (finalTolerance < rawTolerance)
+                {
+                    // The computed 3*SD exceeded the ceiling: show the computed
+                    // tolerance and the cap actually in use.
+                    rtToleranceLine = string.Format(ic,
+                        "  RT tolerance: +/-{0:F2} min before -> +/-{1:F2} min computed (3xSD), capped at +/-{2:F2} min, after calibration",
+                        initialRtTolerance, rawTolerance, finalTolerance);
+                }
+                else
+                {
+                    rtToleranceLine = string.Format(ic,
+                        "  RT tolerance: +/-{0:F2} min before -> +/-{1:F2} min after calibration",
+                        initialRtTolerance, finalTolerance);
+                }
+                ctx.LogInfo(rtToleranceLine);
                 ctx.LogInfo(string.Format(ic,
                     "  RT fit: MAD={0:F3} min, residual SD={1:F3} min, R^2={2:F4}, n={3} points",
                     stats.MAD, stats.ResidualSD, stats.RSquared, stats.NPoints));
             }
 
-            EmitMassCalibrationLine(ctx, "MS1", ms1Cal);
-            EmitMassCalibrationLine(ctx, "MS2", ms2Cal);
+            EmitMassCalibrationLine(ctx, "MS1", "precursor", ms1Cal);
+            EmitMassCalibrationLine(ctx, "MS2", "fragment", ms2Cal);
         }
 
         /// <summary>
@@ -1654,7 +1676,7 @@ namespace pwiz.Osprey.Tasks
         /// when the level had no usable errors.
         /// </summary>
         private static void EmitMassCalibrationLine(
-            PipelineContext ctx, string level, MzCalibrationResult cal)
+            PipelineContext ctx, string level, string matchNoun, MzCalibrationResult cal)
         {
             var ic = CultureInfo.InvariantCulture;
             if (cal == null || !cal.Calibrated)
@@ -1664,8 +1686,8 @@ namespace pwiz.Osprey.Tasks
             }
             double tolerance = cal.AdjustedTolerance ?? (Math.Abs(cal.Mean) + 3.0 * cal.SD);
             ctx.LogInfo(string.Format(ic,
-                "  {0} mass: correction={1:F2} {2}, SD={3:F2} {2}, tolerance=+/-{4:F2} {2} ({5} errors)",
-                level, cal.Mean, cal.Unit, cal.SD, tolerance, cal.Count));
+                "  {0} mass: correction={1:F2} {2}, SD={3:F2} {2}, tolerance=+/-{4:F2} {2} (n={5} {6} matches)",
+                level, cal.Mean, cal.Unit, cal.SD, tolerance, cal.Count, matchNoun));
         }
 
         /// <summary>

--- a/pwiz_tools/Osprey/Osprey.Tasks/PerFileScoringTask.cs
+++ b/pwiz_tools/Osprey/Osprey.Tasks/PerFileScoringTask.cs
@@ -1636,28 +1636,40 @@ namespace pwiz.Osprey.Tasks
                 double rawTolerance = RTCalibration.SearchWindowRaw(stats.MAD);
                 double finalTolerance = RTCalibration.SearchWindowHalfWidth(
                     stats.MAD, config.RtCalibration.MinRtTolerance, config.RtCalibration.MaxRtTolerance);
+                string beforeStr = initialRtTolerance.ToString("F2", ic);
+                string rawStr = rawTolerance.ToString("F2", ic);
+                string finalStr = finalTolerance.ToString("F2", ic);
                 string rtToleranceLine;
-                if (finalTolerance > rawTolerance)
+                if (double.IsNaN(finalTolerance))
                 {
-                    // The computed 3*SD was tighter than the floor: show the real
+                    // Degenerate calibration (e.g. NaN MAD): no usable spread to report.
+                    rtToleranceLine = string.Format(ic,
+                        "  RT tolerance: +/-{0} min before -> undetermined after calibration (no usable RT spread)",
+                        beforeStr);
+                }
+                else if (rawStr == finalStr)
+                {
+                    // In range, or a clamp too small to show at this precision: a single
+                    // value is unambiguous, so skip the computed-vs-clamp call-out.
+                    rtToleranceLine = string.Format(ic,
+                        "  RT tolerance: +/-{0} min before -> +/-{1} min after calibration",
+                        beforeStr, finalStr);
+                }
+                else if (finalTolerance > rawTolerance)
+                {
+                    // The computed 3*MAD*1.4826 was tighter than the floor: show the
                     // computed tolerance and the floor actually in use.
                     rtToleranceLine = string.Format(ic,
-                        "  RT tolerance: +/-{0:F2} min before -> +/-{1:F2} min computed (3xSD), using +/-{2:F2} min floor, after calibration",
-                        initialRtTolerance, rawTolerance, finalTolerance);
-                }
-                else if (finalTolerance < rawTolerance)
-                {
-                    // The computed 3*SD exceeded the ceiling: show the computed
-                    // tolerance and the cap actually in use.
-                    rtToleranceLine = string.Format(ic,
-                        "  RT tolerance: +/-{0:F2} min before -> +/-{1:F2} min computed (3xSD), capped at +/-{2:F2} min, after calibration",
-                        initialRtTolerance, rawTolerance, finalTolerance);
+                        "  RT tolerance: +/-{0} min before -> +/-{1} min computed (3*MAD*1.4826), using +/-{2} min floor, after calibration",
+                        beforeStr, rawStr, finalStr);
                 }
                 else
                 {
+                    // finalTolerance < rawTolerance: the computed value exceeded the
+                    // ceiling, so show the computed tolerance and the cap in use.
                     rtToleranceLine = string.Format(ic,
-                        "  RT tolerance: +/-{0:F2} min before -> +/-{1:F2} min after calibration",
-                        initialRtTolerance, finalTolerance);
+                        "  RT tolerance: +/-{0} min before -> +/-{1} min computed (3*MAD*1.4826), capped at +/-{2} min, after calibration",
+                        beforeStr, rawStr, finalStr);
                 }
                 ctx.LogInfo(rtToleranceLine);
                 ctx.LogInfo(string.Format(ic,

--- a/pwiz_tools/Osprey/Osprey.Test/CalibrationTest.cs
+++ b/pwiz_tools/Osprey/Osprey.Test/CalibrationTest.cs
@@ -543,6 +543,35 @@ namespace pwiz.Osprey.Test
         }
 
         /// <summary>
+        /// <see cref="RTCalibration.SearchWindowRaw"/> is the unclamped
+        /// <c>3 * MAD * 1.4826</c> the console summary reports as the computed
+        /// tolerance. Verifies the formula and the small / large / in-range MAD
+        /// cases that select the summary's floor / cap / in-range wording.
+        /// </summary>
+        [TestMethod]
+        public void TestSearchWindowRaw()
+        {
+            // Unclamped 3 * 1.4826 * MAD.
+            double mad = 0.30;
+            Assert.AreEqual(3.0 * mad * 1.4826,
+                RTCalibration.SearchWindowRaw(mad), TOLERANCE);
+            Assert.AreEqual(0.0, RTCalibration.SearchWindowRaw(0.0), TOLERANCE);
+
+            // The raw value vs the clamped SearchWindowHalfWidth selects which
+            // branch the summary reports: below the floor, above the ceiling, or
+            // in range (equal).
+            Assert.IsTrue(RTCalibration.SearchWindowRaw(0.001)
+                < RTCalibration.SearchWindowHalfWidth(0.001, 0.5, 3.0));
+            Assert.IsTrue(RTCalibration.SearchWindowRaw(5.0)
+                > RTCalibration.SearchWindowHalfWidth(5.0, 0.5, 3.0));
+            Assert.AreEqual(RTCalibration.SearchWindowRaw(0.30),
+                RTCalibration.SearchWindowHalfWidth(0.30, 0.5, 3.0), TOLERANCE);
+
+            // A NaN MAD propagates, so the summary treats it as undetermined.
+            Assert.IsTrue(double.IsNaN(RTCalibration.SearchWindowRaw(double.NaN)));
+        }
+
+        /// <summary>
         /// Verifies save and load of calibration file to disk.
         /// </summary>
         [TestMethod]


### PR DESCRIPTION
## Summary

* Renamed the RT search-window "half-width" to "RT tolerance" in the per-file calibration summary, matching the config (`MinRtTolerance` / `MaxRtTolerance`) and the MS1/MS2 tolerance lines below it
* When the computed tolerance clamps, show the computed `3*MAD*1.4826` value and the floor/cap actually in use (and suppress the call-out when the two round to the same value); guard a degenerate NaN MAD
* Relabeled the mass-calibration `(N errors)` counts as `(n=N precursor matches)` / `(n=N fragment matches)` in both the summary and the verbose per-pass lines, since they are matched-peak counts, not failures

Requested by Mike.

Fixes #4387

## Test plan

- [x] Full Osprey unit suite passes (454 passed, 3 skipped); added `TestSearchWindowRaw` covering the unclamped `3*MAD*1.4826` and the floor/cap/in-range branch selection
- [x] ReSharper inspection adds no new warnings
- [x] Console-text only; search output (blib) is byte-identical

Co-Authored-By: Claude <noreply@anthropic.com>
