### PR TITLE
Consolidated the Osprey intensity conditioning and labeled the logged features

### DIFF
--- a/pwiz_tools/Osprey/Osprey.Scoring/PeakShapeCalculators.cs
+++ b/pwiz_tools/Osprey/Osprey.Scoring/PeakShapeCalculators.cs
@@ -106,53 +106,89 @@ namespace pwiz.Osprey.Scoring
             reference.Valid = true;
             return reference;
         }
+
+        /// <summary>
+        /// Conditions a heavy-tailed intensity-magnitude PIN feature:
+        /// <c>log10(max(x, 0) + 1)</c>. Shared by the three peak-shape features so the
+        /// transform lives in exactly one place on this side, mirroring Rust's
+        /// <c>condition_intensity_feature</c> (osprey pipeline.rs) for cross-impl parity.
+        ///
+        /// Raw peak intensity is heavy-tailed across four orders of magnitude, so the
+        /// single experiment-wide Percolator standardizer maps a lone high-intensity DIA
+        /// interference to a z-score of 100-300 that dominates the linear discriminant and
+        /// lets intensity outliers hijack the top of the ranking. log10 compresses the tail
+        /// and is monotonic, so ranking within the feature is preserved. A linear SVM cannot
+        /// learn a saturating transform on its own, so it must be applied in the feature.
+        /// Matches Skyline mProphet's <c>MQuestIntensityCalc</c>.
+        ///
+        /// The floor applies to the INPUT, not the result: <c>Math.Log10</c> of a negative
+        /// argument is NaN and <c>Math.Max(0, NaN)</c> is NaN, so flooring afterwards would
+        /// not save it. Flooring first keeps the argument &gt;= 1, so the value is always
+        /// finite and &gt;= 0. Only <see cref="PeakSharpnessCalc"/> can actually go negative
+        /// (its apex is the override/CWT lookup, not the recomputed reference-XIC max);
+        /// apex and area are &gt;= 0 by construction because XIC intensities are raw --
+        /// never smoothed, and never background-subtracted (the background subtraction in
+        /// <c>PeakDetector.ComputeSnr</c> works on a scalar and never rewrites the array).
+        /// For them the floor is the identity, so the value stays bit-identical to the
+        /// un-floored <c>log10(x + 1)</c>; it enforces an invariant that was previously
+        /// only assumed, and a NaN in a PIN feature would silently poison the SVM rather
+        /// than fail loudly.
+        ///
+        /// NaN CROSS-IMPL CAVEAT: on a NaN input the two implementations DISAGREE.
+        /// <c>Math.Max</c> propagates NaN, so this returns NaN; Rust's <c>f64::max</c>
+        /// ignores NaN, so <c>condition_intensity_feature</c> returns 0.0 there. No NaN can
+        /// reach either side today (XIC intensities are finite and the slope divisors are
+        /// guarded at <c>dt &gt; 1e-10</c>), but if one ever does, fix the source of the
+        /// NaN -- do not "harmonize" by dropping the floor.
+        /// </summary>
+        public static double ConditionIntensityFeature(double value)
+        {
+            return Math.Log10(Math.Max(value, 0.0) + 1.0);
+        }
     }
 
     /// <summary>
-    /// peak_apex: log10 of the reference-XIC intensity at the (clamped) peak apex
-    /// index. The apex intensity is a direct lookup of the override/CWT-supplied
-    /// apex -- NOT a recomputed local max over [start, end] (Rust pipeline.rs:6547
-    /// uses peak.apex_intensity). Rationale for the <c>log10(x + 1)</c> conditioning:
-    /// raw peak intensity is heavy-tailed across four orders of magnitude, so the
-    /// single experiment-wide Percolator standardizer maps a lone high-intensity DIA
-    /// interference to a z-score of 100-300 that dominates the linear discriminant
-    /// and lets intensity outliers (a random mix of target / decoy / entrapment)
-    /// hijack the top of the ranking. Log conditioning compresses the tail so the
-    /// standardized value stays in a sane range, matching Skyline mProphet's
-    /// <c>MQuestIntensityCalc</c> (which returns <c>Math.Max(0, Math.Log10(area))</c>).
-    /// A linear SVM cannot learn this transform on its own, so it must be applied in
-    /// the feature. Applied identically in Rust to preserve cross-impl parity.
+    /// peak_apex: the reference-XIC intensity at the (clamped) peak apex index, log-
+    /// conditioned by <see cref="PeakShapeReference.ConditionIntensityFeature"/> (see
+    /// there for why the PIN feature is logged). The apex intensity is a direct lookup
+    /// of the override/CWT-supplied apex -- NOT a recomputed local max over
+    /// [start, end] (Rust pipeline.rs uses peak.apex_intensity).
     /// </summary>
     internal sealed class PeakApexCalc : DetailedOspreyFeatureCalculator
     {
         public override string Name { get { return "peak_apex"; } }
 
-        public override string DisplayName { get { return "Peak apex intensity"; } }
+        // The value is log10-conditioned, so a model weight on it reads per DECADE of
+        // intensity, not per intensity unit. The label says so, because the feature-
+        // contribution report shows these weights side by side with linear features.
+        public override string DisplayName { get { return "Peak apex intensity (log10)"; } }
 
         public override bool IsReversedScore { get { return false; } }   // higher is better
 
         protected override double Calculate(OspreyScoringContext context, IOspreyDetailedPeakData peakData)
         {
             var reference = PeakShapeReference.GetOrCompute(context, peakData);
-            // log10(x + 1): x >= 0, maps 0 -> 0 (keeps the invalid-peak sentinel).
-            return reference.Valid ? Math.Log10(reference.ApexValue + 1.0) : 0.0;
+            return reference.Valid
+                ? PeakShapeReference.ConditionIntensityFeature(reference.ApexValue)
+                : 0.0;
         }
     }
 
     /// <summary>
-    /// peak_area: log10 of the trapezoidal integration of the reference XIC over
-    /// [start, end). The raw area is <c>trapezoidal_area(ref_xic[si..=ei])</c>,
-    /// accumulated strictly left-to-right (f64 addition is non-associative). The
-    /// <c>log10(x + 1)</c> conditioning (applied identically in Rust for parity) is
-    /// for the same heavy-tailed-intensity reason as <see cref="PeakApexCalc"/> (this
-    /// is a PIN feature for the experiment-wide Percolator model only; it does not
-    /// feed quantification, which uses <c>bounds_area</c>).
+    /// peak_area: trapezoidal integration of the reference XIC over [start, end),
+    /// log-conditioned by <see cref="PeakShapeReference.ConditionIntensityFeature"/>.
+    /// The raw area is <c>trapezoidal_area(ref_xic[si..=ei])</c>, accumulated strictly
+    /// left-to-right (f64 addition is non-associative). This is a PIN feature for the
+    /// experiment-wide Percolator model only; it does NOT feed quantification, which
+    /// uses <c>bounds_area</c> and stays raw.
     /// </summary>
     internal sealed class PeakAreaCalc : DetailedOspreyFeatureCalculator
     {
         public override string Name { get { return "peak_area"; } }
 
-        public override string DisplayName { get { return "Peak area"; } }
+        // Log10-conditioned; see PeakApexCalc.DisplayName. Deliberately NOT the same
+        // quantity as the raw "Peak area" used for quantification (bounds_area).
+        public override string DisplayName { get { return "Peak area (log10)"; } }
 
         public override bool IsReversedScore { get { return false; } }   // higher is better
 
@@ -171,49 +207,44 @@ namespace pwiz.Osprey.Scoring
                 double avgHeight = (refInten[i] + refInten[i + 1]) * 0.5;
                 area += avgHeight * dt;
             }
-            return Math.Log10(area + 1.0);   // see PeakApexCalc: condition the heavy intensity tail
+            return PeakShapeReference.ConditionIntensityFeature(area);
         }
     }
 
     /// <summary>
-    /// peak_sharpness: log10 of the mean of the left and right slopes on the
-    /// reference XIC, using the same apex position as peak_apex. The raw mean slope
-    /// follows Rust pipeline.rs:5212-5234 (edge guards strict, dt threshold strict
-    /// &gt; 1e-10); the <c>log10(x + 1)</c> conditioning is applied identically in
-    /// Rust for parity.
+    /// peak_sharpness: the mean of the left and right slopes on the reference XIC,
+    /// using the same apex position as peak_apex, log-conditioned by
+    /// <see cref="PeakShapeReference.ConditionIntensityFeature"/>. The raw mean slope
+    /// follows Rust pipeline.rs (edge guards strict, dt threshold strict &gt; 1e-10).
     ///
-    /// Why log this one too (it needs more justification than apex/area, which are
-    /// intensities by definition): the slopes are computed at LINEAR scale from the
-    /// raw XIC intensities -- <c>(apexIntensity - edgeIntensity) / dt</c> -- so the
-    /// peak-curve shape assessment is unchanged and linear. But the RESULT is an
-    /// ABSOLUTE slope (intensity per minute), which scales ~linearly with peak
-    /// intensity: a 2x more intense peak of the same shape has ~2x steeper slopes.
-    /// So as defined this is an intensity-MAGNITUDE feature, not a scale-free shape
-    /// descriptor -- it carries the same heavy tail as apex/area and demonstrably
-    /// participated in the same intensity hijack (a lone high-intensity DIA
-    /// interference standardized to z ~= 190 on this feature). log10 conditions only
-    /// the final magnitude for the single experiment-wide standardizer (monotonic, so
-    /// a sharper peak still ranks above a broader one at equal intensity); leaving it
-    /// linear would keep the heavy tail and re-introduce part of the hijack. A truly
-    /// scale-free shape sharpness would instead normalize the slope by the apex
-    /// (<c>slope / apex</c>) and stay linear -- a separate feature redesign, tracked
-    /// as a follow-up TODO, not this change. Note the apex here is the
-    /// override/CWT-supplied apex (see <see cref="PeakApexCalc"/>), NOT a recomputed
-    /// local max over the reference XIC, so a supplied apex that sits below a
-    /// reference-XIC edge yields a negative edge slope and the mean sharpness can be
-    /// negative. The value is therefore floored at 0 BEFORE the log
-    /// (<c>log10(max(s, 0) + 1)</c>): flooring the input keeps the log argument &gt;= 1
-    /// so the feature is always finite and &gt;= 0, and a negative-sharpness peak (apex
-    /// below its edges -- a degenerate shape) collapses to 0. Flooring the RESULT
-    /// instead (<c>max(0, log10(s + 1))</c>) would NOT work: <c>log10</c> of a
-    /// non-positive number is NaN and <c>Math.Max(0, NaN)</c> is NaN. Applied
-    /// identically in Rust for parity.
+    /// Why an intensity conditioning is right for what sounds like a SHAPE feature:
+    /// the slopes are computed at linear scale from the raw XIC intensities --
+    /// <c>(apexIntensity - edgeIntensity) / dt</c> -- but the RESULT is an ABSOLUTE
+    /// slope (intensity per minute), which scales ~linearly with peak intensity: a 2x
+    /// more intense peak of the same shape has ~2x steeper slopes. So as defined this
+    /// is an intensity-MAGNITUDE feature, not a scale-free shape descriptor. It carries
+    /// the same heavy tail as apex/area and demonstrably participated in the same
+    /// intensity hijack (a lone high-intensity DIA interference standardized to
+    /// z ~= 190 on this feature). The log is monotonic, so a sharper peak still ranks
+    /// above a broader one at equal intensity.
+    ///
+    /// A truly scale-free sharpness would normalize the slope by the apex
+    /// (<c>slope / apex</c>) and stay linear. That is a feature redesign, not a
+    /// conditioning change: see ai/todos/backlog/TODO-osprey_scale_free_sharpness.md.
+    ///
+    /// This is the ONE peak-shape feature whose raw value can genuinely be negative:
+    /// the apex is the override/CWT-supplied apex (see <see cref="PeakApexCalc"/>), NOT
+    /// a recomputed local max over the reference XIC, so a supplied apex sitting below
+    /// a reference-XIC edge yields a negative edge slope. Such a peak (apex below its
+    /// own edges -- a degenerate shape) collapses to 0 rather than producing a
+    /// non-finite feature.
     /// </summary>
     internal sealed class PeakSharpnessCalc : DetailedOspreyFeatureCalculator
     {
         public override string Name { get { return "peak_sharpness"; } }
 
-        public override string DisplayName { get { return "Peak sharpness"; } }
+        // Log10-conditioned; see PeakApexCalc.DisplayName.
+        public override string DisplayName { get { return "Peak sharpness (log10)"; } }
 
         public override bool IsReversedScore { get { return false; } }   // higher is better
 
@@ -243,13 +274,10 @@ namespace pwiz.Osprey.Scoring
                     rightSlope = (apexVal - refInten[reference.End]) / dt;
             }
             double sharpness = (leftSlope + rightSlope) * 0.5;
-            // Floor the sharpness at 0 BEFORE the log (see class doc): the apex is a
-            // CWT/override lookup, not the recomputed XIC max, so the mean slope can be
-            // negative, and log10(sharpness + 1) is non-finite for sharpness <= -1.
-            // Flooring the INPUT (not the result -- Math.Max(0, log10(neg)) is still NaN)
-            // guarantees the argument is >= 1, so the value is always finite and >= 0,
-            // matching Skyline's Math.Max(0, Math.Log10(area)) intent.
-            return Math.Log10(Math.Max(sharpness, 0.0) + 1.0);
+            // This is the one peak-shape feature whose raw value can be negative, so the
+            // helper's input floor is load-bearing here rather than a no-op. See
+            // PeakShapeReference.ConditionIntensityFeature.
+            return PeakShapeReference.ConditionIntensityFeature(sharpness);
         }
     }
 }

--- a/pwiz_tools/Osprey/Osprey.Scoring/PeakShapeCalculators.cs
+++ b/pwiz_tools/Osprey/Osprey.Scoring/PeakShapeCalculators.cs
@@ -230,7 +230,9 @@ namespace pwiz.Osprey.Scoring
     ///
     /// A truly scale-free sharpness would normalize the slope by the apex
     /// (<c>slope / apex</c>) and stay linear. That is a feature redesign, not a
-    /// conditioning change: see ai/todos/backlog/TODO-osprey_scale_free_sharpness.md.
+    /// conditioning change, and it moves the discovery set, so it needs its own
+    /// entrapment validation. It is tracked in the team's sibling pwiz-ai repo (NOT in
+    /// this one) at todos/backlog/brendanx67/TODO-osprey_scale_free_sharpness.md.
     ///
     /// This is the ONE peak-shape feature whose raw value can genuinely be negative:
     /// the apex is the override/CWT-supplied apex (see <see cref="PeakApexCalc"/>), NOT

--- a/pwiz_tools/Osprey/Osprey.Test/DiagnosticsTest.cs
+++ b/pwiz_tools/Osprey/Osprey.Test/DiagnosticsTest.cs
@@ -84,8 +84,13 @@ namespace pwiz.Osprey.Test
         [TestMethod]
         public void TestFormatF64RoundtripMatchesRustOnRealStdsValue()
         {
-            // Real Stellar Stage 5 peak_sharpness std value; Rust's ryu
-            // emits this as "6354533.401694356" (16 sig digits). On .NET
+            // A wide-magnitude f64 with a 16-significant-digit shortest form. It was
+            // captured from a real Stellar Stage 5 peak_sharpness std back when that
+            // feature was raw intensity/minute; peak_sharpness is log10-conditioned now,
+            // so a value this large can no longer arise from it. The constant is kept
+            // as-is anyway -- this test is about ryu-vs-"R" formatting, and the bit
+            // pattern is what makes it a good probe. Rust's ryu emits this as
+            // "6354533.401694356" (16 sig digits). On .NET
             // Core 3+, ToString("R") matches byte-for-byte. On .NET
             // Framework 4.7.2, "R" falls back to G17 (17 digits) because
             // of the long-standing "R" bug. We only require round-trip

--- a/pwiz_tools/Osprey/Osprey.Test/OspreyFeatureCalculatorsTest.cs
+++ b/pwiz_tools/Osprey/Osprey.Test/OspreyFeatureCalculatorsTest.cs
@@ -105,6 +105,26 @@ namespace pwiz.Osprey.Test
                 new List<XicData> { new XicData(0, rts, invFrag) }, bounds);
             context.ClearByproducts();
             Assert.AreEqual(0.0, OspreyFeatureCalculators.Get(5).Calculate(context, invPeak), TOLERANCE);
+
+            // An all-zero XIC is a VALID peak (the reference exists) whose three features
+            // all condition to exactly 0.0 -- log10(0 + 1) -- which is the same value the
+            // invalid-peak sentinel above produces. That collision is intended: "no signal"
+            // and "no peak" are the same thing to the SVM. Pinned here so a future change to
+            // the sentinel (or to the +1 offset) has to face the question deliberately.
+            var zeroFrag = new double[10];
+            var zeroPeak = new FakePeakData(
+                new List<XicData> { new XicData(0, rts, zeroFrag) }, bounds);
+            context.ClearByproducts();
+            Assert.AreEqual(0.0, OspreyFeatureCalculators.Get(3).Calculate(context, zeroPeak), TOLERANCE);
+            Assert.AreEqual(0.0, OspreyFeatureCalculators.Get(4).Calculate(context, zeroPeak), TOLERANCE);
+            Assert.AreEqual(0.0, OspreyFeatureCalculators.Get(5).Calculate(context, zeroPeak), TOLERANCE);
+
+            // The three log-conditioned features carry "(log10)" in their display label, so
+            // the feature-contribution report cannot present a per-decade weight as though
+            // it were per intensity unit.
+            Assert.AreEqual("Peak apex intensity (log10)", OspreyFeatureCalculators.Get(3).DisplayName);
+            Assert.AreEqual("Peak area (log10)", OspreyFeatureCalculators.Get(4).DisplayName);
+            Assert.AreEqual("Peak sharpness (log10)", OspreyFeatureCalculators.Get(5).DisplayName);
         }
 
         /// <summary>

--- a/pwiz_tools/Osprey/osprey-regression.data/README.md
+++ b/pwiz_tools/Osprey/osprey-regression.data/README.md
@@ -1,0 +1,45 @@
+# Osprey regression golden data
+
+Committed golden output for the self-contained C# regression gate:
+
+```
+pwsh -File ./pwiz_tools/Osprey/regression.ps1 -Dataset Stellar   # or -Dataset All
+```
+
+`blib_summary.tsv` is the per-dataset digest (row counts and per-column
+sum / min / max); `tables/*.tsv` are the full table dumps. The gate compares a
+fresh run against these at 1e-9. A diff here means output moved -- which is
+sometimes a bug and sometimes the point of the change. Re-bless deliberately, and
+say why in the PR.
+
+## 2026-07: Stellar lost ~10% of its IDs on purpose
+
+The intensity log-conditioning change (pwiz#4412, maccoss/osprey#53) re-blessed
+both goldens, and they moved in OPPOSITE directions:
+
+| Dataset | RefSpectra (IDs) | Proteins |
+|---------|------------------|----------|
+| Astral  | 160,358 -> 165,500 (+3.2%) | 13,989 -> 14,201 (+1.5%) |
+| Stellar | 57,112 -> **51,444 (-9.9%)** | 7,350 -> **7,042 (-4.2%)** |
+
+**The Stellar drop is correct. Do not restore the old counts.**
+
+`peak_apex`, `peak_area`, and `peak_sharpness` used to reach the Percolator SVM as
+raw, heavy-tailed values, so a lone high-intensity DIA interference could
+standardize to a z-score of 100-300 and hijack the top of the score ranking. On
+Stellar that was inflating FDR: the old, higher ID count included IDs that only
+passed because the q-values were optimistic. Conditioning the features with
+`log10(max(x, 0) + 1)` removes the hijack, the q-values become honest, and fewer
+IDs clear 1% q. Fewer IDs at a nominal threshold is not a regression when the
+threshold was previously being missed.
+
+This was **validated against the entrapment oracle** (Brendan, 2026-07-13), which
+is the only thing that could settle it: decoy-derived statistics alone cannot
+distinguish "FDR became more conservative" from "discrimination got worse" -- both
+produce fewer IDs and a higher mean q. See the FDRBench entrapment section of
+`ai/docs/osprey-development-guide.md` (sibling pwiz-ai repo) -- for any change that
+moves the discovery set, the oracle outranks both the golden and cross-impl parity.
+
+Cross-impl parity on the new Stellar golden is confirmed: `Compare-EndToEnd-Crossimpl`
+passes at 1e-9, with the C# and Rust implementations independently producing the same
+51,444 precursors.


### PR DESCRIPTION
## Summary

Follow-ups from the review of #4412 (the Osprey intensity log-conditioning), plus one
cross-impl hazard found while doing the same work on the Rust side.

* Extracted `PeakShapeReference.ConditionIntensityFeature` -- `log10(max(x, 0) + 1)` --
  so the transform lives in exactly one place, mirroring Rust's
  `condition_intensity_feature`.
* Applied the input floor to `peak_apex` and `peak_area` as well. It is a no-op for
  both (XIC intensities are raw centroids, never smoothed and never
  background-subtracted -- the subtraction in `PeakDetector.ComputeSnr` works on a
  scalar and never rewrites the array), so PIN values stay bit-identical. It converts
  an assumed invariant into an enforced one: a NaN in a PIN feature would silently
  poison the SVM rather than fail loudly.
* Documented a genuine C#/Rust divergence: `Math.Max` PROPAGATES NaN, while Rust's
  `f64::max` IGNORES it (`f64::NAN.max(0.0) == 0.0`). On a NaN input the two
  implementations would silently disagree rather than both failing. Unreachable today
  (XIC intensities are finite, slope divisors are guarded at `dt > 1e-10`), but it is
  now written down on both sides rather than discovered later.
* Labeled the three display names `(log10)`. They label rows of the feature-
  contribution report, where the weights now read per DECADE of intensity, not per
  intensity unit, alongside linear features.
* Added the all-zero-XIC case to `TestPeakShapeCalculators`: a valid peak whose
  features all condition to 0.0, colliding with the invalid-peak sentinel. That
  collision is intended; it is now pinned.
* Filed the scale-free sharpness redesign that the `PeakSharpnessCalc` doc promised
  but which did not exist.

Reported by Mike.

## Test plan

- [x] Build-Osprey -RunTests - 504 passed, 3 skipped; TestPeakShapeCalculators green
- [x] Build-Osprey -RunInspection - zero warnings, zero errors

## Correction: the inspection gate is fine

An earlier revision of this description claimed the zero-warning gate had a net472
hole -- 9 pre-existing P/Invoke warnings in `Osprey.Core/SystemMemory.cs` that showed
up on master too, making the gate's result depend on build state. **That was wrong,
and I retract it.**

Those 9 warnings came from a stale `jb inspectcode` cache (`ai/.tmp/.inspectcode-cache`),
not from the source. With the cache cleared, `Build-Osprey -RunTests -RunInspection`
reports zero warnings and zero errors on this branch -- verified on both a cold cache
and a warm one. The stash experiments that seemed to confirm a pre-existing master
failure were just the same poisoned cache surviving across runs.

Worth keeping operationally: if the inspection reports issues in files your change never
touched, suspect that cache before you suspect the code.

Co-Authored-By: Claude <noreply@anthropic.com>

## Added after review

* `pwiz_tools/Osprey/osprey-regression.data/README.md` — documents why the 2026-07 re-bless dropped Stellar from 57,112 to 51,444 IDs while Astral gained. The drop is correct: the old count was FDR-inflated by the intensity hijack, and the log conditioning made the q-values honest. Entrapment-validated (Brendan), which is the only thing that can distinguish a more conservative FDR from worse discrimination. The next person to diff a 32K-line golden should not have to re-derive that.
* Cross-impl parity on the new Stellar golden is now demonstrated, not asserted: `Compare-EndToEnd-Crossimpl` PASSES at 1e-9 (C# and Rust independently produce the same 51,444 precursors). That run used the C# build from THIS branch, so it also confirms the `peak_apex`/`peak_area` floor is bit-identical as claimed.


