### PR TITLE
Bounded Osprey large-run memory across the resume, HPC-merge, and Stage-6 planning paths

### DIFF
--- a/pwiz_tools/Osprey/Osprey.Core/ProgressReporter.cs
+++ b/pwiz_tools/Osprey/Osprey.Core/ProgressReporter.cs
@@ -23,6 +23,7 @@
 
 using System;
 using System.Diagnostics;
+using System.Globalization;
 
 namespace pwiz.Osprey.Core
 {
@@ -157,8 +158,9 @@ namespace pwiz.Osprey.Core
                     // when the phase calls Report; a phase that blocks inside one bulk
                     // operation (no Report calls) needs to be wrapped in a reporter first.
                     double pctExact = _total > 0 ? 100.0 * current / _total : 100.0;
-                    OspreyOutput.Out.WriteLine("{0}  {1:0.00}% ({2:N0}/{3:N0}, {4} elapsed)",
-                        _indent, pctExact, current, _total, FormatElapsed(_stopwatch.Elapsed));
+                    OspreyOutput.Out.WriteLine(string.Format(CultureInfo.InvariantCulture,
+                        "{0}  {1:0.00}% ({2:N0}/{3:N0}, {4} elapsed)",
+                        _indent, pctExact, current, _total, FormatElapsed(_stopwatch.Elapsed)));
                     _lastPercent = percent;
                     _lastReportSeconds = now;
                 }
@@ -188,10 +190,10 @@ namespace pwiz.Osprey.Core
         private static string FormatElapsed(TimeSpan elapsed)
         {
             if (elapsed.TotalHours >= 1)
-                return string.Format("{0}h{1:00}m", (int)elapsed.TotalHours, elapsed.Minutes);
+                return string.Format(CultureInfo.InvariantCulture, "{0}h{1:00}m", (int)elapsed.TotalHours, elapsed.Minutes);
             if (elapsed.TotalMinutes >= 1)
-                return string.Format("{0}m{1:00}s", (int)elapsed.TotalMinutes, elapsed.Seconds);
-            return string.Format("{0}s", (int)elapsed.TotalSeconds);
+                return string.Format(CultureInfo.InvariantCulture, "{0}m{1:00}s", (int)elapsed.TotalMinutes, elapsed.Seconds);
+            return string.Format(CultureInfo.InvariantCulture, "{0}s", (int)elapsed.TotalSeconds);
         }
     }
 }

--- a/pwiz_tools/Osprey/Osprey.Core/ProgressReporter.cs
+++ b/pwiz_tools/Osprey/Osprey.Core/ProgressReporter.cs
@@ -147,15 +147,18 @@ namespace pwiz.Osprey.Core
                 }
                 else if (percent < 100 && now - _lastReportSeconds >= _heartbeatSeconds)
                 {
-                    // Frozen-percent heartbeat: a phase advancing slower than 1% per
-                    // _heartbeatSeconds would otherwise print nothing until it crosses the
-                    // next whole percent, so the console looks hung. Reprint the current
-                    // percent with elapsed time -- reassurance the run is alive, and
-                    // pathological slowness becomes visible in real time. percent may have
-                    // crept up since the last line (still < 1 over the report interval), so
-                    // print it, not the stale _lastPercent.
-                    OspreyOutput.Out.WriteLine("{0}  {1}% ({2} elapsed)",
-                        _indent, percent, FormatElapsed(_stopwatch.Elapsed));
+                    // Slow-phase heartbeat: when progress is under 1% per _heartbeatSeconds
+                    // the integer percent freezes, so switch to FINER granularity -- a
+                    // fractional percent plus the running item count -- so a genuinely
+                    // moving job shows a moving number (real progress), not just a ticking
+                    // clock. Elapsed still surfaces pathological slowness. Fast phases
+                    // advance the whole percent within the report interval and never reach
+                    // this idle window, so they stay clutter-free. NOTE: this only fires
+                    // when the phase calls Report; a phase that blocks inside one bulk
+                    // operation (no Report calls) needs to be wrapped in a reporter first.
+                    double pctExact = _total > 0 ? 100.0 * current / _total : 100.0;
+                    OspreyOutput.Out.WriteLine("{0}  {1:0.00}% ({2:N0}/{3:N0}, {4} elapsed)",
+                        _indent, pctExact, current, _total, FormatElapsed(_stopwatch.Elapsed));
                     _lastPercent = percent;
                     _lastReportSeconds = now;
                 }

--- a/pwiz_tools/Osprey/Osprey.Core/ProgressReporter.cs
+++ b/pwiz_tools/Osprey/Osprey.Core/ProgressReporter.cs
@@ -60,9 +60,24 @@ namespace pwiz.Osprey.Core
         /// </summary>
         public const double IO_INTERVAL_SECONDS = 5.0;
 
+        /// <summary>
+        /// Idle threshold for the frozen-percent heartbeat. When a determinate phase
+        /// progresses slower than 1% per this many seconds, the integer percent does not
+        /// advance, so the advance-gated <see cref="Report"/> would print nothing for as
+        /// long as it takes to cross the next whole percent -- the console looks hung
+        /// exactly when progress is slowest and a watching user most needs reassurance
+        /// (an 82-file Stage-6 rescore went ~1 h silent this way). After this long with no
+        /// line, Report reprints the current percent with elapsed time. Fast phases advance
+        /// the percent within the report interval and never reach the idle window, so no
+        /// extra lines appear on them. Wider than <see cref="IO_INTERVAL_SECONDS"/> so it
+        /// only trips on genuinely stalled-looking phases.
+        /// </summary>
+        public const double HEARTBEAT_SECONDS = 30.0;
+
         private readonly long _total;
         private readonly string _indent;
         private readonly double _intervalSeconds;
+        private readonly double _heartbeatSeconds;
         private readonly Stopwatch _stopwatch;
         private readonly object _lock = new object();
         // Non-null only inside a MultiProgressReporter per-file scope (--parallel-files):
@@ -86,11 +101,15 @@ namespace pwiz.Osprey.Core
         /// <param name="indent">Leading whitespace for the heading so it lines up with the
         /// matching completion line; the percent lines are indented one level (2 spaces) deeper.</param>
         /// <param name="intervalSeconds">Minimum seconds between percent lines (timer throttle).</param>
-        public ProgressReporter(string activity, long total, string indent = "", double intervalSeconds = 1.0)
+        /// <param name="heartbeatSeconds">Idle threshold for the frozen-percent heartbeat
+        /// (see <see cref="HEARTBEAT_SECONDS"/>). Injectable so tests can trip it quickly.</param>
+        public ProgressReporter(string activity, long total, string indent = "", double intervalSeconds = 1.0,
+            double heartbeatSeconds = HEARTBEAT_SECONDS)
         {
             _total = total;
             _indent = indent;
             _intervalSeconds = intervalSeconds;
+            _heartbeatSeconds = heartbeatSeconds;
             _sink = MultiProgressReporter.CurrentSink;
             _stopwatch = Stopwatch.StartNew();
             OspreyOutput.Out.WriteLine("{0}{1}...", indent, activity);
@@ -126,6 +145,20 @@ namespace pwiz.Osprey.Core
                     _lastPercent = percent;
                     _lastReportSeconds = now;
                 }
+                else if (percent < 100 && now - _lastReportSeconds >= _heartbeatSeconds)
+                {
+                    // Frozen-percent heartbeat: a phase advancing slower than 1% per
+                    // _heartbeatSeconds would otherwise print nothing until it crosses the
+                    // next whole percent, so the console looks hung. Reprint the current
+                    // percent with elapsed time -- reassurance the run is alive, and
+                    // pathological slowness becomes visible in real time. percent may have
+                    // crept up since the last line (still < 1 over the report interval), so
+                    // print it, not the stale _lastPercent.
+                    OspreyOutput.Out.WriteLine("{0}  {1}% ({2} elapsed)",
+                        _indent, percent, FormatElapsed(_stopwatch.Elapsed));
+                    _lastPercent = percent;
+                    _lastReportSeconds = now;
+                }
             }
         }
 
@@ -144,6 +177,18 @@ namespace pwiz.Osprey.Core
                 if (_lastPercent < 100)
                     OspreyOutput.Out.WriteLine("{0}  100%", _indent);
             }
+        }
+
+        /// <summary>
+        /// Compact elapsed-time formatting for the heartbeat line: "45s", "2m03s", "1h05m".
+        /// </summary>
+        private static string FormatElapsed(TimeSpan elapsed)
+        {
+            if (elapsed.TotalHours >= 1)
+                return string.Format("{0}h{1:00}m", (int)elapsed.TotalHours, elapsed.Minutes);
+            if (elapsed.TotalMinutes >= 1)
+                return string.Format("{0}m{1:00}s", (int)elapsed.TotalMinutes, elapsed.Seconds);
+            return string.Format("{0}s", (int)elapsed.TotalSeconds);
         }
     }
 }

--- a/pwiz_tools/Osprey/Osprey.FDR/PercolatorEngine.cs
+++ b/pwiz_tools/Osprey/Osprey.FDR/PercolatorEngine.cs
@@ -734,6 +734,9 @@ namespace pwiz.Osprey.FDR
             //    supplied, so SelectBestPerPrecursor never dereferences the entries arg
             //    -- passing an empty list is exactly what lets this path avoid the
             //    full-N PercolatorEntry buffer the FdrEntry streaming path allocates.
+            // Phase marker: the dedup + subsample over all N rows is a multi-minute
+            // silent span on an 82-file join; announce it so the console is not blank.
+            logInfo(string.Format(@"Selecting training subset from {0} scored entries...", n));
             int[] bestIdx;
             int[] trainSubsetGlobalIdx = PercolatorFdr.BuildTrainingSubset(
                 labels, entryIds, peptides, Array.Empty<PercolatorEntry>(), maxTrain,
@@ -784,6 +787,8 @@ namespace pwiz.Osprey.FDR
             }
 
             var subsetByFile = PercolatorFdr.GroupIndicesByFileName(subsetEntries);
+            logInfo(string.Format(@"Loading training-subset feature vectors from {0} file(s)...",
+                subsetByFile.Count));
             foreach (var kvp in subsetByFile)
             {
                 IReadOnlyList<double[]> rows = loadFileFeatures(kvp.Key);

--- a/pwiz_tools/Osprey/Osprey.FDR/PercolatorFdr.cs
+++ b/pwiz_tools/Osprey/Osprey.FDR/PercolatorFdr.cs
@@ -1155,29 +1155,30 @@ namespace pwiz.Osprey.FDR
             // covers a slow single file. Console-only -- never touches finalScores /
             // the sink, so byte-identity is unaffected.
             int gi = 0;
-            var scoreProgress = new ProgressReporter(string.Format(@"Scoring {0} entries", n), n);
-            foreach (var kvp in perFile)
+            using (var scoreProgress = new ProgressReporter(string.Format(@"Scoring {0} entries", n), n))
             {
-                IReadOnlyList<double[]> rows = loadFileFeatures(kvp.Key);
-                var projRows = kvp.Value;
-                for (int r = 0; r < projRows.Count; r++)
+                foreach (var kvp in perFile)
                 {
-                    var proj = projRows[r];
-                    double[] featRow = ResolveFeatureRow(
-                        rows, proj.ParquetIndex, proj.CoelutionSum, nFeatures);
-                    Array.Copy(featRow, 0, featureBuf, 0, nFeatures);
-                    standardizer.TransformSlice(featureBuf);
-                    double score = avgBias;
-                    for (int j = 0; j < nFeatures; j++)
-                        score += avgWeights[j] * featureBuf[j];
-                    finalScores[gi] = score;
+                    IReadOnlyList<double[]> rows = loadFileFeatures(kvp.Key);
+                    var projRows = kvp.Value;
+                    for (int r = 0; r < projRows.Count; r++)
+                    {
+                        var proj = projRows[r];
+                        double[] featRow = ResolveFeatureRow(
+                            rows, proj.ParquetIndex, proj.CoelutionSum, nFeatures);
+                        Array.Copy(featRow, 0, featureBuf, 0, nFeatures);
+                        standardizer.TransformSlice(featureBuf);
+                        double score = avgBias;
+                        for (int j = 0; j < nFeatures; j++)
+                            score += avgWeights[j] * featureBuf[j];
+                        finalScores[gi] = score;
 
-                    contribAcc.Add(featureBuf, proj.IsDecoy);
-                    gi++;
+                        contribAcc.Add(featureBuf, proj.IsDecoy);
+                        gi++;
+                    }
+                    scoreProgress.Report(gi);
                 }
-                scoreProgress.Report(gi);
             }
-            scoreProgress.Dispose();
 
             var contributions = contribAcc.Build(trainResults.FoldWeights, config.FeatureInfos);
             EmitFeatureContributions(contributions);

--- a/pwiz_tools/Osprey/Osprey.FDR/PercolatorFdr.cs
+++ b/pwiz_tools/Osprey/Osprey.FDR/PercolatorFdr.cs
@@ -1150,7 +1150,12 @@ namespace pwiz.Osprey.FDR
             // per-entry math and the per-file iteration order match the
             // PercolatorEntry streaming loop exactly, so finalScores + the
             // contribution sums are byte-for-byte identical.
+            // Per-file progress so this full-population score pass (~15 min silent at
+            // 344M rows on the 82-file first-pass join) shows movement; the heartbeat
+            // covers a slow single file. Console-only -- never touches finalScores /
+            // the sink, so byte-identity is unaffected.
             int gi = 0;
+            var scoreProgress = new ProgressReporter(string.Format(@"Scoring {0} entries", n), n);
             foreach (var kvp in perFile)
             {
                 IReadOnlyList<double[]> rows = loadFileFeatures(kvp.Key);
@@ -1170,7 +1175,9 @@ namespace pwiz.Osprey.FDR
                     contribAcc.Add(featureBuf, proj.IsDecoy);
                     gi++;
                 }
+                scoreProgress.Report(gi);
             }
+            scoreProgress.Dispose();
 
             var contributions = contribAcc.Build(trainResults.FoldWeights, config.FeatureInfos);
             EmitFeatureContributions(contributions);

--- a/pwiz_tools/Osprey/Osprey.FDR/Reconciliation/ReconciliationPlanner.cs
+++ b/pwiz_tools/Osprey/Osprey.FDR/Reconciliation/ReconciliationPlanner.cs
@@ -54,8 +54,11 @@ namespace pwiz.Osprey.FDR.Reconciliation
         private const int SIGMA_CLIP_MIN_SURVIVORS = 20;
 
         /// <summary>
-        /// Plan inter-replicate peak reconciliation for all entries across all
-        /// runs.
+        /// Plan inter-replicate peak reconciliation for all entries across all runs.
+        /// In-memory / test overload: takes the per-file CWT candidate lists as a
+        /// materialized dictionary and adapts it to the streaming overload below.
+        /// Production (Stage 6) uses the streaming overload so it never holds all
+        /// files' candidates resident.
         /// </summary>
         /// <returns>
         /// A dictionary keyed by (fileName, entryIndex) for entries that need
@@ -70,12 +73,46 @@ namespace pwiz.Osprey.FDR.Reconciliation
             IReadOnlyDictionary<string, RTCalibration> perFileOriginalCal,
             double experimentFdr)
         {
+            if (perFileCwtCandidates == null)
+                throw new ArgumentNullException(nameof(perFileCwtCandidates));
+            return Plan(consensus, perFileEntries,
+                fileName => perFileCwtCandidates.TryGetValue(fileName, out var fileCwt)
+                    ? fileCwt
+                    : null,
+                perFileRefinedCal, perFileOriginalCal, experimentFdr);
+        }
+
+        /// <summary>
+        /// Plan inter-replicate peak reconciliation for all entries across all runs.
+        /// Streaming entry point: <paramref name="loadFileCwt"/> supplies one file's
+        /// CWT candidate lists (indexed by <see cref="FdrEntry.ParquetIndex"/>) on
+        /// demand -- it is called once per file inside the per-file loop and its
+        /// result falls out of scope before the next file, so no more than one file's
+        /// candidates are resident at a time (the streaming fix for the 82-file
+        /// Stage-6 planning OOM). It may return null for a file with no candidates
+        /// (treated as empty). The cross-file inputs (the passing-base-id set, the
+        /// consensus map) never touch CWT candidates, so the streamed result is
+        /// element-for-element identical to loading them all up front.
+        /// </summary>
+        /// <returns>
+        /// A dictionary keyed by (fileName, entryIndex) for entries that need
+        /// re-scoring. Entries absent from the map implicitly retain their
+        /// current peak (ReconcileAction.Keep).
+        /// </returns>
+        public static IReadOnlyDictionary<(string File, int Index), ReconcileAction> Plan(
+            IReadOnlyList<PeptideConsensusRT> consensus,
+            IReadOnlyList<KeyValuePair<string, IReadOnlyList<FdrEntry>>> perFileEntries,
+            Func<string, IReadOnlyList<IReadOnlyList<CwtCandidate>>> loadFileCwt,
+            IReadOnlyDictionary<string, RTCalibration> perFileRefinedCal,
+            IReadOnlyDictionary<string, RTCalibration> perFileOriginalCal,
+            double experimentFdr)
+        {
             if (consensus == null)
                 throw new ArgumentNullException(nameof(consensus));
             if (perFileEntries == null)
                 throw new ArgumentNullException(nameof(perFileEntries));
-            if (perFileCwtCandidates == null)
-                throw new ArgumentNullException(nameof(perFileCwtCandidates));
+            if (loadFileCwt == null)
+                throw new ArgumentNullException(nameof(loadFileCwt));
             if (perFileRefinedCal == null)
                 throw new ArgumentNullException(nameof(perFileRefinedCal));
             if (perFileOriginalCal == null)
@@ -189,8 +226,9 @@ namespace pwiz.Osprey.FDR.Reconciliation
                     Math.Max(globalWithinPeptideMadLib * MAD_TO_SIGMA * SIGMA_FACTOR, MIN_RT_TOLERANCE),
                     fileCalToleranceCeiling);
 
-                if (!perFileCwtCandidates.TryGetValue(fileName, out var fileCwt))
-                    fileCwt = emptyCwt;
+                // Load this file's CWT candidates on demand and release them at
+                // the end of the iteration -- one file resident at a time.
+                var fileCwt = loadFileCwt(fileName) ?? emptyCwt;
 
                 for (int entryIdx = 0; entryIdx < entries.Count; entryIdx++)
                 {

--- a/pwiz_tools/Osprey/Osprey.IO/ParquetScoreCache.cs
+++ b/pwiz_tools/Osprey/Osprey.IO/ParquetScoreCache.cs
@@ -894,6 +894,30 @@ namespace pwiz.Osprey.IO
             }
         }
 
+        /// <summary>
+        /// Footer-only check that a scores parquet carries the PIN feature columns,
+        /// reading the schema WITHOUT decoding any column data. The lean resume /
+        /// HPC-merge paths stream only the scalar stub columns
+        /// (<see cref="ReadFdrStubScalars"/>) and never materialize the 21-float
+        /// feature vectors, so they lose the fat path's implicit
+        /// <c>features.Count == stubs.Count</c> corruption guard (which throws when
+        /// <see cref="LoadPinFeaturesFromParquet"/> yields zero rows because the
+        /// feature schema is absent). This restores an equivalent fail-fast up front
+        /// without paying the feature-load memory the lean path exists to avoid.
+        /// Presence of the first PIN feature column is decisive: parquet keeps every
+        /// column in a row group the same length, so a present column has the stub
+        /// row count, and an absent one is exactly the desync the fat path rejected.
+        /// </summary>
+        public static bool HasPinFeatureColumns(string path)
+        {
+            using (var stream = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.Read))
+            using (var reader = RunSync(ParquetReader.CreateAsync(stream)))
+            {
+                var fieldsByName = BuildFieldLookup(reader);
+                return fieldsByName.ContainsKey(PIN_FEATURE_NAMES[0]);
+            }
+        }
+
         #endregion
 
         #region Load PIN Features

--- a/pwiz_tools/Osprey/Osprey.IO/ParquetScoreCache.cs
+++ b/pwiz_tools/Osprey/Osprey.IO/ParquetScoreCache.cs
@@ -871,6 +871,29 @@ namespace pwiz.Osprey.IO
             return allCandidates;
         }
 
+        /// <summary>
+        /// Footer-only probe of a scores parquet: the total row count and whether
+        /// the <c>cwt_candidates</c> column is present, read from the Parquet
+        /// metadata WITHOUT decoding any column data. Lets Stage 6 validate that
+        /// every file's stub <see cref="FdrEntry.ParquetIndex"/> is in range (the
+        /// reconciliation all-or-nothing gate) without holding all files'
+        /// candidate lists resident -- the streaming counterpart of
+        /// <see cref="LoadCwtCandidatesFromParquet"/>, whose per-file result count
+        /// equals the returned <c>RowCount</c> when the column is present and 0 when
+        /// it is absent (that method returns an empty list for a missing column).
+        /// </summary>
+        public static (long RowCount, bool HasCwtCandidatesField) ProbeCwtRowMetadata(string path)
+        {
+            using (var stream = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.Read))
+            using (var reader = RunSync(ParquetReader.CreateAsync(stream)))
+            {
+                long rowCount = reader.Metadata?.NumRows ?? 0L;
+                var fieldsByName = BuildFieldLookup(reader);
+                bool hasCwt = fieldsByName.ContainsKey(FIELD_CWT_CANDIDATES.Name);
+                return (rowCount, hasCwt);
+            }
+        }
+
         #endregion
 
         #region Load PIN Features

--- a/pwiz_tools/Osprey/Osprey.Tasks/CwtCandidateLoader.cs
+++ b/pwiz_tools/Osprey/Osprey.Tasks/CwtCandidateLoader.cs
@@ -30,75 +30,120 @@ using pwiz.Osprey.IO;
 namespace pwiz.Osprey.Tasks
 {
     /// <summary>
-    /// Loads the per-file CWT candidate lists the Stage 6 reconciliation planner
+    /// Streams the per-file CWT candidate lists the Stage 6 reconciliation planner
     /// indexes by <see cref="FdrEntry.ParquetIndex"/> (mirrors Rust
-    /// reconciliation.rs:672). For each file it reads the stored Stage-4 CWT rows
-    /// from the parquet cache and validates that every post-compaction stub's
-    /// ParquetIndex falls within the loaded row count; a file whose parquet is
-    /// missing, fails to load, or has an out-of-range max index is omitted (with a
-    /// warning), which the caller treats as "no reconciliation planning for this
-    /// file".
-    ///
-    /// Extracted verbatim from <c>FirstJoinTask.PlanStage6</c> as pure code motion
-    /// so the planning block reads as a sequencer; behavior is unchanged.
+    /// reconciliation.rs:672). <see cref="ValidateAllInRange"/> confirms up front --
+    /// via a footer-only metadata probe, nothing held resident -- that every
+    /// post-compaction stub's ParquetIndex is in range of its file's parquet row
+    /// count (the reconciliation all-or-nothing gate); the planner then pulls each
+    /// file's candidates on demand through <see cref="LoadOneFile"/> and releases
+    /// them before the next file. This replaces the former eager <c>Load</c> that
+    /// decoded and held EVERY file's candidate lists at once -- the all-runs buffer
+    /// that OOM'd the 82-file Stage-6 planning phase on a 64 GB box. A file whose
+    /// parquet is missing, fails to load, or has an out-of-range max index fails the
+    /// gate (with a warning), which the caller treats as "no reconciliation
+    /// planning" -- the same decision the eager loader produced, byte-identical.
     /// </summary>
     internal static class CwtCandidateLoader
     {
         /// <summary>
-        /// Load and bounds-validate the per-file CWT candidate lists. Returns the
-        /// map keyed by file name; only files that loaded cleanly and passed the
-        /// ParquetIndex bounds check are present. Logging is via
-        /// <paramref name="logWarning"/> so this can run without a live context.
+        /// Validate -- via a footer-only metadata probe, decoding no CWT blobs and
+        /// holding nothing resident -- that EVERY file's post-compaction stubs have
+        /// a <see cref="FdrEntry.ParquetIndex"/> in range of its scores parquet's
+        /// row count. This is the reconciliation all-or-nothing gate the caller
+        /// reads (reconciliation runs only when every file passes); returns true
+        /// only then, and reports the passing count via <paramref name="validFileCount"/>
+        /// for the "loaded for X/Y files" log on a partial failure. The valid/invalid
+        /// decision and the two warning messages mirror the former eager loader
+        /// exactly, so the gate is byte-identical -- only the residency changes.
         /// </summary>
-        internal static Dictionary<string, IReadOnlyList<IReadOnlyList<CwtCandidate>>> Load(
+        internal static bool ValidateAllInRange(
             List<KeyValuePair<string, List<FdrEntry>>> perFileEntries,
+            IReadOnlyDictionary<string, string> perFileParquetPaths,
+            Action<string> logWarning,
+            out int validFileCount)
+        {
+            validFileCount = 0;
+            foreach (var kvp in perFileEntries)
+            {
+                // Missing path / file: the former eager loader silently omitted the
+                // file (no warning), which failed the all-files gate. Keep that.
+                if (!perFileParquetPaths.TryGetValue(kvp.Key, out string parquetPath) ||
+                    !File.Exists(parquetPath))
+                    continue;
+
+                long effectiveRowCount;
+                try
+                {
+                    var probe = ParquetScoreCache.ProbeCwtRowMetadata(parquetPath);
+                    // LoadCwtCandidatesFromParquet yields an empty list (count 0)
+                    // when the cwt_candidates column is absent, so a file lacking it
+                    // reads as zero rows here -- matching the former bounds check.
+                    effectiveRowCount = probe.HasCwtCandidatesField ? probe.RowCount : 0L;
+                }
+                catch (Exception ex)
+                {
+                    logWarning(string.Format(
+                        @"Failed to load CWT candidates for {0}: {1}",
+                        kvp.Key, ex.Message));
+                    continue;
+                }
+
+                // The planner indexes CWT lists by entry.ParquetIndex (mirrors Rust
+                // at reconciliation.rs:672). effectiveRowCount is the parquet's raw
+                // Stage-4 row count; kvp.Value.Count is the post-first-pass-compaction
+                // stub count. They are not equal by design -- what we validate is that
+                // every stub's ParquetIndex falls within the parquet's rows.
+                uint maxIdx = MaxParquetIndex(kvp.Value);
+                if (kvp.Value.Count > 0 && maxIdx >= effectiveRowCount)
+                {
+                    logWarning(string.Format(
+                        @"CWT candidate row count out of range for {0}: " +
+                        @"max stub ParquetIndex={1}, parquet has {2} rows -- " +
+                        @"skipping reconciliation planning for this file",
+                        kvp.Key, maxIdx, effectiveRowCount));
+                    continue;
+                }
+                validFileCount++;
+            }
+            return validFileCount == perFileEntries.Count;
+        }
+
+        /// <summary>
+        /// Load and convert ONE file's CWT candidate lists (indexed by
+        /// <see cref="FdrEntry.ParquetIndex"/>) for the planner to consume and
+        /// release before moving to the next file -- the streaming replacement for
+        /// the former eager all-files load. Returns an empty list when the parquet
+        /// path is unknown, missing, or fails to decode; the planner then falls back
+        /// to no candidates for that file (its entries keep their current peak), the
+        /// same fallback its per-entry bounds guard already applies. The all-files
+        /// in-range gate is enforced up front by <see cref="ValidateAllInRange"/>,
+        /// so on the planning path this is the happy-path loader.
+        /// </summary>
+        internal static IReadOnlyList<IReadOnlyList<CwtCandidate>> LoadOneFile(
+            string fileName,
             IReadOnlyDictionary<string, string> perFileParquetPaths,
             Action<string> logWarning)
         {
-            var perFileCwtCandidates =
-                new Dictionary<string, IReadOnlyList<IReadOnlyList<CwtCandidate>>>();
-            foreach (var kvp in perFileEntries)
+            if (!perFileParquetPaths.TryGetValue(fileName, out string parquetPath) ||
+                !File.Exists(parquetPath))
+                return Array.Empty<IReadOnlyList<CwtCandidate>>();
+
+            try
             {
-                if (perFileParquetPaths.TryGetValue(kvp.Key, out string parquetPath) &&
-                    File.Exists(parquetPath))
-                {
-                    try
-                    {
-                        var cwtRows = ParquetScoreCache
-                            .LoadCwtCandidatesFromParquet(parquetPath);
-                        // The planner indexes CWT lists by
-                        // entry.ParquetIndex (mirrors Rust at
-                        // reconciliation.rs:672). cwtRows.Count is
-                        // the parquet's raw Stage-4 row count;
-                        // kvp.Value.Count is the post-first-pass-
-                        // compaction stub count. They are not
-                        // equal by design — what we actually need
-                        // to validate is that every stub's
-                        // ParquetIndex falls within cwtRows.
-                        uint maxIdx = MaxParquetIndex(kvp.Value);
-                        if (kvp.Value.Count > 0 && maxIdx >= cwtRows.Count)
-                        {
-                            logWarning(string.Format(
-                                @"CWT candidate row count out of range for {0}: " +
-                                @"max stub ParquetIndex={1}, parquet has {2} rows -- " +
-                                @"skipping reconciliation planning for this file",
-                                kvp.Key, maxIdx, cwtRows.Count));
-                            continue;
-                        }
-                        var converted = new List<IReadOnlyList<CwtCandidate>>(cwtRows.Count);
-                        foreach (var row in cwtRows)
-                            converted.Add(row);
-                        perFileCwtCandidates[kvp.Key] = converted;
-                    }
-                    catch (Exception ex)
-                    {
-                        logWarning(string.Format(
-                            @"Failed to load CWT candidates for {0}: {1}",
-                            kvp.Key, ex.Message));
-                    }
-                }
+                var cwtRows = ParquetScoreCache.LoadCwtCandidatesFromParquet(parquetPath);
+                var converted = new List<IReadOnlyList<CwtCandidate>>(cwtRows.Count);
+                foreach (var row in cwtRows)
+                    converted.Add(row);
+                return converted;
             }
-            return perFileCwtCandidates;
+            catch (Exception ex)
+            {
+                logWarning(string.Format(
+                    @"Failed to load CWT candidates for {0}: {1}",
+                    fileName, ex.Message));
+                return Array.Empty<IReadOnlyList<CwtCandidate>>();
+            }
         }
 
         /// <summary>

--- a/pwiz_tools/Osprey/Osprey.Tasks/CwtCandidateLoader.cs
+++ b/pwiz_tools/Osprey/Osprey.Tasks/CwtCandidateLoader.cs
@@ -40,94 +40,91 @@ namespace pwiz.Osprey.Tasks
     /// them before the next file. This replaces the former eager <c>Load</c> that
     /// decoded and held EVERY file's candidate lists at once -- the all-runs buffer
     /// that OOM'd the 82-file Stage-6 planning phase on a 64 GB box. A file whose
-    /// parquet is missing, fails to load, or has an out-of-range max index fails the
-    /// gate (with a warning), which the caller treats as "no reconciliation
-    /// planning" -- the same decision the eager loader produced, byte-identical.
+    /// parquet is missing, fails to decode, or has an out-of-range max index ABORTS the
+    /// run (fail-fast) with a clear error naming the file to delete + regenerate: a
+    /// corrupt Stage-4 output must stop the pipeline, never silently produce partial or
+    /// feature-degraded reconciliation. Byte-identical on valid inputs.
     /// </summary>
     internal static class CwtCandidateLoader
     {
         /// <summary>
-        /// Validate -- via a footer-only metadata probe, decoding no CWT blobs and
-        /// holding nothing resident -- that EVERY file's post-compaction stubs have
-        /// a <see cref="FdrEntry.ParquetIndex"/> in range of its scores parquet's
-        /// row count. This is the reconciliation all-or-nothing gate the caller
-        /// reads (reconciliation runs only when every file passes); returns true
-        /// only then, and reports the passing count via <paramref name="validFileCount"/>
-        /// for the "loaded for X/Y files" log on a partial failure. The valid/invalid
-        /// decision and the two warning messages mirror the former eager loader
-        /// exactly, so the gate is byte-identical -- only the residency changes.
+        /// Fail-fast validation -- via a footer-only metadata probe, decoding no CWT
+        /// blobs and holding nothing resident -- that EVERY file's post-compaction
+        /// stubs have a <see cref="FdrEntry.ParquetIndex"/> in range of its scores
+        /// parquet's row count, and that the parquet is present and readable. THROWS
+        /// <see cref="InvalidDataException"/> (naming every offending file) if any file
+        /// is missing, unreadable, or out of range -- a corrupt Stage-4 output stops the
+        /// run before Stage 6 rather than silently reconciling only the good files. A
+        /// footer-clean file whose CWT blob column still fails to decode is caught during
+        /// planning by <see cref="LoadOneFile"/>, which throws the same way.
         /// </summary>
-        internal static bool ValidateAllInRange(
+        internal static void ValidateAllInRange(
             List<KeyValuePair<string, List<FdrEntry>>> perFileEntries,
-            IReadOnlyDictionary<string, string> perFileParquetPaths,
-            Action<string> logWarning,
-            out int validFileCount)
+            IReadOnlyDictionary<string, string> perFileParquetPaths)
         {
-            validFileCount = 0;
+            var invalid = new List<string>();
             foreach (var kvp in perFileEntries)
             {
-                // Missing path / file: the former eager loader silently omitted the
-                // file (no warning), which failed the all-files gate. Keep that.
                 if (!perFileParquetPaths.TryGetValue(kvp.Key, out string parquetPath) ||
                     !File.Exists(parquetPath))
+                {
+                    invalid.Add(string.Format(@"{0} (scores parquet missing)", kvp.Key));
                     continue;
+                }
 
                 long effectiveRowCount;
                 try
                 {
                     var probe = ParquetScoreCache.ProbeCwtRowMetadata(parquetPath);
-                    // LoadCwtCandidatesFromParquet yields an empty list (count 0)
-                    // when the cwt_candidates column is absent, so a file lacking it
-                    // reads as zero rows here -- matching the former bounds check.
+                    // LoadCwtCandidatesFromParquet yields an empty list (count 0) when
+                    // the cwt_candidates column is absent, so a file lacking it reads as
+                    // zero rows here -- and thus fails the in-range check below.
                     effectiveRowCount = probe.HasCwtCandidatesField ? probe.RowCount : 0L;
                 }
                 catch (Exception ex)
                 {
-                    logWarning(string.Format(
-                        @"Failed to load CWT candidates for {0}: {1}",
-                        kvp.Key, ex.Message));
+                    invalid.Add(string.Format(@"{0} (unreadable: {1})", kvp.Key, ex.Message));
                     continue;
                 }
 
-                // The planner indexes CWT lists by entry.ParquetIndex (mirrors Rust
-                // at reconciliation.rs:672). effectiveRowCount is the parquet's raw
-                // Stage-4 row count; kvp.Value.Count is the post-first-pass-compaction
-                // stub count. They are not equal by design -- what we validate is that
-                // every stub's ParquetIndex falls within the parquet's rows.
+                // The planner indexes CWT lists by entry.ParquetIndex (mirrors Rust at
+                // reconciliation.rs:672). effectiveRowCount is the parquet's raw Stage-4
+                // row count; kvp.Value.Count is the post-compaction stub count -- unequal
+                // by design. What must hold is that every stub's ParquetIndex is in range.
                 uint maxIdx = MaxParquetIndex(kvp.Value);
                 if (kvp.Value.Count > 0 && maxIdx >= effectiveRowCount)
-                {
-                    logWarning(string.Format(
-                        @"CWT candidate row count out of range for {0}: " +
-                        @"max stub ParquetIndex={1}, parquet has {2} rows -- " +
-                        @"skipping reconciliation planning for this file",
+                    invalid.Add(string.Format(
+                        @"{0} (max stub ParquetIndex {1} >= {2} parquet rows)",
                         kvp.Key, maxIdx, effectiveRowCount));
-                    continue;
-                }
-                validFileCount++;
             }
-            return validFileCount == perFileEntries.Count;
+
+            if (invalid.Count > 0)
+                throw new InvalidDataException(string.Format(
+                    @"Reconciliation planning aborted: {0} of {1} file(s) have missing or corrupt CWT " +
+                    @"candidates and cannot be reconciled: [{2}]. Delete the affected .scores.parquet " +
+                    @"file(s) and re-run so they are regenerated.",
+                    invalid.Count, perFileEntries.Count, string.Join(@"; ", invalid)));
         }
 
         /// <summary>
         /// Load and convert ONE file's CWT candidate lists (indexed by
-        /// <see cref="FdrEntry.ParquetIndex"/>) for the planner to consume and
-        /// release before moving to the next file -- the streaming replacement for
-        /// the former eager all-files load. Returns an empty list when the parquet
-        /// path is unknown, missing, or fails to decode; the planner then falls back
-        /// to no candidates for that file (its entries keep their current peak), the
-        /// same fallback its per-entry bounds guard already applies. The all-files
-        /// in-range gate is enforced up front by <see cref="ValidateAllInRange"/>,
-        /// so on the planning path this is the happy-path loader.
+        /// <see cref="FdrEntry.ParquetIndex"/>) for the planner to consume and release
+        /// before moving to the next file -- the streaming replacement for the former
+        /// eager all-files load. THROWS <see cref="InvalidDataException"/> if the parquet
+        /// is missing or its CWT blob column fails to decode (a corrupt Stage-4 output),
+        /// so the run fails fast rather than silently reconciling with this file's peaks
+        /// kept. The cheap missing / out-of-range cases are already caught up front by
+        /// <see cref="ValidateAllInRange"/>; this catches a footer-clean-but-corrupt blob.
         /// </summary>
         internal static IReadOnlyList<IReadOnlyList<CwtCandidate>> LoadOneFile(
             string fileName,
-            IReadOnlyDictionary<string, string> perFileParquetPaths,
-            Action<string> logWarning)
+            IReadOnlyDictionary<string, string> perFileParquetPaths)
         {
             if (!perFileParquetPaths.TryGetValue(fileName, out string parquetPath) ||
                 !File.Exists(parquetPath))
-                return Array.Empty<IReadOnlyList<CwtCandidate>>();
+                throw new InvalidDataException(string.Format(
+                    @"Reconciliation planning aborted: scores parquet for {0} is missing. Delete any " +
+                    @"partial outputs and re-run so it is regenerated.", fileName));
 
             try
             {
@@ -139,10 +136,10 @@ namespace pwiz.Osprey.Tasks
             }
             catch (Exception ex)
             {
-                logWarning(string.Format(
-                    @"Failed to load CWT candidates for {0}: {1}",
-                    fileName, ex.Message));
-                return Array.Empty<IReadOnlyList<CwtCandidate>>();
+                throw new InvalidDataException(string.Format(
+                    @"Reconciliation planning aborted: failed to decode CWT candidates from {0}: {1}. " +
+                    @"The scores parquet is corrupt -- delete it and re-run to regenerate.",
+                    parquetPath, ex.Message));
             }
         }
 

--- a/pwiz_tools/Osprey/Osprey.Tasks/PerFileScoringTask.cs
+++ b/pwiz_tools/Osprey/Osprey.Tasks/PerFileScoringTask.cs
@@ -479,9 +479,14 @@ namespace pwiz.Osprey.Tasks
             // so it should not emit a file-parallelism decision line.
             ctx.RunPlan.EffectiveFileParallelism = ResolveFileParallelism(config, nFiles, null);
 
+            // Compute the reconciled-2nd-pass-bundle predicate ONCE here and thread it to
+            // both the loader (lean/fat choice) and the hydrator, so a sidecar appearing
+            // between two separate disk reads cannot make them disagree (lean empty stubs
+            // + a firing bundle hydrator). Static on a real merge node; belt-and-suspenders.
+            bool hasReconSidecars = AllHaveReconSidecars(config);
             var swAllFiles = Stopwatch.StartNew();
             var projections = LoadJoinOnlyScores(config, perFileEntries, perFileParquetPaths,
-                perFileCalibrations, perFileIsolationMz, ctx);
+                perFileCalibrations, perFileIsolationMz, hasReconSidecars, ctx);
             swAllFiles.Stop();
             ctx.LogInfo(string.Format(@"[TIMING] All files processed: {0:F1}s",
                 swAllFiles.Elapsed.TotalSeconds));
@@ -517,7 +522,7 @@ namespace pwiz.Osprey.Tasks
             //
             // The disk state determines the hydration shape, not the CLI
             // flag (Phase C principle: mechanism-driven, not flag-driven).
-            if (!HydrateRescoreBundleIfPresent(config, perFileEntries, ctx))
+            if (!HydrateRescoreBundleIfPresent(config, perFileEntries, hasReconSidecars, ctx))
                 return false;
 
             return FinalizeAndCheck(ctx, perFileEntries, perFileCalibrations,
@@ -612,6 +617,21 @@ namespace pwiz.Osprey.Tasks
                             // scores stream straight into the projection, no fat stub or
                             // feature vector allocated. Byte-identical to the fat path
                             // (TestFdrProjectionBuilderMatchesBuildFromEntries + mode2).
+                            // Fail-fast corruption guard: the fat path threw on
+                            // features.Count != stubs.Count; streaming scalars never loads
+                            // features, so restore that check up front via a footer-only
+                            // probe (no feature memory). A foreign/truncated parquet missing
+                            // the feature schema stops the run here rather than surfacing at
+                            // a murkier point downstream. NOT applied to Run's fresh-compute
+                            // lean path (#4400), whose parquets this same run just wrote.
+                            if (!ParquetScoreCache.HasPinFeatureColumns(scoresPath))
+                            {
+                                ctx.LogError(string.Format(
+                                    @"  Resume rehydrate: {0} is missing the PIN feature columns -- it is not a valid Osprey scores parquet. Delete it and re-run so it is regenerated.",
+                                    scoresPath));
+                                ctx.ExitCode = 1;
+                                return false;
+                            }
                             LoadCalibrationAndIsolation(scoresPath, fileName, perFileCalibrations, perFileIsolationMz, ctx);
                             try
                             {
@@ -1070,6 +1090,7 @@ namespace pwiz.Osprey.Tasks
             Dictionary<string, string> perFileParquetPaths,
             ConcurrentDictionary<string, RTCalibration> perFileCalibrations,
             ConcurrentDictionary<string, IReadOnlyList<(double Lo, double Hi)>> perFileIsolationMz,
+            bool hasReconSidecars,
             PipelineContext ctx)
         {
             // --task FirstPassFDR: load per-file FdrEntry stubs directly from
@@ -1096,7 +1117,7 @@ namespace pwiz.Osprey.Tasks
             // the merge needs the resident pool (an opt-in feature output) or is a
             // reconciled 2nd-pass bundle hydration (AllHaveReconSidecars -- FirstJoin
             // skips Percolator there and HydrateReconciliationOverlay reads the fat stubs).
-            var builder = (!NeedsResidentPool(config) && !AllHaveReconSidecars(config))
+            var builder = (!NeedsResidentPool(config) && !hasReconSidecars)
                 ? new FdrProjectionSet.Builder()
                 : null;
             for (int fileIdx = 0; fileIdx < config.InputScores.Count; fileIdx++)
@@ -1114,6 +1135,17 @@ namespace pwiz.Osprey.Tasks
                 {
                     // Lean: stream 32 B projection rows straight from the parquet; no
                     // fat FdrEntry stub or 21-float feature vector is ever allocated.
+                    // Fail-fast corruption guard: the fat branch below throws on
+                    // features.Count != stubs.Count; streaming scalars never loads
+                    // features, so restore that check up front via a footer-only probe
+                    // (no feature memory). A merge node pointed at a foreign/truncated
+                    // parquet missing the feature schema stops here rather than surfacing
+                    // downstream. The scores-group hash check above (ValidateScoresParquetGroup)
+                    // catches a wrong-library parquet; this catches a same-library corrupt one.
+                    if (!ParquetScoreCache.HasPinFeatureColumns(parquetPath))
+                        throw new InvalidDataException(string.Format(
+                            @"--input-scores: parquet {0} is missing the PIN feature columns -- it is not a valid Osprey scores parquet. Delete it and re-run so it is regenerated.",
+                            parquetPath));
                     builder.BeginFile(fileName);
                     ParquetScoreCache.ReadFdrStubScalars(parquetPath,
                         (entryId, charge, isDecoy, coelutionSum, modseq) =>
@@ -1234,10 +1266,10 @@ namespace pwiz.Osprey.Tasks
         private bool HydrateRescoreBundleIfPresent(
             OspreyConfig config,
             List<KeyValuePair<string, List<FdrEntry>>> perFileEntries,
+            bool hasReconSidecars,
             PipelineContext ctx)
         {
-            bool allHave1stPassAndRecon = AllHaveReconSidecars(config);
-            if (allHave1stPassAndRecon)
+            if (hasReconSidecars)
             {
                 try
                 {

--- a/pwiz_tools/Osprey/Osprey.Tasks/PerFileScoringTask.cs
+++ b/pwiz_tools/Osprey/Osprey.Tasks/PerFileScoringTask.cs
@@ -480,15 +480,23 @@ namespace pwiz.Osprey.Tasks
             ctx.RunPlan.EffectiveFileParallelism = ResolveFileParallelism(config, nFiles, null);
 
             var swAllFiles = Stopwatch.StartNew();
-            LoadJoinOnlyScores(config, perFileEntries, perFileParquetPaths,
+            var projections = LoadJoinOnlyScores(config, perFileEntries, perFileParquetPaths,
                 perFileCalibrations, perFileIsolationMz, ctx);
             swAllFiles.Stop();
             ctx.LogInfo(string.Format(@"[TIMING] All files processed: {0:F1}s",
                 swAllFiles.Elapsed.TotalSeconds));
 
-            int totalScored = 0;
-            foreach (var kvp in perFileEntries)
-                totalScored += kvp.Value.Count;
+            int totalScored;
+            if (projections != null)
+            {
+                totalScored = projections.TotalRows;
+            }
+            else
+            {
+                totalScored = 0;
+                foreach (var kvp in perFileEntries)
+                    totalScored += kvp.Value.Count;
+            }
 
             ctx.LogInfo(string.Empty);
             ctx.LogInfo(string.Format(
@@ -513,7 +521,7 @@ namespace pwiz.Osprey.Tasks
                 return false;
 
             return FinalizeAndCheck(ctx, perFileEntries, perFileCalibrations,
-                perFileIsolationMz, perFileParquetPaths, nFiles, totalScored);
+                perFileIsolationMz, perFileParquetPaths, nFiles, totalScored, projections);
         }
 
         /// <summary>
@@ -1056,7 +1064,7 @@ namespace pwiz.Osprey.Tasks
         /// <paramref name="perFileEntries"/>, <paramref name="perFileParquetPaths"/>,
         /// and <paramref name="perFileCalibrations"/>.
         /// </summary>
-        private void LoadJoinOnlyScores(
+        private FdrProjectionSet LoadJoinOnlyScores(
             OspreyConfig config,
             List<KeyValuePair<string, List<FdrEntry>>> perFileEntries,
             Dictionary<string, string> perFileParquetPaths,
@@ -1081,6 +1089,16 @@ namespace pwiz.Osprey.Tasks
             ctx.LogInfo(string.Format(
                 @"--input-scores: loading {0} per-file score parquet(s)",
                 config.InputScores.Count));
+            // Lean on the HPC merge/join too (#4400): a large first-pass merge node
+            // loading every worker's .scores.parquet used to rebuild the full fat
+            // FdrEntry stubs + PIN features (~53 GB at 82 files) -- the same Stage-5
+            // blowup the resume path had. Stream 32 B FdrProjection rows instead, unless
+            // the merge needs the resident pool (an opt-in feature output) or is a
+            // reconciled 2nd-pass bundle hydration (AllHaveReconSidecars -- FirstJoin
+            // skips Percolator there and HydrateReconciliationOverlay reads the fat stubs).
+            var builder = (!NeedsResidentPool(config) && !AllHaveReconSidecars(config))
+                ? new FdrProjectionSet.Builder()
+                : null;
             for (int fileIdx = 0; fileIdx < config.InputScores.Count; fileIdx++)
             {
                 string parquetPath = config.InputScores[fileIdx];
@@ -1092,21 +1110,35 @@ namespace pwiz.Osprey.Tasks
                     RescoreHydration.SyntheticInputFromParquet(parquetPath)) ?? string.Empty;
                 ctx.LogInfo(string.Format(@"===== Loading file {0}/{1}: {2} (from {3}) =====",
                     fileIdx + 1, config.InputScores.Count, fileName, parquetPath));
-                var stubs = ParquetScoreCache.LoadFdrStubsFromParquet(parquetPath);
-                // Stage 5+ (Percolator SVM) requires the 21 PIN features
-                // on each FdrEntry. Load them in lockstep with the stubs
-                // and bind by row index (parquet rows are stable).
-                var features = ParquetScoreCache.LoadPinFeaturesFromParquet(parquetPath);
-                if (features.Count != stubs.Count)
+                if (builder != null)
                 {
-                    throw new InvalidDataException(string.Format(
-                        @"--input-scores: parquet {0} has {1} stubs but {2} feature rows",
-                        parquetPath, stubs.Count, features.Count));
+                    // Lean: stream 32 B projection rows straight from the parquet; no
+                    // fat FdrEntry stub or 21-float feature vector is ever allocated.
+                    builder.BeginFile(fileName);
+                    ParquetScoreCache.ReadFdrStubScalars(parquetPath,
+                        (entryId, charge, isDecoy, coelutionSum, modseq) =>
+                            builder.AddRow(entryId, charge, isDecoy, coelutionSum, modseq));
+                    builder.EndFile();
+                    perFileEntries.Add(new KeyValuePair<string, List<FdrEntry>>(fileName, new List<FdrEntry>()));
                 }
-                for (int j = 0; j < stubs.Count; j++)
-                    stubs[j].Features = features[j];
-                ctx.LogInfo(string.Format(@"  Loaded {0} FDR stubs + features", stubs.Count));
-                perFileEntries.Add(new KeyValuePair<string, List<FdrEntry>>(fileName, stubs));
+                else
+                {
+                    // Fat: Stage 5+ (Percolator SVM) requires the 21 PIN features on each
+                    // FdrEntry (or the reconciled-bundle overlay reads the stubs). Load
+                    // them in lockstep with the stubs and bind by row index (rows stable).
+                    var stubs = ParquetScoreCache.LoadFdrStubsFromParquet(parquetPath);
+                    var features = ParquetScoreCache.LoadPinFeaturesFromParquet(parquetPath);
+                    if (features.Count != stubs.Count)
+                    {
+                        throw new InvalidDataException(string.Format(
+                            @"--input-scores: parquet {0} has {1} stubs but {2} feature rows",
+                            parquetPath, stubs.Count, features.Count));
+                    }
+                    for (int j = 0; j < stubs.Count; j++)
+                        stubs[j].Features = features[j];
+                    ctx.LogInfo(string.Format(@"  Loaded {0} FDR stubs + features", stubs.Count));
+                    perFileEntries.Add(new KeyValuePair<string, List<FdrEntry>>(fileName, stubs));
+                }
                 perFileParquetPaths[fileName] = parquetPath;
 
                 // Best-effort calibration JSON load for Stage 6
@@ -1159,6 +1191,7 @@ namespace pwiz.Osprey.Tasks
             }
             if (ctx.Diagnostics?.CalibrationOnly ?? false)
                 OspreyDiagnosticsLog.ExitAfterDump(@"OSPREY_CALIBRATION_ONLY");
+            return builder?.Build();
         }
 
         /// <summary>
@@ -1203,17 +1236,7 @@ namespace pwiz.Osprey.Tasks
             List<KeyValuePair<string, List<FdrEntry>>> perFileEntries,
             PipelineContext ctx)
         {
-            bool allHave1stPassAndRecon = true;
-            foreach (var parquetPath in config.InputScores)
-            {
-                string syntheticInput = RescoreHydration.SyntheticInputFromParquet(parquetPath);
-                if (!File.Exists(FdrScoresSidecar.Pass1Path(syntheticInput))
-                    || !File.Exists(ReconciliationFile.PathForInput(syntheticInput)))
-                {
-                    allHave1stPassAndRecon = false;
-                    break;
-                }
-            }
+            bool allHave1stPassAndRecon = AllHaveReconSidecars(config);
             if (allHave1stPassAndRecon)
             {
                 try
@@ -1248,6 +1271,26 @@ namespace pwiz.Osprey.Tasks
                     _rescoreInputs.TotalActions,
                     _rescoreInputs.RefinedCalibrations.Count,
                     _rescoreInputs.TotalGapFillTargets));
+            }
+            return true;
+        }
+
+        /// <summary>
+        /// True when EVERY <c>--input-scores</c> parquet has both its first-pass
+        /// <c>.fdr_scores.bin</c> and its <c>.reconciliation.json</c> sidecar -- the
+        /// signature of a reconciled 2nd-pass merge whose <see cref="HydrateRescoreBundleIfPresent"/>
+        /// overlays q-values onto the resident stubs (FirstJoin skips Percolator there).
+        /// <see cref="LoadJoinOnlyScores"/> reads this to keep the fat pool on that path,
+        /// since the lean projection would drop the stubs the overlay needs.
+        /// </summary>
+        private static bool AllHaveReconSidecars(OspreyConfig config)
+        {
+            foreach (var parquetPath in config.InputScores)
+            {
+                string syntheticInput = RescoreHydration.SyntheticInputFromParquet(parquetPath);
+                if (!File.Exists(FdrScoresSidecar.Pass1Path(syntheticInput))
+                    || !File.Exists(ReconciliationFile.PathForInput(syntheticInput)))
+                    return false;
             }
             return true;
         }

--- a/pwiz_tools/Osprey/Osprey.Tasks/PerFileScoringTask.cs
+++ b/pwiz_tools/Osprey/Osprey.Tasks/PerFileScoringTask.cs
@@ -365,13 +365,7 @@ namespace pwiz.Osprey.Tasks
             // combination -- a non-Percolator FdrMethod, OSPREY_FDR_PROJECTION=0, or the
             // resident-pool consumers (--model-diagnostics / FDRBench pass 1, which walk
             // the full pre-compaction FdrEntry pool) -- still needs the fat stubs here.
-            bool needsResidentPool =
-                ctx.Config.ExpectReconciledInput ||
-                !OspreyEnvironment.UseFdrProjection ||
-                ctx.Config.FdrMethod != FdrMethod.Percolator ||
-                ctx.Config.ModelDiagnostics ||
-                (!string.IsNullOrEmpty(ctx.Config.OutputFdrBench) && ctx.Config.FdrBenchPass == 1) ||
-                OspreyEnvironment.Pass2TransferQ;
+            bool needsResidentPool = NeedsResidentPool(ctx.Config);
 
             FdrProjectionSet projections = null;
             int totalScored = 0;
@@ -565,37 +559,95 @@ namespace pwiz.Osprey.Tasks
             // so it should not emit a file-parallelism decision line.
             ctx.RunPlan.EffectiveFileParallelism = ResolveFileParallelism(config, nFiles, null);
 
+            // Lean on resume too (#4400): a pure straight-through resume (all files
+            // skipped) used to rematerialize the full fat FdrEntry stub buffer + PIN
+            // features here -- ~53 GB across 82 files, the exact cost #4400 removed for
+            // the Run path -- because this path had no lean branch. Mirror Run: stream
+            // 32 B FdrProjection rows from each parquet unless an opt-in output genuinely
+            // needs the resident pool. FirstJoin consumes the projection set identically
+            // whether Run or this path produced it.
+            bool needsResidentPool = NeedsResidentPool(config);
+            FdrProjectionSet projections = null;
+
             var swAllFiles = Stopwatch.StartNew();
             if (config.InputFiles != null)
             {
-                // Sequential in InputFiles order to match Run's "collect in
-                // original order" -- downstream FirstJoin iterates perFileEntries.
-                foreach (string inputFile in config.InputFiles)
+                var builder = needsResidentPool ? null : new FdrProjectionSet.Builder();
+                // Per-file progress so this all-files load is not a silent multi-minute
+                // stall on a large resume (the phase that looked hung on the 82-file run).
+                using (var loadProgress = new ProgressReporter(@"Loading scored entries", config.InputFiles.Count))
                 {
-                    string fileName = Path.GetFileNameWithoutExtension(inputFile);
-                    string scoresPath = ParquetScoreCache.GetScoresPath(inputFile);
-                    // Strict load: CanRehydrate already certified these outputs
-                    // valid, so a failure is a genuine fault, not a "fall back to
-                    // rescore" case -- TryLoadStubsAndCalibration logs it as an
-                    // error (no misleading "will rescore" warning). Fail loudly;
-                    // Rehydrate must not compute.
-                    var stubs = TryLoadStubsAndCalibration(scoresPath, fileName, perFileCalibrations, perFileIsolationMz, ctx, resumeStrict: true);
-                    if (stubs == null)
+                    int fileIdx = 0;
+                    // Sequential in InputFiles order to match Run's "collect in original
+                    // order" -- downstream FirstJoin iterates perFileEntries.
+                    foreach (string inputFile in config.InputFiles)
                     {
-                        ctx.ExitCode = 1;
-                        return false;
+                        string fileName = Path.GetFileNameWithoutExtension(inputFile);
+                        string scoresPath = ParquetScoreCache.GetScoresPath(inputFile);
+                        if (needsResidentPool)
+                        {
+                            // Fat path: an opt-in output reads every entry's resident
+                            // features. Strict load: CanRehydrate already certified these
+                            // outputs valid, so a null is a genuine fault, not a "fall back
+                            // to rescore" case. Fail loudly; Rehydrate must not compute.
+                            var stubs = TryLoadStubsAndCalibration(scoresPath, fileName, perFileCalibrations, perFileIsolationMz, ctx, resumeStrict: true);
+                            if (stubs == null)
+                            {
+                                ctx.ExitCode = 1;
+                                return false;
+                            }
+                            perFileEntries.Add(new KeyValuePair<string, List<FdrEntry>>(fileName, stubs));
+                        }
+                        else
+                        {
+                            // Lean path: calibration + isolation still load (cheap); the
+                            // scores stream straight into the projection, no fat stub or
+                            // feature vector allocated. Byte-identical to the fat path
+                            // (TestFdrProjectionBuilderMatchesBuildFromEntries + mode2).
+                            LoadCalibrationAndIsolation(scoresPath, fileName, perFileCalibrations, perFileIsolationMz, ctx);
+                            try
+                            {
+                                builder.BeginFile(fileName);
+                                ParquetScoreCache.ReadFdrStubScalars(scoresPath,
+                                    (entryId, charge, isDecoy, coelutionSum, modseq) =>
+                                        builder.AddRow(entryId, charge, isDecoy, coelutionSum, modseq));
+                                builder.EndFile();
+                            }
+                            catch (Exception ex)
+                            {
+                                ctx.LogError(string.Format(
+                                    @"  Resume rehydrate: failed to load valid-on-disk scores from {0}: {1}",
+                                    scoresPath, ex.Message));
+                                ctx.ExitCode = 1;
+                                return false;
+                            }
+                            // Empty stub list on the lean path (mirrors Run), so the file-
+                            // count guard + ScoredEntries consumers still see one entry per
+                            // scored file.
+                            perFileEntries.Add(new KeyValuePair<string, List<FdrEntry>>(fileName, new List<FdrEntry>()));
+                        }
+                        perFileParquetPaths[fileName] = scoresPath;
+                        loadProgress.Report(++fileIdx);
                     }
-                    perFileEntries.Add(new KeyValuePair<string, List<FdrEntry>>(fileName, stubs));
-                    perFileParquetPaths[fileName] = scoresPath;
                 }
+                if (builder != null)
+                    projections = builder.Build();
             }
             swAllFiles.Stop();
             ctx.LogInfo(string.Format(@"[TIMING] All files processed: {0:F1}s",
                 swAllFiles.Elapsed.TotalSeconds));
 
-            int totalScored = 0;
-            foreach (var kvp in perFileEntries)
-                totalScored += kvp.Value.Count;
+            int totalScored;
+            if (projections != null)
+            {
+                totalScored = projections.TotalRows;
+            }
+            else
+            {
+                totalScored = 0;
+                foreach (var kvp in perFileEntries)
+                    totalScored += kvp.Value.Count;
+            }
 
             ctx.LogInfo(string.Empty);
             ctx.LogInfo(string.Format(
@@ -603,7 +655,7 @@ namespace pwiz.Osprey.Tasks
                 totalScored, nFiles));
 
             return FinalizeAndCheck(ctx, perFileEntries, perFileCalibrations,
-                perFileIsolationMz, perFileParquetPaths, nFiles, totalScored);
+                perFileIsolationMz, perFileParquetPaths, nFiles, totalScored, projections);
         }
 
         /// <summary>
@@ -1258,6 +1310,77 @@ namespace pwiz.Osprey.Tasks
         }
 
         /// <summary>
+        /// Whether Stage 5 needs the resident fat-stub first-pass pool rather than the
+        /// lean streamed <see cref="FdrProjection"/> set (#4400). True when an opt-in
+        /// output reads every entry's in-memory features/scores (--model-diagnostics,
+        /// FDRBench pass 1, OSPREY_PASS2_QVALUE=transfer), when the projection path is off
+        /// (OSPREY_FDR_PROJECTION=0 / non-Percolator FDR), or on the reconciled-input
+        /// worker join. Shared by <see cref="Run"/> and <see cref="RehydrateFromOwnOutputs"/>
+        /// so the compute and resume paths make the identical lean/fat choice -- otherwise a
+        /// pure resume rebuilds the ~53 GB fat buffer #4400 dropped for straight-through.
+        /// </summary>
+        private static bool NeedsResidentPool(OspreyConfig config)
+        {
+            return config.ExpectReconciledInput ||
+                   !OspreyEnvironment.UseFdrProjection ||
+                   config.FdrMethod != FdrMethod.Percolator ||
+                   config.ModelDiagnostics ||
+                   (!string.IsNullOrEmpty(config.OutputFdrBench) && config.FdrBenchPass == 1) ||
+                   OspreyEnvironment.Pass2TransferQ;
+        }
+
+        /// <summary>
+        /// Load a resumed file's RT calibration + gap-fill isolation m/z coverage from its
+        /// sibling <c>calibration.json</c> into the shared maps, so a cached-calibration
+        /// file gets the same filter input a fresh ProcessFile computes (mirrors Rust's
+        /// isolation_intervals_from_cal). Independent of the stub/projection load, so both
+        /// the fat (<see cref="TryLoadStubsAndCalibration"/>) and lean resume paths reuse it.
+        /// A failure is logged and swallowed -- calibration is an enrichment, not a gate.
+        /// </summary>
+        private static void LoadCalibrationAndIsolation(
+            string scoresPath,
+            string fileName,
+            ConcurrentDictionary<string, RTCalibration> perFileCalibrations,
+            ConcurrentDictionary<string, IReadOnlyList<(double Lo, double Hi)>> perFileIsolationMz,
+            PipelineContext ctx)
+        {
+            try
+            {
+                string parquetDir = Path.GetDirectoryName(Path.GetFullPath(scoresPath));
+                if (parquetDir != null)
+                {
+                    string calStemPath = Path.Combine(parquetDir, fileName);
+                    string calPath = CalibrationIO.CalibrationPathForInput(calStemPath, parquetDir);
+                    if (File.Exists(calPath))
+                    {
+                        var calParams = CalibrationIO.LoadCalibration(calPath);
+                        if (calParams.RtCalibration != null && calParams.RtCalibration.ModelParams != null)
+                        {
+                            var mp = calParams.RtCalibration.ModelParams;
+                            var rtCal = RTCalibration.FromModelParams(
+                                mp.LibraryRts, mp.FittedRts, mp.AbsResiduals,
+                                calParams.RtCalibration.ResidualSD);
+                            perFileCalibrations[fileName] = rtCal;
+                        }
+
+                        // Rehydrate the gap-fill m/z coverage from the isolation_scheme
+                        // block too (independent of RT cal), so a resumed / cached-
+                        // calibration file gets the same filter input a fresh ProcessFile
+                        // computes. Mirrors Rust's isolation_intervals_from_cal (pipeline.rs).
+                        var isoIntervals = IsolationIntervalsFromWindows(
+                            calParams.Metadata?.IsolationScheme?.Windows);
+                        if (isoIntervals != null)
+                            perFileIsolationMz[fileName] = isoIntervals;
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                ctx.LogWarning(string.Format(@"  Failed to load calibration for {0}: {1}", fileName, ex.Message));
+            }
+        }
+
+        /// <summary>
         /// Best-effort load of one file's stubs + PIN features from a
         /// <c>.scores.parquet</c> plus the calibration sibling. Returns
         /// the stub list on success or <c>null</c> on a stub/feature read
@@ -1312,41 +1435,7 @@ namespace pwiz.Osprey.Tasks
                 return null;
             }
 
-            try
-            {
-                string parquetDir = Path.GetDirectoryName(Path.GetFullPath(scoresPath));
-                if (parquetDir != null)
-                {
-                    string calStemPath = Path.Combine(parquetDir, fileName);
-                    string calPath = CalibrationIO.CalibrationPathForInput(calStemPath, parquetDir);
-                    if (File.Exists(calPath))
-                    {
-                        var calParams = CalibrationIO.LoadCalibration(calPath);
-                        if (calParams.RtCalibration != null && calParams.RtCalibration.ModelParams != null)
-                        {
-                            var mp = calParams.RtCalibration.ModelParams;
-                            var rtCal = RTCalibration.FromModelParams(
-                                mp.LibraryRts, mp.FittedRts, mp.AbsResiduals,
-                                calParams.RtCalibration.ResidualSD);
-                            perFileCalibrations[fileName] = rtCal;
-                        }
-
-                        // Rehydrate the gap-fill m/z coverage from the
-                        // isolation_scheme block too (independent of RT cal), so a
-                        // resumed / cached-calibration file gets the same filter
-                        // input a fresh ProcessFile computes. Mirrors Rust's
-                        // isolation_intervals_from_cal (pipeline.rs).
-                        var isoIntervals = IsolationIntervalsFromWindows(
-                            calParams.Metadata?.IsolationScheme?.Windows);
-                        if (isoIntervals != null)
-                            perFileIsolationMz[fileName] = isoIntervals;
-                    }
-                }
-            }
-            catch (Exception ex)
-            {
-                ctx.LogWarning(string.Format(@"  Failed to load calibration for {0}: {1}", fileName, ex.Message));
-            }
+            LoadCalibrationAndIsolation(scoresPath, fileName, perFileCalibrations, perFileIsolationMz, ctx);
             return stubs;
         }
 

--- a/pwiz_tools/Osprey/Osprey.Tasks/Stage6Planner.cs
+++ b/pwiz_tools/Osprey/Osprey.Tasks/Stage6Planner.cs
@@ -264,8 +264,14 @@ namespace pwiz.Osprey.Tasks
             OspreyConfig config)
         {
             IReadOnlyDictionary<(string File, int Index), ReconcileAction> reconciliationActions = null;
-            var perFileCwtCandidates = CwtCandidateLoader.Load(
-                perFileEntries, perFileParquetPaths, _ctx.LogWarning);
+            // Metadata-only gate: confirm every file's stubs are in range of its
+            // parquet's row count WITHOUT decoding or holding any file's CWT
+            // candidates. The former eager all-files load held every run's candidate
+            // lists at once -- the buffer that OOM'd the 82-file Stage-6 planning
+            // phase; the planner below now streams each file's candidates on demand
+            // and releases them before the next file.
+            bool allCwtInRange = CwtCandidateLoader.ValidateAllInRange(
+                perFileEntries, perFileParquetPaths, _ctx.LogWarning, out int cwtValidFileCount);
             var perFileForPlan = new List<KeyValuePair<string,
                 IReadOnlyList<FdrEntry>>>(perFileEntries.Count);
             foreach (var kvp in perFileEntries)
@@ -273,13 +279,13 @@ namespace pwiz.Osprey.Tasks
                 perFileForPlan.Add(new KeyValuePair<string,
                     IReadOnlyList<FdrEntry>>(kvp.Key, kvp.Value));
             }
-            if (perFileCwtCandidates.Count == perFileEntries.Count
-                && consensus.Count > 0)
+            if (allCwtInRange && consensus.Count > 0)
             {
                 reconciliationActions = ReconciliationPlanner.Plan(
                     consensus,
                     perFileForPlan,
-                    perFileCwtCandidates,
+                    fileName => CwtCandidateLoader.LoadOneFile(
+                        fileName, perFileParquetPaths, _ctx.LogWarning),
                     refinedCalibrations,
                     perFileCalibrations,
                     config.Reconciliation.ConsensusFdr);
@@ -295,7 +301,7 @@ namespace pwiz.Osprey.Tasks
             {
                 _ctx.LogInfo(string.Format(
                     @"Reconciliation: skipped (CWT candidates loaded for {0}/{1} files)",
-                    perFileCwtCandidates.Count, perFileEntries.Count));
+                    cwtValidFileCount, perFileEntries.Count));
             }
 
             // Stage 6 cross-impl bisection dump for the planner output. Fires

--- a/pwiz_tools/Osprey/Osprey.Tasks/Stage6Planner.cs
+++ b/pwiz_tools/Osprey/Osprey.Tasks/Stage6Planner.cs
@@ -264,14 +264,14 @@ namespace pwiz.Osprey.Tasks
             OspreyConfig config)
         {
             IReadOnlyDictionary<(string File, int Index), ReconcileAction> reconciliationActions = null;
-            // Metadata-only gate: confirm every file's stubs are in range of its
-            // parquet's row count WITHOUT decoding or holding any file's CWT
-            // candidates. The former eager all-files load held every run's candidate
-            // lists at once -- the buffer that OOM'd the 82-file Stage-6 planning
-            // phase; the planner below now streams each file's candidates on demand
-            // and releases them before the next file.
-            bool allCwtInRange = CwtCandidateLoader.ValidateAllInRange(
-                perFileEntries, perFileParquetPaths, _ctx.LogWarning, out int cwtValidFileCount);
+            // Fail-fast: a footer-only metadata check confirms every file's stubs are in
+            // range of its parquet (no decode, nothing resident -- the former eager
+            // all-files load was the buffer that OOM'd the 82-file Stage-6 planning). A
+            // missing / corrupt / out-of-range Stage-4 parquet THROWS here, aborting the
+            // run with a clear "delete + regenerate {file}" error rather than reconciling
+            // only the good files. The planner then streams each file's candidates on
+            // demand (LoadOneFile, which throws the same way on a corrupt CWT blob).
+            CwtCandidateLoader.ValidateAllInRange(perFileEntries, perFileParquetPaths);
             var perFileForPlan = new List<KeyValuePair<string,
                 IReadOnlyList<FdrEntry>>>(perFileEntries.Count);
             foreach (var kvp in perFileEntries)
@@ -279,13 +279,14 @@ namespace pwiz.Osprey.Tasks
                 perFileForPlan.Add(new KeyValuePair<string,
                     IReadOnlyList<FdrEntry>>(kvp.Key, kvp.Value));
             }
-            if (allCwtInRange && consensus.Count > 0)
+            // Empty consensus (single-file / no cross-file evidence) is a legitimate
+            // skip, not an error -- only a corrupt input aborts (above).
+            if (consensus.Count > 0)
             {
                 reconciliationActions = ReconciliationPlanner.Plan(
                     consensus,
                     perFileForPlan,
-                    fileName => CwtCandidateLoader.LoadOneFile(
-                        fileName, perFileParquetPaths, _ctx.LogWarning),
+                    fileName => CwtCandidateLoader.LoadOneFile(fileName, perFileParquetPaths),
                     refinedCalibrations,
                     perFileCalibrations,
                     config.Reconciliation.ConsensusFdr);
@@ -293,15 +294,9 @@ namespace pwiz.Osprey.Tasks
                     @"Reconciliation: {0} per-(file, entry) actions planned",
                     reconciliationActions.Count));
             }
-            else if (consensus.Count == 0)
-            {
-                _ctx.LogInfo(@"Reconciliation: skipped (empty consensus; single-file or no cross-file evidence)");
-            }
             else
             {
-                _ctx.LogInfo(string.Format(
-                    @"Reconciliation: skipped (CWT candidates loaded for {0}/{1} files)",
-                    cwtValidFileCount, perFileEntries.Count));
+                _ctx.LogInfo(@"Reconciliation: skipped (empty consensus; single-file or no cross-file evidence)");
             }
 
             // Stage 6 cross-impl bisection dump for the planner output. Fires

--- a/pwiz_tools/Osprey/Osprey.Test/IOTest.cs
+++ b/pwiz_tools/Osprey/Osprey.Test/IOTest.cs
@@ -29,6 +29,9 @@ using System.IO;
 using System.IO.Compression;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Newtonsoft.Json;
+using Parquet;
+using Parquet.Data;
+using Parquet.Schema;
 using pwiz.Osprey.Chromatography;
 using pwiz.Osprey.Core;
 using pwiz.Osprey.FDR.Reconciliation;
@@ -1489,6 +1492,13 @@ namespace pwiz.Osprey.Test
                 Assert.AreEqual(0u, stubs[0].ParquetIndex);
                 Assert.AreEqual(1u, stubs[1].ParquetIndex);
 
+                // A valid Osprey parquet must pass the lean-path feature-presence
+                // guard (else the resume/HPC-merge fail-fast would reject every real
+                // run). This also pins the writer's first feature column name to the
+                // PIN_FEATURE_NAMES[0] the probe checks -- a rename desync between them
+                // would silently break both.
+                Assert.IsTrue(ParquetScoreCache.HasPinFeatureColumns(path));
+
                 // Read PIN features
                 var features = ParquetScoreCache.LoadPinFeaturesFromParquet(path);
                 Assert.AreEqual(3, features.Count);
@@ -1508,6 +1518,40 @@ namespace pwiz.Osprey.Test
                     { "osprey.version", "2.0.0" },
                 };
                 Assert.IsFalse(ParquetScoreCache.ValidateMetadata(path, wrongMeta));
+            }
+            finally
+            {
+                TryDeleteFile(path);
+            }
+        }
+
+        /// <summary>
+        /// A parquet that carries the scalar stub columns but NOT the PIN feature
+        /// columns (a foreign or truncated scores file) must fail the lean-path
+        /// feature-presence guard, so the resume / HPC-merge paths abort up front
+        /// instead of streaming scalars from an untrustworthy file. Writes a minimal
+        /// single-column parquet lacking the feature schema and asserts the footer
+        /// probe reports it. Paired with the positive assertion in
+        /// <see cref="TestParquetScoreCacheRoundTrip"/>.
+        /// </summary>
+        [TestMethod]
+        public void TestHasPinFeatureColumnsRejectsFeaturelessParquet()
+        {
+            string path = Path.GetTempFileName() + ".parquet";
+            try
+            {
+                var entryIdField = new DataField<uint>("entry_id");
+                var schema = new ParquetSchema(entryIdField);
+                using (var stream = new FileStream(path, FileMode.Create, FileAccess.Write))
+                using (var writer = ParquetWriter.CreateAsync(schema, stream).GetAwaiter().GetResult())
+                using (var group = writer.CreateRowGroup())
+                {
+                    group.WriteColumnAsync(new DataColumn(entryIdField, new[] { 1u, 2u, 3u }))
+                        .GetAwaiter().GetResult();
+                }
+
+                Assert.IsFalse(ParquetScoreCache.HasPinFeatureColumns(path),
+                    "A parquet without the PIN feature columns must be rejected by the lean-path guard.");
             }
             finally
             {

--- a/pwiz_tools/Osprey/Osprey.Test/IOTest.cs
+++ b/pwiz_tools/Osprey/Osprey.Test/IOTest.cs
@@ -1537,12 +1537,16 @@ namespace pwiz.Osprey.Test
         [TestMethod]
         public void TestHasPinFeatureColumnsRejectsFeaturelessParquet()
         {
-            string path = Path.GetTempFileName() + ".parquet";
-            try
+            // FileSaver owns the scratch file's lifecycle: write the fixture to its
+            // sibling temp, probe that, and never Commit() -- Dispose discards the temp
+            // (no leaked temp file, cleaned up even if an assertion throws).
+            string dest = Path.Combine(Path.GetTempPath(),
+                @"osprey_haspin_" + Path.GetRandomFileName() + @".parquet");
+            using (var saver = new FileSaver(dest))
             {
                 var entryIdField = new DataField<uint>("entry_id");
                 var schema = new ParquetSchema(entryIdField);
-                using (var stream = new FileStream(path, FileMode.Create, FileAccess.Write))
+                using (var stream = new FileStream(saver.SafeName, FileMode.Create, FileAccess.Write))
                 using (var writer = ParquetWriter.CreateAsync(schema, stream).GetAwaiter().GetResult())
                 using (var group = writer.CreateRowGroup())
                 {
@@ -1550,12 +1554,8 @@ namespace pwiz.Osprey.Test
                         .GetAwaiter().GetResult();
                 }
 
-                Assert.IsFalse(ParquetScoreCache.HasPinFeatureColumns(path),
+                Assert.IsFalse(ParquetScoreCache.HasPinFeatureColumns(saver.SafeName),
                     "A parquet without the PIN feature columns must be rejected by the lean-path guard.");
-            }
-            finally
-            {
-                TryDeleteFile(path);
             }
         }
 

--- a/pwiz_tools/Osprey/Osprey.Test/IOTest.cs
+++ b/pwiz_tools/Osprey/Osprey.Test/IOTest.cs
@@ -1413,8 +1413,12 @@ namespace pwiz.Osprey.Test
         [TestMethod]
         public void TestParquetScoreCacheRoundTrip()
         {
-            string path = Path.GetTempFileName() + ".parquet";
-            try
+            // FileSaver owns the scratch file's lifecycle: write + read back through
+            // its sibling temp and never Commit() -- Dispose discards it (no leaked
+            // GetTempFileName file, cleaned up even if an assertion throws).
+            string dest = Path.Combine(Path.GetTempPath(),
+                @"osprey_roundtrip_" + Path.GetRandomFileName() + @".parquet");
+            using (var saver = new FileSaver(dest))
             {
                 // Create test entries
                 var entries = new List<CoelutionScoredEntry>();
@@ -1471,11 +1475,11 @@ namespace pwiz.Osprey.Test
                 };
 
                 // Write
-                ParquetScoreCache.WriteScoresParquet(path, entries, metadata);
-                Assert.IsTrue(File.Exists(path), "Parquet file should exist");
+                ParquetScoreCache.WriteScoresParquet(saver.SafeName, entries, metadata);
+                Assert.IsTrue(File.Exists(saver.SafeName), "Parquet file should exist");
 
                 // Read FDR stubs
-                var stubs = ParquetScoreCache.LoadFdrStubsFromParquet(path);
+                var stubs = ParquetScoreCache.LoadFdrStubsFromParquet(saver.SafeName);
                 Assert.AreEqual(3, stubs.Count);
                 Assert.AreEqual(100u, stubs[0].EntryId);
                 Assert.AreEqual(101u, stubs[1].EntryId);
@@ -1497,10 +1501,10 @@ namespace pwiz.Osprey.Test
                 // run). This also pins the writer's first feature column name to the
                 // PIN_FEATURE_NAMES[0] the probe checks -- a rename desync between them
                 // would silently break both.
-                Assert.IsTrue(ParquetScoreCache.HasPinFeatureColumns(path));
+                Assert.IsTrue(ParquetScoreCache.HasPinFeatureColumns(saver.SafeName));
 
                 // Read PIN features
-                var features = ParquetScoreCache.LoadPinFeaturesFromParquet(path);
+                var features = ParquetScoreCache.LoadPinFeaturesFromParquet(saver.SafeName);
                 Assert.AreEqual(3, features.Count);
                 Assert.AreEqual(ParquetScoreCache.NUM_PIN_FEATURES, features[0].Length);
                 // Check first entry features
@@ -1512,16 +1516,12 @@ namespace pwiz.Osprey.Test
                 Assert.AreEqual(2.6, features[1][6], 0.001);
 
                 // Validate metadata
-                Assert.IsTrue(ParquetScoreCache.ValidateMetadata(path, metadata));
+                Assert.IsTrue(ParquetScoreCache.ValidateMetadata(saver.SafeName, metadata));
                 var wrongMeta = new Dictionary<string, string>
                 {
                     { "osprey.version", "2.0.0" },
                 };
-                Assert.IsFalse(ParquetScoreCache.ValidateMetadata(path, wrongMeta));
-            }
-            finally
-            {
-                TryDeleteFile(path);
+                Assert.IsFalse(ParquetScoreCache.ValidateMetadata(saver.SafeName, wrongMeta));
             }
         }
 

--- a/pwiz_tools/Osprey/Osprey.Test/ProgressReporterTest.cs
+++ b/pwiz_tools/Osprey/Osprey.Test/ProgressReporterTest.cs
@@ -1,0 +1,94 @@
+/*
+ * Original author: Brendan MacLean <brendanx .at. uw.edu>,
+ *                  MacCoss Lab, Department of Genome Sciences, UW
+ * AI assistance: Claude Code (Claude Opus 4.8) <noreply .at. anthropic.com>
+ *
+ * Based on osprey (https://github.com/MacCossLab/osprey)
+ *   by Michael J. MacCoss, MacCoss Lab, Department of Genome Sciences, UW
+ *
+ * Copyright 2026 University of Washington - Seattle, WA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using pwiz.Osprey.Core;
+
+namespace pwiz.Osprey.Test
+{
+    /// <summary>
+    /// Unit tests for <see cref="ProgressReporter"/>'s frozen-percent heartbeat: a phase
+    /// advancing slower than 1% per <see cref="ProgressReporter.HEARTBEAT_SECONDS"/> must
+    /// still emit a line so it never looks hung, while a normally-advancing phase must not
+    /// gain heartbeat clutter. The heartbeat interval is injected small/large so the
+    /// timer-driven behavior is deterministic without a real 30 s wait.
+    /// </summary>
+    [TestClass]
+    public class ProgressReporterTest
+    {
+        [TestMethod]
+        public void TestProgressReporterHeartbeat()
+        {
+            // Frozen integer percent (1 of 1,000,000 == 0%): after the idle threshold the
+            // reporter reprints the current percent with an elapsed parenthetical so the
+            // console stays alive. intervalSeconds 0 lets the initial advance print at once.
+            var frozen = CaptureLines(total: 1000000, intervalSeconds: 0.0, heartbeatSeconds: 0.05,
+                act: p =>
+                {
+                    p.Report(1);            // prints "0%"
+                    Thread.Sleep(150);      // idle past the 0.05 s heartbeat threshold
+                    p.Report(1);            // still 0% -> heartbeat line
+                });
+            // Only the heartbeat line carries the "(... elapsed)" parenthetical; the plain
+            // "N%" advance lines and the heading do not (punctuation, not localizable text).
+            StringAssert.Contains(string.Join("\n", frozen), "(");
+
+            // A phase that advances on every report but never idles past a (wide) heartbeat
+            // threshold emits only advance lines -- no heartbeat clutter on healthy phases.
+            var fast = CaptureLines(total: 100, intervalSeconds: 0.0, heartbeatSeconds: 999.0,
+                act: p =>
+                {
+                    p.Report(25);
+                    p.Report(50);
+                    p.Report(75);
+                });
+            Assert.IsFalse(string.Join("\n", fast).Contains("("),
+                "a fast, always-advancing phase should emit no heartbeat line");
+        }
+
+        /// <summary>
+        /// Run <paramref name="act"/> against a <see cref="ProgressReporter"/> whose output is
+        /// captured through a scoped writer (AsyncLocal, so no cross-test static leak) and
+        /// return the non-empty output lines.
+        /// </summary>
+        private static List<string> CaptureLines(long total, double intervalSeconds,
+            double heartbeatSeconds, Action<ProgressReporter> act)
+        {
+            var writer = new StringWriter();
+            using (OspreyOutput.PushScopedOut(writer))
+            using (var reporter = new ProgressReporter(@"phase", total, string.Empty,
+                intervalSeconds, heartbeatSeconds))
+            {
+                act(reporter);
+            }
+            return writer.ToString()
+                .Split(new[] { "\r\n", "\n" }, StringSplitOptions.RemoveEmptyEntries)
+                .ToList();
+        }
+    }
+}

--- a/pwiz_tools/Osprey/Osprey/OspreyFileDiagnostics.cs
+++ b/pwiz_tools/Osprey/Osprey/OspreyFileDiagnostics.cs
@@ -1724,7 +1724,7 @@ namespace pwiz.Osprey
 
         /// <summary>
         /// Dump the per-(file, entry) <see cref="ReconcileAction"/> map
-        /// produced by <see cref="ReconciliationPlanner"/>.Plan to
+        /// produced by <c>ReconciliationPlanner.Plan</c> to
         /// <c>cs_stage6_reconciliation.tsv</c>. Used for cross-impl parity
         /// of the planner output -- pairs with the Rust
         /// <c>dump_stage6_reconciliation</c> helper. Columns:

--- a/pwiz_tools/Osprey/Osprey/OspreyFileDiagnostics.cs
+++ b/pwiz_tools/Osprey/Osprey/OspreyFileDiagnostics.cs
@@ -1724,7 +1724,7 @@ namespace pwiz.Osprey
 
         /// <summary>
         /// Dump the per-(file, entry) <see cref="ReconcileAction"/> map
-        /// produced by <see cref="ReconciliationPlanner.Plan"/> to
+        /// produced by <see cref="ReconciliationPlanner"/>.Plan to
         /// <c>cs_stage6_reconciliation.tsv</c>. Used for cross-impl parity
         /// of the planner output -- pairs with the Rust
         /// <c>dump_stage6_reconciliation</c> helper. Columns:


### PR DESCRIPTION
## Summary

Three all-runs-resident memory ceilings kept a large Osprey run (82-file SEA-AD
Astral, ~2x-entrapment library) from fitting a 64 GB box. #4400 (straight-through
`FdrProjection` streaming) and #4394 (reconciliation transient drop) did not cover
them. This bounds all three, byte-identical, and lands the first successful 82-file
run.

* **Stage-6 reconciliation planning** amassed every file's CWT candidate lists at
  once (indexed to the full pre-compaction row count) -- the exact structure the
  82-file run OOM'd at. `CwtCandidateLoader.Load` -> a footer-only metadata gate
  `ValidateAllInRange` (no blob decode, nothing resident) + a per-file streaming
  `LoadOneFile`; `ReconciliationPlanner.Plan` pulls one file's candidates on demand
  via a `Func<>` loader. The lever #4394 explicitly deferred.
* **Straight-through resume** (`PerFileScoringTask.RehydrateFromOwnOutputs`)
  rehydrated the full fat `FdrEntry` stubs + PIN features (~53 GB at 82 files) with
  no lean branch -- the #4400 cost still paid on resume. Now takes the same
  `needsResidentPool`-gated lean projection branch as `Run`.
* **HPC merge/join** (`LoadJoinOnlyScores`, the `--input-scores` merge node) had the
  identical unconditional fat-stub load -- a large HPC first-pass merge would blow up
  Stage 5 the same way. Same lean fix, gated additionally on `!AllHaveReconSidecars`
  so the reconciled 2nd-pass bundle merge (which overlays q onto the stubs and skips
  Percolator) stays fat.
* **Progress**: a `ProgressReporter` frozen-percent heartbeat -- on a phase slower
  than 1%/interval it reprints `N.NN% (done/total, elapsed)` so slow phases stop
  looking hung -- and wrapped the previously-silent all-files resume load in a
  reporter. Heartbeat + elapsed formatting use `CultureInfo.InvariantCulture`.

Shared helpers (`NeedsResidentPool`, `LoadCalibrationAndIsolation`,
`AllHaveReconSidecars`) keep the compute / resume / merge paths making the identical
lean-vs-fat choice.

### Fail-fast on corrupt inputs (no silent degradation)

The lean streaming paths drop the fat path's implicit corruption guards, so a
foreign/truncated parquet could otherwise degrade output instead of stopping. The
lean paths now fail fast, matching the old hard-fail (byte-identical on valid inputs):

* **Stage-6 CWT planning**: `ValidateAllInRange` / `LoadOneFile` now *throw*
  (naming the offending file, "delete the affected `.scores.parquet` and re-run")
  on a missing / unreadable / out-of-range / undecodable candidate file, rather than
  skipping reconciliation for that file and silently keeping its peaks.
* **Lean resume + HPC-merge**: the fat path threw on
  `features.Count != stubs.Count`; streaming scalars never loads features, so a
  footer-only `ParquetScoreCache.HasPinFeatureColumns` probe (no feature memory)
  restores an equivalent up-front check -- a parquet missing the PIN feature schema
  stops the run with a "delete it and re-run to regenerate" message. Deliberately
  NOT applied to `Run`'s fresh-compute lean path (#4400), whose parquets the same run
  just wrote.
* The reconciled-2nd-pass-bundle predicate is computed once in the merge path and
  threaded to both the loader and the hydrator, so a sidecar appearing between two
  separate disk reads cannot make the lean/fat choice and the bundle hydrator
  disagree (TOCTOU).

Not in scope: streaming `--model-diagnostics` itself (it still forces the resident
pool via `needsResidentPool`) -- a focused follow-up.

Requested by Brendan.

## Test plan

- [x] `TestProgressReporterHeartbeat` - frozen-percent heartbeat fires, fast phase stays clean
- [x] `TestHasPinFeatureColumnsRejectsFeaturelessParquet` + round-trip positive assertion - lean-path guard rejects a features-less parquet, passes a valid one (pins writer/probe column-name agreement)
- [x] Build net472 + net8.0, zero warnings; ReSharper inspection clean on changed files (509 tests pass)
- [x] `regression.ps1 -Dataset Stellar` mode1/2/3 byte-identical (mode2 = resume path, mode3 = HPC merge path) - re-run after self-review fail-fast changes; PASS (golden blib 45,064,192)
- [x] `Test-PerfGate.ps1 -Dataset Stellar` - perf-neutral (total median -6.8% vs baseline, all reps faster; no stage regressed)
- [ ] TeamCity Osprey Windows .NET Perf/Regression (Astral) on the PR ref
- [x] 82-file no-mdiag resume: cleared all three ceilings end-to-end (Stage-6 `6,472,914 per-(file,entry) actions planned` - the line that never appeared before); memory cycled ~14->60 GB per file, CommitFree ~47 GB, no OOM

Co-Authored-By: Claude <noreply@anthropic.com>
