### PR TITLE
Bounded the first-pass FDR q-value reconstruction (Part B, step 1)

### DIFF
--- a/pwiz_tools/Osprey/Osprey.FDR/PercolatorEngine.cs
+++ b/pwiz_tools/Osprey/Osprey.FDR/PercolatorEngine.cs
@@ -706,19 +706,18 @@ namespace pwiz.Osprey.FDR
             int maxTrain = percConfig.MaxTrainSize;
 
             // Flat identity + best-score arrays from the projection, built ONCE:
-            // labels/entryIds/peptides/fileNames drive BOTH the subset selection here
-            // and the score/compete pass below. bestScores (= CoelutionSum) ranks
+            // labels/entryIds/peptides drive the subset selection here (the score/compete
+            // pass below reads the projection's own PerFile keys, so no flat fileNames array
+            // is built -- issue #4355 Part B). bestScores (= CoelutionSum) ranks
             // best-per-precursor before any Score exists (risk #2), byte-identical to
             // Features[0] on the first pass.
             var labels = new bool[n];
             var entryIds = new uint[n];
             var peptides = new string[n];
-            var fileNames = new string[n];
             var bestScores = new double[n];
             int gi = 0;
             for (int f = 0; f < nFiles; f++)
             {
-                string fileName = perFile[f].Key;
                 var rows = perFile[f].Value;
                 for (int r = 0; r < rows.Count; r++)
                 {
@@ -726,7 +725,6 @@ namespace pwiz.Osprey.FDR
                     labels[gi] = proj.IsDecoy;
                     entryIds[gi] = proj.EntryId;
                     peptides[gi] = peptideById[proj.PeptideId];
-                    fileNames[gi] = fileName;
                     bestScores[gi] = proj.CoelutionSum;
                     gi++;
                 }
@@ -843,7 +841,7 @@ namespace pwiz.Osprey.FDR
             //    to the sink (no PercolatorResult list). Reuses the flat identity
             //    arrays already built above.
             PercolatorFdr.ScoreProjectionAndComputeFdrInPlace(
-                perFile, labels, entryIds, peptides, fileNames, trainResults, percConfig,
+                perFile, labels, entryIds, peptides, trainResults, percConfig,
                 loadFileFeatures, sink, captureContributions);
             return false;
         }

--- a/pwiz_tools/Osprey/Osprey.FDR/PercolatorFdr.cs
+++ b/pwiz_tools/Osprey/Osprey.FDR/PercolatorFdr.cs
@@ -1107,21 +1107,36 @@ namespace pwiz.Osprey.FDR
             for (int i = 0; i < n; i++)
             {
                 double runBoth = Math.Max(runPrecursorQvalues[i], runPeptideQvalues[i]);
-                double curPrec;
-                if (!minRunBothByEntryId.TryGetValue(entryIds[i], out curPrec) || runBoth < curPrec)
-                    minRunBothByEntryId[entryIds[i]] = runBoth;
-
-                // Empty ModifiedSequence has no peptide identity; do not bucket unrelated
-                // entries under an empty key (mirrors the resident overload).
-                if (string.IsNullOrEmpty(peptides[i]))
-                    continue;
-                // Peptide identity is (ModifiedSequence, IsDecoy) so a decoy's good run never
-                // lowers its paired target's peptide floor.
-                var pkey = (peptides[i], labels[i]);
-                double curPept;
-                if (!minRunBothByPeptide.TryGetValue(pkey, out curPept) || runBoth < curPept)
-                    minRunBothByPeptide[pkey] = runBoth;
+                UpdateExperimentQClampFloor(
+                    minRunBothByEntryId, minRunBothByPeptide, entryIds[i], peptides[i], labels[i], runBoth);
             }
+        }
+
+        /// <summary>
+        /// Folds one row into the best-of-runs clamp floors (issue #4390): tracks the minimum over
+        /// an entry's / peptide's rows of <paramref name="runBoth"/> = <c>max(runPrecursorQ,
+        /// runPeptideQ)</c>, keyed by <paramref name="entryId"/> and by
+        /// <c>(<paramref name="peptide"/>, <paramref name="isDecoy"/>)</c>. Shared by
+        /// <see cref="BuildExperimentQClampFloors"/> (flat path) and the projection score pass's
+        /// floor reduction so the two cannot drift on a byte-identity-locked path (issue #4355
+        /// Part B). An empty ModifiedSequence has no peptide identity and is not bucketed; peptide
+        /// identity is (sequence, isDecoy) so a decoy's good run never lowers its target's floor.
+        /// </summary>
+        private static void UpdateExperimentQClampFloor(
+            Dictionary<uint, double> minRunBothByEntryId,
+            Dictionary<(string, bool), double> minRunBothByPeptide,
+            uint entryId, string peptide, bool isDecoy, double runBoth)
+        {
+            double curPrec;
+            if (!minRunBothByEntryId.TryGetValue(entryId, out curPrec) || runBoth < curPrec)
+                minRunBothByEntryId[entryId] = runBoth;
+
+            if (string.IsNullOrEmpty(peptide))
+                return;
+            var pkey = (peptide, isDecoy);
+            double curPept;
+            if (!minRunBothByPeptide.TryGetValue(pkey, out curPept) || runBoth < curPept)
+                minRunBothByPeptide[pkey] = runBoth;
         }
 
         /// <summary>
@@ -1308,15 +1323,8 @@ namespace pwiz.Osprey.FDR
                     {
                         int g = off + r;
                         double runBoth = Math.Max(runPrecFile[r], runPeptFile[r]);
-                        double curPrec;
-                        if (!minRunBothByEntryId.TryGetValue(entryIds[g], out curPrec) || runBoth < curPrec)
-                            minRunBothByEntryId[entryIds[g]] = runBoth;
-                        if (string.IsNullOrEmpty(peptides[g]))
-                            continue;
-                        var pkey = (peptides[g], labels[g]);
-                        double curPept;
-                        if (!minRunBothByPeptide.TryGetValue(pkey, out curPept) || runBoth < curPept)
-                            minRunBothByPeptide[pkey] = runBoth;
+                        UpdateExperimentQClampFloor(
+                            minRunBothByEntryId, minRunBothByPeptide, entryIds[g], peptides[g], labels[g], runBoth);
                     }
                     off += count;
                     floorProgress?.Report(++floorFile);
@@ -2379,87 +2387,70 @@ namespace pwiz.Osprey.FDR
         // ============================================================
 
         /// <summary>
-        /// One file's per-run PRECURSOR q-values, over that file's own local slice (issue
-        /// #4355 Part B). Byte-identical to the per-file group body of
-        /// <see cref="ComputePerRunPrecursorQvalues"/> -- same competition + conservative-q,
-        /// winners get their q and every other row stays 1.0 -- but bounded to one file's rows,
-        /// so the projection score pass never holds a full double[n] per-run array. Returns a
-        /// local array indexed 0..count-1 (the caller scatters it back).
+        /// One file's per-run PRECURSOR q-values. Competes the file's rows -- the contiguous
+        /// global index range in <paramref name="indices"/> (<c>[off, off+count)</c>) -- directly
+        /// over the global score-pass arrays (no per-file slice copy; issue #4355 Part B), then
+        /// maps each winning global index back to its local offset. Byte-identical to the per-file
+        /// group body of <see cref="ComputePerRunPrecursorQvalues"/>: winners get their q, every
+        /// other row stays 1.0. Returns a local array indexed 0..count-1 (the caller scatters it back).
         /// </summary>
         private static double[] ComputePerRunPrecursorQvaluesForFile(
-            double[] fileScores, bool[] fileLabels, uint[] fileEntryIds)
+            double[] scores, bool[] labels, uint[] entryIds, int[] indices, int off)
         {
-            int count = fileScores.Length;
+            int count = indices.Length;
             var qvalues = new double[count];
             for (int i = 0; i < count; i++)
                 qvalues[i] = 1.0;
 
-            var allIndices = new int[count];
-            for (int i = 0; i < count; i++)
-                allIndices[i] = i;
-
             int[] wi;
             double[] ws;
             bool[] wd;
-            CompeteFromIndices(fileScores, fileLabels, fileEntryIds, allIndices, out wi, out ws, out wd);
+            CompeteFromIndices(scores, labels, entryIds, indices, out wi, out ws, out wd);
 
             var q = new double[wi.Length];
             ComputeConservativeQvalues(ws, wd, q);
             for (int rank = 0; rank < wi.Length; rank++)
-                qvalues[wi[rank]] = q[rank];
+                qvalues[wi[rank] - off] = q[rank];   // wi[rank] is a global index in [off, off+count)
             return qvalues;
         }
 
         /// <summary>
-        /// One file's per-run PEPTIDE q-values, over that file's own local slice (issue #4355
-        /// Part B). Byte-identical to the per-file group body of
-        /// <see cref="ComputePerRunPeptideQvalues"/>: best-per-peptide over the file, competition,
+        /// One file's per-run PEPTIDE q-values, competing directly over the global arrays via the
+        /// file's contiguous global index range <paramref name="indices"/> (<c>[off, off+count)</c>)
+        /// -- no per-file slice copy (issue #4355 Part B). Byte-identical to the per-file group body
+        /// of <see cref="ComputePerRunPeptideQvalues"/>: best-per-peptide over the file, competition,
         /// then the peptide's q propagated to every row of that peptide (others stay 1.0).
-        /// Bounded to one file's rows.
+        /// <see cref="BestPrecursorPerPeptide"/> returns global indices, which
+        /// <see cref="CompeteFromIndices"/> then competes directly (both take an index subset).
+        /// Returns a local array indexed 0..count-1.
         /// </summary>
         private static double[] ComputePerRunPeptideQvaluesForFile(
-            double[] fileScores, bool[] fileLabels, uint[] fileEntryIds, string[] filePeptides)
+            double[] scores, bool[] labels, uint[] entryIds, string[] peptides, int[] indices, int off)
         {
-            int count = fileScores.Length;
+            int count = indices.Length;
             var qvalues = new double[count];
             for (int i = 0; i < count; i++)
                 qvalues[i] = 1.0;
 
-            var allIndices = new int[count];
-            for (int i = 0; i < count; i++)
-                allIndices[i] = i;
-
-            var bestPerPeptide = BestPrecursorPerPeptide(allIndices, fileScores, fileLabels, filePeptides);
-
-            var peptScores = new double[bestPerPeptide.Length];
-            var peptLabels = new bool[bestPerPeptide.Length];
-            var peptEntryIds = new uint[bestPerPeptide.Length];
-            var peptIndices = new int[bestPerPeptide.Length];
-            for (int i = 0; i < bestPerPeptide.Length; i++)
-            {
-                peptScores[i] = fileScores[bestPerPeptide[i]];
-                peptLabels[i] = fileLabels[bestPerPeptide[i]];
-                peptEntryIds[i] = fileEntryIds[bestPerPeptide[i]];
-                peptIndices[i] = i;
-            }
+            var bestPerPeptide = BestPrecursorPerPeptide(indices, scores, labels, peptides);
 
             int[] wi;
             double[] ws;
             bool[] wd;
-            CompeteFromIndices(peptScores, peptLabels, peptEntryIds, peptIndices, out wi, out ws, out wd);
+            CompeteFromIndices(scores, labels, entryIds, bestPerPeptide, out wi, out ws, out wd);
 
             var q = new double[wi.Length];
             ComputeConservativeQvalues(ws, wd, q);
 
             var peptideQvalue = new Dictionary<string, double>();
             for (int rank = 0; rank < wi.Length; rank++)
-                peptideQvalue[filePeptides[bestPerPeptide[wi[rank]]]] = q[rank];
+                peptideQvalue[peptides[wi[rank]]] = q[rank];   // wi[rank] is a global index
 
-            for (int i = 0; i < count; i++)
+            for (int r = 0; r < count; r++)
             {
                 double qv;
-                if (peptideQvalue.TryGetValue(filePeptides[i], out qv))
-                    qvalues[i] = qv;
+                if (peptideQvalue.TryGetValue(peptides[off + r], out qv))
+                    qvalues[r] = qv;
             }
             return qvalues;
         }
@@ -2475,20 +2466,14 @@ namespace pwiz.Osprey.FDR
             int off, int count,
             out double[] runPrecursorQvalues, out double[] runPeptideQvalues)
         {
-            var fileScores = new double[count];
-            var fileLabels = new bool[count];
-            var fileEntryIds = new uint[count];
-            var filePeptides = new string[count];
+            // A file's rows are the contiguous global range [off, off+count); compete directly over
+            // the global arrays through this index buffer instead of copying four per-file slices
+            // (issue #4355 Part B, Copilot review). One int[count] shared by both per-run passes.
+            var indices = new int[count];
             for (int r = 0; r < count; r++)
-            {
-                int g = off + r;
-                fileScores[r] = scores[g];
-                fileLabels[r] = labels[g];
-                fileEntryIds[r] = entryIds[g];
-                filePeptides[r] = peptides[g];
-            }
-            runPrecursorQvalues = ComputePerRunPrecursorQvaluesForFile(fileScores, fileLabels, fileEntryIds);
-            runPeptideQvalues = ComputePerRunPeptideQvaluesForFile(fileScores, fileLabels, fileEntryIds, filePeptides);
+                indices[r] = off + r;
+            runPrecursorQvalues = ComputePerRunPrecursorQvaluesForFile(scores, labels, entryIds, indices, off);
+            runPeptideQvalues = ComputePerRunPeptideQvaluesForFile(scores, labels, entryIds, peptides, indices, off);
         }
 
         private static double[] ComputePerRunPrecursorQvalues(

--- a/pwiz_tools/Osprey/Osprey.FDR/PercolatorFdr.cs
+++ b/pwiz_tools/Osprey/Osprey.FDR/PercolatorFdr.cs
@@ -1140,9 +1140,12 @@ namespace pwiz.Osprey.FDR
         /// of the <see cref="PercolatorEntry"/> path.
         ///
         /// The caller passes the flat <paramref name="labels"/> / <paramref name="entryIds"/>
-        /// / <paramref name="peptides"/> / <paramref name="fileNames"/> arrays it
-        /// already built (in nested file/row order) for training-subset selection, so
-        /// they are not rebuilt here; this method walks <paramref name="perFile"/> in
+        /// / <paramref name="peptides"/> arrays it already built (in nested file/row order)
+        /// for training-subset selection, so they are not rebuilt here; this method walks
+        /// <paramref name="perFile"/> in the SAME nested order (its own key is the file name,
+        /// so no flat <c>fileNames</c> array is needed) and zips the results back, keeping every
+        /// index aligned. The feature-contribution accumulation runs in per-file order identical
+        /// to the <see cref="PercolatorEntry"/>
         /// that SAME nested order to compute <c>finalScores</c> and to zip the results
         /// back, keeping every index aligned. The feature-contribution accumulation
         /// runs in per-file order identical to the <see cref="PercolatorEntry"/>
@@ -1152,7 +1155,7 @@ namespace pwiz.Osprey.FDR
         /// </summary>
         internal static void ScoreProjectionAndComputeFdrInPlace(
             List<KeyValuePair<string, List<FdrProjection>>> perFile,
-            bool[] labels, uint[] entryIds, string[] peptides, string[] fileNames,
+            bool[] labels, uint[] entryIds, string[] peptides,
             PercolatorResults trainResults, PercolatorConfig config,
             Func<string, IReadOnlyList<double[]>> loadFileFeatures,
             IFdrOutputSink sink,
@@ -1249,23 +1252,15 @@ namespace pwiz.Osprey.FDR
             // ComputeStreamingCompetitionQvalues), so the streamed outputs are identical.
             var pepByWinnerIdx = ComputePepWinnerMap(finalScores, labels, entryIds);
 
-            // Experiment q-values: the single-file shortcut is exp == per-run (matching
-            // ComputeStreamingCompetitionQvalues), so the maps are built only when multi-file.
-            bool isSingleFile = new HashSet<string>(fileNames).Count <= 1;
-            Dictionary<uint, double> expPrecByBaseId = isSingleFile
-                ? null : ComputeExperimentPrecursorQMap(finalScores, labels, entryIds);
-            Dictionary<string, double> expPeptByPeptide = isSingleFile
-                ? null : ComputeExperimentPeptideQMap(finalScores, labels, entryIds, peptides);
-
             // The per-file q-value passes below slice each file as one contiguous block
             // [off, off+count). The full-length ComputePerRun* path instead grouped by file
-            // NAME, which is robust to a file appearing in more than one PerFile entry; the
+            // name, which is robust to a file appearing in more than one PerFile entry; the
             // slice is not (it would split one file's competition in two -> different run q ->
             // different clamp floors -> different bytes). Every population the pipeline builds
-            // has distinct PerFile keys (fileNames is assigned straight from PerFile order), so
-            // this is an invariant, not a live case -- assert it so a future duplicate-key
-            // producer (e.g. a 2nd-pass reconciliation re-opening a file) fails fast instead of
-            // silently diverging.
+            // has distinct PerFile keys, so this is an invariant, not a live case -- assert it
+            // (the single-file test + per-file passes below depend on it) so a future
+            // duplicate-key producer (e.g. a 2nd-pass reconciliation re-opening a file) fails
+            // fast instead of silently diverging.
             var seenFileKeys = new HashSet<string>(StringComparer.Ordinal);
             foreach (var kvp in perFile)
                 if (!seenFileKeys.Add(kvp.Key))
@@ -1273,6 +1268,23 @@ namespace pwiz.Osprey.FDR
                         @"ScoreProjectionAndComputeFdrInPlace: duplicate per-file key '{0}'; the " +
                         @"bounded per-file q-value pass requires one contiguous block per file.",
                         kvp.Key));
+
+            // Experiment q-values: the single-file shortcut is exp == per-run (matching
+            // ComputeStreamingCompetitionQvalues), built only when multi-file. With distinct
+            // keys (asserted above) the file count is just the number of non-empty PerFile
+            // entries, so no flat fileNames[n] array is needed -- the caller no longer builds
+            // one (issue #4355 Part B: dropping a full O(n) string reference array). This
+            // reproduces the retired `new HashSet<string>(fileNames).Count <= 1` exactly (both
+            // count the distinct files that contribute rows).
+            int nonEmptyFiles = 0;
+            foreach (var kvp in perFile)
+                if (kvp.Value.Count > 0)
+                    nonEmptyFiles++;
+            bool isSingleFile = nonEmptyFiles <= 1;
+            Dictionary<uint, double> expPrecByBaseId = isSingleFile
+                ? null : ComputeExperimentPrecursorQMap(finalScores, labels, entryIds);
+            Dictionary<string, double> expPeptByPeptide = isSingleFile
+                ? null : ComputeExperimentPeptideQMap(finalScores, labels, entryIds, peptides);
 
             // Best-of-runs monotonicity floors (issue #4390): the min-over-runs combined run q
             // that ClampExperimentQToBestRunFlat floors experiment q up to, keyed by EntryId and

--- a/pwiz_tools/Osprey/Osprey.FDR/PercolatorFdr.cs
+++ b/pwiz_tools/Osprey/Osprey.FDR/PercolatorFdr.cs
@@ -1238,21 +1238,15 @@ namespace pwiz.Osprey.FDR
             captureContributions?.Invoke(contributions);
 
             // Bounded q-value reconstruction (issue #4355 Part B): rather than materialize
-            // five full-length double[n] q-value arrays (~14 GB at an 82-file join), build
-            // only the intrinsically-bounded lookups the write-back reads -- PEP is one value
-            // per competition winner, experiment q is one value per base_id / per peptide, and
-            // the clamp floor is one value per entry / per peptide -- and assign each row's
-            // q-values from them as they stream to the sink. The competition + q-value math is
-            // byte-for-byte the shared code the five-array path used (ComputePepWinnerMap /
-            // ComputeExperimentPrecursorQMap / ComputeExperimentPeptideQMap /
-            // BuildExperimentQClampFloors all back ComputeStreamingCompetitionQvalues too), so
-            // the streamed outputs are identical. The per-run q-values stay full-length here
-            // (Part B stage 1a-ii streams them per-file).
-            var runPrecursorQvalues = ComputePerRunPrecursorQvalues(
-                finalScores, labels, entryIds, fileNames);
-            var runPeptideQvalues = ComputePerRunPeptideQvalues(
-                finalScores, labels, entryIds, fileNames, peptides);
-
+            // five full-length double[n] q-value arrays (~14 GB at an 82-file join), build only
+            // the intrinsically-bounded lookups the write-back reads. PEP is one value per
+            // competition winner and experiment q is one value per base_id / per peptide (both
+            // O(distinct), built once); the PER-RUN q-values are per-file, so they are computed
+            // one file at a time from that file's slice, never a full double[n] array. The
+            // competition + q-value math is byte-for-byte the shared code the five-array path
+            // used (ComputePepWinnerMap / ComputeExperimentPrecursorQMap /
+            // ComputeExperimentPeptideQMap / ComputePerFileRunQvalues all mirror
+            // ComputeStreamingCompetitionQvalues), so the streamed outputs are identical.
             var pepByWinnerIdx = ComputePepWinnerMap(finalScores, labels, entryIds);
 
             // Experiment q-values: the single-file shortcut is exp == per-run (matching
@@ -1263,59 +1257,93 @@ namespace pwiz.Osprey.FDR
             Dictionary<string, double> expPeptByPeptide = isSingleFile
                 ? null : ComputeExperimentPeptideQMap(finalScores, labels, entryIds, peptides);
 
-            // Best-of-runs monotonicity floors (issue #4390), the same min-over-runs combined
-            // run q that ClampExperimentQToBestRunFlat applies, held as bounded per-entry /
-            // per-peptide maps and applied inline below. min/max are order-independent -> the
-            // clamped experiment q is byte-identical to the flat clamp on the full arrays.
-            BuildExperimentQClampFloors(
-                entryIds, labels, peptides, runPrecursorQvalues, runPeptideQvalues,
-                out var minRunBothByEntryId, out var minRunBothByPeptide);
+            // Best-of-runs monotonicity floors (issue #4390): the min-over-runs combined run q
+            // that ClampExperimentQToBestRunFlat floors experiment q up to, keyed by EntryId and
+            // by (peptide, isDecoy). The global minimum must be known before any row is emitted,
+            // so a first pass computes each file's per-run q-values (bounded, one file at a time)
+            // and reduces them into the floor maps; the emit pass below recomputes them per file
+            // to assign. min/max are order-independent -> byte-identical to the flat clamp.
+            var minRunBothByEntryId = new Dictionary<uint, double>();
+            var minRunBothByPeptide = new Dictionary<(string, bool), double>();
+            using (var floorProgress = QProgress(@"Per-run q-value floors", perFile.Count, n))
+            {
+                int off = 0;
+                int floorFile = 0;
+                foreach (var kvp in perFile)
+                {
+                    int count = kvp.Value.Count;
+                    ComputePerFileRunQvalues(
+                        finalScores, labels, entryIds, peptides, off, count,
+                        out double[] runPrecFile, out double[] runPeptFile);
+                    for (int r = 0; r < count; r++)
+                    {
+                        int g = off + r;
+                        double runBoth = Math.Max(runPrecFile[r], runPeptFile[r]);
+                        double curPrec;
+                        if (!minRunBothByEntryId.TryGetValue(entryIds[g], out curPrec) || runBoth < curPrec)
+                            minRunBothByEntryId[entryIds[g]] = runBoth;
+                        if (string.IsNullOrEmpty(peptides[g]))
+                            continue;
+                        var pkey = (peptides[g], labels[g]);
+                        double curPept;
+                        if (!minRunBothByPeptide.TryGetValue(pkey, out curPept) || runBoth < curPept)
+                            minRunBothByPeptide[pkey] = runBoth;
+                    }
+                    off += count;
+                    floorProgress?.Report(++floorFile);
+                }
+            }
 
-            // Write the Score onto the projection rows and stream each row's five q-values to
-            // the sink, assigned from the bounded lookups (issue #4355 struct-shrink S0 / Part
-            // B). FdrProjection is a readonly struct, so Score is replaced via WithScore. Same
-            // nested (file, row) walk as the scoring loop, so wgi stays aligned to finalScores
-            // and the sink sees the identical order the five-array write-back produced.
+            // Emit pass: recompute each file's per-run q-values, assign every row's five q-values
+            // from the bounded lookups, write the Score onto the projection row (FdrProjection is
+            // a readonly struct, so via WithScore), and stream to the sink -- same nested (file,
+            // row) order as the scoring loop, so the sink sees the order the five-array write-back
+            // produced.
             int wgi = 0;
             int fileIdx = 0;
             foreach (var kvp in perFile)
             {
                 var projRows = kvp.Value;
-                for (int r = 0; r < projRows.Count; r++)
+                int count = projRows.Count;
+                ComputePerFileRunQvalues(
+                    finalScores, labels, entryIds, peptides, wgi, count,
+                    out double[] runPrecFile, out double[] runPeptFile);
+                for (int r = 0; r < count; r++)
                 {
-                    double rp = runPrecursorQvalues[wgi];
-                    double rpe = runPeptideQvalues[wgi];
+                    int g = wgi + r;
+                    double rp = runPrecFile[r];
+                    double rpe = runPeptFile[r];
 
                     // Experiment precursor: base_id map (or per-run on the single-file
                     // shortcut), floored up to the entry's min-over-runs combined run q.
                     double ep = isSingleFile
                         ? rp
-                        : (expPrecByBaseId.TryGetValue(entryIds[wgi] & BASE_ID_MASK, out double epv)
+                        : (expPrecByBaseId.TryGetValue(entryIds[g] & BASE_ID_MASK, out double epv)
                             ? epv : 1.0);
-                    if (minRunBothByEntryId.TryGetValue(entryIds[wgi], out double floorPrec) &&
+                    if (minRunBothByEntryId.TryGetValue(entryIds[g], out double floorPrec) &&
                         floorPrec > ep)
                         ep = floorPrec;
 
                     // Experiment peptide: peptide map (or per-run on the shortcut), floored up
                     // to the (peptide, isDecoy) min-over-runs combined run q. An empty peptide
                     // has no peptide identity and is not floored (matches the flat clamp).
-                    string pept = peptides[wgi];
+                    string pept = peptides[g];
                     double epe = isSingleFile
                         ? rpe
                         : (expPeptByPeptide.TryGetValue(pept, out double epev) ? epev : 1.0);
                     if (!string.IsNullOrEmpty(pept) &&
-                        minRunBothByPeptide.TryGetValue((pept, labels[wgi]), out double floorPept) &&
+                        minRunBothByPeptide.TryGetValue((pept, labels[g]), out double floorPept) &&
                         floorPept > epe)
                         epe = floorPept;
 
-                    double pep = pepByWinnerIdx.TryGetValue(wgi, out double pv) ? pv : 1.0;
+                    double pep = pepByWinnerIdx.TryGetValue(g, out double pv) ? pv : 1.0;
 
-                    projRows[r] = projRows[r].WithScore(finalScores[wgi]);
+                    projRows[r] = projRows[r].WithScore(finalScores[g]);
                     sink.Accept(fileIdx, r, projRows[r].EntryId, projRows[r].IsDecoy,
-                        finalScores[wgi],
+                        finalScores[g],
                         new FdrQValues(rp, rpe, ep, epe, pep));
-                    wgi++;
                 }
+                wgi += count;
                 fileIdx++;
             }
         }
@@ -2320,6 +2348,119 @@ namespace pwiz.Osprey.FDR
         // ============================================================
         // Per-run and experiment-level q-value computation
         // ============================================================
+
+        /// <summary>
+        /// One file's per-run PRECURSOR q-values, over that file's own local slice (issue
+        /// #4355 Part B). Byte-identical to the per-file group body of
+        /// <see cref="ComputePerRunPrecursorQvalues"/> -- same competition + conservative-q,
+        /// winners get their q and every other row stays 1.0 -- but bounded to one file's rows,
+        /// so the projection score pass never holds a full double[n] per-run array. Returns a
+        /// local array indexed 0..count-1 (the caller scatters it back).
+        /// </summary>
+        private static double[] ComputePerRunPrecursorQvaluesForFile(
+            double[] fileScores, bool[] fileLabels, uint[] fileEntryIds)
+        {
+            int count = fileScores.Length;
+            var qvalues = new double[count];
+            for (int i = 0; i < count; i++)
+                qvalues[i] = 1.0;
+
+            var allIndices = new int[count];
+            for (int i = 0; i < count; i++)
+                allIndices[i] = i;
+
+            int[] wi;
+            double[] ws;
+            bool[] wd;
+            CompeteFromIndices(fileScores, fileLabels, fileEntryIds, allIndices, out wi, out ws, out wd);
+
+            var q = new double[wi.Length];
+            ComputeConservativeQvalues(ws, wd, q);
+            for (int rank = 0; rank < wi.Length; rank++)
+                qvalues[wi[rank]] = q[rank];
+            return qvalues;
+        }
+
+        /// <summary>
+        /// One file's per-run PEPTIDE q-values, over that file's own local slice (issue #4355
+        /// Part B). Byte-identical to the per-file group body of
+        /// <see cref="ComputePerRunPeptideQvalues"/>: best-per-peptide over the file, competition,
+        /// then the peptide's q propagated to every row of that peptide (others stay 1.0).
+        /// Bounded to one file's rows.
+        /// </summary>
+        private static double[] ComputePerRunPeptideQvaluesForFile(
+            double[] fileScores, bool[] fileLabels, uint[] fileEntryIds, string[] filePeptides)
+        {
+            int count = fileScores.Length;
+            var qvalues = new double[count];
+            for (int i = 0; i < count; i++)
+                qvalues[i] = 1.0;
+
+            var allIndices = new int[count];
+            for (int i = 0; i < count; i++)
+                allIndices[i] = i;
+
+            var bestPerPeptide = BestPrecursorPerPeptide(allIndices, fileScores, fileLabels, filePeptides);
+
+            var peptScores = new double[bestPerPeptide.Length];
+            var peptLabels = new bool[bestPerPeptide.Length];
+            var peptEntryIds = new uint[bestPerPeptide.Length];
+            var peptIndices = new int[bestPerPeptide.Length];
+            for (int i = 0; i < bestPerPeptide.Length; i++)
+            {
+                peptScores[i] = fileScores[bestPerPeptide[i]];
+                peptLabels[i] = fileLabels[bestPerPeptide[i]];
+                peptEntryIds[i] = fileEntryIds[bestPerPeptide[i]];
+                peptIndices[i] = i;
+            }
+
+            int[] wi;
+            double[] ws;
+            bool[] wd;
+            CompeteFromIndices(peptScores, peptLabels, peptEntryIds, peptIndices, out wi, out ws, out wd);
+
+            var q = new double[wi.Length];
+            ComputeConservativeQvalues(ws, wd, q);
+
+            var peptideQvalue = new Dictionary<string, double>();
+            for (int rank = 0; rank < wi.Length; rank++)
+                peptideQvalue[filePeptides[bestPerPeptide[wi[rank]]]] = q[rank];
+
+            for (int i = 0; i < count; i++)
+            {
+                double qv;
+                if (peptideQvalue.TryGetValue(filePeptides[i], out qv))
+                    qvalues[i] = qv;
+            }
+            return qvalues;
+        }
+
+        /// <summary>
+        /// Computes one file's per-run precursor + peptide q-values from its contiguous slice
+        /// <c>[off, off+count)</c> of the flat score-pass arrays (nested (file, row) order, so a
+        /// file's rows are contiguous). Used by the projection score pass in place of the full
+        /// double[n] per-run arrays (issue #4355 Part B); bounded to one file.
+        /// </summary>
+        private static void ComputePerFileRunQvalues(
+            double[] scores, bool[] labels, uint[] entryIds, string[] peptides,
+            int off, int count,
+            out double[] runPrecursorQvalues, out double[] runPeptideQvalues)
+        {
+            var fileScores = new double[count];
+            var fileLabels = new bool[count];
+            var fileEntryIds = new uint[count];
+            var filePeptides = new string[count];
+            for (int r = 0; r < count; r++)
+            {
+                int g = off + r;
+                fileScores[r] = scores[g];
+                fileLabels[r] = labels[g];
+                fileEntryIds[r] = entryIds[g];
+                filePeptides[r] = peptides[g];
+            }
+            runPrecursorQvalues = ComputePerRunPrecursorQvaluesForFile(fileScores, fileLabels, fileEntryIds);
+            runPeptideQvalues = ComputePerRunPeptideQvaluesForFile(fileScores, fileLabels, fileEntryIds, filePeptides);
+        }
 
         private static double[] ComputePerRunPrecursorQvalues(
             double[] scores, bool[] labels, uint[] entryIds, string[] fileNames)

--- a/pwiz_tools/Osprey/Osprey.FDR/PercolatorFdr.cs
+++ b/pwiz_tools/Osprey/Osprey.FDR/PercolatorFdr.cs
@@ -1257,6 +1257,23 @@ namespace pwiz.Osprey.FDR
             Dictionary<string, double> expPeptByPeptide = isSingleFile
                 ? null : ComputeExperimentPeptideQMap(finalScores, labels, entryIds, peptides);
 
+            // The per-file q-value passes below slice each file as one contiguous block
+            // [off, off+count). The full-length ComputePerRun* path instead grouped by file
+            // NAME, which is robust to a file appearing in more than one PerFile entry; the
+            // slice is not (it would split one file's competition in two -> different run q ->
+            // different clamp floors -> different bytes). Every population the pipeline builds
+            // has distinct PerFile keys (fileNames is assigned straight from PerFile order), so
+            // this is an invariant, not a live case -- assert it so a future duplicate-key
+            // producer (e.g. a 2nd-pass reconciliation re-opening a file) fails fast instead of
+            // silently diverging.
+            var seenFileKeys = new HashSet<string>(StringComparer.Ordinal);
+            foreach (var kvp in perFile)
+                if (!seenFileKeys.Add(kvp.Key))
+                    throw new InvalidOperationException(string.Format(
+                        @"ScoreProjectionAndComputeFdrInPlace: duplicate per-file key '{0}'; the " +
+                        @"bounded per-file q-value pass requires one contiguous block per file.",
+                        kvp.Key));
+
             // Best-of-runs monotonicity floors (issue #4390): the min-over-runs combined run q
             // that ClampExperimentQToBestRunFlat floors experiment q up to, keyed by EntryId and
             // by (peptide, isDecoy). The global minimum must be known before any row is emitted,

--- a/pwiz_tools/Osprey/Osprey.FDR/PercolatorFdr.cs
+++ b/pwiz_tools/Osprey/Osprey.FDR/PercolatorFdr.cs
@@ -952,51 +952,16 @@ namespace pwiz.Osprey.FDR
         {
             int n = finalScores.Length;
 
-            // PEP via global target-decoy competition. CompeteAll returns
-            // winners sorted by score-descending (matches the direct-path
-            // Percolator flow and is what ComputeConservativeQvalues needs
-            // downstream). Rust's streaming path uses compute_fdr_from_stubs
-            // instead, which iterates a base_id-ascending-sorted union of
-            // targets + decoys -- because PepEstimator.FitDefault's KDE sum
-            // is NOT associative and HashMap iteration order would leak 1-
-            // ULP-level noise into every PEP value. For cross-impl byte
-            // parity we must feed PepEstimator in the same base_id-sorted
-            // order Rust uses, not CompeteAll's score-sorted order. Reorder
-            // a parallel copy here; the score-sorted arrays stay intact for
-            // the per-run / experiment q-value calls below.
-            int[] winnerIndices;
-            double[] winnerScores;
-            bool[] winnerIsDecoy;
-            // Throttled progress over the ~344M-row population competition (the big walk that
-            // ran silent at 82 files); null (silent) on small runs. Console-only, byte-neutral.
-            using (var pepProgress = QProgress(@"Population target/decoy competition", n, n))
-                CompeteAll(finalScores, labels, entryIds,
-                    out winnerIndices, out winnerScores, out winnerIsDecoy, pepProgress);
-
-            int nWinners = winnerIndices.Length;
-            var pepOrder = new int[nWinners];
-            for (int k = 0; k < nWinners; k++)
-                pepOrder[k] = k;
-            Array.Sort(pepOrder, (a, b) => // Array.Sort OK: TDC's CompeteAll already produced one winner per base_id, so each base_id appears at most once in pepOrder -- no ties.
-            {
-                uint ba = entryIds[winnerIndices[a]] & BASE_ID_MASK;
-                uint bb = entryIds[winnerIndices[b]] & BASE_ID_MASK;
-                return ba.CompareTo(bb);
-            });
-            var pepScores = new double[nWinners];
-            var pepIsDecoy = new bool[nWinners];
-            for (int k = 0; k < nWinners; k++)
-            {
-                pepScores[k] = winnerScores[pepOrder[k]];
-                pepIsDecoy[k] = winnerIsDecoy[pepOrder[k]];
-            }
-
-            var pepEstimator = PepEstimator.FitDefault(pepScores, pepIsDecoy);
+            // PEP via global target-decoy competition. The bounded winner->PEP map
+            // (base_id-ascending KDE order -- see ComputePepWinnerMap) is expanded to the
+            // full per-row peps array here; the projection score pass reads the map directly
+            // so the O(n) array is never materialized (issue #4355 Part B).
+            var pepByWinnerIdx = ComputePepWinnerMap(finalScores, labels, entryIds);
             peps = new double[n];
             for (int i = 0; i < n; i++)
                 peps[i] = 1.0;
-            foreach (int idx in winnerIndices)
-                peps[idx] = pepEstimator.PosteriorError(finalScores[idx]);
+            foreach (var kv in pepByWinnerIdx)
+                peps[kv.Key] = kv.Value;
 
             // Per-run precursor + peptide q-values (each file independently).
             runPrecursorQvalues = ComputePerRunPrecursorQvalues(
@@ -1031,6 +996,59 @@ namespace pwiz.Osprey.FDR
         }
 
         /// <summary>
+        /// Bounded (O(base_ids)) posterior-error-probability (PEP) map: the global
+        /// target-decoy competition winner index -&gt; its PEP. This is the intrinsic working
+        /// set of the PEP step -- one PEP per competition winner (every other row's PEP is the
+        /// default 1.0) -- so the projection score pass
+        /// (<see cref="ScoreProjectionAndComputeFdrInPlace"/>) reads the map directly to set
+        /// the winning rows' PEP without materializing the O(n) per-row array (issue #4355
+        /// Part B). <see cref="ComputeStreamingCompetitionQvalues"/> expands the same map, so
+        /// both share the one PEP fit and cannot drift.
+        ///
+        /// The KDE is fed in base_id-ascending order (risk #6): CompeteAll returns winners
+        /// score-descending, but PepEstimator.FitDefault's KDE sum is NOT associative, so for
+        /// cross-impl byte parity the winners must be reordered to the same base_id-sorted
+        /// order Rust's compute_fdr_from_stubs uses before the fit.
+        /// </summary>
+        private static Dictionary<int, double> ComputePepWinnerMap(
+            double[] finalScores, bool[] labels, uint[] entryIds)
+        {
+            int n = finalScores.Length;
+            int[] winnerIndices;
+            double[] winnerScores;
+            bool[] winnerIsDecoy;
+            // Throttled progress over the ~344M-row population competition (the big walk that
+            // ran silent at 82 files); null (silent) on small runs. Console-only, byte-neutral.
+            using (var pepProgress = QProgress(@"Population target/decoy competition", n, n))
+                CompeteAll(finalScores, labels, entryIds,
+                    out winnerIndices, out winnerScores, out winnerIsDecoy, pepProgress);
+
+            int nWinners = winnerIndices.Length;
+            var pepOrder = new int[nWinners];
+            for (int k = 0; k < nWinners; k++)
+                pepOrder[k] = k;
+            Array.Sort(pepOrder, (a, b) => // Array.Sort OK: TDC's CompeteAll already produced one winner per base_id, so each base_id appears at most once in pepOrder -- no ties.
+            {
+                uint ba = entryIds[winnerIndices[a]] & BASE_ID_MASK;
+                uint bb = entryIds[winnerIndices[b]] & BASE_ID_MASK;
+                return ba.CompareTo(bb);
+            });
+            var pepScores = new double[nWinners];
+            var pepIsDecoy = new bool[nWinners];
+            for (int k = 0; k < nWinners; k++)
+            {
+                pepScores[k] = winnerScores[pepOrder[k]];
+                pepIsDecoy[k] = winnerIsDecoy[pepOrder[k]];
+            }
+
+            var pepEstimator = PepEstimator.FitDefault(pepScores, pepIsDecoy);
+            var pepByWinnerIdx = new Dictionary<int, double>(nWinners);
+            foreach (int idx in winnerIndices)
+                pepByWinnerIdx[idx] = pepEstimator.PosteriorError(finalScores[idx]);
+            return pepByWinnerIdx;
+        }
+
+        /// <summary>
         /// Memory-bounded flat form of <see cref="PercolatorEngine.ClampExperimentQToBestRun"/>
         /// (issue #4378): floor each experiment q up to the entry's best (min-over-runs)
         /// combined run q (<c>runBoth = max(runPrecursorQ, runPeptideQ)</c>), keyed by EntryId
@@ -1045,9 +1063,47 @@ namespace pwiz.Osprey.FDR
             double[] runPrecursorQvalues, double[] runPeptideQvalues,
             double[] expPrecursorQvalues, double[] expPeptideQvalues)
         {
+            BuildExperimentQClampFloors(
+                entryIds, labels, peptides, runPrecursorQvalues, runPeptideQvalues,
+                out var minRunBothByEntryId, out var minRunBothByPeptide);
+
             int n = entryIds.Length;
-            var minRunBothByEntryId = new Dictionary<uint, double>();
-            var minRunBothByPeptide = new Dictionary<(string, bool), double>();
+            for (int i = 0; i < n; i++)
+            {
+                double floorPrec;
+                if (minRunBothByEntryId.TryGetValue(entryIds[i], out floorPrec) &&
+                    floorPrec > expPrecursorQvalues[i])
+                    expPrecursorQvalues[i] = floorPrec;
+
+                if (!string.IsNullOrEmpty(peptides[i]))
+                {
+                    double floorPept;
+                    if (minRunBothByPeptide.TryGetValue((peptides[i], labels[i]), out floorPept) &&
+                        floorPept > expPeptideQvalues[i])
+                        expPeptideQvalues[i] = floorPept;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Builds the min-over-runs combined-run-q floors that
+        /// <see cref="ClampExperimentQToBestRunFlat"/> applies:
+        /// <c>minRunBothByEntryId[entryId]</c> and <c>minRunBothByPeptide[(peptide, isDecoy)]</c>
+        /// = the minimum over that entry's / peptide's rows of
+        /// <c>max(runPrecursorQ, runPeptideQ)</c>. Bounded (O(distinct entryIds) +
+        /// O(distinct peptides)), shared with the projection score pass
+        /// (<see cref="ScoreProjectionAndComputeFdrInPlace"/>) so both clamp identically
+        /// without a resident per-row experiment-q array (issue #4355 Part B).
+        /// </summary>
+        private static void BuildExperimentQClampFloors(
+            uint[] entryIds, bool[] labels, string[] peptides,
+            double[] runPrecursorQvalues, double[] runPeptideQvalues,
+            out Dictionary<uint, double> minRunBothByEntryId,
+            out Dictionary<(string, bool), double> minRunBothByPeptide)
+        {
+            int n = entryIds.Length;
+            minRunBothByEntryId = new Dictionary<uint, double>();
+            minRunBothByPeptide = new Dictionary<(string, bool), double>();
             for (int i = 0; i < n; i++)
             {
                 double runBoth = Math.Max(runPrecursorQvalues[i], runPeptideQvalues[i]);
@@ -1065,22 +1121,6 @@ namespace pwiz.Osprey.FDR
                 double curPept;
                 if (!minRunBothByPeptide.TryGetValue(pkey, out curPept) || runBoth < curPept)
                     minRunBothByPeptide[pkey] = runBoth;
-            }
-
-            for (int i = 0; i < n; i++)
-            {
-                double floorPrec;
-                if (minRunBothByEntryId.TryGetValue(entryIds[i], out floorPrec) &&
-                    floorPrec > expPrecursorQvalues[i])
-                    expPrecursorQvalues[i] = floorPrec;
-
-                if (!string.IsNullOrEmpty(peptides[i]))
-                {
-                    double floorPept;
-                    if (minRunBothByPeptide.TryGetValue((peptides[i], labels[i]), out floorPept) &&
-                        floorPept > expPeptideQvalues[i])
-                        expPeptideQvalues[i] = floorPept;
-                }
             }
         }
 
@@ -1197,19 +1237,45 @@ namespace pwiz.Osprey.FDR
             // request them; a pure hand-off, so scoring stays byte-identical.
             captureContributions?.Invoke(contributions);
 
-            double[] peps, runPrecursorQvalues, runPeptideQvalues,
-                     expPrecursorQvalues, expPeptideQvalues;
-            ComputeStreamingCompetitionQvalues(
-                finalScores, labels, entryIds, peptides, fileNames,
-                out peps, out runPrecursorQvalues, out runPeptideQvalues,
-                out expPrecursorQvalues, out expPeptideQvalues);
+            // Bounded q-value reconstruction (issue #4355 Part B): rather than materialize
+            // five full-length double[n] q-value arrays (~14 GB at an 82-file join), build
+            // only the intrinsically-bounded lookups the write-back reads -- PEP is one value
+            // per competition winner, experiment q is one value per base_id / per peptide, and
+            // the clamp floor is one value per entry / per peptide -- and assign each row's
+            // q-values from them as they stream to the sink. The competition + q-value math is
+            // byte-for-byte the shared code the five-array path used (ComputePepWinnerMap /
+            // ComputeExperimentPrecursorQMap / ComputeExperimentPeptideQMap /
+            // BuildExperimentQClampFloors all back ComputeStreamingCompetitionQvalues too), so
+            // the streamed outputs are identical. The per-run q-values stay full-length here
+            // (Part B stage 1a-ii streams them per-file).
+            var runPrecursorQvalues = ComputePerRunPrecursorQvalues(
+                finalScores, labels, entryIds, fileNames);
+            var runPeptideQvalues = ComputePerRunPeptideQvalues(
+                finalScores, labels, entryIds, fileNames, peptides);
 
-            // Write the Score straight onto the projection rows (no PercolatorResult
-            // list) and stream the five q-value outputs to the sink (issue #4355
-            // struct-shrink S0). FdrProjection is a readonly struct, so each row's
-            // Score is replaced via WithScore; the q-values no longer live on the
-            // struct. Same nested (file, row) walk as the scoring loop, so index wgi
-            // stays aligned to finalScores / the q-value arrays.
+            var pepByWinnerIdx = ComputePepWinnerMap(finalScores, labels, entryIds);
+
+            // Experiment q-values: the single-file shortcut is exp == per-run (matching
+            // ComputeStreamingCompetitionQvalues), so the maps are built only when multi-file.
+            bool isSingleFile = new HashSet<string>(fileNames).Count <= 1;
+            Dictionary<uint, double> expPrecByBaseId = isSingleFile
+                ? null : ComputeExperimentPrecursorQMap(finalScores, labels, entryIds);
+            Dictionary<string, double> expPeptByPeptide = isSingleFile
+                ? null : ComputeExperimentPeptideQMap(finalScores, labels, entryIds, peptides);
+
+            // Best-of-runs monotonicity floors (issue #4390), the same min-over-runs combined
+            // run q that ClampExperimentQToBestRunFlat applies, held as bounded per-entry /
+            // per-peptide maps and applied inline below. min/max are order-independent -> the
+            // clamped experiment q is byte-identical to the flat clamp on the full arrays.
+            BuildExperimentQClampFloors(
+                entryIds, labels, peptides, runPrecursorQvalues, runPeptideQvalues,
+                out var minRunBothByEntryId, out var minRunBothByPeptide);
+
+            // Write the Score onto the projection rows and stream each row's five q-values to
+            // the sink, assigned from the bounded lookups (issue #4355 struct-shrink S0 / Part
+            // B). FdrProjection is a readonly struct, so Score is replaced via WithScore. Same
+            // nested (file, row) walk as the scoring loop, so wgi stays aligned to finalScores
+            // and the sink sees the identical order the five-array write-back produced.
             int wgi = 0;
             int fileIdx = 0;
             foreach (var kvp in perFile)
@@ -1217,12 +1283,37 @@ namespace pwiz.Osprey.FDR
                 var projRows = kvp.Value;
                 for (int r = 0; r < projRows.Count; r++)
                 {
+                    double rp = runPrecursorQvalues[wgi];
+                    double rpe = runPeptideQvalues[wgi];
+
+                    // Experiment precursor: base_id map (or per-run on the single-file
+                    // shortcut), floored up to the entry's min-over-runs combined run q.
+                    double ep = isSingleFile
+                        ? rp
+                        : (expPrecByBaseId.TryGetValue(entryIds[wgi] & BASE_ID_MASK, out double epv)
+                            ? epv : 1.0);
+                    if (minRunBothByEntryId.TryGetValue(entryIds[wgi], out double floorPrec) &&
+                        floorPrec > ep)
+                        ep = floorPrec;
+
+                    // Experiment peptide: peptide map (or per-run on the shortcut), floored up
+                    // to the (peptide, isDecoy) min-over-runs combined run q. An empty peptide
+                    // has no peptide identity and is not floored (matches the flat clamp).
+                    string pept = peptides[wgi];
+                    double epe = isSingleFile
+                        ? rpe
+                        : (expPeptByPeptide.TryGetValue(pept, out double epev) ? epev : 1.0);
+                    if (!string.IsNullOrEmpty(pept) &&
+                        minRunBothByPeptide.TryGetValue((pept, labels[wgi]), out double floorPept) &&
+                        floorPept > epe)
+                        epe = floorPept;
+
+                    double pep = pepByWinnerIdx.TryGetValue(wgi, out double pv) ? pv : 1.0;
+
                     projRows[r] = projRows[r].WithScore(finalScores[wgi]);
                     sink.Accept(fileIdx, r, projRows[r].EntryId, projRows[r].IsDecoy,
                         finalScores[wgi],
-                        new FdrQValues(
-                            runPrecursorQvalues[wgi], runPeptideQvalues[wgi],
-                            expPrecursorQvalues[wgi], expPeptideQvalues[wgi], peps[wgi]));
+                        new FdrQValues(rp, rpe, ep, epe, pep));
                     wgi++;
                 }
                 fileIdx++;
@@ -2356,14 +2447,20 @@ namespace pwiz.Osprey.FDR
             return qvalues;
         }
 
-        private static double[] ComputeExperimentPrecursorQvalues(
+        /// <summary>
+        /// Bounded (O(base_ids)) experiment-precursor q map: <c>base_id -&gt; q</c>. This is
+        /// the intrinsic working set of the experiment-precursor competition -- one q per
+        /// distinct base_id -- so it is what the projection score pass
+        /// (<see cref="ScoreProjectionAndComputeFdrInPlace"/>) reads to assign each row's
+        /// experiment-precursor q WITHOUT ever materializing the O(n) per-row array
+        /// (issue #4355 Part B, bounded q-value reconstruction). The full-length
+        /// <see cref="ComputeExperimentPrecursorQvalues"/> wrapper simply expands this map,
+        /// so the two share the SAME competition + conservative-q math and cannot drift.
+        /// </summary>
+        private static Dictionary<uint, double> ComputeExperimentPrecursorQMap(
             double[] scores, bool[] labels, uint[] entryIds)
         {
             int n = scores.Length;
-            var qvalues = new double[n];
-            for (int i = 0; i < n; i++)
-                qvalues[i] = 1.0;
-
             int[] wi;
             double[] ws;
             bool[] wd;
@@ -2373,38 +2470,49 @@ namespace pwiz.Osprey.FDR
             var q = new double[wi.Length];
             ComputeConservativeQvalues(ws, wd, q);
 
-            // Propagate the winner's q-value to all observations sharing the
-            // same base_id (both target and decoy sides). Matches Rust's
-            // base_id_exp_prec_q HashMap at osprey-fdr/src/percolator.rs:2168
-            // -- without this, non-winning per-file observations of a
-            // multi-file precursor stay at q=1.0 and downstream stages that
-            // gate on experiment_precursor_qvalue (Stage 6 calibration refit
-            // and reconciliation) miss the bulk of the consensus pool.
+            // Winner's q-value keyed by base_id -- assigned to all observations sharing the
+            // same base_id (both target and decoy sides) at expand/assign time. Matches
+            // Rust's base_id_exp_prec_q HashMap at osprey-fdr/src/percolator.rs:2168 --
+            // without this, non-winning per-file observations of a multi-file precursor stay
+            // at q=1.0 and downstream stages that gate on experiment_precursor_qvalue (Stage
+            // 6 calibration refit and reconciliation) miss the bulk of the consensus pool.
             var baseIdExpQ = new Dictionary<uint, double>();
             for (int rank = 0; rank < wi.Length; rank++)
             {
                 uint baseId = entryIds[wi[rank]] & BASE_ID_MASK;
                 baseIdExpQ[baseId] = q[rank];
             }
-            for (int i = 0; i < n; i++)
-            {
-                uint baseId = entryIds[i] & BASE_ID_MASK;
-                double qv;
-                if (baseIdExpQ.TryGetValue(baseId, out qv))
-                    qvalues[i] = qv;
-            }
-
-            return qvalues;
+            return baseIdExpQ;
         }
 
-        private static double[] ComputeExperimentPeptideQvalues(
-            double[] scores, bool[] labels, uint[] entryIds, string[] peptides)
+        private static double[] ComputeExperimentPrecursorQvalues(
+            double[] scores, bool[] labels, uint[] entryIds)
         {
             int n = scores.Length;
             var qvalues = new double[n];
+            var baseIdExpQ = ComputeExperimentPrecursorQMap(scores, labels, entryIds);
             for (int i = 0; i < n; i++)
-                qvalues[i] = 1.0;
+            {
+                double qv;
+                qvalues[i] = baseIdExpQ.TryGetValue(entryIds[i] & BASE_ID_MASK, out qv) ? qv : 1.0;
+            }
+            return qvalues;
+        }
 
+        /// <summary>
+        /// Bounded (O(peptides)) experiment-peptide q map: <c>peptide -&gt; q</c>. The
+        /// intrinsic working set of the experiment-peptide competition -- one q per distinct
+        /// peptide string -- which the projection score pass
+        /// (<see cref="ScoreProjectionAndComputeFdrInPlace"/>) reads to assign each row's
+        /// experiment-peptide q without materializing the O(n) per-row array (issue #4355
+        /// Part B). The full-length <see cref="ComputeExperimentPeptideQvalues"/> wrapper
+        /// expands this map, so both share the SAME best-per-peptide + competition +
+        /// conservative-q math and cannot drift.
+        /// </summary>
+        private static Dictionary<string, double> ComputeExperimentPeptideQMap(
+            double[] scores, bool[] labels, uint[] entryIds, string[] peptides)
+        {
+            int n = scores.Length;
             var allIndices = new int[n];
             for (int i = 0; i < n; i++)
                 allIndices[i] = i;
@@ -2439,14 +2547,20 @@ namespace pwiz.Osprey.FDR
                 int globalIdx = bestPerPeptide[wi[rank]];
                 peptideQvalue[peptides[globalIdx]] = q[rank];
             }
+            return peptideQvalue;
+        }
 
+        private static double[] ComputeExperimentPeptideQvalues(
+            double[] scores, bool[] labels, uint[] entryIds, string[] peptides)
+        {
+            int n = scores.Length;
+            var qvalues = new double[n];
+            var peptideQvalue = ComputeExperimentPeptideQMap(scores, labels, entryIds, peptides);
             for (int i = 0; i < n; i++)
             {
                 double qv;
-                if (peptideQvalue.TryGetValue(peptides[i], out qv))
-                    qvalues[i] = qv;
+                qvalues[i] = peptideQvalue.TryGetValue(peptides[i], out qv) ? qv : 1.0;
             }
-
             return qvalues;
         }
 

--- a/pwiz_tools/Osprey/Osprey.IO/LibraryCache.cs
+++ b/pwiz_tools/Osprey/Osprey.IO/LibraryCache.cs
@@ -187,6 +187,23 @@ namespace pwiz.Osprey.IO
         public static List<LibraryEntry> LoadCache(string path, string expectedLibraryHash,
             Action<string> logInfo, out LibraryCacheStatus status)
         {
+            return LoadCache(path, expectedLibraryHash, false, logInfo, out status);
+        }
+
+        /// <summary>
+        /// Overload that can leave each entry's fragment peaks unretained. With
+        /// <paramref name="omitFragments"/> the fragment blocks are still read
+        /// (to advance the stream past them) but discarded, so the returned
+        /// entries keep their six identity scalars and an empty
+        /// <see cref="LibraryEntry.Fragments"/>. Used by a FirstPassFDR /
+        /// <c>StopAfterStage5</c> worker, whose FDR stages read only the scalars,
+        /// to skip retaining the ~3.2 GB (SEA-AD scale) of fragment arrays. The
+        /// scalars, modifications, protein IDs and gene names are unchanged, so
+        /// the six values every downstream stage reads are byte-identical.
+        /// </summary>
+        public static List<LibraryEntry> LoadCache(string path, string expectedLibraryHash,
+            bool omitFragments, Action<string> logInfo, out LibraryCacheStatus status)
+        {
             using (var stream = new FileStream(path, FileMode.Open, FileAccess.Read))
             using (var r = new BinaryReader(stream))
             {
@@ -260,33 +277,45 @@ namespace pwiz.Osprey.IO
                         };
                     }
 
-                    // Fragments
+                    // Fragments. When omitting, still read each fragment's bytes
+                    // (to advance the stream to the protein-ID block that follows)
+                    // but discard them, leaving a shared empty array.
                     uint nFrags = r.ReadUInt32();
-                    var fragments = nFrags == 0
-                        ? Array.Empty<LibraryFragment>()
-                        : new LibraryFragment[nFrags];
-                    for (uint fi = 0; fi < nFrags; fi++)
+                    LibraryFragment[] fragments;
+                    if (omitFragments)
                     {
-                        double mz = r.ReadDouble();
-                        float relativeIntensity = r.ReadSingle();
-                        IonType ionType = ByteToIonType(r.ReadByte());
-                        byte ordinal = r.ReadByte();
-                        byte fragCharge = r.ReadByte();
-                        var (lossCode, lossMass) = ReadNeutralLoss(r);
-
-                        fragments[fi] = new LibraryFragment
+                        fragments = Array.Empty<LibraryFragment>();
+                        for (uint fi = 0; fi < nFrags; fi++)
+                            SkipFragment(r);
+                    }
+                    else
+                    {
+                        fragments = nFrags == 0
+                            ? Array.Empty<LibraryFragment>()
+                            : new LibraryFragment[nFrags];
+                        for (uint fi = 0; fi < nFrags; fi++)
                         {
-                            Mz = mz,
-                            RelativeIntensity = relativeIntensity,
-                            Annotation = new FragmentAnnotation
+                            double mz = r.ReadDouble();
+                            float relativeIntensity = r.ReadSingle();
+                            IonType ionType = ByteToIonType(r.ReadByte());
+                            byte ordinal = r.ReadByte();
+                            byte fragCharge = r.ReadByte();
+                            var (lossCode, lossMass) = ReadNeutralLoss(r);
+
+                            fragments[fi] = new LibraryFragment
                             {
-                                IonType = ionType,
-                                Ordinal = ordinal,
-                                Charge = fragCharge,
-                                NeutralLoss = lossCode,
-                                CustomLossMass = lossMass
-                            }
-                        };
+                                Mz = mz,
+                                RelativeIntensity = relativeIntensity,
+                                Annotation = new FragmentAnnotation
+                                {
+                                    IonType = ionType,
+                                    Ordinal = ordinal,
+                                    Charge = fragCharge,
+                                    NeutralLoss = lossCode,
+                                    CustomLossMass = lossMass
+                                }
+                            };
+                        }
                     }
 
                     // Protein IDs / gene names (share one empty array when none).
@@ -429,6 +458,22 @@ namespace pwiz.Osprey.IO
                     throw new InvalidDataException(string.Format(
                         "Unknown neutral loss tag: {0}", tag));
             }
+        }
+
+        /// <summary>
+        /// Read past one fragment record without materializing it, advancing the
+        /// reader exactly as the full fragment read would. Must stay in lockstep
+        /// with the fragment write in <see cref="SaveCache"/> / the full read in
+        /// <see cref="LoadCache(string,string,bool,Action{string},out LibraryCacheStatus)"/>.
+        /// </summary>
+        private static void SkipFragment(BinaryReader r)
+        {
+            r.ReadDouble();     // Mz
+            r.ReadSingle();     // RelativeIntensity
+            r.ReadByte();       // IonType
+            r.ReadByte();       // Ordinal
+            r.ReadByte();       // Charge
+            ReadNeutralLoss(r); // NeutralLoss tag (+ optional custom mass)
         }
 
         private static bool BytesEqual(byte[] a, byte[] b)

--- a/pwiz_tools/Osprey/Osprey.IO/LibraryCache.cs
+++ b/pwiz_tools/Osprey/Osprey.IO/LibraryCache.cs
@@ -281,6 +281,15 @@ namespace pwiz.Osprey.IO
                     // (to advance the stream to the protein-ID block that follows)
                     // but discard them, leaving a shared empty array.
                     uint nFrags = r.ReadUInt32();
+                    // Peak-less entries (0 fragments) are a BiblioSpec MS1-feature-finding artifact,
+                    // not valid for DIA search; fail fast rather than let one reach decoy generation
+                    // or a lean OmitFragments load (issue #4355 / PR #4434 review). A stale cache
+                    // built before this guard rebuilds from source, which fails fast there too.
+                    if (nFrags == 0)
+                        throw new InvalidDataException(string.Format(
+                            "Library entry {0} ({1}) has no fragment peaks; peak-less entries support " +
+                            "BiblioSpec MS1 feature finding and are not valid for DIA search.",
+                            id, modifiedSequence));
                     LibraryFragment[] fragments;
                     if (omitFragments)
                     {
@@ -290,9 +299,7 @@ namespace pwiz.Osprey.IO
                     }
                     else
                     {
-                        fragments = nFrags == 0
-                            ? Array.Empty<LibraryFragment>()
-                            : new LibraryFragment[nFrags];
+                        fragments = new LibraryFragment[nFrags];   // nFrags > 0: 0-fragment entries fail fast above
                         for (uint fi = 0; fi < nFrags; fi++)
                         {
                             double mz = r.ReadDouble();

--- a/pwiz_tools/Osprey/Osprey.IO/LibraryLoadOptions.cs
+++ b/pwiz_tools/Osprey/Osprey.IO/LibraryLoadOptions.cs
@@ -1,0 +1,57 @@
+/*
+ * Original author: Brendan MacLean <brendanx .at. uw.edu>,
+ *                  MacCoss Lab, Department of Genome Sciences, UW
+ * AI assistance: Claude Code (Claude Opus 4.8) <noreply .at. anthropic.com>
+ *
+ * Based on osprey (https://github.com/MacCossLab/osprey)
+ *   by Michael J. MacCoss, MacCoss Lab, Department of Genome Sciences, UW
+ *
+ * Copyright 2026 University of Washington - Seattle, WA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace pwiz.Osprey.IO
+{
+    /// <summary>
+    /// Optional knobs for <see cref="LibraryLoader.Load(pwiz.Osprey.Core.OspreyConfig,LibraryLoadOptions,System.Action{string},System.Action{string})"/>.
+    /// A carrier so callers with different needs (full pipeline vs. an
+    /// FDR-only worker) can shape the load without a growing parameter list.
+    /// </summary>
+    public sealed class LibraryLoadOptions
+    {
+        /// <summary>
+        /// Shared "no special handling" instance (a full load with every
+        /// fragment peak retained). Immutable: never mutate this instance.
+        /// </summary>
+        public static readonly LibraryLoadOptions Default = new LibraryLoadOptions();
+
+        /// <summary>
+        /// When true, the loaded library keeps every entry's six identity
+        /// scalars (Id, ModifiedSequence, Charge, PrecursorMz, IsDecoy,
+        /// ProteinIds) but drops the per-entry <see cref="pwiz.Osprey.Core.LibraryEntry.Fragments"/>
+        /// peak arrays -- the ~3.2 GB (SEA-AD scale) of fragment m/z + intensity
+        /// that a FirstPassFDR / <c>StopAfterStage5</c> worker never reads (the
+        /// FDR stages consume only the scalars). Set ONLY for a run that stops
+        /// after Stage 5; a run that later writes the .blib needs the fragments.
+        ///
+        /// Byte-identity note: the loader still reads the fragment blocks (to
+        /// count them for the min-fragment filter and to tie-break duplicates in
+        /// <see cref="LibraryDeduplicator"/>) and writes them to the shared
+        /// .libcache; only the RETAINED per-entry arrays are dropped, after all
+        /// count-dependent work is done. Decoy generation is told about the
+        /// omission separately so it skips its own fragment-count gate.
+        /// </summary>
+        public bool OmitFragments { get; set; }
+    }
+}

--- a/pwiz_tools/Osprey/Osprey.IO/LibraryLoader.cs
+++ b/pwiz_tools/Osprey/Osprey.IO/LibraryLoader.cs
@@ -48,6 +48,28 @@ namespace pwiz.Osprey.IO
         public static List<LibraryEntry> Load(OspreyConfig config,
             Action<string> logInfo, Action<string> logWarning)
         {
+            return Load(config, LibraryLoadOptions.Default, logInfo, logWarning);
+        }
+
+        /// <summary>
+        /// Load spectral library from the configured source, using binary cache
+        /// when available. Matches Rust's .libcache mechanism for fast reload.
+        ///
+        /// With <see cref="LibraryLoadOptions.OmitFragments"/>, the returned
+        /// entries carry their six identity scalars but no fragment peaks -- the
+        /// dead weight for a FirstPassFDR / <c>StopAfterStage5</c> worker. The
+        /// cache-read path skips retaining the fragment blocks; the source-parse
+        /// path loads fragments in full (the min-fragment filter and
+        /// <see cref="LibraryDeduplicator"/> both need the counts), writes the
+        /// shared .libcache in full, then drops the retained arrays. So the
+        /// returned library is lean exactly when <see cref="LibraryLoadOptions.OmitFragments"/>
+        /// is set, and the on-disk cache is unaffected.
+        /// </summary>
+        public static List<LibraryEntry> Load(OspreyConfig config, LibraryLoadOptions options,
+            Action<string> logInfo, Action<string> logWarning)
+        {
+            // A null carrier means "no special handling" (a full load).
+            options = options ?? LibraryLoadOptions.Default;
             // Default the injected log callbacks to no-ops so a null delegate
             // cannot NRE this public API (matches PipelineContext's pattern).
             logInfo = logInfo ?? (_ => { });
@@ -82,7 +104,10 @@ namespace pwiz.Osprey.IO
                     LibraryCache.LibraryCacheStatus status;
                     // The cache reader interns the repeated strings as it builds
                     // each entry's arrays and logs a one-line collapse summary.
-                    var cached = LibraryCache.LoadCache(cachePath, libraryHash, logInfo, out status);
+                    // OmitFragments has it read-and-discard the fragment blocks so
+                    // the returned entries stay lean (no ~3.2 GB of peak arrays).
+                    var cached = LibraryCache.LoadCache(
+                        cachePath, libraryHash, options.OmitFragments, logInfo, out status);
                     if (cached != null && cached.Count > 0)
                     {
                         logInfo(string.Format(
@@ -146,6 +171,19 @@ namespace pwiz.Osprey.IO
             catch (Exception ex)
             {
                 logWarning(string.Format("Failed to save library cache: {0}", ex.Message));
+            }
+
+            // Drop the retained fragment arrays now that every fragment-count
+            // dependency is satisfied (the min-fragment filter in the loaders,
+            // LibraryDeduplicator's fragment-count tie-break, and the full cache
+            // save above). The six identity scalars are untouched, so a
+            // StopAfterStage5 worker gets the resident-memory win with output
+            // unchanged. Done here rather than in each loader so the source-parse
+            // path returns a library as lean as the cache-read path.
+            if (options.OmitFragments)
+            {
+                foreach (var entry in entries)
+                    entry.Fragments = Array.Empty<LibraryFragment>();
             }
 
             return entries;

--- a/pwiz_tools/Osprey/Osprey.IO/LibraryLoader.cs
+++ b/pwiz_tools/Osprey/Osprey.IO/LibraryLoader.cs
@@ -159,6 +159,18 @@ namespace pwiz.Osprey.IO
 
             logInfo(string.Format("Loaded {0} library entries", entries.Count));
 
+            // Peak-less entries (0 fragments) are a BiblioSpec MS1-feature-finding artifact and are
+            // not valid for DIA search; fail fast at load (issue #4355 / PR #4434 review), before the
+            // cache save, so a bad entry never reaches the cache, decoy generation (which would
+            // silently exclude it), or a lean OmitFragments load (which would retain a phantom and
+            // diverge the FirstPassFDR reconciliation bytes).
+            foreach (var entry in entries)
+                if (entry.Fragments.Count == 0)
+                    throw new InvalidDataException(string.Format(
+                        "Library entry {0} ({1}) has no fragment peaks; peak-less entries support " +
+                        "BiblioSpec MS1 feature finding and are not valid for DIA search.",
+                        entry.Id, entry.ModifiedSequence));
+
             // Save binary cache for next run
             try
             {

--- a/pwiz_tools/Osprey/Osprey.Scoring/DecoyGenerator.cs
+++ b/pwiz_tools/Osprey/Osprey.Scoring/DecoyGenerator.cs
@@ -206,10 +206,22 @@ namespace pwiz.Osprey.Scoring
         /// logger is now an injected <paramref name="logInfo"/> callback so Scoring stays
         /// free of a Tasks/PipelineContext dependency. Arithmetic is unchanged, so
         /// cross-impl parity is unaffected.
+        ///
+        /// <paramref name="omitFragments"/> supports the lean library a
+        /// FirstPassFDR / <c>StopAfterStage5</c> worker loads (fragment peaks
+        /// dropped, six identity scalars kept). When set: the empty-fragment
+        /// exclusion gate is skipped (every real library entry has >= 1 fragment,
+        /// so the gate never excluded any, and the loaded entries now carry no
+        /// fragments), and each decoy is built with an empty fragment list
+        /// (RecalculateFragments is skipped -- decoy fragments are the same dead
+        /// weight the targets dropped). The decoys' six identity scalars are
+        /// derived from the target scalars and the collision-checked sequence,
+        /// never from fragment content, so the target/decoy set the FDR stages
+        /// see is byte-identical to a full load.
         /// </summary>
         public static List<LibraryEntry> GenerateAllWithCollisionDetection(
             List<LibraryEntry> targets, OspreyConfig config,
-            Action<string> logInfo,
+            Action<string> logInfo, bool omitFragments,
             out List<LibraryEntry> validTargets)
         {
             // Public API: tolerate a missing logger as a no-op rather than throwing.
@@ -233,7 +245,12 @@ namespace pwiz.Osprey.Scoring
             Parallel.For(0, targets.Count, i =>
             {
                 var target = targets[i];
-                if (target.IsDecoy || target.Fragments == null || target.Fragments.Count == 0)
+                // The fragment-count gate is skipped under omitFragments: the
+                // library was loaded lean (every entry keeps only its scalars),
+                // and every real entry had >= 1 fragment before the drop, so the
+                // gate could not have excluded any. The IsDecoy skip is kept.
+                if (target.IsDecoy ||
+                    (!omitFragments && (target.Fragments == null || target.Fragments.Count == 0)))
                 {
                     results[i] = (null, null, 0);
                     return;
@@ -246,7 +263,7 @@ namespace pwiz.Osprey.Scoring
 
                 if (reversedSeq != target.Sequence && !targetSequences.Contains(reversedSeq))
                 {
-                    var decoy = BuildDecoyFromSequence(target, reversedSeq, mapping);
+                    var decoy = BuildDecoyFromSequence(target, reversedSeq, mapping, omitFragments);
                     if (decoy != null)
                     {
                         results[i] = (target, decoy, 1);
@@ -261,7 +278,7 @@ namespace pwiz.Osprey.Scoring
                     string cycledSeq = gen.CycleSequence(target.Sequence, cycleLength, out mapping);
                     if (cycledSeq != target.Sequence && !targetSequences.Contains(cycledSeq))
                     {
-                        var decoy = BuildDecoyFromSequence(target, cycledSeq, mapping);
+                        var decoy = BuildDecoyFromSequence(target, cycledSeq, mapping, omitFragments);
                         if (decoy != null)
                         {
                             results[i] = (target, decoy, 2);
@@ -352,9 +369,12 @@ namespace pwiz.Osprey.Scoring
         /// <summary>
         /// Build a decoy LibraryEntry from a decoy sequence and position mapping.
         /// Mirrors <see cref="Generate"/>'s construction but takes an already-chosen sequence.
+        /// With <paramref name="omitFragments"/> the decoy gets an empty fragment
+        /// list (RecalculateFragments is skipped) -- the identity scalars are
+        /// unchanged, matching the lean library a StopAfterStage5 worker loads.
         /// </summary>
         private static LibraryEntry BuildDecoyFromSequence(
-            LibraryEntry target, string decoySequence, int[] positionMapping)
+            LibraryEntry target, string decoySequence, int[] positionMapping, bool omitFragments)
         {
             var decoy = new LibraryEntry(
                 target.Id | 0x80000000u,
@@ -367,8 +387,9 @@ namespace pwiz.Osprey.Scoring
             decoy.IsDecoy = true;
             decoy.Modifications = RemapModificationsStatic(
                 target.Modifications, positionMapping);
-            decoy.Fragments = RecalculateFragmentsStatic(
-                target, positionMapping, decoySequence);
+            decoy.Fragments = omitFragments
+                ? Array.Empty<LibraryFragment>()
+                : RecalculateFragmentsStatic(target, positionMapping, decoySequence);
             // Strings stay un-interned here (this runs in a Parallel.For body);
             // the sequential collection loop interns every decoy afterwards.
             decoy.ProteinIds = BuildDecoyProteinIds(target.ProteinIds, null);

--- a/pwiz_tools/Osprey/Osprey.Tasks/PerFileScoringTask.cs
+++ b/pwiz_tools/Osprey/Osprey.Tasks/PerFileScoringTask.cs
@@ -837,8 +837,19 @@ namespace pwiz.Osprey.Tasks
         {
             fullLibrary = null;
 
+            // A StopAfterStage5 worker (--task FirstPassFDR) reads only the six
+            // identity scalars per library entry (the FDR stages never touch
+            // fragments), so skip retaining the fragment peaks -- ~3.2 GB at
+            // SEA-AD scale of otherwise-resident dead weight. Gate strictly on
+            // StopAfterStage5: a straight-through run (or any run that later
+            // writes the .blib) still needs the fragments. Decoy generation and
+            // the fragment diagnostic below are told about the omission so they
+            // stay byte-identical (see LibraryLoadOptions / DecoyGenerator).
+            bool omitFragments = config.StopAfterStage5;
+            var loadOptions = new LibraryLoadOptions { OmitFragments = omitFragments };
+
             var swLibrary = Stopwatch.StartNew();
-            var library = LibraryLoader.Load(config, ctx.LogInfo, ctx.LogWarning);
+            var library = LibraryLoader.Load(config, loadOptions, ctx.LogInfo, ctx.LogWarning);
             if (library == null || library.Count == 0)
             {
                 ctx.LogError(@"Library is empty after loading");
@@ -893,7 +904,7 @@ namespace pwiz.Osprey.Tasks
                 // its own pool and logs the collapse summary; no post-pass
                 // interning is needed here.
                 decoys = DecoyGenerator.GenerateAllWithCollisionDetection(
-                    library, config, ctx.LogInfo, out List<LibraryEntry> validTargets);
+                    library, config, ctx.LogInfo, omitFragments, out List<LibraryEntry> validTargets);
                 library = validTargets;
             }
             else
@@ -918,21 +929,27 @@ namespace pwiz.Osprey.Tasks
             ctx.LogInfo(string.Format(@"[COUNT] Full library: {0} ({1} targets + {2} decoys)",
                 fullLibrary.Count, library.Count, decoys.Count));
 
-            // Count entries with few fragments (diagnostic for entry count parity)
-            int nZeroFrag = 0, nOneFrag = 0, nTwoFrag = 0;
-            foreach (var entry in fullLibrary)
+            // Count entries with few fragments (diagnostic for entry count
+            // parity). Skipped when fragments were omitted: the entries carry no
+            // fragment arrays by design, so every count would read 0 and the line
+            // would misreport the whole library as sub-3-fragment.
+            if (!omitFragments)
             {
-                int fc = entry.Fragments != null ? entry.Fragments.Count : 0;
-                if (fc == 0)
-                    nZeroFrag++;
-                else if (fc == 1)
-                    nOneFrag++;
-                else if (fc == 2)
-                    nTwoFrag++;
+                int nZeroFrag = 0, nOneFrag = 0, nTwoFrag = 0;
+                foreach (var entry in fullLibrary)
+                {
+                    int fc = entry.Fragments != null ? entry.Fragments.Count : 0;
+                    if (fc == 0)
+                        nZeroFrag++;
+                    else if (fc == 1)
+                        nOneFrag++;
+                    else if (fc == 2)
+                        nTwoFrag++;
+                }
+                if (nZeroFrag + nOneFrag + nTwoFrag > 0)
+                    ctx.LogInfo(string.Format(@"[COUNT] Entries with <3 fragments: {0} (0={1}, 1={2}, 2={3})",
+                        nZeroFrag + nOneFrag + nTwoFrag, nZeroFrag, nOneFrag, nTwoFrag));
             }
-            if (nZeroFrag + nOneFrag + nTwoFrag > 0)
-                ctx.LogInfo(string.Format(@"[COUNT] Entries with <3 fragments: {0} (0={1}, 1={2}, 2={3})",
-                    nZeroFrag + nOneFrag + nTwoFrag, nZeroFrag, nOneFrag, nTwoFrag));
 
             // Build library lookup by ID for fast access
             var libraryById = new Dictionary<uint, LibraryEntry>(fullLibrary.Count);

--- a/pwiz_tools/Osprey/Osprey.Tasks/PerFileScoringTask.cs
+++ b/pwiz_tools/Osprey/Osprey.Tasks/PerFileScoringTask.cs
@@ -1207,7 +1207,13 @@ namespace pwiz.Osprey.Tasks
                         throw new InvalidDataException(string.Format(
                             @"--input-scores: parquet {0} is missing the PIN feature columns -- it is not a valid Osprey scores parquet. Delete it and re-run so it is regenerated.",
                             parquetPath));
-                    builder.BeginFile(fileName);
+                    // Pre-size the per-file projection list to the parquet row count (footer
+                    // NumRows, no column data) so the 32 B rows fill one right-sized backing
+                    // array instead of the List's doubling growth -- byte-neutral, ~5.4 GB less
+                    // resident at 82 files (issue #4355 Part B; the pre-size was measured on the
+                    // memory branch). A 0/missing count just falls back to an un-hinted list.
+                    long rowCountHint = ParquetScoreCache.ProbeCwtRowMetadata(parquetPath).RowCount;
+                    builder.BeginFile(fileName, checked((int)rowCountHint));
                     ParquetScoreCache.ReadFdrStubScalars(parquetPath,
                         (entryId, charge, isDecoy, coelutionSum, modseq) =>
                             builder.AddRow(entryId, charge, isDecoy, coelutionSum, modseq));

--- a/pwiz_tools/Osprey/Osprey.Test/IOTest.cs
+++ b/pwiz_tools/Osprey/Osprey.Test/IOTest.cs
@@ -1142,6 +1142,39 @@ namespace pwiz.Osprey.Test
         }
 
         [TestMethod]
+        public void TestLibraryCacheRejectsPeaklessEntry()
+        {
+            // Peak-less (0-fragment) entries are a BiblioSpec MS1-feature-finding artifact and are
+            // not valid for DIA search: the cache reader must fail fast (PR #4434 review) rather than
+            // let one reach decoy generation (which would silently exclude it) or a lean OmitFragments
+            // load (which would retain a phantom and diverge the FirstPassFDR reconciliation bytes).
+            var entries = new List<LibraryEntry>
+            {
+                MakeTestEntry(0),                                    // fragment-carrying: valid
+                new LibraryEntry(1, "BBB", "BBB", 2, 400.0, 20.0)    // no fragments: must be rejected
+            };
+
+            string tempPath = Path.Combine(Path.GetTempPath(),
+                "osprey_test_peakless_" + Guid.NewGuid().ToString("N") + ".libcache");
+            try
+            {
+                LibraryCache.SaveCache(tempPath, entries, "peakless-hash");
+
+                // Both the full and the lean (OmitFragments) cache reads must fail fast on the
+                // 0-fragment entry (the guard is upstream of the omit branch).
+                Assert.ThrowsException<InvalidDataException>(() =>
+                    LibraryCache.LoadCache(tempPath, "peakless-hash", false, null, out _));
+                Assert.ThrowsException<InvalidDataException>(() =>
+                    LibraryCache.LoadCache(tempPath, "peakless-hash", true, null, out _));
+            }
+            finally
+            {
+                if (File.Exists(tempPath))
+                    File.Delete(tempPath);
+            }
+        }
+
+        [TestMethod]
         public void TestLibraryCacheIdentityHash()
         {
             // The .libcache stamps the source library's identity hash into its

--- a/pwiz_tools/Osprey/Osprey.Test/IOTest.cs
+++ b/pwiz_tools/Osprey/Osprey.Test/IOTest.cs
@@ -1072,6 +1072,76 @@ namespace pwiz.Osprey.Test
         }
 
         [TestMethod]
+        public void TestLibraryCacheOmitFragments()
+        {
+            // A FirstPassFDR / StopAfterStage5 worker loads the library lean: the
+            // six identity scalars per entry are kept, but the fragment peaks
+            // (~3.2 GB at SEA-AD scale) are read past and discarded. The skip must
+            // land the reader on the same following bytes as a full read, so the
+            // scalars, sequence, RT, modifications, protein IDs and gene names all
+            // stay byte-identical -- only Fragments is emptied. MakeTestEntry's
+            // custom-neutral-loss fragment exercises the variable-length skip.
+            var entries = new List<LibraryEntry>
+            {
+                MakeTestEntry(0),
+                MakeTestEntry(1)
+            };
+
+            string tempPath = Path.Combine(Path.GetTempPath(),
+                "osprey_test_omit_" + Guid.NewGuid().ToString("N") + ".libcache");
+
+            try
+            {
+                LibraryCache.SaveCache(tempPath, entries, "omit-hash");
+
+                // Control: a normal (full) load still carries every fragment.
+                var full = LibraryCache.LoadCache(tempPath, "omit-hash", false, null,
+                    out LibraryCache.LibraryCacheStatus fullStatus);
+                Assert.AreEqual(LibraryCache.LibraryCacheStatus.Loaded, fullStatus);
+                Assert.IsNotNull(full);
+                Assert.AreEqual(3, full[0].Fragments.Count);
+
+                // Lean: same entry count, every non-fragment member preserved,
+                // Fragments emptied.
+                var lean = LibraryCache.LoadCache(tempPath, "omit-hash", true, null,
+                    out LibraryCache.LibraryCacheStatus leanStatus);
+                Assert.AreEqual(LibraryCache.LibraryCacheStatus.Loaded, leanStatus);
+                Assert.IsNotNull(lean);
+                Assert.AreEqual(entries.Count, lean.Count);
+
+                for (int i = 0; i < entries.Count; i++)
+                {
+                    var orig = entries[i];
+                    var copy = lean[i];
+
+                    // The six scalars the FDR stages read must be intact...
+                    Assert.AreEqual(orig.Id, copy.Id);
+                    Assert.AreEqual(orig.ModifiedSequence, copy.ModifiedSequence);
+                    Assert.AreEqual(orig.Charge, copy.Charge);
+                    Assert.AreEqual(orig.PrecursorMz, copy.PrecursorMz, 1e-10);
+                    Assert.AreEqual(orig.IsDecoy, copy.IsDecoy);
+                    CollectionAssert.AreEqual(orig.ProteinIds.ToArray(), copy.ProteinIds.ToArray());
+
+                    // ...along with the other non-fragment members that follow the
+                    // fragment block on disk (proving the skip advanced correctly)...
+                    Assert.AreEqual(orig.Sequence, copy.Sequence);
+                    Assert.AreEqual(orig.RetentionTime, copy.RetentionTime, 1e-10);
+                    Assert.AreEqual(orig.RtCalibrated, copy.RtCalibrated);
+                    Assert.AreEqual(orig.Modifications.Count, copy.Modifications.Count);
+                    CollectionAssert.AreEqual(orig.GeneNames.ToArray(), copy.GeneNames.ToArray());
+
+                    // ...but the fragment peaks are dropped.
+                    Assert.AreEqual(0, copy.Fragments.Count);
+                }
+            }
+            finally
+            {
+                if (File.Exists(tempPath))
+                    File.Delete(tempPath);
+            }
+        }
+
+        [TestMethod]
         public void TestLibraryCacheIdentityHash()
         {
             // The .libcache stamps the source library's identity hash into its

--- a/pwiz_tools/Osprey/Osprey.Test/ScoringTest.cs
+++ b/pwiz_tools/Osprey/Osprey.Test/ScoringTest.cs
@@ -939,6 +939,100 @@ namespace pwiz.Osprey.Test
         }
 
         /// <summary>
+        /// A StopAfterStage5 worker loads the library lean (fragment peaks
+        /// dropped), so decoy generation runs in omit mode. It must produce the
+        /// SAME set of valid targets and decoys, with byte-identical six identity
+        /// scalars (Id, ModifiedSequence, Charge, PrecursorMz, IsDecoy,
+        /// ProteinIds), as a full-fragment run -- differing only in that the decoy
+        /// fragment lists are empty. This guards the byte-identity of the
+        /// FirstPassFDR target+decoy set, whose members the FDR stages look up by
+        /// the six scalars alone.
+        /// </summary>
+        [TestMethod]
+        public void TestDecoyGenerationOmitFragments()
+        {
+            var config = new OspreyConfig(); // DecoyMethod defaults to Reverse
+
+            var full = MakeDecoyTestTargets();
+            // Simulate the lean load: same entries, but no retained fragments.
+            var lean = MakeDecoyTestTargets();
+            foreach (var t in lean)
+                t.Fragments = Array.Empty<LibraryFragment>();
+
+            var fullDecoys = DecoyGenerator.GenerateAllWithCollisionDetection(
+                full, config, null, false, out var fullValid);
+            var leanDecoys = DecoyGenerator.GenerateAllWithCollisionDetection(
+                lean, config, null, true, out var leanValid);
+
+            // Valid-target membership is sequence / collision driven, never
+            // fragment-content driven, so the two runs keep the same targets.
+            Assert.AreEqual(fullValid.Count, leanValid.Count);
+            for (int i = 0; i < fullValid.Count; i++)
+                Assert.AreEqual(fullValid[i].Id, leanValid[i].Id);
+
+            // Same decoys, six identity scalars byte-identical...
+            Assert.IsTrue(fullDecoys.Count > 0, "Expected at least one decoy");
+            Assert.AreEqual(fullDecoys.Count, leanDecoys.Count);
+            for (int i = 0; i < fullDecoys.Count; i++)
+            {
+                var fd = fullDecoys[i];
+                var ld = leanDecoys[i];
+                Assert.AreEqual(fd.Id, ld.Id);
+                Assert.AreEqual(fd.ModifiedSequence, ld.ModifiedSequence);
+                Assert.AreEqual(fd.Charge, ld.Charge);
+                Assert.AreEqual(fd.PrecursorMz, ld.PrecursorMz, 1e-10);
+                Assert.AreEqual(fd.IsDecoy, ld.IsDecoy);
+                CollectionAssert.AreEqual(fd.ProteinIds.ToArray(), ld.ProteinIds.ToArray());
+
+                // ...but the lean decoy carries no fragments (dead weight for FDR),
+                // while the full-mode decoy still recalculates them.
+                Assert.IsTrue(fd.Fragments.Count > 0, "Full-mode decoy should keep fragments");
+                Assert.AreEqual(0, ld.Fragments.Count, "Lean-mode decoy fragments must be empty");
+            }
+        }
+
+        /// <summary>
+        /// Two trypsin (C-terminal K) targets whose reversals collide with
+        /// neither each other nor the originals, so both yield reversed decoys.
+        /// </summary>
+        private static List<LibraryEntry> MakeDecoyTestTargets()
+        {
+            var t1 = new LibraryEntry(1, "PEPTIDEK", "PEPTIDEK", 2, 471.2567, 25.3);
+            t1.ProteinIds = new[] { "P11111" };
+            t1.Fragments = new[]
+            {
+                new LibraryFragment
+                {
+                    Mz = 147.11, RelativeIntensity = 1.0f,
+                    Annotation = new FragmentAnnotation { IonType = IonType.Y, Ordinal = 1, Charge = 1 }
+                },
+                new LibraryFragment
+                {
+                    Mz = 262.14, RelativeIntensity = 0.5f,
+                    Annotation = new FragmentAnnotation { IonType = IonType.B, Ordinal = 2, Charge = 1 }
+                }
+            };
+
+            var t2 = new LibraryEntry(2, "SAMPLERK", "SAMPLERK", 3, 402.55, 30.1);
+            t2.ProteinIds = new[] { "Q22222" };
+            t2.Fragments = new[]
+            {
+                new LibraryFragment
+                {
+                    Mz = 175.12, RelativeIntensity = 1.0f,
+                    Annotation = new FragmentAnnotation { IonType = IonType.Y, Ordinal = 1, Charge = 1 }
+                },
+                new LibraryFragment
+                {
+                    Mz = 288.20, RelativeIntensity = 0.4f,
+                    Annotation = new FragmentAnnotation { IonType = IonType.B, Ordinal = 2, Charge = 1 }
+                }
+            };
+
+            return new List<LibraryEntry> { t1, t2 };
+        }
+
+        /// <summary>
         /// Session 9 fix: scan boundary must use strict less-than for the
         /// upper bound break to prevent off-by-one. When the last spectrum
         /// RT equals exactly expectedRt + tolerance, it must be included.


### PR DESCRIPTION
## Summary

Bounding Osprey `--task FirstPassFDR` memory in file count (Part B). Four byte-identical commits:

* **Bounded q-value reconstruction** — the projection score pass no longer materializes the five full-length `double[n]` q-value arrays; each row's PEP + experiment + per-run q-values now come from intrinsically-bounded lookups (base_id->q, peptide->q, winner->PEP, per-file run q, clamp floors) shared with the population path. Removes ~14 GB of transient at an 82-file join.
* **Distinct-per-file-key guard** — a fail-fast so the new per-file slicing can't silently diverge from the old fileName-grouping (self-review finding). Byte-neutral.
* **Lean library (`OmitFragments`)** — drops ~3.2 GB of `LibraryEntry.Fragments` for `StopAfterStage5` FDR-only workers (which read only 6 library scalars). Byte-identical by design: dedup stays full, decoy-gen gets an omit mode, fragments dropped only after the count-dependent Stage-1 steps, and the shared `.libcache` is always written full.

## Measurement (82-file SEA-AD Astral, `--task FirstPassFDR`)
* Byte-identical discovery at scale: 1,870,745 precursors pass; compaction 344,615,472 -> 12,405,655 (90,544 base_ids) — identical to baseline.
* Peak commit (`peak_paged`) 76.09 GB vs recorded baseline 86.97 GB (-12.5%; understated — this branch lacks the separable capacity-hint the baseline build had).

## Test plan
- [x] regression.ps1 -Dataset Stellar mode1/2/3 byte-identical (blib 45,064,192 B); mode3 exercises the lean FirstPassFDR path
- [x] Build-Osprey Debug -RunTests -RunInspection (changed files inspection-clean)
- [x] Self-review (fresh-context agent) on the q-value diff — clean
- [ ] regression.ps1 -Dataset All (TeamCity Astral) — NEEDS MANUAL TRIGGER on pull/4434
- [ ] 82-file lean-library re-measure (in progress)

## Not in this PR (proven feasible, next session)
Increment 2 — dropping the resident `FdrProjection[]` (3.36 GB) + `FdrProjectionOutputs` (1.09 GB), the true O(files) core. Code-traced: protein FDR + compaction read only what is already in the per-file 1st-pass sidecar + library, so they can stream and the resident buffers are redundant.

See ai/todos/active/TODO-20260717_osprey_firstpassfdr_memory_peak.md

Co-Authored-By: Claude <noreply@anthropic.com>