### PR TITLE
Added a page-level Pass 1 / Pass 2 switch to the Osprey model-diagnostics report

### DIFF
--- a/pwiz_tools/Osprey/Osprey.FDR/ModelDiagnostics/ModelDiagnosticsData.cs
+++ b/pwiz_tools/Osprey/Osprey.FDR/ModelDiagnostics/ModelDiagnosticsData.cs
@@ -82,15 +82,20 @@ namespace pwiz.Osprey.FDR.ModelDiagnostics
         public bool ModelDegenerate { get; set; }
         public List<FeatureRow> Model { get; set; }
         /// <summary>
-        /// The second-pass model (feature table + composite score histogram),
-        /// present whenever the second pass retrained Percolator on the
-        /// post-reconciliation reported pool -- i.e. any run where Stage 6
-        /// reconciliation rescored entries. Null on a single-pass run (no
-        /// reconciliation). The Model tab
-        /// offers a Pass 1 / Pass 2 selector when this is present. Shares
-        /// <see cref="FeatureHistEdges"/> with pass 1 (same standardized bins).
+        /// The complete pass-2 (final reported pool) bundle -- every pass-dependent
+        /// card recomputed on the post-compaction, second-pass-q-valued pool -- so the
+        /// report's top-level Pass 1 / Pass 2 switch can re-source the whole page at
+        /// once. Null on a single-pass run (no reconciliation), which hides the switch.
+        /// Its structural half (<see cref="Pass2Data.Model"/> /
+        /// <see cref="Pass2Data.DensityRatio"/> / <see cref="Pass2Data.WinFraction"/>)
+        /// is present only when the second pass RETRAINED Percolator; under
+        /// <c>OSPREY_PASS2_QVALUE=transfer</c> it is null and the report's structural
+        /// cards degrade to a "pass-2 model n/a" note, while the q-driven half still
+        /// renders. Built by the end-of-run writer (MergeNodeTask) via
+        /// <see cref="BuildPass2"/>. Shares <see cref="FeatureHistEdges"/> with pass 1
+        /// (same standardized bins).
         /// </summary>
-        public ModelPass ModelPass2 { get; set; }
+        public Pass2Data Pass2 { get; set; }
         /// <summary>
         /// Shared bin edges for the per-feature standardized-value histograms
         /// (<see cref="FeatureRow.TargetHist"/> / <see cref="FeatureRow.DecoyHist"/>),
@@ -145,6 +150,48 @@ namespace pwiz.Osprey.FDR.ModelDiagnostics
             public bool Degenerate { get; set; }
             public List<FeatureRow> Features { get; set; }
             public ScoreHistogram Scores { get; set; }
+        }
+
+        /// <summary>
+        /// The complete pass-2 (final reported pool) bundle behind the report's
+        /// top-level Pass 1 / Pass 2 switch: every pass-dependent card recomputed on
+        /// the post-compaction, second-pass-q-valued pool. Split into a STRUCTURAL half
+        /// (score/model-derived) and a Q-DRIVEN half (reported-pool q-derived), because
+        /// the two become available under different second-pass modes:
+        /// <list type="bullet">
+        /// <item>Retrain (<c>OSPREY_PASS2_QVALUE=percolator</c>): a second Percolator
+        /// model exists, so BOTH halves are built.</item>
+        /// <item>Confidence transfer (<c>OSPREY_PASS2_QVALUE=transfer</c>): no retrained
+        /// model, so the structural half is null (the report's Model / Density /
+        /// Competition cards show a "pass-2 model n/a" note) while the q-driven half --
+        /// which needs only the transferred q -- still renders.</item>
+        /// </list>
+        /// </summary>
+        public sealed class Pass2Data
+        {
+            // ----- structural half (null under confidence-transfer mode) -----
+            /// <summary>The second-pass model: feature table, composite separation, and
+            /// composite score histogram (the Density plot's source). Null when the second
+            /// pass did not retrain (transfer mode). Shares
+            /// <see cref="FeatureHistEdges"/> with pass 1.</summary>
+            public ModelPass Model { get; set; }
+            /// <summary>Non-parametric null-alignment density ratios over the pass-2
+            /// composite scores. Null when <see cref="Model"/> is (transfer mode).</summary>
+            public DensityRatioData DensityRatio { get; set; }
+            /// <summary>Paired decoy-win fraction over the pass-2 reported pool. Null when
+            /// <see cref="Model"/> is (transfer mode).</summary>
+            public WinFractionData WinFraction { get; set; }
+
+            // ----- q-driven half (present whenever a second-pass q exists) -----
+            /// <summary>FDR-calibration views (experiment + per-run) for the reported pool.
+            /// Empty when the pool carries no entrapment (nothing to calibrate against).</summary>
+            public List<FdpView> FdpViews { get; set; }
+            /// <summary>Identification-yield curve (both precursor-q scopes) on the reported pool.</summary>
+            public IdYieldData IdYield { get; set; }
+            /// <summary>Cross-run detection reproducibility on the reported pool.</summary>
+            public CrossRunDetection CrossRun { get; set; }
+            /// <summary>Per-file passing precursor counts on the reported pool.</summary>
+            public List<FileSummaryRow> PerFile { get; set; }
         }
 
         /// <summary>One row of the trained-model feature-contribution table.</summary>
@@ -480,7 +527,6 @@ namespace pwiz.Osprey.FDR.ModelDiagnostics
                 FdrLevel = fdrLevel.ToString(),
                 FileCount = perFileEntries.Count,
                 Model = new List<FeatureRow>(),
-                PerFile = new List<FileSummaryRow>(),
             };
 
             bool haveManifest = classByBaseId != null && classByBaseId.Count > 0;
@@ -489,38 +535,10 @@ namespace pwiz.Osprey.FDR.ModelDiagnostics
             var precs = ReduceToPrecs(perFileEntries, classByBaseId, pairByBaseId, haveManifest,
                 out int nWithClass, out int nWithoutClass);
 
-            // Per-file passing summary at the run-level peptide FDR (kept separate
-            // from the reduction so the same reduction serves pass 1 and pass 2).
-            // Non-decoy passing entries split into real targets vs entrapment
-            // (p_target) by the library base-id class, so the table mirrors the
-            // top-line target / decoy / entrapment breakdown.
-            foreach (var kvp in perFileEntries)
-            {
-                int fileTargets = 0, fileDecoys = 0, fileEntrap = 0;
-                foreach (var e in kvp.Value)
-                {
-                    // Gate on the run-level q for the CONFIGURED FDR level (precursor /
-                    // peptide / both), the same value the pipeline reports on -- not a
-                    // hardcoded peptide q, which would miscount a precursor-controlled run.
-                    if (e.EffectiveRunQvalue(fdrLevel) > runFdr)
-                        continue;
-                    if (e.IsDecoy)
-                    {
-                        fileDecoys++;
-                        continue;
-                    }
-                    uint baseId = e.EntryId & BASE_ID_MASK;
-                    if (haveManifest && classByBaseId.TryGetValue(baseId, out var cls)
-                        && cls == EntrapmentClass.PTarget)
-                        fileEntrap++;
-                    else
-                        fileTargets++;
-                }
-                data.PerFile.Add(new FileSummaryRow
-                {
-                    File = kvp.Key, Targets = fileTargets, Decoys = fileDecoys, Entrapment = fileEntrap,
-                });
-            }
+            // Per-file passing summary at the run-level FDR (kept separate from the
+            // reduction so the same reduction serves pass 1 and pass 2). Factored into
+            // BuildPerFile so pass 2 reports the same table on the reported pool.
+            data.PerFile = BuildPerFile(perFileEntries, classByBaseId, haveManifest, runFdr, fdrLevel);
             foreach (var p in precs)
             {
                 switch (p.Class)
@@ -580,9 +598,104 @@ namespace pwiz.Osprey.FDR.ModelDiagnostics
             return data;
         }
 
+        /// <summary>
+        /// Build the complete pass-2 (final reported pool) bundle behind the report's
+        /// top-level Pass 1 / Pass 2 switch. Called by the end-of-run writer
+        /// (MergeNodeTask) with the post-compaction, second-pass-q-valued pool
+        /// (<c>RescoredEntries</c>) -- the same pool the pass-2 FDRBench TSV is written
+        /// from -- so the HTML pass-2 cards and stock FDRBench see the identical
+        /// peptides and q-values. The classification / pairing / ratio inputs come
+        /// from the searched library exactly as pass 1 (see ModelDiagnosticsReport).
+        ///
+        /// The STRUCTURAL half (Model / DensityRatio / WinFraction) is built only when
+        /// the second pass RETRAINED Percolator (<paramref name="pass2Contributions"/>
+        /// non-null); under <c>OSPREY_PASS2_QVALUE=transfer</c> there is no retrained
+        /// model, so it stays null and the report's Model / Density / Competition cards
+        /// degrade to a "pass-2 model n/a" note. The Q-DRIVEN half (FdpViews / IdYield /
+        /// CrossRun / PerFile) is always built from the reported pool (FdpViews is empty
+        /// when the pool carries no entrapment).
+        /// </summary>
+        public static Pass2Data BuildPass2(
+            IReadOnlyList<KeyValuePair<string, List<FdrEntry>>> perFileEntries,
+            FeatureContributions pass2Contributions,
+            IReadOnlyDictionary<uint, EntrapmentClass> classByBaseId,
+            IReadOnlyDictionary<uint, uint> pairByBaseId,
+            double entrapmentRatio,
+            double runFdr,
+            FdrLevel fdrLevel)
+        {
+            bool haveManifest = classByBaseId != null && classByBaseId.Count > 0;
+            var precs = ReduceToPrecs(perFileEntries, classByBaseId, pairByBaseId, haveManifest,
+                out _, out _);
+
+            var pass2 = new Pass2Data
+            {
+                // Q-driven half: available whenever a second pass produced reported
+                // q-values (retrain OR confidence transfer). Entrapment-independent
+                // except FdpViews (which is empty without an entrapment pool).
+                PerFile = BuildPerFile(perFileEntries, classByBaseId, haveManifest, runFdr, fdrLevel),
+                IdYield = BuildIdYield(precs),
+                CrossRun = BuildCrossRunDetection(perFileEntries, classByBaseId, haveManifest,
+                    entrapmentRatio, runFdr, fdrLevel),
+                FdpViews = BuildPass2FdpViews(perFileEntries, classByBaseId, pairByBaseId, entrapmentRatio),
+            };
+
+            // Structural half: only when the second pass retrained on the reported pool.
+            // BuildModelPass2 returns null when contributions are null (transfer mode),
+            // which leaves DensityRatio / WinFraction null too -- the report's structural
+            // cards then show their n/a note under the top-level Pass 2 mode.
+            pass2.Model = BuildModelPass2(perFileEntries, pass2Contributions, classByBaseId, pairByBaseId);
+            if (pass2.Model != null)
+            {
+                bool hasEntrapment = precs.Any(p => p.Class == EntrapmentClass.PTarget);
+                pass2.DensityRatio = BuildDensityRatio(pass2.Model.Scores, hasEntrapment);
+                pass2.WinFraction = BuildWinFraction(perFileEntries, classByBaseId, haveManifest);
+            }
+            return pass2;
+        }
+
         // Mask clearing the decoy high bit from an EntryId to get the shared
         // target/decoy library base-id (same convention as FdrBenchInputWriter).
         private const uint BASE_ID_MASK = 0x7FFFFFFF;
+
+        // Per-file passing precursor counts at the run-level FDR for the CONFIGURED
+        // level (precursor / peptide / both) via EffectiveRunQvalue -- the value the
+        // pipeline reports on, not a hardcoded peptide q. Non-decoy passing entries
+        // split into real targets vs entrapment (p_target) by the library base-id
+        // class, mirroring the top-line breakdown. Shared by pass 1 (Build) and pass 2
+        // (BuildPass2) so both passes label their per-file table with the same rule.
+        private static List<FileSummaryRow> BuildPerFile(
+            IReadOnlyList<KeyValuePair<string, List<FdrEntry>>> perFileEntries,
+            IReadOnlyDictionary<uint, EntrapmentClass> classByBaseId, bool haveManifest,
+            double runFdr, FdrLevel fdrLevel)
+        {
+            var perFile = new List<FileSummaryRow>();
+            foreach (var kvp in perFileEntries)
+            {
+                int fileTargets = 0, fileDecoys = 0, fileEntrap = 0;
+                foreach (var e in kvp.Value)
+                {
+                    if (e.EffectiveRunQvalue(fdrLevel) > runFdr)
+                        continue;
+                    if (e.IsDecoy)
+                    {
+                        fileDecoys++;
+                        continue;
+                    }
+                    uint baseId = e.EntryId & BASE_ID_MASK;
+                    if (haveManifest && classByBaseId.TryGetValue(baseId, out var cls)
+                        && cls == EntrapmentClass.PTarget)
+                        fileEntrap++;
+                    else
+                        fileTargets++;
+                }
+                perFile.Add(new FileSummaryRow
+                {
+                    File = kvp.Key, Targets = fileTargets, Decoys = fileDecoys, Entrapment = fileEntrap,
+                });
+            }
+            return perFile;
+        }
 
         // Build the feature-contribution table rows (most-influential first) from a
         // trained model, carrying each feature's per-class histogram when collected.

--- a/pwiz_tools/Osprey/Osprey.Tasks/ModelDiagnostics/ModelDiagnosticsReport.cs
+++ b/pwiz_tools/Osprey/Osprey.Tasks/ModelDiagnostics/ModelDiagnosticsReport.cs
@@ -153,30 +153,25 @@ namespace pwiz.Osprey.Tasks.ModelDiagnostics
                 BuildClassificationFromLibrary(config, libraryById, logInfo,
                     out classByBaseId, out pairByBaseId, out entrapmentRatio);
 
-                // Pass-2 FDR calibration views from the reported pool (when it carries entrapment).
-                var pass2Views = ModelDiagnosticsData.BuildPass2FdpViews(
-                    perFileEntries, classByBaseId, pairByBaseId, entrapmentRatio);
-                if (pass2Views.Count > 0)
-                {
-                    if (data.FdpViews == null)
-                        data.FdpViews = new List<ModelDiagnosticsData.FdpView>();
-                    data.FdpViews.AddRange(pass2Views);
-                }
-
-                // Pass-2 model view (feature table + composite) whenever the second
-                // pass retrained Percolator on the reported pool (any reconciled run);
-                // null otherwise.
-                data.ModelPass2 = ModelDiagnosticsData.BuildModelPass2(
-                    perFileEntries, pass2Contributions, classByBaseId, pairByBaseId);
+                // Build the complete pass-2 (final reported pool) bundle -- every
+                // pass-dependent card recomputed on this post-compaction, second-pass
+                // q-valued pool -- so the page's top-level Pass 1 / Pass 2 switch can
+                // re-source the whole page. The structural half is null under
+                // confidence-transfer mode (pass2Contributions == null); the q-driven
+                // half is always built (FdpViews empty without an entrapment pool).
+                data.Pass2 = ModelDiagnosticsData.BuildPass2(
+                    perFileEntries, pass2Contributions, classByBaseId, pairByBaseId,
+                    entrapmentRatio, config.RunFdr, config.FdrLevel);
 
                 string outPath = RenderAndWrite(data, config);
                 // Consume the FirstJoin -> MergeNode hand-off sidecar unconditionally
                 // once the report is finalized (deleting it in every path avoids
                 // leaving a stray .data.json in the output directory).
                 TryDelete(sidecarPath);
+                int pass2ViewCount = data.Pass2?.FdpViews?.Count ?? 0;
                 logInfo(string.Format(
                     @"[MODEL-DIAGNOSTICS] finalized report ({0} pass-2 FDR view(s); pass-2 model {1}); re-wrote: {2}",
-                    pass2Views.Count, data.ModelPass2 != null ? @"included" : @"n/a", outPath));
+                    pass2ViewCount, data.Pass2?.Model != null ? @"included" : @"n/a", outPath));
             }
             catch (Exception ex)
             {

--- a/pwiz_tools/Osprey/Osprey.Tasks/ModelDiagnostics/model-diagnostics-template.html
+++ b/pwiz_tools/Osprey/Osprey.Tasks/ModelDiagnostics/model-diagnostics-template.html
@@ -38,11 +38,25 @@ h1 .sub{color:var(--muted);font-weight:450;font-size:13px}
 .chip b{font-weight:650}
 .chip.tgt b{color:var(--target)} .chip.dec b{color:var(--decoy)}
 .chip.pt b{color:var(--ptarget)} .chip.pd b{color:var(--pdecoy)}
-nav{display:flex;gap:4px;border-bottom:1px solid var(--line);margin-bottom:18px;flex-wrap:wrap}
+.navbar{display:flex;align-items:flex-end;justify-content:space-between;gap:16px;
+  border-bottom:1px solid var(--line);margin-bottom:18px;flex-wrap:wrap}
+nav{display:flex;gap:4px;flex-wrap:wrap}
 nav button{background:none;border:none;color:var(--muted);font:inherit;font-weight:550;
   padding:9px 14px;cursor:pointer;border-bottom:2px solid transparent;margin-bottom:-1px}
 nav button:hover{color:var(--ink)}
 nav button.on{color:var(--accent);border-bottom-color:var(--accent)}
+/* Top-level Pass 1 / Pass 2 switch: one global mode that re-sources every
+   pass-dependent plot and table on the page at once. Sits at the right of the
+   tab bar; hidden when only one FDR pass ran. */
+.passsel{display:flex;align-items:center;gap:6px;padding-bottom:6px}
+.passsel .lbl{color:var(--muted);font-size:11.5px;font-weight:600;text-transform:uppercase;letter-spacing:.03em}
+.passsel button{background:var(--panel);border:1px solid var(--line);color:var(--muted);font:inherit;
+  font-size:12px;font-weight:600;padding:5px 12px;border-radius:8px;cursor:pointer;box-shadow:var(--shadow)}
+.passsel button:hover{color:var(--ink)}
+.passsel button.on{background:var(--accent);border-color:var(--accent);color:#fff}
+/* Graceful "n/a for this pass" note replacing a card's chart under the top-level
+   Pass 2 mode when the 2nd pass used confidence transfer (no retrained model). */
+.na{color:var(--muted);font-size:13px;padding:18px 4px;font-style:italic}
 .tab{display:none} .tab.on{display:block}
 .card{background:var(--panel);border:1px solid var(--line);border-radius:12px;
   padding:18px;box-shadow:var(--shadow);margin-bottom:18px}
@@ -126,7 +140,7 @@ code{font-family:ui-monospace,Menlo,Consolas,monospace;background:var(--grid);pa
   html,body{background:#fff}
   *{-webkit-print-color-adjust:exact!important;print-color-adjust:exact!important}
   .wrap{max-width:none;padding:0 4px}
-  nav,.printbtn,.tip,.vbtns,#scoreBack,.iconbtn{display:none!important}
+  nav,.printbtn,.tip,.vbtns,.passsel,#scoreBack,.iconbtn{display:none!important}
   header{page-break-after:avoid}
   .tab{display:block!important;page-break-before:always;break-before:page}
   .tab:first-of-type{page-break-before:avoid;break-before:avoid}
@@ -153,7 +167,10 @@ code{font-family:ui-monospace,Menlo,Consolas,monospace;background:var(--grid);pa
   </div>
 </header>
 <div class="chips" id="chips"></div>
-<nav id="nav"></nav>
+<div class="navbar">
+  <nav id="nav"></nav>
+  <div class="passsel" id="passSel"></div>
+</div>
 
 <section class="tab" data-tab="model">
   <div class="card">
@@ -165,7 +182,7 @@ code{font-family:ui-monospace,Menlo,Consolas,monospace;background:var(--grid);pa
       into each feature's percent contribution to the composite target&ndash;decoy separation.
       Rows in <b style="color:var(--bad)">red</b> have a trained coefficient whose sign is opposite the
       feature's expected direction (behaving against expectation).</p>
-    <div class="vbtns" id="modelPassSel" style="margin-bottom:12px"></div>
+    <div id="modelNa" class="na" style="display:none"></div>
     <div id="modelWrap" class="collapsewrap collapsed"><div id="modelTable"></div></div>
   </div>
   <div class="card">
@@ -209,35 +226,28 @@ code{font-family:ui-monospace,Menlo,Consolas,monospace;background:var(--grid);pa
 </section>
 
 <section class="tab" data-tab="fdr">
+  <div class="card" id="fdrScopeCard">
+    <h2>FDR scope &mdash; experiment-wide vs per-run</h2>
+    <p class="desc">Both cards below switch together between two Osprey q-value scopes. The
+      <b>experiment-wide</b> q is pooled across runs (the value <code>--fdrbench</code> emits, so the calibration
+      curve reproduces the FDRBench plot exactly); the <b>per-run</b> q gates each run on its own &mdash; the
+      picture FDRBench collapses runs and cannot show. This is orthogonal to the page-level Pass&nbsp;1&nbsp;/&nbsp;Pass&nbsp;2 switch.</p>
+    <div class="vbtns" id="fdrScopeSel"></div>
+  </div>
   <div class="card" id="fdpCard">
     <h2>FDR calibration &mdash; Osprey q vs true FDP</h2>
     <p class="desc">Entrapment-measured true false-discovery proportion versus Osprey's own q-value, computed
-      in-process from the pairing manifest &mdash; no FDRBench install. Pick a q-axis: the
-      <b>experiment-wide</b> views reproduce the FDRBench <code>--fdrbench</code> plots exactly (FDRBench just
-      counts entrapment on the q Osprey emits); the <b>per-run</b> views are a picture FDRBench can't show.
-      Each view has a [0,&nbsp;2%] zoom (FDP axis auto-scaled) and a full-extent panel.</p>
-    <div class="vbtns" id="fdpViewSel"></div>
+      in-process from the pairing manifest &mdash; no FDRBench install. At the <b>experiment-wide</b> scope this
+      reproduces the FDRBench <code>--fdrbench</code> plot exactly (FDRBench just counts entrapment on the q Osprey
+      emits); the <b>per-run</b> scope is a picture FDRBench can't show. Each has a [0,&nbsp;2%] zoom (FDP axis
+      auto-scaled) and a full-extent panel.</p>
     <div class="kpis" id="fdpKpis"></div>
     <div class="legend" id="fdpLegend"></div>
     <div class="chartbox" id="fdpChart"></div>
     <p class="note" id="fdpNote"></p>
     <div class="print-only" id="fdpPrintAll"></div>
   </div>
-</section>
-
-<section class="tab" data-tab="repro">
-  <div class="card" id="reproScopeCard">
-    <h2>FDR scope &mdash; per-run vs experiment-wide</h2>
-    <p class="desc">These panels switch together between two q-value scopes. <b>Per-run</b> gates each
-      detection on its run-level q only. <b>Experiment-wide</b> also requires the experiment-wide q to pass
-      (<code>max(run&nbsp;q,&nbsp;experiment&nbsp;q)</code>) &mdash; the value that controls the dataset-wide
-      multiple testing. Per-run FDR does not bound the experiment-wide error, and the gap grows with run
-      count: false positives are ~random per run, so they land at <b>k=1</b> and inflate the union, while
-      real precursors recur. Flip to experiment-wide and the k=1 bump should shrink and the union flatten
-      &mdash; the global-FDR effect (Collins <i>et&nbsp;al.</i> 2017; Rosenberger <i>et&nbsp;al.</i> 2017).</p>
-    <div class="vbtns" id="reproScopeSel"></div>
-  </div>
-  <div class="card">
+  <div class="card" id="yieldCard">
     <h2>Identification yield</h2>
     <p class="desc">Accepted real-target precursors as the reported q-value threshold sweeps, at the scope
       selected above. The per-run curve keeps climbing (admitting non-reproducing precursors); the
@@ -245,6 +255,15 @@ code{font-family:ui-monospace,Menlo,Consolas,monospace;background:var(--grid);pa
       is itself an FDR-control tell.</p>
     <div class="chartbox" id="yieldChart"></div>
   </div>
+</section>
+
+<section class="tab" data-tab="repro">
+  <p class="desc" style="margin:0 0 8px;max-width:105ch">Cross-run reproducibility, gated on one q-value scope.
+    <b>Per-run</b> gates each detection on its run-level q; <b>experiment-wide</b> also requires the
+    experiment-wide q (<code>max(run&nbsp;q,&nbsp;experiment&nbsp;q)</code>), the value that controls dataset-wide
+    multiple testing. Per-run FDR does not bound the experiment-wide error, so flipping to experiment-wide should
+    shrink the k=1 bump and flatten the union (Collins <i>et&nbsp;al.</i> 2017; Rosenberger <i>et&nbsp;al.</i> 2017).</p>
+  <div class="vbtns" id="reproScopeSel" style="margin-bottom:16px"></div>
   <div class="card" id="detByRunCard">
     <h2>Precursor detections by run</h2>
     <p class="desc">Detections per run (bars) with the running <b>union</b> (unique precursors seen so far) and
@@ -300,11 +319,13 @@ code{font-family:ui-monospace,Menlo,Consolas,monospace;background:var(--grid);pa
 <section class="tab" data-tab="summary">
   <div class="card">
     <h2>Run summary</h2>
+    <p class="desc">Best-per-precursor <b>population counts</b> &mdash; not q-gated, so these are the same
+      regardless of the Pass&nbsp;1&nbsp;/&nbsp;Pass&nbsp;2 switch.</p>
     <div class="kpis" id="sumKpis"></div>
   </div>
   <div class="card">
     <h2>Per-file passing precursors</h2>
-    <p class="desc">Precursors passing the run-level FDR, per input file.</p>
+    <p class="desc" id="fileDesc">Precursors passing the run-level FDR, per input file.</p>
     <div id="fileTable"></div>
   </div>
 </section>
@@ -353,7 +374,9 @@ function esc(s){return String(s).replace(/[&<>]/g,c=>({"&":"&amp;","<":"&lt;",">
 const TABS=[["model","Model"],["density","Density"],["fdr","FDR calibration"],["repro","Reproducibility"],["competition","Competition"],["summary","Summary"]];
 const nav=document.getElementById("nav");
 TABS.forEach((t,i)=>{const tab=document.querySelector('.tab[data-tab="'+t[0]+'"]');
-  if(t[0]==="fdr"&&!D.hasEntrapment)return; // no entrapment => no FDP tab
+  // The FDR tab is always shown: it carries the always-present Identification yield
+  // curve; its entrapment-only "q vs true FDP" card hides itself when there is no
+  // entrapment (see drawFdpCard).
   const b=H(nav,"button",{},t[1]);
   b.onclick=()=>{document.querySelectorAll("nav button").forEach(x=>x.classList.remove("on"));
     document.querySelectorAll(".tab").forEach(x=>x.classList.remove("on"));
@@ -384,29 +407,93 @@ function legend(node,items){node.innerHTML="";items.forEach(it=>{const s=H(node,
   H(s,"i",{class:it.line?"ln":"",style:"background:"+it.color});H(s,"span",{},it.name);
   if(it.toggle){s.onclick=()=>{s.classList.toggle("off");it.toggle(s.classList.contains("off"));};}});}
 
-// ---------- Model: feature table (pass 1, + pass 2 when the second pass retrained) ----------
+// ========== top-level Pass 1 / Pass 2 switch ==========
+// One global mode that re-sources EVERY pass-dependent plot and table on the page
+// at once (the thesis of this report: "which pass" is a single page-level mode, not
+// a per-card afterthought). Pass 1 = the pre-compaction first-pass pool (top-level
+// D fields); Pass 2 = the final reported pool (D.pass2), present whenever a second
+// pass ran. A pass carries a STRUCTURAL half (model / composite scores / density /
+// win-fraction) and a Q-DRIVEN half (FDR calibration / yield / cross-run / per-file).
+// Under OSPREY_PASS2_QVALUE=transfer the 2nd pass does not retrain, so pass 2's
+// structural half is absent (bundle.hasStructural=false) and those cards show an
+// "n/a for this pass" note while the q-driven cards still render.
 const HAS_FEATHIST = !!(D.featureHistEdges && D.featureHistEdges.length>1);
-const MODEL_PASSES=[{pass:1,label:"1st pass",features:D.model||[],scores:D.scores,
-  degenerate:D.modelDegenerate,desc:"pre-compaction first-pass training set"}];
-if(D.modelPass2)MODEL_PASSES.push({pass:2,label:"2nd pass",features:D.modelPass2.features||[],
-  scores:D.modelPass2.scores,degenerate:D.modelPass2.degenerate,
-  desc:"post-reconciliation retrain on the reported pool"});
-let CURP=MODEL_PASSES[0];
+function passBundle(p){
+  if(p===1)return {pass:1,label:"1st pass",desc:"pre-compaction first-pass training set",
+    hasStructural:true,
+    features:D.model||[],modelDegenerate:D.modelDegenerate,scores:D.scores,
+    densityRatio:D.densityRatio,winFraction:D.winFraction,
+    fdpViews:D.fdpViews,idYield:D.idYield,crossRun:D.crossRun,perFile:D.perFile};
+  const m=D.pass2.model;   // null under confidence-transfer mode
+  return {pass:2,label:"2nd pass",desc:"post-reconciliation reported pool",
+    hasStructural:!!m,
+    features:m?(m.features||[]):[],modelDegenerate:m?m.degenerate:false,scores:m?m.scores:null,
+    densityRatio:D.pass2.densityRatio,winFraction:D.pass2.winFraction,
+    fdpViews:D.pass2.fdpViews,idYield:D.pass2.idYield,crossRun:D.pass2.crossRun,perFile:D.pass2.perFile};
+}
+const PASSES=[passBundle(1)];
+if(D.pass2)PASSES.push(passBundle(2));
+let PI=0;
+const B=()=>PASSES[PI];   // the active pass bundle
 if(!HAS_FEATHIST){const tip=document.getElementById("scoreTip");if(tip)tip.style.display="none";}
 
-// Pass selector — only shown when a second Percolator model exists.
-(function(){const sel=document.getElementById("modelPassSel");
-  if(MODEL_PASSES.length<2){sel.style.display="none";return;}
-  MODEL_PASSES.forEach((mp,k)=>{const b=H(sel,"button",{class:k===0?"on":""},
-    mp.label+(mp.pass===2?"  (≠ pass 1)":""));
-    b.onclick=()=>{sel.querySelectorAll("button").forEach(x=>x.classList.remove("on"));b.classList.add("on");renderModel(mp);};});
+// The per-card "n/a for this pass" copy (structural cards under transfer mode).
+const PASS2_NA_MODEL="<b>Pass-2 model n/a.</b> The 2nd pass used confidence transfer (no retrain), "+
+  "so there is no pass-2 feature model. Switch to <b>Pass 1</b>, or use the q-driven tabs (FDR calibration, "+
+  "Reproducibility, Summary) for pass-2 results.";
+const PASS2_NA_COMPOSITE="Pass-2 composite score distribution n/a &mdash; confidence transfer (no retrained model).";
+const PASS2_NA_DENSITY="Pass-2 score density n/a &mdash; confidence transfer (no retrained model). "+
+  "The q-driven FDR-calibration and reproducibility views are available for pass 2.";
+const PASS2_NA_COMPETITION="Pass-2 decoy-win competition n/a &mdash; confidence transfer (no retrained model).";
+// Replace a chart with a graceful n/a note and clear its legend.
+function naChart(hostId,legId,msgHtml){
+  const h=document.getElementById(hostId);
+  if(h){h.innerHTML="";H(h,"div",{class:"na",html:msgHtml});}
+  if(legId){const l=document.getElementById(legId);if(l)l.innerHTML="";}
+}
+
+// Pass switch UI (right of the tab bar); hidden unless a second pass ran.
+(function(){const sel=document.getElementById("passSel");
+  if(PASSES.length<2){sel.style.display="none";return;}
+  H(sel,"span",{class:"lbl"},"pass");
+  PASSES.forEach((b,k)=>{const btn=H(sel,"button",{class:k===0?"on":""},b.label);
+    btn.title = b.pass===2
+      ? (b.hasStructural ? "2nd-pass Percolator retrain on the final reported pool"
+                         : "2nd-pass confidence transfer (no retrain): q-driven cards only")
+      : "1st-pass pre-compaction training pool";
+    btn.onclick=()=>{if(PI===k)return;PI=k;
+      sel.querySelectorAll("button").forEach(x=>x.classList.remove("on"));btn.classList.add("on");
+      renderPass();};});
 })();
 
-// (Re)render the Model tab for one pass: feature table, print grid, and the
-// composite chart below. Called on load and on a pass switch.
-function renderModel(mp){
-  CURP=mp;
-  const rows=mp.features||[];const host=document.getElementById("modelTable");host.innerHTML="";
+// Re-source every pass-dependent card for the active pass (called on load + toggle).
+function renderPass(){
+  const b=B();
+  renderModelTab(b);
+  renderDensityTab(b);
+  renderFdrTab(b);
+  renderReproTab(b);
+  renderCompetitionTab(b);
+  renderPerFile(b);
+}
+
+// (Re)render the Model tab for the active pass: feature table, print grid, and the
+// composite chart below. Under Pass 2 confidence-transfer (no retrained model) the
+// whole structural card degrades to an n/a note.
+function renderModelTab(b){
+  const na=document.getElementById("modelNa"), wrap=document.getElementById("modelWrap"),
+        toggle=document.getElementById("modelToggle"), fpc=document.getElementById("featPrintCard");
+  if(!b.hasStructural){
+    na.style.display="";na.innerHTML=PASS2_NA_MODEL;
+    wrap.style.display="none";toggle.style.display="none";if(fpc)fpc.style.display="none";
+    document.getElementById("scoreHdr").childNodes[0].nodeValue="Composite score distribution ";
+    document.getElementById("scoreDesc").innerHTML="";
+    document.getElementById("scoreBack").style.display="none";
+    naChart("scoreChart","scoreLegend",PASS2_NA_COMPOSITE);
+    return;
+  }
+  na.style.display="none";wrap.style.display="";
+  const rows=b.features||[];const host=document.getElementById("modelTable");host.innerHTML="";
   const maxP=Math.max(1,...rows.map(r=>Math.abs(r.percent)||0));
   const t=H(host,"table",{});const htr=H(H(t,"thead",{}),"tr",{});
   [["Feature","l"],["Coefficient",""],["Contribution",""]].forEach(h=>H(htr,"th",{class:h[1]},h[0]));
@@ -420,12 +507,12 @@ function renderModel(mp){
     H(td,"span",{},pct(r.percent/100,1));
     if(clickable(r))tr.onclick=()=>selectFeature(r,tr);
   });
-  if(mp.degenerate)H(host,"p",{class:"note"},"Composite separation is degenerate; percentages unavailable.");
+  if(b.modelDegenerate)H(host,"p",{class:"note"},"Composite separation is degenerate; percentages unavailable.");
   if(!rows.length)H(host,"p",{class:"note"},"Model table unavailable — the first-pass model was not retrained on this run (resumed / rehydrated).");
 
   // Collapse/expand: best-fit height so the score plot below stays visible; toggle
   // reveals the full table. Preserve the collapsed/expanded choice across passes.
-  const wrap=document.getElementById("modelWrap"), btn=document.getElementById("modelToggle");
+  const btn=toggle;
   function syncToggle(){btn.innerHTML=wrap.classList.contains("collapsed")?"Show all &#9662;":"Best fit &#9652;";}
   if(wrap.classList.contains("collapsed") && wrap.scrollHeight<=wrap.clientHeight+4){
     btn.style.display="none";wrap.classList.remove("collapsed");
@@ -434,10 +521,9 @@ function renderModel(mp){
   syncToggle();
 
   // Print-only: render every feature's distribution for THIS pass so the PDF shows them all.
-  const fpc=document.getElementById("featPrintCard");
   if(HAS_FEATHIST && rows.some(r=>r.targetHist)){
     const grid=document.getElementById("featPrintAll");grid.innerHTML="";
-    if(MODEL_PASSES.length>1)H(grid,"div",{style:"grid-column:1/-1;font-weight:600;font-size:12.5px",html:mp.label+" model"});
+    if(PASSES.length>1)H(grid,"div",{style:"grid-column:1/-1;font-weight:600;font-size:12.5px",html:b.label+" model"});
     rows.filter(r=>r.targetHist).forEach(r=>{
       const cell=H(grid,"div",{class:"featcell"});
       H(cell,"h3",{},r.label);
@@ -492,17 +578,17 @@ function drawFeatureSvg(container,r,W,Hh){
 }
 function showComposite(){
   document.querySelectorAll("#modelTable tr.sel").forEach(x=>x.classList.remove("sel"));
-  const multi=MODEL_PASSES.length>1;
+  const cur=B(), multi=PASSES.length>1;
   document.getElementById("scoreHdr").childNodes[0].nodeValue=
-    (multi?CURP.label+" composite score distribution ":"Composite score distribution ");
+    (multi?cur.label+" composite score distribution ":"Composite score distribution ");
   document.getElementById("scoreDesc").innerHTML=
-    'Best-per-precursor composite score for each class'+(multi?" ("+CURP.desc+")":"")+
+    'Best-per-precursor composite score for each class'+(multi?" ("+cur.desc+")":"")+
     ', with a normal curve fit to the decoy scores &mdash; the Osprey analog of Skyline\'s mProphet '+
     '"Model Scores" view, extended with entrapment. '+
     '<span id="scoreTip"><b>Click any feature row above</b> to see that individual score\'s target/decoy '+
     'distribution (the mProphet "Feature Scores" view).</span>';
   document.getElementById("scoreBack").style.display="none";
-  classHist(CURP.scores,"scoreChart","scoreLegend",false);
+  classHist(B().scores,"scoreChart","scoreLegend",false);
 }
 document.getElementById("scoreBack").onclick=(e)=>{e.preventDefault();showComposite();};
 
@@ -590,10 +676,19 @@ function classHist(H0,hostId,legId,normalize){
     .concat(normalize===false&&H0.decoyStd>0?[{name:"decoy normal",color:COL.decoy,line:true,toggle:o=>{off.decoynorm=o;draw();}}]:[]));
   draw();
 }
-renderModel(MODEL_PASSES[0]);   // Model tab: table + composite for pass 1 (default)
-classHist(D.scores,"densChart","densLegend",true);   // Density tab: pass-1 composite density
+// ========== Density tab: composite score density + null-alignment ratio ==========
+// Both cards re-source for the active pass. Under Pass 2 confidence-transfer (no
+// retrained model) the structural density cards degrade to an n/a note.
+function renderDensityTab(b){
+  if(!b.hasStructural){
+    naChart("densChart","densLegend",PASS2_NA_DENSITY);
+    const rc=document.getElementById("ratioCard");if(rc)rc.style.display="none";
+    return;
+  }
+  classHist(b.scores,"densChart","densLegend",true);   // area-normalized composite density
+  drawDensityRatio(b.densityRatio);
+}
 
-// ---------- Density tab: non-parametric null-alignment density ratio ----------
 // Storey's original check: divide the per-class densities. target:decoy is the
 // diagnostic (flat null plateau = decoys track the false-target null; a sloping
 // left side = they don't); p_target:p_decoy is the matched-null reference (~1).
@@ -601,10 +696,11 @@ classHist(D.scores,"densChart","densLegend",true);   // Density tab: pass-1 comp
 function logTicks(lo,hi){const out=[];const k0=Math.floor(Math.log10(lo)),k1=Math.ceil(Math.log10(hi));
   for(let k=k0;k<=k1;k++)[1,2,5].forEach(m=>{const v=m*Math.pow(10,k);if(v>=lo&&v<=hi)out.push(v);});return out;}
 function ratioFmt(v){return v>=1?(+v.toFixed(v<10?1:0)).toString():(+v.toFixed(2)).toString();}
-(function(){
-  const dr=D.densityRatio, card=document.getElementById("ratioCard");
+function drawDensityRatio(dr){
+  const card=document.getElementById("ratioCard");
   const num=v=>Number(v);
   if(!dr||!dr.binCenters||!dr.targetDecoy){if(card)card.style.display="none";return;}
+  if(card)card.style.display="";
   const cx=dr.binCenters, nb=cx.length;
   const hasRef=!!(dr.hasEntrapment && dr.pTargetPDecoy);
   const series=[{k:"td",name:"target : decoy",color:COL.accent,v:dr.targetDecoy}];
@@ -674,17 +770,54 @@ function ratioFmt(v){return v>=1?(+v.toFixed(v<10?1:0)).toString():(+v.toFixed(2
       " This is a <b>marginal</b> check: a target-side score boost that leaves the decoy and entrapment marginals "+
       "intact is invisible here &mdash; see the paired decoy-win fraction (Competition) for that."
     : "Not enough populated null-region bins on this run to measure the plateau tilt.";
-})();
+}
 
-// ---------- FDR calibration (multiple q-scope / pass views) ----------
-if(D.fdpViews && D.fdpViews.length){
-  const views=D.fdpViews; let vi=0;
-  const host=document.getElementById("fdpChart"), sel=document.getElementById("fdpViewSel");
-  const series=[{k:"lower",name:"lower-bound FDP",color:COL.ptarget,key:"lowerBound"},
-                {k:"combined",name:"combined FDP",color:COL.target,key:"combined"},
-                {k:"paired",name:"paired FDP",color:COL.pdecoy,key:"paired"}];
-  const off={lower:false,combined:false,paired:false};
-  const opIdx=(f,q)=>Math.max(0,Math.min(lowerB(f.q,q)-1,f.q.length-1));
+// ========== FDR calibration + Identification yield (one exp/run scope selector) ==========
+// The FDR tab carries a single experiment-wide / per-run SCOPE selector (orthogonal
+// to the page-level Pass switch) that drives BOTH the entrapment "q vs true FDP"
+// calibration card and the always-present yield curve. For the active pass, the two
+// scope views come from bundle.fdpViews (one per scope); yield reads
+// bundle.idYield.targets{Experiment,Run}. The FDP card hides itself when the pass /
+// pool carries no entrapment; the yield card is shown on every run.
+const FDP_SERIES=[{k:"lower",name:"lower-bound FDP",color:COL.ptarget,key:"lowerBound"},
+                  {k:"combined",name:"combined FDP",color:COL.target,key:"combined"},
+                  {k:"paired",name:"paired FDP",color:COL.pdecoy,key:"paired"}];
+const fdpOff={lower:false,combined:false,paired:false};
+let fdrScope=0;   // 0 = experiment-wide, 1 = per-run (shared by the FDP card and yield)
+const fdrScopeKey=()=>fdrScope===0?"experiment":"run";
+const fdrScopeName=()=>fdrScope===0?"experiment-wide":"per-run";
+const opIdx=(f,q)=>Math.max(0,Math.min(lowerB(f.q,q)-1,f.q.length-1));
+
+// Rebuild the FDR tab for the active pass: the shared scope selector, the FDP
+// calibration card (entrapment only), and the yield card (always).
+function renderFdrTab(b){
+  const ssel=document.getElementById("fdrScopeSel");ssel.innerHTML="";
+  [["experiment","experiment-wide"],["run","per-run"]].forEach((sc,k)=>{
+    const btn=H(ssel,"button",{class:"vbtn"+(k===fdrScope?" on":"")},sc[1]);
+    btn.onclick=()=>{if(fdrScope===k)return;fdrScope=k;renderFdrTab(B());};});
+  drawFdpCard(b);
+  drawYield(b);
+}
+
+// The entrapment "q vs true FDP" calibration card for the active pass + scope. Hidden
+// when the pass carries no entrapment views (a plain target+decoy run, or a pass whose
+// reported pool has no entrapment). Its scope card also hides when neither card has an
+// entrapment view AND there is a yield curve -- the scope selector still drives yield.
+function drawFdpCard(b){
+  const card=document.getElementById("fdpCard");
+  const views=b.fdpViews||[];
+  const f=views.find(v=>v.scope===fdrScopeKey())||null;
+  const scopeCard=document.getElementById("fdrScopeCard");
+  if(!f){card.style.display="none";
+    // With no entrapment the exp/run scope no longer changes the FDP card, but it
+    // still switches the yield curve, so keep the selector card visible. Clear the
+    // print block so a pass with no entrapment doesn't inherit the other pass's panels.
+    const pall0=document.getElementById("fdpPrintAll");if(pall0)pall0.innerHTML="";
+    if(scopeCard)scopeCard.style.display="";
+    return;}
+  card.style.display="";if(scopeCard)scopeCard.style.display="";
+  const host=document.getElementById("fdpChart");host.innerHTML="";
+  const series=FDP_SERIES, off=fdpOff;
   function drawPanel(parent,f,xmax,title){
     const W=560,Hh=330,box={l:62,t:28,w:W-80,h:Hh-66};
     const s=svg(W,Hh);parent.appendChild(s);
@@ -721,45 +854,63 @@ if(D.fdpViews && D.fdpViews.length){
       showTip(ev,html);});
     ov.addEventListener("mouseleave",hideTip);
   }
-  function render(){
-    const f=views[vi];host.innerHTML="";
-    const wrap=H(host,"div",{style:"display:flex;gap:14px;flex-wrap:wrap"});
-    const maxq=f.q[f.q.length-1]||1;
-    drawPanel(H(wrap,"div",{}),f,0.02,"zoom  q in [0, 2%]");
-    drawPanel(H(wrap,"div",{}),f,Math.max(0.02,maxq),"full extent");
-    const i1=opIdx(f,0.01);const kp=document.getElementById("fdpKpis");kp.innerHTML="";
-    kpi(kp,"discoveries @1% q",fmt(f.nTargetAccepted[i1],0),"");
-    kpi(kp,"combined FDP @1% q",pct(f.combined[i1],2),cls(f.combined[i1],0.01));
-    if(f.paired)kpi(kp,"paired FDP @1% q",pct(f.paired[i1],2),cls(f.paired[i1],0.01));
-    kpi(kp,"lower-bound @1% q",pct(f.lowerBound[i1],2),"");
-    kpi(kp,"max q",pct(maxq,1),"");
-    document.getElementById("fdpNote").innerHTML=
-      (f.matchesFdrBench
-        ? "<b>Reproduces the FDRBench plot</b> — x is Osprey's <b>experiment-wide precursor</b> q, the exact value <code>--fdrbench</code> hands to FDRBench (which only counts entrapment on it). No FDRBench install needed. "
-        : "<b>Per-run view</b> (new) — x is Osprey's <b>per-run precursor</b> q; FDRBench collapses runs so it can't show this. ")
-      + "The dashed line is y=x (perfect calibration); the curve above it means the reported q is anti-conservative there. Entrapment DB ratio r = "+fmt(f.entrapmentRatio,2)+"."
-      + (f.pairedSuppressedPartial ? " <b>Paired FDP omitted</b> — it is a 1-fold estimator that needs a ~1:1 entrapment library (r near 1); combined and lower-bound remain valid at this ratio (<a href='https://github.com/ProteoWizard/pwiz/blob/master/pwiz_tools/Osprey/docs/fractional-entrapment.md' target='_blank' rel='noopener'>why non-1:1 is valid</a>)." : "");
-  }
-  sel.innerHTML="";
-  views.forEach((v,k)=>{const b=H(sel,"button",{class:"vbtn"+(k===0?" on":"")},v.label+(v.matchesFdrBench?"  (= FDRBench)":""));
-    b.onclick=()=>{vi=k;sel.querySelectorAll("button").forEach(x=>x.classList.remove("on"));b.classList.add("on");render();};});
-  legend(document.getElementById("fdpLegend"),series.filter(se=>views.some(v=>v[se.key])).map(se=>({name:se.name,color:se.color,toggle:o=>{off[se.k]=o;render();}})));
-  render();
-  // Print-only: render ALL views so the PDF captures every FDR plot, not just the
-  // one selected on screen. Reuses drawPanel; a per-view title + 1%-q summary line.
-  const pall=document.getElementById("fdpPrintAll");
-  views.forEach(f=>{
+  // Draw the two panels (zoom + full) for the scope-selected view f.
+  const wrap=H(host,"div",{style:"display:flex;gap:14px;flex-wrap:wrap"});
+  const maxq=f.q[f.q.length-1]||1;
+  drawPanel(H(wrap,"div",{}),f,0.02,"zoom  q in [0, 2%]");
+  drawPanel(H(wrap,"div",{}),f,Math.max(0.02,maxq),"full extent");
+  const i1=opIdx(f,0.01);const kp=document.getElementById("fdpKpis");kp.innerHTML="";
+  kpi(kp,"discoveries @1% q",fmt(f.nTargetAccepted[i1],0),"");
+  kpi(kp,"combined FDP @1% q",pct(f.combined[i1],2),cls(f.combined[i1],0.01));
+  if(f.paired)kpi(kp,"paired FDP @1% q",pct(f.paired[i1],2),cls(f.paired[i1],0.01));
+  kpi(kp,"lower-bound @1% q",pct(f.lowerBound[i1],2),"");
+  kpi(kp,"max q",pct(maxq,1),"");
+  document.getElementById("fdpNote").innerHTML=
+    (f.matchesFdrBench
+      ? "<b>Reproduces the FDRBench plot</b> — x is Osprey's <b>experiment-wide precursor</b> q, the exact value <code>--fdrbench</code> hands to FDRBench (which only counts entrapment on it). No FDRBench install needed. "
+      : "<b>Per-run view</b> — x is Osprey's <b>per-run precursor</b> q; FDRBench collapses runs so it can't show this. ")
+    + "The dashed line is y=x (perfect calibration); the curve above it means the reported q is anti-conservative there. Entrapment DB ratio r = "+fmt(f.entrapmentRatio,2)+"."
+    + (f.pairedSuppressedPartial ? " <b>Paired FDP omitted</b> — it is a 1-fold estimator that needs a ~1:1 entrapment library (r near 1); combined and lower-bound remain valid at this ratio (<a href='https://github.com/ProteoWizard/pwiz/blob/master/pwiz_tools/Osprey/docs/fractional-entrapment.md' target='_blank' rel='noopener'>why non-1:1 is valid</a>)." : "");
+  legend(document.getElementById("fdpLegend"),series.filter(se=>f[se.key]).map(se=>({name:se.name,color:se.color,toggle:o=>{off[se.k]=o;drawFdpCard(B());}})));
+  // Print-only: render BOTH scope views of THIS pass so the PDF captures the full FDR
+  // calibration for the printed pass, not just the on-screen scope. Cleared first so a
+  // pass/scope switch doesn't accumulate stale panels.
+  const pall=document.getElementById("fdpPrintAll");pall.innerHTML="";
+  views.forEach(fv=>{
     const blk=H(pall,"div",{style:"margin-bottom:16px"});
-    H(blk,"h3",{style:"font-size:13px;margin:0 0 3px;font-weight:600"},f.label+(f.matchesFdrBench?"  (= FDRBench)":""));
-    const i1=opIdx(f,0.01);
+    H(blk,"h3",{style:"font-size:13px;margin:0 0 3px;font-weight:600"},fv.label+(fv.matchesFdrBench?"  (= FDRBench)":""));
+    const j1=opIdx(fv,0.01);
     H(blk,"div",{style:"color:var(--muted);font-size:11px;margin-bottom:4px",
-      html:"discoveries @1% q "+fmt(f.nTargetAccepted[i1],0)+" &middot; combined "+pct(f.combined[i1],2)+
-        (f.paired?" &middot; paired "+pct(f.paired[i1],2):"")+" &middot; lower "+pct(f.lowerBound[i1],2)});
+      html:"discoveries @1% q "+fmt(fv.nTargetAccepted[j1],0)+" &middot; combined "+pct(fv.combined[j1],2)+
+        (fv.paired?" &middot; paired "+pct(fv.paired[j1],2):"")+" &middot; lower "+pct(fv.lowerBound[j1],2)});
     const wrap2=H(blk,"div",{style:"display:flex;gap:14px;flex-wrap:wrap"});
-    const maxq=f.q[f.q.length-1]||1;
-    drawPanel(H(wrap2,"div",{}),f,0.02,"zoom  q in [0, 2%]");
-    drawPanel(H(wrap2,"div",{}),f,Math.max(0.02,maxq),"full extent");
+    const mq=fv.q[fv.q.length-1]||1;
+    drawPanel(H(wrap2,"div",{}),fv,0.02,"zoom  q in [0, 2%]");
+    drawPanel(H(wrap2,"div",{}),fv,Math.max(0.02,mq),"full extent");
   });
+}
+
+// The always-present Identification yield curve for the active pass at the FDR tab's
+// exp/run scope. Entrapment-independent (real targets only), so it renders on every run.
+function drawYield(b){
+  const y=b.idYield, card=document.getElementById("yieldCard");
+  if(!y||!y.q){if(card)card.style.display="none";return;}
+  if(card)card.style.display="";
+  const t=(fdrScope===0?y.targetsExperiment:y.targetsRun)||[], name=fdrScopeName();
+  const host=document.getElementById("yieldChart");host.innerHTML="";
+  const W=680,Hh=300,box={l:60,t:14,w:W-78,h:Hh-56};
+  const s=svg(W,Hh);host.appendChild(s);
+  const xmax=0.1, ymax=Math.max(1,...t)*1.08;
+  const sc=axes(s,box,[0,xmax],[0,ymax],{xlab:"reported q-value ("+name+")",ylab:"accepted targets",xfmt:v=>pct(v,0),yfmt:v=>trim(v)});
+  E(s,"line",{x1:sc.x(D.runFdr),y1:box.t,x2:sc.x(D.runFdr),y2:box.t+box.h,stroke:COL.muted,"stroke-dasharray":"2 3",opacity:.7});
+  let path="";y.q.forEach((qq,i)=>{path+=(i?"L":"M")+sc.x(qq).toFixed(1)+" "+sc.y(t[i]).toFixed(1)+" ";});
+  E(s,"path",{d:path,fill:"none",stroke:COL.accent,"stroke-width":2});
+  const ov=E(s,"rect",{x:box.l,y:box.t,width:box.w,height:box.h,fill:"transparent"});
+  ov.addEventListener("mousemove",ev=>{const rb=s.getBoundingClientRect();
+    const q=((ev.clientX-rb.left)/rb.width*W-box.l)/box.w*xmax;
+    let i=Math.min(lowerB(y.q,q),y.q.length-1);if(i<0)i=0;
+    showTip(ev,"<b>q = "+pct(y.q[i],2)+"</b> ("+name+")<br>"+fmt(t[i],0)+" accepted targets");});
+  ov.addEventListener("mouseleave",hideTip);
 }
 function cls(v,q){return v==null?"":(v<=q*1.15?"good":v<=q*1.6?"warn":"bad");}
 // Flag a paired-coin fraction by its distance from a fair 50%, and a real-vs-
@@ -768,40 +919,29 @@ function cls(v,q){return v==null?"":(v<=q*1.15?"good":v<=q*1.6?"warn":"bad");}
 function coinCls(v){v=Number(v);return isNaN(v)?"":(Math.abs(v-0.5)<=0.05?"good":Math.abs(v-0.5)<=0.15?"warn":"bad");}
 function gapCls(g){g=Number(g);return isNaN(g)?"":(g<=0.05?"good":g<=0.15?"warn":"bad");}
 
-// ---------- Reproducibility tab: one per-run / experiment-wide scope drives all 3 plots ----------
+// ========== Reproducibility tab: one exp/run scope drives the cross-run plots ==========
 // scope 0 = experiment-wide (max(run q, exp q), the globally-controlled view; default),
-// 1 = per-run (run q only). Yield reads D.idYield.targets{Experiment,Run}; the two cross-run
-// plots read the matching D.crossRun.{experiment,perRun} CrossRunView.
-(function(){
-  const cr=D.crossRun;
+// 1 = per-run (run q only). Re-sources for the active pass from bundle.crossRun; the
+// exp/run scope (reproScope) is orthogonal to the page-level Pass switch and persists
+// across pass toggles. (Identification yield moved to the FDR-calibration tab.)
+let reproScope=0;
+function renderReproTab(b){
+  const cr=b.crossRun;
   const hasCross=!!(cr && cr.perRun && cr.perRun.perRunCount && cr.perRun.perRunCount.length);
-  const hasYield=!!(D.idYield && D.idYield.q);
-  if(!hasCross && !hasYield)return;
+  const sel0=document.getElementById("reproScopeSel");
+  if(!hasCross){
+    if(sel0)sel0.style.display="none";
+    ["detByRunCard","runHistCard","unionFdpCard"].forEach(id=>{const c=document.getElementById(id);if(c)c.style.display="none";});
+    return;
+  }
+  if(sel0)sel0.style.display="";
+  ["detByRunCard","runHistCard"].forEach(id=>{const c=document.getElementById(id);if(c)c.style.display="";});
   const SCOPES=[{k:"experiment",name:"experiment-wide"},{k:"run",name:"per-run"}];
-  let scope=0;
-  const N=hasCross?cr.perRun.perRunCount.length:0;
+  let scope=reproScope;
+  const N=cr.perRun.perRunCount.length;
   const view=()=>scope===0?cr.experiment:cr.perRun;                       // CrossRunView for current scope
   const detOff={bars:false,union:false,inter:false,half:false};
   const histOff={ent:false};   // entrapment overlay on the run-count histogram
-
-  function drawYield(){
-    if(!hasYield)return;
-    const y=D.idYield, t=(scope===0?y.targetsExperiment:y.targetsRun)||[], name=SCOPES[scope].name;
-    const host=document.getElementById("yieldChart");host.innerHTML="";
-    const W=680,Hh=300,box={l:60,t:14,w:W-78,h:Hh-56};
-    const s=svg(W,Hh);host.appendChild(s);
-    const xmax=0.1, ymax=Math.max(1,...t)*1.08;
-    const sc=axes(s,box,[0,xmax],[0,ymax],{xlab:"reported q-value ("+name+")",ylab:"accepted targets",xfmt:v=>pct(v,0),yfmt:v=>trim(v)});
-    E(s,"line",{x1:sc.x(D.runFdr),y1:box.t,x2:sc.x(D.runFdr),y2:box.t+box.h,stroke:COL.muted,"stroke-dasharray":"2 3",opacity:.7});
-    let path="";y.q.forEach((qq,i)=>{path+=(i?"L":"M")+sc.x(qq).toFixed(1)+" "+sc.y(t[i]).toFixed(1)+" ";});
-    E(s,"path",{d:path,fill:"none",stroke:COL.accent,"stroke-width":2});
-    const ov=E(s,"rect",{x:box.l,y:box.t,width:box.w,height:box.h,fill:"transparent"});
-    ov.addEventListener("mousemove",ev=>{const rb=s.getBoundingClientRect();
-      const q=((ev.clientX-rb.left)/rb.width*W-box.l)/box.w*xmax;
-      let i=Math.min(lowerB(y.q,q),y.q.length-1);if(i<0)i=0;
-      showTip(ev,"<b>q = "+pct(y.q[i],2)+"</b> ("+name+")<br>"+fmt(t[i],0)+" accepted targets");});
-    ov.addEventListener("mouseleave",hideTip);
-  }
 
   function drawDet(){
     if(!hasCross)return;
@@ -962,8 +1102,8 @@ function gapCls(g){g=Number(g);return isNaN(g)?"":(g<=0.05?"good":g<=0.15?"warn"
         : "The two track closely here; the gap is expected to widen at higher run counts.");
   }
 
-  function renderRepro(){drawYield();drawDet();drawHist();}
-  if(hasCross)legend(document.getElementById("detLegend"),[
+  function renderRepro(){drawDet();drawHist();}
+  legend(document.getElementById("detLegend"),[
     {name:"detected / run",color:COL.target,toggle:o=>{detOff.bars=o;drawDet();}},
     {name:"cumulative union",color:COL.pdecoy,line:true,toggle:o=>{detOff.union=o;drawDet();}},
     {name:"cumulative intersection",color:COL.ink,line:true,toggle:o=>{detOff.inter=o;drawDet();}},
@@ -971,26 +1111,40 @@ function gapCls(g){g=Number(g);return isNaN(g)?"":(g<=0.05?"good":g<=0.15?"warn"
   ]);
   // Run-count histogram legend, only when the entrapment overlay exists (both scopes
   // carry the entrapment arrays when a manifest is present).
-  if(hasCross && cr.experiment && cr.experiment.entrapmentRunCountHistogram)
+  if(cr.experiment && cr.experiment.entrapmentRunCountHistogram)
     legend(document.getElementById("runHistLegend"),[
       {name:"real targets",color:COL.target},
       {name:"entrapment FDP (right axis)",color:COL.warn,line:true,toggle:o=>{histOff.ent=o;drawHist();}},
     ]);
-  if(hasCross && cr.perRun && cr.perRun.unionFdp && N>=2)
+  else legend(document.getElementById("runHistLegend"),[]);
+  if(cr.perRun && cr.perRun.unionFdp && N>=2)
     legend(document.getElementById("unionFdpLegend"),[
       {name:"per-run union FDP",color:COL.decoy,line:true},
       {name:"experiment-wide union FDP",color:COL.accent,line:true},
     ]);
   const sel=document.getElementById("reproScopeSel");sel.innerHTML="";
-  SCOPES.forEach((sco,k)=>{const b=H(sel,"button",{class:k===scope?"on":""},sco.name);
-    b.onclick=()=>{scope=k;sel.querySelectorAll("button").forEach(x=>x.classList.remove("on"));b.classList.add("on");renderRepro();};});
+  SCOPES.forEach((sco,k)=>{const btn=H(sel,"button",{class:k===scope?"on":""},sco.name);
+    btn.onclick=()=>{scope=k;reproScope=k;sel.querySelectorAll("button").forEach(x=>x.classList.remove("on"));btn.classList.add("on");renderRepro();};});
   renderRepro();
   drawUnionFdp();   // scope-independent (shows both curves); drawn once
-})();
+}
 
-// ---------- competition: win fraction ----------
-if(D.winFraction && D.winFraction.binCenters){
-  const w=D.winFraction;const W=680,Hh=340,box={l:52,t:14,w:W-70,h:Hh-58};
+// ========== Competition tab: paired decoy-win fraction ==========
+// Structural card (built from the pass's reported-pool scores). Under Pass 2
+// confidence-transfer (no retrained model) it degrades to an n/a note.
+function renderCompetitionTab(b){
+  if(!b.hasStructural){
+    naChart("wfChart","wfLegend",PASS2_NA_COMPETITION);
+    document.getElementById("wfKpis").innerHTML="";document.getElementById("wfNote").innerHTML="";
+    return;
+  }
+  const w=b.winFraction;
+  if(!w||!w.binCenters){
+    naChart("wfChart","wfLegend","No competition data on this pass.");
+    document.getElementById("wfKpis").innerHTML="";document.getElementById("wfNote").innerHTML="";
+    return;
+  }
+  const W=680,Hh=340,box={l:52,t:14,w:W-70,h:Hh-58};
   const host=document.getElementById("wfChart");
   const xd=[w.binCenters[0],w.binCenters[w.binCenters.length-1]];
   const off={real:false,ent:false};
@@ -1036,13 +1190,18 @@ if(D.winFraction && D.winFraction.binCenters){
       : "Without an entrapment library this is confounded by true positives, but a real coin well below 50% in the null band is still suspect.");
 }
 
-// ---------- summary ----------
+// ---------- summary: population KPIs (pass-independent, not q-gated) ----------
 (function(){const k=document.getElementById("sumKpis");
   kpi(k,"targets (best/prec)",fmt(D.nTarget,0),"");
   kpi(k,"decoys",fmt(D.nDecoy,0),"");
   if(D.hasEntrapment){kpi(k,"entrapment",fmt(D.npTarget,0),"");}
   kpi(k,"features",fmt(D.featureCount,0),"");
-  const rows=D.perFile||[];const host=document.getElementById("fileTable");
+})();
+
+// Per-file passing precursors for the active pass -- the only q-gated Summary element,
+// so it re-sources with the pass switch (the KPIs above do not).
+function renderPerFile(b){
+  const rows=b.perFile||[];const host=document.getElementById("fileTable");host.innerHTML="";
   const t=H(host,"table",{});const htr=H(H(t,"thead",{}),"tr",{});
   const cols=[["File","l"],["Targets",""]];
   if(D.hasEntrapment)cols.push(["Entrapment",""]);
@@ -1053,10 +1212,16 @@ if(D.winFraction && D.winFraction.binCenters){
     H(tr,"td",{class:"num"},fmt(r.targets,0));
     if(D.hasEntrapment)H(tr,"td",{class:"num"},fmt(r.entrapment,0));
     H(tr,"td",{class:"num"},fmt(r.decoys,0));});
-})();
+  const fd=document.getElementById("fileDesc");
+  if(fd)fd.innerHTML="Precursors passing the run-level FDR, per input file"+
+    (PASSES.length>1?" &mdash; <b>"+b.label+"</b> ("+(b.pass===2?"final reported pool":"pre-compaction first-pass pool")+").":".");
+}
 
 function kpi(host,label,val,c){const d=H(host,"div",{class:"kpi"});H(d,"div",{class:"v "+(c||"")},val);H(d,"div",{class:"k"},label);}
 function lowerB(a,v){let lo=0,hi=a.length;while(lo<hi){const m=(lo+hi)>>1;if(a[m]<v)lo=m+1;else hi=m;}return lo;}
+
+// Initial render of every pass-dependent card for the default pass (Pass 1).
+renderPass();
 
 // Print / Save-as-PDF: the @media print stylesheet stacks every tab, forces the
 // light palette, expands the feature table, and swaps the single interactive FDR

--- a/pwiz_tools/Osprey/Osprey.Tasks/ModelDiagnostics/model-diagnostics-template.html
+++ b/pwiz_tools/Osprey/Osprey.Tasks/ModelDiagnostics/model-diagnostics-template.html
@@ -140,7 +140,7 @@ code{font-family:ui-monospace,Menlo,Consolas,monospace;background:var(--grid);pa
   html,body{background:#fff}
   *{-webkit-print-color-adjust:exact!important;print-color-adjust:exact!important}
   .wrap{max-width:none;padding:0 4px}
-  nav,.printbtn,.tip,.vbtns,.passsel,#scoreBack,.iconbtn{display:none!important}
+  .navbar,nav,.printbtn,.tip,.vbtns,.passsel,#scoreBack,.iconbtn{display:none!important}
   header{page-break-after:avoid}
   .tab{display:block!important;page-break-before:always;break-before:page}
   .tab:first-of-type{page-break-before:avoid;break-before:avoid}

--- a/pwiz_tools/Osprey/Osprey.Test/ModelDiagnosticsDataTest.cs
+++ b/pwiz_tools/Osprey/Osprey.Test/ModelDiagnosticsDataTest.cs
@@ -569,7 +569,10 @@ namespace pwiz.Osprey.Test
             Assert.IsNotNull(noEnt.CrossRun);
             Assert.AreEqual(1, noEnt.PerFile[0].Targets);
 
-            // --- The Pass2 bundle survives the sidecar Newtonsoft round-trip with pass 1.
+            // --- The Pass2 bundle survives a Newtonsoft round-trip (camelCase +
+            // NaN-as-literal) -- the same serialization robustness the HTML embed relies
+            // on. (Pass2 itself is built at MergeNode and serialized only into the HTML,
+            // never through the FirstJoin->MergeNode data sidecar, which carries pass 1.)
             var data = ModelDiagnosticsData.Build(Wrap(entries), null, cls, null, 1.0, 0.01, FdrLevel.Peptide);
             data.Pass2 = retrain;
             var settings = new JsonSerializerSettings

--- a/pwiz_tools/Osprey/Osprey.Test/ModelDiagnosticsDataTest.cs
+++ b/pwiz_tools/Osprey/Osprey.Test/ModelDiagnosticsDataTest.cs
@@ -51,6 +51,7 @@ namespace pwiz.Osprey.Test
             TestFeatureTableContributions();
             TestBaseIdClassificationAndInvalidDrop();
             TestPass2FdpViews();
+            TestBuildPass2();
             TestSidecarRoundTrip();
             TestFeatureHistograms();
             TestModelPass2();
@@ -493,6 +494,96 @@ namespace pwiz.Osprey.Test
                 Wrap(new List<FdrEntry> { Entry(1, false, 5, 0.001, "T", 2) }),
                 new Dictionary<uint, EntrapmentClass> { { 1u, EntrapmentClass.Target } }, null, 1.0);
             Assert.AreEqual(0, noEntrap.Count);
+        }
+
+        // The complete pass-2 bundle (BuildPass2) behind the report's top-level Pass 1
+        // / Pass 2 switch: every pass-dependent card recomputed on the reported pool.
+        // The STRUCTURAL half (Model / DensityRatio / WinFraction) is present only when
+        // the second pass RETRAINED (contributions non-null); under confidence-transfer
+        // (contributions null) it degrades to null while the Q-DRIVEN half (FdpViews /
+        // IdYield / CrossRun / PerFile) still builds. FdpViews is empty without an
+        // entrapment pool. The bundle survives the sidecar round-trip alongside pass 1.
+        private static void TestBuildPass2()
+        {
+            // A reported pool with entrapment: 8 real targets (+ their decoys, so the
+            // structural density / win-fraction have both sides) and 2 entrapment.
+            var entries = new List<FdrEntry>();
+            var cls = new Dictionary<uint, EntrapmentClass>();
+            for (int i = 0; i < 8; i++)
+            {
+                entries.Add(Entry((uint)(100 + i), false, 8 - i, 0.001 * (i + 1), "T" + i, 2));
+                entries.Add(Entry((uint)(100 + i) | DECOY_BIT, true, 1.0 + 0.1 * i, 0.5, "D" + i, 2));
+                cls[(uint)(100 + i)] = EntrapmentClass.Target;
+            }
+            AddEntrap(entries, cls, 200, 5.5, 0.003, "P0");
+            AddEntrap(entries, cls, 201, 1.5, 0.005, "P1");
+
+            // Retrain contributions (same 2-feature shape as TestModelPass2).
+            var infos = new[]
+            {
+                new OspreyFeatureInfo("f0", "Feature Zero", false),
+                new OspreyFeatureInfo("f1", "Feature One", false),
+            };
+            var acc = new FeatureContributions.Accumulator(2, true);
+            for (int i = 0; i < 10; i++) acc.Add(new[] { 2.0, 0.5 }, false);
+            for (int i = 0; i < 10; i++) acc.Add(new[] { -1.0, 0.0 }, true);
+            var contrib = acc.Build(new List<double[]> { new[] { 2.0, -1.0 } }, infos);
+
+            // --- Retrain path: structural AND q-driven halves both present.
+            var retrain = ModelDiagnosticsData.BuildPass2(
+                Wrap(entries), contrib, cls, null, 1.0, 0.01, FdrLevel.Peptide);
+            Assert.IsNotNull(retrain.Model);                    // retrained -> structural present
+            Assert.IsNotNull(retrain.Model.Scores);
+            Assert.IsNotNull(retrain.DensityRatio);
+            Assert.IsNotNull(retrain.WinFraction);
+            Assert.IsNotNull(retrain.IdYield);                  // q-driven
+            Assert.IsNotNull(retrain.CrossRun);
+            Assert.AreEqual(1, retrain.PerFile.Count);
+            Assert.AreEqual(2, retrain.FdpViews.Count);         // experiment + per-run
+            Assert.IsTrue(retrain.FdpViews.All(v => v.Pass == 2));
+
+            // --- Transfer path: contributions null -> structural half degrades to null,
+            // q-driven half (which needs only the transferred q) still builds.
+            var transfer = ModelDiagnosticsData.BuildPass2(
+                Wrap(entries), null, cls, null, 1.0, 0.01, FdrLevel.Peptide);
+            Assert.IsNull(transfer.Model);                      // no retrain -> structural n/a
+            Assert.IsNull(transfer.DensityRatio);
+            Assert.IsNull(transfer.WinFraction);
+            Assert.IsNotNull(transfer.IdYield);
+            Assert.IsNotNull(transfer.CrossRun);
+            Assert.AreEqual(2, transfer.FdpViews.Count);        // entrapment pool -> FDP views exist
+            // The mode changes only the structural half: the q-driven half is identical.
+            Assert.AreEqual(retrain.PerFile[0].Targets, transfer.PerFile[0].Targets);
+
+            // --- No entrapment: FdpViews empty, entrapment-free q-driven cards remain.
+            var plain = new List<FdrEntry>
+            {
+                Entry(1, false, 5, 0.001, "A", 2),
+                Entry(1 | DECOY_BIT, true, 1, 0.5, "DA", 2),
+            };
+            var noEnt = ModelDiagnosticsData.BuildPass2(Wrap(plain), null,
+                new Dictionary<uint, EntrapmentClass> { { 1u, EntrapmentClass.Target } },
+                null, 1.0, 0.01, FdrLevel.Peptide);
+            Assert.AreEqual(0, noEnt.FdpViews.Count);
+            Assert.IsNotNull(noEnt.IdYield);
+            Assert.IsNotNull(noEnt.CrossRun);
+            Assert.AreEqual(1, noEnt.PerFile[0].Targets);
+
+            // --- The Pass2 bundle survives the sidecar Newtonsoft round-trip with pass 1.
+            var data = ModelDiagnosticsData.Build(Wrap(entries), null, cls, null, 1.0, 0.01, FdrLevel.Peptide);
+            data.Pass2 = retrain;
+            var settings = new JsonSerializerSettings
+            {
+                ContractResolver = new CamelCasePropertyNamesContractResolver(),
+                FloatFormatHandling = FloatFormatHandling.Symbol,
+                FloatParseHandling = FloatParseHandling.Double,
+            };
+            var back = JsonConvert.DeserializeObject<ModelDiagnosticsData>(
+                JsonConvert.SerializeObject(data, settings), settings);
+            Assert.IsNotNull(back.Pass2);
+            Assert.IsNotNull(back.Pass2.Model);
+            Assert.AreEqual(retrain.FdpViews.Count, back.Pass2.FdpViews.Count);
+            Assert.AreEqual(retrain.Model.Features.Count, back.Pass2.Model.Features.Count);
         }
 
         // The pass-1 data model must survive a Newtonsoft round-trip (camelCase +


### PR DESCRIPTION
## Summary

* Added a page-level Pass 1 / Pass 2 switch to the `--model-diagnostics` report; one global mode re-sources every pass-dependent plot and table at once.
* Grouped all pass-2 diagnostics into a `Pass2Data` bundle computed by `BuildPass2` on the reported (post-compaction) pool: a structural half (model / composite scores / density / win-fraction, null under confidence-transfer 2nd passes) and a q-driven half (FDR calibration / yield / cross-run / per-file, always present).
* Structural cards (Model / Density / Competition) degrade to an "n/a for this pass" note under transfer mode while the q-driven cards keep rendering.
* Moved Identification yield onto the FDR-calibration tab under a shared experiment-wide / per-run scope selector (orthogonal to the pass switch); reorganized the Reproducibility tab to lead with detections-by-run.

## Test plan

- [x] TestModelDiagnosticsData - extended with a BuildPass2 case (retrain / transfer / no-entrapment / sidecar round-trip); full Osprey.Test suite 502 passed / 3 skipped
- [x] Osprey code inspection clean for changed files
- [x] regression.ps1 -Dataset Stellar - PASS (byte-identical vs golden, HPC==straight, resume==straight; report is off the golden path)
- [x] Real end-to-end render - re-ran Stages 5-7 of the 20-file SEA-AD r0.5 run; confirmed the pass switch re-sources every tab (incl. Reproducibility / Competition / Summary) on real data

Co-Authored-By: Claude <noreply@anthropic.com>