### PR TITLE
Streamed --model-diagnostics off the projection path so 82-file runs fit memory

### DIFF
--- a/pwiz_tools/Osprey/Osprey.FDR/FdrProjectionOutput.cs
+++ b/pwiz_tools/Osprey/Osprey.FDR/FdrProjectionOutput.cs
@@ -73,6 +73,27 @@ namespace pwiz.Osprey.FDR
                     throw new ArgumentOutOfRangeException(nameof(level));
             }
         }
+
+        /// <summary>
+        /// Effective experiment-level q-value for the FDR control level, matching
+        /// <see cref="FdrEntry.EffectiveExperimentQvalue"/> exactly. Used by the
+        /// streaming <c>--model-diagnostics</c> accumulator's cross-run experiment
+        /// gate, where the entry is off the struct and only these q-values are live.
+        /// </summary>
+        public double EffectiveExperimentQvalue(FdrLevel level)
+        {
+            switch (level)
+            {
+                case FdrLevel.Precursor:
+                    return ExperimentPrecursorQvalue;
+                case FdrLevel.Peptide:
+                    return ExperimentPeptideQvalue;
+                case FdrLevel.Both:
+                    return Math.Max(ExperimentPrecursorQvalue, ExperimentPeptideQvalue);
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(level));
+            }
+        }
     }
 
     /// <summary>

--- a/pwiz_tools/Osprey/Osprey.FDR/ModelDiagnostics/ModelDiagnosticsData.Accumulator.cs
+++ b/pwiz_tools/Osprey/Osprey.FDR/ModelDiagnostics/ModelDiagnosticsData.Accumulator.cs
@@ -1,0 +1,311 @@
+/*
+ * Original author: Brendan MacLean <brendanx .at. uw.edu>,
+ *                  MacCoss Lab, Department of Genome Sciences, UW
+ * AI assistance: Claude Code (Claude Opus 4.8) <noreply .at. anthropic.com>
+ *
+ * Copyright 2026 University of Washington - Seattle, WA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using pwiz.Osprey.Core;
+
+namespace pwiz.Osprey.FDR.ModelDiagnostics
+{
+    public sealed partial class ModelDiagnosticsData
+    {
+        /// <summary>
+        /// Streaming builder for the pass-1 <see cref="ModelDiagnosticsData"/> that folds each
+        /// first-pass FDR row into the SAME reduced structures the batch <see cref="Build"/>
+        /// derives from the resident pool, WITHOUT ever holding the full pre-compaction
+        /// <see cref="FdrEntry"/> pool resident. Fed one row at a time from the projection
+        /// score-pass sink (<c>FdrProjectionSinkBase.Accept</c>) in nested (file, row) order;
+        /// <see cref="Build"/> then runs the identical downstream builders over the accumulated
+        /// reductions.
+        ///
+        /// Why this is byte-identical with the batch <see cref="Build"/>: every reduction here --
+        /// best-per-precursor (max score, min q per modseq|charge), per-file passing counts,
+        /// cross-run passing key-sets, and win-fraction per-base_id max scores -- is
+        /// ORDER-INDEPENDENT. Within a (modseq|charge) key the class / is_decoy / pair_index are
+        /// invariant (base_id is constant and a decoy carries a distinct sequence), so the
+        /// max-score/min-q reduction lands on the same values whatever order rows arrive; the
+        /// per-file counts and cross-run sets are tallies/sets keyed on identity; the win-fraction
+        /// reduction is a per-base_id max. The shared downstream builders (score histogram,
+        /// density ratio, id-yield, FDP views, cross-run views, win fraction) then consume only
+        /// the reduced state. So the streamed reduction reproduces the resident reduction
+        /// element-for-element, while the 340M-row pre-compaction pool that OOM'd an 82-file
+        /// --model-diagnostics run at the join is never materialized -- the accumulator holds only
+        /// ~unique-precursor / ~base_id-sized maps.
+        /// </summary>
+        public sealed class Accumulator
+        {
+            private readonly IReadOnlyDictionary<uint, EntrapmentClass> _classByBaseId;
+            private readonly IReadOnlyDictionary<uint, uint> _pairByBaseId;
+            private readonly bool _haveManifest;
+            private readonly double _entrapmentRatio;
+            private readonly double _runFdr;
+            private readonly FdrLevel _fdrLevel;
+            private readonly string[] _runNames;
+            private readonly int _nFiles;
+
+            // Best-per-precursor, keyed modseq|charge (== ReduceToPrecs).
+            private readonly Dictionary<string, Prec> _best =
+                new Dictionary<string, Prec>(StringComparer.Ordinal);
+            private int _nWithClass;
+            private int _nWithoutClass;
+
+            // Per-file passing counts at the run-level FDR (== BuildPerFile).
+            private readonly int[] _fileTargets;
+            private readonly int[] _fileDecoys;
+            private readonly int[] _fileEntrap;
+
+            // Per-file passing key-sets for the cross-run reproducibility view
+            // (== BuildCrossRunDetection): real targets (run/exp gate) + entrapment (run/exp gate).
+            private readonly List<HashSet<string>> _runSets;
+            private readonly List<HashSet<string>> _expSets;
+            private readonly List<HashSet<string>> _entRunSets;
+            private readonly List<HashSet<string>> _entExpSets;
+            private bool _anyEntrapment;
+
+            // Win fraction: base_id -> [best target score, best decoy score] + target-side class
+            // (== BuildWinFraction).
+            private readonly Dictionary<uint, double[]> _bt = new Dictionary<uint, double[]>();
+            private readonly Dictionary<uint, EntrapmentClass> _tClass =
+                new Dictionary<uint, EntrapmentClass>();
+
+            /// <param name="runNames">Input-file names in scoring (input-file) order -- the x for
+            /// the per-file table and cross-run curves; also fixes <see cref="FileCount"/>.</param>
+            /// <param name="classByBaseId">library base_id -> target-side entrapment class, exactly
+            /// as passed to the batch <see cref="Build"/> (null/empty degrades to is_decoy-only).</param>
+            /// <param name="pairByBaseId">library base_id -> peptide_pair_index (paired FDP), may be null.</param>
+            /// <param name="entrapmentRatio">entrapment-to-target DB ratio r.</param>
+            /// <param name="runFdr">configured run-level FDR.</param>
+            /// <param name="fdrLevel">reported FDR control level (drives EffectiveRunQvalue).</param>
+            public Accumulator(
+                string[] runNames,
+                IReadOnlyDictionary<uint, EntrapmentClass> classByBaseId,
+                IReadOnlyDictionary<uint, uint> pairByBaseId,
+                double entrapmentRatio,
+                double runFdr,
+                FdrLevel fdrLevel)
+            {
+                _runNames = runNames ?? throw new ArgumentNullException(nameof(runNames));
+                _nFiles = runNames.Length;
+                _classByBaseId = classByBaseId;
+                _pairByBaseId = pairByBaseId;
+                _haveManifest = classByBaseId != null && classByBaseId.Count > 0;
+                _entrapmentRatio = entrapmentRatio;
+                _runFdr = runFdr;
+                _fdrLevel = fdrLevel;
+
+                _fileTargets = new int[_nFiles];
+                _fileDecoys = new int[_nFiles];
+                _fileEntrap = new int[_nFiles];
+                _runSets = NewSets(_nFiles);
+                _expSets = NewSets(_nFiles);
+                _entRunSets = NewSets(_nFiles);
+                _entExpSets = NewSets(_nFiles);
+            }
+
+            private static List<HashSet<string>> NewSets(int n)
+            {
+                var list = new List<HashSet<string>>(n);
+                for (int i = 0; i < n; i++)
+                    list.Add(new HashSet<string>(StringComparer.Ordinal));
+                return list;
+            }
+
+            /// <summary>
+            /// Fold one scored, pre-compaction first-pass row into the reduced state, mirroring the
+            /// per-entry work the batch ReduceToPrecs / BuildPerFile / BuildCrossRunDetection /
+            /// BuildWinFraction passes do for one <see cref="FdrEntry"/>. Called once per projection
+            /// row in nested (file, row) order from the score-pass sink. <paramref name="q"/> is the
+            /// row's freshly computed first-pass q-values (the report reads only run/experiment
+            /// precursor + peptide q; protein q is not needed and is filled after this pass).
+            /// </summary>
+            public void Add(int fileIdx, string modifiedSequence, byte charge, uint entryId,
+                bool isDecoy, double score, in FdrQValues q)
+            {
+                uint baseId = entryId & BASE_ID_MASK;
+                EntrapmentClass cls = Classify(isDecoy, baseId, _classByBaseId, _haveManifest,
+                    ref _nWithClass, ref _nWithoutClass);
+                string key = modifiedSequence + "|" + charge;
+
+                // --- best-per-precursor (== ReduceToPrecs: max score, min q at each scope) ---
+                uint pairIdx = 0;
+                bool hasPair = _pairByBaseId != null && _pairByBaseId.TryGetValue(baseId, out pairIdx);
+                if (!_best.TryGetValue(key, out var cur))
+                {
+                    cur = new Prec
+                    {
+                        Score = score,
+                        QRunPrecursor = q.RunPrecursorQvalue,
+                        QExpPrecursor = q.ExperimentPrecursorQvalue,
+                        IsDecoy = isDecoy,
+                        Class = cls,
+                        PairIndex = pairIdx,
+                        Charge = charge,
+                        HasPair = hasPair,
+                    };
+                }
+                else
+                {
+                    if (score > cur.Score)
+                    {
+                        cur.Score = score;
+                        cur.IsDecoy = isDecoy;
+                        cur.Class = cls;
+                        cur.PairIndex = pairIdx;
+                        cur.HasPair = hasPair;
+                    }
+                    if (q.RunPrecursorQvalue < cur.QRunPrecursor)
+                        cur.QRunPrecursor = q.RunPrecursorQvalue;
+                    if (q.ExperimentPrecursorQvalue < cur.QExpPrecursor)
+                        cur.QExpPrecursor = q.ExperimentPrecursorQvalue;
+                }
+                _best[key] = cur;
+
+                // --- per-file passing counts (== BuildPerFile) + cross-run key-sets
+                //     (== BuildCrossRunDetection): the run-level FDR gate, decoys counted but
+                //     excluded from the reproducibility sets, entrapment routed to its own sets. ---
+                bool isEntrap = _haveManifest && _classByBaseId != null
+                    && _classByBaseId.TryGetValue(baseId, out var pcls)
+                    && pcls == EntrapmentClass.PTarget;
+                if (q.EffectiveRunQvalue(_fdrLevel) <= _runFdr)
+                {
+                    if (isDecoy)
+                    {
+                        _fileDecoys[fileIdx]++;
+                    }
+                    else
+                    {
+                        if (isEntrap)
+                            _fileEntrap[fileIdx]++;
+                        else
+                            _fileTargets[fileIdx]++;
+
+                        bool expOk = q.EffectiveExperimentQvalue(_fdrLevel) <= _runFdr;
+                        if (isEntrap)
+                        {
+                            _entRunSets[fileIdx].Add(key);
+                            if (expOk)
+                                _entExpSets[fileIdx].Add(key);
+                            _anyEntrapment = true;
+                        }
+                        else
+                        {
+                            _runSets[fileIdx].Add(key);
+                            if (expOk)
+                                _expSets[fileIdx].Add(key);
+                        }
+                    }
+                }
+
+                // --- win fraction per base_id (== BuildWinFraction: best target vs best decoy) ---
+                if (!_bt.TryGetValue(baseId, out var slot))
+                {
+                    slot = new[] { double.NegativeInfinity, double.NegativeInfinity };
+                    _bt[baseId] = slot;
+                }
+                if (isDecoy)
+                {
+                    if (score > slot[1]) slot[1] = score;
+                }
+                else if (score > slot[0])
+                {
+                    slot[0] = score;
+                    _tClass[baseId] = _haveManifest && _classByBaseId != null
+                        && _classByBaseId.TryGetValue(baseId, out var c)
+                        ? c : EntrapmentClass.Target;
+                }
+            }
+
+            /// <summary>
+            /// Assemble the pass-1 <see cref="ModelDiagnosticsData"/> from the accumulated
+            /// reductions, running the SAME downstream builders the batch <see cref="Build"/> uses
+            /// (only the reduction source differs). <paramref name="contributions"/> is the trained
+            /// first-pass model (null on a non-Percolator / rehydrated run -> no Model tab).
+            /// </summary>
+            public ModelDiagnosticsData Build(FeatureContributions contributions)
+            {
+                var precs = _best.Values.ToList();
+                var data = new ModelDiagnosticsData
+                {
+                    RunFdr = _runFdr,
+                    FdrLevel = _fdrLevel.ToString(),
+                    FileCount = _nFiles,
+                    Model = new List<FeatureRow>(),
+                };
+
+                // Per-file passing summary (== BuildPerFile), one row per file in input order.
+                var perFile = new List<FileSummaryRow>(_nFiles);
+                for (int f = 0; f < _nFiles; f++)
+                {
+                    perFile.Add(new FileSummaryRow
+                    {
+                        File = _runNames[f],
+                        Targets = _fileTargets[f],
+                        Decoys = _fileDecoys[f],
+                        Entrapment = _fileEntrap[f],
+                    });
+                }
+                data.PerFile = perFile;
+
+                foreach (var p in precs)
+                {
+                    switch (p.Class)
+                    {
+                        case EntrapmentClass.Target: data.NTarget++; break;
+                        case EntrapmentClass.Decoy: data.NDecoy++; break;
+                        case EntrapmentClass.PTarget: data.NPTarget++; break;
+                        case EntrapmentClass.PDecoy: data.NPDecoy++; break;
+                    }
+                }
+                data.HasEntrapment = data.NPTarget > 0;
+                data.FeatureCount = contributions?.Features.Count ?? 0;
+                data.NClassifiedFromManifest = _nWithClass;
+                data.NUnclassified = _nWithoutClass;
+
+                if (contributions != null)
+                {
+                    data.ModelComposite = contributions.Composite;
+                    data.ModelDegenerate = contributions.IsDegenerate;
+                    data.FeatureHistEdges = contributions.HistogramEdges;
+                    data.Model = BuildFeatureRows(contributions);
+                }
+
+                data.Scores = BuildScoreHistogram(precs);
+                data.DensityRatio = BuildDensityRatio(data.Scores, data.HasEntrapment);
+                data.IdYield = BuildIdYield(precs);
+
+                double r = _entrapmentRatio > 0 ? _entrapmentRatio : 1.0;
+                data.CrossRun = new CrossRunDetection
+                {
+                    RunNames = _runNames,
+                    PerRun = ComputeCrossRunView(_runSets, _anyEntrapment ? _entRunSets : null, _nFiles, r),
+                    Experiment = ComputeCrossRunView(_expSets, _anyEntrapment ? _entExpSets : null, _nFiles, r),
+                };
+
+                data.WinFraction = BuildWinFractionFromReduced(_bt, _tClass);
+
+                if (data.HasEntrapment)
+                    data.FdpViews = BuildFdpViewsFromPrecs(precs, r, 1);
+
+                return data;
+            }
+        }
+    }
+}

--- a/pwiz_tools/Osprey/Osprey.FDR/ModelDiagnostics/ModelDiagnosticsData.Accumulator.cs
+++ b/pwiz_tools/Osprey/Osprey.FDR/ModelDiagnostics/ModelDiagnosticsData.Accumulator.cs
@@ -45,10 +45,18 @@ namespace pwiz.Osprey.FDR.ModelDiagnostics
         /// per-file counts and cross-run sets are tallies/sets keyed on identity; the win-fraction
         /// reduction is a per-base_id max. The shared downstream builders (score histogram,
         /// density ratio, id-yield, FDP views, cross-run views, win fraction) then consume only
-        /// the reduced state. So the streamed reduction reproduces the resident reduction
+        /// the reduced state and are order-safe (they sort, or are pure counts/sets) with ONE
+        /// order-sensitive step: BuildScoreHistogram's decoy mean/std accumulate floating-point
+        /// sums, which are not associative. Those stay bit-identical only because both paths
+        /// enumerate the reduced best-per-precursor set in the SAME order -- FdrProjectionSet
+        /// (BuildFromEntries / the streaming Builder, element-for-element parity) preserves the
+        /// resident per-file FdrEntry row order, and the score pass walks perFile in the same
+        /// nested order the batch ReduceToPrecs walks perFileEntries, so _best.Values enumerates
+        /// identically. So the streamed reduction reproduces the resident reduction
         /// element-for-element, while the 340M-row pre-compaction pool that OOM'd an 82-file
         /// --model-diagnostics run at the join is never materialized -- the accumulator holds only
-        /// ~unique-precursor / ~base_id-sized maps.
+        /// ~unique-precursor / ~base_id-sized maps. (A future change that reorders projection rows
+        /// within a file would threaten this last invariant -- keep the row order stable.)
         /// </summary>
         public sealed class Accumulator
         {

--- a/pwiz_tools/Osprey/Osprey.FDR/ModelDiagnostics/ModelDiagnosticsData.cs
+++ b/pwiz_tools/Osprey/Osprey.FDR/ModelDiagnostics/ModelDiagnosticsData.cs
@@ -824,7 +824,7 @@ namespace pwiz.Osprey.FDR.ModelDiagnostics
                 foreach (var e in kvp.Value)
                 {
                     uint baseId = e.EntryId & BASE_ID_MASK;
-                    EntrapmentClass cls = Classify(e, baseId, classByBaseId, haveManifest,
+                    EntrapmentClass cls = Classify(e.IsDecoy, baseId, classByBaseId, haveManifest,
                         ref wc, ref woc);
                     uint pairIdx = 0;
                     bool hasPair = pairByBaseId != null &&
@@ -873,7 +873,7 @@ namespace pwiz.Osprey.FDR.ModelDiagnostics
             return best.Values.ToList();
         }
 
-        private static EntrapmentClass Classify(FdrEntry e, uint baseId,
+        private static EntrapmentClass Classify(bool isDecoy, uint baseId,
             IReadOnlyDictionary<uint, EntrapmentClass> classByBaseId, bool haveManifest,
             ref int nWithClass, ref int nWithoutClass)
         {
@@ -885,18 +885,18 @@ namespace pwiz.Osprey.FDR.ModelDiagnostics
             if (haveManifest && classByBaseId.TryGetValue(baseId, out var cls))
             {
                 nWithClass++;
-                if (!e.IsDecoy)
+                if (!isDecoy)
                     return cls;                    // Target or PTarget
                 // Decoy side inherits its target's partition.
                 return cls == EntrapmentClass.PTarget
                     ? EntrapmentClass.PDecoy : EntrapmentClass.Decoy;
             }
             if (!haveManifest)
-                return e.IsDecoy ? EntrapmentClass.Decoy : EntrapmentClass.Target;
+                return isDecoy ? EntrapmentClass.Decoy : EntrapmentClass.Target;
             // Base-id not in the classification map. A decoy is still definitely a
             // decoy (e.g. an unpaired decoy-side entry whose target-side base-id
             // isn't present) -- classify and don't count it as unclassified.
-            if (e.IsDecoy)
+            if (isDecoy)
                 return EntrapmentClass.Decoy;
             // A non-decoy we genuinely cannot class as target vs entrapment: exclude
             // it from the entrapment FDP (Unknown) and count it, so a real coverage
@@ -1477,6 +1477,19 @@ namespace pwiz.Osprey.FDR.ModelDiagnostics
                 }
             }
 
+            return BuildWinFractionFromReduced(bt, tClass);
+        }
+
+        // Assemble the win-fraction curves from the reduced per-base_id best
+        // target/decoy scores (<paramref name="bt"/> = base_id -> [tScore, dScore]) and
+        // target-side class (<paramref name="tClass"/>). Shared by the batch
+        // <see cref="BuildWinFraction"/> and the streaming --model-diagnostics
+        // accumulator, which build the identical (bt, tClass) reduction from
+        // perFileEntries vs streamed projection rows respectively (both a max over
+        // scores, so the two reductions agree regardless of visitation order).
+        private static WinFractionData BuildWinFractionFromReduced(
+            Dictionary<uint, double[]> bt, Dictionary<uint, EntrapmentClass> tClass)
+        {
             var realWin = new List<KeyValuePair<double, bool>>();   // (winnerScore, decoyWon)
             var entWin = new List<KeyValuePair<double, bool>>();
             foreach (var pair in bt)

--- a/pwiz_tools/Osprey/Osprey.FDR/PercolatorEngine.cs
+++ b/pwiz_tools/Osprey/Osprey.FDR/PercolatorEngine.cs
@@ -216,7 +216,8 @@ namespace pwiz.Osprey.FDR
             IFdrOutputSink sink,
             PercolatorDiagnosticsConfig diagnostics = null,
             string passLabel = @"First-pass",
-            Func<string, IReadOnlyList<double[]>> loadFileFeatures = null)
+            Func<string, IReadOnlyList<double[]>> loadFileFeatures = null,
+            Action<FeatureContributions> captureContributions = null)
         {
             // The lean FdrProjection no longer stores the q-value outputs (issue #4355
             // struct-shrink S0): the score pass hands them to this per-pass sink (the
@@ -275,7 +276,7 @@ namespace pwiz.Osprey.FDR
                 passLabel, n));
             bool streamingAbort = RunStreamingIntoProjection(
                 projections.PerFile, peptideById, percConfig, logInfo, passLabel,
-                loadFileFeatures, sink);
+                loadFileFeatures, sink, captureContributions);
             if (streamingAbort)
                 return true;
 
@@ -673,7 +674,8 @@ namespace pwiz.Osprey.FDR
             Action<string> logInfo,
             string passLabel,
             Func<string, IReadOnlyList<double[]>> loadFileFeatures,
-            IFdrOutputSink sink)
+            IFdrOutputSink sink,
+            Action<FeatureContributions> captureContributions = null)
         {
             if (loadFileFeatures == null)
                 throw new InvalidOperationException(
@@ -834,7 +836,7 @@ namespace pwiz.Osprey.FDR
             //    arrays already built above.
             PercolatorFdr.ScoreProjectionAndComputeFdrInPlace(
                 perFile, labels, entryIds, peptides, fileNames, trainResults, percConfig,
-                loadFileFeatures, sink);
+                loadFileFeatures, sink, captureContributions);
             return false;
         }
 

--- a/pwiz_tools/Osprey/Osprey.FDR/PercolatorEngine.cs
+++ b/pwiz_tools/Osprey/Osprey.FDR/PercolatorEngine.cs
@@ -789,17 +789,25 @@ namespace pwiz.Osprey.FDR
             }
 
             var subsetByFile = PercolatorFdr.GroupIndicesByFileName(subsetEntries);
-            logInfo(string.Format(@"Loading training-subset feature vectors from {0} file(s)...",
-                subsetByFile.Count));
-            foreach (var kvp in subsetByFile)
+            // Per-file progress: loading the training-subset feature vectors from every file
+            // ran ~5 min silent before cross-validation. Console-only, never touches the
+            // loaded features, so training is byte-identical.
+            using (var loadProgress = new ProgressReporter(
+                string.Format(@"Loading training-subset feature vectors from {0} file(s)", subsetByFile.Count),
+                subsetByFile.Count))
             {
-                IReadOnlyList<double[]> rows = loadFileFeatures(kvp.Key);
-                foreach (int k in kvp.Value)
+                int loadDone = 0;
+                foreach (var kvp in subsetByFile)
                 {
-                    var entry = subsetEntries[k];
-                    entry.Features = (double[])PercolatorFdr.ResolveFeatureRow(
-                        rows, entry.ParquetIndex, entry.CoelutionSum,
-                        percConfig.FeatureInfos.Length).Clone();
+                    loadProgress.Report(++loadDone);
+                    IReadOnlyList<double[]> rows = loadFileFeatures(kvp.Key);
+                    foreach (int k in kvp.Value)
+                    {
+                        var entry = subsetEntries[k];
+                        entry.Features = (double[])PercolatorFdr.ResolveFeatureRow(
+                            rows, entry.ParquetIndex, entry.CoelutionSum,
+                            percConfig.FeatureInfos.Length).Clone();
+                    }
                 }
             }
 

--- a/pwiz_tools/Osprey/Osprey.FDR/PercolatorFdr.cs
+++ b/pwiz_tools/Osprey/Osprey.FDR/PercolatorFdr.cs
@@ -951,13 +951,6 @@ namespace pwiz.Osprey.FDR
             out double[] expPeptideQvalues)
         {
             int n = finalScores.Length;
-            // Phase markers for the large-population first-pass q-value computation, which ran
-            // ~9 min silent at 344M rows after the score pass (several bulk sub-steps, not one
-            // loop). Gated on a large n so fast runs (tests, Stellar) stay clutter-free;
-            // console-only, never affects the q-values.
-            bool logQvaluePhases = n > 2_000_000;
-            if (logQvaluePhases)
-                OspreyOutput.Out.WriteLine(@"Competing target/decoy and estimating PEP...");
 
             // PEP via global target-decoy competition. CompeteAll returns
             // winners sorted by score-descending (matches the direct-path
@@ -974,8 +967,11 @@ namespace pwiz.Osprey.FDR
             int[] winnerIndices;
             double[] winnerScores;
             bool[] winnerIsDecoy;
-            CompeteAll(finalScores, labels, entryIds,
-                out winnerIndices, out winnerScores, out winnerIsDecoy);
+            // Throttled progress over the ~344M-row population competition (the big walk that
+            // ran silent at 82 files); null (silent) on small runs. Console-only, byte-neutral.
+            using (var pepProgress = QProgress(@"Population target/decoy competition", n, n))
+                CompeteAll(finalScores, labels, entryIds,
+                    out winnerIndices, out winnerScores, out winnerIsDecoy, pepProgress);
 
             int nWinners = winnerIndices.Length;
             var pepOrder = new int[nWinners];
@@ -1003,8 +999,6 @@ namespace pwiz.Osprey.FDR
                 peps[idx] = pepEstimator.PosteriorError(finalScores[idx]);
 
             // Per-run precursor + peptide q-values (each file independently).
-            if (logQvaluePhases)
-                OspreyOutput.Out.WriteLine(@"  Per-run precursor + peptide q-values...");
             runPrecursorQvalues = ComputePerRunPrecursorQvalues(
                 finalScores, labels, entryIds, fileNames);
             runPeptideQvalues = ComputePerRunPeptideQvalues(
@@ -1012,8 +1006,6 @@ namespace pwiz.Osprey.FDR
 
             // Experiment-level q-values: single-file shortcut matches
             // direct-path semantics.
-            if (logQvaluePhases)
-                OspreyOutput.Out.WriteLine(@"  Experiment-level q-values...");
             var uniqueFiles = new HashSet<string>(fileNames);
             bool isSingleFile = uniqueFiles.Count <= 1;
             if (isSingleFile)
@@ -1562,13 +1554,22 @@ namespace pwiz.Osprey.FDR
             int[] indices,
             out int[] winnerIndices,
             out double[] winnerScores,
-            out bool[] winnerIsDecoy)
+            out bool[] winnerIsDecoy,
+            ProgressReporter progress = null)
         {
             var targets = new Dictionary<uint, KeyValuePair<int, double>>();
             var decoys = new Dictionary<uint, KeyValuePair<int, double>>();
 
+            // Throttled per-row progress for the large experiment / PEP competitions -- the
+            // ~344M-row base_id reduction below ran ~90 s silent at 82 files. Console-only via
+            // the caller's reporter (null on the small per-file per-run calls, which report at
+            // their own per-file granularity); never affects the winners, so q-values are
+            // byte-identical.
+            long processed = 0;
             foreach (int idx in indices)
             {
+                if (progress != null && (++processed & 0x3FFFFF) == 0)
+                    progress.Report(processed);
                 uint baseId = entryIds[idx] & BASE_ID_MASK;
                 if (labels[idx])
                 {
@@ -1654,13 +1655,14 @@ namespace pwiz.Osprey.FDR
             uint[] entryIds,
             out int[] winnerIndices,
             out double[] winnerScores,
-            out bool[] winnerIsDecoy)
+            out bool[] winnerIsDecoy,
+            ProgressReporter progress = null)
         {
             var allIndices = new int[scores.Length];
             for (int i = 0; i < scores.Length; i++)
                 allIndices[i] = i;
             CompeteFromIndices(scores, labels, entryIds, allIndices,
-                out winnerIndices, out winnerScores, out winnerIsDecoy);
+                out winnerIndices, out winnerScores, out winnerIsDecoy, progress);
         }
 
         /// <summary>
@@ -2248,8 +2250,11 @@ namespace pwiz.Osprey.FDR
                 list.Add(i);
             }
 
+            var progress = QProgress(@"Per-run precursor q-values", fileGroups.Count, n);
+            int fileDone = 0;
             foreach (var group in fileGroups.Values)
             {
+                progress?.Report(++fileDone);
                 var fileScores = new double[group.Count];
                 var fileLabels = new bool[group.Count];
                 var fileEntryIds = new uint[group.Count];
@@ -2277,6 +2282,7 @@ namespace pwiz.Osprey.FDR
                     qvalues[globalIdx] = q[rank];
                 }
             }
+            progress?.Dispose();
 
             return qvalues;
         }
@@ -2302,8 +2308,11 @@ namespace pwiz.Osprey.FDR
                 list.Add(i);
             }
 
+            var progress = QProgress(@"Per-run peptide q-values", fileGroups.Count, n);
+            int fileDone = 0;
             foreach (var group in fileGroups.Values)
             {
+                progress?.Report(++fileDone);
                 var bestPerPeptide = BestPrecursorPerPeptide(
                     group.ToArray(), scores, labels, peptides);
 
@@ -2342,6 +2351,7 @@ namespace pwiz.Osprey.FDR
                         qvalues[idx] = qv;
                 }
             }
+            progress?.Dispose();
 
             return qvalues;
         }
@@ -2357,7 +2367,8 @@ namespace pwiz.Osprey.FDR
             int[] wi;
             double[] ws;
             bool[] wd;
-            CompeteAll(scores, labels, entryIds, out wi, out ws, out wd);
+            using (var progress = QProgress(@"Experiment precursor q-values", n, n))
+                CompeteAll(scores, labels, entryIds, out wi, out ws, out wd, progress);
 
             var q = new double[wi.Length];
             ComputeConservativeQvalues(ws, wd, q);
@@ -2415,8 +2426,9 @@ namespace pwiz.Osprey.FDR
             int[] wi;
             double[] ws;
             bool[] wd;
-            CompeteFromIndices(peptScores, peptLabels, peptEntryIds, allPeptIndices,
-                out wi, out ws, out wd);
+            using (var progress = QProgress(@"Experiment peptide q-values", bestPerPeptide.Length, bestPerPeptide.Length))
+                CompeteFromIndices(peptScores, peptLabels, peptEntryIds, allPeptIndices,
+                    out wi, out ws, out wd, progress);
 
             var q = new double[wi.Length];
             ComputeConservativeQvalues(ws, wd, q);
@@ -2436,6 +2448,14 @@ namespace pwiz.Osprey.FDR
             }
 
             return qvalues;
+        }
+
+        // A console progress reporter for the large first-pass q-value / competition passes,
+        // or null (no output) when the population is small enough that the pass is sub-second
+        // -- keeps unit tests / Stellar clutter-free. Console-only; never affects the q-values.
+        private static ProgressReporter QProgress(string activity, long reportTotal, long workSize)
+        {
+            return workSize > 2_000_000 ? new ProgressReporter(activity, reportTotal) : null;
         }
 
         // ============================================================

--- a/pwiz_tools/Osprey/Osprey.FDR/PercolatorFdr.cs
+++ b/pwiz_tools/Osprey/Osprey.FDR/PercolatorFdr.cs
@@ -1112,7 +1112,8 @@ namespace pwiz.Osprey.FDR
             bool[] labels, uint[] entryIds, string[] peptides, string[] fileNames,
             PercolatorResults trainResults, PercolatorConfig config,
             Func<string, IReadOnlyList<double[]>> loadFileFeatures,
-            IFdrOutputSink sink)
+            IFdrOutputSink sink,
+            Action<FeatureContributions> captureContributions = null)
         {
             if (loadFileFeatures == null)
                 throw new InvalidOperationException(
@@ -1144,7 +1145,13 @@ namespace pwiz.Osprey.FDR
             var standardizer = trainResults.Standardizer;
             var finalScores = new double[n];
             var featureBuf = new double[nFeatures];
-            var contribAcc = new FeatureContributions.Accumulator(nFeatures);
+            // Collect the per-feature target/decoy standardized-value histograms when
+            // --model-diagnostics asked for them (config.CollectFeatureHistograms == ModelDiagnostics,
+            // set in BuildProjectionPercolatorConfig). The full-population Add loop below feeds the
+            // identical standardized featureBuf the resident path bins, so the Model tab's
+            // per-feature distributions are byte-identical to the resident build's; off the
+            // production path this stays a plain (no-histogram) accumulator.
+            var contribAcc = new FeatureContributions.Accumulator(nFeatures, config.CollectFeatureHistograms);
 
             // Streaming score pass over the projection, one file at a time. The
             // per-entry math and the per-file iteration order match the
@@ -1182,6 +1189,10 @@ namespace pwiz.Osprey.FDR
 
             var contributions = contribAcc.Build(trainResults.FoldWeights, config.FeatureInfos);
             EmitFeatureContributions(contributions);
+            // Surface the trained model's contributions to the caller (the projection-path
+            // --model-diagnostics report reads them). No-op (null) on every path that does not
+            // request them; a pure hand-off, so scoring stays byte-identical.
+            captureContributions?.Invoke(contributions);
 
             double[] peps, runPrecursorQvalues, runPeptideQvalues,
                      expPrecursorQvalues, expPeptideQvalues;

--- a/pwiz_tools/Osprey/Osprey.FDR/PercolatorFdr.cs
+++ b/pwiz_tools/Osprey/Osprey.FDR/PercolatorFdr.cs
@@ -951,6 +951,13 @@ namespace pwiz.Osprey.FDR
             out double[] expPeptideQvalues)
         {
             int n = finalScores.Length;
+            // Phase markers for the large-population first-pass q-value computation, which ran
+            // ~9 min silent at 344M rows after the score pass (several bulk sub-steps, not one
+            // loop). Gated on a large n so fast runs (tests, Stellar) stay clutter-free;
+            // console-only, never affects the q-values.
+            bool logQvaluePhases = n > 2_000_000;
+            if (logQvaluePhases)
+                OspreyOutput.Out.WriteLine(@"Competing target/decoy and estimating PEP...");
 
             // PEP via global target-decoy competition. CompeteAll returns
             // winners sorted by score-descending (matches the direct-path
@@ -996,6 +1003,8 @@ namespace pwiz.Osprey.FDR
                 peps[idx] = pepEstimator.PosteriorError(finalScores[idx]);
 
             // Per-run precursor + peptide q-values (each file independently).
+            if (logQvaluePhases)
+                OspreyOutput.Out.WriteLine(@"  Per-run precursor + peptide q-values...");
             runPrecursorQvalues = ComputePerRunPrecursorQvalues(
                 finalScores, labels, entryIds, fileNames);
             runPeptideQvalues = ComputePerRunPeptideQvalues(
@@ -1003,6 +1012,8 @@ namespace pwiz.Osprey.FDR
 
             // Experiment-level q-values: single-file shortcut matches
             // direct-path semantics.
+            if (logQvaluePhases)
+                OspreyOutput.Out.WriteLine(@"  Experiment-level q-values...");
             var uniqueFiles = new HashSet<string>(fileNames);
             bool isSingleFile = uniqueFiles.Count <= 1;
             if (isSingleFile)

--- a/pwiz_tools/Osprey/Osprey.FDR/Reconciliation/ReconciliationPlanner.cs
+++ b/pwiz_tools/Osprey/Osprey.FDR/Reconciliation/ReconciliationPlanner.cs
@@ -183,8 +183,15 @@ namespace pwiz.Osprey.FDR.Reconciliation
             var actions = new Dictionary<(string, int), ReconcileAction>();
             var emptyCwt = new List<IReadOnlyList<CwtCandidate>>();
 
+            // Per-file progress: planning reconciliation actions across all files ran
+            // ~5 min silent on the 82-file join. Console-only, never affects the plan.
+            var planProgress = new ProgressReporter(
+                string.Format(@"Planning reconciliation across {0} file(s)", perFileEntries.Count),
+                perFileEntries.Count);
+            int planIdx = 0;
             foreach (var fileKvp in perFileEntries)
             {
+                planProgress.Report(++planIdx);
                 string fileName = fileKvp.Key;
                 var entries = fileKvp.Value;
 
@@ -267,6 +274,7 @@ namespace pwiz.Osprey.FDR.Reconciliation
                         actions[(fileName, entryIdx)] = action;
                 }
             }
+            planProgress.Dispose();
 
             return actions;
         }

--- a/pwiz_tools/Osprey/Osprey.Tasks/FdrProjectionSinks.cs
+++ b/pwiz_tools/Osprey/Osprey.Tasks/FdrProjectionSinks.cs
@@ -25,6 +25,7 @@ using System;
 using System.Collections.Generic;
 using pwiz.Osprey.Core;
 using pwiz.Osprey.FDR;
+using pwiz.Osprey.FDR.ModelDiagnostics;
 using pwiz.Osprey.IO;
 
 namespace pwiz.Osprey.Tasks
@@ -51,9 +52,14 @@ namespace pwiz.Osprey.Tasks
         private readonly int[] _fileTargets;
         private readonly int[] _fileDecoys;
         private readonly Dictionary<string, double> _bestQByPrecursor;
+        // Streaming --model-diagnostics accumulator (null off the report path): folds every
+        // pre-compaction row into the reduced report structures so the projection path can emit
+        // the pass-1 report without holding the resident FdrEntry pool. Fed in Accept.
+        private readonly ModelDiagnosticsData.Accumulator _mdiagAccumulator;
 
         protected FdrProjectionSinkBase(
-            FdrProjectionSet projections, OspreyConfig config, string passLabel)
+            FdrProjectionSet projections, OspreyConfig config, string passLabel,
+            ModelDiagnosticsData.Accumulator mdiagAccumulator = null)
         {
             Projections = projections;
             _fdrLevel = config.FdrLevel;
@@ -63,6 +69,7 @@ namespace pwiz.Osprey.Tasks
             _fileTargets = new int[nFiles];
             _fileDecoys = new int[nFiles];
             _bestQByPrecursor = new Dictionary<string, double>(StringComparer.Ordinal);
+            _mdiagAccumulator = mdiagAccumulator;
         }
 
         /// <summary>
@@ -98,6 +105,16 @@ namespace pwiz.Osprey.Tasks
                 double existing;
                 if (!_bestQByPrecursor.TryGetValue(pkey, out existing) || eff < existing)
                     _bestQByPrecursor[pkey] = eff;
+            }
+
+            // --model-diagnostics: fold this pre-compaction row into the streaming report
+            // reductions (every row -- targets, decoys, entrapment, failing -- not just the
+            // passing set the [COUNT] tally reads). Null off the report path.
+            if (_mdiagAccumulator != null)
+            {
+                var mproj = Projections.PerFile[fileIdx].Value[rowIdx];
+                _mdiagAccumulator.Add(fileIdx, Projections.PeptideById[mproj.PeptideId],
+                    mproj.Charge, entryId, isDecoy, score, in q);
             }
 
             AcceptOutput(fileIdx, rowIdx, entryId, isDecoy, score, in q);
@@ -170,8 +187,9 @@ namespace pwiz.Osprey.Tasks
 
         public FdrStoringSink(
             FdrProjectionSet projections, OspreyConfig config, string passLabel,
-            Func<string, IReadOnlyList<FdrScoreRecord>, int> flushPartial)
-            : base(projections, config, passLabel)
+            Func<string, IReadOnlyList<FdrScoreRecord>, int> flushPartial,
+            ModelDiagnosticsData.Accumulator mdiagAccumulator = null)
+            : base(projections, config, passLabel, mdiagAccumulator)
         {
             _outputs = new FdrProjectionOutputs(projections);
             _flushPartial = flushPartial;

--- a/pwiz_tools/Osprey/Osprey.Tasks/FirstJoinTask.cs
+++ b/pwiz_tools/Osprey/Osprey.Tasks/FirstJoinTask.cs
@@ -259,19 +259,25 @@ namespace pwiz.Osprey.Tasks
             // legacy compacted buffer does -- the blast radius is confined to this
             // pre-compaction span. Falls back to the legacy FdrEntry-buffer path
             // (the byte-identity oracle) when the flag is off or FdrMethod != Percolator.
-            // --model-diagnostics and FDRBench pass-1 (#4377) both read the full
-            // pre-compaction first-pass pool resident (decoys + entrapment, with scores) --
-            // exactly what the projection path drops to bound memory -- so when either
-            // opt-in output is requested, take the resident (legacy) path so those reports
-            // still emit. Both are off the default output path, so byte-identity is
-            // unaffected (the regression gate never sets either).
+            // FDRBench pass-1 (#4377) reads the full pre-compaction first-pass pool resident
+            // (decoys + entrapment, with scores) -- exactly what the projection path drops to
+            // bound memory -- so when it is requested, take the resident (legacy) path so that
+            // report still emits. Off the default output path, so byte-identity is unaffected
+            // (the regression gate never sets it).
             // OSPREY_PASS2_QVALUE=transfer also needs the resident first-pass pool: it
             // captures the frozen 1st-pass model and builds the FULL pre-compaction
             // score->q table (BuildFullPopulationScoreQTable, below), both of which read
             // every entry's in-memory Stage-4 features -- exactly what the projection path
             // streams and drops. The regression gate never sets the env var, so byte-identity
-            // on the default percolator path is unaffected (same rationale as --model-diagnostics).
-            bool needsResidentFirstPassPool = config.ModelDiagnostics ||
+            // on the default percolator path is unaffected.
+            // --model-diagnostics is NOT here: it now STREAMS its pass-1 report off the
+            // projection path via a ModelDiagnosticsData.Accumulator fed by the score-pass sink
+            // (RunFirstPassProjection below), folding each pre-compaction row into the reduced
+            // report structures rather than holding the whole-run FdrEntry pool resident -- which
+            // OOM'd an 82-file run at the join. The reductions are order-independent, so the
+            // streamed report is byte-identical to the resident build, and it stays off the
+            // default output path.
+            bool needsResidentFirstPassPool =
                 (!string.IsNullOrEmpty(config.OutputFdrBench) && config.FdrBenchPass == 1) ||
                 OspreyEnvironment.Pass2TransferQ;
             if (OspreyEnvironment.UseFdrProjection && config.FdrMethod == FdrMethod.Percolator &&
@@ -598,7 +604,7 @@ namespace pwiz.Osprey.Tasks
             if (config.ModelDiagnostics)
             {
                 var libraryById = ctx.Get<LibraryById>().Value;
-                var cal = BuildCalibrationData(ctx, perFileEntries);
+                var cal = BuildCalibrationData(ctx, perFileEntries.ConvertAll(kv => kv.Key));
                 ModelDiagnosticsReport.Write(perFileEntries, contributions, libraryById, cal, config, ctx.LogInfo);
             }
         }
@@ -607,7 +613,7 @@ namespace pwiz.Osprey.Tasks
         /// Assemble the CAL-view <see cref="ModelDiagnosticsData.CalibrationData"/> for
         /// the report from the per-file calibration diagnostics
         /// (<see cref="PerFileCalibrationDiagnostics"/>) PerFileScoringTask captured at
-        /// Stage 3. The rows are ordered by <paramref name="perFileEntries"/> (input-file
+        /// Stage 3. The rows are ordered by <paramref name="orderedFileNames"/> (input-file
         /// order) so the report's file selector matches the rest of the page. Returns
         /// <c>null</c> when no rows were captured (a resumed / rehydrated run, or none of
         /// the files calibrated), which hides the CAL tab. HasEntrapment is true when any
@@ -616,7 +622,7 @@ namespace pwiz.Osprey.Tasks
         /// </summary>
         private static ModelDiagnosticsData.CalibrationData BuildCalibrationData(
             PipelineContext ctx,
-            IReadOnlyList<KeyValuePair<string, List<FdrEntry>>> perFileEntries)
+            IReadOnlyList<string> orderedFileNames)
         {
             IReadOnlyDictionary<string, ModelDiagnosticsData.CalFileRow> byFile = null;
             string massUnit = null;
@@ -628,14 +634,14 @@ namespace pwiz.Osprey.Tasks
             if (byFile == null || byFile.Count == 0)
                 return null;
 
-            var files = new List<ModelDiagnosticsData.CalFileRow>(perFileEntries.Count);
+            var files = new List<ModelDiagnosticsData.CalFileRow>(orderedFileNames.Count);
             var omitted = new List<string>();
-            foreach (var kvp in perFileEntries)
+            foreach (var name in orderedFileNames)
             {
-                if (byFile.TryGetValue(kvp.Key, out var row) && row != null)
+                if (byFile.TryGetValue(name, out var row) && row != null)
                     files.Add(row);
                 else
-                    omitted.Add(kvp.Key);
+                    omitted.Add(name);
             }
             // A file with no captured calibration diagnostics (calibration failed / was skipped, or a
             // distributed run that did not persist matches) would otherwise vanish from the CAL
@@ -645,7 +651,7 @@ namespace pwiz.Osprey.Tasks
                 ctx.LogWarning(string.Format(
                     "CAL view: {0} of {1} file(s) have no captured calibration diagnostics and are " +
                     "omitted from the calibration report: [{2}]",
-                    omitted.Count, perFileEntries.Count, string.Join(", ", omitted)));
+                    omitted.Count, orderedFileNames.Count, string.Join(", ", omitted)));
             if (files.Count == 0)
                 return null;
 
@@ -668,6 +674,27 @@ namespace pwiz.Osprey.Tasks
                 MassUnit = !string.IsNullOrEmpty(massUnit) ? massUnit : @"ppm",
                 FileCount = files.Count,
             };
+        }
+
+        /// <summary>
+        /// Build the streaming <see cref="ModelDiagnosticsData.Accumulator"/> that the projection
+        /// path's score-pass sink folds each pre-compaction row into, so the pass-1
+        /// <c>--model-diagnostics</c> report emits without the resident FdrEntry pool. Derives the
+        /// entrapment classification from the searched library -- the same source and one-time
+        /// logging as the resident <see cref="ModelDiagnosticsReport.Write"/> path -- and seeds the
+        /// accumulator with the input-file order (from the projection) plus the run FDR level.
+        /// </summary>
+        private static ModelDiagnosticsData.Accumulator BuildModelDiagnosticsAccumulator(
+            FdrProjectionSet projections, OspreyConfig config, PipelineContext ctx)
+        {
+            var libraryById = ctx.Get<LibraryById>().Value;
+            ModelDiagnosticsReport.BuildClassificationFromLibrary(config, libraryById, ctx.LogInfo,
+                out var classByBaseId, out var pairByBaseId, out var entrapmentRatio);
+            var runNames = new string[projections.PerFile.Count];
+            for (int i = 0; i < runNames.Length; i++)
+                runNames[i] = projections.PerFile[i].Key;
+            return new ModelDiagnosticsData.Accumulator(
+                runNames, classByBaseId, pairByBaseId, entrapmentRatio, config.RunFdr, config.FdrLevel);
         }
 
         /// <summary>
@@ -1563,13 +1590,26 @@ namespace pwiz.Osprey.Tasks
                 return 0;
             }
 
-            var sink = new FdrStoringSink(projections, config, @"First-pass", FlushPartialSidecar);
+            // --model-diagnostics: build the streaming report accumulator (entrapment
+            // classification from the searched library) and hand it to the score-pass sink, which
+            // folds every pre-compaction row into it; capture the trained model for the Model tab.
+            // Null off the report path, so byte-neutral there.
+            var mdiagAccumulator = config.ModelDiagnostics
+                ? BuildModelDiagnosticsAccumulator(projections, config, ctx)
+                : null;
+            FeatureContributions mdiagContributions = null;
+            Action<FeatureContributions> captureContributions = null;
+            if (mdiagAccumulator != null)
+                captureContributions = c => mdiagContributions = c;
+
+            var sink = new FdrStoringSink(projections, config, @"First-pass", FlushPartialSidecar,
+                mdiagAccumulator);
             var swFdr = Stopwatch.StartNew();
             bool aborted = PercolatorEngine.RunPercolatorFdr(
                 projections, config,
                 OspreyFeatureCalculators.BuildFeatureInfos(ParquetScoreCache.PIN_FEATURE_NAMES),
                 ctx.LogInfo, sink, BuildPercolatorDiagnostics(ctx.Diagnostics),
-                @"First-pass", loadFileFeatures);
+                @"First-pass", loadFileFeatures, captureContributions);
             swFdr.Stop();
             var outputs = sink.Outputs;
             if (aborted)
@@ -1586,6 +1626,19 @@ namespace pwiz.Osprey.Tasks
                 string.Format(@"(post-GC, projection path, rows={0})", projections.TotalRows));
 
             LogFirstPassResultsProjection(projections, sink, config, ctx);
+
+            // --model-diagnostics: emit the pass-1 HTML report from the streamed accumulator.
+            // Placed here -- after first-pass Percolator, BEFORE first-pass protein FDR -- to
+            // match the resident path's report point (LogFirstPassResultsAndDump runs before
+            // RunFirstPassProteinFdr), so neither build reads a protein q the report does not use.
+            // The CAL view comes from the Stage-3 per-file byproduct; the Model tab from the
+            // captured first-pass contributions.
+            if (mdiagAccumulator != null)
+            {
+                var cal = BuildCalibrationData(ctx, projections.PerFile.ConvertAll(kv => kv.Key));
+                ModelDiagnosticsReport.WriteFromAccumulator(
+                    mdiagAccumulator, mdiagContributions, cal, config, ctx.LogInfo);
+            }
 
             // First-pass protein FDR over the projection (sets RunProteinQvalue on
             // every row). The Stage-6 diagnostic dump reads the returned artifacts,

--- a/pwiz_tools/Osprey/Osprey.Tasks/FirstJoinTask.cs
+++ b/pwiz_tools/Osprey/Osprey.Tasks/FirstJoinTask.cs
@@ -1865,8 +1865,15 @@ namespace pwiz.Osprey.Tasks
             PipelineContext ctx)
         {
             var survivors = new List<KeyValuePair<string, List<FdrEntry>>>(projections.PerFile.Count);
+            // Per-file progress: reloading each file's survivor stubs from parquet + the 1st-pass
+            // sidecar was the ~70 s silent "First-pass compaction" gap at 82 files. Console-only.
+            var reloadProgress = new ProgressReporter(
+                string.Format(@"Reloading first-pass survivors from {0} file(s)", projections.PerFile.Count),
+                projections.PerFile.Count);
+            int reloadDone = 0;
             foreach (var kvp in projections.PerFile)
             {
+                reloadProgress.Report(++reloadDone);
                 string fileName = kvp.Key;
                 if (!perFileParquetPaths.TryGetValue(fileName, out string parquetPath))
                 {
@@ -1917,6 +1924,7 @@ namespace pwiz.Osprey.Tasks
                 });
                 survivors.Add(new KeyValuePair<string, List<FdrEntry>>(fileName, stubs));
             }
+            reloadProgress.Dispose();
             return survivors;
         }
     }

--- a/pwiz_tools/Osprey/Osprey.Tasks/ModelDiagnostics/ModelDiagnosticsReport.cs
+++ b/pwiz_tools/Osprey/Osprey.Tasks/ModelDiagnostics/ModelDiagnosticsReport.cs
@@ -313,6 +313,12 @@ namespace pwiz.Osprey.Tasks.ModelDiagnostics
             if (libraryById == null)
                 return;
 
+            // Label this phase so it is not silent: classifying the searched library
+            // (6.3M entries on the 82-file Astral run) for model diagnostics ran for
+            // minutes at the top of first-pass FDR. Console-only, never affects the
+            // classification.
+            logInfo(string.Format(@"Classifying {0} library entries for model diagnostics...",
+                libraryById.Count));
             var pairing = EntrapmentPairing.Build(libraryById, config.DecoyPairingManifestPath);
 
             int nTarget = 0, nPTarget = 0;

--- a/pwiz_tools/Osprey/Osprey.Tasks/ModelDiagnostics/ModelDiagnosticsReport.cs
+++ b/pwiz_tools/Osprey/Osprey.Tasks/ModelDiagnostics/ModelDiagnosticsReport.cs
@@ -125,6 +125,57 @@ namespace pwiz.Osprey.Tasks.ModelDiagnostics
         }
 
         /// <summary>
+        /// Projection-path counterpart of <see cref="Write"/>: build and write the pass-1 report
+        /// from the streamed <see cref="ModelDiagnosticsData.Accumulator"/> (fed per-row by the
+        /// first-pass score sink) instead of the resident pre-compaction pool that OOM'd an
+        /// 82-file run at the join. The accumulator already holds the entrapment classification
+        /// (built by <see cref="BuildClassificationFromLibrary"/> when it was constructed, and
+        /// logged once there), so this only assembles the data model, attaches the CAL view + run
+        /// metadata, renders the HTML, and stashes the pass-1 data sidecar for MergeNodeTask's
+        /// pass-2 enrichment. Byte-identical to <see cref="Write"/> on the same input: the
+        /// accumulator's streamed reductions reproduce the resident reductions (they are
+        /// order-independent). Any failure is logged and swallowed; a diagnostics artifact never
+        /// aborts a real run.
+        /// </summary>
+        public static void WriteFromAccumulator(
+            ModelDiagnosticsData.Accumulator accumulator,
+            FeatureContributions contributions,
+            ModelDiagnosticsData.CalibrationData cal,
+            OspreyConfig config,
+            Action<string> logInfo)
+        {
+            try
+            {
+                var data = accumulator.Build(contributions);
+                // The CAL view: per-file calibration diagnostics captured at Stage 3 (null when
+                // none were captured -- a resumed run, or no files calibrated). Serialized into the
+                // pass-1 data sidecar below so it round-trips into WritePass2AndFinalize's reloaded
+                // object graph and survives to the final page (same as Write).
+                data.Cal = cal;
+                if (contributions == null)
+                    logInfo(@"[MODEL-DIAGNOSTICS] first-pass model not retrained on this run " +
+                            @"(resumed/rehydrated); the Model tab's feature table and per-feature " +
+                            @"distributions are unavailable. Clear the 1st-pass FDR sidecars to force a retrain.");
+                data.GeneratedUtc = DateTime.UtcNow.ToString(
+                    @"yyyy-MM-dd HH:mm:ss 'UTC'", CultureInfo.InvariantCulture);
+                data.OspreyVersion = OspreyVersion.DisplayVersion;
+                data.OutputName = OutputStem(config);
+
+                string outPath = RenderAndWrite(data, config);
+                // Stash the pass-1 data so MergeNodeTask can append the pass-2 (final reported pool)
+                // FDP views and re-render one page with both.
+                WriteDataSidecar(data, config);
+
+                logInfo(string.Format(@"[MODEL-DIAGNOSTICS] wrote model diagnostics report: {0}", outPath));
+            }
+            catch (Exception ex)
+            {
+                // Never let a diagnostics-only artifact take down a real run.
+                logInfo(string.Format(@"[MODEL-DIAGNOSTICS] report generation failed: {0}", ex.Message));
+            }
+        }
+
+        /// <summary>
         /// End-of-run enrichment: reload the pass-1 data sidecar, compute the
         /// pass-2 (final reported pool) FDP calibration views from the
         /// post-compaction, second-pass-q-valued <paramref name="perFileEntries"/>
@@ -248,7 +299,7 @@ namespace pwiz.Osprey.Tasks.ModelDiagnostics
         /// <paramref name="entrapmentRatio"/> is the library p_target/target count
         /// ratio r (1.0 for a balanced 1-fold entrapment library).
         /// </summary>
-        private static void BuildClassificationFromLibrary(
+        internal static void BuildClassificationFromLibrary(
             OspreyConfig config,
             IReadOnlyDictionary<uint, LibraryEntry> libraryById,
             Action<string> logInfo,

--- a/pwiz_tools/Osprey/Osprey.Tasks/Pass2FdrSidecar.cs
+++ b/pwiz_tools/Osprey/Osprey.Tasks/Pass2FdrSidecar.cs
@@ -475,8 +475,15 @@ namespace pwiz.Osprey.Tasks
             // before second-pass FDR via the cache path).
             var swReloadFeats = Stopwatch.StartNew();
             int nReloaded = 0;
+            // Per-file progress: reloading each file's reconciled PIN features from parquet
+            // ran ~10 min silent before 2nd-pass Percolator. Console-only.
+            var reloadProgress = new ProgressReporter(
+                string.Format(@"Reloading reconciled features from {0} file(s)", perFileEntries.Count),
+                perFileEntries.Count);
+            int reloadIdx = 0;
             foreach (var kvp in perFileEntries)
             {
+                reloadProgress.Report(++reloadIdx);
                 if (!perFileParquetPaths.TryGetValue(kvp.Key, out string parquetPath))
                 {
                     // No first-join parquet was produced (or mapped) for this
@@ -528,6 +535,7 @@ namespace pwiz.Osprey.Tasks
                 }
                 nReloaded += nMapped;
             }
+            reloadProgress.Dispose();
             swReloadFeats.Stop();
             ctx.LogInfo(string.Format(
                 "[TIMING] Reloaded PIN features for {0} entries: {1:F1}s",

--- a/pwiz_tools/Osprey/Osprey.Tasks/PerFileScoringTask.cs
+++ b/pwiz_tools/Osprey/Osprey.Tasks/PerFileScoringTask.cs
@@ -372,18 +372,28 @@ namespace pwiz.Osprey.Tasks
 
             if (needsResidentPool)
             {
-                foreach (string fileName in scoredFileNames)
+                // Per-file progress: loading every file's fat FdrEntry stubs from parquet
+                // ran ~15 min silent (~53 GB) at the 82-file join. Console-only, never
+                // touches the stubs, so the loaded pool is byte-identical.
+                using (var loadProgress = new ProgressReporter(
+                    string.Format(@"Loading scored entries from {0} file(s)", scoredFileNames.Count),
+                    scoredFileNames.Count))
                 {
-                    string parquetPath = perFileParquetPaths[fileName];
-                    // A scored file always has a parquet here; the sole exception is
-                    // the OSPREY_EXIT_AFTER_CALIBRATION bench short-circuit, which
-                    // returns an empty result without writing one. Skip that case so
-                    // the run still stops cleanly at the "no scored entries" gate
-                    // below rather than throwing on a missing file.
-                    if (!File.Exists(parquetPath))
-                        continue;
-                    perFileEntries.Add(new KeyValuePair<string, List<FdrEntry>>(
-                        fileName, ParquetScoreCache.LoadFdrStubsFromParquet(parquetPath)));
+                    int loadDone = 0;
+                    foreach (string fileName in scoredFileNames)
+                    {
+                        loadProgress.Report(++loadDone);
+                        string parquetPath = perFileParquetPaths[fileName];
+                        // A scored file always has a parquet here; the sole exception is
+                        // the OSPREY_EXIT_AFTER_CALIBRATION bench short-circuit, which
+                        // returns an empty result without writing one. Skip that case so
+                        // the run still stops cleanly at the "no scored entries" gate
+                        // below rather than throwing on a missing file.
+                        if (!File.Exists(parquetPath))
+                            continue;
+                        perFileEntries.Add(new KeyValuePair<string, List<FdrEntry>>(
+                            fileName, ParquetScoreCache.LoadFdrStubsFromParquet(parquetPath)));
+                    }
                 }
                 foreach (var kvp in perFileEntries)
                     totalScored += kvp.Value.Count;
@@ -399,21 +409,31 @@ namespace pwiz.Osprey.Tasks
                 // is element-for-element identical to BuildFromEntries (pinned by
                 // TestFdrProjectionBuilderMatchesBuildFromEntries).
                 var builder = new FdrProjectionSet.Builder();
-                foreach (string fileName in scoredFileNames)
+                // Per-file progress: streaming 32 B projection rows from each parquet is
+                // the lean path, but reading 82 files still ran minutes silent. Console-only,
+                // never touches the streamed rows, so the projection is byte-identical.
+                using (var streamProgress = new ProgressReporter(
+                    string.Format(@"Streaming projection from {0} file(s)", scoredFileNames.Count),
+                    scoredFileNames.Count))
                 {
-                    string parquetPath = perFileParquetPaths[fileName];
-                    if (!File.Exists(parquetPath))
-                        continue;
-                    builder.BeginFile(fileName);
-                    ParquetScoreCache.ReadFdrStubScalars(parquetPath,
-                        (entryId, charge, isDecoy, coelutionSum, modseq) =>
-                            builder.AddRow(entryId, charge, isDecoy, coelutionSum, modseq));
-                    builder.EndFile();
-                    // Keep the per-file key and ordering so ScoredEntries consumers and
-                    // the file-count guard below still see one entry per scored file;
-                    // the stub lists themselves stay empty on this path.
-                    perFileEntries.Add(new KeyValuePair<string, List<FdrEntry>>(
-                        fileName, new List<FdrEntry>()));
+                    int streamDone = 0;
+                    foreach (string fileName in scoredFileNames)
+                    {
+                        streamProgress.Report(++streamDone);
+                        string parquetPath = perFileParquetPaths[fileName];
+                        if (!File.Exists(parquetPath))
+                            continue;
+                        builder.BeginFile(fileName);
+                        ParquetScoreCache.ReadFdrStubScalars(parquetPath,
+                            (entryId, charge, isDecoy, coelutionSum, modseq) =>
+                                builder.AddRow(entryId, charge, isDecoy, coelutionSum, modseq));
+                        builder.EndFile();
+                        // Keep the per-file key and ordering so ScoredEntries consumers and
+                        // the file-count guard below still see one entry per scored file;
+                        // the stub lists themselves stay empty on this path.
+                        perFileEntries.Add(new KeyValuePair<string, List<FdrEntry>>(
+                            fileName, new List<FdrEntry>()));
+                    }
                 }
                 projections = builder.Build();
                 totalScored = projections.TotalRows;
@@ -579,7 +599,14 @@ namespace pwiz.Osprey.Tasks
             // 32 B FdrProjection rows from each parquet unless an opt-in output genuinely
             // needs the resident pool. FirstJoin consumes the projection set identically
             // whether Run or this path produced it.
-            bool needsResidentPool = NeedsResidentPool(config);
+            //
+            // --model-diagnostics is the one resume-only exception to Run's lean choice:
+            // Run streams the report off the first-pass Percolator score pass (the streaming
+            // Accumulator), but a resume SKIPS that score pass (sidecar q-values), so FirstJoin's
+            // resume path emits the report via the batch ModelDiagnosticsReport.Write, which reads
+            // the RESIDENT per-file entries. Force the fat pool here so that report is populated
+            // (matches pre-lean behavior); the compute Run path stays lean.
+            bool needsResidentPool = NeedsResidentPool(config) || config.ModelDiagnostics;
             FdrProjectionSet projections = null;
 
             var swAllFiles = Stopwatch.StartNew();
@@ -731,9 +758,10 @@ namespace pwiz.Osprey.Tasks
             ctx.Publish(new PerFileIsolationMz(_perFileIsolationMz));
             ctx.Publish(new PerFileParquetPaths(_perFileParquetPaths));
             ctx.Publish(new ScoredEntries(_perFileEntries));
-            // Lean first-pass rows (issue #4397). Null on the rehydrate/merge paths and
-            // on --model-diagnostics / FDRBench pass 1, which publish fat stubs above;
-            // FirstJoinTask falls back to ScoredEntries whenever this is null.
+            // Lean first-pass rows (issue #4397). Null on the rehydrate/merge paths (including
+            // a --model-diagnostics resume, which needs resident entries for the batch report)
+            // and on FDRBench pass 1 / OSPREY_PASS2_QVALUE=transfer, which publish fat stubs
+            // above; FirstJoinTask falls back to ScoredEntries whenever this is null.
             ctx.Publish(new FdrProjections(projections));
             ctx.Publish(new RescoreBundle(_rescoreInputs));
 
@@ -1387,19 +1415,25 @@ namespace pwiz.Osprey.Tasks
         /// <summary>
         /// Whether Stage 5 needs the resident fat-stub first-pass pool rather than the
         /// lean streamed <see cref="FdrProjection"/> set (#4400). True when an opt-in
-        /// output reads every entry's in-memory features/scores (--model-diagnostics,
-        /// FDRBench pass 1, OSPREY_PASS2_QVALUE=transfer), when the projection path is off
+        /// output reads every entry's in-memory features/scores (FDRBench pass 1,
+        /// OSPREY_PASS2_QVALUE=transfer), when the projection path is off
         /// (OSPREY_FDR_PROJECTION=0 / non-Percolator FDR), or on the reconciled-input
         /// worker join. Shared by <see cref="Run"/> and <see cref="RehydrateFromOwnOutputs"/>
         /// so the compute and resume paths make the identical lean/fat choice -- otherwise a
         /// pure resume rebuilds the ~53 GB fat buffer #4400 dropped for straight-through.
+        ///
+        /// --model-diagnostics is NOT here: it streams its pass-1 report off the projection
+        /// path via a ModelDiagnosticsData.Accumulator fed by the score-pass sink (mirrors the
+        /// FirstJoinTask join-gate that already dropped it), folding each pre-compaction row into
+        /// the reduced report rather than holding the whole-run pool resident -- which peaked
+        /// ~100 GB on an 82-file mdiag run. The reductions are order-independent, so the streamed
+        /// report is byte-identical to the resident build.
         /// </summary>
         private static bool NeedsResidentPool(OspreyConfig config)
         {
             return config.ExpectReconciledInput ||
                    !OspreyEnvironment.UseFdrProjection ||
                    config.FdrMethod != FdrMethod.Percolator ||
-                   config.ModelDiagnostics ||
                    (!string.IsNullOrEmpty(config.OutputFdrBench) && config.FdrBenchPass == 1) ||
                    OspreyEnvironment.Pass2TransferQ;
         }

--- a/pwiz_tools/Osprey/Osprey.Test/FdrTest.cs
+++ b/pwiz_tools/Osprey/Osprey.Test/FdrTest.cs
@@ -699,14 +699,13 @@ namespace pwiz.Osprey.Test
             public FdrQValues QAt(int fileIdx, int rowIdx) => _q[(fileIdx, rowIdx)];
         }
 
-        // ReSharper disable once InvalidXmlDocComment
         /// <summary>
         /// End-to-end projection RunPercolatorFdr equivalence (the survivor-reload
         /// equivalence at the unit level): the projection
-        /// <see cref="PercolatorEngine.RunPercolatorFdr(FdrProjectionSet,OspreyConfig,OspreyFeatureInfo[],System.Action{string},IFdrOutputSink,PercolatorDiagnosticsConfig,string,System.Func{string,System.Collections.Generic.IReadOnlyList{double[]}})"/>
-        /// overload must produce byte-identical Score + q-values to the FdrEntry
-        /// <see cref="PercolatorEngine.RunPercolatorFdr(List{KeyValuePair{string,List{FdrEntry}}},OspreyConfig,OspreyFeatureInfo[],System.Action{string},FeatureContributions,PercolatorDiagnosticsConfig,string,System.Func{string,System.Collections.Generic.IReadOnlyList{double[]}})"/>
-        /// overload -- the flag-off byte-identity ORACLE -- on the same input, at the
+        /// <see cref="PercolatorEngine.RunPercolatorFdr(FdrProjectionSet,OspreyConfig,OspreyFeatureInfo[],System.Action{string},IFdrOutputSink,PercolatorDiagnosticsConfig,string,System.Func{string,System.Collections.Generic.IReadOnlyList{double[]}},System.Action{FeatureContributions})"/>
+        /// overload must produce byte-identical Score + q-values to the FdrEntry-buffer
+        /// <see cref="PercolatorEngine"/> RunPercolatorFdr overload (the one that takes the
+        /// per-file <see cref="FdrEntry"/> lists) -- the flag-off byte-identity ORACLE -- on the same input, at the
         /// shared production config. Streaming-only: both overloads always take the
         /// streaming SVM path (best-per-precursor subsample, Stage 5 standardizer fit
         /// on that subset), so this checks that the two buffer shapes -- the FdrEntry

--- a/pwiz_tools/Osprey/Osprey.Test/ModelDiagnosticsDataTest.cs
+++ b/pwiz_tools/Osprey/Osprey.Test/ModelDiagnosticsDataTest.cs
@@ -60,6 +60,105 @@ namespace pwiz.Osprey.Test
             TestCrossRunDetection();
             TestPassingSetHonorsFdrLevel();
             TestCalibrationBuildCalFile();
+            TestStreamingAccumulatorMatchesBatch();
+        }
+
+        // The streaming pass-1 accumulator (fed per-row off the projection score-pass sink so an
+        // 82-file --model-diagnostics run need not hold the resident pre-compaction pool) must
+        // produce a byte-identical data model to the batch Build over the resident pool. A 3-file
+        // entrapment fixture populates EVERY card -- real targets + decoys, entrapment + p_decoys,
+        // pair indices, a precursor seen across files (cross-file best-per-precursor merge),
+        // q-failing entries + distinct run vs experiment q (cross-run gates), and a trained model
+        // (Model tab). Both paths serialize under the sidecar settings and must match exactly.
+        private static void TestStreamingAccumulatorMatchesBatch()
+        {
+            var cls = new Dictionary<uint, EntrapmentClass>();
+            var pair = new Dictionary<uint, uint>();
+            var f1 = new List<FdrEntry>();
+            var f2 = new List<FdrEntry>();
+            var f3 = new List<FdrEntry>();
+            for (int i = 0; i < 6; i++)
+            {
+                uint tid = (uint)(100 + i);
+                // Real target + decoy, seen in f1 AND f2 with different scores/q so the cross-file
+                // best-per-precursor reduction (max score, min q) is exercised; f3 keeps the first 3.
+                f1.Add(Entry(tid, false, 8.0 - i, 0.001 * (i + 1), "T" + i, 2));
+                f1.Add(Entry(tid | DECOY_BIT, true, 1.0 + 0.1 * i, 0.5, "D" + i, 2));
+                f2.Add(Entry(tid, false, 7.5 - i, 0.002 * (i + 1), "T" + i, 2));
+                f2.Add(Entry(tid | DECOY_BIT, true, 1.2 + 0.1 * i, 0.5, "D" + i, 2));
+                cls[tid] = EntrapmentClass.Target;
+                pair[tid] = (uint)i;
+                if (i < 3)
+                    f3.Add(Entry(tid, false, 6.0 - i, 0.001 * (i + 1), "T" + i, 2));
+            }
+            // Entrapment (p_target) + p_decoy, paired by index to the targets above.
+            for (int i = 0; i < 4; i++)
+            {
+                uint pid = (uint)(200 + i);
+                f1.Add(Entry(pid, false, 5.5 - i, 0.003 + 0.001 * i, "P" + i, 2));
+                f1.Add(Entry(pid | DECOY_BIT, true, 0.9 + 0.05 * i, 0.5, "PD" + i, 2));
+                cls[pid] = EntrapmentClass.PTarget;
+                pair[pid] = (uint)i;
+            }
+            // A precursor whose run q passes but experiment q fails, in two runs (experiment gate).
+            f2.Add(EntryRunExp(300, 0.001, 0.20, "G"));
+            f3.Add(EntryRunExp(300, 0.001, 0.20, "G"));
+            cls[300] = EntrapmentClass.Target;
+
+            var perFileEntries = WrapFiles(f1, f2, f3);
+            const double r = 1.0, runFdr = 0.01;
+            const FdrLevel level = FdrLevel.Peptide;
+
+            // A trained model so the Model tab (feature table + per-feature histograms) is compared.
+            var infos = new[]
+            {
+                new OspreyFeatureInfo("f0", "Feature Zero", false),
+                new OspreyFeatureInfo("f1", "Feature One", false),
+            };
+            var facc = new FeatureContributions.Accumulator(2, true);
+            for (int i = 0; i < 10; i++) facc.Add(new[] { 2.0, 0.5 }, false);
+            for (int i = 0; i < 10; i++) facc.Add(new[] { -1.0, 0.0 }, true);
+            var contrib = facc.Build(new List<double[]> { new[] { 2.0, -1.0 } }, infos);
+
+            // Batch build (the resident-path oracle).
+            var batch = ModelDiagnosticsData.Build(perFileEntries, contrib, cls, pair, r, runFdr, level);
+
+            // Streaming build: feed each row through the accumulator in nested (file, row) order,
+            // exactly as the projection score-pass sink does (protein q is unused, so pass 0).
+            var runNames = perFileEntries.Select(kv => kv.Key).ToArray();
+            var acc = new ModelDiagnosticsData.Accumulator(runNames, cls, pair, r, runFdr, level);
+            for (int fi = 0; fi < perFileEntries.Count; fi++)
+            {
+                foreach (var e in perFileEntries[fi].Value)
+                {
+                    acc.Add(fi, e.ModifiedSequence, e.Charge, e.EntryId, e.IsDecoy, e.Score,
+                        new FdrQValues(e.RunPrecursorQvalue, e.RunPeptideQvalue,
+                            e.ExperimentPrecursorQvalue, e.ExperimentPeptideQvalue, 0.0));
+                }
+            }
+            var streamed = acc.Build(contrib);
+
+            // Byte-identity under the sidecar settings the HTML embed round-trips through.
+            var settings = new JsonSerializerSettings
+            {
+                ContractResolver = new CamelCasePropertyNamesContractResolver(),
+                FloatFormatHandling = FloatFormatHandling.Symbol,
+                FloatParseHandling = FloatParseHandling.Double,
+            };
+            Assert.AreEqual(
+                JsonConvert.SerializeObject(batch, settings),
+                JsonConvert.SerializeObject(streamed, settings),
+                @"streaming --model-diagnostics accumulator must byte-match the resident batch build");
+
+            // Guard against a vacuous all-null match: the fixture must actually populate the cards.
+            Assert.IsTrue(batch.HasEntrapment);
+            Assert.IsNotNull(batch.FdpViews);
+            Assert.IsTrue(batch.FdpViews.Count > 0);
+            Assert.IsNotNull(batch.CrossRun);
+            Assert.IsNotNull(batch.WinFraction);
+            Assert.IsTrue(batch.WinFraction.HasEntrapment);
+            Assert.AreEqual(2, batch.Model.Count);
+            Assert.IsTrue(batch.NTarget > 0 && batch.NPTarget > 0 && batch.NDecoy > 0);
         }
 
         /// <summary>

--- a/pwiz_tools/Osprey/Osprey.Test/ModelDiagnosticsDataTest.cs
+++ b/pwiz_tools/Osprey/Osprey.Test/ModelDiagnosticsDataTest.cs
@@ -159,6 +159,21 @@ namespace pwiz.Osprey.Test
             Assert.IsTrue(batch.WinFraction.HasEntrapment);
             Assert.AreEqual(2, batch.Model.Count);
             Assert.IsTrue(batch.NTarget > 0 && batch.NPTarget > 0 && batch.NDecoy > 0);
+
+            // Degrade path: a plain target+decoy run with NO manifest (null classByBaseId /
+            // pairByBaseId) -- the accumulator must still byte-match the batch build there.
+            var batchNM = ModelDiagnosticsData.Build(perFileEntries, contrib, null, null, r, runFdr, level);
+            var accNM = new ModelDiagnosticsData.Accumulator(runNames, null, null, r, runFdr, level);
+            for (int fi = 0; fi < perFileEntries.Count; fi++)
+                foreach (var e in perFileEntries[fi].Value)
+                    accNM.Add(fi, e.ModifiedSequence, e.Charge, e.EntryId, e.IsDecoy, e.Score,
+                        new FdrQValues(e.RunPrecursorQvalue, e.RunPeptideQvalue,
+                            e.ExperimentPrecursorQvalue, e.ExperimentPeptideQvalue, 0.0));
+            Assert.AreEqual(
+                JsonConvert.SerializeObject(batchNM, settings),
+                JsonConvert.SerializeObject(accNM.Build(contrib), settings),
+                @"streaming accumulator must byte-match the batch build on the no-manifest degrade path");
+            Assert.IsFalse(batchNM.HasEntrapment, @"no manifest -> is_decoy-only split, no entrapment");
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary

* Streams the `--model-diagnostics` pass-1 report off the projection path so it no longer
  forces the resident pre-compaction first-pass pool. On an 82-file SEA-AD Astral run that
  pool is ~340M `FdrEntry` objects and OOMs a 64 GB box at the first-join, so the 82-file
  `--model-diagnostics` comparison could never be produced.
* Added a nested `ModelDiagnosticsData.Accumulator` (mirrors `FeatureContributions.Accumulator`)
  fed per-row by the first-pass projection score sink (`FdrProjectionSinkBase.Accept`); its
  `Build` runs the SAME downstream builders as the batch `ModelDiagnosticsData.Build`. Every
  report card derives from the reduced best-per-precursor set (bounded by unique precursors /
  base-ids, not raw entries); those reductions are order-independent (within a `modseq|charge`
  key the class / is_decoy / pair are invariant), so folding each row as it streams reproduces
  the batch reduction byte-for-byte.
* Dropped `config.ModelDiagnostics` from `FirstJoinTask`'s `needsResidentFirstPassPool` gate so
  mdiag takes the projection path; the resident path keeps the old batch `Write` as the
  byte-identity oracle. The projection SVM now surfaces `FeatureContributions` (Model tab) via a
  capture callback and collects the per-feature histograms. Pass-2 report (MergeNode, small
  reported pool) unchanged.
* The transfer arm (`OSPREY_PASS2_QVALUE=transfer`) still forces the resident pool via its own
  `Pass2TransferQ` term (the full score→q table) — a separate, smaller follow-up. The default
  percolator arm is unblocked by this change alone.

Stacked on #4419 (base = `Skyline/work/20260713_osprey_diagnostics_memory`); retarget to
`master` after #4419 squash-merges.

Requested by Brendan.

See ai/todos/active/TODO-20260714_osprey_mdiag_streaming.md

## Test plan

- [x] TestStreamingAccumulatorMatchesBatch - streaming `Accumulator` vs batch `Build` serialize
  to identical JSON on a 3-file entrapment fixture that populates every card
- [x] Osprey pre-commit - build (net472 + net8.0), inspection 0 warnings, 506/509 tests
- [x] regression.ps1 -Dataset Stellar - mode1/2/3 blib byte-identical (45,064,192 bytes); the
  change does not touch the default-path output
- [x] End-to-end report byte-identity on the r~1.0 Astral entrapment data - resident
  (`OSPREY_FDR_PROJECTION=0`) vs projection `--model-diagnostics` HTML identical modulo the
  generated timestamp (both 355,761 bytes); the projection path produces `out.model-diagnostics.html`
- [ ] 82-file `--model-diagnostics` run (in progress) - confirming it clears the former
  first-join OOM at full scale and produces the 82-file `out.model-diagnostics.html`

Co-Authored-By: Claude <noreply@anthropic.com>
