### PR TITLE
Streamed the first-pass FDR projection from parquet, dropping the 53 GB stub buffer

### DIFF
--- a/pwiz_tools/Osprey/Osprey.FDR/FdrProjection.cs
+++ b/pwiz_tools/Osprey/Osprey.FDR/FdrProjection.cs
@@ -297,5 +297,105 @@ namespace pwiz.Osprey.FDR
 
             return new FdrProjectionSet(perFile, peptideById);
         }
+
+        /// <summary>
+        /// Streaming builder that produces a byte-identical <see cref="FdrProjectionSet"/>
+        /// without ever materializing the fat <see cref="FdrEntry"/> stub buffer. The
+        /// 191M-row stub rematerialize (PerFileScoringTask) cost ~53 GB on an 82-file
+        /// Astral run purely to be converted here into 32 B rows; feeding parquet scalars
+        /// straight in drops that to ~6 GB.
+        ///
+        /// Parity invariant: <see cref="BuildFromEntries"/> assigns
+        /// <see cref="FdrProjection.PeptideId"/> as the Ordinal rank of the modified
+        /// sequence among the distinct set across ALL files. A streaming pass cannot know
+        /// that rank up front, so ids are assigned in INSERTION order while rows arrive and
+        /// remapped to the ordinal rank in <see cref="Build"/>. Row order, file order and
+        /// <see cref="FdrProjection.ParquetIndex"/> are unchanged, so the result is
+        /// element-for-element identical to <see cref="BuildFromEntries"/>.
+        /// </summary>
+        public sealed class Builder
+        {
+            private readonly Dictionary<string, int> _insertionIdByPeptide =
+                new Dictionary<string, int>(StringComparer.Ordinal);
+            private readonly List<string> _distinctByInsertion = new List<string>();
+            private readonly List<KeyValuePair<string, List<FdrProjection>>> _perFile =
+                new List<KeyValuePair<string, List<FdrProjection>>>();
+            private List<FdrProjection> _rows;
+            private ushort _fileIdx;
+
+            /// <summary>
+            /// Open a file's row list. Files must be added in the same order the join
+            /// expects (the scoring order), which is what fixes <see cref="FdrProjection.FileIdx"/>.
+            /// </summary>
+            public void BeginFile(string fileName, int capacityHint = 0)
+            {
+                _rows = capacityHint > 0
+                    ? new List<FdrProjection>(capacityHint)
+                    : new List<FdrProjection>();
+                _perFile.Add(new KeyValuePair<string, List<FdrProjection>>(fileName, _rows));
+            }
+
+            /// <summary>
+            /// Append one parquet row of the open file. <see cref="FdrProjection.ParquetIndex"/>
+            /// is the running per-file row ordinal, matching
+            /// <c>LoadFdrStubsFromParquet</c>'s <c>ParquetIndex = stubs.Count</c>.
+            /// <see cref="FdrProjection.Score"/> stays 0 -- the FDR pass writes it back.
+            /// </summary>
+            public void AddRow(uint entryId, byte charge, bool isDecoy, double coelutionSum,
+                string modifiedSequence)
+            {
+                string modseq = modifiedSequence ?? string.Empty;
+                if (!_insertionIdByPeptide.TryGetValue(modseq, out int insertionId))
+                {
+                    insertionId = _distinctByInsertion.Count;
+                    _insertionIdByPeptide[modseq] = insertionId;
+                    _distinctByInsertion.Add(modseq);
+                }
+                _rows.Add(new FdrProjection(
+                    entryId, (uint)_rows.Count, insertionId, _fileIdx, charge, isDecoy,
+                    coelutionSum, 0.0));
+            }
+
+            /// <summary>Close the open file and advance <see cref="FdrProjection.FileIdx"/>.</summary>
+            public void EndFile()
+            {
+                _rows = null;
+                _fileIdx++;
+            }
+
+            /// <summary>
+            /// Sort the distinct peptides Ordinal, remap every row's insertion-order
+            /// <see cref="FdrProjection.PeptideId"/> to its ordinal rank, and return the set.
+            /// The remap table is one int per distinct peptide (~9 MB at 2.3M peptides).
+            /// </summary>
+            public FdrProjectionSet Build()
+            {
+                var peptideById = _distinctByInsertion.ToArray();
+                Array.Sort(peptideById, StringComparer.Ordinal); // Array.Sort OK: _distinctByInsertion is de-duplicated (grow-only via _insertionIdByPeptide), no two strings are equal, so the Ordinal comparer never ties -- the same argument BuildFromEntries makes for its List.Sort.
+
+                var ordinalIdByPeptide =
+                    new Dictionary<string, int>(peptideById.Length, StringComparer.Ordinal);
+                for (int id = 0; id < peptideById.Length; id++)
+                    ordinalIdByPeptide[peptideById[id]] = id;
+
+                var remap = new int[_distinctByInsertion.Count];
+                for (int insertionId = 0; insertionId < remap.Length; insertionId++)
+                    remap[insertionId] = ordinalIdByPeptide[_distinctByInsertion[insertionId]];
+
+                foreach (var kvp in _perFile)
+                {
+                    var rows = kvp.Value;
+                    for (int i = 0; i < rows.Count; i++)
+                    {
+                        var r = rows[i];
+                        rows[i] = new FdrProjection(
+                            r.EntryId, r.ParquetIndex, remap[r.PeptideId], r.FileIdx,
+                            r.Charge, r.IsDecoy, r.CoelutionSum, r.Score);
+                    }
+                }
+
+                return new FdrProjectionSet(_perFile, peptideById);
+            }
+        }
     }
 }

--- a/pwiz_tools/Osprey/Osprey.FDR/FdrProjection.cs
+++ b/pwiz_tools/Osprey/Osprey.FDR/FdrProjection.cs
@@ -312,6 +312,12 @@ namespace pwiz.Osprey.FDR
         /// remapped to the ordinal rank in <see cref="Build"/>. Row order, file order and
         /// <see cref="FdrProjection.ParquetIndex"/> are unchanged, so the result is
         /// element-for-element identical to <see cref="BuildFromEntries"/>.
+        ///
+        /// NOT thread-safe, by design: <see cref="FdrProjection.FileIdx"/> and the
+        /// per-file <see cref="FdrProjection.ParquetIndex"/> running counts are only
+        /// meaningful if files are added in a deterministic sequence. Callers must drive
+        /// BeginFile/AddRow/EndFile from a single thread (PerFileScoringTask does, after
+        /// its per-file scoring fan-out has already joined).
         /// </summary>
         public sealed class Builder
         {

--- a/pwiz_tools/Osprey/Osprey.IO/ParquetScoreCache.cs
+++ b/pwiz_tools/Osprey/Osprey.IO/ParquetScoreCache.cs
@@ -772,6 +772,58 @@ namespace pwiz.Osprey.IO
         }
 
         /// <summary>
+        /// Streams the scalar stub columns of a <c>.scores.parquet</c> without allocating a
+        /// single <see cref="FdrEntry"/>. Reads exactly the five columns the first-pass
+        /// FdrProjection needs -- entry_id, charge, is_decoy, coelution_sum,
+        /// modified_sequence -- and invokes <paramref name="onRow"/> once per row in the
+        /// same order as <see cref="LoadFdrStubsFromParquet"/>, applying the identical
+        /// "skip this row group when entry_id/is_decoy are absent" rule. The caller's
+        /// running row count therefore equals that method's <c>ParquetIndex</c>.
+        ///
+        /// Exists because rematerializing the whole 191M-row stub buffer just to convert it
+        /// into 32 B projection rows cost ~53 GB on an 82-file Astral run. Osprey.IO must
+        /// not depend on Osprey.FDR, so the projection row is assembled by the caller from
+        /// these scalars rather than returned from here.
+        /// </summary>
+        public static void ReadFdrStubScalars(string path,
+            Action<uint, byte, bool, double, string> onRow)
+        {
+            if (onRow == null)
+                throw new ArgumentNullException(nameof(onRow));
+
+            using (var stream = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.Read))
+            using (var reader = RunSync(ParquetReader.CreateAsync(stream)))
+            {
+                var fieldsByName = BuildFieldLookup(reader);
+                for (int g = 0; g < reader.RowGroupCount; g++)
+                {
+                    using (var groupReader = reader.OpenRowGroupReader(g))
+                    {
+                        var entryIdCol = ReadColumnByName<uint[]>(groupReader, fieldsByName, FIELD_ENTRY_ID.Name);
+                        var isDecoyCol = ReadColumnByName<bool[]>(groupReader, fieldsByName, FIELD_IS_DECOY.Name);
+                        var chargeCol = ReadColumnByName<byte[]>(groupReader, fieldsByName, FIELD_CHARGE.Name);
+                        var modseqCol = ReadColumnByName<string[]>(groupReader, fieldsByName, FIELD_MODIFIED_SEQUENCE.Name);
+                        var coelutionCol = ReadColumnByName<double[]>(groupReader, fieldsByName, FIELD_COELUTION_SUM.Name);
+
+                        if (entryIdCol == null || isDecoyCol == null)
+                            continue;
+
+                        int rowCount = entryIdCol.Length;
+                        for (int row = 0; row < rowCount; row++)
+                        {
+                            onRow(
+                                entryIdCol[row],
+                                chargeCol != null ? chargeCol[row] : (byte)0,
+                                isDecoyCol[row],
+                                coelutionCol != null ? coelutionCol[row] : 0.0,
+                                modseqCol != null ? modseqCol[row] : string.Empty);
+                        }
+                    }
+                }
+            }
+        }
+
+        /// <summary>
         /// Load only the <c>cwt_candidates</c> column from a Parquet cache,
         /// returning one <see cref="CwtCandidate"/> list per row in the same
         /// order as <see cref="LoadFdrStubsFromParquet"/>. Used by Stage 6

--- a/pwiz_tools/Osprey/Osprey.Tasks/FirstJoinTask.cs
+++ b/pwiz_tools/Osprey/Osprey.Tasks/FirstJoinTask.cs
@@ -260,8 +260,13 @@ namespace pwiz.Osprey.Tasks
             if (OspreyEnvironment.UseFdrProjection && config.FdrMethod == FdrMethod.Percolator &&
                 !needsResidentFirstPassPool)
             {
+                // Null unless PerFileScoring took the lean path and streamed the rows
+                // straight from parquet (issue #4397); RunFirstPassProjection then builds
+                // from the fat stubs instead.
+                var prebuiltProjections = ctx.Get<FdrProjections>().Value;
                 var survivors = RunFirstPassProjection(
-                    perFileEntries, perFileParquetPaths, fullLibrary, config, ctx, loadFileFeatures);
+                    perFileEntries, perFileParquetPaths, fullLibrary, config, ctx, loadFileFeatures,
+                    prebuiltProjections);
                 if (survivors == null)
                     return false;  // StopAfterStage5 sidecar failure; ExitCode already set
                 perFileEntries = survivors;
@@ -1348,17 +1353,20 @@ namespace pwiz.Osprey.Tasks
             List<LibraryEntry> fullLibrary,
             OspreyConfig config,
             PipelineContext ctx,
-            Func<string, IReadOnlyList<double[]>> loadFileFeatures)
+            Func<string, IReadOnlyList<double[]>> loadFileFeatures,
+            FdrProjectionSet prebuiltProjections)
         {
-            // Build the projection, releasing each file's FdrEntry stubs (and their
-            // per-row modseq strings) INCREMENTALLY as its rows are built
-            // (releaseStubs: true) -- the full projection never coexists with the full
-            // stub buffer, so the "projection built" spike is gone. The interned
-            // peptide table keeps only the M distinct modified sequences. Clearing the
-            // hand-off ScoredEntries lists is safe: nothing downstream of this task
-            // reads ScoredEntries on a compute path -- the survivor buffer is
-            // published as CompactedEntries.
-            var projections = FdrProjectionSet.BuildFromEntries(perFileEntries, releaseStubs: true);
+            // Preferred path (issue #4397): PerFileScoring streamed these rows straight
+            // out of the per-file .scores.parquet, so the fat FdrEntry stub buffer was
+            // never allocated at all (it cost ~53 GB at 191M rows). Fall back to building
+            // from stubs on the paths that still publish them -- rehydrate/merge, or when
+            // a resident pool is required. BuildFromEntries releases each file's stubs
+            // incrementally (releaseStubs: true) so the projection never coexists with the
+            // full stub buffer. Clearing the hand-off ScoredEntries lists is safe: nothing
+            // downstream of this task reads ScoredEntries on a compute path -- the survivor
+            // buffer is published as CompactedEntries.
+            var projections = prebuiltProjections ??
+                FdrProjectionSet.BuildFromEntries(perFileEntries, releaseStubs: true);
             int beforeCount = projections.TotalRows;
             ProfilerHooks.LogMemoryStatsIfEnabled(ctx.LogInfo, string.Format(
                 @"projection built: {0} rows, {1} distinct peptides; FdrEntry stubs released",

--- a/pwiz_tools/Osprey/Osprey.Tasks/PerFileScoringTask.cs
+++ b/pwiz_tools/Osprey/Osprey.Tasks/PerFileScoringTask.cs
@@ -95,7 +95,14 @@ namespace pwiz.Osprey.Tasks
         public override IEnumerable<Type> Publishes => new[]
         {
             typeof(FullLibrary), typeof(LibraryById), typeof(PerFileCalibrations),
-            typeof(PerFileParquetPaths), typeof(RescoreBundle), typeof(ScoredEntries)
+            typeof(PerFileParquetPaths), typeof(RescoreBundle), typeof(ScoredEntries),
+            // Must be declared, not just published: PipelineContext builds its
+            // producer registry from this list, so an undeclared byproduct cannot be
+            // lazily materialized and ctx.Get<T> throws UnknownByproductException on a
+            // cache miss. Without this entry FdrProjections only resolves because
+            // FirstJoinTask happens to read ScoredEntries first, which materializes
+            // this task and co-publishes both -- an ordering coupling, not a contract.
+            typeof(FdrProjections)
         };
 
         // Outputs reached by downstream tasks through ctx.Demand<PerFileScoringTask>().

--- a/pwiz_tools/Osprey/Osprey.Tasks/PerFileScoringTask.cs
+++ b/pwiz_tools/Osprey/Osprey.Tasks/PerFileScoringTask.cs
@@ -31,6 +31,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using pwiz.Osprey.Chromatography;
 using pwiz.Osprey.Core;
+using pwiz.Osprey.FDR;
 using pwiz.Osprey.IO;
 using pwiz.Osprey.Scoring;
 
@@ -331,23 +332,69 @@ namespace pwiz.Osprey.Tasks
             // live per-file RTCalibration objects in perFileCalibrations are NOT
             // reloaded: they are not stored in .scores.parquet, so they must stay
             // the live objects harvested during scoring.
-            foreach (string fileName in scoredFileNames)
-            {
-                string parquetPath = perFileParquetPaths[fileName];
-                // A scored file always has a parquet here; the sole exception is
-                // the OSPREY_EXIT_AFTER_CALIBRATION bench short-circuit, which
-                // returns an empty result without writing one. Skip that case so
-                // the run still stops cleanly at the "no scored entries" gate
-                // below rather than throwing on a missing file.
-                if (!File.Exists(parquetPath))
-                    continue;
-                perFileEntries.Add(new KeyValuePair<string, List<FdrEntry>>(
-                    fileName, ParquetScoreCache.LoadFdrStubsFromParquet(parquetPath)));
-            }
+            // The lean path is valid only where FirstJoinTask actually consumes a
+            // projection. It must mirror that task's dispatch exactly (FirstJoinTask.cs:
+            // UseFdrProjection && Percolator && !needsResidentFirstPassPool): any other
+            // combination -- a non-Percolator FdrMethod, OSPREY_FDR_PROJECTION=0, or the
+            // resident-pool consumers (--model-diagnostics / FDRBench pass 1, which walk
+            // the full pre-compaction FdrEntry pool) -- still needs the fat stubs here.
+            bool needsResidentPool =
+                !OspreyEnvironment.UseFdrProjection ||
+                ctx.Config.FdrMethod != FdrMethod.Percolator ||
+                ctx.Config.ModelDiagnostics ||
+                (!string.IsNullOrEmpty(ctx.Config.OutputFdrBench) && ctx.Config.FdrBenchPass == 1);
 
+            FdrProjectionSet projections = null;
             int totalScored = 0;
-            foreach (var kvp in perFileEntries)
-                totalScored += kvp.Value.Count;
+
+            if (needsResidentPool)
+            {
+                foreach (string fileName in scoredFileNames)
+                {
+                    string parquetPath = perFileParquetPaths[fileName];
+                    // A scored file always has a parquet here; the sole exception is
+                    // the OSPREY_EXIT_AFTER_CALIBRATION bench short-circuit, which
+                    // returns an empty result without writing one. Skip that case so
+                    // the run still stops cleanly at the "no scored entries" gate
+                    // below rather than throwing on a missing file.
+                    if (!File.Exists(parquetPath))
+                        continue;
+                    perFileEntries.Add(new KeyValuePair<string, List<FdrEntry>>(
+                        fileName, ParquetScoreCache.LoadFdrStubsFromParquet(parquetPath)));
+                }
+                foreach (var kvp in perFileEntries)
+                    totalScored += kvp.Value.Count;
+            }
+            else
+            {
+                // Issue #4397: rematerializing every file's FdrEntry stubs here cost
+                // ~53 GB on an 82-file Astral run (191M x ~280 B) purely so FirstJoin
+                // could convert them into 32 B FdrProjection rows and drop them. Stream
+                // the projection rows straight out of each .scores.parquet instead --
+                // no FdrEntry is ever allocated. Peptide ids arrive in insertion order
+                // and are remapped to the global Ordinal rank by Build(), so the result
+                // is element-for-element identical to BuildFromEntries (pinned by
+                // TestFdrProjectionBuilderMatchesBuildFromEntries).
+                var builder = new FdrProjectionSet.Builder();
+                foreach (string fileName in scoredFileNames)
+                {
+                    string parquetPath = perFileParquetPaths[fileName];
+                    if (!File.Exists(parquetPath))
+                        continue;
+                    builder.BeginFile(fileName);
+                    ParquetScoreCache.ReadFdrStubScalars(parquetPath,
+                        (entryId, charge, isDecoy, coelutionSum, modseq) =>
+                            builder.AddRow(entryId, charge, isDecoy, coelutionSum, modseq));
+                    builder.EndFile();
+                    // Keep the per-file key and ordering so ScoredEntries consumers and
+                    // the file-count guard below still see one entry per scored file;
+                    // the stub lists themselves stay empty on this path.
+                    perFileEntries.Add(new KeyValuePair<string, List<FdrEntry>>(
+                        fileName, new List<FdrEntry>()));
+                }
+                projections = builder.Build();
+                totalScored = projections.TotalRows;
+            }
 
             ctx.LogInfo(string.Empty);
             ctx.LogInfo(string.Format(
@@ -355,7 +402,7 @@ namespace pwiz.Osprey.Tasks
                 totalScored, nFiles));
 
             return FinalizeAndCheck(ctx, perFileEntries, perFileCalibrations,
-                perFileParquetPaths, nFiles, totalScored);
+                perFileParquetPaths, nFiles, totalScored, projections);
         }
 
         public override bool Rehydrate(PipelineContext ctx)
@@ -536,7 +583,7 @@ namespace pwiz.Osprey.Tasks
             List<KeyValuePair<string, List<FdrEntry>>> perFileEntries,
             ConcurrentDictionary<string, RTCalibration> perFileCalibrations,
             Dictionary<string, string> perFileParquetPaths,
-            int nFiles, int totalScored)
+            int nFiles, int totalScored, FdrProjectionSet projections = null)
         {
             _perFileEntries = perFileEntries;
             _perFileCalibrations = perFileCalibrations;
@@ -557,6 +604,10 @@ namespace pwiz.Osprey.Tasks
             ctx.Publish(new PerFileCalibrations(_perFileCalibrations));
             ctx.Publish(new PerFileParquetPaths(_perFileParquetPaths));
             ctx.Publish(new ScoredEntries(_perFileEntries));
+            // Lean first-pass rows (issue #4397). Null on the rehydrate/merge paths and
+            // on --model-diagnostics / FDRBench pass 1, which publish fat stubs above;
+            // FirstJoinTask falls back to ScoredEntries whenever this is null.
+            ctx.Publish(new FdrProjections(projections));
             ctx.Publish(new RescoreBundle(_rescoreInputs));
 
             if (perFileEntries.Count == 0 || totalScored == 0)

--- a/pwiz_tools/Osprey/Osprey.Tasks/PerFileScoringTask.cs
+++ b/pwiz_tools/Osprey/Osprey.Tasks/PerFileScoringTask.cs
@@ -346,6 +346,7 @@ namespace pwiz.Osprey.Tasks
             // resident-pool consumers (--model-diagnostics / FDRBench pass 1, which walk
             // the full pre-compaction FdrEntry pool) -- still needs the fat stubs here.
             bool needsResidentPool =
+                ctx.Config.ExpectReconciledInput ||
                 !OspreyEnvironment.UseFdrProjection ||
                 ctx.Config.FdrMethod != FdrMethod.Percolator ||
                 ctx.Config.ModelDiagnostics ||

--- a/pwiz_tools/Osprey/Osprey.Tasks/PipelineByproducts.cs
+++ b/pwiz_tools/Osprey/Osprey.Tasks/PipelineByproducts.cs
@@ -24,6 +24,7 @@
 using System.Collections.Generic;
 using pwiz.Osprey.Chromatography;
 using pwiz.Osprey.Core;
+using pwiz.Osprey.FDR;
 using pwiz.Osprey.FDR.Reconciliation;
 
 namespace pwiz.Osprey.Tasks
@@ -169,6 +170,20 @@ namespace pwiz.Osprey.Tasks
     internal sealed class ScoredEntries : PerFileEntries
     {
         public ScoredEntries(List<KeyValuePair<string, List<FdrEntry>>> value) : base(value) { }
+    }
+
+    /// <summary>
+    /// The lean first-pass projection built straight from each file's .scores.parquet,
+    /// bypassing the fat <see cref="FdrEntry"/> stub buffer entirely (issue #4397:
+    /// rematerializing 191M stubs to convert them into 32 B rows cost ~53 GB).
+    /// <c>Value</c> is null when the run needs the resident stub pool instead
+    /// (--model-diagnostics / FDRBench pass 1) or on the rehydrate/merge paths, which
+    /// still publish fat stubs via <see cref="ScoredEntries"/>.
+    /// </summary>
+    internal sealed class FdrProjections
+    {
+        public FdrProjectionSet Value { get; }
+        public FdrProjections(FdrProjectionSet value) { Value = value; }
     }
 
     /// <summary>The buffer after FirstJoin's first-pass FDR + compaction.</summary>

--- a/pwiz_tools/Osprey/Osprey.Test/FdrTest.cs
+++ b/pwiz_tools/Osprey/Osprey.Test/FdrTest.cs
@@ -1984,6 +1984,66 @@ namespace pwiz.Osprey.Test
             }
         }
 
+        /// <summary>
+        /// Byte-parity gate for the streaming lean-stub load. <see cref="FdrProjectionSet.Builder"/>
+        /// must produce an element-for-element identical set to
+        /// <see cref="FdrProjectionSet.BuildFromEntries"/> without ever allocating an
+        /// <see cref="FdrEntry"/> (rematerializing 191M fat stubs just to convert them cost
+        /// ~53 GB on an 82-file Astral run). The builder assigns peptide ids in INSERTION
+        /// order and remaps them to the global Ordinal rank in Build(); this pins that the
+        /// remap reproduces BuildFromEntries' assignment across files, which is the invariant
+        /// the SVM subsample and protein-FDR join depend on.
+        /// </summary>
+        [TestMethod]
+        public void TestFdrProjectionBuilderMatchesBuildFromEntries()
+        {
+            // Insertion order deliberately NOT ordinal, with duplicates within and across
+            // files, so an insertion-order id assignment differs from the ordinal one.
+            var seqsA = new[] { "peptide", "B", "AAA", "b" };
+            var seqsB = new[] { "b", "AAA", "zeta", "peptide" };
+
+            var perFile = new List<KeyValuePair<string, List<FdrEntry>>>
+            {
+                new KeyValuePair<string, List<FdrEntry>>("fileA", MakeColdStubs(seqsA, 100)),
+                new KeyValuePair<string, List<FdrEntry>>("fileB", MakeColdStubs(seqsB, 200))
+            };
+
+            var expected = FdrProjectionSet.BuildFromEntries(perFile);
+
+            // Same rows, streamed in exactly as ParquetScoreCache.ReadFdrStubScalars feeds them.
+            var builder = new FdrProjectionSet.Builder();
+            foreach (var kvp in perFile)
+            {
+                builder.BeginFile(kvp.Key, kvp.Value.Count);
+                foreach (var e in kvp.Value)
+                    builder.AddRow(e.EntryId, e.Charge, e.IsDecoy, e.CoelutionSum, e.ModifiedSequence);
+                builder.EndFile();
+            }
+            var actual = builder.Build();
+
+            CollectionAssert.AreEqual(expected.PeptideById, actual.PeptideById,
+                "interned peptide table must be identical");
+            Assert.AreEqual(expected.PerFile.Count, actual.PerFile.Count);
+            for (int f = 0; f < expected.PerFile.Count; f++)
+            {
+                Assert.AreEqual(expected.PerFile[f].Key, actual.PerFile[f].Key);
+                var exp = expected.PerFile[f].Value;
+                var act = actual.PerFile[f].Value;
+                Assert.AreEqual(exp.Count, act.Count);
+                for (int i = 0; i < exp.Count; i++)
+                {
+                    Assert.AreEqual(exp[i].EntryId, act[i].EntryId, "EntryId");
+                    Assert.AreEqual(exp[i].ParquetIndex, act[i].ParquetIndex, "ParquetIndex");
+                    Assert.AreEqual(exp[i].PeptideId, act[i].PeptideId, "PeptideId");
+                    Assert.AreEqual(exp[i].FileIdx, act[i].FileIdx, "FileIdx");
+                    Assert.AreEqual(exp[i].Charge, act[i].Charge, "Charge");
+                    Assert.AreEqual(exp[i].IsDecoy, act[i].IsDecoy, "IsDecoy");
+                    Assert.AreEqual(exp[i].CoelutionSum, act[i].CoelutionSum, "CoelutionSum");
+                    Assert.AreEqual(exp[i].Score, act[i].Score, "Score");
+                }
+            }
+        }
+
         private static LibraryEntry MakeLibEntry(
             uint id, string modifiedSequence, string[] proteinIds, bool isDecoy)
         {
@@ -1992,6 +2052,31 @@ namespace pwiz.Osprey.Test
                 ProteinIds = new List<string>(proteinIds),
                 IsDecoy = isDecoy
             };
+        }
+
+        /// <summary>
+        /// Cold FdrEntry stubs shaped exactly as
+        /// <c>ParquetScoreCache.LoadFdrStubsFromParquet</c> returns them: ParquetIndex is
+        /// the per-file row ordinal, the heavy arrays stay null, and Score stays 0 (the
+        /// first-pass FDR writes it back). Matching that shape is what makes the
+        /// BuildFromEntries-vs-Builder comparison meaningful.
+        /// </summary>
+        private static List<FdrEntry> MakeColdStubs(string[] modifiedSequences, uint firstEntryId)
+        {
+            var stubs = new List<FdrEntry>(modifiedSequences.Length);
+            for (int i = 0; i < modifiedSequences.Length; i++)
+            {
+                stubs.Add(new FdrEntry
+                {
+                    EntryId = firstEntryId + (uint)i,
+                    ParquetIndex = (uint)i,
+                    ModifiedSequence = modifiedSequences[i],
+                    Charge = (byte)(2 + (i % 2)),
+                    IsDecoy = (i % 3) == 0,
+                    CoelutionSum = 1.5 * (i + 1)
+                });
+            }
+            return stubs;
         }
     }
 }


### PR DESCRIPTION
## Summary

* `PerFileScoringTask` rematerialized **191,227,519 fat `FdrEntry` stubs (~53.13 GB** on an 82-file Astral run) from the per-file `.scores.parquet`, only for `FirstJoinTask` to immediately convert each ~280 B object into a 32 B `FdrProjection` and drop it.
* It now streams `FdrProjection` rows straight out of parquet -- **no `FdrEntry` is ever allocated** on that path -- and publishes them; `FirstJoinTask` consumes the prebuilt set instead of calling `BuildFromEntries`.
* Fat stubs are still produced on the rehydrate/merge paths and for `--model-diagnostics` / FDRBench pass 1. The lean gate mirrors `FirstJoinTask`'s dispatch exactly (`UseFdrProjection && FdrMethod == Percolator && !needsResidentFirstPassPool`), so a non-Percolator method or `OSPREY_FDR_PROJECTION=0` still gets a populated stub buffer.
* Reads five parquet columns instead of eleven (`FdrProjection` carries no scan/RT/bounds).

**Byte-parity mechanism:** `BuildFromEntries` assigns `PeptideId` as the global Ordinal rank of the modified sequence across *all* files, which a streaming loader cannot know up front. `FdrProjectionSet.Builder` assigns insertion-order ids while rows arrive and remaps them to the Ordinal rank in `Build()` (remap table ~9 MB at 2.3M peptides). Row order, file order and `ParquetIndex` are unchanged, so the result is element-for-element identical.

**Layering:** `Osprey.IO` must not depend on `Osprey.FDR`, so `ParquetScoreCache.ReadFdrStubScalars` streams scalars through a callback and `Osprey.Tasks` assembles the rows -- the same pattern as the existing `loadFileFeatures` delegate.

Expected: `[MEM Stage 5 start]` drops from **53.13 GB to ~6 GB** (191M x 32 B). Not yet measured at scale -- see test plan.

Requested by Mike.

Fixes #4397

## Test plan

- [x] `TestFdrProjectionBuilderMatchesBuildFromEntries` - pins `Builder` element-for-element against `BuildFromEntries`
- [x] Build + 474 unit tests green
- [x] `regression.ps1 -Dataset Stellar` - **mode1/2/3 PASS, byte-identical**. mode1 exercises the new lean path; mode2 (resume) and mode3 (HPC chain) exercise the fat-stub rehydrate fallback
- [x] `Test-PerfGate.ps1 -Dataset Stellar` - **PASSED**, total +0.1% median. `stage5` +2.3% median (below the 5% WARN) is consistent with the ordinal remap pass; Stellar is only ~7M rows
- [ ] 82-file Astral run with `OSPREY_LOG_MEMORY=1` to confirm 53 -> ~6 GB, and to check the remap cost at 191M rows
- [x] `regression.ps1 -Dataset All` before merge

## Notes

Based on #4378 (needs `FdrProjection`, which lives there), so this is stacked -- retarget to master when #4378 merges.

Co-Authored-By: Claude <noreply@anthropic.com>
