### PR TITLE
Fixed intermittent floating GraphFullScan teardown hang

### DIFF
--- a/pwiz_tools/Skyline/SkylineGraphs.cs
+++ b/pwiz_tools/Skyline/SkylineGraphs.cs
@@ -301,11 +301,24 @@ namespace pwiz.Skyline
                     listUpdateGraphs.Add(_graphSpectrum);
             }
 
+            // The Full Scan graph is always shown as a floating window, and DigitalRune's
+            // floating-pane teardown intermittently wedges the UI thread in a native SetWindowRgn
+            // call when it runs while the dock panel layout is locked (SuspendLayout + CoverControl).
+            // When the graph is about to be torn down anyway - because results were removed, or
+            // because a saved layout is about to replace it - close it here, before locking the
+            // layout below, where closing a floating window is safe.
+            string layoutFile = GetViewFile(DocumentFilePath);
+            bool willLoadLayout = docIdChanged && File.Exists(layoutFile);
+            if (_graphFullScan != null &&
+                (willLoadLayout || (_graphFullScan.Visible && !settingsNew.HasResults)))
+            {
+                DestroyGraphFullScan();
+            }
+
             using (var layoutLock = new DockPanelLayoutLock(dockPanel))
             {
                 bool deserialized = false;
-                string layoutFile = GetViewFile(DocumentFilePath);
-                if (docIdChanged && File.Exists(layoutFile))
+                if (willLoadLayout)
                 {
                     layoutLock.EnsureLocked();
                     try
@@ -326,13 +339,6 @@ namespace pwiz.Skyline
                 }
 
                 ViewMenu.UpdateGraphUi(layoutLock.EnsureLocked, settingsNew, deserialized);
-
-                var enable = settingsNew.HasResults;
-                if (_graphFullScan != null && _graphFullScan.Visible && !enable)
-                {
-                    layoutLock.EnsureLocked();
-                    DestroyGraphFullScan();
-                }
 
                 if (!ReferenceEquals(settingsNew.MeasuredResults, settingsOld.MeasuredResults))
                 {
@@ -481,6 +487,11 @@ namespace pwiz.Skyline
         // Load view layout from the given stream.
         public void LoadLayout(Stream layoutStream)
         {
+            // Close a floating Full Scan graph before locking the layout, to avoid the DigitalRune
+            // floating-pane SetWindowRgn teardown wedge (see UpdateGraphUI). No-op when the caller
+            // already destroyed it.
+            if (_graphFullScan != null)
+                DestroyGraphFullScan();
             using (new DockPanelLayoutLock(dockPanel, true))
             {
                 if (Program.SkylineOffscreen)
@@ -529,7 +540,8 @@ namespace pwiz.Skyline
             HideFindResults(true);
             foreach (var graphChrom in _listGraphChrom.ToArray())
                 DestroyGraphChrom(graphChrom);
-            DestroyGraphFullScan();
+            // GraphFullScan is destroyed up front in LoadLayout, before the layout lock, because its
+            // floating-pane teardown must not run under the lock (DigitalRune SetWindowRgn wedge).
             dockPanel.LoadFromXml(layoutStream, DeserializeForm);
 
             InsertFilesViewIntoLegacyLayout();

--- a/pwiz_tools/Skyline/TestFunctional/MixedPolarityFullScanTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/MixedPolarityFullScanTest.cs
@@ -187,6 +187,16 @@ namespace pwiz.SkylineTestFunctional
             WaitForGraphs();
             RunUI(() => graphFullScan.ChangeScan(-1));
             WaitForGraphs();
+
+            // Regression guard for the floating-GraphFullScan teardown hang: the Full Scan graph is
+            // always shown floating, and removing all results while it is open makes UpdateGraphUI
+            // tear it down. That teardown used to run under the dock panel layout lock, where
+            // DigitalRune's floating-pane teardown intermittently wedged the UI thread in a native
+            // SetWindowRgn call. Assert the graph is actually destroyed (and, implicitly, that
+            // closing it here does not hang).
+            Assert.IsNotNull(SkylineWindow.GraphFullScan);
+            RunUI(() => SkylineWindow.ModifyDocument("Remove results", document => document.ChangeMeasuredResults(null)));
+            WaitForConditionUI(() => SkylineWindow.GraphFullScan == null);
         }
     }
 }

--- a/pwiz_tools/Skyline/TestFunctional/MixedPolarityFullScanTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/MixedPolarityFullScanTest.cs
@@ -194,9 +194,10 @@ namespace pwiz.SkylineTestFunctional
             // DigitalRune's floating-pane teardown intermittently wedged the UI thread in a native
             // SetWindowRgn call. Assert the graph is actually destroyed (and, implicitly, that
             // closing it here does not hang).
-            Assert.IsNotNull(SkylineWindow.GraphFullScan);
+            Assert.IsNotNull(SkylineWindow.GraphFullScan, "Full Scan graph should be open before removing results");
             RunUI(() => SkylineWindow.ModifyDocument("Remove results", document => document.ChangeMeasuredResults(null)));
-            WaitForConditionUI(() => SkylineWindow.GraphFullScan == null);
+            WaitForConditionUI(() => SkylineWindow.GraphFullScan == null,
+                "Full Scan graph was not destroyed after removing results");
         }
     }
 }


### PR DESCRIPTION
## Summary

* The Full Scan graph is always shown as a floating window; DigitalRune's floating-pane teardown intermittently wedged the UI thread in a native `SetWindowRgn` call when it ran under a held `DockPanelLayoutLock` (SuspendLayout + CoverControl), hanging the whole run. Seen on the 2026-07-07 trunk nightly (`TestRunner` exit -1); also reachable by users who remove all results (or load a no-results document / saved layout) with a floating Full Scan graph open.
* Destroy the graph *before* the layout lock in `UpdateGraphUI` and `LoadLayout`, instead of under it. Empirically, closing it with the layout unlocked is safe; only the held lock triggers the native wedge.
* Added a deterministic regression guard to `MixedPolarityFullScanTest`: with the graph open, remove results and assert `SkylineWindow.GraphFullScan == null`.

## Test plan

- [x] TestMixedPolarityFullScan - 2500 iterations x 5 languages, no hang (unfixed reproduced a hang ~1/700, at iteration 709)
- [x] FullScanGraphTest - 5 languages
- [x] CodeInspection test + full-solution ReSharper inspection - clean
- [x] Fresh-context self-review - no blocking findings

Co-Authored-By: Claude <noreply@anthropic.com>
