### PR TITLE
Improved the Osprey model-diagnostics calibration views

### DIFF
--- a/pwiz_tools/Osprey/Osprey.Tasks/ModelDiagnostics/model-diagnostics-template.html
+++ b/pwiz_tools/Osprey/Osprey.Tasks/ModelDiagnostics/model-diagnostics-template.html
@@ -137,7 +137,7 @@ svg{display:block;max-width:100%;height:auto;font:11px ui-monospace,Menlo,Consol
 .legend i{width:11px;height:11px;border-radius:3px;display:inline-block}
 .legend i.ln{height:3px;border-radius:2px;width:16px}
 .axis line,.axis path{stroke:var(--hair);stroke-width:1;shape-rendering:crispEdges}
-.grid line{stroke:var(--grid);stroke-width:1;shape-rendering:crispEdges}
+.grid line{stroke:var(--line);stroke-width:1;shape-rendering:crispEdges}
 .axis text{fill:var(--muted)} .axtitle{fill:var(--muted);font-size:11.5px}
 .tip{position:fixed;pointer-events:none;background:var(--ink);color:var(--bg);padding:6px 9px;
   border-radius:7px;font-size:11.5px;opacity:0;transition:opacity .08s;z-index:9;white-space:nowrap;
@@ -474,8 +474,8 @@ code{font-family:ui-monospace,Menlo,Consolas,monospace;background:var(--grid);pa
         anchor-set size, the residual MS1/MS2 mass error (mean&nbsp;±&nbsp;sd), the RT alignment fit (R²) and its
         post-cal RT window. Cells that sit far from the pack (median&nbsp;±&nbsp;3·MAD) are shown in
         <b style="color:var(--warn)">amber</b>. A row in <b style="color:var(--bad)">red</b> did not calibrate;
-        a <b style="color:var(--warn)">· single-feature</b> tag marks a file that calibrated successfully but whose
-        anchor-scoring model reduced to one feature.
+        an amber <b style="color:var(--warn)">⚠</b> after a file name marks a file that calibrated successfully but
+        whose anchor-scoring model reduced to a single feature (hover it for details).
         <b>Click a row</b> to open that file's calibration Model page — the full distributions live on the
         Model / FDR / Reproducibility tabs.</p>
       <div id="calSummaryTable"></div>
@@ -1746,9 +1746,10 @@ function renderCalSummary(){
   files.forEach((f,i)=>{const failed=calNotCalibrated(f), degen=calDegenerate(f);
     const tr=H(tb,"tr",{class:"clk callink"+(failed?" neg":"")});
     const fileTd=H(tr,"td",{class:"l"},(i+1)+". "+calFileName(i)+(failed?"  ⚠":""));
-    // Degenerate-but-calibrated: keep it visible with an amber "single-feature" tag, but NOT
-    // the red failure row. (.flag is scoped to .calpick, so style the tag inline here.)
-    if(degen)H(fileTd,"span",{style:"margin-left:6px;color:var(--warn);font-weight:600"},"· single-feature");
+    // Degenerate-but-calibrated: a compact amber warning glyph with a fly-over (title) so it
+    // does not wrap and inflate the row; the red failure row is reserved for a genuine no-fit.
+    if(degen)H(fileTd,"span",{style:"margin-left:5px;color:var(--warn);cursor:help",
+      title:"This file calibrated successfully, but its calibration-phase model reduced to a single feature (no separable multi-feature signal). Click the row for the Model tab."},"⚠");
     H(tr,"td",{class:"num"},fmt(f.calPeptides,0));
     if(hasEnt){
       H(tr,"td",{class:"num"},fmt(f.entrapment,0));

--- a/pwiz_tools/Osprey/Osprey.Tasks/ModelDiagnostics/model-diagnostics-template.html
+++ b/pwiz_tools/Osprey/Osprey.Tasks/ModelDiagnostics/model-diagnostics-template.html
@@ -1760,7 +1760,7 @@ function renderCalSummary(){
     const t2=H(tr,"td",{class:"num"},meanSd(f.ms2Mean,f.ms2Sd));mark(t2,out(bMs2,num(f.ms2Mean)));
     const tr2=H(tr,"td",{class:"num"},fmt(f.rtRSquared,3));mark(tr2,out(bR2,num(f.rtRSquared)));
     const tw=H(tr,"td",{class:"num"},fmt(f.rtToleranceMin,2));mark(tw,out(bWin,num(f.rtToleranceMin)));
-    tr.onclick=()=>jumpToCalFile(i);
+    wireJump(tr,i);   // click-to-jump, but a drag (text selection) does not navigate
   });
   if(!files.length)H(host,"p",{class:"note"},"No per-file calibration data.");
 }
@@ -1777,20 +1777,56 @@ function highlightCalSelection(){
 // index (syncing the dropdown), re-render, and scroll the tab into view. Wired from the
 // Reproducibility scatter points and the Summary table rows; designed so more links are
 // trivial to add (any element -> jumpToCalFile(i[, "fdr"|"summary"|...])).
-function jumpToCalFile(i,targetTab){
+function activeTabName(){const t=document.querySelector('.tab.on');return t?t.getAttribute("data-tab"):null;}
+
+// A click that navigates must not eat a text selection: jump only when the pointer barely
+// moved between mousedown and click (a real click, not a drag-select) and no text range is
+// selected inside the element. Shared by the Summary rows; reusable for any future link.
+function wireJump(el,i,targetTab){
+  let mx=0,my=0;
+  el.addEventListener("mousedown",e=>{mx=e.clientX;my=e.clientY;});
+  el.addEventListener("click",e=>{
+    if(Math.abs(e.clientX-mx)>5||Math.abs(e.clientY-my)>5)return;               // dragged: selecting text
+    const sel=window.getSelection&&window.getSelection();
+    if(sel&&!sel.isCollapsed&&sel.anchorNode&&el.contains(sel.anchorNode))return; // active selection in-row
+    jumpToCalFile(i,targetTab);
+  });
+}
+
+function jumpToCalFile(i,targetTab,fromPop){
   targetTab=targetTab||"model";
+  // Push a browser-history entry so Back returns to the page we left (e.g. the Summary tab)
+  // scrolled where it was. Skipped when we ARE the Back navigation (fromPop) to avoid a loop.
+  if(!fromPop){try{
+    history.replaceState({calNav:true,tab:activeTabName(),sel:CAL.sel,y:window.scrollY},"");
+    history.pushState({calNav:true,tab:targetTab,sel:i,y:0},"");
+  }catch(_){/* file:// history can throw; navigation still works without Back support */}}
   if(typeof selectCal==="function")selectCal();   // ensure CAL mode (no-op if already on)
   activateTab(targetTab);
   CAL.sel=Math.max(0,Math.min(i,CAL.files.length-1));
   // renderPass() (via selectCal) already rendered CAL; re-sync the just-set file so the
   // dropdown + per-file cards reflect the target (selectCal ran before CAL.sel changed).
   setCalFile(CAL.sel);
-  const tab=document.querySelector('.tab[data-tab="'+targetTab+'"]');
-  if(tab&&tab.scrollIntoView)tab.scrollIntoView({behavior:"smooth",block:"start"});
+  // On a forward jump, scroll the target tab into view. On a Back restore, the popstate
+  // handler restores the saved scroll position instead, so don't fight it here.
+  if(!fromPop){const tab=document.querySelector('.tab[data-tab="'+targetTab+'"]');
+    if(tab&&tab.scrollIntoView)tab.scrollIntoView({behavior:"smooth",block:"start"});}
 }
 
 // Initial render of every pass-dependent card for the default pass (Pass 1).
 renderPass();
+
+// Browser Back/forward support for the cross-tab jump links. We manage scroll ourselves
+// (manual) and seed a baseline entry for the initial view, so the first Back after a jump
+// restores the tab + file + scroll position captured at jump time rather than leaving the page.
+if(history.scrollRestoration)history.scrollRestoration="manual";
+try{history.replaceState({calNav:true,tab:activeTabName(),sel:CAL.sel,y:0},"");}catch(_){}
+window.addEventListener("popstate",e=>{
+  const st=e.state; if(!st||!st.calNav||!st.tab)return;
+  jumpToCalFile(st.sel==null?CAL.sel:st.sel, st.tab, true);   // fromPop: restore without re-pushing
+  // Restore scroll after the tab swap + re-render settles (two frames for layout).
+  requestAnimationFrame(()=>requestAnimationFrame(()=>window.scrollTo(0,st.y||0)));
+});
 
 // Print / Save-as-PDF: the @media print stylesheet stacks every tab, forces the
 // light palette, expands the feature table, and swaps the single interactive FDR

--- a/pwiz_tools/Osprey/Osprey.Tasks/ModelDiagnostics/model-diagnostics-template.html
+++ b/pwiz_tools/Osprey/Osprey.Tasks/ModelDiagnostics/model-diagnostics-template.html
@@ -1515,7 +1515,7 @@ function buildCalPickers(){
     // amber for a successful-but-degenerate (single-feature) calibration.
     const selF=CAL.files[CAL.sel];
     if(calNotCalibrated(selF))H(p,"span",{class:"flag",style:"color:var(--bad)"},"⚠ this file did not calibrate");
-    else if(calDegenerate(selF))H(p,"span",{class:"flag"},"· single-feature calibration model");
+    else if(calDegenerate(selF))H(p,"span",{class:"flag"},"· single-feature model");
   });
 }
 

--- a/pwiz_tools/Osprey/Osprey.Tasks/ModelDiagnostics/model-diagnostics-template.html
+++ b/pwiz_tools/Osprey/Osprey.Tasks/ModelDiagnostics/model-diagnostics-template.html
@@ -473,7 +473,9 @@ code{font-family:ui-monospace,Menlo,Consolas,monospace;background:var(--grid);pa
       <p class="desc">An at-a-glance per-file health scan of the calibration Osprey applied to each input file:
         anchor-set size, the residual MS1/MS2 mass error (mean&nbsp;±&nbsp;sd), the RT alignment fit (R²) and its
         post-cal RT window. Cells that sit far from the pack (median&nbsp;±&nbsp;3·MAD) are shown in
-        <b style="color:var(--warn)">amber</b>; rows in <b style="color:var(--bad)">red</b> failed to calibrate.
+        <b style="color:var(--warn)">amber</b>. A row in <b style="color:var(--bad)">red</b> did not calibrate;
+        a <b style="color:var(--warn)">· single-feature</b> tag marks a file that calibrated successfully but whose
+        anchor-scoring model reduced to one feature.
         <b>Click a row</b> to open that file's calibration Model page — the full distributions live on the
         Model / FDR / Reproducibility tabs.</p>
       <div id="calSummaryTable"></div>
@@ -1468,7 +1470,15 @@ const CAL_FDP_SERIES=[{k:"lower",name:"lower-bound FDP",color:COL.ptarget,key:"l
                       {k:"paired",name:"paired FDP",color:COL.pdecoy,key:"paired"}];
 const calFdpOff={lower:false,combined:false,paired:false};
 const calFileName=i=>{const f=CAL.files[i];return f?(f.file||("file "+(i+1))):("file "+(i+1));};
-const calIsBad=f=>!!(f&&(f.degenerate||f.calibrated===false));
+// Two DISTINCT calibration states (the data carries them as independent booleans):
+//   calNotCalibrated -- no RT/mass fit was accepted for the file; a genuine failure (red).
+//   calDegenerate    -- the fit WAS accepted, but the calibration-phase LDA collapsed to a
+//                       single feature (a valid, if minimal, anchor-scoring model). Amber
+//                       note, NOT a failure -- the file calibrated successfully.
+// calibrated===false is the only true-failure signal; the degenerate flag only ever rides
+// along on a successful fit, so it must never be rendered as "did not calibrate".
+const calNotCalibrated=f=>!!(f&&f.calibrated===false);
+const calDegenerate=f=>!!(f&&f.degenerate&&f.calibrated!==false);
 
 function renderCal(){
   buildCalPickers();
@@ -1493,7 +1503,7 @@ function buildCalPickers(){
     prev.onclick=()=>{setCalFile(CAL.sel-1);};
     const sel=H(p,"select",{id:host+"Sel"});
     CAL.files.forEach((f,i)=>{const o=H(sel,"option",{value:String(i)},
-      (i+1)+". "+calFileName(i)+(calIsBad(f)?"  ⚠ not calibrated":""));
+      (i+1)+". "+calFileName(i)+(calNotCalibrated(f)?"  ⚠ not calibrated":calDegenerate(f)?"  · single-feature model":""));
       if(i===CAL.sel)o.setAttribute("selected","");});
     sel.value=String(CAL.sel);
     sel.onchange=()=>{setCalFile(+sel.value);};
@@ -1501,8 +1511,11 @@ function buildCalPickers(){
     const next=H(p,"button",{class:"step",type:"button",title:"Next file","aria-label":"Next file"},"▶");
     if(CAL.sel>=last)next.setAttribute("disabled","");
     next.onclick=()=>{setCalFile(CAL.sel+1);};
-    // A compact flag when the selected file failed to calibrate.
-    if(calIsBad(CAL.files[CAL.sel]))H(p,"span",{class:"flag"},"⚠ this file did not calibrate");
+    // A compact flag for the selected file's calibration state: red for a genuine failure,
+    // amber for a successful-but-degenerate (single-feature) calibration.
+    const selF=CAL.files[CAL.sel];
+    if(calNotCalibrated(selF))H(p,"span",{class:"flag",style:"color:var(--bad)"},"⚠ this file did not calibrate");
+    else if(calDegenerate(selF))H(p,"span",{class:"flag"},"· single-feature calibration model");
   });
 }
 
@@ -1524,27 +1537,35 @@ function renderCalModel(){
   const na=document.getElementById("calModelNa"), host=document.getElementById("calModelTable");
   host.innerHTML="";na.style.display="none";
   if(!f){na.style.display="";na.innerHTML="No calibration data for this file.";return;}
-  if(calIsBad(f)){na.style.display="";
+  const failed=calNotCalibrated(f), degen=calDegenerate(f);
+  if(failed){na.style.display="";
     na.innerHTML="<b>"+esc(calFileName(CAL.sel))+" did not calibrate.</b> "+
-      "The calibration model for this file is degenerate (too few usable anchors or no separable signal), "+
-      "so no feature contributions or discriminant distribution are available.";}
+      "No RT/mass fit was accepted for this file, so no feature contributions or "+
+      "discriminant distribution are available.";}
   const rows=f.features||[];
-  if(rows.length && !calIsBad(f))
+  // A degenerate file DID calibrate: show its (single-feature) contribution table with a note,
+  // rather than hiding it behind a failure message. Only a genuine no-fit suppresses the table.
+  if(rows.length && !failed){
     buildFeatureTable(host,rows,{});   // static (no per-row click) -- cal features carry no per-feature histogram
-  else if(!calIsBad(f))
+    if(degen)H(host,"p",{class:"note"},
+      "This file calibrated successfully, but its calibration-phase LDA reduced to the single "+
+      "feature shown at 100% above; the other features carried no separable signal across folds. "+
+      "A single-feature anchor discriminant still produced a valid RT/mass calibration for this file.");
+  }
+  else if(!failed)
     H(host,"p",{class:"note"},"No calibration feature model for this file.");
   // Composite calibration-discriminant distribution (reuse classHist; cal target/decoy are the
   // calibration classes). The entrapment p_target/p_decoy series ARE shown when present, so a
   // contaminated anchor set is visible -- hence noEntrapment:false below.
   const scoreHost="calScoreChart", scoreLeg="calScoreLegend";
-  if(f.scores && f.scores.binEdges && f.scores.binEdges.length>1 && !calIsBad(f))
+  if(f.scores && f.scores.binEdges && f.scores.binEdges.length>1 && !failed)
     classHist(f.scores,scoreHost,scoreLeg,false,
       {noEntrapment:false,targetName:"calibration target",decoyName:"calibration decoy"});
   else naChart(scoreHost,scoreLeg,"No calibration discriminant distribution for this file.");
   document.getElementById("calScoreHdr").textContent="Calibration discriminant score distribution — "+calFileName(CAL.sel);
   // Print-only: every file's composite discriminant (the dropdown shows one on screen).
   const pall=document.getElementById("calModelPrintAll");if(pall){pall.innerHTML="";
-    CAL.files.forEach((cf,i)=>{if(calIsBad(cf)||!cf.scores||!cf.scores.binEdges)return;
+    CAL.files.forEach((cf,i)=>{if(calNotCalibrated(cf)||!cf.scores||!cf.scores.binEdges)return;
       const cell=H(pall,"div",{class:"calfilecell"});
       H(cell,"h3",{style:"font-size:12.5px;margin:6px 0 2px;font-weight:600"},(i+1)+". "+calFileName(i));
       const cid="calPrintScore"+i;H(cell,"div",{class:"chartbox",id:cid});
@@ -1673,11 +1694,14 @@ function drawCalScatter(grid,p,files,N,num){
   files.forEach((f,i)=>{const v=p.val(f);if(isNaN(v))return;const cx=sc.x(i+1),cy=sc.y(Math.max(lo,Math.min(hi,v)));
     if(p.err){const e=num(p.err(f));if(!isNaN(e)&&e>0){
       E(s,"line",{x1:cx,x2:cx,y1:sc.y(Math.max(lo,v-e)),y2:sc.y(Math.min(hi,v+e)),stroke:COL.target,opacity:.35,"stroke-width":1});}}
-    const bad=calIsBad(f), out=isOut(v);
-    const c=E(s,"circle",{cx:cx,cy:cy,r:bad?3.4:3,
-      fill:bad?COL.decoy:(out?COL.warn:COL.target),class:"callink"});
+    // Red is reserved for a genuine calibration failure (calibrated===false). A degenerate
+    // (single-feature) file DID calibrate, so it is drawn as a normal point -- it still gets
+    // the amber outlier ring if it sits far from the pack on this metric, same as any file.
+    const failed=calNotCalibrated(f), degen=calDegenerate(f), out=isOut(v);
+    const c=E(s,"circle",{cx:cx,cy:cy,r:failed?3.4:3,
+      fill:failed?COL.decoy:(out?COL.warn:COL.target),class:"callink"});
     c.addEventListener("mousemove",ev=>showTip(ev,"<b>"+(i+1)+". "+esc(calFileName(i))+"</b><br>"+
-      p.title+": "+p.fmt(v)+(out?"  ⚠ outlier":"")+(bad?"<br>⚠ not calibrated":"")+"<br><i>click to open Model</i>"));
+      p.title+": "+p.fmt(v)+(out?"  ⚠ outlier":"")+(failed?"<br>⚠ not calibrated":degen?"<br>· single-feature model":"")+"<br><i>click to open Model</i>"));
     c.addEventListener("mouseleave",hideTip);
     c.addEventListener("click",()=>jumpToCalFile(i));
   });
@@ -1719,9 +1743,12 @@ function renderCalSummary(){
   const meanSd=(m,sd)=>isNaN(num(m))?"–":fmt(m,1)+" ± "+fmt(num(sd),1)+" "+unit;
   // Mark a cell as an outlier: bold + amber so a bad file pops out of the scan.
   const mark=(td,bad)=>{if(bad){td.style.color="var(--warn)";td.style.fontWeight="700";}};
-  files.forEach((f,i)=>{const bad=calIsBad(f);
-    const tr=H(tb,"tr",{class:"clk callink"+(bad?" neg":"")});
-    H(tr,"td",{class:"l"},(i+1)+". "+calFileName(i)+(bad?"  ⚠":""));
+  files.forEach((f,i)=>{const failed=calNotCalibrated(f), degen=calDegenerate(f);
+    const tr=H(tb,"tr",{class:"clk callink"+(failed?" neg":"")});
+    const fileTd=H(tr,"td",{class:"l"},(i+1)+". "+calFileName(i)+(failed?"  ⚠":""));
+    // Degenerate-but-calibrated: keep it visible with an amber "single-feature" tag, but NOT
+    // the red failure row. (.flag is scoped to .calpick, so style the tag inline here.)
+    if(degen)H(fileTd,"span",{style:"margin-left:6px;color:var(--warn);font-weight:600"},"· single-feature");
     H(tr,"td",{class:"num"},fmt(f.calPeptides,0));
     if(hasEnt){
       H(tr,"td",{class:"num"},fmt(f.entrapment,0));


### PR DESCRIPTION
## Summary

Several improvements to the `--model-diagnostics` CAL (calibration) views, found while reviewing the first full 82-file SEA-AD Astral-DIA run. All changes are in the self-contained HTML template; no C# data change.

* **Fixed a mislabeled calibration.** Two files were flagged "did not calibrate / too few usable anchors" (red) despite calibrating successfully (RT r² ≈ 0.998). Root cause: the template collapsed two independent booleans — `calibrated` and `degenerate` — into one verdict. `degenerate` means the calibration-phase LDA reduced to a single feature (here `libcosine_apex` at 100%), which still yields a valid calibration. Split into `calNotCalibrated` (genuine no-fit → red) and `calDegenerate` (calibrated but single-feature → amber). The Model tab now shows the single-feature contribution table with an explanatory note; the Summary marks the file with a compact amber ⚠ carrying a hover explanation (no layout-breaking inline label); the Reproducibility scatter no longer draws these files as red dots.
* **Improved chart readability.** Strengthened the gridline color (`--grid` → `--line`) so the faint Reproducibility background lines read clearly, especially in dark mode, while staying subordinate to the axis lines.
* **Summary navigation.** Clicking a Summary row that jumps to a file's Model page now pushes a browser-history entry, so Back returns to the Summary tab scrolled where it was. A click navigates only when the pointer barely moved and no text is selected, so click-and-drag text selection no longer triggers the jump.

Reported by Brendan.

## Test plan

- [x] Build-Osprey Debug -RunTests — 506 passed, 3 skipped
- [x] node --check on the edited app script
- [x] Regenerated the 82-file run's HTML and verified against the real data: 0 files `calibrated===false`, exactly 2 `degenerate` files (`libcosine_apex` 100%) render amber single-feature
- [x] Headless-Chrome self-test of the navigation: forward jump pushes a back-point + activates Model; popstate restores the Summary tab; a 40px drag does not navigate while a 1px click does

Co-Authored-By: Claude <noreply@anthropic.com>