### PR TITLE
Streamed the Stage-6 reconciled parquet transfer group-by-group

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -229,6 +229,11 @@ PublishScripts/
 # NuGet v3's project.json files produces more ignorable files
 *.nuget.props
 *.nuget.targets
+# Spurious NuGet.Config regenerated in a .nuget folder nested inside another
+# .nuget folder (seen only on some machines, e.g. idpicker/.nuget/.nuget/); never
+# part of the project. Anchored to the nested case so the tracked top-level
+# idpicker/.nuget/ files (NuGet.Config, NuGet.exe, NuGet.targets) are unaffected.
+**/.nuget/.nuget/
 
 # Microsoft Azure Build Output
 csx/

--- a/pwiz_tools/Osprey/Osprey.IO/ParquetScoreCache.cs
+++ b/pwiz_tools/Osprey/Osprey.IO/ParquetScoreCache.cs
@@ -322,137 +322,161 @@ namespace pwiz.Osprey.IO
             // columns) for rows [start, start+count) in the sorted order above,
             // then releases them once the group is flushed -- so peak residency
             // is one row group's columns + native compression buffers rather
-            // than the whole file's.
+            // than the whole file's. BuildFdrEntryColumns holds the per-row column
+            // build so the Stage-6 streaming reconciled transfer reuses the exact
+            // same layout per row group.
             WriteChunkedParquet(path, schema, metadata, n, (start, count) =>
             {
-                var entryIds = new uint[count];
-                var isDecoys = new bool[count];
-                var sequences = new string[count];
-                var modifiedSequences = new string[count];
-                var charges = new byte[count];
-                var precursorMzs = new double[count];
-                var proteinIds = new string[count];
-                var scanNumbers = new uint[count];
-                var apexRts = new double[count];
-                var startRts = new double[count];
-                var endRts = new double[count];
-                var boundsAreas = new double[count];
-                var boundsSnrs = new double[count];
-                var fileNames = new string[count];
-                // The blob columns below carry per-entry binary payloads
-                // matching Rust pipeline.rs:1620-1645's encoding:
-                //   cwt_candidates             = u32 LE count + N×(6×f64 LE)
-                //   fragment_mzs               = M×f64 LE   (no count prefix)
-                //   fragment_intensities       = M×f32 LE   (no count prefix)
-                //   reference_xic_rts          = K×f64 LE
-                //   reference_xic_intensities  = K×f64 LE
-                // Length is recovered on read as bytes / sizeof(element).
-                var cwtCandidates = new byte[count][];
-                var fragmentMzs = new byte[count][];
-                var fragmentIntensities = new byte[count][];
-                var refXicRts = new byte[count][];
-                var refXicIntensities = new byte[count][];
-                var featureArrays = new double[NUM_PIN_FEATURES][];
-                for (int f = 0; f < NUM_PIN_FEATURES; f++)
-                    featureArrays[f] = new double[count];
-
+                var chunk = new FdrEntry[count];
                 for (int j = 0; j < count; j++)
+                    chunk[j] = entries[sortedIndices[start + j]];
+                return BuildFdrEntryColumns(chunk, start, libraryById, fileName, featureFields);
+            });
+        }
+
+        /// <summary>
+        /// Assemble one row group's <see cref="DataColumn"/> list from a chunk of
+        /// <see cref="FdrEntry"/> rows already in their final output order. Each
+        /// entry's <see cref="FdrEntry.ParquetIndex"/> is (re)assigned to its global
+        /// row position <paramref name="startIndex"/> + j, matching
+        /// <see cref="LoadFdrStubsFromParquet"/>'s read-side "ParquetIndex = row"
+        /// convention. Shared by the chunked <see cref="WriteScoresParquet(string,List{FdrEntry},Dictionary{string,string},Dictionary{uint,LibraryEntry},string)"/>
+        /// write and the Stage-6 streaming reconciled transfer
+        /// (<see cref="StreamReconciledScoresParquet"/>) so both emit byte-identical
+        /// row groups.
+        /// </summary>
+        private static List<DataColumn> BuildFdrEntryColumns(IReadOnlyList<FdrEntry> entries,
+            int startIndex, Dictionary<uint, LibraryEntry> libraryById, string fileName,
+            DataField[] featureFields)
+        {
+            int count = entries.Count;
+            var entryIds = new uint[count];
+            var isDecoys = new bool[count];
+            var sequences = new string[count];
+            var modifiedSequences = new string[count];
+            var charges = new byte[count];
+            var precursorMzs = new double[count];
+            var proteinIds = new string[count];
+            var scanNumbers = new uint[count];
+            var apexRts = new double[count];
+            var startRts = new double[count];
+            var endRts = new double[count];
+            var boundsAreas = new double[count];
+            var boundsSnrs = new double[count];
+            var fileNames = new string[count];
+            // The blob columns below carry per-entry binary payloads
+            // matching Rust pipeline.rs:1620-1645's encoding:
+            //   cwt_candidates             = u32 LE count + N×(6×f64 LE)
+            //   fragment_mzs               = M×f64 LE   (no count prefix)
+            //   fragment_intensities       = M×f32 LE   (no count prefix)
+            //   reference_xic_rts          = K×f64 LE
+            //   reference_xic_intensities  = K×f64 LE
+            // Length is recovered on read as bytes / sizeof(element).
+            var cwtCandidates = new byte[count][];
+            var fragmentMzs = new byte[count][];
+            var fragmentIntensities = new byte[count][];
+            var refXicRts = new byte[count][];
+            var refXicIntensities = new byte[count][];
+            var featureArrays = new double[NUM_PIN_FEATURES][];
+            for (int f = 0; f < NUM_PIN_FEATURES; f++)
+                featureArrays[f] = new double[count];
+
+            for (int j = 0; j < count; j++)
+            {
+                var entry = entries[j];
+                // Assign ParquetIndex to match the global row position we are
+                // about to write. Mirrors LoadFdrStubsFromParquet, which
+                // assigns ParquetIndex = row on read. Without this
+                // assignment, in-memory entries reach Stage 5
+                // ReconciliationPlanner with ParquetIndex = 0 (FdrEntry
+                // default), and every entry's per-file CWT lookup
+                // (fileCwt[entry.ParquetIndex]) grabs the first row's
+                // CwtCandidate list instead of its own -- the planner
+                // then force-integrates almost every entry because the
+                // wrong CWT list has no candidate near the expected RT.
+                // The HPC chain path was unaffected because its entries
+                // are reloaded via LoadFdrStubsFromParquet, which sets
+                // ParquetIndex correctly. Found by C# in-memory vs
+                // C# HPC-chain strict-rehydration bisection on Stellar
+                // (Stage 5 boundary check: .1st-pass.fdr_scores.bin
+                // byte-identical but reconciliation.json action shape
+                // diverged -- 35K use_cwt actions on HPC side, 814 on
+                // in-memory side, total identical).
+                entry.ParquetIndex = (uint)(startIndex + j);
+                entryIds[j] = entry.EntryId;
+                isDecoys[j] = entry.IsDecoy;
+                charges[j] = entry.Charge;
+                scanNumbers[j] = entry.ScanNumber;
+                modifiedSequences[j] = entry.ModifiedSequence ?? string.Empty;
+                apexRts[j] = entry.ApexRt;
+                startRts[j] = entry.StartRt;
+                endRts[j] = entry.EndRt;
+                boundsAreas[j] = entry.BoundsArea;
+                boundsSnrs[j] = entry.BoundsSnr;
+                fileNames[j] = fileName ?? string.Empty;
+                fragmentMzs[j] = EncodeF64Blob(entry.FragmentMzs);
+                fragmentIntensities[j] = EncodeF32Blob(entry.FragmentIntensities);
+                refXicRts[j] = EncodeF64Blob(entry.ReferenceXicRts);
+                refXicIntensities[j] = EncodeF64Blob(entry.ReferenceXicIntensities);
+
+                // Mirror Rust's invariant: every row carries a cwt_candidates
+                // blob, even when the candidate list is empty. Rust's
+                // pipeline.rs::write_scores_parquet (at the cwt_candidates
+                // serialization site) unconditionally appends a 4-byte
+                // little-endian count prefix, so an entry with zero
+                // candidates becomes a 4-byte zero-length blob, never a
+                // null cell. ~57k post-compaction stubs per Stellar file
+                // had no peaks; without this normalization C# emitted
+                // null cells while Rust emitted empty blobs, producing
+                // a spurious cross-impl parquet diff at end-of-Stage-6.
+                //
+                // TODO(osprey-rust): the proper fix is on the Rust side --
+                // pipeline.rs should write null for empty candidate lists,
+                // which is more parquet-idiomatic and saves 4 bytes per
+                // empty row for downstream consumers. When that lands in
+                // maccoss/osprey, revert this branch to the original
+                // "skip null/empty" form.
+                // Use Array.Empty<>() (not `new List<>()`) on the null
+                // branch so we still emit the 4-byte zero-count blob
+                // without allocating a fresh List per empty row.
+                // CwtCandidateCodec.Encode takes IReadOnlyList<CwtCandidate>
+                // which both List<T> and T[] satisfy.
+                cwtCandidates[j] = CwtCandidateCodec.Encode(
+                    entry.CwtCandidates ?? (IReadOnlyList<CwtCandidate>)Array.Empty<CwtCandidate>());
+
+                LibraryEntry libEntry = null;
+                if (libraryById != null)
+                    libraryById.TryGetValue(entry.EntryId, out libEntry);
+                if (libEntry != null)
                 {
-                    var entry = entries[sortedIndices[start + j]];
-                    // Assign ParquetIndex to match the global row position we are
-                    // about to write. Mirrors LoadFdrStubsFromParquet, which
-                    // assigns ParquetIndex = row on read. Without this
-                    // assignment, in-memory entries reach Stage 5
-                    // ReconciliationPlanner with ParquetIndex = 0 (FdrEntry
-                    // default), and every entry's per-file CWT lookup
-                    // (fileCwt[entry.ParquetIndex]) grabs the first row's
-                    // CwtCandidate list instead of its own -- the planner
-                    // then force-integrates almost every entry because the
-                    // wrong CWT list has no candidate near the expected RT.
-                    // The HPC chain path was unaffected because its entries
-                    // are reloaded via LoadFdrStubsFromParquet, which sets
-                    // ParquetIndex correctly. Found by C# in-memory vs
-                    // C# HPC-chain strict-rehydration bisection on Stellar
-                    // (Stage 5 boundary check: .1st-pass.fdr_scores.bin
-                    // byte-identical but reconciliation.json action shape
-                    // diverged -- 35K use_cwt actions on HPC side, 814 on
-                    // in-memory side, total identical).
-                    entry.ParquetIndex = (uint)(start + j);
-                    entryIds[j] = entry.EntryId;
-                    isDecoys[j] = entry.IsDecoy;
-                    charges[j] = entry.Charge;
-                    scanNumbers[j] = entry.ScanNumber;
-                    modifiedSequences[j] = entry.ModifiedSequence ?? string.Empty;
-                    apexRts[j] = entry.ApexRt;
-                    startRts[j] = entry.StartRt;
-                    endRts[j] = entry.EndRt;
-                    boundsAreas[j] = entry.BoundsArea;
-                    boundsSnrs[j] = entry.BoundsSnr;
-                    fileNames[j] = fileName ?? string.Empty;
-                    fragmentMzs[j] = EncodeF64Blob(entry.FragmentMzs);
-                    fragmentIntensities[j] = EncodeF32Blob(entry.FragmentIntensities);
-                    refXicRts[j] = EncodeF64Blob(entry.ReferenceXicRts);
-                    refXicIntensities[j] = EncodeF64Blob(entry.ReferenceXicIntensities);
-
-                    // Mirror Rust's invariant: every row carries a cwt_candidates
-                    // blob, even when the candidate list is empty. Rust's
-                    // pipeline.rs::write_scores_parquet (at the cwt_candidates
-                    // serialization site) unconditionally appends a 4-byte
-                    // little-endian count prefix, so an entry with zero
-                    // candidates becomes a 4-byte zero-length blob, never a
-                    // null cell. ~57k post-compaction stubs per Stellar file
-                    // had no peaks; without this normalization C# emitted
-                    // null cells while Rust emitted empty blobs, producing
-                    // a spurious cross-impl parquet diff at end-of-Stage-6.
-                    //
-                    // TODO(osprey-rust): the proper fix is on the Rust side --
-                    // pipeline.rs should write null for empty candidate lists,
-                    // which is more parquet-idiomatic and saves 4 bytes per
-                    // empty row for downstream consumers. When that lands in
-                    // maccoss/osprey, revert this branch to the original
-                    // "skip null/empty" form.
-                    // Use Array.Empty<>() (not `new List<>()`) on the null
-                    // branch so we still emit the 4-byte zero-count blob
-                    // without allocating a fresh List per empty row.
-                    // CwtCandidateCodec.Encode takes IReadOnlyList<CwtCandidate>
-                    // which both List<T> and T[] satisfy.
-                    cwtCandidates[j] = CwtCandidateCodec.Encode(
-                        entry.CwtCandidates ?? (IReadOnlyList<CwtCandidate>)Array.Empty<CwtCandidate>());
-
-                    LibraryEntry libEntry = null;
-                    if (libraryById != null)
-                        libraryById.TryGetValue(entry.EntryId, out libEntry);
-                    if (libEntry != null)
-                    {
-                        sequences[j] = libEntry.Sequence ?? string.Empty;
-                        precursorMzs[j] = libEntry.PrecursorMz;
-                        proteinIds[j] = libEntry.ProteinIds != null
-                            ? string.Join(";", libEntry.ProteinIds)
-                            : null;
-                    }
-                    else
-                    {
-                        sequences[j] = string.Empty;
-                        precursorMzs[j] = 0.0;
-                        proteinIds[j] = null;
-                    }
-
-                    var featureVec = entry.Features;
-                    if (featureVec != null && featureVec.Length == NUM_PIN_FEATURES)
-                    {
-                        for (int f = 0; f < NUM_PIN_FEATURES; f++)
-                            featureArrays[f][j] = Finite(featureVec[f]);
-                    }
-                    // else: leave zeros (entries without features can't drive Stage 5+).
+                    sequences[j] = libEntry.Sequence ?? string.Empty;
+                    precursorMzs[j] = libEntry.PrecursorMz;
+                    proteinIds[j] = libEntry.ProteinIds != null
+                        ? string.Join(";", libEntry.ProteinIds)
+                        : null;
+                }
+                else
+                {
+                    sequences[j] = string.Empty;
+                    precursorMzs[j] = 0.0;
+                    proteinIds[j] = null;
                 }
 
-                return BuildRowGroupColumns(
-                    entryIds, isDecoys, sequences, modifiedSequences, charges,
-                    precursorMzs, proteinIds, scanNumbers, apexRts, startRts, endRts,
-                    boundsAreas, boundsSnrs, fileNames, cwtCandidates, fragmentMzs,
-                    fragmentIntensities, refXicRts, refXicIntensities,
-                    featureFields, featureArrays);
-            });
+                var featureVec = entry.Features;
+                if (featureVec != null && featureVec.Length == NUM_PIN_FEATURES)
+                {
+                    for (int f = 0; f < NUM_PIN_FEATURES; f++)
+                        featureArrays[f][j] = Finite(featureVec[f]);
+                }
+                // else: leave zeros (entries without features can't drive Stage 5+).
+            }
+
+            return BuildRowGroupColumns(
+                entryIds, isDecoys, sequences, modifiedSequences, charges,
+                precursorMzs, proteinIds, scanNumbers, apexRts, startRts, endRts,
+                boundsAreas, boundsSnrs, fileNames, cwtCandidates, fragmentMzs,
+                fragmentIntensities, refXicRts, refXicIntensities,
+                featureFields, featureArrays);
         }
 
         /// <summary>
@@ -970,80 +994,264 @@ namespace pwiz.Osprey.IO
         public static List<FdrEntry> LoadFullFdrEntries(string path)
         {
             var entries = new List<FdrEntry>();
-            var featureFields = BuildFeatureFields();
 
             using (var stream = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.Read))
             using (var reader = RunSync(ParquetReader.CreateAsync(stream)))
             {
                 var fieldsByName = BuildFieldLookup(reader);
                 for (int g = 0; g < reader.RowGroupCount; g++)
+                    entries.AddRange(ReadFdrEntryGroup(reader, g, fieldsByName, entries.Count));
+            }
+
+            return entries;
+        }
+
+        /// <summary>
+        /// Stream the Stage-6 reconciled transfer: read <paramref name="originalPath"/>
+        /// one row group at a time, overlay the re-scored rows from
+        /// <paramref name="overlayByIndex"/> (keyed by the original row's
+        /// <see cref="FdrEntry.ParquetIndex"/>), MERGE the <paramref name="gapFill"/> rows
+        /// into their canonical (entry_id, charge, scan_number) sorted position, and write
+        /// the result to <paramref name="reconciledPath"/> as bounded row groups. Peak
+        /// residency is one original row group being read + one output group being filled +
+        /// the small resident overlay map / gap-fill list -- it never materializes the whole
+        /// file's <see cref="FdrEntry"/> list the way LoadFullFdrEntries +
+        /// <see cref="WriteScoresParquet(string,List{FdrEntry},Dictionary{string,string},Dictionary{uint,LibraryEntry},string)"/>
+        /// did (the ~4.4 GB reload this replaces).
+        ///
+        /// The reconciled physical row order must equal the former load-all + re-sort write:
+        /// Pass 2's projection sort recovers scan order from the reconciled row index (see
+        /// Pass2FdrSidecar / TestScanOmittedProjectionSortMatchesLegacyOrder), so gap-fill
+        /// CANNOT simply be appended at the end -- it must interleave by scan. The original
+        /// rows are already in canonical order (Stage 4 wrote them sorted, and an overlay
+        /// preserves the row's key), so a single-pass 2-way merge of the streamed original
+        /// rows with the sorted gap-fill list reproduces the exact stable-sorted sequence
+        /// WriteScoresParquet produced, without ever holding the whole file. No gate compares
+        /// .scores.parquet bytes directly (regression + cross-impl compare the blib +
+        /// protein-FDR at 1e-9); this physical equivalence is what keeps them green.
+        /// See ai/todos/active/TODO-20260717_osprey_stage6_chunked_reconciled_transfer.md.
+        ///
+        /// Returns the replaced-row, appended-row (gap-fill), and original-row counts.
+        /// Overlay indices that fall past the original's rows are dropped with a warning
+        /// (never written), matching the whole-file overlay's out-of-range handling.
+        /// </summary>
+        public static (int NReplaced, int NAppended, int OrigRowCount) StreamReconciledScoresParquet(
+            string originalPath, string reconciledPath,
+            IReadOnlyDictionary<uint, FdrEntry> overlayByIndex,
+            IReadOnlyList<FdrEntry> gapFill,
+            Dictionary<string, string> metadata,
+            Dictionary<uint, LibraryEntry> libraryById, string fileName,
+            Action<string> logWarning)
+        {
+            if (originalPath == null)
+                throw new ArgumentNullException(nameof(originalPath));
+            if (reconciledPath == null)
+                throw new ArgumentNullException(nameof(reconciledPath));
+            if (overlayByIndex == null)
+                overlayByIndex = new Dictionary<uint, FdrEntry>();
+
+            // Sort gap-fill into canonical (entry_id, charge, scan_number) order with a
+            // STABLE sort (LINQ OrderBy), mirroring the former WriteScoresParquet OrderBy.
+            // The 2-way merge below emits each original row before an equal-key gap-fill
+            // row, exactly as that stable sort placed the (earlier-in-list) original rows
+            // ahead of an appended equal-key gap-fill row.
+            var sortedGapFill = (gapFill ?? Array.Empty<FdrEntry>())
+                .OrderBy(e => e.EntryId).ThenBy(e => e.Charge).ThenBy(e => e.ScanNumber)
+                .ToList();
+            int gapFillCount = sortedGapFill.Count;
+
+            var featureFields = BuildFeatureFields();
+            var schema = BuildWriteSchema(featureFields);
+            int rowsPerGroup = Math.Max(1, RowGroupRowCapForTest ?? MAX_ROWS_PER_ROW_GROUP);
+
+            int nReplaced = 0;
+            int origRowCount = 0;
+
+            using (var readStream = new FileStream(originalPath, FileMode.Open, FileAccess.Read, FileShare.Read))
+            using (var reader = RunSync(ParquetReader.CreateAsync(readStream)))
+            using (var saver = new FileSaver(reconciledPath))
+            {
+                var fieldsByName = BuildFieldLookup(reader);
+                int totalRows = checked((int)(reader.Metadata?.NumRows ?? 0L)) + gapFillCount;
+
+                using (var writeStream = new FileStream(saver.SafeName, FileMode.Create, FileAccess.Write))
+                using (var writer = RunSync(ParquetWriter.CreateAsync(schema, writeStream)))
+                using (var progress = new ProgressReporter(
+                    string.Format("Writing {0} entries", totalRows), totalRows, string.Empty,
+                    ProgressReporter.IO_INTERVAL_SECONDS))
                 {
-                    using (var groupReader = reader.OpenRowGroupReader(g))
+                    writer.CompressionMethod = CompressionMethod.Zstd;
+                    if (metadata != null && metadata.Count > 0)
+                        writer.CustomMetadata = metadata;
+
+                    // Output accumulator: fill to rowsPerGroup, flush as one bounded row
+                    // group, release. `written` is the running output row position;
+                    // `origRead` is the running ORIGINAL row count the overlay is keyed on.
+                    var buffer = new List<FdrEntry>(rowsPerGroup);
+                    int written = 0;
+                    int origRead = 0;
+                    int gapIdx = 0;
+
+                    void FlushGroup()
                     {
-                        var entryIdCol = ReadColumnByName<uint[]>(groupReader, fieldsByName, FIELD_ENTRY_ID.Name);
-                        var isDecoyCol = ReadColumnByName<bool[]>(groupReader, fieldsByName, FIELD_IS_DECOY.Name);
-                        var chargeCol = ReadColumnByName<byte[]>(groupReader, fieldsByName, FIELD_CHARGE.Name);
-                        var scanCol = ReadColumnByName<uint[]>(groupReader, fieldsByName, FIELD_SCAN_NUMBER.Name);
-                        var modseqCol = ReadColumnByName<string[]>(groupReader, fieldsByName, FIELD_MODIFIED_SEQUENCE.Name);
-                        var apexCol = ReadColumnByName<double[]>(groupReader, fieldsByName, FIELD_APEX_RT.Name);
-                        var startCol = ReadColumnByName<double[]>(groupReader, fieldsByName, FIELD_START_RT.Name);
-                        var endCol = ReadColumnByName<double[]>(groupReader, fieldsByName, FIELD_END_RT.Name);
-                        var coelutionCol = ReadColumnByName<double[]>(groupReader, fieldsByName, FIELD_COELUTION_SUM.Name);
-                        var cwtCol = ReadColumnByName<byte[][]>(groupReader, fieldsByName, FIELD_CWT_CANDIDATES.Name);
-                        var boundsAreaCol = ReadColumnByName<double[]>(groupReader, fieldsByName, FIELD_BOUNDS_AREA.Name);
-                        var boundsSnrCol = ReadColumnByName<double[]>(groupReader, fieldsByName, FIELD_BOUNDS_SNR.Name);
-                        var fragMzCol = ReadColumnByName<byte[][]>(groupReader, fieldsByName, FIELD_FRAGMENT_MZS.Name);
-                        var fragIntCol = ReadColumnByName<byte[][]>(groupReader, fieldsByName, FIELD_FRAGMENT_INTENSITIES.Name);
-                        var refXicRtsCol = ReadColumnByName<byte[][]>(groupReader, fieldsByName, FIELD_REFERENCE_XIC_RTS.Name);
-                        var refXicIntsCol = ReadColumnByName<byte[][]>(groupReader, fieldsByName, FIELD_REFERENCE_XIC_INTENSITIES.Name);
-
-                        if (entryIdCol == null || isDecoyCol == null)
-                            continue;
-
-                        var featureCols = new double[NUM_PIN_FEATURES][];
-                        for (int f = 0; f < NUM_PIN_FEATURES; f++)
-                            featureCols[f] = ReadColumnByName<double[]>(groupReader, fieldsByName, featureFields[f].Name);
-
-                        int rowCount = entryIdCol.Length;
-                        for (int row = 0; row < rowCount; row++)
-                        {
-                            var features = new double[NUM_PIN_FEATURES];
-                            for (int f = 0; f < NUM_PIN_FEATURES; f++)
-                            {
-                                double v = featureCols[f] != null ? featureCols[f][row] : 0.0;
-                                features[f] = double.IsNaN(v) || double.IsInfinity(v) ? 0.0 : v;
-                            }
-
-                            List<CwtCandidate> cwt = null;
-                            if (cwtCol != null && cwtCol[row] != null && cwtCol[row].Length > 0)
-                                cwt = CwtCandidateCodec.Decode(cwtCol[row]);
-
-                            entries.Add(new FdrEntry
-                            {
-                                EntryId = entryIdCol[row],
-                                ParquetIndex = (uint)entries.Count,
-                                IsDecoy = isDecoyCol[row],
-                                Charge = chargeCol != null ? chargeCol[row] : (byte)0,
-                                ScanNumber = scanCol != null ? scanCol[row] : 0u,
-                                ApexRt = apexCol != null ? apexCol[row] : 0.0,
-                                StartRt = startCol != null ? startCol[row] : 0.0,
-                                EndRt = endCol != null ? endCol[row] : 0.0,
-                                CoelutionSum = coelutionCol != null ? coelutionCol[row] : 0.0,
-                                ModifiedSequence = modseqCol != null ? modseqCol[row] : string.Empty,
-                                Features = features,
-                                CwtCandidates = cwt,
-                                BoundsArea = boundsAreaCol != null ? boundsAreaCol[row] : 0.0,
-                                BoundsSnr = boundsSnrCol != null ? boundsSnrCol[row] : 0.0,
-                                FragmentMzs = DecodeF64Blob(fragMzCol != null ? fragMzCol[row] : null),
-                                FragmentIntensities = DecodeF32Blob(fragIntCol != null ? fragIntCol[row] : null),
-                                ReferenceXicRts = DecodeF64Blob(refXicRtsCol != null ? refXicRtsCol[row] : null),
-                                ReferenceXicIntensities = DecodeF64Blob(refXicIntsCol != null ? refXicIntsCol[row] : null),
-                            });
-                        }
+                        if (buffer.Count == 0)
+                            return;
+                        using (var group = writer.CreateRowGroup())
+                            WriteRowGroupColumns(group, BuildFdrEntryColumns(
+                                buffer, written, libraryById, fileName, featureFields));
+                        written += buffer.Count;
+                        progress.Report(written);
+                        buffer.Clear();
                     }
+
+                    for (int g = 0; g < reader.RowGroupCount; g++)
+                    {
+                        var groupEntries = ReadFdrEntryGroup(reader, g, fieldsByName, origRead);
+                        for (int j = 0; j < groupEntries.Count; j++)
+                        {
+                            var row = groupEntries[j];
+                            FdrEntry rescored;
+                            if (overlayByIndex.Count > 0 &&
+                                overlayByIndex.TryGetValue((uint)(origRead + j), out rescored))
+                            {
+                                row = rescored;
+                                nReplaced++;
+                            }
+                            // Emit gap-fill rows that sort strictly before this original
+                            // row; a key tie keeps the original first (stable-sort order).
+                            while (gapIdx < gapFillCount && KeyLess(sortedGapFill[gapIdx], row))
+                            {
+                                buffer.Add(sortedGapFill[gapIdx++]);
+                                if (buffer.Count == rowsPerGroup)
+                                    FlushGroup();
+                            }
+                            buffer.Add(row);
+                            if (buffer.Count == rowsPerGroup)
+                                FlushGroup();
+                        }
+                        origRead += groupEntries.Count;
+                    }
+                    origRowCount = origRead;
+
+                    // Trailing gap-fill (keys at or beyond the last original row).
+                    while (gapIdx < gapFillCount)
+                    {
+                        buffer.Add(sortedGapFill[gapIdx++]);
+                        if (buffer.Count == rowsPerGroup)
+                            FlushGroup();
+                    }
+                    FlushGroup();
+                }
+                saver.Commit();
+            }
+
+            // Overlay indices that never matched a streamed row lie past the original's
+            // rows; report them exactly as the whole-file overlay did -- dropped, never
+            // written -- so a corrupt ParquetIndex still surfaces a warning.
+            if (nReplaced < overlayByIndex.Count && logWarning != null)
+            {
+                foreach (var kv in overlayByIndex)
+                {
+                    if (kv.Key >= (uint)origRowCount)
+                        logWarning(string.Format(
+                            "Stage 6 write-back: ParquetIndex {0} out of range for {1} ({2} rows)",
+                            kv.Key, fileName, origRowCount));
                 }
             }
 
+            return (nReplaced, gapFillCount, origRowCount);
+        }
+
+        // Strict (entry_id, charge, scan_number) less-than, the canonical scores-parquet
+        // sort key. Used by the Stage-6 streaming merge to interleave gap-fill rows into
+        // the already-sorted original stream. A key tie returns false so the original row
+        // is emitted first, matching the stable WriteScoresParquet re-sort.
+        private static bool KeyLess(FdrEntry a, FdrEntry b)
+        {
+            if (a.EntryId != b.EntryId)
+                return a.EntryId < b.EntryId;
+            if (a.Charge != b.Charge)
+                return a.Charge < b.Charge;
+            return a.ScanNumber < b.ScanNumber;
+        }
+
+        /// <summary>
+        /// Read one row group's full <see cref="FdrEntry"/> rows -- the per-group body of
+        /// <see cref="LoadFullFdrEntries"/>, extracted so the Stage-6 streaming reconciled
+        /// transfer (<see cref="StreamReconciledScoresParquet"/>) can read the original
+        /// parquet one group at a time instead of materializing every row. Each row's
+        /// <see cref="FdrEntry.ParquetIndex"/> is the running global position
+        /// <paramref name="startParquetIndex"/> + row, matching the whole-file loader.
+        /// Returns an empty list when the group lacks the entry_id / is_decoy columns
+        /// (the same "skip this group" rule the whole-file loader applies).
+        /// </summary>
+        private static List<FdrEntry> ReadFdrEntryGroup(ParquetReader reader, int g,
+            IReadOnlyDictionary<string, DataField> fieldsByName, int startParquetIndex)
+        {
+            var entries = new List<FdrEntry>();
+            using (var groupReader = reader.OpenRowGroupReader(g))
+            {
+                var entryIdCol = ReadColumnByName<uint[]>(groupReader, fieldsByName, FIELD_ENTRY_ID.Name);
+                var isDecoyCol = ReadColumnByName<bool[]>(groupReader, fieldsByName, FIELD_IS_DECOY.Name);
+                var chargeCol = ReadColumnByName<byte[]>(groupReader, fieldsByName, FIELD_CHARGE.Name);
+                var scanCol = ReadColumnByName<uint[]>(groupReader, fieldsByName, FIELD_SCAN_NUMBER.Name);
+                var modseqCol = ReadColumnByName<string[]>(groupReader, fieldsByName, FIELD_MODIFIED_SEQUENCE.Name);
+                var apexCol = ReadColumnByName<double[]>(groupReader, fieldsByName, FIELD_APEX_RT.Name);
+                var startCol = ReadColumnByName<double[]>(groupReader, fieldsByName, FIELD_START_RT.Name);
+                var endCol = ReadColumnByName<double[]>(groupReader, fieldsByName, FIELD_END_RT.Name);
+                var coelutionCol = ReadColumnByName<double[]>(groupReader, fieldsByName, FIELD_COELUTION_SUM.Name);
+                var cwtCol = ReadColumnByName<byte[][]>(groupReader, fieldsByName, FIELD_CWT_CANDIDATES.Name);
+                var boundsAreaCol = ReadColumnByName<double[]>(groupReader, fieldsByName, FIELD_BOUNDS_AREA.Name);
+                var boundsSnrCol = ReadColumnByName<double[]>(groupReader, fieldsByName, FIELD_BOUNDS_SNR.Name);
+                var fragMzCol = ReadColumnByName<byte[][]>(groupReader, fieldsByName, FIELD_FRAGMENT_MZS.Name);
+                var fragIntCol = ReadColumnByName<byte[][]>(groupReader, fieldsByName, FIELD_FRAGMENT_INTENSITIES.Name);
+                var refXicRtsCol = ReadColumnByName<byte[][]>(groupReader, fieldsByName, FIELD_REFERENCE_XIC_RTS.Name);
+                var refXicIntsCol = ReadColumnByName<byte[][]>(groupReader, fieldsByName, FIELD_REFERENCE_XIC_INTENSITIES.Name);
+
+                if (entryIdCol == null || isDecoyCol == null)
+                    return entries;
+
+                var featureCols = new double[NUM_PIN_FEATURES][];
+                for (int f = 0; f < NUM_PIN_FEATURES; f++)
+                    featureCols[f] = ReadColumnByName<double[]>(groupReader, fieldsByName, PIN_FEATURE_NAMES[f]);
+
+                int rowCount = entryIdCol.Length;
+                for (int row = 0; row < rowCount; row++)
+                {
+                    var features = new double[NUM_PIN_FEATURES];
+                    for (int f = 0; f < NUM_PIN_FEATURES; f++)
+                    {
+                        double v = featureCols[f] != null ? featureCols[f][row] : 0.0;
+                        features[f] = double.IsNaN(v) || double.IsInfinity(v) ? 0.0 : v;
+                    }
+
+                    List<CwtCandidate> cwt = null;
+                    if (cwtCol != null && cwtCol[row] != null && cwtCol[row].Length > 0)
+                        cwt = CwtCandidateCodec.Decode(cwtCol[row]);
+
+                    entries.Add(new FdrEntry
+                    {
+                        EntryId = entryIdCol[row],
+                        ParquetIndex = (uint)(startParquetIndex + entries.Count),
+                        IsDecoy = isDecoyCol[row],
+                        Charge = chargeCol != null ? chargeCol[row] : (byte)0,
+                        ScanNumber = scanCol != null ? scanCol[row] : 0u,
+                        ApexRt = apexCol != null ? apexCol[row] : 0.0,
+                        StartRt = startCol != null ? startCol[row] : 0.0,
+                        EndRt = endCol != null ? endCol[row] : 0.0,
+                        CoelutionSum = coelutionCol != null ? coelutionCol[row] : 0.0,
+                        ModifiedSequence = modseqCol != null ? modseqCol[row] : string.Empty,
+                        Features = features,
+                        CwtCandidates = cwt,
+                        BoundsArea = boundsAreaCol != null ? boundsAreaCol[row] : 0.0,
+                        BoundsSnr = boundsSnrCol != null ? boundsSnrCol[row] : 0.0,
+                        FragmentMzs = DecodeF64Blob(fragMzCol != null ? fragMzCol[row] : null),
+                        FragmentIntensities = DecodeF32Blob(fragIntCol != null ? fragIntCol[row] : null),
+                        ReferenceXicRts = DecodeF64Blob(refXicRtsCol != null ? refXicRtsCol[row] : null),
+                        ReferenceXicIntensities = DecodeF64Blob(refXicIntsCol != null ? refXicIntsCol[row] : null),
+                    });
+                }
+            }
             return entries;
         }
 

--- a/pwiz_tools/Osprey/Osprey.IO/ParquetScoreCache.cs
+++ b/pwiz_tools/Osprey/Osprey.IO/ParquetScoreCache.cs
@@ -1104,6 +1104,31 @@ namespace pwiz.Osprey.IO
                         buffer.Clear();
                     }
 
+                    // Emit one row in output order, GUARDING canonical monotonicity. The
+                    // merge preserves (entry_id, charge, scan_number) order only if the
+                    // original parquet is already sorted AND each overlay keeps the key of the
+                    // row it replaces -- but a reconciliation rescore can move the apex scan,
+                    // so an overlay CAN change scan_number. If that (or a mis-sorted original)
+                    // makes an emitted row's key fall below the previous, the output would be
+                    // non-canonical and silently corrupt Pass 2's scan recovery. Hard-fail
+                    // instead (ReconciledParquetWriter.Write re-throws this to abort the run,
+                    // rather than skipping the file). No-op on valid, already-sorted input.
+                    FdrEntry lastEmitted = null;
+                    void Emit(FdrEntry e)
+                    {
+                        if (lastEmitted != null && KeyLess(e, lastEmitted))
+                            throw new InvalidOperationException(string.Format(
+                                "Stage 6 reconciled transfer for {0}: rows out of canonical " +
+                                "(entry_id, charge, scan_number) order at output row {1} -- the " +
+                                "original parquet is not sorted, or a re-scored overlay changed its " +
+                                "scan across a same-(entry_id,charge) sibling. Refusing to write a " +
+                                "mis-ordered reconciled parquet.", fileName, written + buffer.Count));
+                        lastEmitted = e;
+                        buffer.Add(e);
+                        if (buffer.Count == rowsPerGroup)
+                            FlushGroup();
+                    }
+
                     for (int g = 0; g < reader.RowGroupCount; g++)
                     {
                         var groupEntries = ReadFdrEntryGroup(reader, g, fieldsByName, origRead);
@@ -1120,14 +1145,8 @@ namespace pwiz.Osprey.IO
                             // Emit gap-fill rows that sort strictly before this original
                             // row; a key tie keeps the original first (stable-sort order).
                             while (gapIdx < gapFillCount && KeyLess(sortedGapFill[gapIdx], row))
-                            {
-                                buffer.Add(sortedGapFill[gapIdx++]);
-                                if (buffer.Count == rowsPerGroup)
-                                    FlushGroup();
-                            }
-                            buffer.Add(row);
-                            if (buffer.Count == rowsPerGroup)
-                                FlushGroup();
+                                Emit(sortedGapFill[gapIdx++]);
+                            Emit(row);
                         }
                         origRead += groupEntries.Count;
                     }
@@ -1135,11 +1154,7 @@ namespace pwiz.Osprey.IO
 
                     // Trailing gap-fill (keys at or beyond the last original row).
                     while (gapIdx < gapFillCount)
-                    {
-                        buffer.Add(sortedGapFill[gapIdx++]);
-                        if (buffer.Count == rowsPerGroup)
-                            FlushGroup();
-                    }
+                        Emit(sortedGapFill[gapIdx++]);
                     FlushGroup();
                 }
                 saver.Commit();

--- a/pwiz_tools/Osprey/Osprey.Tasks/FirstJoinTask.cs
+++ b/pwiz_tools/Osprey/Osprey.Tasks/FirstJoinTask.cs
@@ -400,7 +400,7 @@ namespace pwiz.Osprey.Tasks
                 // --input-scores / per-file-resume stub loaders DO populate
                 // FdrEntry.Features when hydrating, so null them defensively to keep the
                 // "Features != null means this entry was rescored" sentinel that
-                // ReconciledParquetWriter.ApplyRescoredRows relies on valid going into
+                // ReconciledParquetWriter.BuildOverlay relies on valid going into
                 // Stage 6 (mirrors the resume-rehydrate re-null and
                 // PerFileScoringTask.HydrateRescoreBundleIfPresent). MergeNode reloads
                 // features from the reconciled parquet.

--- a/pwiz_tools/Osprey/Osprey.Tasks/ReconciledParquetWriter.cs
+++ b/pwiz_tools/Osprey/Osprey.Tasks/ReconciledParquetWriter.cs
@@ -30,26 +30,32 @@ namespace pwiz.Osprey.Tasks
 {
     /// <summary>
     /// Writes the reconciled per-file <c>.scores-reconciled.parquet</c> for
-    /// Stage 6. Reloads the original Stage 4 parquet's full per-row data
-    /// (identity, boundaries, 21 PIN features, CWT candidate lists), overlays the
-    /// re-scored rows in place by <see cref="FdrEntry.ParquetIndex"/>, appends
-    /// gap-fill rows at the end, then writes a SEPARATE reconciled sibling with
-    /// reconciliation metadata -- the original parquet is never overwritten.
+    /// Stage 6 by STREAMING the original Stage 4 parquet group-by-group: each
+    /// original row group is read, the re-scored rows whose original
+    /// <see cref="FdrEntry.ParquetIndex"/> falls in that group are overlaid, and the
+    /// group is written straight through to a SEPARATE reconciled sibling (the
+    /// original is never overwritten); gap-fill rows are merged into their canonical
+    /// (entry_id, charge, scan_number) sorted position. Peak residency is one original
+    /// row group rather than the whole file's <see cref="FdrEntry"/> list -- see
+    /// <see cref="ParquetScoreCache.StreamReconciledScoresParquet"/>.
     ///
-    /// Extracted verbatim from <c>PerFileRescoreTask.WriteReconciledParquet</c> so
-    /// the row-overlay and metadata-hash logic can be unit-tested without a live
-    /// <see cref="PipelineContext"/>: the only context dependency was logging, now
-    /// taken as <see cref="Action{T}"/> callbacks. Behavior (and therefore the
-    /// reconciled parquet bytes) is unchanged. Mirrors Rust pipeline.rs:3050-3110.
+    /// The overlay/gap-fill split (<see cref="BuildOverlay"/>) and metadata-hash
+    /// selection (<see cref="BuildReconciliationMetadata"/>) are pure and unit-tested
+    /// here; the streaming transfer itself is covered by the IO round-trip test.
+    /// Logging is taken as <see cref="Action{T}"/> callbacks so no live
+    /// <see cref="PipelineContext"/> is needed. The streaming merge reproduces the exact
+    /// physical row order of the former load-all + re-sort write (gap-fill interleaved by
+    /// scan, not appended at the end), which Pass 2's projection sort relies on. Mirrors
+    /// Rust pipeline.rs:3050-3110.
     /// </summary>
     internal static class ReconciledParquetWriter
     {
         /// <summary>
-        /// Reload <paramref name="originalPath"/>, overlay re-scored + gap-fill
-        /// rows from <paramref name="fdrEntries"/>, and write the result to
-        /// <paramref name="reconciledPath"/>. Returns true when the reconciled
-        /// parquet was written; false on a reload/write failure (so the caller
-        /// does not stamp a validity sidecar over a stale or absent output).
+        /// Stream <paramref name="originalPath"/> group-by-group, overlaying the
+        /// re-scored + gap-fill rows from <paramref name="fdrEntries"/>, and write the
+        /// result to <paramref name="reconciledPath"/>. Returns true when the reconciled
+        /// parquet was written; false on a read/write failure (so the caller does not
+        /// stamp a validity sidecar over a stale or absent output).
         /// </summary>
         internal static bool Write(string originalPath, string reconciledPath,
             List<FdrEntry> fdrEntries,
@@ -57,121 +63,82 @@ namespace pwiz.Osprey.Tasks
             IReadOnlyList<string> joinFileStems,
             Action<string> logInfo, Action<string> logWarning)
         {
-            // 1. Reload the original parquet's per-row state (read-only).
-            List<FdrEntry> fullEntries;
-            try
-            {
-                fullEntries = ParquetScoreCache.LoadFullFdrEntries(originalPath);
-            }
-            catch (Exception ex)
-            {
-                logWarning(string.Format(
-                    "Stage 6 write-back: failed to reload {0}: {1} (skipping)",
-                    originalPath, ex.Message));
-                return false;
-            }
-            int origRowCount = fullEntries.Count;
+            // 1. Split the re-scored entries into the small resident overlay map
+            //    (keyed by original ParquetIndex) + the gap-fill list. No whole-file
+            //    materialization -- these hold references into the per-file fdrEntries.
+            var overlayByIndex = new Dictionary<uint, FdrEntry>();
+            var gapFill = new List<FdrEntry>();
+            BuildOverlay(fdrEntries, overlayByIndex, gapFill);
 
-            // 2-3. Overlay re-scored rows by ParquetIndex and append gap-fill rows.
-            int nReplaced = ApplyRescoredRows(fullEntries, fdrEntries, fileName,
-                logWarning, out int nAppended);
-
-            // 4. Build libraryById for the WriteScoresParquet sequence /
-            //    precursor_mz / protein_ids columns.
+            // 2. libraryById for the sequence / precursor_mz / protein_ids columns.
             var libraryById = new Dictionary<uint, LibraryEntry>(fullLibrary.Count);
             foreach (var libEntry in fullLibrary)
                 libraryById[libEntry.Id] = libEntry;
 
-            // 5. Reconciliation metadata (mirrors Rust build_reconciled_metadata).
+            // 3. Reconciliation metadata (mirrors Rust build_reconciled_metadata).
             var metadata = BuildReconciliationMetadata(config, joinFileStems);
 
+            // 4. Stream the reconciled transfer group-by-group: read the original,
+            //    overlay re-scored rows, merge gap-fill into canonical position, write
+            //    the sibling. Peak residency is one original row group, not the whole file.
+            int nReplaced, nAppended, origRowCount;
             try
             {
-                ParquetScoreCache.WriteScoresParquet(reconciledPath, fullEntries,
-                    metadata, libraryById, fileName);
+                var result = ParquetScoreCache.StreamReconciledScoresParquet(
+                    originalPath, reconciledPath, overlayByIndex, gapFill,
+                    metadata, libraryById, fileName, logWarning);
+                nReplaced = result.NReplaced;
+                nAppended = result.NAppended;
+                origRowCount = result.OrigRowCount;
             }
             catch (Exception ex)
             {
                 logWarning(string.Format(
-                    "Stage 6 write-back: failed to write reconciled scores for {0}: {1}",
-                    fileName, ex.Message));
+                    "Stage 6 write-back: failed to transfer {0} -> {1}: {2}",
+                    originalPath, reconciledPath, ex.Message));
                 return false;
             }
 
             logInfo(string.Format(
                 "  Wrote reconciled parquet for {0}: {1} rows ({2} replaced + {3} appended; original {4} rows)",
-                fileName, fullEntries.Count, nReplaced, nAppended, origRowCount));
+                fileName, origRowCount + nAppended, nReplaced, nAppended, origRowCount));
             return true;
         }
 
         /// <summary>
-        /// Overlay the re-scored rows in <paramref name="fdrEntries"/> onto
-        /// <paramref name="fullEntries"/> (loaded from the original parquet) in
-        /// place by <see cref="FdrEntry.ParquetIndex"/>, then append the gap-fill
-        /// rows at the end, reassigning each gap-fill stub's
-        /// <see cref="FdrEntry.ParquetIndex"/> to the row it now occupies so a
-        /// downstream worker can locate its features. Returns the replaced-row
-        /// count; <paramref name="nAppended"/> receives the appended-row count.
+        /// Split the re-scored entries in <paramref name="fdrEntries"/> into the resident
+        /// overlay map <paramref name="overlayByIndex"/> (keyed by original
+        /// <see cref="FdrEntry.ParquetIndex"/>) and the <paramref name="gapFill"/> list
+        /// that <see cref="ParquetScoreCache.StreamReconciledScoresParquet"/> consumes --
+        /// the streaming replacement for the former load-all + in-place overlay (no
+        /// whole-file <see cref="FdrEntry"/> list is ever built).
         ///
-        /// Replacement is keyed on <see cref="FdrEntry.ParquetIndex"/> (NOT
-        /// post-compaction Vec position; the two diverge after first-pass FDR
-        /// drops non-passing entries). Re-scored rows are detected by
-        /// <see cref="FdrEntry.Features"/> != null: hydration's
-        /// LoadFdrStubsFromParquet does NOT populate Features, so unchanged
-        /// post-compaction stubs (Features == null) leave their corresponding
-        /// <paramref name="fullEntries"/> row alone, preserving Features +
-        /// CwtCandidates + the binary blob columns from the original parquet.
-        /// Gap-fill stubs carry ParquetIndex == uint.MaxValue and are appended.
+        /// Replacement is keyed on <see cref="FdrEntry.ParquetIndex"/> (NOT post-compaction
+        /// Vec position; the two diverge after first-pass FDR drops non-passing entries).
+        /// Re-scored rows are detected by <see cref="FdrEntry.Features"/> != null:
+        /// hydration's LoadFdrStubsFromParquet does NOT populate Features, so an unchanged
+        /// post-compaction stub (Features == null) is skipped, leaving its original parquet
+        /// row (Features + CwtCandidates + the binary blob columns) to stream through
+        /// untouched. A row with <see cref="FdrEntry.ParquetIndex"/> == uint.MaxValue is a
+        /// gap-fill stub (absent from the original parquet) and is appended; every other
+        /// re-scored row overlays the original row at its ParquetIndex (last write wins,
+        /// matching the former fullEntries[pqIdx] = entry). Out-of-range indices are
+        /// reported by the streaming write, not here.
         /// </summary>
-        internal static int ApplyRescoredRows(List<FdrEntry> fullEntries,
-            List<FdrEntry> fdrEntries, string fileName,
-            Action<string> logWarning, out int nAppended)
+        internal static void BuildOverlay(List<FdrEntry> fdrEntries,
+            Dictionary<uint, FdrEntry> overlayByIndex, List<FdrEntry> gapFill)
         {
-            // Replace re-scored rows (Phase 1 + Phase 2 existing-entry overlay).
-            int nReplaced = 0;
             foreach (var entry in fdrEntries)
             {
                 if (entry.ParquetIndex == uint.MaxValue)
-                    continue;
-                if (entry.Features == null)
-                    continue;  // hydrated stub, never re-scored
-                int pqIdx = (int)entry.ParquetIndex;
-                if (pqIdx < 0 || pqIdx >= fullEntries.Count)
                 {
-                    logWarning(string.Format(
-                        "Stage 6 write-back: ParquetIndex {0} out of range for {1} ({2} rows)",
-                        pqIdx, fileName, fullEntries.Count));
+                    gapFill.Add(entry);
                     continue;
                 }
-                fullEntries[pqIdx] = entry;
-                nReplaced++;
+                if (entry.Features == null)
+                    continue;  // hydrated stub, never re-scored
+                overlayByIndex[entry.ParquetIndex] = entry;
             }
-
-            // Append gap-fill rows at the end, reassigning ParquetIndex.
-            //
-            // GUARD (single-invocation invariant): this loop CONSUMES the gap-fill
-            // sentinel by overwriting entry.ParquetIndex (uint.MaxValue) with the
-            // appended row position in place. Callers MUST therefore pass a FRESH
-            // per-file fdrEntries list per invocation -- re-running this method on
-            // the same list would find no sentinels to append (so nothing re-appends)
-            // while the already-reassigned gap-fill rows would present to the replace
-            // loop above as in-range / out-of-range re-scores and corrupt the overlay.
-            // Not reachable today: WriteReconciledParquet builds the fdrEntries list
-            // fresh from the per-file stubs on every call. No Debug.Assert here -- the
-            // double-Write footprint (Features != null, ParquetIndex past the original
-            // rows) is indistinguishable from a legitimate out-of-range stub, which
-            // the replace loop already handles with a warning.
-            nAppended = 0;
-            foreach (var entry in fdrEntries)
-            {
-                if (entry.ParquetIndex != uint.MaxValue)
-                    continue;
-                entry.ParquetIndex = (uint)fullEntries.Count;
-                fullEntries.Add(entry);
-                nAppended++;
-            }
-
-            return nReplaced;
         }
 
         /// <summary>

--- a/pwiz_tools/Osprey/Osprey.Tasks/ReconciledParquetWriter.cs
+++ b/pwiz_tools/Osprey/Osprey.Tasks/ReconciledParquetWriter.cs
@@ -91,7 +91,11 @@ namespace pwiz.Osprey.Tasks
                 nAppended = result.NAppended;
                 origRowCount = result.OrigRowCount;
             }
-            catch (Exception ex)
+            // A read/write IO failure is a recoverable per-file skip (clears the sidecar,
+            // re-rescored next run). But an InvalidOperationException from the streaming
+            // merge is the canonical-order invariant guard firing -- that is silently-invalid
+            // output, so let it propagate and ABORT the run (hard-fail over warn-and-proceed).
+            catch (Exception ex) when (!(ex is InvalidOperationException))
             {
                 logWarning(string.Format(
                     "Stage 6 write-back: failed to transfer {0} -> {1}: {2}",

--- a/pwiz_tools/Osprey/Osprey.Test/IOTest.cs
+++ b/pwiz_tools/Osprey/Osprey.Test/IOTest.cs
@@ -2433,8 +2433,8 @@ namespace pwiz.Osprey.Test
         /// group-by-group with an overlay map + gap-fill list
         /// (<see cref="ParquetScoreCache.StreamReconciledScoresParquet"/>) is logically
         /// identical -- same rows, same per-row features + blobs -- to the former
-        /// load-all + in-place overlay + re-sort write, including the appended gap-fill
-        /// (which the streaming path leaves at the physical end). Also asserts the
+        /// load-all + in-place overlay + re-sort write, including the gap-fill (which the
+        /// streaming path merges into canonical (entry_id, charge, scan) position). Also asserts the
         /// replaced / appended / original counts, the out-of-range warning, and that the
         /// output is genuinely multi-group.
         /// </summary>

--- a/pwiz_tools/Osprey/Osprey.Test/IOTest.cs
+++ b/pwiz_tools/Osprey/Osprey.Test/IOTest.cs
@@ -2428,6 +2428,189 @@ namespace pwiz.Osprey.Test
             }
         }
 
+        /// <summary>
+        /// Stage-6 streaming reconciled transfer: streaming the original parquet
+        /// group-by-group with an overlay map + gap-fill list
+        /// (<see cref="ParquetScoreCache.StreamReconciledScoresParquet"/>) is logically
+        /// identical -- same rows, same per-row features + blobs -- to the former
+        /// load-all + in-place overlay + re-sort write, including the appended gap-fill
+        /// (which the streaming path leaves at the physical end). Also asserts the
+        /// replaced / appended / original counts, the out-of-range warning, and that the
+        /// output is genuinely multi-group.
+        /// </summary>
+        [TestMethod]
+        public void TestStreamReconciledTransferMatchesLoadAllOverlay()
+        {
+            string dir = Path.Combine(Path.GetTempPath(),
+                "osprey_stream_recon_" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(dir);
+            try
+            {
+                // Original rows: out-of-order ids so the write's canonical sort runs,
+                // distinct features + blobs per row so any chunk-boundary mismap surfaces
+                // as a value mismatch rather than a silent pass.
+                var original = new List<FdrEntry>();
+                foreach (uint id in new uint[] { 5, 2, 9, 1, 7, 3, 8 })
+                    original.Add(MakeStreamEntry(id, id * 100.0));
+
+                string originalPath = Path.Combine(dir, "orig.scores.parquet");
+                string refPath = Path.Combine(dir, "ref.scores-reconciled.parquet");
+                string streamPath = Path.Combine(dir, "stream.scores-reconciled.parquet");
+
+                // Write the original as several bounded row groups (cap 3 -> 3 groups).
+                ParquetScoreCache.RowGroupRowCapForTest = 3;
+                ParquetScoreCache.WriteScoresParquet(originalPath, original, null, null, "f.mzML");
+
+                // Map each original entry_id to the global row position the write assigned,
+                // so the overlay indices below hit the right rows.
+                var posById = new Dictionary<uint, uint>();
+                foreach (var e in ParquetScoreCache.LoadFullFdrEntries(originalPath))
+                    posById[e.EntryId] = e.ParquetIndex;
+
+                // Overlay two existing rows (id 3, id 8) with distinctly re-scored
+                // features/blobs; leave id 2 un-overlaid (its original row must stream
+                // through untouched); and one out-of-range index that must be dropped
+                // with a warning.
+                var overlayByIndex = new Dictionary<uint, FdrEntry>
+                {
+                    { posById[3], MakeStreamEntry(3, 7777.0) },
+                    { posById[8], MakeStreamEntry(8, 8888.0) },
+                    { 999u, MakeStreamEntry(200, 1.0) },   // out of range -> dropped + warned
+                };
+                // Gap-fill ids 4 and 6 fall BETWEEN existing original ids (3 < 4 < 5 < 6 <
+                // 7), so the streaming merge must interleave them into canonical position;
+                // a plain append-at-end would misplace them and the physical-order check
+                // below would fail. Listed out of order so the merge's own sort is exercised.
+                var gapFill = new List<FdrEntry>
+                {
+                    MakeStreamEntry(6, 60060.0),
+                    MakeStreamEntry(4, 40040.0),
+                };
+
+                // Reference (old behavior): load the whole file, overlay in place by index,
+                // append gap-fill, re-sort on write.
+                var oldFull = ParquetScoreCache.LoadFullFdrEntries(originalPath);
+                foreach (var kv in overlayByIndex)
+                    if (kv.Key < oldFull.Count)
+                        oldFull[(int)kv.Key] = kv.Value;
+                oldFull.AddRange(gapFill);
+                ParquetScoreCache.WriteScoresParquet(refPath, oldFull, null, null, "f.mzML");
+                var refResult = ParquetScoreCache.LoadFullFdrEntries(refPath);
+
+                // New behavior: stream the transfer.
+                var warnings = new List<string>();
+                var result = ParquetScoreCache.StreamReconciledScoresParquet(
+                    originalPath, streamPath, overlayByIndex, gapFill, null, null, "f.mzML", warnings.Add);
+                ParquetScoreCache.RowGroupRowCapForTest = null;
+
+                // Counts: two in-range overlays replaced, two gap-fill appended, 7 originals.
+                Assert.AreEqual(2, result.NReplaced);
+                Assert.AreEqual(2, result.NAppended);
+                Assert.AreEqual(7, result.OrigRowCount);
+
+                // The one out-of-range overlay index is dropped with exactly one warning.
+                Assert.AreEqual(1, warnings.Count);
+
+                // The stream output is genuinely multi-group (3 original groups + gap-fill).
+                Assert.IsTrue(CountRowGroups(streamPath) >= 3,
+                    "streaming reconciled transfer must preserve bounded row groups");
+
+                // Physical order: the streaming merge must emit rows already in canonical
+                // (entry_id, charge, scan_number) order -- gap-fill interleaved by scan,
+                // NOT appended at the end. This is the guarantee Pass 2's projection sort
+                // relies on; a plain append would leave ids 4/6 after id 9 and fail here.
+                var streamResult = ParquetScoreCache.LoadFullFdrEntries(streamPath);
+                Comparison<FdrEntry> byKey = (a, b) =>
+                {
+                    int c = a.EntryId.CompareTo(b.EntryId);
+                    if (c != 0)
+                        return c;
+                    c = a.Charge.CompareTo(b.Charge);
+                    return c != 0 ? c : a.ScanNumber.CompareTo(b.ScanNumber);
+                };
+                for (int i = 1; i < streamResult.Count; i++)
+                    Assert.IsTrue(byKey(streamResult[i - 1], streamResult[i]) <= 0,
+                        "streaming reconciled transfer must emit rows in canonical sorted order");
+
+                // Logical equivalence: same rows, same values (both canonical after sort).
+                refResult.Sort(byKey);
+                streamResult.Sort(byKey);
+                AssertStreamRowsEqual(refResult, streamResult);
+
+                // The overlay actually took effect: id 3 / id 8 carry the re-scored
+                // features, while the un-overlaid id 2 keeps its ORIGINAL features.
+                Assert.AreEqual(7777.0, RowById(streamResult, 3).Features[0]);
+                Assert.AreEqual(8888.0, RowById(streamResult, 8).Features[0]);
+                Assert.AreEqual(200.0, RowById(streamResult, 2).Features[0]);
+            }
+            finally
+            {
+                ParquetScoreCache.RowGroupRowCapForTest = null;
+                try { Directory.Delete(dir, true); } catch (IOException) { }
+            }
+        }
+
+        // Build an FdrEntry with a per-row-distinct feature vector (feature[f] = baseValue + f)
+        // and distinct fragment / XIC blobs derived from baseValue, so a chunk-boundary row
+        // mismap -- or an overlay row silently keeping the ORIGINAL blobs -- surfaces as a
+        // value mismatch. Key fields (entry_id, charge, scan_number) stay id-derived so an
+        // overlay preserves the canonical sort key of the row it replaces.
+        private static FdrEntry MakeStreamEntry(uint id, double baseValue)
+        {
+            var features = new double[ParquetScoreCache.NUM_PIN_FEATURES];
+            for (int f = 0; f < features.Length; f++)
+                features[f] = baseValue + f;
+            return new FdrEntry
+            {
+                EntryId = id,
+                IsDecoy = (id & 1u) == 0,
+                Charge = 2,
+                ScanNumber = id * 10,
+                ApexRt = id + 0.5,
+                StartRt = id + 0.1,
+                EndRt = id + 0.9,
+                BoundsArea = id + 0.3,
+                BoundsSnr = id + 0.7,
+                ModifiedSequence = "PEPTIDE" + id,
+                Features = features,
+                FragmentMzs = new[] { baseValue + 0.25, baseValue + 0.75 },
+                FragmentIntensities = new[] { (float)baseValue, (float)(baseValue + 1) },
+                ReferenceXicRts = new[] { baseValue + 1.5, baseValue + 2.5 },
+                ReferenceXicIntensities = new[] { baseValue * 2.0, baseValue * 3.0 },
+            };
+        }
+
+        private static FdrEntry RowById(List<FdrEntry> rows, uint id)
+        {
+            return rows.First(e => e.EntryId == id);
+        }
+
+        private static void AssertStreamRowsEqual(List<FdrEntry> expected, List<FdrEntry> actual)
+        {
+            Assert.AreEqual(expected.Count, actual.Count);
+            for (int i = 0; i < expected.Count; i++)
+            {
+                var e = expected[i];
+                var a = actual[i];
+                Assert.AreEqual(e.EntryId, a.EntryId);
+                Assert.AreEqual(e.IsDecoy, a.IsDecoy);
+                Assert.AreEqual(e.Charge, a.Charge);
+                Assert.AreEqual(e.ScanNumber, a.ScanNumber);
+                Assert.AreEqual(e.ApexRt, a.ApexRt);
+                Assert.AreEqual(e.StartRt, a.StartRt);
+                Assert.AreEqual(e.EndRt, a.EndRt);
+                Assert.AreEqual(e.CoelutionSum, a.CoelutionSum);
+                Assert.AreEqual(e.BoundsArea, a.BoundsArea);
+                Assert.AreEqual(e.BoundsSnr, a.BoundsSnr);
+                Assert.AreEqual(e.ModifiedSequence, a.ModifiedSequence);
+                CollectionAssert.AreEqual(e.Features, a.Features);
+                CollectionAssert.AreEqual(e.FragmentMzs, a.FragmentMzs);
+                CollectionAssert.AreEqual(e.FragmentIntensities, a.FragmentIntensities);
+                CollectionAssert.AreEqual(e.ReferenceXicRts, a.ReferenceXicRts);
+                CollectionAssert.AreEqual(e.ReferenceXicIntensities, a.ReferenceXicIntensities);
+            }
+        }
+
         private static int CountRowGroups(string path)
         {
             using (var stream = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.Read))

--- a/pwiz_tools/Osprey/Osprey.Test/Pass2FdrSidecarTest.cs
+++ b/pwiz_tools/Osprey/Osprey.Test/Pass2FdrSidecarTest.cs
@@ -110,8 +110,8 @@ namespace pwiz.Osprey.Test
         /// a <c>(entry_id, charge)</c> group. The never-asserted corner -- exercised
         /// here -- is the scan-tie / gap-fill case: the reconciled re-sort is a STABLE
         /// <c>OrderBy(EntryId).ThenBy(Charge).ThenBy(ScanNumber)</c> with NO ParquetIndex
-        /// tiebreak (<c>ParquetScoreCache.WriteScoresParquet</c>) and gap-fill rows are
-        /// appended (<c>ReconciledParquetWriter.ApplyRescoredRows</c>). Two clean 8-file
+        /// tiebreak, which the streaming transfer reproduces by merging gap-fill rows into
+        /// canonical position (<c>ParquetScoreCache.StreamReconciledScoresParquet</c>). Two clean 8-file
         /// Carafe runs were byte-identical end-to-end but never asserted this in
         /// isolation.
         ///

--- a/pwiz_tools/Osprey/Osprey.Test/Pass2FdrSidecarTest.cs
+++ b/pwiz_tools/Osprey/Osprey.Test/Pass2FdrSidecarTest.cs
@@ -119,11 +119,11 @@ namespace pwiz.Osprey.Test
         /// group: multiple distinct scans, a scan-tie (two rows sharing
         /// <c>(EntryId, Charge, ScanNumber)</c> with different original ParquetIndex),
         /// and an appended gap-fill row (the <see cref="uint.MaxValue"/> sentinel). The
-        /// reconciled parquet is produced by the REAL Stage-6 paths -- the gap-fill is
-        /// appended through <c>ReconciledParquetWriter.ApplyRescoredRows</c>, written and
-        /// stably re-sorted by <c>ParquetScoreCache.WriteScoresParquet</c>, and read back
-        /// through <c>BuildReconciledIdentityToRow</c> -- so the tie/gap-fill placement
-        /// is production's, not a mock. The projection itself is baked by the real
+        /// reconciled parquet is produced by the REAL Stage-6 path -- the gap-fill is
+        /// merged into canonical scan position by
+        /// <c>ParquetScoreCache.StreamReconciledScoresParquet</c> and read back through
+        /// <c>BuildReconciledIdentityToRow</c> -- so the tie/gap-fill placement is
+        /// production's, not a mock. The projection itself is baked by the real
         /// <see cref="FdrProjectionSet.BuildFromEntries"/> resolver path.
         /// </summary>
         [TestMethod]
@@ -149,9 +149,10 @@ namespace pwiz.Osprey.Test
             var rowG = MakeSurvivor(100, 2, 15, uint.MaxValue, 70.0, false); // gap-fill sentinel
             var survivors = new List<FdrEntry> { rowS, rowR, rowT, rowG, rowP, rowU, rowQ };
 
-            // Build the reconciled parquet through the REAL Stage-6 paths on fresh clones
-            // (the writer reassigns ParquetIndex, so cloning keeps the survivor buffer's
-            // original ParquetIndex -- the legacy sort tiebreak -- intact).
+            // Build the reconciled parquet through the REAL Stage-6 streaming path: write
+            // the survivor rows as the original scores parquet, then stream-transfer them
+            // with the gap-fill row, whose scan (15) the merge interleaves between the
+            // scan-10 and scan-20 rows -- exactly where the former load-all + re-sort put it.
             var reconEntries = new List<FdrEntry>
             {
                 MakeSurvivor(100, 2, 10, 0, 10.0, false),
@@ -162,16 +163,17 @@ namespace pwiz.Osprey.Test
                 MakeSurvivor(200, 3, 25, 5, 60.0, true),
             };
             var reconGapFill = MakeSurvivor(100, 2, 15, uint.MaxValue, 70.0, false);
-            ReconciledParquetWriter.ApplyRescoredRows(
-                reconEntries, new List<FdrEntry> { reconGapFill }, fileName, s => { },
-                out int nAppended);
-            Assert.AreEqual(1, nAppended, @"gap-fill row must append through the real Stage-6 path");
 
-            string reconciledPath = Path.Combine(Path.GetTempPath(),
-                @"osprey_pass2sort_" + Guid.NewGuid().ToString(@"N") + @".parquet");
+            string tmpStem = @"osprey_pass2sort_" + Guid.NewGuid().ToString(@"N");
+            string originalPath = Path.Combine(Path.GetTempPath(), tmpStem + @".scores.parquet");
+            string reconciledPath = Path.Combine(Path.GetTempPath(), tmpStem + @".scores-reconciled.parquet");
             try
             {
-                ParquetScoreCache.WriteScoresParquet(reconciledPath, reconEntries, null, null, fileName);
+                ParquetScoreCache.WriteScoresParquet(originalPath, reconEntries, null, null, fileName);
+                var streamResult = ParquetScoreCache.StreamReconciledScoresParquet(
+                    originalPath, reconciledPath, new Dictionary<uint, FdrEntry>(),
+                    new List<FdrEntry> { reconGapFill }, null, null, fileName, s => { });
+                Assert.AreEqual(1, streamResult.NAppended, @"gap-fill row must append through the real Stage-6 path");
 
                 // REAL identity -> reconciled-row map (last-write-wins collapses a scan-tie).
                 var reconMap = Pass2FdrSidecar.BuildReconciledIdentityToRow(reconciledPath);
@@ -223,6 +225,8 @@ namespace pwiz.Osprey.Test
             }
             finally
             {
+                if (File.Exists(originalPath))
+                    File.Delete(originalPath);
                 if (File.Exists(reconciledPath))
                     File.Delete(reconciledPath);
             }

--- a/pwiz_tools/Osprey/Osprey.Test/ReconciledParquetWriterTest.cs
+++ b/pwiz_tools/Osprey/Osprey.Test/ReconciledParquetWriterTest.cs
@@ -38,52 +38,36 @@ namespace pwiz.Osprey.Test
     public class ReconciledParquetWriterTest
     {
         /// <summary>
-        /// ApplyRescoredRows must: overlay re-scored rows in place by
-        /// ParquetIndex, leave hydrated stubs (Features == null) untouched,
-        /// append gap-fill rows (ParquetIndex == uint.MaxValue) at the end with a
-        /// reassigned ParquetIndex, and warn-and-skip an out-of-range index.
+        /// BuildOverlay must: key each re-scored row (Features != null,
+        /// ParquetIndex != uint.MaxValue) into the overlay map by its original
+        /// ParquetIndex, skip hydrated stubs (Features == null), and collect
+        /// gap-fill rows (ParquetIndex == uint.MaxValue) into the append list.
+        /// Out-of-range detection is the streaming write's job, so an out-of-range
+        /// index still lands in the overlay map here.
         /// </summary>
         [TestMethod]
-        public void TestApplyRescoredRowsOverlayAndAppend()
+        public void TestBuildOverlaySplit()
         {
-            // Original parquet rows (loaded read-only). Identified by EntryId.
-            var fullEntries = new List<FdrEntry>
-            {
-                new FdrEntry { EntryId = 100 },
-                new FdrEntry { EntryId = 101 },
-                new FdrEntry { EntryId = 102 },
-            };
-
             var rescored = new FdrEntry { EntryId = 201, ParquetIndex = 1, Features = new[] { 1.0 } };
             var hydratedStub = new FdrEntry { EntryId = 202, ParquetIndex = 0, Features = null };
-            var gapFill = new FdrEntry { EntryId = 203, ParquetIndex = uint.MaxValue, Features = new[] { 2.0 } };
+            var gapFillEntry = new FdrEntry { EntryId = 203, ParquetIndex = uint.MaxValue, Features = new[] { 2.0 } };
             var outOfRange = new FdrEntry { EntryId = 204, ParquetIndex = 99, Features = new[] { 3.0 } };
-            var fdrEntries = new List<FdrEntry> { rescored, hydratedStub, gapFill, outOfRange };
+            var fdrEntries = new List<FdrEntry> { rescored, hydratedStub, gapFillEntry, outOfRange };
 
-            var warnings = new List<string>();
-            int nReplaced = ReconciledParquetWriter.ApplyRescoredRows(
-                fullEntries, fdrEntries, "file1", warnings.Add, out int nAppended);
+            var overlayByIndex = new Dictionary<uint, FdrEntry>();
+            var gapFill = new List<FdrEntry>();
+            ReconciledParquetWriter.BuildOverlay(fdrEntries, overlayByIndex, gapFill);
 
-            // Only the in-range rescored row counts as a replacement.
-            Assert.AreEqual(1, nReplaced);
-            // Only the gap-fill row is appended.
-            Assert.AreEqual(1, nAppended);
+            // Re-scored in-range row keyed by its ParquetIndex; hydrated stub skipped;
+            // out-of-range row still present (the streaming write drops it, not BuildOverlay).
+            Assert.AreEqual(2, overlayByIndex.Count);
+            Assert.AreSame(rescored, overlayByIndex[1]);
+            Assert.AreSame(outOfRange, overlayByIndex[99]);
+            Assert.IsFalse(overlayByIndex.ContainsKey(0), "hydrated stub (Features == null) must be skipped");
 
-            // Row 1 was overlaid with the rescored entry; rows 0 and 2 untouched
-            // (hydrated stub at index 0 must NOT clobber its original row).
-            Assert.AreEqual(4, fullEntries.Count);
-            Assert.AreEqual(100u, fullEntries[0].EntryId);
-            Assert.AreEqual(201u, fullEntries[1].EntryId);
-            Assert.AreEqual(102u, fullEntries[2].EntryId);
-
-            // Gap-fill row appended at the end with ParquetIndex reassigned to the
-            // row it now occupies.
-            Assert.AreEqual(203u, fullEntries[3].EntryId);
-            Assert.AreEqual(3u, gapFill.ParquetIndex);
-
-            // The out-of-range index is dropped (not replaced, not appended) with
-            // exactly one warning emitted.
-            Assert.AreEqual(1, warnings.Count);
+            // Only the gap-fill row is collected for append.
+            Assert.AreEqual(1, gapFill.Count);
+            Assert.AreSame(gapFillEntry, gapFill[0]);
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary

* Stream the Stage-6 reconciled parquet transfer group-by-group (read -> overlay -> k-way merge -> bounded-group write) instead of reloading the whole file's `List<FdrEntry>`, overlaying in place, and re-sorting on write. Residency is ~one original row group + the small overlay map, not the whole 1.68M-row list.
* Gap-fill is merged into canonical (entry_id, charge, scan) position (not appended), reproducing the former physical row order byte-for-byte -- Pass 2's projection sort depends on it (`TestScanOmittedProjectionSortMatchesLegacyOrder`).
* Extracted `BuildFdrEntryColumns` / `ReadFdrEntryGroup`; `ReconciledParquetWriter` now splits via `BuildOverlay` + `StreamReconciledScoresParquet`.
* Also ignores the spurious nested `idpicker/.nuget/.nuget/` NuGet.Config.

Note: this is **not** a max-RSS fix. Measurement showed the reconciled-write peak is Server-GC retained-committed heap, not the reload; the change stands on byte-identity, ~1.5 GB less managed churn/file (helps the `--threads` commit scaling), and simpler code. See ai/todos/active/TODO-20260717_osprey_stage6_chunked_reconciled_transfer.md.

## Test plan

- [x] `regression.ps1 -Dataset Stellar` mode1 (vs golden) / mode2 (resume) / mode3 (HPC chain) -- byte-identical blib (45,064,192 B)
- [x] `Build-Osprey.ps1 -RunTests -RunInspection` -- 513 tests, zero-warning inspection
- [x] `TestStreamReconciledTransferMatchesLoadAllOverlay` -- multi-group streaming == load-all overlay (logical rows + canonical physical order + out-of-range warning)
- [x] `TestBuildOverlaySplit`, `TestScanOmittedProjectionSortMatchesLegacyOrder` (rebuilt on the streaming path)
- [ ] `Test-PerfGate.ps1 -Dataset Stellar` (running)
- [ ] TeamCity Astral Perf/Regression (Brendan-gated)

Co-Authored-By: Claude <noreply@anthropic.com>