### PR TITLE
Site-determining ion assistant for modification localization

### DIFF
--- a/pwiz_tools/Skyline/Controls/ControlsResources.designer.cs
+++ b/pwiz_tools/Skyline/Controls/ControlsResources.designer.cs
@@ -180,6 +180,15 @@ namespace pwiz.Skyline.Controls {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Show only site-determining ions.
+        /// </summary>
+        public static string PopupPickList_SiteDetermining_ToolTip {
+            get {
+                return ResourceManager.GetString("PopupPickList_SiteDetermining_ToolTip", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   Looks up a localized string similar to Auto-select filtered {0}.
         /// </summary>
         public static string PopupPickList_UpdateAutoManageUI_Auto_select_filtered__0_ {

--- a/pwiz_tools/Skyline/Controls/ControlsResources.designer.cs
+++ b/pwiz_tools/Skyline/Controls/ControlsResources.designer.cs
@@ -180,7 +180,16 @@ namespace pwiz.Skyline.Controls {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Show only site-determining ions.
+        ///   Looks up a localized string similar to No ions uniquely localize this modification.
+        /// </summary>
+        public static string PopupPickList_SiteDetermining_NoneFound {
+            get {
+                return ResourceManager.GetString("PopupPickList_SiteDetermining_NoneFound", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Show only ions that uniquely localize modifications.
         /// </summary>
         public static string PopupPickList_SiteDetermining_ToolTip {
             get {

--- a/pwiz_tools/Skyline/Controls/ControlsResources.resx
+++ b/pwiz_tools/Skyline/Controls/ControlsResources.resx
@@ -154,8 +154,11 @@
   <data name="MessageBoxHelper_ValidateNumberListTextBox__0__must_contain_a_comma_separated_list_of_integers_from__1__to__2__" xml:space="preserve">
     <value>{0} must contain a comma separated list of integers from {1} to {2}.</value>
   </data>
+  <data name="PopupPickList_SiteDetermining_NoneFound" xml:space="preserve">
+    <value>No ions uniquely localize this modification</value>
+  </data>
   <data name="PopupPickList_SiteDetermining_ToolTip" xml:space="preserve">
-    <value>Show only site-determining ions</value>
+    <value>Show only ions that uniquely localize modifications</value>
   </data>
   <data name="PopupPickList_UpdateAutoManageUI_Auto_select_filtered__0_" xml:space="preserve">
     <value>Auto-select filtered {0}</value>

--- a/pwiz_tools/Skyline/Controls/ControlsResources.resx
+++ b/pwiz_tools/Skyline/Controls/ControlsResources.resx
@@ -154,6 +154,9 @@
   <data name="MessageBoxHelper_ValidateNumberListTextBox__0__must_contain_a_comma_separated_list_of_integers_from__1__to__2__" xml:space="preserve">
     <value>{0} must contain a comma separated list of integers from {1} to {2}.</value>
   </data>
+  <data name="PopupPickList_SiteDetermining_ToolTip" xml:space="preserve">
+    <value>Show only site-determining ions</value>
+  </data>
   <data name="PopupPickList_UpdateAutoManageUI_Auto_select_filtered__0_" xml:space="preserve">
     <value>Auto-select filtered {0}</value>
   </data>

--- a/pwiz_tools/Skyline/Controls/PopupPickList.Designer.cs
+++ b/pwiz_tools/Skyline/Controls/PopupPickList.Designer.cs
@@ -42,6 +42,7 @@ namespace pwiz.Skyline.Controls
             this.textSearch = new System.Windows.Forms.TextBox();
             this.cbSynchronize = new System.Windows.Forms.CheckBox();
             this.pickListMulti = new System.Windows.Forms.ListBox();
+            this.lblSiteDeterminingEmpty = new System.Windows.Forms.Label();
             this.toolStrip1.SuspendLayout();
             this.SuspendLayout();
             // 
@@ -153,12 +154,20 @@ namespace pwiz.Skyline.Controls
             this.pickListMulti.MouseDown += new System.Windows.Forms.MouseEventHandler(this.pickListMulti_MouseDown);
             this.pickListMulti.MouseLeave += new System.EventHandler(this.pickListMulti_MouseLeave);
             this.pickListMulti.MouseMove += new System.Windows.Forms.MouseEventHandler(this.pickListMulti_MouseMove);
-            // 
+            //
+            // lblSiteDeterminingEmpty
+            //
+            this.lblSiteDeterminingEmpty.BackColor = System.Drawing.SystemColors.Window;
+            this.lblSiteDeterminingEmpty.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+            this.lblSiteDeterminingEmpty.Visible = false;
+            this.lblSiteDeterminingEmpty.Name = "lblSiteDeterminingEmpty";
+            //
             // PopupPickList
-            // 
+            //
             resources.ApplyResources(this, "$this");
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.ControlBox = false;
+            this.Controls.Add(this.lblSiteDeterminingEmpty);
             this.Controls.Add(this.pickListMulti);
             this.Controls.Add(this.cbSynchronize);
             this.Controls.Add(this.textSearch);
@@ -193,5 +202,6 @@ namespace pwiz.Skyline.Controls
         private System.Windows.Forms.ToolStripButton tbbSiteDetermining;
         private System.Windows.Forms.CheckBox cbSynchronize;
         private System.Windows.Forms.ListBox pickListMulti;
+        private System.Windows.Forms.Label lblSiteDeterminingEmpty;
     }
 }

--- a/pwiz_tools/Skyline/Controls/PopupPickList.Designer.cs
+++ b/pwiz_tools/Skyline/Controls/PopupPickList.Designer.cs
@@ -37,6 +37,7 @@ namespace pwiz.Skyline.Controls
             this.tbbAutoManageChildren = new System.Windows.Forms.ToolStripButton();
             this.toolStripSeparator2 = new System.Windows.Forms.ToolStripSeparator();
             this.tbbFind = new System.Windows.Forms.ToolStripButton();
+            this.tbbSiteDetermining = new System.Windows.Forms.ToolStripButton();
             this.cbItems = new System.Windows.Forms.CheckBox();
             this.textSearch = new System.Windows.Forms.TextBox();
             this.cbSynchronize = new System.Windows.Forms.CheckBox();
@@ -55,7 +56,8 @@ namespace pwiz.Skyline.Controls
             this.tbbFilter,
             this.tbbAutoManageChildren,
             this.toolStripSeparator2,
-            this.tbbFind});
+            this.tbbFind,
+            this.tbbSiteDetermining});
             this.toolStrip1.Name = "toolStrip1";
             // 
             // tbbOk
@@ -111,7 +113,15 @@ namespace pwiz.Skyline.Controls
             resources.ApplyResources(this.tbbFind, "tbbFind");
             this.tbbFind.Name = "tbbFind";
             this.tbbFind.Click += new System.EventHandler(this.tbbFind_Click);
-            // 
+            //
+            // tbbSiteDetermining
+            //
+            this.tbbSiteDetermining.CheckOnClick = true;
+            this.tbbSiteDetermining.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+            this.tbbSiteDetermining.Image = global::pwiz.Skyline.Properties.Resources.Ions_fragments;
+            this.tbbSiteDetermining.Name = "tbbSiteDetermining";
+            this.tbbSiteDetermining.Click += new System.EventHandler(this.tbbSiteDetermining_Click);
+            //
             // cbItems
             // 
             resources.ApplyResources(this.cbItems, "cbItems");
@@ -180,6 +190,7 @@ namespace pwiz.Skyline.Controls
         private System.Windows.Forms.ToolStripSeparator toolStripSeparator2;
         private System.Windows.Forms.ToolStripButton tbbFind;
         private System.Windows.Forms.ToolStripButton tbbAutoManageChildren;
+        private System.Windows.Forms.ToolStripButton tbbSiteDetermining;
         private System.Windows.Forms.CheckBox cbSynchronize;
         private System.Windows.Forms.ListBox pickListMulti;
     }

--- a/pwiz_tools/Skyline/Controls/PopupPickList.cs
+++ b/pwiz_tools/Skyline/Controls/PopupPickList.cs
@@ -122,6 +122,13 @@ namespace pwiz.Skyline.Controls
                 cbSynchronize.Text = synchLabelText;
                 cbSynchronize.Checked = _picker.IsSynchSiblings;
             }
+
+            // Overlay the empty-state hint on the choices list. Shown only when the
+            // site-determining filter is on but no ion uniquely localizes the modification.
+            lblSiteDeterminingEmpty.Text = ControlsResources.PopupPickList_SiteDetermining_NoneFound;
+            lblSiteDeterminingEmpty.Bounds = pickListMulti.Bounds;
+            lblSiteDeterminingEmpty.Anchor = pickListMulti.Anchor;
+            lblSiteDeterminingEmpty.BringToFront();
         }
 
         public IEnumerable<string> ItemNames
@@ -170,6 +177,15 @@ namespace pwiz.Skyline.Controls
         public bool SiteDeterminingButtonVisible
         {
             get { return tbbSiteDetermining.Visible; }
+        }
+
+        /// <summary>
+        /// Test support: whether the empty-state hint (shown when the site-determining filter
+        /// leaves no visible choices) is currently displayed.
+        /// </summary>
+        public bool SiteDeterminingEmptyHintVisible
+        {
+            get { return lblSiteDeterminingEmpty.Visible; }
         }
 
         public Rectangle GetItemTextRectangle(int i)
@@ -300,6 +316,11 @@ namespace pwiz.Skyline.Controls
                 }
             }
             pickListMulti.EndUpdate();
+
+            // Show the empty-state hint when the site-determining filter is on and it left the
+            // choices list empty (no ion uniquely localizes the modification).
+            lblSiteDeterminingEmpty.Visible = _siteDeterminingOnly && pickListMulti.Items.Count == 0;
+
             UpdateSelectAll();
         }
 

--- a/pwiz_tools/Skyline/Controls/PopupPickList.cs
+++ b/pwiz_tools/Skyline/Controls/PopupPickList.cs
@@ -133,6 +133,45 @@ namespace pwiz.Skyline.Controls
             }
         }
 
+        /// <summary>
+        /// Test support: the <see cref="DocNode"/> behind each currently visible choice, in
+        /// display order. Lets a test map a visible pick to its underlying identity (e.g. a
+        /// <see cref="Transition"/>) rather than relying on the (localized) label.
+        /// </summary>
+        public IEnumerable<DocNode> VisibleChoices
+        {
+            get
+            {
+                for (int i = 0; i < pickListMulti.Items.Count; i++)
+                    yield return GetVisibleChoice(i).Choice;
+            }
+        }
+
+        /// <summary>
+        /// Test support: toggles the "site-determining ions only" filter the same way the
+        /// <see cref="tbbSiteDetermining"/> toolbar button does.
+        /// </summary>
+        public bool SiteDeterminingFilter
+        {
+            get { return _siteDeterminingOnly; }
+            set
+            {
+                _siteDeterminingOnly = value;
+                if (tbbSiteDetermining.Visible)
+                    tbbSiteDetermining.Checked = value;
+                ShowChoices();
+            }
+        }
+
+        /// <summary>
+        /// Test support: whether the site-determining ions toggle button is showing (only for
+        /// localizable peptides).
+        /// </summary>
+        public bool SiteDeterminingButtonVisible
+        {
+            get { return tbbSiteDetermining.Visible; }
+        }
+
         public Rectangle GetItemTextRectangle(int i)
         {
             var rect = pickListMulti.GetItemRectangle(i);

--- a/pwiz_tools/Skyline/Controls/PopupPickList.cs
+++ b/pwiz_tools/Skyline/Controls/PopupPickList.cs
@@ -45,6 +45,7 @@ namespace pwiz.Skyline.Controls
         private bool _closing;
         private bool _autoManageChildren;
         private bool _selectalInternalChange;
+        private bool _siteDeterminingOnly;
 
         private int _leftText;
 
@@ -98,6 +99,11 @@ namespace pwiz.Skyline.Controls
             // change what is picked.
             _autoManageChildren = _picker.AutoManageChildren;
             UpdateAutoManageUI();
+
+            // Show the site-determining ions toggle only for localizable peptides.
+            bool canSd = _picker is ISiteDeterminingIonPicker sd && sd.CanShowSiteDeterminingIons;
+            tbbSiteDetermining.Visible = canSd;
+            tbbSiteDetermining.ToolTipText = ControlsResources.PopupPickList_SiteDetermining_ToolTip;
 
             // Hide the synchronize checkbox, or set its label correctly
             string synchLabelText = _picker.SynchSiblingsLabel;
@@ -246,6 +252,9 @@ namespace pwiz.Skyline.Controls
             for (int i = 0; i < _choices.Count; i++)
             {
                 var choice = _choices[i];
+                if (_siteDeterminingOnly && _picker is ISiteDeterminingIonPicker sd2 &&
+                    !sd2.IsSiteDeterminingChoice(choice.Choice))
+                    continue;
                 if (!textSearch.Visible || AcceptChoice(choice, searches))
                 {
                     pickListMulti.Items.Add(choice);
@@ -360,6 +369,12 @@ namespace pwiz.Skyline.Controls
         private void tbbAutoManageChildren_Click(object sender, EventArgs e)
         {
             ToggleAutoManageChildren();
+        }
+
+        private void tbbSiteDetermining_Click(object sender, EventArgs e)
+        {
+            _siteDeterminingOnly = tbbSiteDetermining.Checked;
+            ShowChoices();
         }
 
         public void ToggleAutoManageChildren()

--- a/pwiz_tools/Skyline/Controls/SeqNode/SrmTreeNode.cs
+++ b/pwiz_tools/Skyline/Controls/SeqNode/SrmTreeNode.cs
@@ -845,6 +845,31 @@ namespace pwiz.Skyline.Controls.SeqNode
     }
 
     /// <summary>
+    /// Optional capability a child picker may implement to expose a "site-determining
+    /// ions" filter in the <see cref="PopupPickList"/>, for peptides that carry an
+    /// ambiguous (localizable) modification.
+    /// </summary>
+    public interface ISiteDeterminingIonPicker
+    {
+        /// <summary>
+        /// True when the picker's peptide is localizable, so the site-determining
+        /// ions toggle should be offered.
+        /// </summary>
+        bool CanShowSiteDeterminingIons { get; }
+
+        /// <summary>
+        /// True when the given choice is a site-determining product ion.
+        /// </summary>
+        bool IsSiteDeterminingChoice(DocNode choice);
+
+        /// <summary>
+        /// The resolved modification's name for the given choice, or null when the
+        /// choice is not site-determining.
+        /// </summary>
+        string GetSiteDeterminingTip(DocNode choice);
+    }
+
+    /// <summary>
     /// Implement to support the <see cref="PopupPickList"/> user interface for
     /// picking children of a <see cref="SrmTreeNode"/>.
     /// </summary>

--- a/pwiz_tools/Skyline/Controls/SeqNode/SrmTreeNode.cs
+++ b/pwiz_tools/Skyline/Controls/SeqNode/SrmTreeNode.cs
@@ -858,7 +858,9 @@ namespace pwiz.Skyline.Controls.SeqNode
         bool CanShowSiteDeterminingIons { get; }
 
         /// <summary>
-        /// True when the given choice is a site-determining product ion.
+        /// True when the given choice is a product ion that uniquely localizes the modification
+        /// (no other positional placement produces it). May match nothing when the placement is
+        /// unresolvable, in which case the filtered list is legitimately empty.
         /// </summary>
         bool IsSiteDeterminingChoice(DocNode choice);
 

--- a/pwiz_tools/Skyline/Controls/SeqNode/TransitionGroupTreeNode.cs
+++ b/pwiz_tools/Skyline/Controls/SeqNode/TransitionGroupTreeNode.cs
@@ -29,6 +29,7 @@ using pwiz.Skyline.Model.Databinding;
 using pwiz.Skyline.Model.Databinding.Entities;
 using pwiz.Skyline.Model.DocSettings;
 using pwiz.Skyline.Model.Lib;
+using pwiz.Skyline.Model.Localization;
 using pwiz.Skyline.Model.Results.Spectra;
 using pwiz.Skyline.Properties;
 using pwiz.Skyline.Util;
@@ -37,8 +38,9 @@ using Transition = pwiz.Skyline.Model.Transition;
 
 namespace pwiz.Skyline.Controls.SeqNode
 {
-    public class TransitionGroupTreeNode : SrmTreeNodeParent
+    public class TransitionGroupTreeNode : SrmTreeNodeParent, ISiteDeterminingIonPicker
     {
+        private SiteDeterminingIonAnalyzer _siteDeterminingAnalyzer;
         public static TransitionGroupTreeNode CreateInstance(SequenceTree tree, DocNode nodeDoc)
         {
             Debug.Assert(nodeDoc is TransitionGroupDocNode);
@@ -354,6 +356,47 @@ namespace pwiz.Skyline.Controls.SeqNode
             return true;
         }
         
+        #endregion
+
+        #region ISiteDeterminingIonPicker Members
+
+        private SiteDeterminingIonAnalyzer SiteDeterminingAnalyzer
+        {
+            get
+            {
+                var nodePep = PepNode;
+                if (nodePep == null)
+                    return null;
+                return _siteDeterminingAnalyzer ??
+                       (_siteDeterminingAnalyzer = new SiteDeterminingIonAnalyzer(DocSettings, nodePep));
+            }
+        }
+
+        public bool CanShowSiteDeterminingIons
+        {
+            get
+            {
+                var analyzer = SiteDeterminingAnalyzer;
+                return analyzer != null && analyzer.CanLocalize;
+            }
+        }
+
+        public bool IsSiteDeterminingChoice(DocNode choice)
+        {
+            var analyzer = SiteDeterminingAnalyzer;
+            return analyzer != null && choice.Id is Transition transition &&
+                   analyzer.IsSiteDetermining(transition);
+        }
+
+        public string GetSiteDeterminingTip(DocNode choice)
+        {
+            var analyzer = SiteDeterminingAnalyzer;
+            if (analyzer == null || !(choice.Id is Transition transition))
+                return null;
+            var mod = analyzer.GetResolvedModification(transition);
+            return mod?.Name;
+        }
+
         #endregion
 
         #region ITipProvider Members

--- a/pwiz_tools/Skyline/Controls/SeqNode/TransitionGroupTreeNode.cs
+++ b/pwiz_tools/Skyline/Controls/SeqNode/TransitionGroupTreeNode.cs
@@ -381,11 +381,17 @@ namespace pwiz.Skyline.Controls.SeqNode
             }
         }
 
+        /// <summary>
+        /// True when the given choice is an ion that <em>uniquely localizes</em> the modification,
+        /// i.e. no other positional placement produces it (producing-set size == 1). For placements
+        /// that cannot be resolved (e.g. the interior of a serine run) no ion is unique, so the
+        /// filtered list is legitimately empty.
+        /// </summary>
         public bool IsSiteDeterminingChoice(DocNode choice)
         {
             var analyzer = SiteDeterminingAnalyzer;
             return analyzer != null && choice.Id is Transition transition &&
-                   analyzer.IsSiteDetermining(transition);
+                   analyzer.IsUniqueToPrecursor(transition);
         }
 
         public string GetSiteDeterminingTip(DocNode choice)

--- a/pwiz_tools/Skyline/Model/Databinding/Entities/ColumnCaptions.Designer.cs
+++ b/pwiz_tools/Skyline/Model/Databinding/Entities/ColumnCaptions.Designer.cs
@@ -1924,6 +1924,15 @@ namespace pwiz.Skyline.Model.Databinding.Entities {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Localization Isomer Count.
+        /// </summary>
+        public static string LocalizationIsomerCount {
+            get {
+                return ResourceManager.GetString("LocalizationIsomerCount", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   Looks up a localized string similar to Log 2 Fold Change.
         /// </summary>
         public static string Log2FoldChange {
@@ -2274,6 +2283,15 @@ namespace pwiz.Skyline.Model.Databinding.Entities {
             }
         }
         
+        /// <summary>
+        ///   Looks up a localized string similar to Modification Localization Group.
+        /// </summary>
+        public static string ModificationLocalizationGroup {
+            get {
+                return ResourceManager.GetString("ModificationLocalizationGroup", resourceCulture);
+            }
+        }
+
         /// <summary>
         ///   Looks up a localized string similar to Modified Area Proportion.
         /// </summary>

--- a/pwiz_tools/Skyline/Model/Databinding/Entities/ColumnCaptions.resx
+++ b/pwiz_tools/Skyline/Model/Databinding/Entities/ColumnCaptions.resx
@@ -738,6 +738,9 @@
   <data name="LinearFit">
     <value>Linear Fit</value>
   </data>
+  <data name="LocalizationIsomerCount">
+    <value>Localization Isomer Count</value>
+  </data>
   <data name="Log2FoldChange">
     <value>Log 2 Fold Change</value>
   </data>
@@ -854,6 +857,9 @@
   </data>
   <data name="ModelScore">
     <value>Model Score</value>
+  </data>
+  <data name="ModificationLocalizationGroup">
+    <value>Modification Localization Group</value>
   </data>
   <data name="ModifiedAreaProportion">
     <value>Modified Area Proportion</value>

--- a/pwiz_tools/Skyline/Model/Databinding/Entities/ColumnToolTips.Designer.cs
+++ b/pwiz_tools/Skyline/Model/Databinding/Entities/ColumnToolTips.Designer.cs
@@ -1978,6 +1978,15 @@ namespace pwiz.Skyline.Model.Databinding.Entities {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The number of positional isomers arising from ambiguously localized modifications on the peptide..
+        /// </summary>
+        public static string LocalizationIsomerCount {
+            get {
+                return ResourceManager.GetString("LocalizationIsomerCount", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   Looks up a localized string similar to The logarithm base 2 of the fold change value..
         /// </summary>
         public static string Log2FoldChange {
@@ -2335,6 +2344,15 @@ namespace pwiz.Skyline.Model.Databinding.Entities {
             }
         }
         
+        /// <summary>
+        ///   Looks up a localized string similar to A key identifying peptides that share the same unmodified sequence and the same set of ambiguously localized modifications..
+        /// </summary>
+        public static string ModificationLocalizationGroup {
+            get {
+                return ResourceManager.GetString("ModificationLocalizationGroup", resourceCulture);
+            }
+        }
+
         /// <summary>
         ///   Looks up a localized string similar to The normalized area of this peptide result divided by the sum of all peptide results in this protein and replicate that have the same unmodified sequence..
         /// </summary>

--- a/pwiz_tools/Skyline/Model/Databinding/Entities/ColumnToolTips.resx
+++ b/pwiz_tools/Skyline/Model/Databinding/Entities/ColumnToolTips.resx
@@ -774,6 +774,9 @@ The options for determining this value can be specified on the Quantification ta
   <data name="LinearFit">
     <value>The result of doing the linear regression to determine the fold change.</value>
   </data>
+  <data name="LocalizationIsomerCount">
+    <value>The number of positional isomers arising from ambiguously localized modifications on the peptide.</value>
+  </data>
   <data name="Log2FoldChange">
     <value>The logarithm base 2 of the fold change value.</value>
   </data>
@@ -897,6 +900,9 @@ edited all transitions for a precursor use the same integration boundaries</valu
   </data>
   <data name="ModelScore">
     <value>The sum of the feature values weighted according to the currently selected peak scoring model.</value>
+  </data>
+  <data name="ModificationLocalizationGroup">
+    <value>A key identifying peptides that share the same unmodified sequence and the same set of ambiguously localized modifications.</value>
   </data>
   <data name="ModifiedAreaProportion">
     <value>The normalized area of this peptide result divided by the sum of all peptide results in this protein and replicate that have the same unmodified sequence.</value>

--- a/pwiz_tools/Skyline/Model/Databinding/Entities/Peptide.cs
+++ b/pwiz_tools/Skyline/Model/Databinding/Entities/Peptide.cs
@@ -31,6 +31,7 @@ using pwiz.Skyline.Model.DocSettings.AbsoluteQuantification;
 using pwiz.Skyline.Model.ElementLocators;
 using pwiz.Skyline.Model.GroupComparison;
 using pwiz.Skyline.Model.Hibernate;
+using pwiz.Skyline.Model.Localization;
 using pwiz.Skyline.Properties;
 using pwiz.Skyline.Util;
 using pwiz.Skyline.Util.Extensions;
@@ -45,6 +46,8 @@ namespace pwiz.Skyline.Model.Databinding.Entities
     {
         private readonly Protein _protein;
         private readonly CachedValues _cachedValues = new CachedValues();
+        private bool _siteDeterminingIonAnalyzerComputed;
+        private SiteDeterminingIonAnalyzer _siteDeterminingIonAnalyzer;
         public Peptide(SkylineDataSchema dataSchema, IdentityPath identityPath) : this(new Protein(dataSchema, identityPath.GetPathTo(0)), identityPath.Child)
         {
         }
@@ -131,8 +134,49 @@ namespace pwiz.Skyline.Model.Databinding.Entities
             }
         }
 
+        [InvariantDisplayName("ModificationLocalizationGroup")]
+        [Hidden(InUiMode = UiModes.SMALL_MOLECULES)]
+        public string ModificationLocalizationGroup
+        {
+            get
+            {
+                var analyzer = GetSiteDeterminingIonAnalyzer();
+                return analyzer?.LocalizationGroupKey;
+            }
+        }
+
+        [InvariantDisplayName("LocalizationIsomerCount")]
+        [Hidden(InUiMode = UiModes.SMALL_MOLECULES)]
+        [Format(NullValue = TextUtil.EXCEL_NA)]
+        public long? LocalizationIsomerCount
+        {
+            get
+            {
+                var analyzer = GetSiteDeterminingIonAnalyzer();
+                if (analyzer == null || !analyzer.CanLocalize)
+                    return null;
+                return analyzer.IsomerCount;
+            }
+        }
+
+        /// <summary>
+        /// Builds (and memoizes) the <see cref="SiteDeterminingIonAnalyzer"/> for this peptide so
+        /// the two localization columns can share a single analytic precompute. Returns null for
+        /// small molecules.
+        /// </summary>
+        private SiteDeterminingIonAnalyzer GetSiteDeterminingIonAnalyzer()
+        {
+            if (!_siteDeterminingIonAnalyzerComputed)
+            {
+                _siteDeterminingIonAnalyzerComputed = true;
+                if (!IsSmallMolecule())
+                    _siteDeterminingIonAnalyzer = new SiteDeterminingIonAnalyzer(SrmDocument.Settings, DocNode);
+            }
+            return _siteDeterminingIonAnalyzer;
+        }
+
         [Obsolete("use MoleculeName instead")]  // It's a molecule, not an ion
-        public string IonName 
+        public string IonName
         {
             get
             {

--- a/pwiz_tools/Skyline/Model/Localization/SiteDeterminingIonAnalyzer.cs
+++ b/pwiz_tools/Skyline/Model/Localization/SiteDeterminingIonAnalyzer.cs
@@ -1,0 +1,341 @@
+/*
+ * Original author: MacCoss Lab, Department of Genome Sciences, UW
+ * AI assistance: Claude Code (Claude Opus 4.8) <noreply .at. anthropic.com>
+ *
+ * Copyright 2026 University of Washington - Seattle, WA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using pwiz.Skyline.Model.DocSettings;
+
+namespace pwiz.Skyline.Model.Localization
+{
+    /// <summary>
+    /// Pure, model-layer analyzer that identifies site-determining product ions for
+    /// modification-localization, computed analytically (no positional-isomer enumeration).
+    ///
+    /// A modification <c>m</c> that is present with count <c>k</c> on a peptide, and whose
+    /// specificity matches <c>n</c> residues in that peptide, is "ambiguous" when
+    /// <c>C(n, k) &gt; 1</c> (i.e. <c>n &gt; k &gt; 0</c>). Fixed modifications occupy all of
+    /// their sites (<c>n == k</c>) and so are never ambiguous. Isotope-label modifications and
+    /// crosslinkers are treated as fixed context and are ignored.
+    ///
+    /// For a candidate product ion, defined by (<see cref="IonType"/>, cleavage offset), the
+    /// fragment covers a contiguous span of residue indices. The ion is "site-determining" for an
+    /// ambiguous modification when the number of that modification's sites falling inside the span
+    /// can vary across positional placements. See <see cref="IsSiteDetermining"/>.
+    /// </summary>
+    public class SiteDeterminingIonAnalyzer
+    {
+        /// <summary>
+        /// Clamp for integer binomial / product arithmetic. Combinatorial counts can grow past the
+        /// range of <see cref="long"/>; values are clamped here so downstream consumers see a
+        /// large-but-finite sentinel rather than an overflowed (possibly negative) number.
+        /// </summary>
+        public const long MAX_COUNT = 1_000_000_000_000_000L; // 1e15, well within long range
+
+        private readonly int _length;
+        private readonly string _unmodifiedSequence;
+        private readonly IList<AmbiguousMod> _ambiguousMods;
+
+        /// <summary>
+        /// Performs the cheap analytic precompute (candidate positions per ambiguous modification
+        /// via prefix arrays) for a single peptide placement.
+        /// </summary>
+        /// <param name="settings">Document settings (reserved for future mass cross-checks; the
+        /// span analysis itself is purely combinatorial).</param>
+        /// <param name="nodePep">The peptide, including its explicit (light) modification placement.</param>
+        public SiteDeterminingIonAnalyzer(SrmSettings settings, PeptideDocNode nodePep)
+        {
+            _ambiguousMods = new List<AmbiguousMod>();
+
+            var peptide = nodePep.Peptide;
+            if (peptide == null || peptide.IsCustomMolecule)
+                return; // Small molecule / non-proteomic - nothing to localize
+
+            string sequence = peptide.Sequence;
+            if (string.IsNullOrEmpty(sequence))
+                return;
+            _length = sequence.Length;
+            _unmodifiedSequence = sequence;
+
+            var explicitMods = nodePep.ExplicitMods;
+            var staticMods = explicitMods?.StaticModifications;
+            if (staticMods == null || staticMods.Count == 0)
+                return;
+
+            // Group the peptide's explicit static (light) modifications by their StaticMod, so a
+            // modification present on several residues collapses to a single (mod, count) pair.
+            foreach (var group in staticMods.GroupBy(em => em.Modification))
+            {
+                var mod = group.Key;
+                // Skip isotope-label modifications and crosslinkers - fixed context, not localizable.
+                if (mod.LabelAtoms != LabelAtoms.None || mod.CrosslinkerSettings != null)
+                    continue;
+
+                var placedPositions = group.Select(em => em.IndexAA).OrderBy(i => i).ToArray();
+                int k = placedPositions.Length;
+                if (k == 0)
+                    continue;
+
+                // prefixCandidates[i] = number of specificity-matching residues with index < i.
+                var prefixCandidates = new int[_length + 1];
+                for (int i = 0; i < _length; i++)
+                {
+                    prefixCandidates[i + 1] = prefixCandidates[i] +
+                                              (mod.IsApplicableMod(sequence, i) ? 1 : 0);
+                }
+
+                int n = prefixCandidates[_length];
+                // Ambiguous iff C(n, k) > 1, i.e. n > k > 0. Fully determined mods (n == k) excluded.
+                if (n > k)
+                {
+                    _ambiguousMods.Add(new AmbiguousMod(mod, k, n, prefixCandidates, placedPositions));
+                }
+            }
+        }
+
+        /// <summary>
+        /// True iff the peptide carries at least one ambiguous modification, so that localization
+        /// analysis is meaningful.
+        /// </summary>
+        public bool CanLocalize
+        {
+            get { return _ambiguousMods.Count > 0; }
+        }
+
+        /// <summary>
+        /// Number of positional isomers for the peptide, the product over ambiguous modifications
+        /// of <c>C(n, k)</c>. Returns 1 when there are no ambiguous modifications (a single
+        /// arrangement). Clamped to <see cref="MAX_COUNT"/> to guard against overflow.
+        /// </summary>
+        public long IsomerCount
+        {
+            get
+            {
+                long result = 1;
+                foreach (var mod in _ambiguousMods)
+                    result = MultiplyClamped(result, Binomial(mod.SiteCount, mod.Count));
+                return result;
+            }
+        }
+
+        /// <summary>
+        /// Stable grouping key over the ambiguous modifications only: the unmodified sequence
+        /// followed by a sorted list of "<c>ModName*count</c>" entries. Returns null when there
+        /// are no ambiguous modifications. (An ASCII '*' is used as the count separator to keep
+        /// the key free of non-ASCII characters.)
+        /// </summary>
+        public string LocalizationGroupKey
+        {
+            get
+            {
+                if (!CanLocalize)
+                    return null;
+
+                var entries = _ambiguousMods
+                    .Select(mod => mod.Mod.Name + @"*" + mod.Count)
+                    .OrderBy(s => s, StringComparer.Ordinal);
+
+                var sb = new StringBuilder(_unmodifiedSequence ?? string.Empty);
+                sb.Append('[');
+                sb.Append(string.Join(@",", entries));
+                sb.Append(']');
+                return sb.ToString();
+            }
+        }
+
+        /// <summary>
+        /// True iff this product ion's in-span occupancy of some ambiguous modification can vary
+        /// across positional placements, i.e. the ion helps localize that modification. False for
+        /// precursor, custom, and non-proteomic transitions.
+        /// </summary>
+        public bool IsSiteDetermining(Transition transition)
+        {
+            return GetResolvedModification(transition) != null;
+        }
+
+        /// <summary>
+        /// Returns the (primary) ambiguous modification that the given ion resolves, for tooltip /
+        /// reporting use, or null when the ion is not site-determining. When an ion resolves more
+        /// than one modification, the first (in precompute order) is returned.
+        /// </summary>
+        public StaticMod GetResolvedModification(Transition transition)
+        {
+            if (!TryGetSpan(transition, out int lo, out int hi))
+                return null;
+
+            foreach (var mod in _ambiguousMods)
+            {
+                int inside = mod.InsideSpan(lo, hi);
+                int outside = mod.SiteCount - inside;
+                // In-span occupancy ranges over [max(0, k - outside) .. min(k, inside)]. It can
+                // vary (the ion is site-determining) iff that range is non-degenerate.
+                if (Math.Min(mod.Count, inside) > Math.Max(0, mod.Count - outside))
+                    return mod.Mod;
+            }
+            return null;
+        }
+
+        /// <summary>
+        /// Number of positional isomers that produce this exact ion (with the same in-span
+        /// modification masses) as the placement this analyzer was built from. A value of 1 means
+        /// the ion is unique to this isomer. Returns 0 for precursor / custom / non-proteomic
+        /// transitions. Clamped to <see cref="MAX_COUNT"/>.
+        /// </summary>
+        public int GetProducingSetSizeAsInt(Transition transition)
+        {
+            long size = GetProducingSetSize(transition);
+            return size > int.MaxValue ? int.MaxValue : (int) size;
+        }
+
+        /// <summary>
+        /// <see cref="GetProducingSetSizeAsInt"/> as a (clamped) <see cref="long"/>.
+        /// </summary>
+        public long GetProducingSetSize(Transition transition)
+        {
+            if (!TryGetSpan(transition, out int lo, out int hi))
+                return 0;
+
+            long product = 1;
+            foreach (var mod in _ambiguousMods)
+            {
+                int inside = mod.InsideSpan(lo, hi);
+                int outside = mod.SiteCount - inside;
+                int c = mod.PlacedInsideSpan(lo, hi); // Sites of this mod actually inside the span
+                long term = MultiplyClamped(Binomial(inside, c), Binomial(outside, mod.Count - c));
+                product = MultiplyClamped(product, term);
+            }
+            return product;
+        }
+
+        /// <summary>
+        /// True iff this ion is produced by exactly one positional isomer (the placement this
+        /// analyzer was built from) and localization is meaningful for the peptide.
+        /// </summary>
+        public bool IsUniqueToPrecursor(Transition transition)
+        {
+            return CanLocalize && GetProducingSetSize(transition) == 1;
+        }
+
+        private bool TryGetSpan(Transition transition, out int lo, out int hi)
+        {
+            lo = 0;
+            hi = -1;
+            if (transition == null || _length == 0)
+                return false;
+            if (transition.IsPrecursor() || transition.IsCustom())
+                return false;
+
+            var type = transition.IonType;
+            if (type.IsNTerminal())
+            {
+                // a/b/c: residues [0 .. cleavageOffset]
+                lo = 0;
+                hi = transition.CleavageOffset;
+            }
+            else if (type.IsCTerminal())
+            {
+                // x/y/z/zh/zhh: residues [cleavageOffset+1 .. len-1]
+                lo = transition.CleavageOffset + 1;
+                hi = _length - 1;
+            }
+            else
+            {
+                return false;
+            }
+
+            if (lo < 0)
+                lo = 0;
+            if (hi > _length - 1)
+                hi = _length - 1;
+            return hi >= lo;
+        }
+
+        /// <summary>
+        /// Integer binomial coefficient C(n, k) using the multiplicative form (stays integral at
+        /// each step), clamped to <see cref="MAX_COUNT"/> to guard against overflow.
+        /// </summary>
+        private static long Binomial(int n, int k)
+        {
+            if (k < 0 || k > n || n < 0)
+                return 0;
+            if (k == 0 || k == n)
+                return 1;
+            k = Math.Min(k, n - k);
+            long result = 1;
+            for (int i = 1; i <= k; i++)
+            {
+                result = result * (n - k + i) / i;
+                if (result >= MAX_COUNT || result < 0)
+                    return MAX_COUNT;
+            }
+            return result;
+        }
+
+        private static long MultiplyClamped(long a, long b)
+        {
+            if (a == 0 || b == 0)
+                return 0;
+            if (a >= MAX_COUNT || b >= MAX_COUNT)
+                return MAX_COUNT;
+            long result = a * b;
+            if (result >= MAX_COUNT || result < 0)
+                return MAX_COUNT;
+            return result;
+        }
+
+        /// <summary>
+        /// Precomputed per-ambiguous-modification analytic state.
+        /// </summary>
+        private sealed class AmbiguousMod
+        {
+            private readonly int[] _prefixCandidates; // prefixCandidates[i] = # candidate sites with index < i
+            private readonly int[] _placedPositions;  // residue indices where this mod is actually placed
+
+            public AmbiguousMod(StaticMod mod, int count, int siteCount, int[] prefixCandidates, int[] placedPositions)
+            {
+                Mod = mod;
+                Count = count;
+                SiteCount = siteCount;
+                _prefixCandidates = prefixCandidates;
+                _placedPositions = placedPositions;
+            }
+
+            public StaticMod Mod { get; }
+            public int Count { get; }      // k_m
+            public int SiteCount { get; }  // n_m
+
+            public int InsideSpan(int lo, int hi)
+            {
+                // Number of candidate sites with index in [lo .. hi].
+                return _prefixCandidates[hi + 1] - _prefixCandidates[lo];
+            }
+
+            public int PlacedInsideSpan(int lo, int hi)
+            {
+                int c = 0;
+                foreach (int index in _placedPositions)
+                {
+                    if (index >= lo && index <= hi)
+                        c++;
+                }
+                return c;
+            }
+        }
+    }
+}

--- a/pwiz_tools/Skyline/Skyline.csproj
+++ b/pwiz_tools/Skyline/Skyline.csproj
@@ -925,6 +925,7 @@
     <Compile Include="Model\Irt\IrtPeptidePicker.cs" />
     <Compile Include="Model\Irt\Regression.cs" />
     <Compile Include="Model\LegacyCrosslinkConverter.cs" />
+    <Compile Include="Model\Localization\SiteDeterminingIonAnalyzer.cs" />
     <Compile Include="Model\Lib\BlibData\DbRefSpectraPeakAnnotations.cs" />
     <Compile Include="Model\Lib\EncyclopeDiaHelpers.cs" />
     <Compile Include="Model\Lib\ExplicitPeakBounds.cs" />

--- a/pwiz_tools/Skyline/Test/SiteDeterminingIonTest.cs
+++ b/pwiz_tools/Skyline/Test/SiteDeterminingIonTest.cs
@@ -45,9 +45,76 @@ namespace pwiz.SkylineTest
         {
             TestPhosphoNearTerminusUnique();
             TestInteriorSerineNonUnique();
+            TestInteriorSerineRunNoUnique();
+            TestTwoSeparatedCandidatesUnique();
             TestTwoPhosphoAmongFour();
             TestTwoModTypes();
             TestNonLocalizable();
+        }
+
+        /// <summary>
+        /// Mirrors the screenshot peptide: a phospho on an interior serine inside a contiguous run
+        /// of candidate serines. Because a prefix ion reaching the modified serine necessarily also
+        /// covers its neighbor in the run (and likewise for suffix ions), NO fragment ion is unique
+        /// to the placement, even though the peptide is localizable. The site-determining filter
+        /// therefore leaves an empty list (the empty-state hint scenario).
+        /// </summary>
+        private void TestInteriorSerineRunNoUnique()
+        {
+            // A0 A1 S2 S3 S4 A5 K6 - run of three candidate serines (2,3,4); phospho on the middle one.
+            const string seq = "AASSSAK";
+            var settings = SrmSettingsList.GetDefault();
+            var peptide = new Peptide(seq);
+            var nodePep = new PeptideDocNode(peptide, MakeMods(peptide, (PHOSPHO, 3)));
+            var analyzer = new SiteDeterminingIonAnalyzer(settings, nodePep);
+            var group = new TransitionGroup(peptide, Adduct.SINGLY_PROTONATED, IsotopeLabelType.light);
+
+            AssertEx.IsTrue(analyzer.CanLocalize);
+            AssertEx.AreEqual(3L, analyzer.IsomerCount); // C(3,1)
+
+            // For EVERY candidate fragment ion (b and y), the placement is not uniquely localized.
+            int len = seq.Length;
+            for (int offset = 0; offset <= len - 2; offset++)
+            {
+                foreach (var ion in new[] { B(group, offset), Y(group, offset) })
+                    AssertEx.IsTrue(!analyzer.IsUniqueToPrecursor(ion));
+            }
+        }
+
+        /// <summary>
+        /// Two well-separated candidate residues - an N-terminal serine and a much later threonine -
+        /// with the phospho on the N-terminal serine. A short prefix (b) ion that contains only the
+        /// modified serine uniquely localizes the placement, while any fragment whose span covers
+        /// BOTH candidates cannot.
+        /// </summary>
+        private void TestTwoSeparatedCandidatesUnique()
+        {
+            // S0 A1 A2 A3 A4 A5 T6 A7 A8 K9 - candidates: serine 0 and threonine 6; phospho on S0.
+            const string seq = "SAAAAATAAK";
+            var settings = SrmSettingsList.GetDefault();
+            var peptide = new Peptide(seq);
+            var nodePep = new PeptideDocNode(peptide, MakeMods(peptide, (PHOSPHO, 0)));
+            var analyzer = new SiteDeterminingIonAnalyzer(settings, nodePep);
+            var group = new TransitionGroup(peptide, Adduct.SINGLY_PROTONATED, IsotopeLabelType.light);
+
+            AssertEx.IsTrue(analyzer.CanLocalize);
+            AssertEx.AreEqual(2L, analyzer.IsomerCount); // C(2,1)
+
+            // b1 (offset 0) spans only the modified serine, not the later threonine -> unique.
+            var b1 = B(group, 0);
+            AssertEx.IsTrue(analyzer.IsUniqueToPrecursor(b1));
+            AssertEx.AreEqual(1L, analyzer.GetProducingSetSize(b1));
+
+            // b7 (offset 6) spans BOTH candidate residues -> can no longer localize, not unique.
+            var b7 = B(group, 6);
+            AssertEx.IsTrue(!analyzer.IsUniqueToPrecursor(b7));
+            AssertEx.IsTrue(analyzer.GetProducingSetSize(b7) > 1);
+
+            // At least one unique b-ion exists among the prefixes that stop before the threonine.
+            bool anyUnique = false;
+            for (int offset = 0; offset <= 5; offset++)
+                anyUnique |= analyzer.IsUniqueToPrecursor(B(group, offset));
+            AssertEx.IsTrue(anyUnique);
         }
 
         /// <summary>

--- a/pwiz_tools/Skyline/Test/SiteDeterminingIonTest.cs
+++ b/pwiz_tools/Skyline/Test/SiteDeterminingIonTest.cs
@@ -1,0 +1,245 @@
+/*
+ * Original author: MacCoss Lab, Department of Genome Sciences, UW
+ * AI assistance: Claude Code (Claude Opus 4.8) <noreply .at. anthropic.com>
+ *
+ * Copyright 2026 University of Washington - Seattle, WA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+using System.Linq;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using pwiz.Common.Chemistry;
+using pwiz.Skyline.Model;
+using pwiz.Skyline.Model.DocSettings;
+using pwiz.Skyline.Model.Localization;
+using pwiz.Skyline.Properties;
+using pwiz.Skyline.Util;
+using pwiz.SkylineTestUtil;
+
+namespace pwiz.SkylineTest
+{
+    /// <summary>
+    /// Unit tests for <see cref="SiteDeterminingIonAnalyzer"/>, the analytic (no isomer
+    /// enumeration) identifier of site-determining product ions for modification localization.
+    /// </summary>
+    [TestClass]
+    public class SiteDeterminingIonTest : AbstractUnitTest
+    {
+        private static readonly StaticMod PHOSPHO = new StaticMod("Phospho", "S,T,Y", null, true, "PO3H",
+            LabelAtoms.None, RelativeRT.Matching, null, null, null);
+        private static readonly StaticMod OXIDATION = new StaticMod("Oxidation", "M", null, true, "O",
+            LabelAtoms.None, RelativeRT.Matching, null, null, null);
+
+        [TestMethod]
+        public void TestSiteDeterminingIonAnalyzer()
+        {
+            TestPhosphoNearTerminusUnique();
+            TestInteriorSerineNonUnique();
+            TestTwoPhosphoAmongFour();
+            TestTwoModTypes();
+            TestNonLocalizable();
+        }
+
+        /// <summary>
+        /// Case 1: a single phospho on the N-terminal serine of a peptide with two candidate
+        /// serines produces a run of unique, site-determining N-terminal (b) ions. The b-ion whose
+        /// span reaches the second candidate serine can no longer distinguish placements, and the
+        /// analytic span logic is cross-checked against actual fragment m/z values.
+        /// </summary>
+        private void TestPhosphoNearTerminusUnique()
+        {
+            // S0 A1 A2 A3 S4 A5 A6 K7 - candidate serines at indices 0 and 4.
+            const string seq = "SAAASAAK";
+            var settings = SrmSettingsList.GetDefault();
+            var peptide = new Peptide(seq);
+            var modsAt0 = MakeMods(peptide, (PHOSPHO, 0));
+            var nodePep = new PeptideDocNode(peptide, modsAt0);
+            var analyzer = new SiteDeterminingIonAnalyzer(settings, nodePep);
+            var group = new TransitionGroup(peptide, Adduct.SINGLY_PROTONATED, IsotopeLabelType.light);
+
+            AssertEx.IsTrue(analyzer.CanLocalize);
+            AssertEx.AreEqual(2L, analyzer.IsomerCount); // C(2,1)
+            Assert.IsNotNull(analyzer.LocalizationGroupKey);
+
+            // b1..b4 (offsets 0..3) span only the first candidate serine - unique site-determining.
+            for (int offset = 0; offset <= 3; offset++)
+            {
+                var b = B(group, offset);
+                AssertEx.IsTrue(analyzer.IsSiteDetermining(b));
+                AssertEx.AreEqual(1L, analyzer.GetProducingSetSize(b));
+                AssertEx.IsTrue(analyzer.IsUniqueToPrecursor(b));
+                Assert.AreSame(PHOSPHO, analyzer.GetResolvedModification(b));
+            }
+            // b5, b6 (offsets 4, 5) span both candidate serines - can no longer localize.
+            for (int offset = 4; offset <= 5; offset++)
+            {
+                var b = B(group, offset);
+                AssertEx.IsTrue(!analyzer.IsSiteDetermining(b));
+                AssertEx.IsTrue(analyzer.GetProducingSetSize(b) > 1);
+                AssertEx.IsTrue(!analyzer.IsUniqueToPrecursor(b));
+            }
+            // Precursor is never site-determining.
+            var precursor = new Transition(group, 0, Adduct.SINGLY_PROTONATED);
+            AssertEx.IsTrue(!analyzer.IsSiteDetermining(precursor));
+            AssertEx.AreEqual(0L, analyzer.GetProducingSetSize(precursor));
+
+            // Cross-check the span logic against real fragment m/z: compare phospho@0 vs phospho@4.
+            var modsAt4 = MakeMods(peptide, (PHOSPHO, 4));
+            var massesA = settings.GetFragmentCalc(IsotopeLabelType.light, modsAt0).GetFragmentIonMasses(peptide.Target);
+            var massesB = settings.GetFragmentCalc(IsotopeLabelType.light, modsAt4).GetFragmentIonMasses(peptide.Target);
+            for (int offset = 0; offset <= 3; offset++)
+            {
+                // Site-determining b-ions differ by roughly the phospho mass (~80 Da).
+                double diff = massesA[IonType.b, offset].Value - massesB[IonType.b, offset].Value;
+                AssertEx.IsTrue(diff > 50);
+            }
+            for (int offset = 4; offset <= 6; offset++)
+            {
+                // Non-site-determining b-ions carry exactly one phospho for either placement.
+                AssertEx.AreEqual(massesA[IonType.b, offset].Value, massesB[IonType.b, offset].Value, 1e-6);
+            }
+        }
+
+        /// <summary>
+        /// Case 2: a phospho on an interior serine flanked by other candidate serines on both
+        /// sides. Some ions are site-determining, but none is unique to the placement (every
+        /// producing-set size exceeds 1).
+        /// </summary>
+        private void TestInteriorSerineNonUnique()
+        {
+            // S0 A1 S2 A3 S4 A5 K6 - candidate serines at 0, 2, 4; phospho on the middle one.
+            const string seq = "SASASAK";
+            var settings = SrmSettingsList.GetDefault();
+            var peptide = new Peptide(seq);
+            var nodePep = new PeptideDocNode(peptide, MakeMods(peptide, (PHOSPHO, 2)));
+            var analyzer = new SiteDeterminingIonAnalyzer(settings, nodePep);
+            var group = new TransitionGroup(peptide, Adduct.SINGLY_PROTONATED, IsotopeLabelType.light);
+
+            AssertEx.IsTrue(analyzer.CanLocalize);
+            AssertEx.AreEqual(3L, analyzer.IsomerCount); // C(3,1)
+
+            // b3 (offset 2) spans two of the three candidate serines - site-determining, not unique.
+            var b3 = B(group, 2);
+            AssertEx.IsTrue(analyzer.IsSiteDetermining(b3));
+            AssertEx.AreEqual(2L, analyzer.GetProducingSetSize(b3));
+            AssertEx.IsTrue(!analyzer.IsUniqueToPrecursor(b3));
+
+            // No fragment ion (b or y) is unique to this placement, yet at least one is site-determining.
+            bool anySiteDetermining = false;
+            int len = seq.Length;
+            for (int offset = 0; offset <= len - 2; offset++)
+            {
+                foreach (var ion in new[] { B(group, offset), Y(group, offset) })
+                {
+                    AssertEx.IsTrue(!analyzer.IsUniqueToPrecursor(ion));
+                    anySiteDetermining |= analyzer.IsSiteDetermining(ion);
+                }
+            }
+            AssertEx.IsTrue(anySiteDetermining);
+        }
+
+        /// <summary>
+        /// Case 3: two phospho among four candidate serines. IsomerCount is C(4,2) = 6, and a b-ion
+        /// whose span captures exactly the two modified serines is unique to the placement.
+        /// </summary>
+        private void TestTwoPhosphoAmongFour()
+        {
+            // S0 A1 S2 A3 S4 A5 S6 A7 K8 - four candidate serines; phospho on the first two.
+            const string seq = "SASASASAK";
+            var settings = SrmSettingsList.GetDefault();
+            var peptide = new Peptide(seq);
+            var nodePep = new PeptideDocNode(peptide, MakeMods(peptide, (PHOSPHO, 0), (PHOSPHO, 2)));
+            var analyzer = new SiteDeterminingIonAnalyzer(settings, nodePep);
+            var group = new TransitionGroup(peptide, Adduct.SINGLY_PROTONATED, IsotopeLabelType.light);
+
+            AssertEx.IsTrue(analyzer.CanLocalize);
+            AssertEx.AreEqual(6L, analyzer.IsomerCount); // C(4,2)
+
+            var b3 = B(group, 2); // span [0..2] captures exactly serines 0 and 2
+            AssertEx.IsTrue(analyzer.IsSiteDetermining(b3));
+            AssertEx.AreEqual(1L, analyzer.GetProducingSetSize(b3));
+            AssertEx.IsTrue(analyzer.IsUniqueToPrecursor(b3));
+        }
+
+        /// <summary>
+        /// Case 4: two simultaneously-ambiguous modification types (phospho over two serines and
+        /// oxidation over two methionines). IsomerCount is the product of the per-type isomer
+        /// counts, and an ion whose span crosses only the serine region resolves phospho (not
+        /// oxidation) while an ion crossing only the methionine region resolves oxidation.
+        /// </summary>
+        private void TestTwoModTypes()
+        {
+            // S0 S1 A2 A3 M4 M5 K6 - two candidate serines, two candidate methionines.
+            const string seq = "SSAAMMK";
+            var settings = SrmSettingsList.GetDefault();
+            var peptide = new Peptide(seq);
+            var nodePep = new PeptideDocNode(peptide, MakeMods(peptide, (PHOSPHO, 0), (OXIDATION, 4)));
+            var analyzer = new SiteDeterminingIonAnalyzer(settings, nodePep);
+            var group = new TransitionGroup(peptide, Adduct.SINGLY_PROTONATED, IsotopeLabelType.light);
+
+            AssertEx.IsTrue(analyzer.CanLocalize);
+            AssertEx.AreEqual(4L, analyzer.IsomerCount); // C(2,1) * C(2,1)
+
+            // b1 span [0..0] separates the two serines but not the methionines -> resolves phospho.
+            var b1 = B(group, 0);
+            AssertEx.IsTrue(analyzer.IsSiteDetermining(b1));
+            Assert.AreSame(PHOSPHO, analyzer.GetResolvedModification(b1));
+
+            // b5 span [0..4] separates the two methionines but not the serines -> resolves oxidation.
+            var b5 = B(group, 4);
+            AssertEx.IsTrue(analyzer.IsSiteDetermining(b5));
+            Assert.AreSame(OXIDATION, analyzer.GetResolvedModification(b5));
+        }
+
+        /// <summary>
+        /// Case 5: an unmodified peptide and a peptide whose only modification is fully determined
+        /// (a single candidate site) are both non-localizable, with a null group key.
+        /// </summary>
+        private void TestNonLocalizable()
+        {
+            var settings = SrmSettingsList.GetDefault();
+
+            // Unmodified peptide.
+            var pep1 = new Peptide("SASASAK");
+            var analyzer1 = new SiteDeterminingIonAnalyzer(settings, new PeptideDocNode(pep1, (ExplicitMods) null));
+            AssertEx.IsTrue(!analyzer1.CanLocalize);
+            AssertEx.IsNull(analyzer1.LocalizationGroupKey);
+            AssertEx.AreEqual(1L, analyzer1.IsomerCount);
+
+            // Only one candidate serine, so the phospho is fully determined - not ambiguous.
+            var pep2 = new Peptide("SAAAAK");
+            var analyzer2 = new SiteDeterminingIonAnalyzer(settings, new PeptideDocNode(pep2, MakeMods(pep2, (PHOSPHO, 0))));
+            AssertEx.IsTrue(!analyzer2.CanLocalize);
+            AssertEx.IsNull(analyzer2.LocalizationGroupKey);
+        }
+
+        private static ExplicitMods MakeMods(Peptide peptide, params (StaticMod mod, int indexAA)[] placements)
+        {
+            var explicitMods = placements
+                .OrderBy(p => p.indexAA)
+                .Select(p => new ExplicitMod(p.indexAA, p.mod))
+                .ToArray();
+            return new ExplicitMods(peptide, explicitMods, new TypedExplicitModifications[0]);
+        }
+
+        private static Transition B(TransitionGroup group, int offset)
+        {
+            return new Transition(group, IonType.b, offset, 0, Adduct.SINGLY_PROTONATED);
+        }
+
+        private static Transition Y(TransitionGroup group, int offset)
+        {
+            return new Transition(group, IonType.y, offset, 0, Adduct.SINGLY_PROTONATED);
+        }
+    }
+}

--- a/pwiz_tools/Skyline/Test/Test.csproj
+++ b/pwiz_tools/Skyline/Test/Test.csproj
@@ -312,6 +312,7 @@
     <Compile Include="EncyclopeDiaHelpersTest.cs" />
     <Compile Include="SrmSettingsNewTest.cs" />
     <Compile Include="DllFinderUnitTest.cs" />
+    <Compile Include="SiteDeterminingIonTest.cs" />
     <Compile Include="UtilTest.cs" />
     <Compile Include="VariableModTest.cs" />
     <Compile Include="WebEnabledFastaImporterTest.cs" />

--- a/pwiz_tools/Skyline/TestFunctional/SiteDeterminingIonFunctionalTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/SiteDeterminingIonFunctionalTest.cs
@@ -1,0 +1,201 @@
+/*
+ * Original author: MacCoss Lab, Department of Genome Sciences, UW
+ * AI assistance: Claude Code (Claude Opus 4.8) <noreply .at. anthropic.com>
+ *
+ * Copyright 2026 University of Washington - Seattle, WA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using pwiz.Skyline.Controls;
+using pwiz.Skyline.Controls.SeqNode;
+using pwiz.Skyline.EditUI;
+using pwiz.Skyline.Model;
+using pwiz.Skyline.Model.DocSettings;
+using pwiz.Skyline.Model.Localization;
+using pwiz.Skyline.Properties;
+using pwiz.Skyline.SettingsUI;
+using pwiz.SkylineTestUtil;
+
+namespace pwiz.SkylineTestFunctional
+{
+    /// <summary>
+    /// End-to-end test of the "site-determining ions" filter button on the
+    /// <see cref="PopupPickList"/>. Builds a peptide that carries an ambiguously-placed
+    /// phospho (multiple candidate serines, one explicitly modified) and verifies that:
+    ///  - the toggle button appears for the localizable precursor,
+    ///  - toggling it narrows the visible transitions to exactly the site-determining set
+    ///    computed by a freshly-constructed <see cref="SiteDeterminingIonAnalyzer"/>, and
+    ///  - the button is hidden for an unmodified (non-localizable) peptide.
+    ///
+    /// Assertions are made on transition identities (ion type + cleavage offset) and
+    /// booleans/counts, never on localized labels, so the test is translation-proof.
+    /// </summary>
+    [TestClass]
+    public class SiteDeterminingIonFunctionalTest : AbstractFunctionalTest
+    {
+        private const string LOCALIZABLE_SEQ = "SVSSPLSK"; // S0 V1 S2 S3 P4 L5 S6 K7 - four candidate serines
+        private const int PHOSPHO_INDEX = 2;               // Explicit phospho on one interior serine
+        private const string UNMODIFIED_SEQ = "ELVIK";     // No candidate serine -> not localizable
+
+        private static readonly StaticMod PHOSPHO = new StaticMod("Phospho", "S,T,Y", null, true, "PO3H",
+            LabelAtoms.None, RelativeRT.Matching, null, null, null);
+
+        [TestMethod]
+        public void TestSiteDeterminingIonFunctional()
+        {
+            RunFunctionalTest();
+        }
+
+        protected override void DoTest()
+        {
+            // Make phospho available for explicit placement (do NOT pick it as a document static
+            // mod, so it is not implicitly applied to every serine).
+            RunUI(() => Settings.Default.StaticModList.Add(PHOSPHO));
+
+            // Include both b and y ions so the pick list offers a broad transition set.
+            RunDlg<TransitionSettingsUI>(SkylineWindow.ShowTransitionSettingsUI, dlg =>
+            {
+                dlg.SelectedTab = TransitionSettingsUI.TABS.Filter;
+                dlg.PrecursorCharges = "2";
+                dlg.ProductCharges = "1";
+                dlg.FragmentTypes = "b, y";
+                dlg.SetAutoSelect = true;
+                dlg.OkDialog();
+            });
+
+            // Add the two peptides.
+            var docStart = SkylineWindow.Document;
+            RunUI(() => SkylineWindow.Paste(LOCALIZABLE_SEQ));
+            var docPep1 = WaitForDocumentChange(docStart);
+            RunUI(() => SkylineWindow.Paste(UNMODIFIED_SEQ));
+            var docPep2 = WaitForDocumentChange(docPep1);
+
+            // Explicitly phosphorylate exactly one serine of the localizable peptide.
+            SelectPrecursor(LOCALIZABLE_SEQ);
+            RunDlg<EditPepModsDlg>(SkylineWindow.ModifyPeptide, dlg =>
+            {
+                dlg.SelectModification(IsotopeLabelType.light, PHOSPHO_INDEX, PHOSPHO.Name);
+                dlg.OkDialog();
+            });
+            var docMod = WaitForDocumentChange(docPep2);
+
+            // Sanity check: the modified peptide is now localizable.
+            var pepNodeLoc = FindPeptide(docMod, LOCALIZABLE_SEQ);
+            Assert.IsNotNull(pepNodeLoc.ExplicitMods);
+            var analyzer = new SiteDeterminingIonAnalyzer(docMod.Settings, pepNodeLoc);
+            Assert.IsTrue(analyzer.CanLocalize, "Expected the explicitly-phosphorylated peptide to be localizable");
+
+            // Scenario 1 + 2: localizable precursor - button visible; filter narrows to the
+            // site-determining set.
+            SelectPrecursor(LOCALIZABLE_SEQ);
+            RunUI(() =>
+            {
+                var tgNode = (TransitionGroupTreeNode) SkylineWindow.SequenceTree.SelectedNode;
+                Assert.IsTrue(tgNode.CanShowSiteDeterminingIons,
+                    "Picker should report the localizable precursor as showing site-determining ions");
+            });
+
+            RunDlg<PopupPickList>(SkylineWindow.ShowPickChildrenInTest, dlg =>
+            {
+                dlg.ApplyFilter(false);
+                Assert.IsTrue(dlg.SiteDeterminingButtonVisible,
+                    "Site-determining button should be visible for a localizable precursor");
+
+                // Full (unfiltered) transition choices, keyed by identity.
+                var fullChoices = dlg.VisibleChoices.ToArray();
+                Assert.IsTrue(fullChoices.All(c => c.Id is Transition),
+                    "All transition-group children should carry a Transition identity");
+                var fullIndexes = new HashSet<int>(fullChoices.Select(c => c.Id.GlobalIndex));
+
+                // Turn the site-determining filter on and capture the narrowed set.
+                dlg.SiteDeterminingFilter = true;
+                var filteredChoices = dlg.VisibleChoices.ToArray();
+                var filteredIndexes = new HashSet<int>(filteredChoices.Select(c => c.Id.GlobalIndex));
+
+                // Strict, non-empty subset.
+                Assert.IsTrue(filteredIndexes.Count > 0, "Expected at least one site-determining transition");
+                Assert.IsTrue(filteredIndexes.Count < fullIndexes.Count,
+                    "Site-determining set should be a strict subset of all transitions");
+                Assert.IsTrue(filteredIndexes.IsSubsetOf(fullIndexes),
+                    "Site-determining set should be a subset of all transitions");
+
+                // The filtered set is exactly the transitions the analyzer flags as
+                // site-determining (compared by transition identity, not label).
+                foreach (var choice in fullChoices)
+                {
+                    var transition = (Transition) choice.Id;
+                    bool expected = analyzer.IsSiteDetermining(transition);
+                    bool actual = filteredIndexes.Contains(choice.Id.GlobalIndex);
+                    Assert.AreEqual(expected, actual,
+                        "Filter mismatch for {0} offset {1}", transition.IonType, transition.CleavageOffset);
+                }
+
+                dlg.SiteDeterminingFilter = false;
+                dlg.OnCancel();
+            });
+
+            // Scenario 3: unmodified peptide - not localizable, button hidden.
+            SelectPrecursor(UNMODIFIED_SEQ);
+            RunUI(() =>
+            {
+                var tgNode = (TransitionGroupTreeNode) SkylineWindow.SequenceTree.SelectedNode;
+                Assert.IsFalse(tgNode.CanShowSiteDeterminingIons,
+                    "Unmodified peptide should not be localizable");
+            });
+            RunDlg<PopupPickList>(SkylineWindow.ShowPickChildrenInTest, dlg =>
+            {
+                Assert.IsFalse(dlg.SiteDeterminingButtonVisible,
+                    "Site-determining button should be hidden for a non-localizable peptide");
+                dlg.OnCancel();
+            });
+        }
+
+        /// <summary>
+        /// Selects the first precursor (transition group) of the peptide with the given
+        /// unmodified sequence, using an identity path so the tree need not be pre-expanded.
+        /// </summary>
+        private static void SelectPrecursor(string sequence)
+        {
+            var doc = SkylineWindow.Document;
+            var tgPath = FindTransitionGroupPath(doc, sequence);
+            Assert.IsNotNull(tgPath, "Could not find precursor for sequence {0}", sequence);
+            RunUI(() => SkylineWindow.SequenceTree.SelectedPath = tgPath);
+            WaitForConditionUI(() => SkylineWindow.SequenceTree.SelectedNode is TransitionGroupTreeNode);
+        }
+
+        private static IdentityPath FindTransitionGroupPath(SrmDocument doc, string sequence)
+        {
+            foreach (var group in doc.MoleculeGroups)
+            {
+                foreach (var pep in group.Molecules)
+                {
+                    if (!pep.Peptide.IsCustomMolecule && pep.Peptide.Sequence == sequence)
+                    {
+                        var tranGroup = pep.TransitionGroups.First();
+                        return new IdentityPath(group.PeptideGroup, pep.Peptide, tranGroup.TransitionGroup);
+                    }
+                }
+            }
+            return null;
+        }
+
+        private static PeptideDocNode FindPeptide(SrmDocument doc, string sequence)
+        {
+            return doc.Molecules.FirstOrDefault(
+                pep => !pep.Peptide.IsCustomMolecule && pep.Peptide.Sequence == sequence);
+        }
+    }
+}

--- a/pwiz_tools/Skyline/TestFunctional/SiteDeterminingIonFunctionalTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/SiteDeterminingIonFunctionalTest.cs
@@ -24,7 +24,6 @@ using pwiz.Skyline.Controls.SeqNode;
 using pwiz.Skyline.EditUI;
 using pwiz.Skyline.Model;
 using pwiz.Skyline.Model.DocSettings;
-using pwiz.Skyline.Model.Localization;
 using pwiz.Skyline.Properties;
 using pwiz.Skyline.SettingsUI;
 using pwiz.SkylineTestUtil;
@@ -33,22 +32,35 @@ namespace pwiz.SkylineTestFunctional
 {
     /// <summary>
     /// End-to-end test of the "site-determining ions" filter button on the
-    /// <see cref="PopupPickList"/>. Builds a peptide that carries an ambiguously-placed
-    /// phospho (multiple candidate serines, one explicitly modified) and verifies that:
-    ///  - the toggle button appears for the localizable precursor,
-    ///  - toggling it narrows the visible transitions to exactly the site-determining set
-    ///    computed by a freshly-constructed <see cref="SiteDeterminingIonAnalyzer"/>, and
-    ///  - the button is hidden for an unmodified (non-localizable) peptide.
+    /// <see cref="PopupPickList"/>. Rather than checking the filter against the analyzer (which
+    /// would be circular), it uses three peptides with hand-computed expectations:
+    ///  - a RESOLVABLE peptide (two well-separated candidates, one modified) where a specific
+    ///    short prefix ion is uniquely localizing and a specific ion spanning both candidates is
+    ///    not - the filtered set must be a strict, non-empty subset containing the former and not
+    ///    the latter, with no empty-state hint;
+    ///  - an UNRESOLVABLE peptide (modified serine inside a contiguous run of candidate serines)
+    ///    where no ion is unique, so the filtered set is empty and the empty-state hint shows;
+    ///  - a NON-LOCALIZABLE peptide (no candidate residue) where the toggle button is hidden.
     ///
-    /// Assertions are made on transition identities (ion type + cleavage offset) and
-    /// booleans/counts, never on localized labels, so the test is translation-proof.
+    /// Assertions are made on transition identities (ion type + ordinal) and booleans/counts,
+    /// never on localized labels, so the test is translation-proof.
     /// </summary>
     [TestClass]
     public class SiteDeterminingIonFunctionalTest : AbstractFunctionalTest
     {
-        private const string LOCALIZABLE_SEQ = "SVSSPLSK"; // S0 V1 S2 S3 P4 L5 S6 K7 - four candidate serines
-        private const int PHOSPHO_INDEX = 2;               // Explicit phospho on one interior serine
-        private const string UNMODIFIED_SEQ = "ELVIK";     // No candidate serine -> not localizable
+        // Resolvable: S0 A1 A2 A3 A4 A5 T6 A7 A8 K9 - candidates serine 0 and threonine 6; phospho on S0.
+        private const string RESOLVABLE_SEQ = "SAAAAATAAK";
+        private const int RESOLVABLE_PHOSPHO_INDEX = 0;
+        // b3 spans [S0 A1 A2] - only the modified serine -> uniquely localizing (must be present).
+        private const int UNIQUE_B_ORDINAL = 3;
+        // b7 spans [S0..T6] - both candidates -> not localizing (must be absent when filtered).
+        private const int SHARED_B_ORDINAL = 7;
+
+        // Unresolvable: A0 A1 S2 S3 S4 A5 K6 - a run of three candidate serines; phospho on the middle one.
+        private const string SERINE_RUN_SEQ = "AASSSAK";
+        private const int SERINE_RUN_PHOSPHO_INDEX = 3;
+
+        private const string UNMODIFIED_SEQ = "ELVIK"; // No candidate residue -> not localizable
 
         private static readonly StaticMod PHOSPHO = new StaticMod("Phospho", "S,T,Y", null, true, "PO3H",
             LabelAtoms.None, RelativeRT.Matching, null, null, null);
@@ -62,50 +74,48 @@ namespace pwiz.SkylineTestFunctional
         protected override void DoTest()
         {
             // Make phospho available for explicit placement (do NOT pick it as a document static
-            // mod, so it is not implicitly applied to every serine).
+            // mod, so it is not implicitly applied to every candidate residue).
             RunUI(() => Settings.Default.StaticModList.Add(PHOSPHO));
 
-            // Include both b and y ions so the pick list offers a broad transition set.
+            // Offer the full b/y ion series (ordinal 1 .. last ion) so the hand-picked ions
+            // (b3, b7) are always present in the unfiltered choice set.
             RunDlg<TransitionSettingsUI>(SkylineWindow.ShowTransitionSettingsUI, dlg =>
             {
                 dlg.SelectedTab = TransitionSettingsUI.TABS.Filter;
                 dlg.PrecursorCharges = "2";
                 dlg.ProductCharges = "1";
                 dlg.FragmentTypes = "b, y";
+                dlg.RangeFrom = Resources.TransitionFilter_FragmentStartFinders_ion_1;
+                dlg.RangeTo = Resources.TransitionFilter_FragmentEndFinders_last_ion;
                 dlg.SetAutoSelect = true;
                 dlg.OkDialog();
             });
 
-            // Add the two peptides.
+            // Add all three peptides, phosphorylating the two localizable ones on a specific residue.
             var docStart = SkylineWindow.Document;
-            RunUI(() => SkylineWindow.Paste(LOCALIZABLE_SEQ));
-            var docPep1 = WaitForDocumentChange(docStart);
+            var docResolvable = AddPhosphoPeptide(docStart, RESOLVABLE_SEQ, RESOLVABLE_PHOSPHO_INDEX);
+            var docRun = AddPhosphoPeptide(docResolvable, SERINE_RUN_SEQ, SERINE_RUN_PHOSPHO_INDEX);
             RunUI(() => SkylineWindow.Paste(UNMODIFIED_SEQ));
-            var docPep2 = WaitForDocumentChange(docPep1);
+            WaitForDocumentChange(docRun);
 
-            // Explicitly phosphorylate exactly one serine of the localizable peptide.
-            SelectPrecursor(LOCALIZABLE_SEQ);
-            RunDlg<EditPepModsDlg>(SkylineWindow.ModifyPeptide, dlg =>
-            {
-                dlg.SelectModification(IsotopeLabelType.light, PHOSPHO_INDEX, PHOSPHO.Name);
-                dlg.OkDialog();
-            });
-            var docMod = WaitForDocumentChange(docPep2);
+            TestResolvablePeptide();
+            TestUnresolvablePeptide();
+            TestNonLocalizablePeptide();
+        }
 
-            // Sanity check: the modified peptide is now localizable.
-            var pepNodeLoc = FindPeptide(docMod, LOCALIZABLE_SEQ);
-            Assert.IsNotNull(pepNodeLoc.ExplicitMods);
-            var analyzer = new SiteDeterminingIonAnalyzer(docMod.Settings, pepNodeLoc);
-            Assert.IsTrue(analyzer.CanLocalize, "Expected the explicitly-phosphorylated peptide to be localizable");
-
-            // Scenario 1 + 2: localizable precursor - button visible; filter narrows to the
-            // site-determining set.
-            SelectPrecursor(LOCALIZABLE_SEQ);
+        /// <summary>
+        /// Resolvable peptide: the toggle is offered, and turning it on leaves a strict, non-empty
+        /// subset that includes the hand-picked uniquely-localizing b-ion (b3) and excludes the
+        /// hand-picked shared b-ion (b7). No empty-state hint.
+        /// </summary>
+        private void TestResolvablePeptide()
+        {
+            SelectPrecursor(RESOLVABLE_SEQ);
             RunUI(() =>
             {
                 var tgNode = (TransitionGroupTreeNode) SkylineWindow.SequenceTree.SelectedNode;
                 Assert.IsTrue(tgNode.CanShowSiteDeterminingIons,
-                    "Picker should report the localizable precursor as showing site-determining ions");
+                    "Picker should offer site-determining ions for the resolvable precursor");
             });
 
             RunDlg<PopupPickList>(SkylineWindow.ShowPickChildrenInTest, dlg =>
@@ -114,40 +124,76 @@ namespace pwiz.SkylineTestFunctional
                 Assert.IsTrue(dlg.SiteDeterminingButtonVisible,
                     "Site-determining button should be visible for a localizable precursor");
 
-                // Full (unfiltered) transition choices, keyed by identity.
                 var fullChoices = dlg.VisibleChoices.ToArray();
                 Assert.IsTrue(fullChoices.All(c => c.Id is Transition),
                     "All transition-group children should carry a Transition identity");
                 var fullIndexes = new HashSet<int>(fullChoices.Select(c => c.Id.GlobalIndex));
+                // Both hand-picked ions must exist in the full (unfiltered) set for the test to mean anything.
+                Assert.IsTrue(HasIon(fullChoices, IonType.b, UNIQUE_B_ORDINAL), "Full set should contain b3");
+                Assert.IsTrue(HasIon(fullChoices, IonType.b, SHARED_B_ORDINAL), "Full set should contain b7");
 
-                // Turn the site-determining filter on and capture the narrowed set.
                 dlg.SiteDeterminingFilter = true;
                 var filteredChoices = dlg.VisibleChoices.ToArray();
                 var filteredIndexes = new HashSet<int>(filteredChoices.Select(c => c.Id.GlobalIndex));
 
-                // Strict, non-empty subset.
-                Assert.IsTrue(filteredIndexes.Count > 0, "Expected at least one site-determining transition");
+                Assert.IsTrue(filteredIndexes.Count > 0, "Expected at least one uniquely-localizing transition");
                 Assert.IsTrue(filteredIndexes.Count < fullIndexes.Count,
-                    "Site-determining set should be a strict subset of all transitions");
+                    "Uniquely-localizing set should be a strict subset of all transitions");
                 Assert.IsTrue(filteredIndexes.IsSubsetOf(fullIndexes),
-                    "Site-determining set should be a subset of all transitions");
+                    "Uniquely-localizing set should be a subset of all transitions");
 
-                // The filtered set is exactly the transitions the analyzer flags as
-                // site-determining (compared by transition identity, not label).
-                foreach (var choice in fullChoices)
-                {
-                    var transition = (Transition) choice.Id;
-                    bool expected = analyzer.IsSiteDetermining(transition);
-                    bool actual = filteredIndexes.Contains(choice.Id.GlobalIndex);
-                    Assert.AreEqual(expected, actual,
-                        "Filter mismatch for {0} offset {1}", transition.IonType, transition.CleavageOffset);
-                }
+                // Hand-picked expectations: b3 (spans only the modified S0) present; b7 (spans both
+                // S0 and T6) absent.
+                Assert.IsTrue(HasIon(filteredChoices, IonType.b, UNIQUE_B_ORDINAL),
+                    "Filtered set should contain the uniquely-localizing b3 ion");
+                Assert.IsFalse(HasIon(filteredChoices, IonType.b, SHARED_B_ORDINAL),
+                    "Filtered set should not contain the shared b7 ion (spans both candidates)");
+
+                Assert.IsFalse(dlg.SiteDeterminingEmptyHintVisible,
+                    "Empty-state hint should be hidden when the filtered set is non-empty");
 
                 dlg.SiteDeterminingFilter = false;
                 dlg.OnCancel();
             });
+        }
 
-            // Scenario 3: unmodified peptide - not localizable, button hidden.
+        /// <summary>
+        /// Unresolvable peptide: the modified serine sits inside a contiguous run of candidate
+        /// serines, so no ion uniquely localizes it. Turning the filter on empties the list and
+        /// shows the empty-state hint, even though the peptide is localizable.
+        /// </summary>
+        private void TestUnresolvablePeptide()
+        {
+            SelectPrecursor(SERINE_RUN_SEQ);
+            RunUI(() =>
+            {
+                var tgNode = (TransitionGroupTreeNode) SkylineWindow.SequenceTree.SelectedNode;
+                Assert.IsTrue(tgNode.CanShowSiteDeterminingIons,
+                    "Serine-run peptide is still localizable, so the toggle should be offered");
+            });
+
+            RunDlg<PopupPickList>(SkylineWindow.ShowPickChildrenInTest, dlg =>
+            {
+                dlg.ApplyFilter(false);
+                Assert.IsTrue(dlg.SiteDeterminingButtonVisible);
+
+                dlg.SiteDeterminingFilter = true;
+                var filteredChoices = dlg.VisibleChoices.ToArray();
+                Assert.AreEqual(0, filteredChoices.Length,
+                    "No ion uniquely localizes a serine inside a run - filtered set must be empty");
+                Assert.IsTrue(dlg.SiteDeterminingEmptyHintVisible,
+                    "Empty-state hint should show when the filter leaves no visible ions");
+
+                dlg.SiteDeterminingFilter = false;
+                dlg.OnCancel();
+            });
+        }
+
+        /// <summary>
+        /// Non-localizable peptide: no candidate residue, so the toggle button is hidden.
+        /// </summary>
+        private void TestNonLocalizablePeptide()
+        {
             SelectPrecursor(UNMODIFIED_SEQ);
             RunUI(() =>
             {
@@ -161,6 +207,36 @@ namespace pwiz.SkylineTestFunctional
                     "Site-determining button should be hidden for a non-localizable peptide");
                 dlg.OnCancel();
             });
+        }
+
+        /// <summary>
+        /// Pastes the given peptide and phosphorylates the residue at <paramref name="indexAA"/>,
+        /// returning the document after the modification is applied.
+        /// </summary>
+        private SrmDocument AddPhosphoPeptide(SrmDocument docBefore, string sequence, int indexAA)
+        {
+            RunUI(() => SkylineWindow.Paste(sequence));
+            var docPasted = WaitForDocumentChange(docBefore);
+
+            SelectPrecursor(sequence);
+            RunDlg<EditPepModsDlg>(SkylineWindow.ModifyPeptide, dlg =>
+            {
+                dlg.SelectModification(IsotopeLabelType.light, indexAA, PHOSPHO.Name);
+                dlg.OkDialog();
+            });
+            var docMod = WaitForDocumentChange(docPasted);
+
+            var pepNode = FindPeptide(docMod, sequence);
+            Assert.IsNotNull(pepNode.ExplicitMods, "Expected an explicit modification on {0}", sequence);
+            return docMod;
+        }
+
+        /// <summary>
+        /// True when the given choices include a transition of the given ion type and ordinal.
+        /// </summary>
+        private static bool HasIon(IEnumerable<DocNode> choices, IonType type, int ordinal)
+        {
+            return choices.Any(c => c.Id is Transition t && t.IonType == type && t.Ordinal == ordinal);
         }
 
         /// <summary>

--- a/pwiz_tools/Skyline/TestFunctional/TestFunctional.csproj
+++ b/pwiz_tools/Skyline/TestFunctional/TestFunctional.csproj
@@ -340,6 +340,7 @@
     <Compile Include="RescoreRawChromatogramsTest.cs" />
     <Compile Include="SettingsChangeReimportTest.cs" />
     <Compile Include="SimpleRatiosTest.cs" />
+    <Compile Include="SiteDeterminingIonFunctionalTest.cs" />
     <Compile Include="SkylineMenuTest.cs" />
     <Compile Include="SkypTest.cs" />
     <Compile Include="AddLibraryTest.cs" />


### PR DESCRIPTION
## Summary

* Added `SiteDeterminingIonAnalyzer` that computes, analytically (no positional-isomer enumeration, O(L x #mods)), the product ions that uniquely localize a modification among candidate residues; supports multiple simultaneously-ambiguous modifications.
* Added a Pick Children toggle that filters transitions to the ions unique to the current placement, with an empty-state hint ("No ions uniquely localize this modification") when a placement is unresolvable (e.g. an interior serine in a run).
* Added Document Grid columns `ModificationLocalizationGroup` and `LocalizationIsomerCount` on the Peptide entity.

## Test plan

- [x] TestSiteDeterminingIonAnalyzer - unit: terminal/interior/k=2/two-mod-type; unique-vs-empty producing sets, m/z cross-checked against GetFragmentIonMasses
- [x] TestSiteDeterminingIonFunctional - functional: toggle filters to unique ions (resolvable), empty list + hint (unresolvable), button hidden (non-localizable); passes en + fr
- [x] ColumnCaptionLocalizationTest - column caption/tooltip coverage for the new columns
- [x] TestNeutralLoss - existing Pick Children (PopupPickList) regression, unchanged
- [x] Verified live in Skyline on a real phospho PRM document: on AAIELPSLEVLS[+80]DQEEDR the toggle reduces the full ladder to exactly the y7-y11 ions that uniquely localize S12

Co-Authored-By: Claude <noreply@anthropic.com>
