### PR TITLE
Added OSPREY_PASS2_QVALUE transfer mode as a 2nd-pass q kill-switch

### DIFF
--- a/pwiz_tools/Osprey/Osprey.Core/OspreyEnvironment.cs
+++ b/pwiz_tools/Osprey/Osprey.Core/OspreyEnvironment.cs
@@ -158,6 +158,12 @@ namespace pwiz.Osprey.Core
         ///     re-scoring ID gain.
         /// Unset or unrecognized normalizes to the parity-preserving default. Read once at
         /// process start. See ai/todos/active/TODO-20260710_osprey_pass2_recalibration_fix.md.
+        ///
+        /// LIMITATION (experimental mode): use a FRESH <c>--output-dir</c> per mode. The
+        /// per-file 2nd-pass sidecar (.2nd-pass.fdr_scores.bin) is not tagged with the mode,
+        /// so resuming a run in an output dir written under a different mode would reuse the
+        /// other mode's cached q-values. The Part-B work tags the sidecar validity with the
+        /// mode; until then, do not switch modes within one output dir.
         /// </summary>
         public static readonly string Pass2QValue = NormalizePass2QValue(
             Environment.GetEnvironmentVariable(@"OSPREY_PASS2_QVALUE"));

--- a/pwiz_tools/Osprey/Osprey.Core/OspreyEnvironment.cs
+++ b/pwiz_tools/Osprey/Osprey.Core/OspreyEnvironment.cs
@@ -132,6 +132,68 @@ namespace pwiz.Osprey.Core
         /// </summary>
         public static bool UseFdrProjection { get; set; } = IsNotZero(@"OSPREY_FDR_PROJECTION");
 
+        /// <summary>The default <see cref="Pass2QValue"/> mode: retrain the 2nd-pass
+        /// Percolator SVM and recompute a target/decoy null on the reconciled + compacted
+        /// reported pool. Current (PR #4395) behavior; preserves Rust parity.</summary>
+        public const string PASS2_QVALUE_PERCOLATOR = @"percolator";
+
+        /// <summary>The <see cref="Pass2QValue"/> confidence-transfer mode: do NOT retrain
+        /// or re-estimate a null; score each reconciled peak with the frozen 1st-pass model
+        /// and map it to a q via the full pre-compaction 1st-pass score-&gt;q table.</summary>
+        public const string PASS2_QVALUE_TRANSFER = @"transfer";
+
+        /// <summary>
+        /// OSPREY_PASS2_QVALUE: selects how the merge-node 2nd pass assigns the reported
+        /// precursor/peptide q-values AFTER Stage 6 reconciliation. The 2nd-pass peak
+        /// RE-SCORING (better peak choices against the consensus) is kept in ALL modes;
+        /// only the q-value step changes.
+        ///   <see cref="PASS2_QVALUE_PERCOLATOR"/> (default): retrain Percolator + recompute
+        ///     a target/decoy null on the reconciled + compacted pool. Preserves the
+        ///     always-on Rust 2nd pass. Compaction has already stripped most decoys from
+        ///     that pool, so the null is decoy-depleted and the retrained q anti-conservative.
+        ///   <see cref="PASS2_QVALUE_TRANSFER"/>: score each reconciled peak with the FROZEN
+        ///     1st-pass model and read its q from the FULL pre-compaction 1st-pass
+        ///     score-&gt;q table (co-monotonic confidence transfer; Rost 2016 TRIC). No
+        ///     retrain, no reduced-pool null. Restores calibration while keeping the
+        ///     re-scoring ID gain.
+        /// Unset or unrecognized normalizes to the parity-preserving default. Read once at
+        /// process start. See ai/todos/active/TODO-20260710_osprey_pass2_recalibration_fix.md.
+        /// </summary>
+        public static readonly string Pass2QValue = NormalizePass2QValue(
+            Environment.GetEnvironmentVariable(@"OSPREY_PASS2_QVALUE"));
+
+        /// <summary>True when OSPREY_PASS2_QVALUE was set to a value that is neither
+        /// <see cref="PASS2_QVALUE_PERCOLATOR"/> nor <see cref="PASS2_QVALUE_TRANSFER"/> and
+        /// was therefore normalized to the default. The consuming site logs a one-line
+        /// warning so a typo does not silently pick the default.</summary>
+        public static readonly bool Pass2QValueUnrecognized = IsUnrecognizedPass2QValue(
+            Environment.GetEnvironmentVariable(@"OSPREY_PASS2_QVALUE"));
+
+        /// <summary>True when <see cref="Pass2QValue"/> selects the frozen-model
+        /// confidence-transfer path (OSPREY_PASS2_QVALUE=transfer).</summary>
+        public static readonly bool Pass2TransferQ =
+            string.Equals(Pass2QValue, PASS2_QVALUE_TRANSFER, StringComparison.Ordinal);
+
+        private static string NormalizePass2QValue(string raw)
+        {
+            if (string.IsNullOrWhiteSpace(raw))
+                return PASS2_QVALUE_PERCOLATOR;
+            string v = raw.Trim().ToLowerInvariant();
+            if (v == PASS2_QVALUE_TRANSFER)
+                return PASS2_QVALUE_TRANSFER;
+            // Fall back to the parity-preserving default on any unrecognized token; the
+            // consuming site (Pass2FdrSidecar) warns so a typo is visible in the log.
+            return PASS2_QVALUE_PERCOLATOR;
+        }
+
+        private static bool IsUnrecognizedPass2QValue(string raw)
+        {
+            if (string.IsNullOrWhiteSpace(raw))
+                return false;
+            string v = raw.Trim().ToLowerInvariant();
+            return v != PASS2_QVALUE_PERCOLATOR && v != PASS2_QVALUE_TRANSFER;
+        }
+
         private static int ParseIntOrZero(string name)
         {
             string v = Environment.GetEnvironmentVariable(name);

--- a/pwiz_tools/Osprey/Osprey.FDR/PercolatorEngine.cs
+++ b/pwiz_tools/Osprey/Osprey.FDR/PercolatorEngine.cs
@@ -64,7 +64,8 @@ namespace pwiz.Osprey.FDR
             out FeatureContributions contributions,
             PercolatorDiagnosticsConfig diagnostics = null,
             string passLabel = @"First-pass",
-            Func<string, IReadOnlyList<double[]>> loadFileFeatures = null)
+            Func<string, IReadOnlyList<double[]>> loadFileFeatures = null,
+            Action<PercolatorResults> captureModel = null)
         {
             contributions = null;
             int numFeatures = featureInfos.Length;
@@ -122,6 +123,13 @@ namespace pwiz.Osprey.FDR
             // (the --model-diagnostics report reads them). Computed already; this
             // is a pure hand-off, no behavior change on any production path.
             contributions = results.FeatureContributions;
+
+            // Frozen-model capture hook (OSPREY_PASS2_QVALUE=transfer): the caller
+            // can grab the trained model (FoldWeights / FoldBiases / Standardizer)
+            // here so a later 2nd-pass step re-scores reconciled features with this
+            // FROZEN 1st-pass model instead of retraining. No-op (null) on every
+            // default percolator run, so scoring stays byte-identical.
+            captureModel?.Invoke(results);
 
             // A diagnostic-only (*Only) dump fired inside the engine; it left the
             // run as a pure no-op and signalled here. Stop without scoring the

--- a/pwiz_tools/Osprey/Osprey.Tasks/FirstJoinTask.cs
+++ b/pwiz_tools/Osprey/Osprey.Tasks/FirstJoinTask.cs
@@ -324,7 +324,7 @@ namespace pwiz.Osprey.Tasks
                     frozenForTable?.Results != null)
                 {
                     var scoreQTable = Pass2FdrSidecar.BuildFullPopulationScoreQTable(
-                        perFileEntries, frozenForTable.Results, ctx);
+                        perFileEntries, frozenForTable.Results, loadFileFeatures, ctx);
                     if (scoreQTable != null)
                         ctx.Publish(scoreQTable);
                 }

--- a/pwiz_tools/Osprey/Osprey.Tasks/FirstJoinTask.cs
+++ b/pwiz_tools/Osprey/Osprey.Tasks/FirstJoinTask.cs
@@ -1292,8 +1292,15 @@ namespace pwiz.Osprey.Tasks
             if (OspreyEnvironment.Pass2TransferQ &&
                 string.Equals(passLabel, @"First-pass", StringComparison.Ordinal))
             {
+                // Publish is add-only (throws on a duplicate key); guard so a first pass
+                // that somehow ran twice in one process degrades to a no-op rather than a
+                // raw ArgumentException. The passLabel gate already makes this unreachable
+                // on normal paths.
                 captureModel = results =>
-                    ctx.Publish(new FirstPassPercolatorModel { Results = results });
+                {
+                    if (!ctx.TryGet<FirstPassPercolatorModel>(out _))
+                        ctx.Publish(new FirstPassPercolatorModel { Results = results });
+                };
             }
 
             bool aborted = PercolatorEngine.RunPercolatorFdr(

--- a/pwiz_tools/Osprey/Osprey.Tasks/FirstJoinTask.cs
+++ b/pwiz_tools/Osprey/Osprey.Tasks/FirstJoinTask.cs
@@ -264,8 +264,15 @@ namespace pwiz.Osprey.Tasks
             // opt-in output is requested, take the resident (legacy) path so those reports
             // still emit. Both are off the default output path, so byte-identity is
             // unaffected (the regression gate never sets either).
+            // OSPREY_PASS2_QVALUE=transfer also needs the resident first-pass pool: it
+            // captures the frozen 1st-pass model and builds the FULL pre-compaction
+            // score->q table (BuildFullPopulationScoreQTable, below), both of which read
+            // every entry's in-memory Stage-4 features -- exactly what the projection path
+            // streams and drops. The regression gate never sets the env var, so byte-identity
+            // on the default percolator path is unaffected (same rationale as --model-diagnostics).
             bool needsResidentFirstPassPool = config.ModelDiagnostics ||
-                (!string.IsNullOrEmpty(config.OutputFdrBench) && config.FdrBenchPass == 1);
+                (!string.IsNullOrEmpty(config.OutputFdrBench) && config.FdrBenchPass == 1) ||
+                OspreyEnvironment.Pass2TransferQ;
             if (OspreyEnvironment.UseFdrProjection && config.FdrMethod == FdrMethod.Percolator &&
                 !needsResidentFirstPassPool)
             {
@@ -302,6 +309,25 @@ namespace pwiz.Osprey.Tasks
                     string.Format(@"(post-GC, resident pool, files={0})", perFileEntries.Count));
 
                 LogFirstPassResultsAndDump(perFileEntries, config, ctx, featureContributions);
+
+                // OSPREY_PASS2_QVALUE=transfer: build the score->q lookup table NOW, from
+                // the FULL pre-compaction 1st-pass population -- every entry (passing,
+                // failing, target, decoy) still carries its in-memory Stage-4 features and
+                // its unbiased 1st-pass q-values here. The frozen model was published as a
+                // byproduct during RunFdr above. Publishing the full-population table lets
+                // the merge-node 2nd-pass transfer map reconciled-feature scores through a
+                // table that RETAINS the high-q failing/decoy region -- the region compaction
+                // strips out, and whose absence would collapse the transfer's q. Off by
+                // default (byproduct never published on the percolator path).
+                if (OspreyEnvironment.Pass2TransferQ &&
+                    ctx.TryGet<FirstPassPercolatorModel>(out var frozenForTable) &&
+                    frozenForTable?.Results != null)
+                {
+                    var scoreQTable = Pass2FdrSidecar.BuildFullPopulationScoreQTable(
+                        perFileEntries, frozenForTable.Results, ctx);
+                    if (scoreQTable != null)
+                        ctx.Publish(scoreQTable);
+                }
 
                 // First-pass protein FDR: runs on the full pre-compaction
                 // peptide pool so target and decoy proteins compete on a
@@ -1256,11 +1282,26 @@ namespace pwiz.Osprey.Tasks
             // so the engine streams PIN features per file from parquet (issue #4355
             // Phase 4). The 2nd-pass caller (Pass2FdrSidecar) leaves it null and
             // pre-reloads features onto the stubs, so the engine reads them resident.
+
+            // OSPREY_PASS2_QVALUE=transfer: on the FIRST-pass run only, publish the trained
+            // model (FoldWeights / FoldBiases / Standardizer) as a byproduct so the
+            // merge-node 2nd-pass step can re-score reconciled features with this FROZEN
+            // model instead of retraining. Null (a pure no-op in the engine) on the default
+            // percolator path and on the 2nd-pass run, so scoring stays byte-identical.
+            Action<PercolatorResults> captureModel = null;
+            if (OspreyEnvironment.Pass2TransferQ &&
+                string.Equals(passLabel, @"First-pass", StringComparison.Ordinal))
+            {
+                captureModel = results =>
+                    ctx.Publish(new FirstPassPercolatorModel { Results = results });
+            }
+
             bool aborted = PercolatorEngine.RunPercolatorFdr(
                 perFileEntries, config,
                 OspreyFeatureCalculators.BuildFeatureInfos(ParquetScoreCache.PIN_FEATURE_NAMES),
                 ctx.LogInfo, out var contributions,
-                BuildPercolatorDiagnostics(ctx.Diagnostics), passLabel, loadFileFeatures);
+                BuildPercolatorDiagnostics(ctx.Diagnostics), passLabel, loadFileFeatures,
+                captureModel);
             if (aborted)
             {
                 // A diagnostic-only (*Only) Stage 5 dump fired. The FDR engine left

--- a/pwiz_tools/Osprey/Osprey.Tasks/Pass2FdrSidecar.cs
+++ b/pwiz_tools/Osprey/Osprey.Tasks/Pass2FdrSidecar.cs
@@ -889,20 +889,28 @@ namespace pwiz.Osprey.Tasks
         /// Build the FULL 1st-pass-population score-&gt;q table at first-pass FDR time
         /// (called from <see cref="FirstJoinTask"/> BEFORE compaction, while
         /// <paramref name="perFileEntries"/> still holds every entry -- passing, failing,
-        /// target, and decoy -- with its in-memory Stage-4 <see cref="FdrEntry.Features"/>
-        /// and unbiased 1st-pass q-values). Sourcing the table from the full pre-compaction
-        /// null preserves the high-q failing/decoy tail so a peak that reconciliation moved
-        /// to a worse position maps to an honestly higher q -- the tail the decoy-depleted
-        /// compacted pool lacks. Each entry's key is the SAME raw averaged-model score the
-        /// transfer uses (<see cref="ScoreWithFrozenModel"/>), NOT the stored per-fold
-        /// recalibrated <see cref="FdrEntry.Score"/>, so table and transfer stay on one
-        /// scale by construction. Paired q is the entry's effective experiment q (max of
-        /// precursor + peptide). Returns null (logged) when the frozen model is unusable so
-        /// the caller publishes nothing and the transfer falls back to the retrain.
+        /// target, and decoy -- with its unbiased 1st-pass q-values). Sourcing the table
+        /// from the full pre-compaction null preserves the high-q failing/decoy tail so a
+        /// peak that reconciliation moved to a worse position maps to an honestly higher q --
+        /// the tail the decoy-depleted compacted pool lacks.
+        ///
+        /// Features are STREAMED per file from the original Stage-4 parquet via
+        /// <paramref name="loadFileFeatures"/> and addressed by each entry's
+        /// <see cref="FdrEntry.ParquetIndex"/> -- the same source and row binding the
+        /// first-pass Percolator score pass uses. (The resident first-pass path builds lean
+        /// stubs and streams features into the SVM without persisting them onto
+        /// <see cref="FdrEntry.Features"/>, so reading that field here would find nothing.)
+        /// Each entry's key is the SAME raw averaged-model score the transfer uses
+        /// (<see cref="ScoreWithFrozenModel"/>), NOT the stored per-fold recalibrated
+        /// <see cref="FdrEntry.Score"/>, so table and transfer stay on one scale by
+        /// construction. Paired q is the entry's effective experiment q (max of precursor +
+        /// peptide). Returns null (logged) when the frozen model is unusable or no features
+        /// resolved, so the caller publishes nothing and the transfer falls back to the retrain.
         /// </summary>
         internal static FirstPassScoreQTable BuildFullPopulationScoreQTable(
             List<KeyValuePair<string, List<FdrEntry>>> perFileEntries,
             PercolatorResults firstPassModel,
+            Func<string, IReadOnlyList<double[]>> loadFileFeatures,
             PipelineContext ctx)
         {
             if (firstPassModel.FoldWeights == null || firstPassModel.FoldWeights.Count == 0 ||
@@ -913,27 +921,51 @@ namespace pwiz.Osprey.Tasks
                     "frozen 1st-pass model has no fold weights or standardizer.");
                 return null;
             }
+            if (loadFileFeatures == null)
+            {
+                ctx.LogWarning(
+                    "OSPREY_PASS2_QVALUE=transfer: no per-file feature loader supplied; cannot " +
+                    "build the full-population score->q table (transfer will fall back).");
+                return null;
+            }
             AverageFoldModel(firstPassModel, out double[] avgWeights, out double avgBias);
             int nFeatures = avgWeights.Length;
             var standardizer = firstPassModel.Standardizer;
 
-            // Score every entry that still carries its in-memory Stage-4 features (the full
-            // pre-compaction population), paired with its unbiased 1st-pass effective q.
+            // Score every entry in the full pre-compaction population, paired with its
+            // unbiased 1st-pass effective q. Features come from each file's Stage-4 parquet
+            // (loaded once per file) addressed by ParquetIndex.
             var tableScores = new List<double>();
             var tableQs = new List<double>();
             int nSkipped = 0;
             var scratch = new double[nFeatures]; // reused per entry to avoid a per-row allocation
             foreach (var kvp in perFileEntries)
             {
+                IReadOnlyList<double[]> rows;
+                try
+                {
+                    rows = loadFileFeatures(kvp.Key);
+                }
+                catch (Exception ex)
+                {
+                    ctx.LogWarning(string.Format(
+                        "OSPREY_PASS2_QVALUE=transfer: failed to load 1st-pass features for '{0}': {1}; " +
+                        "its entries are excluded from the score->q table.", kvp.Key, ex.Message));
+                    nSkipped += kvp.Value.Count;
+                    continue;
+                }
+                int rowCount = rows?.Count ?? 0;
                 foreach (var entry in kvp.Value)
                 {
-                    if (entry.Features == null || entry.Features.Length != nFeatures)
+                    int idx = (int)entry.ParquetIndex;
+                    if (rows == null || idx < 0 || idx >= rowCount ||
+                        rows[idx] == null || rows[idx].Length != nFeatures)
                     {
                         nSkipped++;
                         continue;
                     }
                     double rawScore = ScoreWithFrozenModel(
-                        entry.Features, standardizer, avgWeights, avgBias, scratch);
+                        rows[idx], standardizer, avgWeights, avgBias, scratch);
                     double effQ = Math.Max(
                         entry.ExperimentPrecursorQvalue, entry.ExperimentPeptideQvalue);
                     tableScores.Add(rawScore);
@@ -943,8 +975,8 @@ namespace pwiz.Osprey.Tasks
             if (tableScores.Count == 0)
             {
                 ctx.LogWarning(
-                    "OSPREY_PASS2_QVALUE=transfer: full-population score->q table build found no " +
-                    "entries with in-memory features; table not published (transfer will fall back).");
+                    "OSPREY_PASS2_QVALUE=transfer: full-population score->q table build resolved no " +
+                    "features from parquet; table not published (transfer will fall back).");
                 return null;
             }
 

--- a/pwiz_tools/Osprey/Osprey.Tasks/Pass2FdrSidecar.cs
+++ b/pwiz_tools/Osprey/Osprey.Tasks/Pass2FdrSidecar.cs
@@ -29,6 +29,7 @@ using System.Linq;
 using pwiz.Osprey.Core;
 using pwiz.Osprey.FDR;
 using pwiz.Osprey.IO;
+using pwiz.Osprey.ML;
 
 namespace pwiz.Osprey.Tasks
 {
@@ -72,6 +73,24 @@ namespace pwiz.Osprey.Tasks
         {
             var config = ctx.Config;
             FeatureContributions pass2Contributions = null;
+
+            // OSPREY_PASS2_QVALUE selects how this 2nd pass assigns reported q-values.
+            // Log the active mode once so a run's provenance is in the log; warn on an
+            // unrecognized token (normalized to the parity-preserving percolator default).
+            if (OspreyEnvironment.Pass2QValueUnrecognized)
+            {
+                ctx.LogWarning(string.Format(
+                    "OSPREY_PASS2_QVALUE was set to an unrecognized value; using the default " +
+                    "'{0}'. Recognized modes: '{0}', '{1}'.",
+                    OspreyEnvironment.PASS2_QVALUE_PERCOLATOR, OspreyEnvironment.PASS2_QVALUE_TRANSFER));
+            }
+            if (OspreyEnvironment.Pass2TransferQ)
+            {
+                ctx.LogInfo(string.Format(
+                    "OSPREY_PASS2_QVALUE={0}: 2nd-pass q comes from the frozen 1st-pass model + " +
+                    "full pre-compaction score->q table (confidence transfer), not a reduced-pool retrain.",
+                    OspreyEnvironment.PASS2_QVALUE_TRANSFER));
+            }
 
             // When the projection 2nd-pass compute ran (flag on), this holds the scored
             // FdrProjectionSet -- non-null is the flag that the StreamingSink already
@@ -147,8 +166,12 @@ namespace pwiz.Osprey.Tasks
                     // streams through a sink and produces none. Route --model-diagnostics to
                     // the resident path so ComputePass2Resident can return the model. Off the
                     // default output path, so byte-identity is unaffected (#4377).
+                    // OSPREY_PASS2_QVALUE=transfer also takes the resident path: the transfer
+                    // needs each survivor's RECONCILED features loaded onto entry.Features (which
+                    // ComputePass2Resident does) so the frozen 1st-pass model can re-score them.
+                    // The projection path streams features to a sink and never lands them resident.
                     if (OspreyEnvironment.UseFdrProjection && config.FdrMethod == FdrMethod.Percolator &&
-                        !config.ModelDiagnostics)
+                        !config.ModelDiagnostics && !OspreyEnvironment.Pass2TransferQ)
                     {
                         // Projection 2nd pass (issue #4374 + #4355 struct-shrink S0 / C1):
                         // stream the reconciled PIN features through the SAME projection
@@ -513,6 +536,30 @@ namespace pwiz.Osprey.Tasks
             switch (config.FdrMethod)
             {
                 case FdrMethod.Percolator:
+                    // OSPREY_PASS2_QVALUE=transfer: instead of retraining a 2nd-pass SVM on
+                    // the decoy-depleted reconciled+compacted set, apply the FROZEN 1st-pass
+                    // model to each entry's RECONCILED features (loaded onto entry.Features
+                    // above) and map the resulting score to a q via the full pre-compaction
+                    // 1st-pass score->q table. Falls through to the retrain if the flag is
+                    // off or the frozen-model / table byproducts were not captured.
+                    if (OspreyEnvironment.Pass2TransferQ &&
+                        ctx.TryGet<FirstPassPercolatorModel>(out var frozenModel) &&
+                        frozenModel?.Results != null &&
+                        TransferQFromFrozenModel(perFileEntries, ctx, frozenModel.Results))
+                    {
+                        // Transferred: no retrained 2nd-pass model in transfer mode -> no
+                        // pass-2 SVM model view for --model-diagnostics (the pass-2 FDR
+                        // calibration curve still renders from the transferred q-values;
+                        // the pass-1 model view still renders too).
+                        return null;
+                    }
+                    if (OspreyEnvironment.Pass2TransferQ)
+                    {
+                        ctx.LogWarning(
+                            "OSPREY_PASS2_QVALUE=transfer could not transfer (frozen 1st-pass " +
+                            "model or full-population score->q table byproduct absent); falling " +
+                            "back to the 2nd-pass Percolator retrain.");
+                    }
                     // Capture the 2nd-pass model for the --model-diagnostics pass-2 model
                     // view (retrained on the post-reconciliation pool, #4377). Capturing
                     // the return value does not change what RunPercolatorFdr does, so the
@@ -770,6 +817,370 @@ namespace pwiz.Osprey.Tasks
                 }
             }
             return nMapped;
+        }
+
+        /// <summary>
+        /// OSPREY_PASS2_QVALUE=transfer. Instead of retraining a 2nd-pass Percolator SVM
+        /// on the decoy-depleted reconciled+compacted set -- which underestimates q
+        /// anti-conservatively -- apply the FROZEN 1st-pass model
+        /// (<paramref name="firstPassModel"/>: averaged fold weights + biases +
+        /// standardizer) to each entry's RECONCILED features (already on
+        /// <see cref="FdrEntry.Features"/>) and map the resulting score to a q via the
+        /// FULL pre-compaction 1st-pass score-&gt;q table (the
+        /// <see cref="FirstPassScoreQTable"/> byproduct built by
+        /// <see cref="BuildFullPopulationScoreQTable"/> at first-pass time). This keeps
+        /// the reconciliation peak-move (a peak moved to a worse position maps through the
+        /// unbiased table to an honestly higher q) while discarding the retrain's
+        /// decoy-depleted null (co-monotonic confidence transfer; Rost 2016 TRIC).
+        /// Returns false (caller falls back to the retrain) when the model is unusable or
+        /// the full-population table byproduct is absent (e.g. a resume path that did not
+        /// run the 1st pass in this process).
+        /// </summary>
+        internal static bool TransferQFromFrozenModel(
+            List<KeyValuePair<string, List<FdrEntry>>> perFileEntries,
+            PipelineContext ctx,
+            PercolatorResults firstPassModel)
+        {
+            if (firstPassModel.FoldWeights == null || firstPassModel.FoldWeights.Count == 0 ||
+                firstPassModel.Standardizer == null)
+            {
+                ctx.LogWarning(
+                    "OSPREY_PASS2_QVALUE=transfer: frozen 1st-pass model has no fold weights " +
+                    "or standardizer; cannot transfer.");
+                return false;
+            }
+            if (!ctx.TryGet<FirstPassScoreQTable>(out var fullTable) ||
+                fullTable?.ScoresDesc == null || fullTable.ScoresDesc.Length == 0)
+            {
+                ctx.LogWarning(
+                    "OSPREY_PASS2_QVALUE=transfer: no FULL-population score->q table byproduct " +
+                    "present (the 1st pass did not build one in this process); cannot transfer.");
+                return false;
+            }
+
+            AverageFoldModel(firstPassModel, out double[] avgWeights, out double avgBias);
+            int nFeatures = avgWeights.Length;
+
+            ctx.LogInfo(string.Format(
+                "OSPREY_PASS2_QVALUE=transfer: using FULL-population score->q table ({0} points, " +
+                "raw-score range [{1:F4}, {2:F4}], q range [{3:E3}, {4:E3}]) from the " +
+                "pre-compaction 1st-pass null.",
+                fullTable.ScoresDesc.Length,
+                fullTable.ScoresDesc[fullTable.ScoresDesc.Length - 1], fullTable.ScoresDesc[0],
+                fullTable.QDesc[0], fullTable.QDesc[fullTable.QDesc.Length - 1]));
+
+            TransferQWithTable(
+                perFileEntries, firstPassModel.Standardizer, avgWeights, avgBias, nFeatures,
+                fullTable.ScoresDesc, fullTable.QDesc, ctx);
+            return true;
+        }
+
+        /// <summary>
+        /// Build the FULL 1st-pass-population score-&gt;q table at first-pass FDR time
+        /// (called from <see cref="FirstJoinTask"/> BEFORE compaction, while
+        /// <paramref name="perFileEntries"/> still holds every entry -- passing, failing,
+        /// target, and decoy -- with its in-memory Stage-4 <see cref="FdrEntry.Features"/>
+        /// and unbiased 1st-pass q-values). Sourcing the table from the full pre-compaction
+        /// null preserves the high-q failing/decoy tail so a peak that reconciliation moved
+        /// to a worse position maps to an honestly higher q -- the tail the decoy-depleted
+        /// compacted pool lacks. Each entry's key is the SAME raw averaged-model score the
+        /// transfer uses (<see cref="ScoreWithFrozenModel"/>), NOT the stored per-fold
+        /// recalibrated <see cref="FdrEntry.Score"/>, so table and transfer stay on one
+        /// scale by construction. Paired q is the entry's effective experiment q (max of
+        /// precursor + peptide). Returns null (logged) when the frozen model is unusable so
+        /// the caller publishes nothing and the transfer falls back to the retrain.
+        /// </summary>
+        internal static FirstPassScoreQTable BuildFullPopulationScoreQTable(
+            List<KeyValuePair<string, List<FdrEntry>>> perFileEntries,
+            PercolatorResults firstPassModel,
+            PipelineContext ctx)
+        {
+            if (firstPassModel.FoldWeights == null || firstPassModel.FoldWeights.Count == 0 ||
+                firstPassModel.Standardizer == null)
+            {
+                ctx.LogWarning(
+                    "OSPREY_PASS2_QVALUE=transfer: cannot build full-population score->q table -- " +
+                    "frozen 1st-pass model has no fold weights or standardizer.");
+                return null;
+            }
+            AverageFoldModel(firstPassModel, out double[] avgWeights, out double avgBias);
+            int nFeatures = avgWeights.Length;
+            var standardizer = firstPassModel.Standardizer;
+
+            // Score every entry that still carries its in-memory Stage-4 features (the full
+            // pre-compaction population), paired with its unbiased 1st-pass effective q.
+            var tableScores = new List<double>();
+            var tableQs = new List<double>();
+            int nSkipped = 0;
+            foreach (var kvp in perFileEntries)
+            {
+                foreach (var entry in kvp.Value)
+                {
+                    if (entry.Features == null || entry.Features.Length != nFeatures)
+                    {
+                        nSkipped++;
+                        continue;
+                    }
+                    double rawScore = ScoreWithFrozenModel(
+                        entry.Features, standardizer, avgWeights, avgBias);
+                    double effQ = Math.Max(
+                        entry.ExperimentPrecursorQvalue, entry.ExperimentPeptideQvalue);
+                    tableScores.Add(rawScore);
+                    tableQs.Add(effQ);
+                }
+            }
+            if (tableScores.Count == 0)
+            {
+                ctx.LogWarning(
+                    "OSPREY_PASS2_QVALUE=transfer: full-population score->q table build found no " +
+                    "entries with in-memory features; table not published (transfer will fall back).");
+                return null;
+            }
+
+            BuildScoreToQTable(tableScores, tableQs, out double[] scoresDesc, out double[] qDesc);
+            ctx.LogInfo(string.Format(
+                "OSPREY_PASS2_QVALUE=transfer: built FULL-population score->q table from {0} entries " +
+                "({1} skipped for missing features; raw-score range [{2:F4}, {3:F4}]; q range [{4:E3}, {5:E3}]).",
+                scoresDesc.Length, nSkipped,
+                scoresDesc[scoresDesc.Length - 1], scoresDesc[0],
+                qDesc[0], qDesc[qDesc.Length - 1]));
+            return new FirstPassScoreQTable { ScoresDesc = scoresDesc, QDesc = qDesc };
+        }
+
+        /// <summary>
+        /// Apply the averaged frozen model to a single raw feature vector: standardize a
+        /// copy, then score = avgBias + sum(avgWeights[j] * feat[j]). Mirrors the per-entry
+        /// math in <c>PercolatorFdr.ScorePopulationAndComputeFdr</c>. Does not mutate
+        /// <paramref name="rawFeatures"/>.
+        /// </summary>
+        internal static double ScoreWithFrozenModel(
+            double[] rawFeatures,
+            FeatureStandardizer standardizer,
+            double[] avgWeights,
+            double avgBias)
+        {
+            var buf = new double[rawFeatures.Length];
+            Array.Copy(rawFeatures, 0, buf, 0, rawFeatures.Length);
+            standardizer.TransformSlice(buf);
+            double score = avgBias;
+            for (int j = 0; j < avgWeights.Length; j++)
+                score += avgWeights[j] * buf[j];
+            return score;
+        }
+
+        /// <summary>Number of equal-count score-quantile bins
+        /// <see cref="BuildScoreToQTable"/> smooths the per-entry q into. Large enough to
+        /// trace the FDR curve finely, small enough that each bin averages out the
+        /// per-entry q noise from the raw-vs-calibrated score scale mismatch.</summary>
+        private const int SCORE_Q_TABLE_BINS = 1000;
+
+        /// <summary>
+        /// Average the frozen Percolator fold weights + biases into a single (weights, bias)
+        /// pair -- the same averaged-model math <c>PercolatorFdr.ScorePopulationAndComputeFdr</c>
+        /// applies before scoring a population. Caller has already verified the model carries
+        /// at least one fold.
+        /// </summary>
+        private static void AverageFoldModel(
+            PercolatorResults model, out double[] avgWeights, out double avgBias)
+        {
+            int nModels = model.FoldWeights.Count;
+            int nFeatures = model.FoldWeights[0].Length;
+            avgWeights = new double[nFeatures];
+            avgBias = 0.0;
+            for (int f = 0; f < nModels; f++)
+            {
+                double[] foldW = model.FoldWeights[f];
+                for (int j = 0; j < nFeatures; j++)
+                    avgWeights[j] += foldW[j];
+                avgBias += model.FoldBiases[f];
+            }
+            for (int j = 0; j < nFeatures; j++)
+                avgWeights[j] /= nModels;
+            avgBias /= nModels;
+        }
+
+        /// <summary>
+        /// Apply the frozen 1st-pass model to each entry's RECONCILED features (already on
+        /// <see cref="FdrEntry.Features"/>), overwrite <see cref="FdrEntry.Score"/> with the
+        /// raw averaged-model score, and map that score to a q via the supplied score-&gt;q
+        /// table (<paramref name="scoresDesc"/> / <paramref name="qDesc"/>). Sets both
+        /// precursor + peptide levels (run + experiment) so the downstream effective-q
+        /// filtering (detected-peptides gate) sees the transferred q.
+        /// </summary>
+        private static void TransferQWithTable(
+            List<KeyValuePair<string, List<FdrEntry>>> perFileEntries,
+            FeatureStandardizer standardizer,
+            double[] avgWeights,
+            double avgBias,
+            int nFeatures,
+            double[] scoresDesc,
+            double[] qDesc,
+            PipelineContext ctx)
+        {
+            int nScored = 0;
+            int nSkipped = 0;
+            foreach (var kvp in perFileEntries)
+            {
+                foreach (var entry in kvp.Value)
+                {
+                    if (entry.Features == null || entry.Features.Length != nFeatures)
+                    {
+                        nSkipped++;
+                        continue;
+                    }
+                    double newScore = ScoreWithFrozenModel(
+                        entry.Features, standardizer, avgWeights, avgBias);
+                    entry.Score = newScore;
+                    double q = LookupQForScore(newScore, scoresDesc, qDesc);
+                    entry.ExperimentPrecursorQvalue = q;
+                    entry.ExperimentPeptideQvalue = q;
+                    entry.RunPrecursorQvalue = q;
+                    entry.RunPeptideQvalue = q;
+                    nScored++;
+                }
+            }
+            ctx.LogInfo(string.Format(
+                "OSPREY_PASS2_QVALUE=transfer: re-scored {0} entries with the FROZEN 1st-pass model " +
+                "on reconciled features ({1} skipped for missing features); q transferred via the " +
+                "score->q table.", nScored, nSkipped));
+        }
+
+        /// <summary>
+        /// Build the score-&gt;q lookup table from parallel (score, q) lists (the raw
+        /// averaged-model score paired with the unbiased 1st-pass effective q). A calibrated
+        /// q is monotone NON-INCREASING in score, but the per-entry pairs are not
+        /// individually monotone (the stored 1st-pass q was computed on the per-fold
+        /// calibrated CV score, a different scale from this raw averaged-model score), so a
+        /// running-min/max envelope would collapse to the global extreme on one outlier.
+        /// Instead: (1) sort by score ascending; (2) partition into
+        /// <see cref="SCORE_Q_TABLE_BINS"/> equal-count quantile bins and take each bin's
+        /// MEAN q; (3) run pool-adjacent-violators (isotonic regression) so q is
+        /// non-decreasing as score decreases. Emits parallel arrays:
+        /// <paramref name="scoresDesc"/> (bin score, descending) and <paramref name="qDesc"/>
+        /// (isotonic bin-mean q, non-decreasing as score decreases).
+        /// </summary>
+        internal static void BuildScoreToQTable(
+            IReadOnlyList<double> scores,
+            IReadOnlyList<double> qs,
+            out double[] scoresDesc,
+            out double[] qDesc)
+        {
+            int nPts = scores.Count;
+            var order = new int[nPts];
+            for (int i = 0; i < nPts; i++)
+                order[i] = i;
+            // Sort indices by score ASCENDING (ties by q ascending, deterministic).
+            Array.Sort(order, (a, b) => // Array.Sort OK: quantile-bin means are tie-order-insensitive, and this table feeds only the OSPREY_PASS2_QVALUE=transfer path (never cross-impl parity output)
+            {
+                int c = scores[a].CompareTo(scores[b]);
+                if (c != 0)
+                    return c;
+                return qs[a].CompareTo(qs[b]);
+            });
+
+            int nBins = Math.Min(SCORE_Q_TABLE_BINS, nPts);
+            var binScoreAsc = new double[nBins];   // representative (max) score in bin
+            var binQAsc = new double[nBins];        // mean q in bin
+            for (int b = 0; b < nBins; b++)
+            {
+                // Equal-count partition of the ascending-sorted points.
+                int start = (int)((long)b * nPts / nBins);
+                int end = (int)((long)(b + 1) * nPts / nBins);
+                if (end <= start)
+                    end = start + 1;
+                double qSum = 0.0;
+                double maxScore = double.NegativeInfinity;
+                for (int k = start; k < end; k++)
+                {
+                    int idx = order[k];
+                    qSum += qs[idx];
+                    if (scores[idx] > maxScore)
+                        maxScore = scores[idx];
+                }
+                binScoreAsc[b] = maxScore;
+                binQAsc[b] = qSum / (end - start);
+            }
+
+            // Pool-adjacent-violators (isotonic regression) over the ascending-score bins to
+            // force q NON-INCREASING as score increases. Blocks are stored low-score-first;
+            // blockW[j] counts bins from the low-score end.
+            var blockQ = new double[nBins];
+            var blockW = new int[nBins];
+            int nBlocks = 0;
+            for (int b = 0; b < nBins; b++)
+            {
+                double q = binQAsc[b];
+                int w = 1;
+                while (nBlocks > 0 && blockQ[nBlocks - 1] < q)
+                {
+                    double pooledSum = blockQ[nBlocks - 1] * blockW[nBlocks - 1] + q * w;
+                    w += blockW[nBlocks - 1];
+                    q = pooledSum / w;
+                    nBlocks--;
+                }
+                blockQ[nBlocks] = q;
+                blockW[nBlocks] = w;
+                nBlocks++;
+            }
+            // Expand blocks back to per-bin isotonic q (low-score-first).
+            var binQIso = new double[nBins];
+            int fillLo = 0;
+            for (int j = 0; j < nBlocks; j++)
+            {
+                for (int c = 0; c < blockW[j]; c++)
+                {
+                    binQIso[fillLo] = blockQ[j];
+                    fillLo++;
+                }
+            }
+
+            // Emit descending-by-score (highest score first) for LookupQForScore.
+            scoresDesc = new double[nBins];
+            qDesc = new double[nBins];
+            for (int b = 0; b < nBins; b++)
+            {
+                scoresDesc[b] = binScoreAsc[nBins - 1 - b];
+                qDesc[b] = binQIso[nBins - 1 - b];
+            }
+        }
+
+        /// <summary>
+        /// Map a score to a q via the score-&gt;q table built by
+        /// <see cref="BuildScoreToQTable"/>. Binary search for the deepest table entry whose
+        /// score is still &gt;= the query score and return its q; clamp at both ends (a score
+        /// above the table max gets the table's minimum q; a score below the table min gets
+        /// the maximum q).
+        /// </summary>
+        internal static double LookupQForScore(
+            double score, double[] scoresDesc, double[] qDesc)
+        {
+            int n = scoresDesc.Length;
+            if (n == 0)
+                return 1.0;
+            // scoresDesc is descending; qDesc is non-decreasing along it. A score above the
+            // best table score is the most confident -> the minimum q at qDesc[0]; a score
+            // below the worst table score is the least confident -> the maximum q at qDesc[n-1].
+            if (score > scoresDesc[0])
+                return qDesc[0];
+            if (score <= scoresDesc[n - 1])
+                return qDesc[n - 1];
+            // Largest index i such that scoresDesc[i] >= score (deepest table position still
+            // at least as good as the query); qDesc non-decreasing -> most conservative q.
+            int lo = 0, hi = n - 1, best = 0;
+            while (lo <= hi)
+            {
+                int mid = (lo + hi) / 2;
+                if (scoresDesc[mid] >= score)
+                {
+                    best = mid;
+                    lo = mid + 1;
+                }
+                else
+                {
+                    hi = mid - 1;
+                }
+            }
+            return qDesc[best];
         }
 
         /// <summary>

--- a/pwiz_tools/Osprey/Osprey.Tasks/Pass2FdrSidecar.cs
+++ b/pwiz_tools/Osprey/Osprey.Tasks/Pass2FdrSidecar.cs
@@ -1032,6 +1032,15 @@ namespace pwiz.Osprey.Tasks
                         entry.Features, standardizer, avgWeights, avgBias);
                     entry.Score = newScore;
                     double q = LookupQForScore(newScore, scoresDesc, qDesc);
+                    // Assign one transferred q to all four q slots (precursor/peptide x
+                    // run/experiment). This is the coarse whole-pool transfer: it collapses
+                    // the precursor-vs-peptide and run-vs-experiment distinctions the
+                    // percolator path maintains, so the reported "experiment q" here is a
+                    // per-observation transferred value, not a genuine across-file estimate.
+                    // The downstream best-of-runs clamp (MergeNodeTask) is then a no-op on
+                    // these equal values. Acceptable for this experimental mode; Part B's
+                    // surgical transfer (Design 1) preserves the survivors' calibrated q
+                    // per level instead. See TODO-20260710_osprey_pass2_recalibration_fix.
                     entry.ExperimentPrecursorQvalue = q;
                     entry.ExperimentPeptideQvalue = q;
                     entry.RunPrecursorQvalue = q;

--- a/pwiz_tools/Osprey/Osprey.Tasks/Pass2FdrSidecar.cs
+++ b/pwiz_tools/Osprey/Osprey.Tasks/Pass2FdrSidecar.cs
@@ -857,6 +857,16 @@ namespace pwiz.Osprey.Tasks
                     "present (the 1st pass did not build one in this process); cannot transfer.");
                 return false;
             }
+            // ScoresDesc and QDesc are built and published together (always parallel), but
+            // guard against a partially-populated byproduct so the logging + lookup below
+            // never index a null or mismatched QDesc.
+            if (fullTable.QDesc == null || fullTable.QDesc.Length != fullTable.ScoresDesc.Length)
+            {
+                ctx.LogWarning(
+                    "OSPREY_PASS2_QVALUE=transfer: score->q table byproduct has a null or " +
+                    "length-mismatched QDesc; cannot transfer.");
+                return false;
+            }
 
             AverageFoldModel(firstPassModel, out double[] avgWeights, out double avgBias);
             int nFeatures = avgWeights.Length;
@@ -912,6 +922,7 @@ namespace pwiz.Osprey.Tasks
             var tableScores = new List<double>();
             var tableQs = new List<double>();
             int nSkipped = 0;
+            var scratch = new double[nFeatures]; // reused per entry to avoid a per-row allocation
             foreach (var kvp in perFileEntries)
             {
                 foreach (var entry in kvp.Value)
@@ -922,7 +933,7 @@ namespace pwiz.Osprey.Tasks
                         continue;
                     }
                     double rawScore = ScoreWithFrozenModel(
-                        entry.Features, standardizer, avgWeights, avgBias);
+                        entry.Features, standardizer, avgWeights, avgBias, scratch);
                     double effQ = Math.Max(
                         entry.ExperimentPrecursorQvalue, entry.ExperimentPeptideQvalue);
                     tableScores.Add(rawScore);
@@ -949,22 +960,25 @@ namespace pwiz.Osprey.Tasks
 
         /// <summary>
         /// Apply the averaged frozen model to a single raw feature vector: standardize a
-        /// copy, then score = avgBias + sum(avgWeights[j] * feat[j]). Mirrors the per-entry
-        /// math in <c>PercolatorFdr.ScorePopulationAndComputeFdr</c>. Does not mutate
-        /// <paramref name="rawFeatures"/>.
+        /// copy into the caller-supplied <paramref name="scratch"/> buffer, then
+        /// score = avgBias + sum(avgWeights[j] * std(feat)[j]). Mirrors the per-entry math
+        /// in <c>PercolatorFdr.ScorePopulationAndComputeFdr</c>, which likewise reuses a
+        /// single feature buffer to avoid a per-entry allocation in the scoring loop. Does
+        /// not mutate <paramref name="rawFeatures"/>; overwrites <paramref name="scratch"/>
+        /// (length must be &gt;= rawFeatures.Length).
         /// </summary>
         internal static double ScoreWithFrozenModel(
             double[] rawFeatures,
             FeatureStandardizer standardizer,
             double[] avgWeights,
-            double avgBias)
+            double avgBias,
+            double[] scratch)
         {
-            var buf = new double[rawFeatures.Length];
-            Array.Copy(rawFeatures, 0, buf, 0, rawFeatures.Length);
-            standardizer.TransformSlice(buf);
+            Array.Copy(rawFeatures, 0, scratch, 0, rawFeatures.Length);
+            standardizer.TransformSlice(scratch);
             double score = avgBias;
             for (int j = 0; j < avgWeights.Length; j++)
-                score += avgWeights[j] * buf[j];
+                score += avgWeights[j] * scratch[j];
             return score;
         }
 
@@ -1019,6 +1033,7 @@ namespace pwiz.Osprey.Tasks
         {
             int nScored = 0;
             int nSkipped = 0;
+            var scratch = new double[nFeatures]; // reused per entry to avoid a per-row allocation
             foreach (var kvp in perFileEntries)
             {
                 foreach (var entry in kvp.Value)
@@ -1029,7 +1044,7 @@ namespace pwiz.Osprey.Tasks
                         continue;
                     }
                     double newScore = ScoreWithFrozenModel(
-                        entry.Features, standardizer, avgWeights, avgBias);
+                        entry.Features, standardizer, avgWeights, avgBias, scratch);
                     entry.Score = newScore;
                     double q = LookupQForScore(newScore, scoresDesc, qDesc);
                     // Assign one transferred q to all four q slots (precursor/peptide x

--- a/pwiz_tools/Osprey/Osprey.Tasks/PerFileScoringTask.cs
+++ b/pwiz_tools/Osprey/Osprey.Tasks/PerFileScoringTask.cs
@@ -357,7 +357,8 @@ namespace pwiz.Osprey.Tasks
                 !OspreyEnvironment.UseFdrProjection ||
                 ctx.Config.FdrMethod != FdrMethod.Percolator ||
                 ctx.Config.ModelDiagnostics ||
-                (!string.IsNullOrEmpty(ctx.Config.OutputFdrBench) && ctx.Config.FdrBenchPass == 1);
+                (!string.IsNullOrEmpty(ctx.Config.OutputFdrBench) && ctx.Config.FdrBenchPass == 1) ||
+                OspreyEnvironment.Pass2TransferQ;
 
             FdrProjectionSet projections = null;
             int totalScored = 0;

--- a/pwiz_tools/Osprey/Osprey.Tasks/PipelineByproducts.cs
+++ b/pwiz_tools/Osprey/Osprey.Tasks/PipelineByproducts.cs
@@ -233,17 +233,22 @@ namespace pwiz.Osprey.Tasks
     /// averaged-model score paired with its unbiased 1st-pass effective q),
     /// captured at first-pass FDR time BEFORE compaction -- so it retains the
     /// high-q failing/decoy region that the compacted reported pool no longer
-    /// holds. Sorted by score descending with a monotone non-increasing q.
-    /// Published only under OSPREY_PASS2_QVALUE=transfer; the merge-node 2nd-pass
-    /// transfer maps each frozen-model reconciled score to a q via THIS table
-    /// instead of one rebuilt from the decoy-depleted compacted entries. Absent
-    /// (never published) on the default percolator path.
+    /// holds. <see cref="ScoresDesc"/> is sorted by score descending; the parallel
+    /// <see cref="QDesc"/> is q as a monotone NON-INCREASING function of score --
+    /// i.e. q is non-decreasing as you walk <see cref="ScoresDesc"/> from high to
+    /// low score (a higher score is a better ID, so a lower q). Published only under
+    /// OSPREY_PASS2_QVALUE=transfer; the merge-node 2nd-pass transfer maps each
+    /// frozen-model reconciled score to a q via THIS table instead of one rebuilt
+    /// from the decoy-depleted compacted entries. Absent (never published) on the
+    /// default percolator path.
     /// </summary>
     internal sealed class FirstPassScoreQTable
     {
         /// <summary>Raw averaged-model scores, sorted descending.</summary>
         public double[] ScoresDesc { get; set; }
-        /// <summary>Monotone non-increasing effective q, parallel to <see cref="ScoresDesc"/>.</summary>
+        /// <summary>Effective q parallel to <see cref="ScoresDesc"/>; q is a monotone
+        /// non-increasing function of score, so this array is non-decreasing as
+        /// <see cref="ScoresDesc"/> descends (higher score -&gt; lower q).</summary>
         public double[] QDesc { get; set; }
     }
 }

--- a/pwiz_tools/Osprey/Osprey.Tasks/PipelineByproducts.cs
+++ b/pwiz_tools/Osprey/Osprey.Tasks/PipelineByproducts.cs
@@ -213,4 +213,37 @@ namespace pwiz.Osprey.Tasks
     {
         public RescoredEntries(List<KeyValuePair<string, List<FdrEntry>>> value) : base(value) { }
     }
+
+    /// <summary>
+    /// The FROZEN 1st-pass Percolator model (fold weights + biases + feature
+    /// standardizer, carried on <see cref="PercolatorResults"/>), captured at
+    /// first-pass FDR time. Published only under the OSPREY_PASS2_QVALUE=transfer
+    /// path so the merge-node 2nd-pass step can re-score reconciled features with
+    /// this frozen model (TRIC-style confidence transfer) instead of retraining a
+    /// decoy-depleted 2nd-pass SVM. Absent (never published) on the default
+    /// percolator path. See ai/todos/active/TODO-20260710_osprey_pass2_recalibration_fix.md.
+    /// </summary>
+    internal sealed class FirstPassPercolatorModel
+    {
+        public PercolatorResults Results { get; set; }
+    }
+
+    /// <summary>
+    /// The FULL 1st-pass-population score-&gt;q lookup table (each entry's raw
+    /// averaged-model score paired with its unbiased 1st-pass effective q),
+    /// captured at first-pass FDR time BEFORE compaction -- so it retains the
+    /// high-q failing/decoy region that the compacted reported pool no longer
+    /// holds. Sorted by score descending with a monotone non-increasing q.
+    /// Published only under OSPREY_PASS2_QVALUE=transfer; the merge-node 2nd-pass
+    /// transfer maps each frozen-model reconciled score to a q via THIS table
+    /// instead of one rebuilt from the decoy-depleted compacted entries. Absent
+    /// (never published) on the default percolator path.
+    /// </summary>
+    internal sealed class FirstPassScoreQTable
+    {
+        /// <summary>Raw averaged-model scores, sorted descending.</summary>
+        public double[] ScoresDesc { get; set; }
+        /// <summary>Monotone non-increasing effective q, parallel to <see cref="ScoresDesc"/>.</summary>
+        public double[] QDesc { get; set; }
+    }
 }

--- a/pwiz_tools/Osprey/Osprey.Test/Pass2FdrSidecarTest.cs
+++ b/pwiz_tools/Osprey/Osprey.Test/Pass2FdrSidecarTest.cs
@@ -258,6 +258,75 @@ namespace pwiz.Osprey.Test
             return a.ParquetIndex.CompareTo(b.ParquetIndex);
         }
 
+        /// <summary>
+        /// The OSPREY_PASS2_QVALUE=transfer score-&gt;q table
+        /// (<see cref="Pass2FdrSidecar.BuildScoreToQTable"/> +
+        /// <see cref="Pass2FdrSidecar.LookupQForScore"/>) must produce a CALIBRATED,
+        /// monotone map even when the input (score, q) pairs are individually
+        /// non-monotone (the raw averaged-model score is a different scale from the
+        /// stored per-fold CV q). Asserts: (a) the emitted table is descending in score
+        /// with q non-decreasing as score falls (isotonic); (b) lookups clamp to the
+        /// table's min q above the top score and max q below the bottom score; (c) the
+        /// lookup is monotone -- a higher query score never yields a larger q.
+        /// </summary>
+        [TestMethod]
+        public void TestTransferScoreQTable()
+        {
+            // Underlying trend: higher score -> lower q, from ~0 at the top to ~0.05 at
+            // the bottom, with a deterministic wobble so adjacent pairs are NOT monotone
+            // (exercises the quantile-bin mean + pool-adjacent-violators smoothing).
+            const int n = 2000;
+            var scores = new List<double>(n);
+            var qs = new List<double>(n);
+            for (int i = 0; i < n; i++)
+            {
+                double s = i * 0.01;                       // 0 .. 19.99, ascending
+                double trend = 0.05 * (n - 1 - i) / (n - 1); // 0.05 at low score -> 0 at high
+                double wobble = 0.01 * Math.Sin(i * 0.7);   // deterministic non-monotone noise
+                double q = Math.Max(0.0, Math.Min(0.05, trend + wobble));
+                scores.Add(s);
+                qs.Add(q);
+            }
+
+            Pass2FdrSidecar.BuildScoreToQTable(
+                scores, qs, out double[] scoresDesc, out double[] qDesc);
+
+            Assert.AreEqual(scoresDesc.Length, qDesc.Length);
+            Assert.IsTrue(scoresDesc.Length > 1);
+
+            // (a) scores descending; q non-decreasing along the descending scores (i.e.
+            // calibrated: q only rises as the score falls).
+            for (int i = 1; i < scoresDesc.Length; i++)
+            {
+                Assert.IsTrue(scoresDesc[i] <= scoresDesc[i - 1],
+                    "score->q table must be sorted by score descending");
+                Assert.IsTrue(qDesc[i] >= qDesc[i - 1] - 1e-12,
+                    "q must be monotone non-decreasing as score decreases (isotonic)");
+            }
+
+            // (b) clamping: a score above the top gets the minimum q; a score below the
+            // bottom gets the maximum q.
+            double qMin = qDesc[0];
+            double qMax = qDesc[qDesc.Length - 1];
+            Assert.AreEqual(qMin, Pass2FdrSidecar.LookupQForScore(1e6, scoresDesc, qDesc), 1e-12);
+            Assert.AreEqual(qMax, Pass2FdrSidecar.LookupQForScore(-1e6, scoresDesc, qDesc), 1e-12);
+            Assert.IsTrue(qMin <= qMax, "top-score q must not exceed bottom-score q");
+
+            // (c) lookup monotonicity: sweep ascending query scores; the returned q must
+            // never increase as the query score increases.
+            double prevQ = double.PositiveInfinity;
+            for (double s = -1.0; s <= 21.0; s += 0.05)
+            {
+                double q = Pass2FdrSidecar.LookupQForScore(s, scoresDesc, qDesc);
+                Assert.IsTrue(q <= prevQ + 1e-12,
+                    "LookupQForScore must be non-increasing in score");
+                prevQ = q;
+            }
+
+            // An empty table returns the conservative q = 1.
+            Assert.AreEqual(1.0, Pass2FdrSidecar.LookupQForScore(0.0, new double[0], new double[0]), 1e-12);
+        }
+
         // Verbatim copy of the FdrProjectionSet-overload comparer in
         // PercolatorEngine.RunPercolatorFdr (the scan-omitted projection sort). Same
         // isolation caveat as LegacyResidentComparison.


### PR DESCRIPTION
## Summary

Adds a committed off-switch for the anti-conservative 2nd-pass q-value estimation that
#4395 made the always-on default. Introduces one `OSPREY_PASS2_QVALUE` selector:

* **`percolator`** (default) - current #4395 behavior: retrain Percolator and recompute a
  target/decoy null on the reconciled + compacted reported pool. Preserves Rust parity.
* **`transfer`** - do NOT retrain or re-estimate a null. Score each reconciled peak with the
  frozen 1st-pass model and read its q from the full pre-compaction 1st-pass score->q table
  (co-monotonic confidence transfer; Rost 2016 TRIC). Keeps the 2nd-pass peak re-scoring
  (the ID gain) while discarding the decoy-depleted null that inflates q.
* Consolidates three uncommitted prototype env vars
  (`OSPREY_PASS2_NO_RECALIBRATE` / `_TRANSFER_Q` / `_RETRAIN_FULLNULL`) into the one selector.

## Why

The 2nd pass re-estimates a target/decoy null on the post-compaction pool, which first-pass
compaction has already stripped of most decoys. Retraining on that decoy-depleted,
target-selected null makes the model over-confident and the reported q anti-conservative
(Stellar libdecoy: true FDP 0.90% -> 1.47% at 1% q). The peak re-scoring is fine; only the
q re-estimation is the problem, so `transfer` keeps the former and replaces the latter. This
is the fast-follow to #4395: it restores calibrated q while the surgical real fix is designed
and validated against the entrapment oracle with Mike. The default stays `percolator`, so the
standing C#/Rust parity gate and the committed golden are unaffected.

## How it works

* The frozen 1st-pass model (averaged fold weights + biases + standardizer) is captured via a
  no-op `captureModel` hook on the first-pass Percolator run.
* The full pre-compaction score->q table is built while every entry still carries its Stage-4
  features and unbiased 1st-pass q (retaining the high-q failing/decoy tail the compacted pool
  lacks), smoothed into equal-count quantile bins with an isotonic (PAV) monotonicity pass.
* At the 2nd pass, `transfer` re-scores each reconciled peak with the frozen model and maps it
  through that table; no SVM retrain, no reduced-pool null.
* `transfer` routes through the resident first-pass + 2nd-pass paths (like `--model-diagnostics`)
  so the features are available; the default projection paths are untouched.

## Test plan

- [x] Debug build + 505 unit tests (502 pass / 3 skip); ReSharper inspection 0 warnings on changed files
- [x] TestTransferScoreQTable - score->q table isotonicity, lookup clamping + monotonicity
- [x] regression.ps1 -Dataset Stellar mode1/2/3 - default `percolator` byte-identical to golden
- [x] Osprey Perf/Regression (Stellar + Astral) via TeamCity on pull/<N>

Entrapment-oracle A/B validation of `transfer` (target ~0.90% FDP) and the surgical Part-B
designs are tracked in the TODO; this PR is the kill-switch + scaffolding.

See ai/todos/active/TODO-20260710_osprey_pass2_recalibration_fix.md

Co-Authored-By: Claude <noreply@anthropic.com>
