### PR TITLE
Bounded Osprey FirstPassFDR resident memory (Increment 2)

### DIFF
--- a/pwiz_tools/Osprey/Osprey.FDR/FdrProjection.cs
+++ b/pwiz_tools/Osprey/Osprey.FDR/FdrProjection.cs
@@ -163,11 +163,64 @@ namespace pwiz.Osprey.FDR
         /// </summary>
         public string[] PeptideById { get; }
 
+        /// <summary>
+        /// Per-file row counts when this set is COUNTS-ONLY (issue #4355 struct-shrink S3,
+        /// Stage B): the 1st-pass streaming score path holds no resident <see cref="FdrProjection"/>
+        /// rows at all -- it streams identity + features straight from parquet -- so the set
+        /// carries only the ordered file names + each file's row count. <c>null</c> on the
+        /// normal / 2nd-pass resident set, where the count is <c>PerFile[f].Value.Count</c>.
+        /// </summary>
+        private readonly int[] _leanRowCounts;
+
         public FdrProjectionSet(
             List<KeyValuePair<string, List<FdrProjection>>> perFile, string[] peptideById)
+            : this(perFile, peptideById, null)
+        {
+        }
+
+        private FdrProjectionSet(
+            List<KeyValuePair<string, List<FdrProjection>>> perFile, string[] peptideById,
+            int[] leanRowCounts)
         {
             PerFile = perFile;
             PeptideById = peptideById;
+            _leanRowCounts = leanRowCounts;
+        }
+
+        /// <summary>
+        /// A COUNTS-ONLY set: the ordered file names + each file's parquet row count, with NO
+        /// resident <see cref="FdrProjection"/> rows and an empty <see cref="PeptideById"/>
+        /// (issue #4355 struct-shrink S3, Stage B). Used by the 1st-pass streaming score path,
+        /// which streams every row (identity + features) straight from parquet, so the O(rows)
+        /// projection buffer is never allocated. Downstream first-pass protein FDR / compaction /
+        /// survivor reload read only the file names (Stage A already moved them off the rows), and
+        /// the score-pass sink reads per-file counts via <see cref="RowCount"/>.
+        /// </summary>
+        public static FdrProjectionSet CountsOnly(IReadOnlyList<string> fileNames, IReadOnlyList<int> rowCounts)
+        {
+            if (fileNames == null) throw new ArgumentNullException(nameof(fileNames));
+            if (rowCounts == null) throw new ArgumentNullException(nameof(rowCounts));
+            if (fileNames.Count != rowCounts.Count)
+                throw new ArgumentException(@"fileNames and rowCounts must be the same length");
+            var perFile = new List<KeyValuePair<string, List<FdrProjection>>>(fileNames.Count);
+            var counts = new int[fileNames.Count];
+            for (int f = 0; f < fileNames.Count; f++)
+            {
+                perFile.Add(new KeyValuePair<string, List<FdrProjection>>(
+                    fileNames[f], new List<FdrProjection>()));
+                counts[f] = rowCounts[f];
+            }
+            return new FdrProjectionSet(perFile, Array.Empty<string>(), counts);
+        }
+
+        /// <summary>
+        /// Row count for a file: the resident row-list count on a normal / 2nd-pass set, or the
+        /// stored per-file count on a <see cref="CountsOnly"/> set (whose row lists are empty).
+        /// The score-pass sink keys its per-file sidecar flush on this, so both shapes work.
+        /// </summary>
+        public int RowCount(int fileIdx)
+        {
+            return _leanRowCounts != null ? _leanRowCounts[fileIdx] : PerFile[fileIdx].Value.Count;
         }
 
         /// <summary>Total projection rows across all files.</summary>
@@ -176,6 +229,12 @@ namespace pwiz.Osprey.FDR
             get
             {
                 int n = 0;
+                if (_leanRowCounts != null)
+                {
+                    foreach (int c in _leanRowCounts)
+                        n += c;
+                    return n;
+                }
                 foreach (var kvp in PerFile)
                     n += kvp.Value.Count;
                 return n;

--- a/pwiz_tools/Osprey/Osprey.FDR/FdrProjection.cs
+++ b/pwiz_tools/Osprey/Osprey.FDR/FdrProjection.cs
@@ -34,12 +34,12 @@ namespace pwiz.Osprey.FDR
     /// (b), FdrProjection struct-shrink S0 / increment C1). The six per-row q-value
     /// OUTPUTS the score pass produces no longer live on the struct: the write-back
     /// hands each row's values to a per-pass <see cref="IFdrOutputSink"/> as an
-    /// <see cref="FdrQValues"/> value (the 2nd pass streams them straight to the
-    /// sidecar; the 1st pass keeps only {RunPeptideQ, RunProteinQ} resident in a
-    /// parallel <see cref="FdrProjectionOutputs"/> array and streams the other four to
-    /// the phase-1 partial sidecar -- issue #4355 struct-shrink S1). Dropping the 48 B
-    /// of q-values takes the resident 2nd-pass peak buffer from 80 -> 32 B, and the
-    /// 1st-pass peak buffer from 80 -> 48 B. Replaces the full <see cref="FdrEntry"/> stub buffer that was
+    /// <see cref="FdrQValues"/> value that both passes stream straight to the per-file
+    /// <c>.fdr_scores.bin</c> sidecar -- never resident (issue #4355 struct-shrink S2;
+    /// S1 kept a 16 B/row 1st-pass {RunPeptideQ, RunProteinQ} array, which first-pass
+    /// protein FDR + compaction now re-read off the sidecar instead). Dropping the
+    /// q-value outputs takes the resident peak buffer from 80 B to this 32 B on both
+    /// passes. Replaces the full <see cref="FdrEntry"/> stub buffer that was
     /// held resident across first-pass Percolator + protein FDR + the 1st-pass sidecar
     /// write + compaction; full <see cref="FdrEntry"/> survivors are reloaded from
     /// parquet + the sidecar after compaction (see <c>FirstJoinTask</c>). Held in a

--- a/pwiz_tools/Osprey/Osprey.FDR/FdrProjection.cs
+++ b/pwiz_tools/Osprey/Osprey.FDR/FdrProjection.cs
@@ -223,6 +223,15 @@ namespace pwiz.Osprey.FDR
             return _leanRowCounts != null ? _leanRowCounts[fileIdx] : PerFile[fileIdx].Value.Count;
         }
 
+        /// <summary>
+        /// True when this set carries only per-file row counts (via <see cref="CountsOnly"/>) with
+        /// no resident <see cref="FdrProjection"/> rows -- the 1st-pass streaming score path builds
+        /// it so the score pass can stream every row from parquet (issue #4355 struct-shrink S3,
+        /// Stage B). The Tasks layer branches on this to pick the streaming score path over the
+        /// resident one.
+        /// </summary>
+        public bool IsCountsOnly => _leanRowCounts != null;
+
         /// <summary>Total projection rows across all files.</summary>
         public int TotalRows
         {
@@ -380,13 +389,28 @@ namespace pwiz.Osprey.FDR
         /// </summary>
         public sealed class Builder
         {
+            private readonly bool _countsOnly;
             private readonly Dictionary<string, int> _insertionIdByPeptide =
                 new Dictionary<string, int>(StringComparer.Ordinal);
             private readonly List<string> _distinctByInsertion = new List<string>();
             private readonly List<KeyValuePair<string, List<FdrProjection>>> _perFile =
                 new List<KeyValuePair<string, List<FdrProjection>>>();
+            private readonly List<string> _countsOnlyFileNames = new List<string>();
+            private readonly List<int> _countsOnlyCounts = new List<int>();
             private List<FdrProjection> _rows;
+            private int _curFileCount;
             private ushort _fileIdx;
+
+            /// <summary>
+            /// <paramref name="countsOnly"/> builds a <see cref="CountsOnly"/> set -- per-file row
+            /// counts, no resident rows and no interned peptide table -- for the 1st-pass streaming
+            /// score path, which re-reads every row's identity + features from parquet (issue #4355
+            /// struct-shrink S3, Stage B). The default full-row build feeds the resident score path.
+            /// </summary>
+            public Builder(bool countsOnly = false)
+            {
+                _countsOnly = countsOnly;
+            }
 
             /// <summary>
             /// Open a file's row list. Files must be added in the same order the join
@@ -394,6 +418,12 @@ namespace pwiz.Osprey.FDR
             /// </summary>
             public void BeginFile(string fileName, int capacityHint = 0)
             {
+                if (_countsOnly)
+                {
+                    _countsOnlyFileNames.Add(fileName);
+                    _curFileCount = 0;
+                    return;
+                }
                 _rows = capacityHint > 0
                     ? new List<FdrProjection>(capacityHint)
                     : new List<FdrProjection>();
@@ -404,11 +434,17 @@ namespace pwiz.Osprey.FDR
             /// Append one parquet row of the open file. <see cref="FdrProjection.ParquetIndex"/>
             /// is the running per-file row ordinal, matching
             /// <c>LoadFdrStubsFromParquet</c>'s <c>ParquetIndex = stubs.Count</c>.
-            /// <see cref="FdrProjection.Score"/> stays 0 -- the FDR pass writes it back.
+            /// <see cref="FdrProjection.Score"/> stays 0 -- the FDR pass writes it back. In
+            /// counts-only mode nothing is materialized -- only the running row count advances.
             /// </summary>
             public void AddRow(uint entryId, byte charge, bool isDecoy, double coelutionSum,
                 string modifiedSequence)
             {
+                if (_countsOnly)
+                {
+                    _curFileCount++;
+                    return;
+                }
                 string modseq = modifiedSequence ?? string.Empty;
                 if (!_insertionIdByPeptide.TryGetValue(modseq, out int insertionId))
                 {
@@ -424,6 +460,11 @@ namespace pwiz.Osprey.FDR
             /// <summary>Close the open file and advance <see cref="FdrProjection.FileIdx"/>.</summary>
             public void EndFile()
             {
+                if (_countsOnly)
+                {
+                    _countsOnlyCounts.Add(_curFileCount);
+                    return;
+                }
                 _rows = null;
                 _fileIdx++;
             }
@@ -431,10 +472,14 @@ namespace pwiz.Osprey.FDR
             /// <summary>
             /// Sort the distinct peptides Ordinal, remap every row's insertion-order
             /// <see cref="FdrProjection.PeptideId"/> to its ordinal rank, and return the set.
-            /// The remap table is one int per distinct peptide (~9 MB at 2.3M peptides).
+            /// The remap table is one int per distinct peptide (~9 MB at 2.3M peptides). In
+            /// counts-only mode returns a <see cref="CountsOnly"/> set (file names + counts).
             /// </summary>
             public FdrProjectionSet Build()
             {
+                if (_countsOnly)
+                    return CountsOnly(_countsOnlyFileNames, _countsOnlyCounts);
+
                 var peptideById = _distinctByInsertion.ToArray();
                 Array.Sort(peptideById, StringComparer.Ordinal); // Array.Sort OK: _distinctByInsertion is de-duplicated (grow-only via _insertionIdByPeptide), no two strings are equal, so the Ordinal comparer never ties -- the same argument BuildFromEntries makes for its List.Sort.
 

--- a/pwiz_tools/Osprey/Osprey.FDR/FdrProjectionOutput.cs
+++ b/pwiz_tools/Osprey/Osprey.FDR/FdrProjectionOutput.cs
@@ -116,15 +116,19 @@ namespace pwiz.Osprey.FDR
     public interface IFdrOutputSink
     {
         /// <summary>
-        /// Accept one scored projection row. <paramref name="fileIdx"/> /
-        /// <paramref name="rowIdx"/> locate the lean struct row within its per-file
-        /// list; <paramref name="entryId"/> / <paramref name="isDecoy"/> identify it;
-        /// <paramref name="score"/> + <paramref name="q"/> are the freshly computed
-        /// outputs. Called once per row, in nested (file, row) order == the flat
-        /// score-pass index order.
+        /// Accept one scored row. <paramref name="fileIdx"/> / <paramref name="rowIdx"/>
+        /// locate the row within its per-file list; <paramref name="entryId"/> /
+        /// <paramref name="isDecoy"/> / <paramref name="charge"/> / <paramref name="peptide"/>
+        /// identify it; <paramref name="score"/> + <paramref name="q"/> are the freshly
+        /// computed outputs. Called once per row, in nested (file, row) order == the flat
+        /// score-pass index order. <paramref name="charge"/> / <paramref name="peptide"/> are
+        /// passed in (not read off a resident row) so the sink's [COUNT] tally + streaming
+        /// --model-diagnostics accumulator work whether the caller holds a resident projection
+        /// (2nd pass) or streams the rows straight from parquet with no resident buffer at all
+        /// (1st-pass streaming, issue #4355 struct-shrink S3 Stage B).
         /// </summary>
         void Accept(int fileIdx, int rowIdx, uint entryId, bool isDecoy,
-            double score, in FdrQValues q);
+            byte charge, string peptide, double score, in FdrQValues q);
 
         /// <summary>
         /// Finalize the pass: emit the tail <c>[COUNT]</c> lines (per-file pass counts,

--- a/pwiz_tools/Osprey/Osprey.FDR/FdrProjectionOutput.cs
+++ b/pwiz_tools/Osprey/Osprey.FDR/FdrProjectionOutput.cs
@@ -104,11 +104,11 @@ namespace pwiz.Osprey.FDR
     /// (<c>PercolatorFdr.ScoreProjectionAndComputeFdrInPlace</c>) instead calls
     /// <see cref="Accept"/> per row, in the existing nested (file, row) order, handing
     /// each row's freshly computed <see cref="FdrQValues"/> + <see cref="FdrProjection.Score"/>
-    /// to a caller-supplied sink. The 2nd pass streams them straight to the
-    /// <c>.2nd-pass.fdr_scores.bin</c> sidecar (never stored -> 32 B resident); the 1st
-    /// pass keeps only {RunPeptideQ, RunProteinQ} in a parallel
-    /// <see cref="FdrProjectionOutputs"/> array (48 B resident) and streams the other
-    /// four q-values to a phase-1 partial sidecar (issue #4355 struct-shrink S1). The
+    /// to a caller-supplied sink. Both passes stream every row straight to the per-file
+    /// <c>.fdr_scores.bin</c> sidecar (never stored -> 32 B resident): the 2nd pass writes
+    /// the final record, the 1st pass writes a phase-1 record whose <c>run_protein_qvalue</c>
+    /// first-pass protein FDR patches from disk afterward (issue #4355 struct-shrink S2; S1
+    /// still kept a 16 B/row 1st-pass {RunPeptideQ, RunProteinQ} array, since removed). The
     /// sink also OWNS the tail <c>[COUNT]</c> tally (<see cref="Finish"/>),
     /// because it is the only place the q-values are live on BOTH passes once they are
     /// off the struct.
@@ -134,74 +134,4 @@ namespace pwiz.Osprey.FDR
         void Finish(Action<string> logInfo);
     }
 
-    /// <summary>
-    /// The 1st-pass parallel RESIDENT q-value array (issue #4355 step (b), FdrProjection
-    /// struct-shrink S1): holds ONLY the two q-values first-pass protein FDR and
-    /// compaction still need resident across ALL rows -- <c>RunPeptideQvalue</c> and
-    /// <c>RunProteinQvalue</c> (a 2 x f64 = 16 B/row struct array, taking the 1st-pass
-    /// resident projection from 80 B to 48 B). Indexed by (fileIdx, rowIdx) against
-    /// <see cref="FdrProjectionSet.PerFile"/>. The OTHER FOUR q-values the score pass
-    /// produces (<c>RunPrecursorQvalue</c>, <c>ExperimentPrecursorQvalue</c>,
-    /// <c>ExperimentPeptideQvalue</c>, <c>Pep</c>) are NO LONGER resident: the 1st-pass
-    /// storing sink streams them straight to the phase-1 partial
-    /// <c>.1st-pass.fdr_scores.bin</c> during the score pass and never keeps them (S0
-    /// kept all six here; S1 drops four to disk). <c>RunPeptideQvalue</c> is stored during
-    /// the score pass via <see cref="SetRunPeptideQvalue"/>; <c>RunProteinQvalue</c> is
-    /// filled by first-pass protein FDR via <see cref="SetRunProteinQvalue"/> (until then
-    /// it holds the 1.0 default) and is applied to the sidecar by the phase-2
-    /// <c>[52..60]</c> patch. Kept as a jagged struct array (not a <c>List</c>) so
-    /// <c>RunProteinQvalue</c> can be written in place.
-    /// </summary>
-    public sealed class FdrProjectionOutputs
-    {
-        // [fileIdx][rowIdx]; a mutable 2-field struct so RunProteinQvalue can be set in
-        // place after the score pass, matching the FdrEntry oracle's post-score
-        // protein-FDR write onto the resident stub.
-        private readonly QValues[][] _rows;
-
-        public FdrProjectionOutputs(FdrProjectionSet projections)
-        {
-            if (projections == null) throw new ArgumentNullException(nameof(projections));
-            var perFile = projections.PerFile;
-            _rows = new QValues[perFile.Count][];
-            for (int f = 0; f < perFile.Count; f++)
-                _rows[f] = new QValues[perFile[f].Value.Count];
-        }
-
-        /// <summary>
-        /// Store a row's run peptide q-value (the protein-FDR detected gate, the
-        /// best-peptide reduction, and compaction all need it resident across the whole
-        /// pass) and reset its <c>RunProteinQvalue</c> to the 1.0 default (mirrors the
-        /// fresh <see cref="FdrEntry"/>'s pre-protein-FDR value); first-pass protein FDR
-        /// overwrites it via <see cref="SetRunProteinQvalue"/>. The other four q-values
-        /// are streamed to the phase-1 sidecar by the sink, not stored here.
-        /// </summary>
-        public void SetRunPeptideQvalue(int fileIdx, int rowIdx, double runPeptideQvalue)
-        {
-            var file = _rows[fileIdx];
-            file[rowIdx].RunPeptideQvalue = runPeptideQvalue;
-            file[rowIdx].RunProteinQvalue = 1.0;
-        }
-
-        /// <summary>Run peptide q-value (protein-FDR detected gate + compaction + best-peptide reduction).</summary>
-        public double RunPeptideQvalue(int fileIdx, int rowIdx) => _rows[fileIdx][rowIdx].RunPeptideQvalue;
-
-        /// <summary>Run protein q-value (written by first-pass protein FDR; read by compaction + the phase-2 sidecar patch).</summary>
-        public double RunProteinQvalue(int fileIdx, int rowIdx) => _rows[fileIdx][rowIdx].RunProteinQvalue;
-
-        /// <summary>Set the first-pass protein-FDR run protein q-value for a row.</summary>
-        public void SetRunProteinQvalue(int fileIdx, int rowIdx, double runProteinQvalue) =>
-            _rows[fileIdx][rowIdx].RunProteinQvalue = runProteinQvalue;
-
-        /// <summary>
-        /// The two per-row q-values the 1st pass keeps resident (issue #4355 struct-shrink
-        /// S1). A mutable struct so <c>RunProteinQvalue</c> can be filled in place after
-        /// protein FDR without re-allocating.
-        /// </summary>
-        public struct QValues
-        {
-            public double RunPeptideQvalue;
-            public double RunProteinQvalue;
-        }
-    }
 }

--- a/pwiz_tools/Osprey/Osprey.FDR/PercolatorEngine.cs
+++ b/pwiz_tools/Osprey/Osprey.FDR/PercolatorEngine.cs
@@ -293,6 +293,43 @@ namespace pwiz.Osprey.FDR
         }
 
         /// <summary>
+        /// Projection-free 1st-pass Percolator (issue #4355 struct-shrink S3, Stage B): the
+        /// FLAT-memory entry point that holds NO resident row buffer. The counterpart of the
+        /// <see cref="RunPercolatorFdr(FdrProjectionSet,OspreyConfig,OspreyFeatureInfo[],System.Action{string},IFdrOutputSink,PercolatorDiagnosticsConfig,string,System.Func{string,System.Collections.Generic.IReadOnlyList{double[]}},System.Action{FeatureContributions})"/>
+        /// projection overload for the lean 1st-pass case, it builds the same parity-locked
+        /// <see cref="PercolatorConfig"/> and delegates to
+        /// <see cref="PercolatorFdr.RunStreamingFirstPass"/>, which streams every row's identity +
+        /// features from the caller-supplied row source instead of a resident
+        /// <see cref="FdrProjectionSet"/>. The caller (Tasks layer) wires
+        /// <paramref name="streamFileRows"/> to the per-file parquet scalar reader and
+        /// <paramref name="loadFileFeatures"/> to the per-file feature loader, keeping this project
+        /// free of an Osprey.IO dependency. Returns <c>true</c> on a diagnostic-only train abort.
+        /// </summary>
+        public static bool RunFirstPassStreaming(
+            IReadOnlyList<string> fileNames,
+            Action<string, Action<uint, byte, bool, double, string>> streamFileRows,
+            Func<string, IReadOnlyList<double[]>> loadFileFeatures,
+            OspreyConfig config,
+            OspreyFeatureInfo[] featureInfos,
+            Action<string> logInfo,
+            IFdrOutputSink sink,
+            PercolatorDiagnosticsConfig diagnostics = null,
+            string passLabel = @"First-pass",
+            Action<FeatureContributions> captureContributions = null)
+        {
+            if (sink == null)
+                throw new ArgumentNullException(nameof(sink));
+            if (loadFileFeatures == null)
+                throw new InvalidOperationException(
+                    @"RunFirstPassStreaming always streams features per file; a per-file feature " +
+                    @"loader is required.");
+            var percConfig = BuildProjectionPercolatorConfig(config, featureInfos, diagnostics);
+            return PercolatorFdr.RunStreamingFirstPass(
+                fileNames, streamFileRows, loadFileFeatures, percConfig, logInfo, passLabel, sink,
+                captureContributions);
+        }
+
+        /// <summary>
         /// Build the first-pass <see cref="PercolatorConfig"/> shared by the legacy
         /// <see cref="FdrEntry"/> path and the projection path. Centralized (issue
         /// #4355 step (b) increment iii) so every SVM knob is IDENTICAL whether the

--- a/pwiz_tools/Osprey/Osprey.FDR/PercolatorFdr.cs
+++ b/pwiz_tools/Osprey/Osprey.FDR/PercolatorFdr.cs
@@ -1010,7 +1010,7 @@ namespace pwiz.Osprey.FDR
         /// cross-impl byte parity the winners must be reordered to the same base_id-sorted
         /// order Rust's compute_fdr_from_stubs uses before the fit.
         /// </summary>
-        private static Dictionary<int, double> ComputePepWinnerMap(
+        internal static Dictionary<int, double> ComputePepWinnerMap(
             double[] finalScores, bool[] labels, uint[] entryIds)
         {
             int n = finalScores.Length;
@@ -1756,7 +1756,7 @@ namespace pwiz.Osprey.FDR
             }
 
             CompeteFromDicts(targets, decoys,
-                out winnerIndices, out winnerScores, out winnerIsDecoy);
+                out winnerIndices, out winnerScores, out winnerIsDecoy, out _);
         }
 
         /// <summary>
@@ -1768,14 +1768,18 @@ namespace pwiz.Osprey.FDR
         /// S3, which builds the identical maps by pushing rows in flat (file,row) order) share the
         /// EXACT compete + sort, and so cannot drift. The stored index is the winning row's flat
         /// index / streaming ordinal; both label the same row because the streaming pass visits
-        /// rows in the same order the flat arrays were built.
+        /// rows in the same order the flat arrays were built. <paramref name="winnerBaseIds"/>
+        /// carries each winner's base_id (the map key) so the streaming path can key the
+        /// experiment-precursor / PEP maps WITHOUT a resident <c>entryIds[]</c> array (the flat
+        /// path recovers the same base_id via <c>entryIds[wi[rank]] &amp; BASE_ID_MASK</c>).
         /// </summary>
         internal static void CompeteFromDicts(
             Dictionary<uint, KeyValuePair<int, double>> targets,
             Dictionary<uint, KeyValuePair<int, double>> decoys,
             out int[] winnerIndices,
             out double[] winnerScores,
-            out bool[] winnerIsDecoy)
+            out bool[] winnerIsDecoy,
+            out uint[] winnerBaseIds)
         {
             // Compete pairs: higher score wins, ties go to decoy
             var winners = new List<Tuple<int, double, bool, uint>>(targets.Count);
@@ -1819,11 +1823,13 @@ namespace pwiz.Osprey.FDR
             winnerIndices = new int[winners.Count];
             winnerScores = new double[winners.Count];
             winnerIsDecoy = new bool[winners.Count];
+            winnerBaseIds = new uint[winners.Count];
             for (int i = 0; i < winners.Count; i++)
             {
                 winnerIndices[i] = winners[i].Item1;
                 winnerScores[i] = winners[i].Item2;
                 winnerIsDecoy[i] = winners[i].Item3;
+                winnerBaseIds[i] = winners[i].Item4;
             }
         }
 
@@ -2634,7 +2640,7 @@ namespace pwiz.Osprey.FDR
         /// <see cref="ComputeExperimentPrecursorQvalues"/> wrapper simply expands this map,
         /// so the two share the SAME competition + conservative-q math and cannot drift.
         /// </summary>
-        private static Dictionary<uint, double> ComputeExperimentPrecursorQMap(
+        internal static Dictionary<uint, double> ComputeExperimentPrecursorQMap(
             double[] scores, bool[] labels, uint[] entryIds)
         {
             int n = scores.Length;
@@ -2686,7 +2692,7 @@ namespace pwiz.Osprey.FDR
         /// expands this map, so both share the SAME best-per-peptide + competition +
         /// conservative-q math and cannot drift.
         /// </summary>
-        private static Dictionary<string, double> ComputeExperimentPeptideQMap(
+        internal static Dictionary<string, double> ComputeExperimentPeptideQMap(
             double[] scores, bool[] labels, uint[] entryIds, string[] peptides)
         {
             int n = scores.Length;
@@ -2739,6 +2745,163 @@ namespace pwiz.Osprey.FDR
                 qvalues[i] = peptideQvalue.TryGetValue(peptides[i], out qv) ? qv : 1.0;
             }
             return qvalues;
+        }
+
+        /// <summary>
+        /// Streaming builder for the three GLOBAL bounded first-pass q maps (issue #4355
+        /// struct-shrink S3, Stage B): the experiment-precursor <c>base_id -&gt; q</c> map, the
+        /// experiment-peptide <c>peptide -&gt; q</c> map, and the PEP <c>winner-ordinal -&gt; pep</c>
+        /// map -- built by pushing each scored row via <see cref="Add"/> in flat (file,row) order
+        /// instead of reading the resident <c>finalScores/labels/entryIds/peptides[n]</c> arrays.
+        /// Bounded: it retains only per-base_id and per-peptide bests (O(distinct)), never an O(n)
+        /// buffer. Each Build* reuses the SAME <see cref="CompeteFromDicts"/> +
+        /// <see cref="ComputeConservativeQvalues"/> (+ <c>PepEstimator</c>) finish the flat
+        /// <see cref="ComputeExperimentPrecursorQMap"/> / <see cref="ComputeExperimentPeptideQMap"/>
+        /// / <see cref="ComputePepWinnerMap"/> run, so a population fed in the same order yields
+        /// byte-identical maps (verified by <c>FdrTest.TestStreamingFirstPassQMatchesFlat</c>). The
+        /// PEP map is keyed by the streaming ordinal <c>g</c>, which equals the flat winner index
+        /// because both visit rows in the same nested (file,row) order.
+        /// </summary>
+        internal sealed class StreamingFirstPassQ
+        {
+            // Global experiment-precursor / PEP competition: base_id -> best (g, score), strict
+            // '>' first-seen, split target/decoy -- the identical maps CompeteAll builds.
+            private readonly Dictionary<uint, KeyValuePair<int, double>> _precTargets =
+                new Dictionary<uint, KeyValuePair<int, double>>();
+            private readonly Dictionary<uint, KeyValuePair<int, double>> _precDecoys =
+                new Dictionary<uint, KeyValuePair<int, double>>();
+            // Experiment-peptide: peptide -> best row, mirroring BestPrecursorPerPeptide.
+            private readonly Dictionary<string, PeptideBest> _peptBest =
+                new Dictionary<string, PeptideBest>();
+
+            /// <summary>Fold one scored row (in flat (file,row) order) into the bounded bests.</summary>
+            public void Add(int g, double score, uint entryId, bool isDecoy, string peptide)
+            {
+                uint baseId = entryId & BASE_ID_MASK;
+                var dict = isDecoy ? _precDecoys : _precTargets;
+                KeyValuePair<int, double> existing;
+                if (dict.TryGetValue(baseId, out existing))
+                {
+                    if (score > existing.Value)
+                        dict[baseId] = new KeyValuePair<int, double>(g, score);
+                }
+                else
+                {
+                    dict[baseId] = new KeyValuePair<int, double>(g, score);
+                }
+
+                PeptideBest pb;
+                if (_peptBest.TryGetValue(peptide, out pb))
+                {
+                    if (score > pb.Score)
+                        _peptBest[peptide] = new PeptideBest(g, score, isDecoy, entryId, peptide);
+                }
+                else
+                {
+                    _peptBest[peptide] = new PeptideBest(g, score, isDecoy, entryId, peptide);
+                }
+            }
+
+            /// <summary>
+            /// Experiment-precursor <c>base_id -&gt; q</c>: compete the global base_id bests,
+            /// conservative-q, keyed by each winner's base_id -- byte-identical to
+            /// <see cref="ComputeExperimentPrecursorQMap"/>.
+            /// </summary>
+            public Dictionary<uint, double> BuildExperimentPrecursorQMap()
+            {
+                CompeteFromDicts(_precTargets, _precDecoys,
+                    out _, out double[] ws, out bool[] wd, out uint[] wb);
+                var q = new double[ws.Length];
+                ComputeConservativeQvalues(ws, wd, q);
+                var map = new Dictionary<uint, double>(wb.Length);
+                for (int rank = 0; rank < wb.Length; rank++)
+                    map[wb[rank]] = q[rank];
+                return map;
+            }
+
+            /// <summary>
+            /// Experiment-peptide <c>peptide -&gt; q</c>: materialize the best-per-peptide set
+            /// sorted by ordinal (matching <see cref="BestPrecursorPerPeptide"/>'s sort), compete
+            /// by base_id, conservative-q, keyed by the winner's peptide -- byte-identical to
+            /// <see cref="ComputeExperimentPeptideQMap"/>.
+            /// </summary>
+            public Dictionary<string, double> BuildExperimentPeptideQMap()
+            {
+                var best = new List<PeptideBest>(_peptBest.Values);
+                best.Sort((a, b) => a.G.CompareTo(b.G)); // Array.Sort OK: G is the unique streaming ordinal of each peptide's best row, so the comparator never ties -- reproduces BestPrecursorPerPeptide's result.Sort() on ascending global index
+                var targets = new Dictionary<uint, KeyValuePair<int, double>>();
+                var decoys = new Dictionary<uint, KeyValuePair<int, double>>();
+                for (int i = 0; i < best.Count; i++)
+                {
+                    uint baseId = best[i].EntryId & BASE_ID_MASK;
+                    var dict = best[i].IsDecoy ? decoys : targets;
+                    KeyValuePair<int, double> existing;
+                    if (dict.TryGetValue(baseId, out existing))
+                    {
+                        if (best[i].Score > existing.Value)
+                            dict[baseId] = new KeyValuePair<int, double>(i, best[i].Score);
+                    }
+                    else
+                    {
+                        dict[baseId] = new KeyValuePair<int, double>(i, best[i].Score);
+                    }
+                }
+                CompeteFromDicts(targets, decoys,
+                    out int[] wi, out double[] ws, out bool[] wd, out _);
+                var q = new double[ws.Length];
+                ComputeConservativeQvalues(ws, wd, q);
+                var map = new Dictionary<string, double>(wi.Length);
+                for (int rank = 0; rank < wi.Length; rank++)
+                    map[best[wi[rank]].Peptide] = q[rank];
+                return map;
+            }
+
+            /// <summary>
+            /// PEP <c>winner-ordinal -&gt; pep</c>: compete the global base_id bests, fit the PEP
+            /// estimator on winners sorted base_id-ascending (the non-associative KDE sum is
+            /// order-sensitive), then posterior-error each winner -- byte-identical to
+            /// <see cref="ComputePepWinnerMap"/>.
+            /// </summary>
+            public Dictionary<int, double> BuildPepWinnerMap()
+            {
+                CompeteFromDicts(_precTargets, _precDecoys,
+                    out int[] wi, out double[] ws, out bool[] wd, out uint[] wb);
+                int nWinners = wi.Length;
+                var pepOrder = new int[nWinners];
+                for (int k = 0; k < nWinners; k++)
+                    pepOrder[k] = k;
+                Array.Sort(pepOrder, (a, b) => wb[a].CompareTo(wb[b])); // Array.Sort OK: one winner per base_id, so wb has no ties -- matches ComputePepWinnerMap
+                var pepScores = new double[nWinners];
+                var pepIsDecoy = new bool[nWinners];
+                for (int k = 0; k < nWinners; k++)
+                {
+                    pepScores[k] = ws[pepOrder[k]];
+                    pepIsDecoy[k] = wd[pepOrder[k]];
+                }
+                var pepEstimator = PepEstimator.FitDefault(pepScores, pepIsDecoy);
+                var map = new Dictionary<int, double>(nWinners);
+                for (int k = 0; k < nWinners; k++)
+                    map[wi[k]] = pepEstimator.PosteriorError(ws[k]);
+                return map;
+            }
+
+            private readonly struct PeptideBest
+            {
+                public readonly int G;
+                public readonly double Score;
+                public readonly bool IsDecoy;
+                public readonly uint EntryId;
+                public readonly string Peptide;
+
+                public PeptideBest(int g, double score, bool isDecoy, uint entryId, string peptide)
+                {
+                    G = g;
+                    Score = score;
+                    IsDecoy = isDecoy;
+                    EntryId = entryId;
+                    Peptide = peptide;
+                }
+            }
         }
 
         // A console progress reporter for the large first-pass q-value / competition passes,

--- a/pwiz_tools/Osprey/Osprey.FDR/PercolatorFdr.cs
+++ b/pwiz_tools/Osprey/Osprey.FDR/PercolatorFdr.cs
@@ -1377,11 +1377,446 @@ namespace pwiz.Osprey.FDR
 
                     projRows[r] = projRows[r].WithScore(finalScores[g]);
                     sink.Accept(fileIdx, r, projRows[r].EntryId, projRows[r].IsDecoy,
-                        finalScores[g],
+                        projRows[r].Charge, pept, finalScores[g],
                         new FdrQValues(rp, rpe, ep, epe, pep));
                 }
                 wgi += count;
                 fileIdx++;
+            }
+        }
+
+        /// <summary>
+        /// One best-per-precursor winner captured while streaming identity in flat (file,row)
+        /// order (issue #4355 struct-shrink S3, Stage B): enough to reproduce
+        /// <see cref="SelectBestPerPrecursor"/>'s output AND build the training-subset
+        /// <see cref="PercolatorEntry"/> without a resident projection. <see cref="G"/> is the
+        /// row's global (file,row) ordinal -- sorting the captured winners by it ascending
+        /// reproduces <c>SelectBestPerPrecursor</c>'s <c>Array.Sort(globalIndex)</c> exactly.
+        /// </summary>
+        private readonly struct FirstPassDedupRow
+        {
+            public readonly int G;
+            public readonly string FileName;
+            public readonly uint EntryId;
+            public readonly byte Charge;
+            public readonly bool IsDecoy;
+            public readonly uint ParquetIndex;
+            public readonly double CoelutionSum;
+            public readonly string Peptide;
+
+            public FirstPassDedupRow(int g, string fileName, uint entryId, byte charge, bool isDecoy,
+                uint parquetIndex, double coelutionSum, string peptide)
+            {
+                G = g;
+                FileName = fileName;
+                EntryId = entryId;
+                Charge = charge;
+                IsDecoy = isDecoy;
+                ParquetIndex = parquetIndex;
+                CoelutionSum = coelutionSum;
+                Peptide = peptide;
+            }
+        }
+
+        /// <summary>
+        /// 1st-pass-ONLY streaming Percolator that holds NO resident row buffer at all (issue
+        /// #4355 struct-shrink S3, Stage B -- the FLAT-memory win): the memory-collapsing fork of
+        /// <see cref="PercolatorEngine.RunStreamingIntoProjection"/> +
+        /// <see cref="ScoreProjectionAndComputeFdrInPlace"/>. Where those hold the resident
+        /// <see cref="FdrProjection"/>[] + the flat <c>labels/entryIds/peptides/finalScores[n]</c>
+        /// arrays (O(pre-compaction rows), the 82->500 file blocker), this streams every row's
+        /// identity + features straight from parquet THREE times -- once to select the training
+        /// subset, once to score + build the bounded q-value maps + clamp floors, once to score +
+        /// emit -- recomputing the SVM score per row instead of parking an O(n) score array. Only
+        /// the SUBSET (&lt;= MaxTrainSize) and the intrinsically-bounded lookups (O(base_ids) /
+        /// O(peptides), via <see cref="StreamingFirstPassQ"/> + per-file run-q) are ever resident,
+        /// so the peak is FLAT in file count.
+        ///
+        /// Byte-identical to the resident projection path on the same rows in the same (file,row)
+        /// order (verified by <c>FdrTest.TestStreamingFirstPassMatchesProjection</c>): the
+        /// training-subset selection reproduces <see cref="SelectBestPerPrecursor"/> +
+        /// <see cref="BuildTrainingSubset"/> (strict-<c>&gt;</c> first-seen dedup ranked on
+        /// CoelutionSum, ascending-global-ordinal order, identical
+        /// <see cref="SubsampleByPeptideGroup"/>), the SVM training runs the SAME
+        /// <see cref="RunPercolator"/> on the SAME subset, and the score + q-value math reuses the
+        /// SAME primitives (<see cref="StreamingFirstPassQ"/>, <see cref="ComputePerFileRunQvalues"/>,
+        /// <see cref="UpdateExperimentQClampFloor"/>). This is 1st-pass-only: the 2nd pass keeps its
+        /// O(survivors) resident projection (Stage 7/8 needs it) via the unchanged
+        /// <see cref="ScoreProjectionAndComputeFdrInPlace"/>.
+        ///
+        /// The caller supplies the row source as delegates (kept free of an Osprey.IO dependency):
+        /// <paramref name="fileNames"/> in the join's file order; <paramref name="streamFileRows"/>
+        /// invokes its callback once per parquet row of a file in row order (== the resident sort's
+        /// order on the 1st pass, since the parquet is written (entry_id,charge,scan)-sorted);
+        /// <paramref name="loadFileFeatures"/> loads one file's feature vectors, indexed by the
+        /// running parquet row ordinal. Returns <c>true</c> on a diagnostic-only train abort.
+        /// </summary>
+        internal static bool RunStreamingFirstPass(
+            IReadOnlyList<string> fileNames,
+            Action<string, Action<uint, byte, bool, double, string>> streamFileRows,
+            Func<string, IReadOnlyList<double[]>> loadFileFeatures,
+            PercolatorConfig percConfig,
+            Action<string> logInfo,
+            string passLabel,
+            IFdrOutputSink sink,
+            Action<FeatureContributions> captureContributions = null)
+        {
+            if (streamFileRows == null)
+                throw new ArgumentNullException(nameof(streamFileRows));
+            if (loadFileFeatures == null)
+                throw new ArgumentNullException(nameof(loadFileFeatures));
+            if (sink == null)
+                throw new ArgumentNullException(nameof(sink));
+
+            int nFiles = fileNames.Count;
+            int nFeatures = percConfig.FeatureInfos.Length;
+            int maxTrain = percConfig.MaxTrainSize;
+            // One file's raw rows buffered at a time (bounded -- the same one-file resident set the
+            // per-file run-q already needs). The stream callback only appends to the buffer's lists
+            // (reference types, never reassigned), so the running row/global ordinals are advanced
+            // in the plain indexed loops below, not captured-and-mutated inside the closure.
+            var buffer = new RowBuffer();
+
+            // ---- Pass 0: stream identity, build the training subset, train the model ----
+            // Best-per-precursor dedup captured WITH identity, in flat (file,row) order. Strict
+            // '>' on CoelutionSum with first-seen (lowest g) winning ties -- exactly
+            // SelectBestPerPrecursor iterating ascending global index. bestScores == CoelutionSum
+            // (byte-identical to Features[0] on the 1st pass), so no feature load is needed here.
+            var bestTarget = new Dictionary<uint, FirstPassDedupRow>();
+            var bestDecoy = new Dictionary<uint, FirstPassDedupRow>();
+            int g = 0;
+            int nInputTargets = 0, nInputDecoys = 0;
+            for (int f = 0; f < nFiles; f++)
+            {
+                string file = fileNames[f];
+                buffer.Clear();
+                streamFileRows(file, buffer.Add);
+                int count = buffer.Count;
+                for (int r = 0; r < count; r++)
+                {
+                    uint entryId = buffer.EntryIds[r];
+                    bool isDecoy = buffer.IsDecoys[r];
+                    double coelutionSum = buffer.CoelutionSums[r];
+                    uint baseId = entryId & BASE_ID_MASK;
+                    var map = isDecoy ? bestDecoy : bestTarget;
+                    if (map.TryGetValue(baseId, out FirstPassDedupRow existing))
+                    {
+                        if (coelutionSum > existing.CoelutionSum)
+                            map[baseId] = new FirstPassDedupRow(
+                                g, file, entryId, buffer.Charges[r], isDecoy, (uint)r, coelutionSum, buffer.Peptides[r]);
+                    }
+                    else
+                    {
+                        map[baseId] = new FirstPassDedupRow(
+                            g, file, entryId, buffer.Charges[r], isDecoy, (uint)r, coelutionSum, buffer.Peptides[r]);
+                    }
+                    if (isDecoy) nInputDecoys++; else nInputTargets++;
+                    g++;
+                }
+            }
+            int n = g;
+            logInfo(string.Format(
+                @"[PATH] {0} first-pass streaming ingest (RunStreamingFirstPass): {1} rows", passLabel, n));
+            logInfo(string.Format(
+                "[COUNT] {0} Percolator input: {1} entries ({2} targets, {3} decoys, {4} features)",
+                passLabel, n, nInputTargets, nInputDecoys, nFeatures));
+
+            // Dedup rows in ascending global ordinal == SelectBestPerPrecursor's Array.Sort of the
+            // winning global indices (each base_id's best is one unique row, so g never ties).
+            var dedup = new List<FirstPassDedupRow>(bestTarget.Count + bestDecoy.Count);
+            dedup.AddRange(bestTarget.Values);
+            dedup.AddRange(bestDecoy.Values);
+            dedup.Sort((a, b) => a.G.CompareTo(b.G)); // Array.Sort OK: G is the unique global row ordinal of each base_id's best row, so the comparator never ties -- reproduces SelectBestPerPrecursor's Array.Sort(result).
+            int m = dedup.Count;
+            int dedupTargets = 0;
+            foreach (var d in dedup)
+                if (!d.IsDecoy) dedupTargets++;
+            logInfo(string.Format(
+                "[COUNT] {0} Percolator streaming best-per-precursor: {1} entries ({2} targets, {3} decoys) from {4} total",
+                passLabel, m, dedupTargets, m - dedupTargets, n));
+
+            // Peptide-grouped subsample when the dedup count exceeds MaxTrainSize (mirrors
+            // BuildTrainingSubset: SelectBestPerPrecursor already ran above via the streaming dedup,
+            // so only the SubsampleByPeptideGroup step remains). localSelected indexes `dedup`.
+            int[] localSelected;
+            if (maxTrain <= 0 || m <= maxTrain)
+            {
+                localSelected = new int[m];
+                for (int i = 0; i < m; i++)
+                    localSelected[i] = i;
+            }
+            else
+            {
+                var dedupLabels = new bool[m];
+                var dedupEntryIds = new uint[m];
+                var dedupPeptides = new string[m];
+                for (int i = 0; i < m; i++)
+                {
+                    dedupLabels[i] = dedup[i].IsDecoy;
+                    dedupEntryIds[i] = dedup[i].EntryId;
+                    dedupPeptides[i] = dedup[i].Peptide;
+                }
+                localSelected = SubsampleByPeptideGroup(
+                    dedupLabels, dedupEntryIds, dedupPeptides, maxTrain, percConfig.Seed);
+            }
+
+            int subTargets = 0;
+            var subsetEntries = new List<PercolatorEntry>(localSelected.Length);
+            foreach (int li in localSelected)
+            {
+                var d = dedup[li];
+                if (!d.IsDecoy) subTargets++;
+                subsetEntries.Add(new PercolatorEntry
+                {
+                    FileName = d.FileName,
+                    Peptide = d.Peptide,
+                    Charge = d.Charge,
+                    IsDecoy = d.IsDecoy,
+                    EntryId = d.EntryId,
+                    ParquetIndex = d.ParquetIndex,
+                    CoelutionSum = d.CoelutionSum,
+                    Features = null
+                });
+            }
+            logInfo(string.Format(
+                "[COUNT] {0} Percolator streaming subsample: {1} entries ({2} targets, {3} decoys)",
+                passLabel, subsetEntries.Count, subTargets, subsetEntries.Count - subTargets));
+
+            // Load ONLY the subset's feature vectors, one file at a time (bounded by MaxTrainSize),
+            // cloning each row so the subset entry owns it -- mirrors RunStreamingIntoProjection.
+            var subsetByFile = GroupIndicesByFileName(subsetEntries);
+            foreach (var kvp in subsetByFile)
+            {
+                IReadOnlyList<double[]> rows = loadFileFeatures(kvp.Key);
+                foreach (int k in kvp.Value)
+                {
+                    var entry = subsetEntries[k];
+                    entry.Features = (double[])ResolveFeatureRow(
+                        rows, entry.ParquetIndex, entry.CoelutionSum, nFeatures).Clone();
+                }
+            }
+
+            var trainConfig = new PercolatorConfig
+            {
+                TrainFdr = percConfig.TrainFdr,
+                TestFdr = percConfig.TestFdr,
+                MaxIterations = percConfig.MaxIterations,
+                NFolds = percConfig.NFolds,
+                Seed = percConfig.Seed,
+                CValues = percConfig.CValues,
+                MaxTrainSize = percConfig.MaxTrainSize,
+                FeatureInfos = percConfig.FeatureInfos,
+                TrainOnly = true,
+                Diagnostics = percConfig.Diagnostics
+            };
+            PercolatorResults trainResults = RunPercolator(subsetEntries, trainConfig);
+            if (trainResults.DiagnosticAbort)
+                return true;
+
+            // Release the pass-0 working sets before the score passes so only the bounded lookups
+            // remain resident across the peak.
+            bestTarget = null;
+            bestDecoy = null;
+            dedup = null;
+            localSelected = null;
+            subsetEntries = null;
+            subsetByFile = null;
+
+            // Average fold weights + biases (identical to ScoreProjectionAndComputeFdrInPlace).
+            int nModels = trainResults.FoldWeights.Count;
+            if (nModels == 0)
+                throw new InvalidOperationException(
+                    @"RunStreamingFirstPass: trainResults contains no fold models");
+            var avgWeights = new double[nFeatures];
+            double avgBias = 0.0;
+            for (int fm = 0; fm < nModels; fm++)
+            {
+                double[] foldW = trainResults.FoldWeights[fm];
+                for (int j = 0; j < nFeatures; j++)
+                    avgWeights[j] += foldW[j];
+                avgBias += trainResults.FoldBiases[fm];
+            }
+            double nModelsD = nModels;
+            for (int j = 0; j < nFeatures; j++)
+                avgWeights[j] /= nModelsD;
+            avgBias /= nModelsD;
+            var standardizer = trainResults.Standardizer;
+            var featureBuf = new double[nFeatures];
+
+            // ---- Pass 1: score + build the 3 bounded q maps + reduce the clamp floors ----
+            // Reuses the verified StreamingFirstPassQ kernel; per-file run-q from a bounded one-file
+            // buffer, reduced into the best-of-runs clamp floors (issue #4390). The score is
+            // recomputed per row (bias first, then the averaged-weight dot product in feature order)
+            // -- byte-for-byte the resident score loop, only without the O(n) finalScores array.
+            var streamingQ = new StreamingFirstPassQ();
+            var minRunBothByEntryId = new Dictionary<uint, double>();
+            var minRunBothByPeptide = new Dictionary<(string, bool), double>();
+            var contribAcc = new FeatureContributions.Accumulator(nFeatures, percConfig.CollectFeatureHistograms);
+            int nonEmptyFiles = 0;
+            int g1 = 0;
+            logInfo(string.Format(@"Running {0} Percolator on {1} entries...", passLabel, n));
+            for (int f = 0; f < nFiles; f++)
+            {
+                IReadOnlyList<double[]> rows = loadFileFeatures(fileNames[f]);
+                buffer.Clear();
+                streamFileRows(fileNames[f], buffer.Add);
+                int count = buffer.Count;
+                if (count > 0)
+                    nonEmptyFiles++;
+                var fScores = new double[count];
+                var fLabels = new bool[count];
+                var fEntryIds = new uint[count];
+                var fPeptides = new string[count];
+                for (int r = 0; r < count; r++)
+                {
+                    // ComputeStreamedScore leaves featureBuf standardized, which contribAcc bins.
+                    double score = ComputeStreamedScore(
+                        avgWeights, avgBias, standardizer, featureBuf, rows, r, buffer.CoelutionSums[r], nFeatures);
+                    bool isDecoy = buffer.IsDecoys[r];
+                    fScores[r] = score;
+                    fLabels[r] = isDecoy;
+                    fEntryIds[r] = buffer.EntryIds[r];
+                    fPeptides[r] = buffer.Peptides[r];
+                    streamingQ.Add(g1, score, buffer.EntryIds[r], isDecoy, buffer.Peptides[r]);
+                    contribAcc.Add(featureBuf, isDecoy);
+                    g1++;
+                }
+                ComputePerFileRunQvalues(
+                    fScores, fLabels, fEntryIds, fPeptides, 0, count,
+                    out double[] runPrecFile, out double[] runPeptFile);
+                for (int r = 0; r < count; r++)
+                {
+                    double runBoth = Math.Max(runPrecFile[r], runPeptFile[r]);
+                    UpdateExperimentQClampFloor(
+                        minRunBothByEntryId, minRunBothByPeptide, fEntryIds[r], fPeptides[r], fLabels[r], runBoth);
+                }
+            }
+
+            var contributions = contribAcc.Build(trainResults.FoldWeights, percConfig.FeatureInfos);
+            EmitFeatureContributions(contributions);
+            captureContributions?.Invoke(contributions);
+
+            // Finalize the bounded lookups. PEP is global (built always); the experiment maps use
+            // the single-file shortcut (exp == per-run) so they are built only when multi-file --
+            // matching ScoreProjectionAndComputeFdrInPlace exactly.
+            var pepByWinnerIdx = streamingQ.BuildPepWinnerMap();
+            bool isSingleFile = nonEmptyFiles <= 1;
+            Dictionary<uint, double> expPrecByBaseId = isSingleFile
+                ? null : streamingQ.BuildExperimentPrecursorQMap();
+            Dictionary<string, double> expPeptByPeptide = isSingleFile
+                ? null : streamingQ.BuildExperimentPeptideQMap();
+
+            // ---- Pass 2: re-score + assign the 5 q-values + stream to the sink ----
+            int gEmit = 0;
+            for (int f = 0; f < nFiles; f++)
+            {
+                IReadOnlyList<double[]> rows = loadFileFeatures(fileNames[f]);
+                buffer.Clear();
+                streamFileRows(fileNames[f], buffer.Add);
+                int count = buffer.Count;
+                var fScores = new double[count];
+                var fLabels = new bool[count];
+                var fEntryIds = new uint[count];
+                var fPeptides = new string[count];
+                var fCharges = new byte[count];
+                for (int r = 0; r < count; r++)
+                {
+                    fScores[r] = ComputeStreamedScore(
+                        avgWeights, avgBias, standardizer, featureBuf, rows, r, buffer.CoelutionSums[r], nFeatures);
+                    fLabels[r] = buffer.IsDecoys[r];
+                    fEntryIds[r] = buffer.EntryIds[r];
+                    fPeptides[r] = buffer.Peptides[r];
+                    fCharges[r] = buffer.Charges[r];
+                }
+                ComputePerFileRunQvalues(
+                    fScores, fLabels, fEntryIds, fPeptides, 0, count,
+                    out double[] runPrecFile, out double[] runPeptFile);
+                for (int r = 0; r < count; r++)
+                {
+                    double rp = runPrecFile[r];
+                    double rpe = runPeptFile[r];
+
+                    double ep = isSingleFile
+                        ? rp
+                        : (expPrecByBaseId.TryGetValue(fEntryIds[r] & BASE_ID_MASK, out double epv) ? epv : 1.0);
+                    if (minRunBothByEntryId.TryGetValue(fEntryIds[r], out double floorPrec) && floorPrec > ep)
+                        ep = floorPrec;
+
+                    string pept = fPeptides[r];
+                    double epe = isSingleFile
+                        ? rpe
+                        : (expPeptByPeptide.TryGetValue(pept, out double epev) ? epev : 1.0);
+                    if (!string.IsNullOrEmpty(pept) &&
+                        minRunBothByPeptide.TryGetValue((pept, fLabels[r]), out double floorPept) && floorPept > epe)
+                        epe = floorPept;
+
+                    double pep = pepByWinnerIdx.TryGetValue(gEmit + r, out double pv) ? pv : 1.0;
+
+                    sink.Accept(f, r, fEntryIds[r], fLabels[r], fCharges[r], pept, fScores[r],
+                        new FdrQValues(rp, rpe, ep, epe, pep));
+                }
+                gEmit += count;
+            }
+            sink.Finish(logInfo);
+            return false;
+        }
+
+        /// <summary>
+        /// Recompute one row's SVM discriminant from its streamed features (issue #4355
+        /// struct-shrink S3, Stage B): resolve the parquet feature row by its running ordinal,
+        /// standardize it in <paramref name="featureBuf"/>, then the averaged-model score = bias
+        /// first + the weight dot product in feature order -- byte-for-byte the resident score
+        /// loop's per-entry math (<see cref="ScoreProjectionAndComputeFdrInPlace"/>). Leaves the
+        /// standardized values in <paramref name="featureBuf"/> so the caller can bin them into
+        /// the feature-contribution accumulator without recomputing.
+        /// </summary>
+        private static double ComputeStreamedScore(
+            double[] avgWeights, double avgBias, FeatureStandardizer standardizer, double[] featureBuf,
+            IReadOnlyList<double[]> rows, int parquetIndex, double coelutionSum, int nFeatures)
+        {
+            double[] featRow = ResolveFeatureRow(rows, (uint)parquetIndex, coelutionSum, nFeatures);
+            Array.Copy(featRow, 0, featureBuf, 0, nFeatures);
+            standardizer.TransformSlice(featureBuf);
+            double score = avgBias;
+            for (int j = 0; j < nFeatures; j++)
+                score += avgWeights[j] * featureBuf[j];
+            return score;
+        }
+
+        /// <summary>
+        /// One file's raw parquet stub rows, buffered by the 1st-pass streaming score path
+        /// (<see cref="RunStreamingFirstPass"/>) so the stream callback only appends to
+        /// reference-type lists (never a captured-and-mutated counter) and the row/global ordinals
+        /// advance in plain indexed loops. Bounded to one file at a time -- the same one-file
+        /// resident set the per-file run-q competition already requires. The five parallel lists
+        /// mirror the <see cref="FdrProjection"/> scalar slice the resident path holds.
+        /// </summary>
+        private sealed class RowBuffer
+        {
+            public readonly List<uint> EntryIds = new List<uint>();
+            public readonly List<byte> Charges = new List<byte>();
+            public readonly List<bool> IsDecoys = new List<bool>();
+            public readonly List<double> CoelutionSums = new List<double>();
+            public readonly List<string> Peptides = new List<string>();
+
+            public int Count => EntryIds.Count;
+
+            public void Clear()
+            {
+                EntryIds.Clear();
+                Charges.Clear();
+                IsDecoys.Clear();
+                CoelutionSums.Clear();
+                Peptides.Clear();
+            }
+
+            public void Add(uint entryId, byte charge, bool isDecoy, double coelutionSum, string peptide)
+            {
+                EntryIds.Add(entryId);
+                Charges.Add(charge);
+                IsDecoys.Add(isDecoy);
+                CoelutionSums.Add(coelutionSum);
+                Peptides.Add(peptide);
             }
         }
 

--- a/pwiz_tools/Osprey/Osprey.FDR/PercolatorFdr.cs
+++ b/pwiz_tools/Osprey/Osprey.FDR/PercolatorFdr.cs
@@ -1585,6 +1585,9 @@ namespace pwiz.Osprey.FDR
             // Load ONLY the subset's feature vectors, one file at a time (bounded by MaxTrainSize),
             // cloning each row so the subset entry owns it -- mirrors RunStreamingIntoProjection.
             var subsetByFile = GroupIndicesByFileName(subsetEntries);
+            int subsetFilesLoaded = 0;
+            using (var loadProgress = new ProgressReporter(string.Format(
+                       @"Loading training-subset feature vectors from {0} file(s)", subsetByFile.Count), subsetByFile.Count))
             foreach (var kvp in subsetByFile)
             {
                 IReadOnlyList<double[]> rows = loadFileFeatures(kvp.Key);
@@ -1594,6 +1597,7 @@ namespace pwiz.Osprey.FDR
                     entry.Features = (double[])ResolveFeatureRow(
                         rows, entry.ParquetIndex, entry.CoelutionSum, nFeatures).Clone();
                 }
+                loadProgress.Report(++subsetFilesLoaded);
             }
 
             var trainConfig = new PercolatorConfig
@@ -1655,6 +1659,10 @@ namespace pwiz.Osprey.FDR
             int nonEmptyFiles = 0;
             int g1 = 0;
             logInfo(string.Format(@"Running {0} Percolator on {1} entries...", passLabel, n));
+            // Fill the previously-silent multi-minute streaming score pass with throttled percent,
+            // mirroring the resident ScoreProjectionAndComputeFdrInPlace "Scoring N entries" line.
+            // Progress is log-only (OspreyOutput.Out), so the FDR output stays byte-identical.
+            using (var scoreProgress = new ProgressReporter(string.Format(@"Scoring {0} entries", n), n))
             for (int f = 0; f < nFiles; f++)
             {
                 IReadOnlyList<double[]> rows = loadFileFeatures(fileNames[f]);
@@ -1680,6 +1688,7 @@ namespace pwiz.Osprey.FDR
                     streamingQ.Add(g1, score, buffer.EntryIds[r], isDecoy, buffer.Peptides[r]);
                     contribAcc.Add(featureBuf, isDecoy);
                     g1++;
+                    scoreProgress.Report(g1);
                 }
                 ComputePerFileRunQvalues(
                     fScores, fLabels, fEntryIds, fPeptides, 0, count,
@@ -1707,7 +1716,10 @@ namespace pwiz.Osprey.FDR
                 ? null : streamingQ.BuildExperimentPeptideQMap();
 
             // ---- Pass 2: re-score + assign the 5 q-values + stream to the sink ----
+            // Progress-reported (log-only) like Pass 1 so the second streaming pass over all rows
+            // is not silent; byte-identical q-values and sink output.
             int gEmit = 0;
+            using (var emitProgress = new ProgressReporter(string.Format(@"Assigning q-values to {0} entries", n), n))
             for (int f = 0; f < nFiles; f++)
             {
                 IReadOnlyList<double[]> rows = loadFileFeatures(fileNames[f]);
@@ -1754,6 +1766,7 @@ namespace pwiz.Osprey.FDR
 
                     sink.Accept(f, r, fEntryIds[r], fLabels[r], fCharges[r], pept, fScores[r],
                         new FdrQValues(rp, rpe, ep, epe, pep));
+                    emitProgress.Report(gEmit + r + 1);
                 }
                 gEmit += count;
             }

--- a/pwiz_tools/Osprey/Osprey.FDR/PercolatorFdr.cs
+++ b/pwiz_tools/Osprey/Osprey.FDR/PercolatorFdr.cs
@@ -1755,6 +1755,28 @@ namespace pwiz.Osprey.FDR
                 }
             }
 
+            CompeteFromDicts(targets, decoys,
+                out winnerIndices, out winnerScores, out winnerIsDecoy);
+        }
+
+        /// <summary>
+        /// Shared finish for target/decoy competition: given per-base_id best-target and
+        /// best-decoy maps (winning row index + score), compete each pair (higher score wins,
+        /// ties to decoy), add unpaired decoys, and sort winners by score desc / base_id asc.
+        /// Extracted from <see cref="CompeteFromIndices"/> so the flat-array path (which builds
+        /// the maps by walking an index subset) and the streaming path (issue #4355 struct-shrink
+        /// S3, which builds the identical maps by pushing rows in flat (file,row) order) share the
+        /// EXACT compete + sort, and so cannot drift. The stored index is the winning row's flat
+        /// index / streaming ordinal; both label the same row because the streaming pass visits
+        /// rows in the same order the flat arrays were built.
+        /// </summary>
+        internal static void CompeteFromDicts(
+            Dictionary<uint, KeyValuePair<int, double>> targets,
+            Dictionary<uint, KeyValuePair<int, double>> decoys,
+            out int[] winnerIndices,
+            out double[] winnerScores,
+            out bool[] winnerIsDecoy)
+        {
             // Compete pairs: higher score wins, ties go to decoy
             var winners = new List<Tuple<int, double, bool, uint>>(targets.Count);
             foreach (var kvp in targets)

--- a/pwiz_tools/Osprey/Osprey.FDR/PercolatorFdr.cs
+++ b/pwiz_tools/Osprey/Osprey.FDR/PercolatorFdr.cs
@@ -1516,7 +1516,7 @@ namespace pwiz.Osprey.FDR
             }
             int n = g;
             logInfo(string.Format(
-                @"[PATH] {0} first-pass streaming ingest (RunStreamingFirstPass): {1} rows", passLabel, n));
+                @"[PATH] {0} streaming ingest (RunStreamingFirstPass): {1} rows", passLabel, n));
             logInfo(string.Format(
                 "[COUNT] {0} Percolator input: {1} entries ({2} targets, {3} decoys, {4} features)",
                 passLabel, n, nInputTargets, nInputDecoys, nFeatures));
@@ -1816,7 +1816,12 @@ namespace pwiz.Osprey.FDR
                 Charges.Add(charge);
                 IsDecoys.Add(isDecoy);
                 CoelutionSums.Add(coelutionSum);
-                Peptides.Add(peptide);
+                // Normalize a null modseq to string.Empty exactly as the resident FdrProjectionSet
+                // .Builder.AddRow does (a present-but-null modified_sequence element survives
+                // ReadFdrStubScalars' column-level guard): a null peptide would otherwise throw as a
+                // Dictionary<string,...> key in StreamingFirstPassQ / SubsampleByPeptideGroup and
+                // would group differently from the resident path's ""-normalized peptides.
+                Peptides.Add(peptide ?? string.Empty);
             }
         }
 

--- a/pwiz_tools/Osprey/Osprey.FDR/ProteinFdr.cs
+++ b/pwiz_tools/Osprey/Osprey.FDR/ProteinFdr.cs
@@ -164,6 +164,86 @@ namespace pwiz.Osprey.FDR
     }
 
     /// <summary>
+    /// Streaming first-pass protein-FDR reducer (issue #4355 struct-shrink S2): builds the
+    /// detected-peptide set + per-peptide best scores from rows fed one at a time, then runs
+    /// the identical parsimony + picked-protein FDR the buffer overloads run. Lets the
+    /// bounded per-file consumer stream each row's <c>(modifiedSequence, isDecoy, score,
+    /// runPeptideQvalue)</c> straight off the <c>.1st-pass.fdr_scores.bin</c> sidecar
+    /// (score / run_peptide_q) + the parquet scalars (modseq / isDecoy) -- read in the Tasks
+    /// layer, which owns the disk I/O -- WITHOUT holding the resident <see cref="FdrProjection"/>
+    /// buffer + the parallel <c>FdrProjectionOutputs</c> array. Both reductions
+    /// (detected-gate + best max-score / min-q) are order-independent and a modified sequence
+    /// maps to a single target/decoy label, so any streaming order reproduces the resident
+    /// <see cref="ProteinFdr.CollectBestPeptideScores(IList{KeyValuePair{string, List{FdrEntry}}})"/>
+    /// path byte-identically. The caller then patches each entry's <c>run_protein_qvalue</c>
+    /// onto the sidecar from <see cref="FirstPassProteinFdrResult.ProteinFdr"/>'s
+    /// <c>PeptideQvalues</c> (replacing the resident <c>PropagateRunProteinQvalues</c> +
+    /// phase-2 patch with one streaming pass).
+    /// </summary>
+    public sealed class FirstPassProteinFdrAccumulator
+    {
+        private readonly double _runFdr;
+        private readonly HashSet<string> _detectedPeptides = new HashSet<string>(StringComparer.Ordinal);
+        private readonly Dictionary<string, PeptideScore> _bestScores = new Dictionary<string, PeptideScore>();
+
+        public FirstPassProteinFdrAccumulator(double runFdr)
+        {
+            _runFdr = runFdr;
+        }
+
+        /// <summary>
+        /// Fold one row into the detected-peptide set (targets passing peptide-level run FDR,
+        /// matching Rust pipeline.rs:4301) and the per-peptide best (max) score / best (min)
+        /// run peptide q-value reduction (matching
+        /// <see cref="ProteinFdr.CollectBestPeptideScores(IList{KeyValuePair{string, List{FdrEntry}}})"/>).
+        /// </summary>
+        public void Add(string modifiedSequence, bool isDecoy, double score, double runPeptideQvalue)
+        {
+            if (!isDecoy && runPeptideQvalue <= _runFdr)
+                _detectedPeptides.Add(modifiedSequence);
+
+            PeptideScore ps;
+            if (_bestScores.TryGetValue(modifiedSequence, out ps))
+            {
+                if (score > ps.Score)
+                    ps.Score = score;
+                if (runPeptideQvalue < ps.BestQvalue)
+                    ps.BestQvalue = runPeptideQvalue;
+            }
+            else
+            {
+                _bestScores[modifiedSequence] = new PeptideScore
+                {
+                    Score = score,
+                    IsDecoy = isDecoy,
+                    BestQvalue = runPeptideQvalue
+                };
+            }
+        }
+
+        /// <summary>
+        /// Run the identical parsimony + picked-protein FDR the buffer path runs and return
+        /// the artifacts (the caller logs summary counts + patches the sidecar's
+        /// <c>run_protein_qvalue</c> from <see cref="ProteinFdrResult.PeptideQvalues"/>). The
+        /// cross-impl best-peptide-scores dump fires here, at the same point the resident
+        /// <see cref="ProteinFdr.CollectBestPeptideScores(IList{KeyValuePair{string, List{FdrEntry}}})"/>
+        /// emits it (after the reduction is complete).
+        /// </summary>
+        public FirstPassProteinFdrResult Finish(IList<LibraryEntry> fullLibrary, OspreyConfig config)
+        {
+            if (FdrDiagnostics.DumpBestPeptideScores)
+                FdrDiagnostics.WriteBestPeptideScoresDump(_bestScores);
+
+            var parsimony = ProteinFdr.BuildProteinParsimony(
+                fullLibrary, config.SharedPeptides, _detectedPeptides);
+            var proteinFdr = ProteinFdr.ComputeProteinFdr(parsimony, _bestScores, config.RunFdr);
+
+            return new FirstPassProteinFdrResult(
+                _detectedPeptides, parsimony, _bestScores, proteinFdr);
+        }
+    }
+
+    /// <summary>
     /// The computed artifacts of a second-pass / run-wide protein-FDR run, returned
     /// by <see cref="ProteinFdrEngine.RunSecondPass"/> so the Tasks-layer caller can
     /// emit the Stage-7 detected-peptides and protein-FDR diagnostic dumps (and the
@@ -834,126 +914,5 @@ namespace pwiz.Osprey.FDR
                 detectedPeptides, parsimony, bestScores, proteinFdr);
         }
 
-        /// <summary>
-        /// Projection-buffer counterpart of
-        /// <see cref="CollectBestPeptideScores(IList{KeyValuePair{string, List{FdrEntry}}})"/>
-        /// (issue #4355 struct-shrink S0): reduce the thin <see cref="FdrProjection"/>
-        /// rows to the per-peptide best (max) SVM score and best (min) run peptide
-        /// q-value. <see cref="FdrProjection.Score"/> + IsDecoy stay resident on the
-        /// lean struct; the run peptide q-value now comes from the parallel
-        /// <paramref name="outputs"/> array (it is no longer a struct field). The
-        /// modified sequence is materialized from <paramref name="peptideById"/>. The
-        /// resulting dictionary is byte-identical to the FdrEntry path (the max/min
-        /// reductions are order-independent, and a modified sequence maps to a single
-        /// target/decoy label).
-        /// </summary>
-        public static Dictionary<string, PeptideScore> CollectBestPeptideScores(
-            IList<KeyValuePair<string, List<FdrProjection>>> perFileProjections,
-            string[] peptideById,
-            FdrProjectionOutputs outputs)
-        {
-            var best = new Dictionary<string, PeptideScore>();
-            for (int f = 0; f < perFileProjections.Count; f++)
-            {
-                var rows = perFileProjections[f].Value;
-                for (int r = 0; r < rows.Count; r++)
-                {
-                    var proj = rows[r];
-                    double runPeptideQvalue = outputs.RunPeptideQvalue(f, r);
-                    string modseq = peptideById[proj.PeptideId];
-                    PeptideScore ps;
-                    if (best.TryGetValue(modseq, out ps))
-                    {
-                        if (proj.Score > ps.Score)
-                            ps.Score = proj.Score;
-                        if (runPeptideQvalue < ps.BestQvalue)
-                            ps.BestQvalue = runPeptideQvalue;
-                    }
-                    else
-                    {
-                        best[modseq] = new PeptideScore
-                        {
-                            Score = proj.Score,
-                            IsDecoy = proj.IsDecoy,
-                            BestQvalue = runPeptideQvalue
-                        };
-                    }
-                }
-            }
-
-            if (FdrDiagnostics.DumpBestPeptideScores)
-                FdrDiagnostics.WriteBestPeptideScoresDump(best);
-
-            return best;
-        }
-
-        /// <summary>
-        /// Projection-buffer counterpart of <see cref="PropagateProteinQvalues"/>:
-        /// write the run protein q-value into the parallel <paramref name="outputs"/>
-        /// array for every row from the parsimony result, keyed by the materialized
-        /// modified sequence (issue #4355 struct-shrink S0 -- the value is no longer a
-        /// struct field). <see cref="FdrEntry.ExperimentProteinQvalue"/> has no
-        /// projection slot (it stays at its 1.0 default until the Stage 7 second pass,
-        /// on the reloaded survivor stubs), so this only sets the run-level value --
-        /// matching the first-pass call's <c>setExperiment: false</c>.
-        /// </summary>
-        public static void PropagateRunProteinQvalues(
-            IList<KeyValuePair<string, List<FdrProjection>>> perFileProjections,
-            string[] peptideById,
-            ProteinFdrResult proteinFdr,
-            FdrProjectionOutputs outputs)
-        {
-            for (int f = 0; f < perFileProjections.Count; f++)
-            {
-                var rows = perFileProjections[f].Value;
-                for (int i = 0; i < rows.Count; i++)
-                {
-                    double q;
-                    if (!proteinFdr.PeptideQvalues.TryGetValue(peptideById[rows[i].PeptideId], out q))
-                        q = 1.0;
-                    outputs.SetRunProteinQvalue(f, i, q);
-                }
-            }
-        }
-
-        /// <summary>
-        /// Projection-buffer counterpart of
-        /// <see cref="RunFirstPassProteinFdr(IList{KeyValuePair{string, List{FdrEntry}}}, IList{LibraryEntry}, OspreyConfig)"/>.
-        /// Builds the detected-peptide set + per-peptide best scores from the
-        /// projection rows (materializing modified sequences from
-        /// <paramref name="peptideById"/>), runs the identical parsimony +
-        /// picked-protein FDR (those helpers are peptide-string-keyed and never
-        /// touch the buffer), and writes the run protein q-value into
-        /// <paramref name="outputs"/> for every row (issue #4355 struct-shrink S0 --
-        /// it is no longer a struct field). Byte-identical to the FdrEntry path.
-        /// </summary>
-        public static FirstPassProteinFdrResult RunFirstPassProteinFdr(
-            IList<KeyValuePair<string, List<FdrProjection>>> perFileProjections,
-            string[] peptideById,
-            FdrProjectionOutputs outputs,
-            IList<LibraryEntry> fullLibrary,
-            OspreyConfig config)
-        {
-            var detectedPeptides = new HashSet<string>(StringComparer.Ordinal);
-            for (int f = 0; f < perFileProjections.Count; f++)
-            {
-                var rows = perFileProjections[f].Value;
-                for (int r = 0; r < rows.Count; r++)
-                {
-                    if (!rows[r].IsDecoy && outputs.RunPeptideQvalue(f, r) <= config.RunFdr)
-                        detectedPeptides.Add(peptideById[rows[r].PeptideId]);
-                }
-            }
-
-            var parsimony = BuildProteinParsimony(
-                fullLibrary, config.SharedPeptides, detectedPeptides);
-            var bestScores = CollectBestPeptideScores(perFileProjections, peptideById, outputs);
-            var proteinFdr = ComputeProteinFdr(parsimony, bestScores, config.RunFdr);
-
-            PropagateRunProteinQvalues(perFileProjections, peptideById, proteinFdr, outputs);
-
-            return new FirstPassProteinFdrResult(
-                detectedPeptides, parsimony, bestScores, proteinFdr);
-        }
     }
 }

--- a/pwiz_tools/Osprey/Osprey.FDR/ProteinFdrEngine.cs
+++ b/pwiz_tools/Osprey/Osprey.FDR/ProteinFdrEngine.cs
@@ -66,65 +66,37 @@ namespace pwiz.Osprey.FDR
         {
             var result = ProteinFdr.RunFirstPassProteinFdr(
                 perFileEntries, fullLibrary, config);
-
-            if (logInfo != null)
-            {
-                logInfo(string.Format(
-                    "[COUNT] First-pass detected peptides for protein FDR: {0} unique",
-                    result.DetectedPeptides.Count));
-
-                int nAtRunFdr = 0;
-                foreach (var qv in result.ProteinFdr.GroupQvalues.Values)
-                {
-                    if (qv <= config.RunFdr)
-                        nAtRunFdr++;
-                }
-                logInfo(string.Format(
-                    "First-pass protein FDR: {0} target groups at {1:P1} FDR",
-                    nAtRunFdr, config.RunFdr));
-            }
-
+            LogFirstPassSummary(result, config, logInfo);
             return result;
         }
 
         /// <summary>
-        /// Projection-buffer counterpart of
-        /// <see cref="RunFirstPass(IList{KeyValuePair{string, List{FdrEntry}}}, IList{LibraryEntry}, OspreyConfig, Action{string})"/>
-        /// (issue #4355 step (b) increment ii): run first-pass protein FDR over the
-        /// thin <see cref="FdrProjection"/> peak buffer, materializing modified
-        /// sequences from <paramref name="peptideById"/> for the library join. Same
-        /// summary logging; the computation is byte-identical (see
-        /// <see cref="ProteinFdr.RunFirstPassProteinFdr(IList{KeyValuePair{string, List{FdrProjection}}}, string[], FdrProjectionOutputs, IList{LibraryEntry}, OspreyConfig)"/>).
+        /// Emit the two first-pass protein-FDR summary lines (detected-peptide count +
+        /// target groups passing run FDR) shared by the resident <see cref="FdrEntry"/>
+        /// facade above and the projection path's streaming reducer
+        /// (<c>FirstJoinTask.RunFirstPassProteinFdrStreaming</c>, which assembles the same
+        /// <see cref="FirstPassProteinFdrResult"/> off the sidecar + parquet scalars rather
+        /// than the resident buffer). <paramref name="logInfo"/> may be null (silent runs).
         /// </summary>
-        public static FirstPassProteinFdrResult RunFirstPass(
-            IList<KeyValuePair<string, List<FdrProjection>>> perFileProjections,
-            string[] peptideById,
-            FdrProjectionOutputs outputs,
-            IList<LibraryEntry> fullLibrary,
-            OspreyConfig config,
-            Action<string> logInfo)
+        public static void LogFirstPassSummary(
+            FirstPassProteinFdrResult result, OspreyConfig config, Action<string> logInfo)
         {
-            var result = ProteinFdr.RunFirstPassProteinFdr(
-                perFileProjections, peptideById, outputs, fullLibrary, config);
+            if (logInfo == null)
+                return;
 
-            if (logInfo != null)
+            logInfo(string.Format(
+                "[COUNT] First-pass detected peptides for protein FDR: {0} unique",
+                result.DetectedPeptides.Count));
+
+            int nAtRunFdr = 0;
+            foreach (var qv in result.ProteinFdr.GroupQvalues.Values)
             {
-                logInfo(string.Format(
-                    "[COUNT] First-pass detected peptides for protein FDR: {0} unique",
-                    result.DetectedPeptides.Count));
-
-                int nAtRunFdr = 0;
-                foreach (var qv in result.ProteinFdr.GroupQvalues.Values)
-                {
-                    if (qv <= config.RunFdr)
-                        nAtRunFdr++;
-                }
-                logInfo(string.Format(
-                    "First-pass protein FDR: {0} target groups at {1:P1} FDR",
-                    nAtRunFdr, config.RunFdr));
+                if (qv <= config.RunFdr)
+                    nAtRunFdr++;
             }
-
-            return result;
+            logInfo(string.Format(
+                "First-pass protein FDR: {0} target groups at {1:P1} FDR",
+                nAtRunFdr, config.RunFdr));
         }
 
         /// <summary>

--- a/pwiz_tools/Osprey/Osprey.IO/FdrScoresSidecar.cs
+++ b/pwiz_tools/Osprey/Osprey.IO/FdrScoresSidecar.cs
@@ -581,5 +581,83 @@ namespace pwiz.Osprey.IO
             }
             return true;
         }
+
+        /// <summary>
+        /// Stream every record of a per-file sidecar to <paramref name="onRecord"/> as a
+        /// decoupled <see cref="FdrScoreRecord"/> (entry_id + SVM score + 5 q-values),
+        /// WITHOUT a parquet stub list. The bounded per-file first-pass consumers -- protein
+        /// FDR and compaction (issue #4355 struct-shrink S2) -- need the score + q-values
+        /// keyed by entry_id but must NOT rematerialize the full <see cref="FdrEntry"/> buffer
+        /// the resident projection replaced; they read one file's records at a time (O(one
+        /// file), not O(all files)) and key them into a per-file map. Same header validation
+        /// as <see cref="TryRead(string,IList{FdrEntry},Pass)"/> (magic / version / pass /
+        /// size); returns <c>false</c> (with the partial callback effects the caller must
+        /// discard) on any mismatch or IO failure. Streams one 60-byte record at a time from
+        /// the source (one record resident, not an O(file-size) whole-file buffer), matching
+        /// <see cref="PatchRunProteinQvalues"/>. Records are delivered in stored (file) order.
+        /// </summary>
+        public static bool ReadRecords(string path, Pass expectedPass, Action<FdrScoreRecord> onRecord)
+        {
+            if (path == null) throw new ArgumentNullException(nameof(path));
+            if (onRecord == null) throw new ArgumentNullException(nameof(onRecord));
+
+            try
+            {
+                using (var src = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.Read))
+                {
+                    if (src.Length < HeaderLength)
+                        return false;
+
+                    var header = new byte[HeaderLength];
+                    if (!ReadFully(src, header, HeaderLength))
+                        return false;
+                    for (int i = 0; i < Magic.Length; i++)
+                    {
+                        if (header[i] != Magic[i])
+                            return false;
+                    }
+                    if (header[8] != FormatVersion)
+                        return false;
+                    if (header[9] != (byte)expectedPass)
+                        return false;
+                    ulong headerCount = BitConverter.ToUInt64(header, 16);
+                    if (!TryComputeExpectedLen(headerCount, out int expectedLen))
+                        return false;
+                    if (src.Length != expectedLen)
+                        return false;
+
+                    var record = new byte[RecordLength];
+                    for (int rec = 0; rec < (int)headerCount; rec++)
+                    {
+                        if (!ReadFully(src, record, RecordLength))
+                            return false;
+                        onRecord(DecodeRecord(record));
+                    }
+                }
+            }
+            catch
+            {
+                return false;
+            }
+            return true;
+        }
+
+        /// <summary>
+        /// Decode one 60-byte record into a <see cref="FdrScoreRecord"/>, reading the exact v3
+        /// field order <see cref="WriteRecord"/> wrote (little-endian). Single-sourced with the
+        /// writer so the read/write byte layout cannot drift.
+        /// </summary>
+        private static FdrScoreRecord DecodeRecord(byte[] rec)
+        {
+            return new FdrScoreRecord(
+                BitConverter.ToUInt32(rec, 0),    // [0..4]  entry_id
+                BitConverter.ToDouble(rec, 4),    // [4..12]  svm_score
+                BitConverter.ToDouble(rec, 12),   // [12..20] run_precursor_qvalue
+                BitConverter.ToDouble(rec, 20),   // [20..28] run_peptide_qvalue
+                BitConverter.ToDouble(rec, 28),   // [28..36] experiment_precursor_qvalue
+                BitConverter.ToDouble(rec, 36),   // [36..44] experiment_peptide_qvalue
+                BitConverter.ToDouble(rec, 44),   // [44..52] pep
+                BitConverter.ToDouble(rec, 52));  // [52..60] run_protein_qvalue
+        }
     }
 }

--- a/pwiz_tools/Osprey/Osprey.Tasks/FdrProjectionSinks.cs
+++ b/pwiz_tools/Osprey/Osprey.Tasks/FdrProjectionSinks.cs
@@ -238,6 +238,15 @@ namespace pwiz.Osprey.Tasks
             {
                 if (!_flushed[f])
                 {
+                    // A file with recorded rows that never reached its last-row flush means the
+                    // 1st-pass streaming score pass emitted fewer rows than the counts-only producer
+                    // recorded (the two independent parquet reads disagreed). Writing a 0-record
+                    // sidecar here would silently corrupt .1st-pass.fdr_scores.bin, so fail loud.
+                    if (Projections.RowCount(f) > 0)
+                        throw new InvalidOperationException(string.Format(
+                            @"First-pass sidecar flush for '{0}' never fired: {1} rows were recorded but " +
+                            @"the score pass emitted fewer -- the parquet row count is inconsistent.",
+                            perFile[f].Key, Projections.RowCount(f)));
                     _partialWriteFailures += _flushPartial(perFile[f].Key, empty);
                     _flushed[f] = true;
                 }

--- a/pwiz_tools/Osprey/Osprey.Tasks/FdrProjectionSinks.cs
+++ b/pwiz_tools/Osprey/Osprey.Tasks/FdrProjectionSinks.cs
@@ -85,11 +85,13 @@ namespace pwiz.Osprey.Tasks
         public IReadOnlyList<int> FilePassingTargets => _fileTargets;
 
         public void Accept(int fileIdx, int rowIdx, uint entryId, bool isDecoy,
-            double score, in FdrQValues q)
+            byte charge, string peptide, double score, in FdrQValues q)
         {
             // Tail [COUNT] tally, identical to the retired inline block: passing =
             // EffectiveRunQvalue <= RunFdr, split target/decoy; best-q-per-precursor
-            // over passing targets keyed by modseq|charge (looked up from the lean row).
+            // over passing targets keyed by modseq|charge. peptide + charge are passed in
+            // (issue #4355 struct-shrink S3 Stage B) so this works whether the caller holds
+            // a resident projection (2nd pass) or streams the row straight from parquet.
             double eff = q.EffectiveRunQvalue(_fdrLevel);
             if (eff <= _runFdr)
             {
@@ -100,8 +102,7 @@ namespace pwiz.Osprey.Tasks
             }
             if (!isDecoy && eff <= _runFdr)
             {
-                var proj = Projections.PerFile[fileIdx].Value[rowIdx];
-                string pkey = Projections.PeptideById[proj.PeptideId] + "|" + proj.Charge;
+                string pkey = peptide + "|" + charge;
                 double existing;
                 if (!_bestQByPrecursor.TryGetValue(pkey, out existing) || eff < existing)
                     _bestQByPrecursor[pkey] = eff;
@@ -111,11 +112,7 @@ namespace pwiz.Osprey.Tasks
             // reductions (every row -- targets, decoys, entrapment, failing -- not just the
             // passing set the [COUNT] tally reads). Null off the report path.
             if (_mdiagAccumulator != null)
-            {
-                var mproj = Projections.PerFile[fileIdx].Value[rowIdx];
-                _mdiagAccumulator.Add(fileIdx, Projections.PeptideById[mproj.PeptideId],
-                    mproj.Charge, entryId, isDecoy, score, in q);
-            }
+                _mdiagAccumulator.Add(fileIdx, peptide, charge, entryId, isDecoy, score, in q);
 
             AcceptOutput(fileIdx, rowIdx, entryId, isDecoy, score, in q);
         }
@@ -218,7 +215,10 @@ namespace pwiz.Osprey.Tasks
                 q.ExperimentPrecursorQvalue, q.ExperimentPeptideQvalue,
                 q.Pep, 1.0));
 
-            if (rowIdx == Projections.PerFile[fileIdx].Value.Count - 1)
+            // RowCount, not PerFile[fileIdx].Value.Count: on the 1st-pass streaming path the
+            // projection carries per-file counts but NO resident rows (issue #4355 struct-shrink
+            // S3 Stage B), so the last-row flush must key on the count, not an empty row list.
+            if (rowIdx == Projections.RowCount(fileIdx) - 1)
             {
                 _partialWriteFailures += _flushPartial(Projections.PerFile[fileIdx].Key, _buffer);
                 _flushed[fileIdx] = true;
@@ -299,8 +299,10 @@ namespace pwiz.Osprey.Tasks
                 q.ExperimentPrecursorQvalue, q.ExperimentPeptideQvalue,
                 q.Pep, runProteinQvalue));
 
-            // Last row of this file: flush its sidecar and release the buffer.
-            if (rowIdx == Projections.PerFile[fileIdx].Value.Count - 1)
+            // Last row of this file: flush its sidecar and release the buffer. RowCount
+            // (not the row list) so the 2nd-pass resident projection and the 1st-pass
+            // streaming counts-only projection both resolve the file's row count.
+            if (rowIdx == Projections.RowCount(fileIdx) - 1)
             {
                 _flushFile(Projections.PerFile[fileIdx].Key, _buffer);
                 _flushed[fileIdx] = true;

--- a/pwiz_tools/Osprey/Osprey.Tasks/FdrProjectionSinks.cs
+++ b/pwiz_tools/Osprey/Osprey.Tasks/FdrProjectionSinks.cs
@@ -161,25 +161,25 @@ namespace pwiz.Osprey.Tasks
     }
 
     /// <summary>
-    /// 1st-pass sink (issue #4355 struct-shrink S1, two-phase sidecar): keeps ONLY the
-    /// two q-values that must stay resident across the whole pass -- <c>RunPeptideQ</c>
-    /// and <c>RunProteinQ</c> -- in a 16 B/row <see cref="FdrProjectionOutputs"/> array
-    /// (1st-pass resident projection = 48 B), and streams the other four q-values
-    /// straight to disk. During the score pass (phase 1) it buffers each file's PARTIAL
-    /// 60-byte <see cref="FdrScoreRecord"/>s in projection order -- with the
+    /// 1st-pass sink (issue #4355 struct-shrink S2, two-phase sidecar): streams ALL of the
+    /// score pass's per-row output straight to disk -- it keeps NO resident q-value array.
+    /// During the score pass (phase 1) it buffers each file's 60-byte
+    /// <see cref="FdrScoreRecord"/>s in projection order -- with the
     /// <c>run_protein_qvalue</c> field held at its 1.0 placeholder -- and flushes the
     /// per-file <c>.1st-pass.fdr_scores.bin</c> via the caller's <c>flushPartial</c>
-    /// callback at the file's last row, so the four streamed q-values are never held
-    /// resident. Empty survivor files are flushed with a 0-record sidecar in
-    /// <see cref="OnFinish"/>. Protein FDR + compaction read <see cref="Outputs"/>; after
-    /// protein FDR the caller runs phase 2, patching each record's <c>[52..60]</c> from
-    /// the resident <c>RunProteinQ</c>. The byte layout is single-sourced through
-    /// <c>FdrScoresSidecar.WriteRecord</c>, so the phase-1 file is byte-identical to the
-    /// pre-S1 single-phase write except for the placeholder column the patch overwrites.
+    /// callback at the file's last row, so a full pass's worth of q-values is never held
+    /// resident (one file's buffer at a time). Empty survivor files are flushed with a
+    /// 0-record sidecar in <see cref="OnFinish"/>. First-pass protein FDR + compaction now
+    /// stream <c>run_peptide_qvalue</c> / <c>run_protein_qvalue</c> back off this sidecar
+    /// (see <c>FirstJoinTask.RunFirstPassProteinFdrStreaming</c>), so the resident
+    /// <c>FdrProjectionOutputs</c> array the pre-S2 sink kept is gone; protein FDR patches
+    /// each record's <c>[52..60]</c> straight onto the sidecar. The byte layout is
+    /// single-sourced through <c>FdrScoresSidecar.WriteRecord</c>, so the phase-1 file is
+    /// byte-identical to the pre-S1 single-phase write except for the placeholder column the
+    /// patch overwrites.
     /// </summary>
     internal sealed class FdrStoringSink : FdrProjectionSinkBase
     {
-        private readonly FdrProjectionOutputs _outputs;
         private readonly Func<string, IReadOnlyList<FdrScoreRecord>, int> _flushPartial;
         private readonly bool[] _flushed;
         private readonly List<FdrScoreRecord> _buffer;
@@ -191,13 +191,10 @@ namespace pwiz.Osprey.Tasks
             ModelDiagnosticsData.Accumulator mdiagAccumulator = null)
             : base(projections, config, passLabel, mdiagAccumulator)
         {
-            _outputs = new FdrProjectionOutputs(projections);
             _flushPartial = flushPartial;
             _flushed = new bool[projections.PerFile.Count];
             _buffer = new List<FdrScoreRecord>();
         }
-
-        public FdrProjectionOutputs Outputs => _outputs;
 
         /// <summary>
         /// Number of per-file phase-1 partial-sidecar writes that failed during the score
@@ -210,16 +207,11 @@ namespace pwiz.Osprey.Tasks
         protected override void AcceptOutput(int fileIdx, int rowIdx, uint entryId,
             bool isDecoy, double score, in FdrQValues q)
         {
-            // Resident: keep ONLY the run peptide q-value (protein FDR + compaction need
-            // it across all rows); run protein q-value stays at its 1.0 placeholder until
-            // first-pass protein FDR fills it (issue #4355 struct-shrink S1).
-            _outputs.SetRunPeptideQvalue(fileIdx, rowIdx, q.RunPeptideQvalue);
-
             // Phase 1 of the two-phase sidecar: buffer this row's PARTIAL record
             // (run_protein_qvalue = 1.0 placeholder) in projection order and flush the
-            // per-file .1st-pass.fdr_scores.bin at the file's last row. The four streamed
-            // q-values (RunPrecursorQ, ExpPrecursorQ, ExpPeptideQ, Pep) go straight to
-            // disk here and are never kept resident; phase 2 patches [52..60] afterward.
+            // per-file .1st-pass.fdr_scores.bin at the file's last row. All five score-pass
+            // q-values (incl. run_peptide_qvalue) go straight to disk here and are never
+            // kept resident; first-pass protein FDR streams them back + patches [52..60].
             _buffer.Add(new FdrScoreRecord(
                 entryId, score,
                 q.RunPrecursorQvalue, q.RunPeptideQvalue,

--- a/pwiz_tools/Osprey/Osprey.Tasks/FirstJoinTask.cs
+++ b/pwiz_tools/Osprey/Osprey.Tasks/FirstJoinTask.cs
@@ -1548,9 +1548,13 @@ namespace pwiz.Osprey.Tasks
             var projections = prebuiltProjections ??
                 FdrProjectionSet.BuildFromEntries(perFileEntries, releaseStubs: true);
             int beforeCount = projections.TotalRows;
-            ProfilerHooks.LogMemoryStatsIfEnabled(ctx.LogInfo, string.Format(
-                @"projection built: {0} rows, {1} distinct peptides; FdrEntry stubs released",
-                beforeCount, projections.PeptideById.Length));
+            ProfilerHooks.LogMemoryStatsIfEnabled(ctx.LogInfo, projections.IsCountsOnly
+                ? string.Format(
+                    @"projection counts-only: {0} rows across {1} files (no resident rows); FdrEntry stubs released",
+                    beforeCount, projections.PerFile.Count)
+                : string.Format(
+                    @"projection built: {0} rows, {1} distinct peptides; FdrEntry stubs released",
+                    beforeCount, projections.PeptideById.Length));
 
             // Stage 5: first-pass Percolator over the projection. Same SVM, same
             // dispatch, same q-values -- only the resident buffer differs. The lean
@@ -1604,12 +1608,33 @@ namespace pwiz.Osprey.Tasks
 
             var sink = new FdrStoringSink(projections, config, @"First-pass", FlushPartialSidecar,
                 mdiagAccumulator);
+            var featureInfos = OspreyFeatureCalculators.BuildFeatureInfos(ParquetScoreCache.PIN_FEATURE_NAMES);
             var swFdr = Stopwatch.StartNew();
-            bool aborted = PercolatorEngine.RunPercolatorFdr(
-                projections, config,
-                OspreyFeatureCalculators.BuildFeatureInfos(ParquetScoreCache.PIN_FEATURE_NAMES),
-                ctx.LogInfo, sink, BuildPercolatorDiagnostics(ctx.Diagnostics),
-                @"First-pass", loadFileFeatures, captureContributions);
+            bool aborted;
+            if (projections.IsCountsOnly)
+            {
+                // Stage B (issue #4355 struct-shrink S3): the lean 1st pass holds NO resident
+                // FdrProjection[] -- stream every row's identity + features from the per-file
+                // .scores.parquet. The row source reads the scalar columns (entry_id / charge /
+                // is_decoy / coelution_sum / modseq) in parquet row order (== the resident sort
+                // order on the 1st pass, since the parquet is written (entry_id,charge,scan)-sorted),
+                // and loadFileFeatures loads that file's feature vectors by the running row ordinal.
+                // perFileParquetPaths has every projection file (the counts-only producer read the
+                // same parquet to count its rows), so the indexer cannot miss.
+                Action<string, Action<uint, byte, bool, double, string>> streamFileRows =
+                    (fileName, onRow) => ParquetScoreCache.ReadFdrStubScalars(perFileParquetPaths[fileName], onRow);
+                aborted = PercolatorEngine.RunFirstPassStreaming(
+                    projections.PerFile.ConvertAll(kv => kv.Key), streamFileRows, loadFileFeatures,
+                    config, featureInfos, ctx.LogInfo, sink, BuildPercolatorDiagnostics(ctx.Diagnostics),
+                    @"First-pass", captureContributions);
+            }
+            else
+            {
+                aborted = PercolatorEngine.RunPercolatorFdr(
+                    projections, config, featureInfos,
+                    ctx.LogInfo, sink, BuildPercolatorDiagnostics(ctx.Diagnostics),
+                    @"First-pass", loadFileFeatures, captureContributions);
+            }
             swFdr.Stop();
             if (aborted)
             {

--- a/pwiz_tools/Osprey/Osprey.Tasks/FirstJoinTask.cs
+++ b/pwiz_tools/Osprey/Osprey.Tasks/FirstJoinTask.cs
@@ -1611,7 +1611,6 @@ namespace pwiz.Osprey.Tasks
                 ctx.LogInfo, sink, BuildPercolatorDiagnostics(ctx.Diagnostics),
                 @"First-pass", loadFileFeatures, captureContributions);
             swFdr.Stop();
-            var outputs = sink.Outputs;
             if (aborted)
             {
                 // A diagnostic-only (*Only) Stage 5 dump fired; mirror the static
@@ -1640,18 +1639,25 @@ namespace pwiz.Osprey.Tasks
                     mdiagAccumulator, mdiagContributions, cal, config, ctx.LogInfo);
             }
 
-            // First-pass protein FDR over the projection (sets RunProteinQvalue on
-            // every row). The Stage-6 diagnostic dump reads the returned artifacts,
-            // exactly as the FdrEntry path's RunFirstPassProteinFdr does. Runs
-            // unconditionally (not gated on --protein-fdr), matching Rust where
-            // config.protein_fdr is a plain f64 (default 0.01), gated only on
-            // !can_skip_fdr.
+            // First-pass protein FDR streamed off the per-file sidecar + parquet scalars
+            // (issue #4355 struct-shrink S2): read each file's Score / run_peptide_qvalue
+            // from the just-written .1st-pass.fdr_scores.bin, joined by entry_id with the
+            // modseq / IsDecoy from the parquet scalars, run the identical parsimony +
+            // picked-protein FDR, and patch each row's run_protein_qvalue [52..60] straight
+            // back onto the sidecar -- so the resident FdrProjectionOutputs array is gone.
+            // The Stage-6 diagnostic dump reads the returned artifacts, exactly as the
+            // FdrEntry path's RunFirstPassProteinFdr does. Runs unconditionally (not gated
+            // on --protein-fdr), matching Rust where config.protein_fdr is a plain f64
+            // (default 0.01), gated only on !can_skip_fdr.
+            int patchFailures = 0;
             if (projections.TotalRows > 0)
             {
                 ctx.LogInfo(string.Empty);
                 var swProt = Stopwatch.StartNew();
-                var proteinResult = ProteinFdrEngine.RunFirstPass(
-                    projections.PerFile, projections.PeptideById, outputs, fullLibrary, config, ctx.LogInfo);
+                var proteinResult = RunFirstPassProteinFdrStreaming(
+                    projections, perFileParquetPaths, fullLibrary, config, ctx, out patchFailures);
+                if (proteinResult == null)
+                    return null;  // streaming sidecar / parquet read fault; ExitCode already set
                 if (ctx.Diagnostics?.DumpProteinFdr ?? false)
                 {
                     ctx.Diagnostics?.WriteStage6ProteinFdrDump(
@@ -1664,16 +1670,12 @@ namespace pwiz.Osprey.Tasks
                     swProt.Elapsed.TotalSeconds));
             }
 
-            // Phase 2 of the two-phase sidecar (issue #4355 struct-shrink S1): now that
-            // first-pass protein FDR has filled RunProteinQ in the resident outputs array,
-            // patch each partial record's run_protein_qvalue [52..60] on disk (located by
-            // entry_id), finalizing the Stage 5 -> Stage 6 boundary artifact AND the
-            // source the survivor reload overlays below. This replaces the pre-S1
-            // single-phase write; the finalized bytes are identical (only the placeholder
-            // [52..60] is overwritten). Combine the phase-1 partial-write failures the
-            // sink accumulated during the score pass with the phase-2 patch failures.
-            int sidecarFailures = sink.PartialWriteFailures + PatchFirstPassSidecarProteinQvalues(
-                projections, outputs, perFileParquetPaths, config, ctx);
+            // The streaming protein FDR above already patched run_protein_qvalue [52..60]
+            // onto each file's sidecar (folding the pre-S2 resident-outputs propagate + the
+            // separate phase-2 patch into one streaming pass). Combine the phase-1
+            // partial-write failures the sink accumulated during the score pass with those
+            // streaming-patch failures for the StopAfterStage5 boundary gate.
+            int sidecarFailures = sink.PartialWriteFailures + patchFailures;
             if (sidecarFailures > 0 && config.StopAfterStage5)
             {
                 ctx.LogError(string.Format(
@@ -1684,9 +1686,11 @@ namespace pwiz.Osprey.Tasks
                 return null;
             }
 
-            // Compaction predicate over the projection -> passing base_id set
-            // (identical to CompactFirstPass's non-bundle branch, risk #7).
-            var firstPassBaseIds = ComputeFirstPassBaseIds(projections, outputs, config);
+            // Compaction predicate streamed over the finalized per-file sidecar -> passing
+            // base_id set (identical to CompactFirstPass's non-bundle branch, risk #7).
+            var firstPassBaseIds = ComputeFirstPassBaseIds(projections, perFileParquetPaths, config, ctx);
+            if (firstPassBaseIds == null)
+                return null;  // streaming sidecar read fault; ExitCode already set
 
             // Reload full FdrEntry survivors from the ORIGINAL parquet + the
             // just-written 1st-pass sidecar. ParquetIndex therefore comes from
@@ -1740,77 +1744,175 @@ namespace pwiz.Osprey.Tasks
         }
 
         /// <summary>
-        /// Phase 2 of the two-phase 1st-pass sidecar (issue #4355 struct-shrink S1): for
-        /// each file, patch the partial <c>.1st-pass.fdr_scores.bin</c> the storing sink
-        /// wrote during the score pass so every record's <c>run_protein_qvalue</c>
-        /// <c>[52..60]</c> carries the finalized value from the resident
-        /// <c>RunProteinQ</c> array (filled by first-pass protein FDR), located by
-        /// <c>entry_id</c>. Same sidecar path resolution as phase 1, so the survivor
-        /// reload and the Stage 6 worker read the identical, byte-finalized file -- which
-        /// is byte-identical to the pre-S1 single-phase write. Returns the number of
-        /// files whose patch failed (missing / unreadable / size-mismatched sidecar);
-        /// files that never got a phase-1 base path were already counted there.
+        /// First-pass protein FDR streamed off disk (issue #4355 struct-shrink S2), replacing
+        /// the resident-projection overload + the separate phase-2 sidecar patch. Pass 1
+        /// builds the detected-peptide set + per-peptide best scores by streaming, per file in
+        /// projection order, the just-written <c>.1st-pass.fdr_scores.bin</c> (Score +
+        /// run_peptide_qvalue keyed by entry_id) joined with the parquet scalars (the modseq
+        /// PeptideById was interned from + IsDecoy) into a pure
+        /// <see cref="FirstPassProteinFdrAccumulator"/>, which runs the identical parsimony +
+        /// picked-protein FDR. Pass 2 patches each file's <c>run_protein_qvalue</c>
+        /// <c>[52..60]</c> from the reducer's peptide -> q map (folding the resident
+        /// <c>PropagateRunProteinQvalues</c> + the old phase-2 patch into one streaming pass).
+        /// Returns <c>null</c> (ExitCode set) on any sidecar / parquet read fault -- the task
+        /// just wrote these files, so a read failure is a genuine fault (the survivor reload
+        /// below would fail on the same file). <paramref name="patchFailures"/> counts files
+        /// whose run_protein_qvalue patch failed, for the StopAfterStage5 boundary gate.
         /// </summary>
-        private int PatchFirstPassSidecarProteinQvalues(
+        private FirstPassProteinFdrResult RunFirstPassProteinFdrStreaming(
             FdrProjectionSet projections,
-            FdrProjectionOutputs outputs,
             IReadOnlyDictionary<string, string> perFileParquetPaths,
+            List<LibraryEntry> fullLibrary,
             OspreyConfig config,
-            PipelineContext ctx)
+            PipelineContext ctx,
+            out int patchFailures)
         {
-            int failures = 0;
-            for (int f = 0; f < projections.PerFile.Count; f++)
+            patchFailures = 0;
+
+            // Pass 1: detected-peptide + best-score reductions, streamed per file in
+            // projection order (the reductions are order-independent, but streaming in the
+            // resident path's file/row order keeps the best-scores insertion order identical).
+            var accumulator = new FirstPassProteinFdrAccumulator(config.RunFdr);
+            foreach (var kvp in projections.PerFile)
             {
-                var kvp = projections.PerFile[f];
+                if (!StreamFirstPassFileScores(kvp.Key, perFileParquetPaths, config, ctx,
+                        (modseq, isDecoy, record) =>
+                            accumulator.Add(modseq, isDecoy, record.Score, record.RunPeptideQvalue)))
+                {
+                    return null;  // ExitCode set in the helper
+                }
+            }
+            var result = accumulator.Finish(fullLibrary, config);
+            ProteinFdrEngine.LogFirstPassSummary(result, config, ctx.LogInfo);
+
+            // Pass 2: patch each file's run_protein_qvalue from peptide -> q. entry_id is
+            // unique within a file, so a per-file entry_id -> q map (one file resident at a
+            // time; bounded) reproduces the resident PropagateRunProteinQvalues + the phase-2
+            // patch byte-for-byte. The modseq MUST come from the parquet scalars (the same
+            // value the pass-1 PeptideQvalues keys were built from), not re-derived from the
+            // library, so the peptide -> q lookup matches.
+            var peptideQvalues = result.ProteinFdr.PeptideQvalues;
+            foreach (var kvp in projections.PerFile)
+            {
                 string fileName = kvp.Key;
                 string sidecarBase = ResolveSidecarBasePath(fileName, perFileParquetPaths, config);
                 if (string.IsNullOrEmpty(sidecarBase))
-                {
-                    // Phase 1 already warned + counted this file; there is no file on
-                    // disk to patch, so do not double-count it here.
-                    continue;
-                }
+                    continue;  // no on-disk sidecar to patch (phase 1 already counted it)
+                string parquetPath = perFileParquetPaths[fileName];  // present: pass 1 read it
                 string fdrPath = FdrScoresSidecar.Pass1Path(sidecarBase);
 
-                // Map this file's entry_id -> finalized run protein q-value (one file at
-                // a time; bounded). entry_id is unique within a file, matching the
-                // sidecar's entry_id-keyed record identity.
-                var rows = kvp.Value;
-                var runProteinByEntryId = new Dictionary<uint, double>(rows.Count);
-                for (int r = 0; r < rows.Count; r++)
-                    runProteinByEntryId[rows[r].EntryId] = outputs.RunProteinQvalue(f, r);
-
+                var runProteinByEntryId = new Dictionary<uint, double>();
                 try
                 {
+                    ParquetScoreCache.ReadFdrStubScalars(parquetPath,
+                        (entryId, charge, isDecoy, coelutionSum, modseq) =>
+                        {
+                            double q;
+                            if (!peptideQvalues.TryGetValue(modseq, out q))
+                                q = 1.0;
+                            runProteinByEntryId[entryId] = q;
+                        });
                     if (!FdrScoresSidecar.PatchRunProteinQvalues(
                             fdrPath, runProteinByEntryId, FdrScoresSidecar.Pass.FirstPass))
                     {
                         ctx.LogWarning(string.Format(
                             "Failed to patch run_protein_qvalue in 1st-pass fdr_scores.bin for {0} " +
                             "(expected at {1})", fileName, fdrPath));
-                        failures++;
+                        patchFailures++;
                     }
                 }
                 catch (Exception ex)
                 {
                     ctx.LogWarning(string.Format(
                         "Failed to patch 1st-pass fdr_scores.bin for {0}: {1}", fileName, ex.Message));
-                    failures++;
+                    patchFailures++;
                 }
             }
-            return failures;
+            return result;
         }
 
         /// <summary>
-        /// Compute the post-first-pass passing base_id set from the projection,
-        /// using the identical predicate as <see cref="CompactFirstPass"/>'s
-        /// non-bundle branch (targets whose run peptide q-value passes the compaction
-        /// peptide gate, or whose run protein q-value passes the always-active
-        /// protein-rescue gate; risk #7). Target and paired decoy share a base_id, so
-        /// the masked id set drives the survivor filter symmetrically.
+        /// Stream one file's first-pass rows to <paramref name="onRow"/> as
+        /// <c>(modseq, isDecoy, FdrScoreRecord)</c>: read the file's
+        /// <c>.1st-pass.fdr_scores.bin</c> into an entry_id -> record map (one file resident;
+        /// bounded), then stream the parquet scalars (the modseq source PeptideById was
+        /// interned from + IsDecoy) in parquet-row order, joining each row to its sidecar
+        /// record by entry_id. Returns <c>false</c> (ExitCode set) on a missing parquet path,
+        /// an unreadable / size-mismatched sidecar, or a parquet row whose entry_id is absent
+        /// from the sidecar (corruption -- the sidecar was written from this same parquet, so
+        /// every row must be present).
+        /// </summary>
+        private bool StreamFirstPassFileScores(
+            string fileName,
+            IReadOnlyDictionary<string, string> perFileParquetPaths,
+            OspreyConfig config,
+            PipelineContext ctx,
+            Action<string, bool, FdrScoreRecord> onRow)
+        {
+            if (!perFileParquetPaths.TryGetValue(fileName, out string parquetPath))
+            {
+                ctx.LogError(string.Format(
+                    @"First-pass protein FDR: no scores parquet path for {0}", fileName));
+                ctx.ExitCode = 1;
+                return false;
+            }
+            string sidecarBase = ResolveSidecarBasePath(fileName, perFileParquetPaths, config);
+            string fdrPath = FdrScoresSidecar.Pass1Path(sidecarBase);
+
+            var recordByEntryId = new Dictionary<uint, FdrScoreRecord>();
+            if (!FdrScoresSidecar.ReadRecords(fdrPath, FdrScoresSidecar.Pass.FirstPass,
+                    record => recordByEntryId[record.EntryId] = record))
+            {
+                ctx.LogError(string.Format(
+                    @"First-pass protein FDR: failed to read .1st-pass.fdr_scores.bin for {0} " +
+                    @"(expected at {1})", fileName, fdrPath));
+                ctx.ExitCode = 1;
+                return false;
+            }
+
+            bool faulted = false;
+            ParquetScoreCache.ReadFdrStubScalars(parquetPath,
+                (entryId, charge, isDecoy, coelutionSum, modseq) =>
+                {
+                    if (faulted)
+                        return;
+                    if (!recordByEntryId.TryGetValue(entryId, out FdrScoreRecord record))
+                    {
+                        faulted = true;
+                        return;
+                    }
+                    onRow(modseq, isDecoy, record);
+                });
+            if (faulted)
+            {
+                ctx.LogError(string.Format(
+                    @"First-pass protein FDR: .1st-pass.fdr_scores.bin for {0} is missing an " +
+                    @"entry_id present in {1} (sidecar / parquet mismatch)", fileName, parquetPath));
+                ctx.ExitCode = 1;
+                return false;
+            }
+            return true;
+        }
+
+        /// <summary>
+        /// Compute the post-first-pass passing base_id set by streaming the finalized per-file
+        /// <c>.1st-pass.fdr_scores.bin</c> sidecar, using the identical predicate as
+        /// <see cref="CompactFirstPass"/>'s non-bundle branch (targets whose run peptide
+        /// q-value passes the compaction peptide gate, or whose run protein q-value passes the
+        /// always-active protein-rescue gate; risk #7). entry_id carries the target/decoy flag
+        /// (<see cref="LibraryEntry.DECOY_ID_BIT"/>) + base_id
+        /// (<see cref="ScoringTaskShared.BASE_ID_MASK"/>): decoys minted
+        /// <c>target.Id | DECOY_ID_BIT</c> are skipped, and target / paired decoy share a
+        /// base_id, so the masked id set drives the survivor filter symmetrically -- exactly
+        /// what the resident (projection + outputs) read did, now off disk (issue #4355
+        /// struct-shrink S2). Returns <c>null</c> (ExitCode set) on a sidecar read fault (the
+        /// same file the survivor reload below overlays).
         /// </summary>
         private static HashSet<uint> ComputeFirstPassBaseIds(
-            FdrProjectionSet projections, FdrProjectionOutputs outputs, OspreyConfig config)
+            FdrProjectionSet projections,
+            IReadOnlyDictionary<string, string> perFileParquetPaths,
+            OspreyConfig config,
+            PipelineContext ctx)
         {
             var firstPassBaseIds = new HashSet<uint>();
             // Peptide-q compaction gate: the dedicated field (default 0.01 = RunFdr)
@@ -1820,23 +1922,33 @@ namespace pwiz.Osprey.Tasks
             double peptideGate = config.ReconciliationCompactionFdr;
             // Protein-rescue gate is always active (default 0.01), matching Rust
             // pipeline.rs:4651/4658 (protein_compaction_gate = config.protein_fdr, a
-            // plain f64, never a null switch). First-pass protein FDR now runs
-            // unconditionally on this path too, so RunProteinQvalue is populated.
+            // plain f64, never a null switch). First-pass protein FDR runs unconditionally
+            // on this path too, so run_protein_qvalue is populated in the finalized sidecar.
             double proteinGate = config.EffectiveProteinFdr;
-            for (int f = 0; f < projections.PerFile.Count; f++)
+            foreach (var kvp in projections.PerFile)
             {
-                var rows = projections.PerFile[f].Value;
-                for (int r = 0; r < rows.Count; r++)
+                string fileName = kvp.Key;
+                string sidecarBase = ResolveSidecarBasePath(fileName, perFileParquetPaths, config);
+                string fdrPath = FdrScoresSidecar.Pass1Path(sidecarBase);
+                if (!FdrScoresSidecar.ReadRecords(fdrPath, FdrScoresSidecar.Pass.FirstPass,
+                        record =>
+                        {
+                            // Decoy bit in entry_id == IsDecoy (decoys minted
+                            // target.Id | DECOY_ID_BIT); skip decoys, mask to the shared base_id.
+                            if ((record.EntryId & LibraryEntry.DECOY_ID_BIT) != 0)
+                                return;
+                            if (record.RunPeptideQvalue <= peptideGate ||
+                                record.RunProteinQvalue <= proteinGate)
+                            {
+                                firstPassBaseIds.Add(record.EntryId & ScoringTaskShared.BASE_ID_MASK);
+                            }
+                        }))
                 {
-                    if (rows[r].IsDecoy)
-                        continue;
-                    // Run peptide/protein q-values now live in the parallel outputs
-                    // array (issue #4355 struct-shrink S0), not on the lean struct.
-                    if (outputs.RunPeptideQvalue(f, r) <= peptideGate ||
-                        outputs.RunProteinQvalue(f, r) <= proteinGate)
-                    {
-                        firstPassBaseIds.Add(rows[r].EntryId & ScoringTaskShared.BASE_ID_MASK);
-                    }
+                    ctx.LogError(string.Format(
+                        @"First-pass compaction: failed to read .1st-pass.fdr_scores.bin for {0} " +
+                        @"(expected at {1})", fileName, fdrPath));
+                    ctx.ExitCode = 1;
+                    return null;
                 }
             }
             return firstPassBaseIds;

--- a/pwiz_tools/Osprey/Osprey.Tasks/FirstJoinTask.cs
+++ b/pwiz_tools/Osprey/Osprey.Tasks/FirstJoinTask.cs
@@ -1862,10 +1862,11 @@ namespace pwiz.Osprey.Tasks
         /// <c>.1st-pass.fdr_scores.bin</c> into an entry_id -> record map (one file resident;
         /// bounded), then stream the parquet scalars (the modseq source PeptideById was
         /// interned from + IsDecoy) in parquet-row order, joining each row to its sidecar
-        /// record by entry_id. Returns <c>false</c> (ExitCode set) on a missing parquet path,
-        /// an unreadable / size-mismatched sidecar, or a parquet row whose entry_id is absent
-        /// from the sidecar (corruption -- the sidecar was written from this same parquet, so
-        /// every row must be present).
+        /// record by entry_id. Returns <c>false</c> (ExitCode set) on a missing parquet path, a
+        /// missing sidecar base path, or an unreadable / size-mismatched sidecar. A parquet row
+        /// whose entry_id is absent from the sidecar is SKIPPED, not a fault: the sidecar is a
+        /// SUBSET of the parquet rows, so a row with no record is simply not a first-pass row
+        /// (superset tolerance mirroring the survivor reload -- see the inline note below).
         /// </summary>
         private bool StreamFirstPassFileScores(
             string fileName,
@@ -1882,6 +1883,13 @@ namespace pwiz.Osprey.Tasks
                 return false;
             }
             string sidecarBase = ResolveSidecarBasePath(fileName, perFileParquetPaths, config);
+            if (string.IsNullOrEmpty(sidecarBase))
+            {
+                ctx.LogError(string.Format(
+                    @"First-pass protein FDR: no sidecar base path for {0}", fileName));
+                ctx.ExitCode = 1;
+                return false;
+            }
             string fdrPath = FdrScoresSidecar.Pass1Path(sidecarBase);
 
             var recordByEntryId = new Dictionary<uint, FdrScoreRecord>();
@@ -1947,6 +1955,13 @@ namespace pwiz.Osprey.Tasks
             {
                 string fileName = kvp.Key;
                 string sidecarBase = ResolveSidecarBasePath(fileName, perFileParquetPaths, config);
+                if (string.IsNullOrEmpty(sidecarBase))
+                {
+                    ctx.LogError(string.Format(
+                        @"First-pass compaction: no sidecar base path for {0}", fileName));
+                    ctx.ExitCode = 1;
+                    return null;
+                }
                 string fdrPath = FdrScoresSidecar.Pass1Path(sidecarBase);
                 if (!FdrScoresSidecar.ReadRecords(fdrPath, FdrScoresSidecar.Pass.FirstPass,
                         record =>

--- a/pwiz_tools/Osprey/Osprey.Tasks/FirstJoinTask.cs
+++ b/pwiz_tools/Osprey/Osprey.Tasks/FirstJoinTask.cs
@@ -1870,27 +1870,20 @@ namespace pwiz.Osprey.Tasks
                 return false;
             }
 
-            bool faulted = false;
             ParquetScoreCache.ReadFdrStubScalars(parquetPath,
                 (entryId, charge, isDecoy, coelutionSum, modseq) =>
                 {
-                    if (faulted)
-                        return;
-                    if (!recordByEntryId.TryGetValue(entryId, out FdrScoreRecord record))
-                    {
-                        faulted = true;
-                        return;
-                    }
-                    onRow(modseq, isDecoy, record);
+                    // Mirror the survivor reload's superset tolerance (FdrScoresSidecar.TryRead):
+                    // the sidecar is written from the projection, a SUBSET of the parquet rows, so
+                    // a parquet row with no sidecar record is not a first-pass row -- skip it (the
+                    // resident path never saw it either). Today parquet == projection == sidecar
+                    // exactly (LoadFdrStubsFromParquet and ReadFdrStubScalars share the row-group
+                    // skip rule with no per-row filter), so this never triggers; keeping the
+                    // reader's contract aligned with the reload's avoids aborting a run on any
+                    // future parquet-superset case (e.g. an Astral gap-fill row).
+                    if (recordByEntryId.TryGetValue(entryId, out FdrScoreRecord record))
+                        onRow(modseq, isDecoy, record);
                 });
-            if (faulted)
-            {
-                ctx.LogError(string.Format(
-                    @"First-pass protein FDR: .1st-pass.fdr_scores.bin for {0} is missing an " +
-                    @"entry_id present in {1} (sidecar / parquet mismatch)", fileName, parquetPath));
-                ctx.ExitCode = 1;
-                return false;
-            }
             return true;
         }
 

--- a/pwiz_tools/Osprey/Osprey.Tasks/FirstJoinTask.cs
+++ b/pwiz_tools/Osprey/Osprey.Tasks/FirstJoinTask.cs
@@ -1833,7 +1833,10 @@ namespace pwiz.Osprey.Tasks
                         (entryId, charge, isDecoy, coelutionSum, modseq) =>
                         {
                             double q;
-                            if (!peptideQvalues.TryGetValue(modseq, out q))
+                            // Normalize a present-but-null modseq to "" so the lookup matches the
+                            // pass-1 PeptideQvalues keys (the accumulator normalizes the same way);
+                            // a null Dictionary key would otherwise throw. See StreamFirstPassFileScores.
+                            if (!peptideQvalues.TryGetValue(modseq ?? string.Empty, out q))
                                 q = 1.0;
                             runProteinByEntryId[entryId] = q;
                         });
@@ -1914,8 +1917,11 @@ namespace pwiz.Osprey.Tasks
                     // skip rule with no per-row filter), so this never triggers; keeping the
                     // reader's contract aligned with the reload's avoids aborting a run on any
                     // future parquet-superset case (e.g. an Astral gap-fill row).
+                    // Normalize a present-but-null modseq to "" so the protein-FDR accumulator's
+                    // Dictionary<string,...> key never sees null (which would throw); matches the
+                    // resident path, where FdrProjectionSet.Builder interned null modseqs as "".
                     if (recordByEntryId.TryGetValue(entryId, out FdrScoreRecord record))
-                        onRow(modseq, isDecoy, record);
+                        onRow(modseq ?? string.Empty, isDecoy, record);
                 });
             return true;
         }

--- a/pwiz_tools/Osprey/Osprey.Tasks/FirstJoinTask.cs
+++ b/pwiz_tools/Osprey/Osprey.Tasks/FirstJoinTask.cs
@@ -1798,8 +1798,12 @@ namespace pwiz.Osprey.Tasks
             // projection order (the reductions are order-independent, but streaming in the
             // resident path's file/row order keeps the best-scores insertion order identical).
             var accumulator = new FirstPassProteinFdrAccumulator(config.RunFdr);
+            int proteinReduceFiles = 0;
+            using (var reduceProgress = new ProgressReporter(string.Format(
+                       @"Computing first-pass protein FDR ({0} files)", projections.PerFile.Count), projections.PerFile.Count))
             foreach (var kvp in projections.PerFile)
             {
+                reduceProgress.Report(++proteinReduceFiles);
                 if (!StreamFirstPassFileScores(kvp.Key, perFileParquetPaths, config, ctx,
                         (modseq, isDecoy, record) =>
                             accumulator.Add(modseq, isDecoy, record.Score, record.RunPeptideQvalue)))
@@ -1817,8 +1821,12 @@ namespace pwiz.Osprey.Tasks
             // value the pass-1 PeptideQvalues keys were built from), not re-derived from the
             // library, so the peptide -> q lookup matches.
             var peptideQvalues = result.ProteinFdr.PeptideQvalues;
+            int proteinPatchFiles = 0;
+            using (var patchProgress = new ProgressReporter(string.Format(
+                       @"Patching first-pass protein q-values ({0} files)", projections.PerFile.Count), projections.PerFile.Count))
             foreach (var kvp in projections.PerFile)
             {
+                patchProgress.Report(++proteinPatchFiles);
                 string fileName = kvp.Key;
                 string sidecarBase = ResolveSidecarBasePath(fileName, perFileParquetPaths, config);
                 if (string.IsNullOrEmpty(sidecarBase))
@@ -1957,8 +1965,12 @@ namespace pwiz.Osprey.Tasks
             // plain f64, never a null switch). First-pass protein FDR runs unconditionally
             // on this path too, so run_protein_qvalue is populated in the finalized sidecar.
             double proteinGate = config.EffectiveProteinFdr;
+            int compactFiles = 0;
+            using (var compactProgress = new ProgressReporter(string.Format(
+                       @"Compacting first-pass results ({0} files)", projections.PerFile.Count), projections.PerFile.Count))
             foreach (var kvp in projections.PerFile)
             {
+                compactProgress.Report(++compactFiles);
                 string fileName = kvp.Key;
                 string sidecarBase = ResolveSidecarBasePath(fileName, perFileParquetPaths, config);
                 if (string.IsNullOrEmpty(sidecarBase))

--- a/pwiz_tools/Osprey/Osprey.Tasks/PerFileScoringTask.cs
+++ b/pwiz_tools/Osprey/Osprey.Tasks/PerFileScoringTask.cs
@@ -419,8 +419,12 @@ namespace pwiz.Osprey.Tasks
                 // no FdrEntry is ever allocated. Peptide ids arrive in insertion order
                 // and are remapped to the global Ordinal rank by Build(), so the result
                 // is element-for-element identical to BuildFromEntries (pinned by
-                // TestFdrProjectionBuilderMatchesBuildFromEntries).
-                var builder = new FdrProjectionSet.Builder();
+                // TestFdrProjectionBuilderMatchesBuildFromEntries). Counts-only (issue #4355
+                // struct-shrink S3, Stage B): the projection carries per-file row counts only --
+                // no 32 B rows -- because the 1st-pass streaming score path re-reads every row's
+                // identity + features from parquet, so the resident FdrProjection[] buffer that
+                // grew O(files) is never allocated.
+                var builder = new FdrProjectionSet.Builder(countsOnly: true);
                 // Per-file progress: streaming 32 B projection rows from each parquet is
                 // the lean path, but reading 82 files still ran minutes silent. Console-only,
                 // never touches the streamed rows, so the projection is byte-identical.
@@ -624,7 +628,10 @@ namespace pwiz.Osprey.Tasks
             var swAllFiles = Stopwatch.StartNew();
             if (config.InputFiles != null)
             {
-                var builder = needsResidentPool ? null : new FdrProjectionSet.Builder();
+                // Counts-only (issue #4355 struct-shrink S3, Stage B): the resume lean path builds
+                // only per-file row counts; the 1st-pass streaming score path re-reads identity +
+                // features from parquet, so no resident FdrProjection[] buffer is allocated.
+                var builder = needsResidentPool ? null : new FdrProjectionSet.Builder(countsOnly: true);
                 // Per-file progress so this all-files load is not a silent multi-minute
                 // stall on a large resume (the phase that looked hung on the 82-file run).
                 using (var loadProgress = new ProgressReporter(@"Loading scored entries", config.InputFiles.Count))
@@ -1178,8 +1185,11 @@ namespace pwiz.Osprey.Tasks
             // the merge needs the resident pool (an opt-in feature output) or is a
             // reconciled 2nd-pass bundle hydration (AllHaveReconSidecars -- FirstJoin
             // skips Percolator there and HydrateReconciliationOverlay reads the fat stubs).
+            // Counts-only (issue #4355 struct-shrink S3, Stage B): the merge-node lean path builds
+            // only per-file row counts; the 1st-pass streaming score path re-reads identity +
+            // features from parquet, so the resident FdrProjection[] buffer is never allocated.
             var builder = (!NeedsResidentPool(config) && !hasReconSidecars)
-                ? new FdrProjectionSet.Builder()
+                ? new FdrProjectionSet.Builder(countsOnly: true)
                 : null;
             for (int fileIdx = 0; fileIdx < config.InputScores.Count; fileIdx++)
             {

--- a/pwiz_tools/Osprey/Osprey.Test/FdrTest.cs
+++ b/pwiz_tools/Osprey/Osprey.Test/FdrTest.cs
@@ -683,12 +683,15 @@ namespace pwiz.Osprey.Test
         {
             private readonly Dictionary<(int, int), double> _scores = new Dictionary<(int, int), double>();
             private readonly Dictionary<(int, int), FdrQValues> _q = new Dictionary<(int, int), FdrQValues>();
+            private readonly Dictionary<(int, int), (uint EntryId, bool IsDecoy, byte Charge, string Peptide)> _ident =
+                new Dictionary<(int, int), (uint, bool, byte, string)>();
 
             public void Accept(int fileIdx, int rowIdx, uint entryId, bool isDecoy,
-                double score, in FdrQValues q)
+                byte charge, string peptide, double score, in FdrQValues q)
             {
                 _scores[(fileIdx, rowIdx)] = score;
                 _q[(fileIdx, rowIdx)] = q;
+                _ident[(fileIdx, rowIdx)] = (entryId, isDecoy, charge, peptide);
             }
 
             public void Finish(Action<string> logInfo)
@@ -697,6 +700,9 @@ namespace pwiz.Osprey.Test
 
             public double ScoreAt(int fileIdx, int rowIdx) => _scores[(fileIdx, rowIdx)];
             public FdrQValues QAt(int fileIdx, int rowIdx) => _q[(fileIdx, rowIdx)];
+            public (uint EntryId, bool IsDecoy, byte Charge, string Peptide) IdentAt(int fileIdx, int rowIdx)
+                => _ident[(fileIdx, rowIdx)];
+            public int Count => _scores.Count;
         }
 
         /// <summary>
@@ -874,6 +880,109 @@ namespace pwiz.Osprey.Test
                     Assert.AreEqual(stubList[i].Pep, q.Pep, 0.0);
                 }
             }
+        }
+
+        /// <summary>
+        /// Issue #4355 struct-shrink S3, Stage B (the FLAT-memory win): the 1st-pass-only
+        /// streaming Percolator that holds NO resident row buffer
+        /// (<see cref="PercolatorFdr.RunStreamingFirstPass"/>) must produce byte-identical
+        /// Score + five q-values + identity (entry_id / charge / peptide / is_decoy) to the
+        /// resident projection streaming path
+        /// (<see cref="PercolatorEngine.RunStreamingIntoProjection"/>) -- the byte-identity
+        /// ORACLE the regression gate's sidecars flow from -- on the same rows in the same
+        /// (file, row) order. Both paths sink every row through an <see cref="IFdrOutputSink"/>,
+        /// so a positional compare of the two sinks proves the fork changed only WHERE THE DATA
+        /// LIVES (streamed from a row source 3x, no O(n) projection / finalScores arrays) and not
+        /// the training-subset selection, SVM training, PEP ordering, per-file run-q, clamp
+        /// floors, or q-value math.
+        ///
+        /// The multi-observation fixture (2 files x 20 precursors x 3 scans) makes
+        /// best-per-precursor dedup collapse the pool to a strict SUBSET, and MaxTrainSize = 60
+        /// (&lt; the 80-row dedup) forces an actual peptide-grouped subsample -- so the streaming
+        /// training-subset selection is exercised against the resident one, not a no-op dedup. If
+        /// the two selected different subsets or trained different models, every Score/q-value
+        /// here would diverge. The fixture carries ParquetIndex == within-file row position, so the
+        /// streaming path's running row ordinal indexes the same feature row the resident path's
+        /// ParquetIndex does (the production invariant: parquet written in row order).
+        /// </summary>
+        [TestMethod]
+        public void TestStreamingFirstPassMatchesProjection()
+        {
+            const int nFeat = 3;
+            var featureInfos = new[]
+            {
+                new OspreyFeatureInfo("feat_a", "Feature A", false),
+                new OspreyFeatureInfo("feat_b", "Feature B", false),
+                new OspreyFeatureInfo("feat_c", "Feature C", false)
+            };
+
+            // Two identical fixtures (deterministic builder) fed to the two paths in the SAME
+            // order; ParquetIndex == within-file position, so the streaming path's running ordinal
+            // resolves the same feature row the resident path's ParquetIndex does.
+            var fixtureRes = BuildMultiObservationEquivFixture(nFeat, out var featuresRes);
+            var fixtureStr = BuildMultiObservationEquivFixture(nFeat, out var featuresStr);
+            var projSet = FdrProjectionSet.BuildFromEntries(fixtureRes);
+
+            var percConfig = new PercolatorConfig
+            {
+                MaxIterations = 10,
+                NFolds = 3,
+                Seed = 42,
+                TrainFdr = 0.01,
+                TestFdr = 0.01,
+                MaxTrainSize = 60,
+                FeatureInfos = featureInfos
+            };
+
+            // Resident projection streaming path (the byte-identity oracle).
+            var sinkRes = new CapturingSink();
+            bool abortRes = PercolatorEngine.RunStreamingIntoProjection(
+                projSet.PerFile, projSet.PeptideById, percConfig, s => { }, "First-pass",
+                f => featuresRes[f], sinkRes);
+            Assert.IsFalse(abortRes);
+
+            // Streaming-from-row-source path (the change under test): identity streamed straight
+            // from the fixture (== parquet), features by fileName, no resident projection.
+            var fileNames = fixtureStr.ConvertAll(kv => kv.Key);
+            Action<string, Action<uint, byte, bool, double, string>> streamFileRows =
+                (name, onRow) =>
+                {
+                    var list = fixtureStr.Find(kv => kv.Key == name).Value;
+                    foreach (var e in list)
+                        onRow(e.EntryId, e.Charge, e.IsDecoy, e.CoelutionSum, e.ModifiedSequence);
+                };
+            var sinkStr = new CapturingSink();
+            bool abortStr = PercolatorFdr.RunStreamingFirstPass(
+                fileNames, streamFileRows, f => featuresStr[f], percConfig, s => { }, "First-pass",
+                sinkStr);
+            Assert.IsFalse(abortStr);
+
+            Assert.AreEqual(sinkRes.Count, sinkStr.Count);
+            Assert.AreEqual(projSet.PerFile.Count, fixtureStr.Count);
+            int compared = 0;
+            for (int f = 0; f < fixtureStr.Count; f++)
+            {
+                var list = fixtureStr[f].Value;
+                for (int r = 0; r < list.Count; r++)
+                {
+                    Assert.AreEqual(sinkRes.ScoreAt(f, r), sinkStr.ScoreAt(f, r), 0.0);
+                    var qRes = sinkRes.QAt(f, r);
+                    var qStr = sinkStr.QAt(f, r);
+                    Assert.AreEqual(qRes.RunPrecursorQvalue, qStr.RunPrecursorQvalue, 0.0);
+                    Assert.AreEqual(qRes.RunPeptideQvalue, qStr.RunPeptideQvalue, 0.0);
+                    Assert.AreEqual(qRes.ExperimentPrecursorQvalue, qStr.ExperimentPrecursorQvalue, 0.0);
+                    Assert.AreEqual(qRes.ExperimentPeptideQvalue, qStr.ExperimentPeptideQvalue, 0.0);
+                    Assert.AreEqual(qRes.Pep, qStr.Pep, 0.0);
+                    var idRes = sinkRes.IdentAt(f, r);
+                    var idStr = sinkStr.IdentAt(f, r);
+                    Assert.AreEqual(idRes.EntryId, idStr.EntryId);
+                    Assert.AreEqual(idRes.IsDecoy, idStr.IsDecoy);
+                    Assert.AreEqual(idRes.Charge, idStr.Charge);
+                    Assert.AreEqual(idRes.Peptide, idStr.Peptide);
+                    compared++;
+                }
+            }
+            Assert.AreEqual(projSet.TotalRows, compared);
         }
 
         /// <summary>

--- a/pwiz_tools/Osprey/Osprey.Test/FdrTest.cs
+++ b/pwiz_tools/Osprey/Osprey.Test/FdrTest.cs
@@ -1547,6 +1547,105 @@ namespace pwiz.Osprey.Test
         #endregion
 
         // ============================================================
+        // Streaming first-pass q maps (Stage B) == flat builders
+        // ============================================================
+
+        #region StreamingFirstPassQ Tests
+
+        /// <summary>
+        /// The Stage B streaming builder (<c>PercolatorFdr.StreamingFirstPassQ</c>) must produce
+        /// experiment-precursor / experiment-peptide / PEP maps BYTE-IDENTICAL to the flat
+        /// array builders when fed the same population in the same flat (file,row) order -- the
+        /// invariant that lets the 1st-pass score pass drop the resident
+        /// finalScores/labels/entryIds/peptides[n] arrays. Uses a deterministic pseudo-random
+        /// multi-file population with score ties (rounded to 1 dp) to exercise the first-seen
+        /// tie-break and the target-vs-decoy-tie-to-decoy rule, and peptides shared across
+        /// base_ids to exercise best-per-peptide.
+        /// </summary>
+        [TestMethod]
+        public void TestStreamingFirstPassQMatchesFlat()
+        {
+            var rng = new Random(20260718);
+            const int nFiles = 4;
+            const int nBaseIds = 60;
+            var perFile = new List<(uint EntryId, bool IsDecoy, double Score, string Peptide)>[nFiles];
+            for (int f = 0; f < nFiles; f++)
+                perFile[f] = new List<(uint, bool, double, string)>();
+
+            for (uint baseId = 1; baseId <= nBaseIds; baseId++)
+            {
+                // Some base_ids share a peptide (different charges) -> best-per-peptide spans base_ids.
+                string peptide = "PEP" + (baseId % 40);
+                foreach (bool isDecoy in new[] { false, true })
+                {
+                    uint entryId = isDecoy ? (baseId | 0x80000000u) : baseId;
+                    int nObs = 1 + rng.Next(nFiles); // 1..nFiles observations
+                    var files = Enumerable.Range(0, nFiles).OrderBy(_ => rng.Next()).Take(nObs);
+                    foreach (int f in files)
+                    {
+                        double score = Math.Round(rng.NextDouble() * 8.0 - 2.0, 1); // 1 dp -> ties
+                        perFile[f].Add((entryId, isDecoy, score, peptide));
+                    }
+                }
+            }
+
+            // Flatten in (file,row) order == the streaming ordinal g.
+            var scores = new List<double>();
+            var labels = new List<bool>();
+            var entryIds = new List<uint>();
+            var peptides = new List<string>();
+            var streaming = new PercolatorFdr.StreamingFirstPassQ();
+            int g = 0;
+            for (int f = 0; f < nFiles; f++)
+            {
+                foreach (var row in perFile[f])
+                {
+                    scores.Add(row.Score);
+                    labels.Add(row.IsDecoy);
+                    entryIds.Add(row.EntryId);
+                    peptides.Add(row.Peptide);
+                    streaming.Add(g, row.Score, row.EntryId, row.IsDecoy, row.Peptide);
+                    g++;
+                }
+            }
+
+            var scoreArr = scores.ToArray();
+            var labelArr = labels.ToArray();
+            var entryIdArr = entryIds.ToArray();
+            var peptideArr = peptides.ToArray();
+
+            AssertMapsEqual(
+                PercolatorFdr.ComputeExperimentPrecursorQMap(scoreArr, labelArr, entryIdArr),
+                streaming.BuildExperimentPrecursorQMap(), "exp-precursor");
+            AssertMapsEqual(
+                PercolatorFdr.ComputeExperimentPeptideQMap(scoreArr, labelArr, entryIdArr, peptideArr),
+                streaming.BuildExperimentPeptideQMap(), "exp-peptide");
+            AssertMapsEqual(
+                PercolatorFdr.ComputePepWinnerMap(scoreArr, labelArr, entryIdArr),
+                streaming.BuildPepWinnerMap(), "pep-winner");
+        }
+
+        private static void AssertMapsEqual<TKey>(
+            Dictionary<TKey, double> flat, Dictionary<TKey, double> streaming, string which)
+        {
+            Assert.AreEqual(flat.Count, streaming.Count,
+                string.Format("{0}: map size differs (flat {1} vs streaming {2})",
+                    which, flat.Count, streaming.Count));
+            foreach (var kvp in flat)
+            {
+                double sv;
+                Assert.IsTrue(streaming.TryGetValue(kvp.Key, out sv),
+                    string.Format("{0}: streaming missing key {1}", which, kvp.Key));
+                // Byte-identical: the streaming path reuses the exact compete + conservative-q +
+                // PepEstimator finish on the same values in the same order, so the doubles match bit-for-bit.
+                Assert.AreEqual(kvp.Value, sv, 0.0,
+                    string.Format("{0}: value differs at key {1}", which, kvp.Key));
+            }
+        }
+
+        #endregion
+
+        // ============================================================
         // ClampExperimentQToBestRun tests
         // ============================================================
 


### PR DESCRIPTION
## Summary

`--task FirstPassFDR` held a resident `FdrProjection[]` peak buffer (~32 B/row) that grew **O(files)** -- ~11 GB at 82 files, ~140 GB projected at 500 files -- the blocker to a 500-file run. Stage B streams the 1st-pass Percolator score pass straight off each per-file `.scores.parquet` instead, so **no resident row buffer is ever allocated** and first-pass resident memory is now **flat in file count**.

* The lean 1st-pass producer builds a counts-only `FdrProjectionSet` (file names + row counts, no 32 B rows, no interned peptide table) in all three sites (in-process Run, resume Rehydrate, merge-node `LoadJoinOnlyScores`).
* `FirstJoinTask.RunFirstPassProjection` routes the counts-only 1st pass through `PercolatorEngine.RunFirstPassStreaming` -> `PercolatorFdr.RunStreamingFirstPass`: three streaming passes over the per-file parquet (train subset selection, q-value maps + clamp floors, emit), recomputing the SVM score per row instead of parking an O(rows) `finalScores[]`. Only the training subset (<= MaxTrainSize) and the intrinsically-bounded q-value lookups (O(base_ids)/O(peptides), via the already-committed `StreamingFirstPassQ` kernel) are ever resident.
* `IFdrOutputSink.Accept` takes `charge` + `peptide` as arguments so the sink needs no resident projection row; the 2nd pass keeps its O(survivors) resident projection and the unchanged resident `ScoreProjectionAndComputeFdrInPlace`.

**Byte-identical** to the resident path (the sidecars -> survivors -> blib are unchanged): the streaming best-per-precursor dedup reproduces `SelectBestPerPrecursor`/`BuildTrainingSubset` exactly (ascending-global-ordinal order, same `SubsampleByPeptideGroup`), and the score + q-value math reuses the same primitives. The load-bearing invariant: on the 1st pass the parquet is written `(entry_id,charge,scan)`-sorted, so streaming in parquet row order reproduces the resident `(EntryId,Charge,ParquetIndex)` sort (including competition first-seen tie-breaks).

**Memory (82-file SEA-AD MTG set, `OSPREY_LOG_MEMORY`, LIVE gc_heap post-GC):**

| Point (LIVE, gc_heap post-GC) | Before resident @82f | After @16f (68M) | After @82f (344M) |
|---|---|---|---|
| projection built | 13.35 GB | 2.28 GB | 2.59 GB |
| first-pass-fdr | ~9.85 GB (16f) | 2.65 GB | 2.35 GB |
| transient peak (gc_heap) | -- | 9.35 GB | 9.75 GB |

The `FdrProjection[]` block is gone and every LIVE point is flat 16f->82f (2.3-2.6 GB) despite 5x the rows -- ~140 GB projected at 500 files is now bounded at ~2.6 GB.

**dotMemory 20-file retention, pre-flip (resident) vs Stage B (streaming), same lean-library + Stage A:**

| snapshot (LIVE managed_heap) | before (resident) | after (streaming) | delta |
|---|---|---|---|
| projection built (stage5-start) | 4.88 GB | 2.28 GB | -2.60 GB |
| first-pass-fdr-live | 4.70 GB | 2.31 GB | -2.39 GB |

The ~2.6 GB delta is exactly the eliminated resident `FdrProjection[]`. Both runs produce byte-identical FDR output (610,776 targets / 6,081 decoys, 7,975 protein groups, 85M->2.67M survivors), and the 20 per-file `.1st-pass.fdr_scores.bin` sidecars are **byte-identical (20/20)** between the resident and streaming paths -- a definitive at-scale byte proof on real HRAM data that exercises the large-population subsample path (so no q-value movement; FDRBench calibration is unchanged by construction).

Known limitation (pre-existing, out of scope): the global row ordinal is `int`, matching the resident path's `int n` array indexing -- both cap at ~2.1B pre-compaction rows; widening to `long` for >2B-row runs is a follow-up (82f @ 344M rows is well under it).

## Test plan

- [x] TestStreamingFirstPassMatchesProjection - streaming path byte-identical to the resident projection path on a multi-file fixture with a FORCED peptide-grouped subsample (the path Stellar/Astral stay under)
- [x] regression.ps1 -Dataset Stellar - byte-identical mode1 (vs golden) / mode3 (HPC chain==straight) / mode2 (resume==straight); all blibs 45,064,192 bytes
- [x] regression.ps1 -Dataset Astral - byte-identical mode1/2/3; all blibs 135,249,920 bytes
- [x] 20-file HRAM sidecar byte-diff (resident vs streaming): 20/20 .1st-pass.fdr_scores.bin identical - at-scale proof the large-population subsample path is byte-identical (subsumes FDRBench)
- [x] 515 unit tests + ReSharper 0-warning inspection
- [x] 16f/82f + dotMemory 20f LIVE memory measurement - projection-built flat 2.28->2.59 GB and FdrProjection[] eliminated (was 13.35 GB @82f / 4.88 GB @20f resident)

Co-Authored-By: Claude <noreply@anthropic.com>
