### PR TITLE
Added a non-parametric null-alignment density-ratio plot to model diagnostics

### DIFF
--- a/pwiz_tools/Osprey/Osprey.FDR/ModelDiagnostics/ModelDiagnosticsData.cs
+++ b/pwiz_tools/Osprey/Osprey.FDR/ModelDiagnostics/ModelDiagnosticsData.cs
@@ -98,6 +98,13 @@ namespace pwiz.Osprey.FDR.ModelDiagnostics
         public double[] FeatureHistEdges { get; set; }
         public ScoreHistogram Scores { get; set; }
         /// <summary>
+        /// Non-parametric null-alignment ratios (Storey-style) derived from
+        /// <see cref="Scores"/>: the per-class score-density ratios target:decoy
+        /// and (when entrapment is present) p_target:p_decoy, plus a left-side
+        /// flatness KPI. Null when there is no score histogram to divide.
+        /// </summary>
+        public DensityRatioData DensityRatio { get; set; }
+        /// <summary>
         /// The FDR-calibration views the report offers. Each pairs an Osprey
         /// q-value axis (run- vs experiment-scope precursor q, at pass 1 or 2)
         /// with the entrapment FDP estimators. The experiment-scope views
@@ -162,6 +169,66 @@ namespace pwiz.Osprey.FDR.ModelDiagnostics
             public double DecoyMean { get; set; }
             public double DecoyStd { get; set; }
             public long DecoyN { get; set; }
+        }
+
+        /// <summary>
+        /// Non-parametric null-alignment ratios and the left-side flatness KPI,
+        /// derived from a <see cref="ScoreHistogram"/>'s per-class count arrays
+        /// (the Storey-style check). Each class density integrates to 1, so the
+        /// ratio lines are pure shape comparisons on a unit scale. Companion to
+        /// the decoy-normal overlay, but with no parametric fit: a decoy that
+        /// tracks the false-target null rides a flat plateau on the null-dominated
+        /// left; one that mistracks makes the target:decoy left side slope.
+        /// </summary>
+        public sealed class DensityRatioData
+        {
+            /// <summary>Score bin centers (the shared x for both ratio lines).</summary>
+            public double[] BinCenters { get; set; }
+            /// <summary>
+            /// target:decoy density ratio per bin -- the diagnostic line. NaN in
+            /// bins empty on either side. Flat on the null-dominated left at the
+            /// null fraction pi0 (&lt; 1; the target carries the true-hit mass),
+            /// then rises where real hits begin.
+            /// </summary>
+            public double[] TargetDecoy { get; set; }
+            /// <summary>
+            /// p_target:p_decoy density ratio per bin -- the matched-null reference
+            /// line, or null when there is no entrapment. Both classes are pure
+            /// null, so it rides ~1 flat throughout: "what a matched null pair
+            /// looks like."
+            /// </summary>
+            public double[] PTargetPDecoy { get; set; }
+            /// <summary>Lower score bound of the null region the flatness KPI was fit over (NaN if unmeasured).</summary>
+            public double NullRegionLo { get; set; }
+            /// <summary>Upper score bound of the null region the flatness KPI was fit over (NaN if unmeasured).</summary>
+            public double NullRegionHi { get; set; }
+            /// <summary>Number of bins that fed the target:decoy flatness fit.</summary>
+            public int NullRegionBins { get; set; }
+            /// <summary>
+            /// Headline KPI: the tilt of the target:decoy plateau across the null
+            /// region -- the weighted least-squares slope of ln(target:decoy)
+            /// against a null-region-normalized score in [0, 1]. ~0 = flat (decoys
+            /// track the false-target null); a large magnitude means the left side
+            /// slopes (a decoy-quality / equal-chance violation), caught with no
+            /// parametric fit. NaN when the null region has too little support to
+            /// assess.
+            /// </summary>
+            public double FlatnessSlope { get; set; }
+            /// <summary>
+            /// Bonus Storey read: the left-plateau height of target:decoy (the
+            /// weighted geometric-mean ratio over the null region) ~ pi0 = 1 -
+            /// true-hit fraction. NaN when unmeasured.
+            /// </summary>
+            public double PlateauRatio { get; set; }
+            /// <summary>
+            /// The reference line's flatness (slope of ln(p_target:p_decoy) over
+            /// the same null window) -- expected ~0 since both are pure null. NaN
+            /// with no entrapment or insufficient support. A same-run "what flat
+            /// looks like" baseline for <see cref="FlatnessSlope"/>.
+            /// </summary>
+            public double RefFlatnessSlope { get; set; }
+            /// <summary>True when the p_target:p_decoy reference line is present (an entrapment run).</summary>
+            public bool HasEntrapment { get; set; }
         }
 
         /// <summary>
@@ -354,6 +421,11 @@ namespace pwiz.Osprey.FDR.ModelDiagnostics
 
             // ---- score histogram + decoy normal fit ----
             data.Scores = BuildScoreHistogram(precs);
+
+            // ---- non-parametric null-alignment density ratios + flatness KPI ----
+            // Divides the per-class density arrays already reduced above; no new
+            // binning pass. Pass 1 only (the Density tab shows the pass-1 densities).
+            data.DensityRatio = BuildDensityRatio(data.Scores, data.HasEntrapment);
 
             // ---- id-yield curve (accepted targets vs q) ----
             data.IdYield = BuildIdYield(precs);
@@ -645,6 +717,208 @@ namespace pwiz.Osprey.FDR.ModelDiagnostics
                 h.DecoyN = dN;
             }
             return h;
+        }
+
+        // Minimum usable bins the flatness fit needs before it will report a KPI
+        // (below this the null region is too sparse to assess -> NaN "cannot assess").
+        private const int MinNullRegionBins = 4;
+
+        /// <summary>
+        /// Build the non-parametric null-alignment density ratios and the
+        /// left-side flatness KPI from a best-per-precursor
+        /// <see cref="ScoreHistogram"/>. Each per-class count array is
+        /// area-normalized to a unit-mass density, then two ratio lines are
+        /// formed -- target:decoy (the diagnostic, Mike's Storey check) and, when
+        /// entrapment is present, p_target:p_decoy (the matched-null reference).
+        /// The flatness KPI is the weighted slope of ln(target:decoy) across the
+        /// null-dominated left region: ~0 when the decoys track the false-target
+        /// null, large when they mistrack -- with no parametric fit. Pure function
+        /// over the histogram (shared by <see cref="Build"/> and unit-tested
+        /// directly); returns null when there is no histogram to divide.
+        /// </summary>
+        public static DensityRatioData BuildDensityRatio(ScoreHistogram h, bool hasEntrapment)
+        {
+            if (h?.BinEdges == null || h.BinEdges.Length < 3)
+                return null;   // need at least two bins to form a ratio line
+            int nb = h.BinEdges.Length - 1;
+            var centers = new double[nb];
+            for (int i = 0; i < nb; i++)
+                centers[i] = 0.5 * (h.BinEdges[i] + h.BinEdges[i + 1]);
+
+            double[] td = DensityRatioSeries(h.Target, h.Decoy, nb);
+            double[] pp = hasEntrapment ? DensityRatioSeries(h.PTarget, h.PDecoy, nb) : null;
+
+            var data = new DensityRatioData
+            {
+                BinCenters = centers,
+                TargetDecoy = td,
+                PTargetPDecoy = pp,
+                HasEntrapment = pp != null,
+                NullRegionLo = double.NaN,
+                NullRegionHi = double.NaN,
+                FlatnessSlope = double.NaN,
+                PlateauRatio = double.NaN,
+                RefFlatnessSlope = double.NaN,
+            };
+            if (td == null)
+                return data;   // no target/decoy mass to divide: ratio lines only
+
+            // Null region: usable left bins (both classes populated) up to the
+            // true-hit onset -- the first bin where the target density sustainedly
+            // meets/exceeds the decoy density (real hits arriving). Capped at the
+            // decoy 95th percentile so a degenerate never-crossing case still
+            // bounds the fit to well-populated bins.
+            int onset = TrueHitOnset(h.Target, h.Decoy, nb);
+            int hi = Math.Min(onset, DecoyQuantileBin(h.Decoy, nb, 0.95));
+
+            var xs = new List<double>();
+            var ys = new List<double>();
+            var ws = new List<double>();
+            for (int i = 0; i < hi; i++)
+                AddFitBin(centers, td, h.Target, h.Decoy, i, xs, ys, ws);
+            if (xs.Count < MinNullRegionBins)
+                return data;   // insufficient null support to assess flatness
+
+            double loScore = xs[0], hiScore = xs[xs.Count - 1];
+            data.NullRegionLo = loScore;
+            data.NullRegionHi = hiScore;
+            data.NullRegionBins = xs.Count;
+            WeightedLogFit(xs, ys, ws, loScore, hiScore, out double slope, out double meanLog);
+            data.FlatnessSlope = slope;
+            data.PlateauRatio = Math.Exp(meanLog);   // weighted geometric-mean ratio ~ pi0
+
+            // Reference line's flatness over the SAME score window, for an
+            // apples-to-apples "what flat looks like" baseline (both p_target and
+            // p_decoy are pure null -> ~0).
+            if (pp != null)
+            {
+                var rxs = new List<double>();
+                var rys = new List<double>();
+                var rws = new List<double>();
+                for (int i = 0; i < nb; i++)
+                {
+                    if (centers[i] < loScore || centers[i] > hiScore)
+                        continue;
+                    AddFitBin(centers, pp, h.PTarget, h.PDecoy, i, rxs, rys, rws);
+                }
+                if (rxs.Count >= MinNullRegionBins)
+                {
+                    WeightedLogFit(rxs, rys, rws, loScore, hiScore, out double rslope, out _);
+                    data.RefFlatnessSlope = rslope;
+                }
+            }
+            return data;
+        }
+
+        // Form one density-ratio line num:den over nb bins:
+        // (num_i / sum(num)) / (den_i / sum(den)). Each class is area-normalized to
+        // unit mass first, so the ratio is a pure shape comparison. NaN where a bin
+        // is empty on either side (a gap the plot skips and the fit excludes) --
+        // never +/-Infinity, which the HTML's JS isNaN() guard would let through.
+        // Null when either class has no mass at all.
+        private static double[] DensityRatioSeries(int[] num, int[] den, int nb)
+        {
+            if (num == null || den == null)
+                return null;
+            long sumN = 0, sumD = 0;
+            for (int i = 0; i < nb; i++) { sumN += num[i]; sumD += den[i]; }
+            if (sumN == 0 || sumD == 0)
+                return null;
+            var r = new double[nb];
+            for (int i = 0; i < nb; i++)
+                r[i] = num[i] <= 0 || den[i] <= 0
+                    ? double.NaN
+                    : ((double)num[i] / sumN) / ((double)den[i] / sumD);
+            return r;
+        }
+
+        // Accumulate one bin into a weighted-log-fit sample set when both classes
+        // are populated (ratio finite and loggable). x = score center, y = ln(ratio),
+        // weight = num*den/(num+den): the inverse of the log-ratio's variance
+        // (~ 1/num + 1/den by the delta method), so sparse bins count for less.
+        private static void AddFitBin(double[] centers, double[] ratio, int[] num, int[] den,
+            int i, List<double> xs, List<double> ys, List<double> ws)
+        {
+            if (num[i] < 1 || den[i] < 1)
+                return;
+            xs.Add(centers[i]);
+            ys.Add(Math.Log(ratio[i]));
+            ws.Add((double)num[i] * den[i] / (num[i] + den[i]));
+        }
+
+        // The true-hit onset: the first bin at which the target density rises to
+        // meet or exceed the decoy density and STAYS there (the next usable bin is
+        // also at/above) -- i.e. where real hits begin to dominate the shared null.
+        // Below it, target:decoy sits on its null plateau (at pi0 < 1). Returns nb
+        // when no sustained crossover exists (a degenerate target~decoy separation),
+        // leaving the decoy-quantile cap to bound the fit. Densities are compared by
+        // cross-multiplication (target_i/sumT >= decoy_i/sumD) to avoid recomputing sums.
+        private static int TrueHitOnset(int[] target, int[] decoy, int nb)
+        {
+            long sumT = 0, sumD = 0;
+            for (int i = 0; i < nb; i++) { sumT += target[i]; sumD += decoy[i]; }
+            if (sumT == 0 || sumD == 0)
+                return nb;
+            for (int i = 0; i < nb; i++)
+            {
+                if (target[i] < 1 || decoy[i] < 1 || !AtOrAbove(target[i], decoy[i], sumT, sumD))
+                    continue;
+                int j = i + 1;
+                while (j < nb && (target[j] < 1 || decoy[j] < 1))
+                    j++;
+                if (j >= nb || AtOrAbove(target[j], decoy[j], sumT, sumD))
+                    return i;
+            }
+            return nb;
+        }
+
+        // target_i/sumT >= decoy_i/sumD, cross-multiplied (all non-negative).
+        private static bool AtOrAbove(int target, int decoy, long sumT, long sumD)
+        {
+            return (double)target * sumD >= (double)decoy * sumT;
+        }
+
+        // The bin index at the given quantile of the decoy score distribution (by
+        // decoy count) -- used to cap the null-region fit to well-populated bins
+        // when no true-hit onset is found. Returns nb-1 as a safe upper bound if
+        // decoys are empty.
+        private static int DecoyQuantileBin(int[] decoy, int nb, double q)
+        {
+            long total = 0;
+            for (int i = 0; i < nb; i++) total += decoy[i];
+            if (total == 0)
+                return nb - 1;
+            long threshold = (long)Math.Ceiling(q * total);
+            long cum = 0;
+            for (int i = 0; i < nb; i++)
+            {
+                cum += decoy[i];
+                if (cum >= threshold)
+                    return i;
+            }
+            return nb - 1;
+        }
+
+        // Weighted least-squares slope of y = ln(ratio) against an x normalized to
+        // [0, 1] across [loScore, hiScore], plus the weighted mean of y. The [0, 1]
+        // normalization makes the slope a scale-free "e-folds of drift across the
+        // null plateau" (0 = perfectly flat), comparable across runs regardless of
+        // the composite score's units. meanLog exponentiates to the weighted
+        // geometric-mean ratio (~ pi0). slope is NaN for a degenerate (single-x) fit.
+        private static void WeightedLogFit(List<double> xs, List<double> ys, List<double> ws,
+            double loScore, double hiScore, out double slope, out double meanLog)
+        {
+            double span = hiScore - loScore;
+            double sw = 0, swx = 0, swy = 0, swxx = 0, swxy = 0;
+            for (int i = 0; i < xs.Count; i++)
+            {
+                double x = span > 0 ? (xs[i] - loScore) / span : 0.0;
+                double y = ys[i], w = ws[i];
+                sw += w; swx += w * x; swy += w * y; swxx += w * x * x; swxy += w * x * y;
+            }
+            meanLog = sw > 0 ? swy / sw : double.NaN;
+            double denom = sw * swxx - swx * swx;
+            slope = Math.Abs(denom) > 1e-12 ? (sw * swxy - swx * swy) / denom : double.NaN;
         }
 
         private static IdYieldData BuildIdYield(List<Prec> precs)

--- a/pwiz_tools/Osprey/Osprey.FDR/ModelDiagnostics/ModelDiagnosticsData.cs
+++ b/pwiz_tools/Osprey/Osprey.FDR/ModelDiagnostics/ModelDiagnosticsData.cs
@@ -723,6 +723,14 @@ namespace pwiz.Osprey.FDR.ModelDiagnostics
         // (below this the null region is too sparse to assess -> NaN "cannot assess").
         private const int MinNullRegionBins = 4;
 
+        // The null-region fit is bounded at this quantile of the decoy (null) score
+        // distribution -- its null-dominated lower portion, below the true-hit
+        // "shoulder" where the target's real hits start lifting the target:decoy
+        // ratio off its plateau. Calibrated on the Stellar libdecoy oracle, where
+        // that plateau is flat below ~the decoy 40th percentile and rises above it;
+        // fitting only the plateau is what makes a calibrated pairing read as flat.
+        private const double NullRegionDecoyQuantile = 0.40;
+
         /// <summary>
         /// Build the non-parametric null-alignment density ratios and the
         /// left-side flatness KPI from a best-per-precursor
@@ -763,13 +771,18 @@ namespace pwiz.Osprey.FDR.ModelDiagnostics
             if (td == null)
                 return data;   // no target/decoy mass to divide: ratio lines only
 
-            // Null region: usable left bins (both classes populated) up to the
-            // true-hit onset -- the first bin where the target density sustainedly
-            // meets/exceeds the decoy density (real hits arriving). Capped at the
-            // decoy 95th percentile so a degenerate never-crossing case still
-            // bounds the fit to well-populated bins.
+            // Null region = the null-dominated lower portion of the decoy (null)
+            // distribution (up to NullRegionDecoyQuantile), where true target hits
+            // are negligible -- they sit at high scores. Fitting only this range
+            // isolates the FLAT plateau Storey's check reads and excludes the
+            // true-hit "shoulder" (the rise a target/decoy crossover would let in:
+            // the crossover lands only after the target has accumulated its true-hit
+            // mass, well past where the ratio departs its plateau). The crossover
+            // onset still caps it as a safety for a degenerate target~decoy
+            // separation (onset fires at bin 0 -> empty region -> "cannot assess").
+            // Both bounds are exclusive (the fit loop below runs over [0, hi)).
             int onset = TrueHitOnset(h.Target, h.Decoy, nb);
-            int hi = Math.Min(onset, DecoyQuantileBin(h.Decoy, nb, 0.95));
+            int hi = Math.Min(onset, DecoyQuantileBin(h.Decoy, nb, NullRegionDecoyQuantile));
 
             var xs = new List<double>();
             var ys = new List<double>();
@@ -843,16 +856,20 @@ namespace pwiz.Osprey.FDR.ModelDiagnostics
                 return;
             xs.Add(centers[i]);
             ys.Add(Math.Log(ratio[i]));
-            ws.Add((double)num[i] * den[i] / (num[i] + den[i]));
+            ws.Add((double)num[i] * den[i] / ((double)num[i] + den[i]));
         }
 
         // The true-hit onset: the first bin at which the target density rises to
-        // meet or exceed the decoy density and STAYS there (the next usable bin is
-        // also at/above) -- i.e. where real hits begin to dominate the shared null.
-        // Below it, target:decoy sits on its null plateau (at pi0 < 1). Returns nb
-        // when no sustained crossover exists (a degenerate target~decoy separation),
-        // leaving the decoy-quantile cap to bound the fit. Densities are compared by
-        // cross-multiplication (target_i/sumT >= decoy_i/sumD) to avoid recomputing sums.
+        // meet or exceed the decoy density and STAYS there (this bin AND the next
+        // two usable bins are all at/above) -- i.e. where real hits begin to
+        // dominate the shared null. Requiring a sustained run keeps a 1-2 bin
+        // statistical bump in the null-dominated left from tripping a false-early
+        // onset (which would only shrink the fit window -- conservative -- but is
+        // still worth guarding). Below the onset, target:decoy sits on its null
+        // plateau (at pi0 < 1). Returns nb when no sustained crossover exists (a
+        // degenerate target~decoy separation), leaving the decoy-quantile cap to
+        // bound the fit. Densities are compared by cross-multiplication
+        // (target_i/sumT >= decoy_i/sumD) to avoid recomputing sums.
         private static int TrueHitOnset(int[] target, int[] decoy, int nb)
         {
             long sumT = 0, sumD = 0;
@@ -863,10 +880,7 @@ namespace pwiz.Osprey.FDR.ModelDiagnostics
             {
                 if (target[i] < 1 || decoy[i] < 1 || !AtOrAbove(target[i], decoy[i], sumT, sumD))
                     continue;
-                int j = i + 1;
-                while (j < nb && (target[j] < 1 || decoy[j] < 1))
-                    j++;
-                if (j >= nb || AtOrAbove(target[j], decoy[j], sumT, sumD))
+                if (SustainedAtOrAbove(target, decoy, nb, i, sumT, sumD, 2))
                     return i;
             }
             return nb;
@@ -878,10 +892,29 @@ namespace pwiz.Osprey.FDR.ModelDiagnostics
             return (double)target * sumD >= (double)decoy * sumT;
         }
 
+        // True when the next `lookahead` USABLE bins after `start` (both classes
+        // populated) are all at/above the decoy density -- or fewer usable bins
+        // remain before nb (a crossover close to the right edge is still real).
+        // Lets TrueHitOnset require a sustained, not single-fluctuation, crossover.
+        private static bool SustainedAtOrAbove(int[] target, int[] decoy, int nb,
+            int start, long sumT, long sumD, int lookahead)
+        {
+            int seen = 0;
+            for (int j = start + 1; j < nb && seen < lookahead; j++)
+            {
+                if (target[j] < 1 || decoy[j] < 1)
+                    continue;
+                if (!AtOrAbove(target[j], decoy[j], sumT, sumD))
+                    return false;
+                seen++;
+            }
+            return true;
+        }
+
         // The bin index at the given quantile of the decoy score distribution (by
-        // decoy count) -- used to cap the null-region fit to well-populated bins
-        // when no true-hit onset is found. Returns nb-1 as a safe upper bound if
-        // decoys are empty.
+        // decoy count) -- the primary null-region upper bound (its null-dominated
+        // lower portion); the true-hit onset only caps it in the degenerate case.
+        // Returns nb-1 as a safe upper bound if decoys are empty.
         private static int DecoyQuantileBin(int[] decoy, int nb, double q)
         {
             long total = 0;

--- a/pwiz_tools/Osprey/Osprey.FDR/ModelDiagnostics/ModelDiagnosticsData.cs
+++ b/pwiz_tools/Osprey/Osprey.FDR/ModelDiagnostics/ModelDiagnosticsData.cs
@@ -772,17 +772,19 @@ namespace pwiz.Osprey.FDR.ModelDiagnostics
                 return data;   // no target/decoy mass to divide: ratio lines only
 
             // Null region = the null-dominated lower portion of the decoy (null)
-            // distribution (up to NullRegionDecoyQuantile), where true target hits
-            // are negligible -- they sit at high scores. Fitting only this range
-            // isolates the FLAT plateau Storey's check reads and excludes the
-            // true-hit "shoulder" (the rise a target/decoy crossover would let in:
-            // the crossover lands only after the target has accumulated its true-hit
-            // mass, well past where the ratio departs its plateau). The crossover
-            // onset still caps it as a safety for a degenerate target~decoy
+            // distribution -- bins up to and including the NullRegionDecoyQuantile
+            // bin, where true target hits are negligible (they sit at high scores).
+            // Fitting only this range isolates the FLAT plateau Storey's check reads
+            // and excludes the true-hit "shoulder" (the rise a target/decoy crossover
+            // would let in: the crossover lands only after the target has accumulated
+            // its true-hit mass, well past where the ratio departs its plateau). The
+            // true-hit onset still caps it as a safety for a degenerate target~decoy
             // separation (onset fires at bin 0 -> empty region -> "cannot assess").
-            // Both bounds are exclusive (the fit loop below runs over [0, hi)).
             int onset = TrueHitOnset(h.Target, h.Decoy, nb);
-            int hi = Math.Min(onset, DecoyQuantileBin(h.Decoy, nb, NullRegionDecoyQuantile));
+            // hi is the exclusive end of the [0, hi) fit loop below: the +1 includes
+            // the decoy-quantile bin itself (still null-dominated), while the onset
+            // bin (the first true-hit bin) stays excluded.
+            int hi = Math.Min(onset, DecoyQuantileBin(h.Decoy, nb, NullRegionDecoyQuantile) + 1);
 
             var xs = new List<double>();
             var ys = new List<double>();

--- a/pwiz_tools/Osprey/Osprey.Tasks/ModelDiagnostics/model-diagnostics-template.html
+++ b/pwiz_tools/Osprey/Osprey.Tasks/ModelDiagnostics/model-diagnostics-template.html
@@ -193,6 +193,19 @@ code{font-family:ui-monospace,Menlo,Consolas,monospace;background:var(--grid);pa
     <div class="legend" id="densLegend"></div>
     <div class="chartbox" id="densChart"></div>
   </div>
+  <div class="card" id="ratioCard">
+    <h2>Null-alignment density ratio (non-parametric)</h2>
+    <p class="desc">The per-class score densities above, divided: <b>target : decoy</b> (the diagnostic) and,
+      when entrapment is present, <b>p_target : p_decoy</b> (a matched-null reference). On a fair (equal-chance)
+      pairing the target:decoy line rides a <b>flat</b> plateau across the null-dominated left side, then rises
+      where real hits begin; a <b>sloping</b> left side means the decoys don't track the false-target null &mdash;
+      an equal-chance / decoy-quality violation, visible with <b>no parametric fit</b> (unlike the decoy-normal
+      overlay, which misfits skewed decoys). Storey's original check.</p>
+    <div class="kpis" id="ratioKpis"></div>
+    <div class="legend" id="ratioLegend"></div>
+    <div class="chartbox" id="ratioChart"></div>
+    <p class="note" id="ratioNote"></p>
+  </div>
 </section>
 
 <section class="tab" data-tab="fdr">
@@ -525,6 +538,87 @@ function classHist(H0,hostId,legId,normalize){
 }
 renderModel(MODEL_PASSES[0]);   // Model tab: table + composite for pass 1 (default)
 classHist(D.scores,"densChart","densLegend",true);   // Density tab: pass-1 composite density
+
+// ---------- Density tab: non-parametric null-alignment density ratio ----------
+// Storey's original check: divide the per-class densities. target:decoy is the
+// diagnostic (flat null plateau = decoys track the false-target null; a sloping
+// left side = they don't); p_target:p_decoy is the matched-null reference (~1).
+// Log-y so the flat plateau and any tilt read clearly against the ratio=1 line.
+function logTicks(lo,hi){const out=[];const k0=Math.floor(Math.log10(lo)),k1=Math.ceil(Math.log10(hi));
+  for(let k=k0;k<=k1;k++)[1,2,5].forEach(m=>{const v=m*Math.pow(10,k);if(v>=lo&&v<=hi)out.push(v);});return out;}
+function ratioFmt(v){return v>=1?(+v.toFixed(v<10?1:0)).toString():(+v.toFixed(2)).toString();}
+(function(){
+  const dr=D.densityRatio, card=document.getElementById("ratioCard");
+  const num=v=>Number(v);
+  if(!dr||!dr.binCenters||!dr.targetDecoy){if(card)card.style.display="none";return;}
+  const cx=dr.binCenters, nb=cx.length;
+  const hasRef=!!(dr.hasEntrapment && dr.pTargetPDecoy);
+  const series=[{k:"td",name:"target : decoy",color:COL.accent,v:dr.targetDecoy}];
+  if(hasRef)series.push({k:"pp",name:"p_target : p_decoy (matched null)",color:COL.ptarget,v:dr.pTargetPDecoy});
+  const off={td:false,pp:false};
+  // Log-y range from finite positive ratios (robust percentiles so a sparse-tail
+  // spike can't blow out the axis), always bracketing the ratio=1 reference.
+  const vals=[];series.forEach(s=>s.v.forEach(v=>{const n=num(v);if(isFinite(n)&&n>0)vals.push(n);}));
+  if(vals.length<2){if(card)card.style.display="none";return;}
+  vals.sort((a,b)=>a-b);
+  const q=p=>vals[Math.min(vals.length-1,Math.max(0,Math.floor(p*(vals.length-1))))];
+  let ylo=Math.min(q(0.02),0.8), yhi=Math.max(q(0.98),1.25); ylo/=1.6; yhi*=1.6;
+  const lylo=Math.log10(ylo), lyhi=Math.log10(yhi);
+  const xd=[cx[0],cx[nb-1]];
+  const W=680,Hh=340,box={l:56,t:16,w:W-74,h:Hh-62};
+  const host=document.getElementById("ratioChart");
+  const X=v=>box.l+(v-xd[0])/((xd[1]-xd[0])||1)*box.w;
+  const Y=v=>box.t+box.h-(Math.log10(v)-lylo)/((lyhi-lylo)||1)*box.h;
+  const nlo=num(dr.nullRegionLo), nhi=num(dr.nullRegionHi), pl=num(dr.plateauRatio);
+  function draw(){
+    host.innerHTML="";const s=svg(W,Hh);host.appendChild(s);
+    const g=E(s,"g",{class:"grid"}),a=E(s,"g",{class:"axis"});
+    logTicks(ylo,yhi).forEach(v=>{E(g,"line",{x1:box.l,x2:box.l+box.w,y1:Y(v),y2:Y(v)});
+      E(a,"text",{x:box.l-7,y:Y(v)+3,"text-anchor":"end"}).textContent=ratioFmt(v);});
+    ticks(xd[0],xd[1],6).forEach(v=>E(a,"text",{x:X(v),y:box.t+box.h+15,"text-anchor":"middle"}).textContent=trim(v));
+    E(a,"line",{x1:box.l,x2:box.l+box.w,y1:box.t+box.h,y2:box.t+box.h});
+    E(a,"line",{x1:box.l,x2:box.l,y1:box.t,y2:box.t+box.h});
+    E(s,"text",{class:"axtitle",x:box.l+box.w/2,y:box.t+box.h+32,"text-anchor":"middle"}).textContent="composite score";
+    E(s,"text",{class:"axtitle",x:14,y:box.t+box.h/2,"text-anchor":"middle",transform:"rotate(-90 14 "+(box.t+box.h/2)+")"}).textContent="density ratio (log)";
+    // null-region shading, the ratio=1 reference, and the plateau (pi0) level
+    if(isFinite(nlo)&&isFinite(nhi)&&nhi>nlo)
+      E(s,"rect",{x:X(nlo),y:box.t,width:Math.max(0,X(nhi)-X(nlo)),height:box.h,fill:COL.muted,opacity:.07});
+    if(1>=ylo&&1<=yhi)E(s,"line",{x1:box.l,x2:box.l+box.w,y1:Y(1),y2:Y(1),stroke:COL.muted,"stroke-dasharray":"4 4","stroke-width":1});
+    if(isFinite(pl)&&pl>=ylo&&pl<=yhi)
+      E(s,"line",{x1:X(isFinite(nlo)?nlo:xd[0]),x2:X(isFinite(nhi)?nhi:xd[1]),y1:Y(pl),y2:Y(pl),stroke:COL.accent,"stroke-dasharray":"2 3","stroke-width":1,opacity:.6});
+    series.forEach(se=>{if(off[se.k])return;let path="",started=false;
+      for(let i=0;i<nb;i++){const v=num(se.v[i]);
+        if(!isFinite(v)||v<=0){started=false;continue;}
+        const yy=Y(Math.min(yhi,Math.max(ylo,v))),xx=X(cx[i]);
+        path+=(started?"L":"M")+xx.toFixed(1)+" "+yy.toFixed(1)+" ";started=true;}
+      E(s,"path",{d:path,fill:"none",stroke:se.color,"stroke-width":1.8,"stroke-linejoin":"round"});});
+    const ov=E(s,"rect",{x:box.l,y:box.t,width:box.w,height:box.h,fill:"transparent"});
+    ov.addEventListener("mousemove",ev=>{const rb=s.getBoundingClientRect();
+      const px=(ev.clientX-rb.left)/rb.width*W;const bi=Math.min(nb-1,Math.max(0,Math.round((px-box.l)/box.w*(nb-1))));
+      let html="<b>score "+trim(cx[bi])+"</b>";
+      series.forEach(se=>{if(off[se.k])return;const v=num(se.v[bi]);
+        html+="<br><span style='color:"+se.color+"'>■</span> "+se.name+": "+(isFinite(v)?fmt(v,2):"–");});
+      showTip(ev,html);});
+    ov.addEventListener("mouseleave",hideTip);
+  }
+  const items=series.map(se=>({name:se.name,color:se.color,toggle:o=>{off[se.k]=o;draw();}}));
+  items.push({name:"ratio = 1",color:COL.muted,line:true});
+  legend(document.getElementById("ratioLegend"),items);
+  draw();
+  const kp=document.getElementById("ratioKpis");kp.innerHTML="";
+  kpi(kp,"null-plateau tilt (T:D)",fmt(dr.flatnessSlope,2),"");
+  kpi(kp,"plateau height (pi0)",fmt(dr.plateauRatio,2),"");
+  if(hasRef)kpi(kp,"reference tilt (P:Pd)",fmt(dr.refFlatnessSlope,2),"");
+  kpi(kp,"null-region bins",fmt(dr.nullRegionBins,0),"");
+  const slope=num(dr.flatnessSlope);
+  document.getElementById("ratioNote").innerHTML= isFinite(slope)
+    ? "Read the shaded null region on the left: a <b>flat</b> target:decoy plateau (tilt near 0) means the decoys "+
+      "track the false-target null; a <b>sloping</b> left side (large tilt) means they don't. The plateau height "+
+      "is a Storey-style &pi;0 (the null fraction 1&minus;&pi;<sub>true</sub>); the curve rises where real hits begin."+
+      (hasRef?" The <b>p_target : p_decoy</b> line (both pure null) is the matched-null reference &mdash; it rides "+
+        "~1 flat, showing what a faithful pairing looks like on this run.":"")
+    : "Not enough populated null-region bins on this run to measure the plateau tilt.";
+})();
 
 // ---------- FDR calibration (multiple q-scope / pass views) ----------
 if(D.fdpViews && D.fdpViews.length){

--- a/pwiz_tools/Osprey/Osprey.Tasks/ModelDiagnostics/model-diagnostics-template.html
+++ b/pwiz_tools/Osprey/Osprey.Tasks/ModelDiagnostics/model-diagnostics-template.html
@@ -237,6 +237,7 @@ code{font-family:ui-monospace,Menlo,Consolas,monospace;background:var(--grid);pa
       binned by the winner's score. A fair null sits at the 50% line. Real pairs dipping below 50% at high score is
       native signal winning as it should; entrapment pairs holding the coin confirms the decoys are honest nulls.
       Marginal densities cannot see this within-pair ordering &mdash; only the competition can.</p>
+    <div class="kpis" id="wfKpis"></div>
     <div class="legend" id="wfLegend"></div>
     <div class="chartbox" id="wfChart"></div>
     <p class="note" id="wfNote"></p>
@@ -613,10 +614,12 @@ function ratioFmt(v){return v>=1?(+v.toFixed(v<10?1:0)).toString():(+v.toFixed(2
   const slope=num(dr.flatnessSlope);
   document.getElementById("ratioNote").innerHTML= isFinite(slope)
     ? "Read the shaded null region on the left: a <b>flat</b> target:decoy plateau (tilt near 0) means the decoys "+
-      "track the false-target null; a <b>sloping</b> left side (large tilt) means they don't. The plateau height "+
-      "is a Storey-style &pi;0 (the null fraction 1&minus;&pi;<sub>true</sub>); the curve rises where real hits begin."+
-      (hasRef?" The <b>p_target : p_decoy</b> line (both pure null) is the matched-null reference &mdash; it rides "+
-        "~1 flat, showing what a faithful pairing looks like on this run.":"")
+      "track the false-target null in <i>shape</i>; a <b>sloping</b> left side (large tilt) means they don't. The plateau "+
+      "height is a Storey-style &pi;0 (the null fraction 1&minus;&pi;<sub>true</sub>); the curve rises where real hits begin."+
+      (hasRef?" The <b>p_target : p_decoy</b> line rides ~1 flat when the entrapment decoys are a faithful null, and "+
+        "slopes when they are not (e.g. generated decoys).":"")+
+      " This is a <b>marginal</b> check: a target-side score boost that leaves the decoy and entrapment marginals "+
+      "intact is invisible here &mdash; see the paired decoy-win fraction (Competition) for that."
     : "Not enough populated null-region bins on this run to measure the plateau tilt.";
 })();
 
@@ -706,6 +709,11 @@ if(D.fdpViews && D.fdpViews.length){
   });
 }
 function cls(v,q){return v==null?"":(v<=q*1.15?"good":v<=q*1.6?"warn":"bad");}
+// Flag a paired-coin fraction by its distance from a fair 50%, and a real-vs-
+// entrapment coin gap (ent - real) by how far the real coin has collapsed below
+// the entrapment ruler. Thresholds are report cues, not a calibrated alarm.
+function coinCls(v){v=Number(v);return isNaN(v)?"":(Math.abs(v-0.5)<=0.05?"good":Math.abs(v-0.5)<=0.15?"warn":"bad");}
+function gapCls(g){g=Number(g);return isNaN(g)?"":(g<=0.05?"good":g<=0.15?"warn":"bad");}
 
 // ---------- ID yield ----------
 if(D.idYield){const y=D.idYield;const W=680,Hh=300,box={l:60,t:14,w:W-78,h:Hh-56};
@@ -745,9 +753,24 @@ if(D.winFraction && D.winFraction.binCenters){
   items.push({name:"fair coin 50%",color:COL.muted,line:true});
   legend(document.getElementById("wfLegend"),items);
   draw();
-  document.getElementById("wfNote").innerHTML="Low-score null band ["+trim(w.nullBandLo)+", "+trim(w.nullBandHi)+"]:  real "+
-    pct(w.nullBandReal,1)+(w.hasEntrapment?"  ·  entrapment "+pct(w.nullBandEnt,1):"")+
-    ". An entrapment coin near 50% is the honest ruler; real pairs below it are native signal winning.";
+  // KPI: the null-band paired coin. A fair target-decoy competition sits at 50%.
+  // The REAL coin collapsing below the ENTRAPMENT coin is real targets beating
+  // their own decoys unfairly -- score inflation that marginal densities and the
+  // entrapment FDP both miss (the target-boost failure). Within-pair, not
+  // marginal: this competition view is the one thing that sees it.
+  (function(){const kp=document.getElementById("wfKpis");if(!kp)return;kp.innerHTML="";
+    const real=w.nullBandReal, ent=w.nullBandEnt;
+    kpi(kp,"real coin (null band)",pct(real,1),coinCls(real));
+    if(w.hasEntrapment){
+      kpi(kp,"entrapment coin (null band)",pct(ent,1),coinCls(ent));
+      const gap=(isFinite(Number(real))&&isFinite(Number(ent)))?Number(ent)-Number(real):NaN;
+      kpi(kp,"coin collapse (ent − real)",isFinite(gap)?pct(gap,1):"–",gapCls(gap));
+    }
+  })();
+  document.getElementById("wfNote").innerHTML="Low-score null band ["+trim(w.nullBandLo)+", "+trim(w.nullBandHi)+"]. "+
+    "A fair target–decoy competition sits at 50%. "+(w.hasEntrapment
+      ? "The entrapment coin is the honest ruler — it holds ~50% under any target-side effect; the <b>real coin collapsing below it</b> means real targets are beating their own decoys unfairly, i.e. score inflation that marginal densities and the entrapment FDP both miss (a target-score boost). This within-pair view is the one that sees it."
+      : "Without an entrapment library this is confounded by true positives, but a real coin well below 50% in the null band is still suspect.");
 }
 
 // ---------- summary ----------

--- a/pwiz_tools/Osprey/Osprey.Tasks/ModelDiagnostics/model-diagnostics-template.html
+++ b/pwiz_tools/Osprey/Osprey.Tasks/ModelDiagnostics/model-diagnostics-template.html
@@ -607,9 +607,9 @@ function ratioFmt(v){return v>=1?(+v.toFixed(v<10?1:0)).toString():(+v.toFixed(2
   legend(document.getElementById("ratioLegend"),items);
   draw();
   const kp=document.getElementById("ratioKpis");kp.innerHTML="";
-  kpi(kp,"null-plateau tilt (T:D)",fmt(dr.flatnessSlope,2),"");
+  kpi(kp,"null-plateau tilt (target:decoy)",fmt(dr.flatnessSlope,2),"");
   kpi(kp,"plateau height (pi0)",fmt(dr.plateauRatio,2),"");
-  if(hasRef)kpi(kp,"reference tilt (P:Pd)",fmt(dr.refFlatnessSlope,2),"");
+  if(hasRef)kpi(kp,"reference tilt (p_target:p_decoy)",fmt(dr.refFlatnessSlope,2),"");
   kpi(kp,"null-region bins",fmt(dr.nullRegionBins,0),"");
   const slope=num(dr.flatnessSlope);
   document.getElementById("ratioNote").innerHTML= isFinite(slope)

--- a/pwiz_tools/Osprey/Osprey.Test/ModelDiagnosticsDataTest.cs
+++ b/pwiz_tools/Osprey/Osprey.Test/ModelDiagnosticsDataTest.cs
@@ -54,6 +54,117 @@ namespace pwiz.Osprey.Test
             TestSidecarRoundTrip();
             TestFeatureHistograms();
             TestModelPass2();
+            TestDensityRatioFlatness();
+        }
+
+        // The non-parametric null-alignment ratio (Mike's Storey check): the ratio
+        // of the per-class score DENSITIES. A matched decoy null gives a FLAT
+        // target:decoy plateau on the null-dominated left (small flatness slope); a
+        // decoy shifted off the false-target null makes that left side SLOPE (large
+        // flatness slope). The p_target:p_decoy reference (both pure null) rides an
+        // exactly-flat ratio of 1. Built directly from a synthetic ScoreHistogram so
+        // the assertions are deterministic (no binning / percentile dependence).
+        private static void TestDensityRatioFlatness()
+        {
+            const int nb = 60;
+            var edges = Edges(nb);
+            // A true-hit bump well to the right of the null, shared by both cases, so
+            // the target's high-score mass sits above the decoy null either way.
+            var trueHit = Bump(nb, 45, 5, 1200);
+
+            // --- Matched: false-target null and decoys share a shape (centered 20).
+            // target = 0.30 * decoy (its false component) + the true-hit bump.
+            var decoyM = Bump(nb, 20, 5, 2000);
+            var targetM = new int[nb];
+            for (int i = 0; i < nb; i++)
+                targetM[i] = (int)System.Math.Round(0.30 * decoyM[i]) + trueHit[i];
+            var hM = Hist(edges, targetM, decoyM, new int[nb], new int[nb]);
+            var drM = ModelDiagnosticsData.BuildDensityRatio(hM, false);
+
+            Assert.IsNotNull(drM);
+            Assert.IsNotNull(drM.TargetDecoy);
+            Assert.IsNull(drM.PTargetPDecoy);                      // no entrapment supplied
+            Assert.IsTrue(drM.NullRegionBins >= 4);
+            Assert.IsFalse(double.IsNaN(drM.FlatnessSlope));
+            // Empty far-left bin -> NaN in the series (never +/-Infinity).
+            Assert.IsTrue(double.IsNaN(drM.TargetDecoy[0]));
+            // Matched: the left plateau is essentially flat.
+            Assert.IsTrue(System.Math.Abs(drM.FlatnessSlope) < 0.15,
+                "matched flatness slope should be ~0, was " + drM.FlatnessSlope);
+            // Plateau height is the null fraction pi0 (< 1: target carries true hits).
+            Assert.IsTrue(drM.PlateauRatio > 0.05 && drM.PlateauRatio < 1.0,
+                "matched plateau ratio (pi0) out of range: " + drM.PlateauRatio);
+
+            // --- Shifted: decoys centered LEFT of the false-target null (too weak,
+            // the gendecoy signature). Same true-hit bump.
+            var decoyS = Bump(nb, 14, 5, 2000);
+            var falseS = Bump(nb, 24, 5, 2000);                    // false-target null, shifted right of decoys
+            var targetS = new int[nb];
+            for (int i = 0; i < nb; i++)
+                targetS[i] = (int)System.Math.Round(0.30 * falseS[i]) + trueHit[i];
+            var hS = Hist(edges, targetS, decoyS, new int[nb], new int[nb]);
+            var drS = ModelDiagnosticsData.BuildDensityRatio(hS, false);
+
+            Assert.IsNotNull(drS);
+            Assert.IsFalse(double.IsNaN(drS.FlatnessSlope));
+            Assert.IsTrue(drS.NullRegionBins >= 4);
+            // The miscalibrated decoy makes the left side clearly slope...
+            Assert.IsTrue(System.Math.Abs(drS.FlatnessSlope) > 0.6,
+                "shifted flatness slope should be large, was " + drS.FlatnessSlope);
+            // ...and much larger than the matched case (the oracle the report leans on).
+            Assert.IsTrue(System.Math.Abs(drS.FlatnessSlope) > 4.0 * System.Math.Abs(drM.FlatnessSlope),
+                "shifted slope " + drS.FlatnessSlope + " should dwarf matched " + drM.FlatnessSlope);
+
+            // --- Reference line: p_target == p_decoy (identical pure-null arrays) ->
+            // the ratio is exactly 1 everywhere, so the reference flatness is exactly 0.
+            var pnull = Bump(nb, 20, 5, 1500);
+            var hEnt = Hist(edges, targetM, decoyM, (int[])pnull.Clone(), (int[])pnull.Clone());
+            var drEnt = ModelDiagnosticsData.BuildDensityRatio(hEnt, true);
+            Assert.IsTrue(drEnt.HasEntrapment);
+            Assert.IsNotNull(drEnt.PTargetPDecoy);
+            // Identical arrays -> unit ratio in every populated bin.
+            for (int i = 0; i < nb; i++)
+                if (!double.IsNaN(drEnt.PTargetPDecoy[i]))
+                    Assert.AreEqual(1.0, drEnt.PTargetPDecoy[i], 1e-9);
+            Assert.IsFalse(double.IsNaN(drEnt.RefFlatnessSlope));
+            Assert.AreEqual(0.0, drEnt.RefFlatnessSlope, 1e-9);   // pure-null reference is dead flat
+
+            // Too little data to assess -> a ratio object with NaN KPIs, not a throw.
+            var hTiny = Hist(edges, Bump(nb, 20, 5, 3), Bump(nb, 20, 5, 3), new int[nb], new int[nb]);
+            var drTiny = ModelDiagnosticsData.BuildDensityRatio(hTiny, false);
+            Assert.IsNotNull(drTiny);
+            Assert.IsTrue(double.IsNaN(drTiny.FlatnessSlope));
+
+            // No histogram to divide -> null.
+            Assert.IsNull(ModelDiagnosticsData.BuildDensityRatio(
+                new ModelDiagnosticsData.ScoreHistogram { BinEdges = new double[0] }, false));
+        }
+
+        // A discretized Gaussian bump (rounded integer counts) over nb unit bins.
+        private static int[] Bump(int nb, double center, double sigma, double peak)
+        {
+            var a = new int[nb];
+            for (int i = 0; i < nb; i++)
+                a[i] = (int)System.Math.Round(peak *
+                    System.Math.Exp(-((i - center) * (i - center)) / (2 * sigma * sigma)));
+            return a;
+        }
+
+        // Unit-width bin edges 0..nb (centers i+0.5).
+        private static double[] Edges(int nb)
+        {
+            var e = new double[nb + 1];
+            for (int i = 0; i <= nb; i++) e[i] = i;
+            return e;
+        }
+
+        private static ModelDiagnosticsData.ScoreHistogram Hist(
+            double[] edges, int[] target, int[] decoy, int[] pTarget, int[] pDecoy)
+        {
+            return new ModelDiagnosticsData.ScoreHistogram
+            {
+                BinEdges = edges, Target = target, Decoy = decoy, PTarget = pTarget, PDecoy = pDecoy,
+            };
         }
 
         // The pass-2 model view (the --protein-fdr retrain) is built from the

--- a/pwiz_tools/Osprey/Osprey.Test/ModelDiagnosticsDataTest.cs
+++ b/pwiz_tools/Osprey/Osprey.Test/ModelDiagnosticsDataTest.cs
@@ -516,6 +516,36 @@ namespace pwiz.Osprey.Test
                     sawCoin = true;
             }
             Assert.IsTrue(sawCoin);
+
+            // In THIS fixture the real pairs are native signal (winner ~5.0, above
+            // the low-score null band), so only the entrapment coin populates the
+            // band -- a fair ~0.5 (the Competition KPI shows the real coin as "-").
+            Assert.IsTrue(System.Math.Abs(wf.NullBandEnt - 0.5) < 0.1);
+
+            // Boost signature: real target-decoy pairs sitting IN the low-score null
+            // band where the target nonetheless wins ~70% of competitions (real
+            // decoy-win ~30%), against entrapment pairs at a fair ~50% in the same
+            // band. Only the paired coin sees this -- the real coin collapses below
+            // the entrapment ruler (the KPI's headline gap), invisible to every
+            // marginal density and to the entrapment FDP.
+            var be = new List<FdrEntry>();
+            var bc = new Dictionary<uint, EntrapmentClass>();
+            for (int i = 0; i < 200; i++)
+            {
+                bool rDecoy = (i % 10) < 3;                 // real decoy-win 30%
+                be.Add(Entry((uint)(1000 + i), false, rDecoy ? 1.7 : 2.0, 0.2, "BR" + i, 2));
+                be.Add(Entry((uint)(1000 + i) | DECOY_BIT, true, rDecoy ? 2.0 : 1.7, 0.5, "BRD" + i, 2));
+                bc[(uint)(1000 + i)] = EntrapmentClass.Target;
+                bool eDecoy = (i % 2 == 0);                 // entrapment coin 50%
+                be.Add(Entry((uint)(5000 + i), false, eDecoy ? 1.7 : 2.0, 0.5, "BE" + i, 2));
+                be.Add(Entry((uint)(5000 + i) | DECOY_BIT, true, eDecoy ? 2.0 : 1.7, 0.5, "BED" + i, 2));
+                bc[(uint)(5000 + i)] = EntrapmentClass.PTarget;
+            }
+            var bwf = ModelDiagnosticsData.Build(Wrap(be), null, bc, null, 1.0, 0.01, "peptide").WinFraction;
+            Assert.IsTrue(bwf.NullBandReal < 0.4, "real coin should be collapsed: " + bwf.NullBandReal);
+            Assert.IsTrue(System.Math.Abs(bwf.NullBandEnt - 0.5) < 0.1, "entrapment coin ~0.5: " + bwf.NullBandEnt);
+            Assert.IsTrue(bwf.NullBandEnt - bwf.NullBandReal > 0.1,
+                "coin collapse gap positive: " + (bwf.NullBandEnt - bwf.NullBandReal));
         }
 
         private static void TestFeatureTableContributions()


### PR DESCRIPTION
## Summary

* Adds a Storey-style non-parametric null-alignment check to the `--model-diagnostics` Density tab: the per-class score densities divided as **target : decoy** (the diagnostic) and, when entrapment is present, **p_target : p_decoy** (a matched-null reference).
* A fair (equal-chance) decoy pairing rides a **flat** plateau on the null-dominated left; a decoy that mistracks the false-target null makes that left side **slope** — visible with **no parametric fit** (unlike the decoy-normal overlay, which misfits skewed decoys).
* Adds a left-side **flatness KPI** (weighted slope of the log ratio over the null region) plus a Storey-style π0 plateau read and a same-run reference tilt. KPI badge only — **no alarm / no threshold-gating** (deliberate scope).
* Computed by a pure `BuildDensityRatio` over the per-class histograms already reduced for the density plot (no new binning pass). **Diagnostics-only**: the blib / FDR output and the regression golden are unchanged.

## Test plan

- [x] `ModelDiagnosticsDataTest` (`TestDensityRatioFlatness`) — synthetic matched vs shifted nulls: matched plateau flat (|slope| < 0.15), shifted left side steep (> 0.6 and > 4× matched), pure-null `p_target:p_decoy` reference exactly flat; NaN-guarded empty bins; too-sparse and no-histogram degrade paths
- [x] `Build-Osprey.ps1 -Configuration Debug -RunTests` — 478 tests pass; the 3 changed files are inspection-clean (the lone local-inspection warning is a pre-existing `RedundantNameQualifier` in the unmodified `PerFileScoringTask.cs:735` from #4381)
- [x] `regression.ps1 -Dataset Stellar` — golden unchanged (diagnostics-only tripwire)
- [x] libdecoy vs gendecoy oracle — flatness(gendecoy target:decoy) >> flatness(libdecoy); reference flat on both
- [x] TeamCity `ProteoWizard_OspreyWindowsNetPerfRegressionTests` on `pull/<N>`

See ai/todos/active/TODO-20260708_osprey_storey_null_ratio.md

Co-authored-by: Claude <noreply@anthropic.com>
