### PR TITLE
Streamed Stage-6 rescore MS2 by isolation window (byte-identical)

### DIFF
--- a/pwiz_tools/Osprey/Osprey.Scoring/ScoringPipeline.cs
+++ b/pwiz_tools/Osprey/Osprey.Scoring/ScoringPipeline.cs
@@ -58,31 +58,6 @@ namespace pwiz.Osprey.Scoring
 
 
         /// <summary>
-        /// Run coelution scoring for all library entries across all isolation
-        /// windows, sourcing each window's MS2 spectra from the full resident list.
-        /// Thin wrapper that wraps <paramref name="spectra"/> in a
-        /// <see cref="ResidentWindowSpectraProvider"/> (MS2 calibration + window
-        /// grouping) and delegates to the provider-driven overload. Used by the
-        /// Stage-6 rescore / gap-fill passes and as the Stage-4 fallback.
-        /// </summary>
-        public List<FdrEntry> RunCoelutionScoring(
-            List<LibraryEntry> fullLibrary,
-            List<Spectrum> spectra,
-            List<MS1Spectrum> ms1Spectra,
-            List<IsolationWindow> isolationWindows,
-            RTCalibration rtCalibration,
-            MzCalibrationResult ms2Calibration,
-            MzCalibrationResult ms1Calibration,
-            ScoringContext context,
-            string passLabel = null,
-            bool consumeInputMzs = false)
-        {
-            var spectraProvider = new ResidentWindowSpectraProvider(spectra, ms2Calibration, consumeInputMzs);
-            return RunCoelutionScoring(fullLibrary, spectraProvider, ms1Spectra, isolationWindows,
-                rtCalibration, ms2Calibration, ms1Calibration, context, passLabel);
-        }
-
-        /// <summary>
         /// Run coelution scoring for all library entries across all isolation windows.
         /// For each window, finds candidate entries whose precursor falls in the window,
         /// extracts fragment XICs, detects CWT peaks, and scores at each peak. Each
@@ -115,15 +90,13 @@ namespace pwiz.Osprey.Scoring
             // never shrinks, so gen-2 keeps the arrays for the full run.
             context.EnsureXcorrScratchPool(scorer.BinConfig.NBins);
 
-            // MS2 calibration of each spectrum and the window grouping now live in
-            // the IWindowSpectraProvider: ResidentWindowSpectraProvider on the
-            // resident / Stage-6 rescore path (it copies + calibrates the whole list
-            // up front, mirroring Rust run_search's calibrated_spectra), and the
-            // streaming index on Stage 4 (it calibrates one window at a time so only
-            // that window's copy is ever live). The provider does NOT mutate the
-            // caller's raw m/z except the gated consumeInputMzs free the Stage-4
-            // caller opts into -- the Stage-6 loop re-scores one shared list, so it
-            // leaves the raw m/z intact for the next call.
+            // MS2 calibration of each spectrum and the window grouping live in the
+            // IWindowSpectraProvider: StreamingWindowSpectraProvider loads one window's
+            // MS2 from the .spectra.bin index on demand and calibrates it in place, so
+            // only the windows being scored concurrently are resident -- both Stage 4
+            // and the Stage-6 rescore / gap-fill passes stream this way (the latter
+            // simply re-reads windows on each pass; there is no shared resident list to
+            // preserve, so nothing here mutates a caller's m/z).
 
             // Determine RT tolerance - global, matching Rust's run_search.
             // Rust computes one tolerance for ALL entries: 3 * MAD * 1.4826,

--- a/pwiz_tools/Osprey/Osprey.Scoring/WindowSpectraProvider.cs
+++ b/pwiz_tools/Osprey/Osprey.Scoring/WindowSpectraProvider.cs
@@ -21,9 +21,7 @@
  * limitations under the License.
  */
 
-using System;
 using System.Collections.Generic;
-using pwiz.Osprey.Chromatography;
 using pwiz.Osprey.Core;
 
 namespace pwiz.Osprey.Scoring
@@ -33,10 +31,12 @@ namespace pwiz.Osprey.Scoring
     /// a time, already MS2-calibrated, keyed by the same
     /// <c>(int)Math.Round(center * 10.0)</c> the in-memory grouping has always
     /// used. This is the seam that lets <see cref="ScoringPipeline"/>.RunCoelutionScoring
-    /// be fed either the whole resident spectra list
-    /// (<see cref="ResidentWindowSpectraProvider"/>) or a streaming, load-on-demand
-    /// source (the per-file streaming path wraps SpectraWindowIndex). Both return
-    /// byte-for-byte identical window spectra, so scoring output is unchanged.
+    /// pull each window from a streaming, load-on-demand source: the concrete
+    /// implementation is Osprey.Tasks' StreamingWindowSpectraProvider, which decodes and
+    /// calibrates one window from the .spectra.bin index per call (Stage-4 scoring and the
+    /// Stage-6 rescore / gap-fill passes both stream through this seam), so scoring never
+    /// materializes the whole resident MS2 list. The window spectra it returns are
+    /// byte-for-byte identical to a full cache load, so scoring output is unchanged.
     /// </summary>
     public interface IWindowSpectraProvider
     {
@@ -54,95 +54,5 @@ namespace pwiz.Osprey.Scoring
         /// sole spectra dependency that survives once scoring is streamed.
         /// </summary>
         IReadOnlyList<double> Ms2RetentionTimes { get; }
-    }
-
-    /// <summary>
-    /// The resident <see cref="IWindowSpectraProvider"/>: it applies MS2
-    /// calibration to a local copy of the full spectra list and groups it by
-    /// window key up front, exactly as <see cref="ScoringPipeline"/>.RunCoelutionScoring
-    /// did inline before the streaming refactor. Used by the Stage-6 rescore /
-    /// gap-fill passes (which re-score one shared spectra list repeatedly) and as
-    /// the Stage-4 fallback when a streaming index cannot be built.
-    /// </summary>
-    public class ResidentWindowSpectraProvider : IWindowSpectraProvider
-    {
-        private readonly Dictionary<int, List<Spectrum>> _spectraByWindowKey;
-
-        /// <param name="spectra">The full resident MS2 list.</param>
-        /// <param name="ms2Calibration">MS2 mass calibration; when calibrated, a
-        /// local calibrated copy is built (the input is never mutated except the
-        /// gated <paramref name="consumeInputMzs"/> free below).</param>
-        /// <param name="consumeInputMzs">When true, free each input spectrum's raw
-        /// m/z array as its calibrated copy is built, so the two ~4 GB copies never
-        /// coexist. Only the single Stage-4 caller passes true; the Stage-6 rescore
-        /// loop calls scoring repeatedly on ONE shared list, so it must NOT set this
-        /// (the next call still reads the raw m/z).</param>
-        public ResidentWindowSpectraProvider(List<Spectrum> spectra,
-            MzCalibrationResult ms2Calibration, bool consumeInputMzs)
-        {
-            // Capture RTs up front (RetentionTime is never freed by consumeInputMzs).
-            var rts = new double[spectra.Count];
-            for (int i = 0; i < spectra.Count; i++)
-                rts[i] = spectra[i].RetentionTime;
-            Ms2RetentionTimes = rts;
-
-            // Apply MS2 calibration to a LOCAL copy of the spectra list, mirroring
-            // Rust run_search which builds calibrated_spectra and operates on it.
-            // Do NOT mutate the input parameter: the Stage 6 rescore loop scores the
-            // same list multiple times, and an in-place offset would accumulate
-            // (mz - mean -> mz - 2*mean -> ...) and mismatch fragments on later calls.
-            List<Spectrum> calibratedSpectra;
-            if (ms2Calibration.Calibrated)
-            {
-                calibratedSpectra = new List<Spectrum>(spectra.Count);
-                for (int si = 0; si < spectra.Count; si++)
-                {
-                    var s = spectra[si];
-                    double[] correctedMzs = new double[s.Mzs.Length];
-                    for (int mi = 0; mi < s.Mzs.Length; mi++)
-                        correctedMzs[mi] = MzCalibration.ApplyCalibration(s.Mzs[mi], ms2Calibration);
-                    calibratedSpectra.Add(new Spectrum
-                    {
-                        ScanNumber = s.ScanNumber,
-                        RetentionTime = s.RetentionTime,
-                        PrecursorMz = s.PrecursorMz,
-                        IsolationWindow = s.IsolationWindow,
-                        Mzs = correctedMzs,
-                        Intensities = s.Intensities
-                    });
-                    // Intensities are shared into the copy, so keep them; only the
-                    // raw m/z is now dead for the single-scoring Stage-4 caller.
-                    if (consumeInputMzs)
-                        s.Mzs = null;
-                }
-            }
-            else
-            {
-                // No calibration -> alias the input list (no copy).
-                calibratedSpectra = spectra;
-            }
-
-            // Group spectra by isolation window center (rounded key) for lookup.
-            _spectraByWindowKey = new Dictionary<int, List<Spectrum>>();
-            foreach (var spectrum in calibratedSpectra)
-            {
-                int key = (int)Math.Round(spectrum.IsolationWindow.Center * 10.0);
-                if (!_spectraByWindowKey.TryGetValue(key, out var list))
-                {
-                    list = new List<Spectrum>();
-                    _spectraByWindowKey[key] = list;
-                }
-                list.Add(spectrum);
-            }
-        }
-
-        public IReadOnlyList<double> Ms2RetentionTimes { get; }
-
-        public List<Spectrum> GetCalibratedWindow(int windowKey)
-        {
-            return _spectraByWindowKey.TryGetValue(windowKey, out var list)
-                ? list
-                : new List<Spectrum>();
-        }
     }
 }

--- a/pwiz_tools/Osprey/Osprey.Tasks/PerFileRescoreTask.cs
+++ b/pwiz_tools/Osprey/Osprey.Tasks/PerFileRescoreTask.cs
@@ -25,6 +25,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using System.Linq;
 using System.Threading.Tasks;
 using pwiz.Osprey.Chromatography;
 using pwiz.Osprey.Core;
@@ -688,15 +689,30 @@ namespace pwiz.Osprey.Tasks
             var (boundaryOverrides, subsetLibrary) =
                 BuildScoringSubset(combinedTargets, fdrEntries, fullLibrary);
 
-            // Segment 1/3 (read): reload this file's spectra -- the file's first
+            // Segment 1/3 (read): index this file's spectra cache -- the file's first
             // progress slice on the --parallel-files "[i] p%" aggregate line.
             MultiProgressReporter.Current?.BeginSegment();
-            // Load spectra: prefer the .spectra.bin cache the original
-            // Stage 1 wrote; fall back to mzML if the cache is missing
-            // or unreadable.
-            List<Spectrum> spectra;
-            List<MS1Spectrum> ms1Spectra;
-            LoadSpectraForRescore(inputFile, fileName, out spectra, out ms1Spectra, ctx);
+            // Stream this file's MS2 by isolation window from the .spectra.bin cache the
+            // original Stage 1-4 run wrote, instead of materializing the whole ~6 GB
+            // resident List<Spectrum>: build the seekable SpectraWindowIndex (MS1 + the
+            // first-cycle isolation windows come from it too) and load each window on
+            // demand during the re-score. Stage 6 REQUIRES that cache; there is no mzML
+            // fallback -- a rescore without the cache is a deployment error, not a reason
+            // to re-read the 6 GB mzML (LoadSpectraForRescore throws).
+            SpectraWindowIndex spectraIndex = LoadSpectraForRescore(inputFile, fileName, ctx);
+            var ms1Spectra = spectraIndex.Ms1Spectra.ToList();
+
+            // Load-boundary memory probe. With streaming this measures the small index +
+            // MS1 on the reconciliation floor (library + this file's parquet stubs) -- the
+            // ~6 GB resident MS2 the resident load used to root here is gone (that reduction
+            // is the point of this change). Kept as permanent instrumentation to catch a
+            // future regression that re-materializes the MS2 at this boundary; the forced-GC
+            // line is the live number and, under Profile-Osprey.ps1 -MemoryProfile, captures
+            // a "perfile-rescore-loaded" retention snapshot. Zero cost -- collection
+            // included -- when OSPREY_LOG_MEMORY is unset.
+            ProfilerHooks.LogMemoryStatsIfEnabled(ctx.LogInfo, @"perfile-rescore-loaded (pre-GC)");
+            ProfilerHooks.LogManagedHeapAfterGcIfEnabled(ctx.LogInfo, @"perfile-rescore-loaded",
+                @"(post-GC, streaming index resident)");
 
             // Load the sibling .calibration.json so the search uses the
             // same MS2/MS1 mass calibrations the original Stage 1-4 run
@@ -733,9 +749,20 @@ namespace pwiz.Osprey.Tasks
             context.BoundaryOverrides = boundaryOverrides;
             context.OriginalRtMad = rtMadFromCalJson;
 
-            // Build isolation windows from the loaded spectra (same as
-            // the first-pass ProcessFile path).
-            var isolationWindows = ScoringTaskShared.ExtractIsolationWindows(spectra);
+            // Isolation windows come straight from the streaming index -- reconstructed
+            // with the same first-cycle dedup + Center sort ScoringTaskShared.ExtractIsolationWindows
+            // applied to the resident list, so the window fan-out is unchanged.
+            var isolationWindows = spectraIndex.IsolationWindows.ToList();
+
+            // Stream each isolation window's calibrated MS2 from the index on demand. ONE
+            // provider is shared across the subset re-score + both gap-fill passes: it holds
+            // no per-window state (each GetCalibratedWindow is a fresh decode + in-place
+            // calibration), so re-scoring the file three times just re-reads windows -- no
+            // resident ~6 GB list, and none of the per-pass whole-list calibrated COPIES the
+            // resident provider built. (That repeated-scoring is exactly why the resident path
+            // had to pass consumeInputMzs:false; streaming has no such constraint.)
+            IWindowSpectraProvider spectraProvider =
+                new StreamingWindowSpectraProvider(spectraIndex, ms2Cal);
 
             // Segment 2/3 (score): the subset re-score; its "Re-scoring isolation
             // windows" reporter feeds this slice (the bulk of the file's motion).
@@ -746,7 +773,7 @@ namespace pwiz.Osprey.Tasks
             if (subsetLibrary.Count > 0)
             {
                 rescored = ScoringTaskShared.Pipeline(ctx).RunCoelutionScoring(
-                    subsetLibrary, spectra, ms1Spectra,
+                    subsetLibrary, spectraProvider, ms1Spectra,
                     isolationWindows, rtCal,
                     ms2Cal, ms1Cal,
                     context, passLabel: "Re-scoring");
@@ -777,7 +804,7 @@ namespace pwiz.Osprey.Tasks
             if (gapFillTargets.Count > 0)
             {
                 var (nGapCwt, nGapForced) = RunGapFillTwoPass(
-                    gapFillTargets, fullLibrary, spectra, ms1Spectra,
+                    gapFillTargets, fullLibrary, spectraProvider, ms1Spectra,
                     isolationWindows, rtCal, ms2Cal, ms1Cal,
                     fileConfig, fileName, rtMadFromCalJson, fdrEntries, ctx);
                 totalGapCwt += nGapCwt;
@@ -790,24 +817,51 @@ namespace pwiz.Osprey.Tasks
             // PHASE 3 -- reconciled parquet write-back + sidecar stamp.
             WriteReconciledAndStamp(fileName, inputFile, fdrEntries, inputs, ctx);
 
-            // Deterministically drop this file's heavy transients before the next
-            // file loads its own: the reloaded spectra (~1.5 GB) and the write-back's
-            // full-parquet reload. At 100s of files these cannot all be resident
-            // (300 files x ~1.5 GB), and .NET's Server GC otherwise defers collection
-            // until it nears the RAM ceiling -- so the reconciliation working set
-            // rides up with file count instead of staying flat. Forcing the collection
-            // here mirrors Rust's per-iteration spectra drop (pipeline.rs:3338, in Rust's
-            // strictly sequential reconciliation file loop) and
-            // keeps the working set at ~the persistent floor + one file's transient.
-            // Output is unchanged (GC timing only). Skipped under file-parallelism > 1,
-            // where concurrent files legitimately share residency and a blocking GC
-            // would stall the other in-flight rescores.
-            spectra = null;
+            // Per-file rescore high-water mark: the raw (pre-GC) working_set peak and
+            // managed_heap since the last collection -- the during-scoring transient (the
+            // per-window streamed+calibrated spectra + the scored/gap-fill entries). With
+            // streaming there is no resident MS2 nor the per-pass whole-list calibrated
+            // copies here, so this is the reduced "after" peak vs the resident baseline.
+            // A forced-GC [MEM] is deliberately NOT taken (it would just show the
+            // post-release floor). Zero cost when OSPREY_LOG_MEMORY is unset.
+            ProfilerHooks.LogMemoryStatsIfEnabled(ctx.LogInfo, @"perfile-rescore-peak (pre-GC)");
+
+            // Apex retention snapshot (dotMemory only). Once the resident MS2 is streamed,
+            // the remaining per-file accumulation is the scored + reconciled entries still
+            // rooted by fdrEntries here (each carries the heavy Features / CwtCandidates /
+            // Fragment* / ReferenceXic* arrays). dotMemory forces its own GC before the
+            // snapshot, so the write-back's parquet-reload transient collapses and the
+            // dominators are exactly that retained entry set -- the next memory lever
+            // (scored-entry streaming, shared with PerFileScoring; see
+            // ai/todos/backlog/brendanx67/TODO-osprey_perfile_scored_entry_streaming.md).
+            // No-op unless a Profile-Osprey.ps1 -MemoryProfile session is attached.
+            ProfilerHooks.CaptureRetentionSnapshot(@"perfile-rescore-apex");
+
+            // Deterministically drop this file's transients before the next file loads its
+            // own: the streaming index + MS1 and the write-back's full-parquet reload. At
+            // 100s of files .NET's Server GC otherwise defers collection until it nears the
+            // RAM ceiling -- so the reconciliation working set rides up with file count
+            // instead of staying flat. Forcing the collection here mirrors Rust's
+            // per-iteration spectra drop (pipeline.rs:3338, in Rust's strictly sequential
+            // reconciliation file loop) and keeps the working set at ~the persistent floor +
+            // one file's transient. Output is unchanged (GC timing only). Skipped under
+            // file-parallelism > 1, where concurrent files legitimately share residency and
+            // a blocking GC would stall the other in-flight rescores.
+            spectraProvider = null;
+            spectraIndex = null;
             ms1Spectra = null;
             isolationWindows = null;
             rescored = null;
             if (ctx.RunPlan.EffectiveFileParallelism <= 1)
                 GC.Collect();
+
+            // Post-release floor: the persistent set that survives after this file's
+            // transients (streaming index, MS1, scored entries) are dropped. Forced-GC so
+            // it is the true floor, and it captures a "perfile-rescore-live" retention
+            // snapshot to pair with the loaded snapshot. Zero cost -- collection included --
+            // when OSPREY_LOG_MEMORY is unset.
+            ProfilerHooks.LogManagedHeapAfterGcIfEnabled(ctx.LogInfo, @"perfile-rescore-live",
+                @"(post-GC, after release)");
 
             return (totalRescored, totalGapCwt, totalGapForced);
         }
@@ -1337,7 +1391,7 @@ namespace pwiz.Osprey.Tasks
         private (int NGapCwt, int NGapForced) RunGapFillTwoPass(
             List<GapFillTarget> gapFillTargets,
             List<LibraryEntry> fullLibrary,
-            List<Spectrum> spectra,
+            IWindowSpectraProvider spectraProvider,
             List<MS1Spectrum> ms1Spectra,
             List<IsolationWindow> isolationWindows,
             RTCalibration rtCal,
@@ -1379,7 +1433,7 @@ namespace pwiz.Osprey.Tasks
 
                 var swCwt = Stopwatch.StartNew();
                 var cwtResults = ScoringTaskShared.Pipeline(ctx).RunCoelutionScoring(
-                    gapFillLibrary, spectra, ms1Spectra,
+                    gapFillLibrary, spectraProvider, ms1Spectra,
                     isolationWindows, rtCal,
                     ms2Cal, ms1Cal,
                     cwtContext, passLabel: "Gap-fill scoring");
@@ -1447,7 +1501,7 @@ namespace pwiz.Osprey.Tasks
 
                 var swForced = Stopwatch.StartNew();
                 var forcedResults = ScoringTaskShared.Pipeline(ctx).RunCoelutionScoring(
-                    forcedLibrary, spectra, ms1Spectra,
+                    forcedLibrary, spectraProvider, ms1Spectra,
                     isolationWindows, rtCal,
                     ms2Cal, ms1Cal,
                     forcedContext, passLabel: "Gap-fill forced integration");
@@ -1477,40 +1531,43 @@ namespace pwiz.Osprey.Tasks
         }
 
         /// <summary>
-        /// Load MS2 spectra + MS1 spectra for the rescore loop. Prefers the
-        /// .spectra.bin cache the original Stage 1 wrote; falls back to
-        /// re-parsing the mzML on cache miss / read error. Mirrors the
-        /// Rust spectra-load block at pipeline.rs:2851-2872.
+        /// Build a streaming <see cref="SpectraWindowIndex"/> over the <c>.spectra.bin</c>
+        /// cache the original Stage 1-4 run wrote, so Stage-6 rescore loads each isolation
+        /// window's MS2 on demand instead of materializing the whole ~6 GB resident
+        /// <c>List&lt;Spectrum&gt;</c>. MS1 + the first-cycle isolation windows come from the
+        /// same index. There is NO mzML fallback: Stage 6 always runs against a file the
+        /// upstream stages already cached, so an absent/invalid cache is a deployment error
+        /// (the mzML may not even be shipped to the rescore worker), and re-reading the 6 GB
+        /// mzML would defeat the streaming this method exists to enable. Throws
+        /// <see cref="InvalidDataException"/> when the cache cannot be indexed.
         /// </summary>
-        private void LoadSpectraForRescore(string inputFile, string fileName,
-            out List<Spectrum> spectra, out List<MS1Spectrum> ms1Spectra, PipelineContext ctx)
+        private SpectraWindowIndex LoadSpectraForRescore(string inputFile, string fileName,
+            PipelineContext ctx)
         {
             string cachePath = SpectraCache.GetCachePath(inputFile);
-            if (File.Exists(cachePath))
+            SpectraWindowIndex index;
+            try
             {
-                try
-                {
-                    var result = SpectraCache.LoadSpectraCache(cachePath, inputFile);
-                    spectra = result.Ms2Spectra;
-                    ms1Spectra = result.Ms1Spectra;
-                    ctx.LogInfo(string.Format(
-                        "  Loaded {1} MS1 and {0} MS/MS spectra from cache for {2}",
-                        spectra.Count, ms1Spectra.Count, fileName));
-                    return;
-                }
-                catch (Exception ex)
-                {
-                    ctx.LogWarning(string.Format(
-                        "Failed to load spectra cache {0}: {1}; falling back to mzML",
-                        cachePath, ex.Message));
-                }
+                // null = absent / stale (source changed) / bad magic-version -- the same
+                // rejection rules LoadSpectraCache applies. Any of them is fatal here.
+                index = SpectraWindowIndex.BuildFromCache(cachePath, inputFile);
             }
-            var fresh = MzmlReader.LoadAllSpectra(inputFile);
-            spectra = fresh.Ms2Spectra;
-            ms1Spectra = fresh.Ms1Spectra;
+            catch (Exception ex)
+            {
+                throw new InvalidDataException(string.Format(
+                    "Stage-6 rescore requires the '{0}' spectra cache written by the per-file " +
+                    "scoring stage, but indexing it failed: {1}", cachePath, ex.Message), ex);
+            }
+            if (index == null)
+                throw new InvalidDataException(string.Format(
+                    "Stage-6 rescore requires the '{0}' spectra cache written by the per-file " +
+                    "scoring stage (absent, stale, or wrong version). Re-run PerFileScoring for " +
+                    "'{1}' so the cache is present beside its outputs.", cachePath, fileName));
+
             ctx.LogInfo(string.Format(
-                "  Loaded {1} MS1 and {0} MS/MS spectra from mzML for {2}",
-                spectra.Count, ms1Spectra.Count, fileName));
+                "  Streaming {1} MS1 and {0} MS/MS spectra from cache for {2}",
+                index.Ms2Count, index.Ms1Spectra.Count, fileName));
+            return index;
         }
 
         /// <summary>

--- a/pwiz_tools/Osprey/Osprey.Tasks/PerFileRescoreTask.cs
+++ b/pwiz_tools/Osprey/Osprey.Tasks/PerFileRescoreTask.cs
@@ -475,7 +475,7 @@ namespace pwiz.Osprey.Tasks
         /// <list type="number">
         ///   <item>Build boundary_overrides keyed by entry_id.</item>
         ///   <item>Subset the library to the entries that need re-scoring.</item>
-        ///   <item>Reload spectra from the .spectra.bin cache or the mzML.</item>
+        ///   <item>Stream MS2 by isolation window from the .spectra.bin cache (required).</item>
         ///   <item>Reload MS2/MS1 mass calibration from the sibling .calibration.json.</item>
         ///   <item>Pick the refined RT calibration when present, else fall back to
         ///       the original first-pass calibration.</item>

--- a/pwiz_tools/Osprey/Osprey.Tasks/StreamingWindowSpectraProvider.cs
+++ b/pwiz_tools/Osprey/Osprey.Tasks/StreamingWindowSpectraProvider.cs
@@ -35,16 +35,13 @@ namespace pwiz.Osprey.Tasks
     /// and applies the MS2 m/z calibration in place, so scoring never materializes
     /// the whole ~6 GB MS2 list -- only the windows being scored concurrently are
     /// resident. The load lives in Osprey.Tasks because it bridges the Osprey.IO
-    /// index and the Osprey.Chromatography calibration; the equivalent
-    /// <see cref="ResidentWindowSpectraProvider"/> lives in Osprey.Scoring because
-    /// it needs neither.
+    /// index and the Osprey.Chromatography calibration.
     ///
-    /// Output is byte-identical to the resident provider: <see cref="SpectraWindowIndex.LoadWindow"/>
-    /// decodes the same bytes the resident cache load decoded, and
-    /// <see cref="MzCalibration.ApplyCalibration"/> is the same pure per-m/z
-    /// function the resident provider applies. Because each window is a fresh
-    /// decode, calibration is done in place (no extra copy) rather than into a new
-    /// array as the shared resident list requires.
+    /// Output is byte-identical to a full resident cache load: <see cref="SpectraWindowIndex.LoadWindow"/>
+    /// decodes the same bytes <c>SpectraCache.LoadSpectraCache</c> would, and
+    /// <see cref="MzCalibration.ApplyCalibration"/> is the same pure per-m/z function
+    /// that a whole-list calibrate-copy applies. Because each window is a fresh decode,
+    /// calibration is done in place (no extra copy) rather than into a new array.
     /// </summary>
     public class StreamingWindowSpectraProvider : IWindowSpectraProvider
     {

--- a/pwiz_tools/Osprey/regression.ps1
+++ b/pwiz_tools/Osprey/regression.ps1
@@ -381,14 +381,19 @@ function Invoke-HpcChain {
     Invoke-OspreyTaskRun -WorkDir $ph2 -CliArgs $a2 -LogName 'phase2.log'
 
     # Phase 3: per-file rescore workers (Stage 6), one independent worker per
-    # file. Each reloads its real mzML + Stage 4 parquet/calibration + the Stage 5
-    # sidecar pair, and writes <stem>.scores-reconciled.parquet + the 2nd-pass bin.
+    # file. Stage 6 STREAMS its MS2 from the .spectra.bin cache phase 1 wrote (there is
+    # no mzML fallback), so each worker gets phase 1's <stem>.spectra.bin + a 0-byte stub
+    # <stem>.mzML (the cache fingerprint check is skipped for a 0-byte source, so the
+    # stub is enough for path derivation and forces a cache hit -- the real 6 GB mzML is
+    # never shipped to a rescore worker). Plus the Stage 4 parquet/calibration + the
+    # Stage 5 sidecar pair; writes <stem>.scores-reconciled.parquet + the 2nd-pass bin.
     $ph3Dirs = @{}
     foreach ($s in $stemList) {
         $ph3 = Join-Path $ChainRoot "phase3_rescore_$s"
         $ph3Dirs[$s] = $ph3
         New-Item -ItemType Directory -Path $ph3 -Force | Out-Null
-        Copy-Item $mzmlByStem[$s] (Join-Path $ph3 (Split-Path -Leaf $mzmlByStem[$s]))
+        Copy-Item (Join-Path $ph1 "$s.spectra.bin")             (Join-Path $ph3 "$s.spectra.bin")
+        New-Item -ItemType File -Path (Join-Path $ph3 "$s.mzML") -Force | Out-Null
         Copy-Item (Join-Path $ph1 "$s.scores.parquet")          (Join-Path $ph3 "$s.scores.parquet")
         Copy-Item (Join-Path $ph1 "$s.calibration.json")        (Join-Path $ph3 "$s.calibration.json")
         Copy-Item (Join-Path $ph2 "$s.1st-pass.fdr_scores.bin") (Join-Path $ph3 "$s.1st-pass.fdr_scores.bin")
@@ -400,12 +405,14 @@ function Invoke-HpcChain {
         Invoke-OspreyTaskRun -WorkDir $ph3 -CliArgs $a3 -LogName 'phase3.log'
         # This worker has written its reconciled parquet + 2nd-pass bin; phase 4
         # consumes only those plus the calibration / reconciliation / 1st-pass
-        # sidecars copied above -- never this worker's mzML, input scores.parquet,
-        # or library. Drop those big inputs now so at most one worker's mzML +
-        # library copy is on disk at a time (the out-of-disk failure was several of
-        # them coexisting with the straight-through leg's spectra caches).
+        # sidecars copied above -- never this worker's spectra cache, input
+        # scores.parquet, or library. Drop those big inputs now so at most one
+        # worker's 6 GB spectra.bin + library copy is on disk at a time (the
+        # out-of-disk failure was several of them coexisting with the
+        # straight-through leg's spectra caches).
         if (-not $KeepOutput) {
-            Remove-Item (Join-Path $ph3 (Split-Path -Leaf $mzmlByStem[$s])) -Force -ErrorAction SilentlyContinue
+            Remove-Item (Join-Path $ph3 "$s.spectra.bin") -Force -ErrorAction SilentlyContinue
+            Remove-Item (Join-Path $ph3 "$s.mzML") -Force -ErrorAction SilentlyContinue
             Remove-Item (Join-Path $ph3 "$s.scores.parquet") -Force -ErrorAction SilentlyContinue
             Remove-Item (Join-Path $ph3 $libName) -Force -ErrorAction SilentlyContinue
             Remove-Item (Join-Path $ph3 ($libName + '.libcache')) -Force -ErrorAction SilentlyContinue


### PR DESCRIPTION
## Summary

* Streams Stage-6 rescore (`PerFileRescoreTask`) MS2 by isolation window from the `.spectra.bin` cache instead of a resident ~6 GB `List<Spectrum>` -- the last full-resident MS2 load in the per-file path. Follow-up to #4427 (Stages 1-4). Byte-identical output.
* `LoadSpectraForRescore` -> `SpectraWindowIndex.BuildFromCache`; MS1 + isolation windows come from the index; one shared `StreamingWindowSpectraProvider` feeds the subset re-score + both gap-fill passes (stateless fresh-per-window decode + in-place calibration, so no resident list and none of the per-pass whole-list calibrated copies).
* No mzML fallback -- an absent/stale cache hard-fails (`InvalidDataException`); Stage 6 always runs against a file the scoring stage cached (see Behavior change).
* Retired the now-callerless `ResidentWindowSpectraProvider` + `RunCoelutionScoring(List<Spectrum>)` wrapper (net -56 lines).
* `regression.ps1` mode3 ships phase-1's `.spectra.bin` (+ a 0-byte stub mzML) to the phase-3 rescore worker so the HPC-chain gate exercises the streaming path.

## Memory / perf (Astral file 49, single-file `--task PerFileRescoring`, median of 3)

| metric | before | after | delta |
|---|---|---|---|
| resident MS2 at load | 8.19 GB | 2.30 GB | -5.88 GB (-72%) |
| working-set peak | 29.8 GB | 14.1 GB | -15.7 GB (-53%) |
| rescore wall (warm) | 64.3 s | 57.5 s | -11% (faster; GC-pressure relief) |

The -5.88 GB matches the directly-measured resident MS2 exactly; the extra working-set drop is the 3 per-pass calibrated copies the resident provider built.

## Behavior change (intentional; surfaced by self-review)

Stage 6 now requires the `.spectra.bin` the scoring stage wrote; there is no mzML reparse fallback. A resume with a separately-configured cache dir that was independently cleaned would now abort with a clear, actionable error (`Re-run PerFileScoring for <file>`) rather than silently re-reading the 6 GB mzML. Straight-through, same-dir resume, and the HPC chain keep the cache beside the outputs, so it is not reachable there.

## Next lever (separate PR)

The dotMemory tail now shows the reconciled-parquet write-back as the tallest peak (~14 GB, mostly unmanaged Arrow/IronCompress) because `WriteScoresParquet` emits one giant row group. Filed as `TODO-osprey_parquet_bounded_rowgroup_write.md` (shared with PerFileScoring).

## Test plan

- [x] `regression.ps1 -Dataset Stellar` mode1 (vs golden) + mode2 (resume) + mode3 (HPC chain, now streams) -- byte-identical (blib 45,064,192)
- [x] 508 unit tests pass; ReSharper inspection 0 errors / 0 warnings
- [x] Fresh-context self-review -- no CRITICAL/HIGH (verified byte-identity, Parallel.For concurrency, mode3 0-byte-stub fingerprint, retirement completeness)
- [ ] `regression.ps1 -Dataset All` (Astral byte-identity) -- maintainer-gated
- [ ] TeamCity Astral Perf/Regression -- maintainer-gated

See ai/todos/active/TODO-20260716_osprey_stage6_rescore_spectra_streaming.md

Co-Authored-By: Claude <noreply@anthropic.com>