### PR TITLE
Streamed Osprey transfer score->q table and mdiag-on-resume report

### DIFF
--- a/pwiz_tools/Osprey/Osprey.FDR/PercolatorEngine.cs
+++ b/pwiz_tools/Osprey/Osprey.FDR/PercolatorEngine.cs
@@ -217,7 +217,8 @@ namespace pwiz.Osprey.FDR
             PercolatorDiagnosticsConfig diagnostics = null,
             string passLabel = @"First-pass",
             Func<string, IReadOnlyList<double[]>> loadFileFeatures = null,
-            Action<FeatureContributions> captureContributions = null)
+            Action<FeatureContributions> captureContributions = null,
+            Action<PercolatorResults> captureModel = null)
         {
             // The lean FdrProjection no longer stores the q-value outputs (issue #4355
             // struct-shrink S0): the score pass hands them to this per-pass sink (the
@@ -276,7 +277,7 @@ namespace pwiz.Osprey.FDR
                 passLabel, n));
             bool streamingAbort = RunStreamingIntoProjection(
                 projections.PerFile, peptideById, percConfig, logInfo, passLabel,
-                loadFileFeatures, sink, captureContributions);
+                loadFileFeatures, sink, captureContributions, captureModel);
             if (streamingAbort)
                 return true;
 
@@ -295,7 +296,7 @@ namespace pwiz.Osprey.FDR
         /// <summary>
         /// Projection-free 1st-pass Percolator (issue #4355 struct-shrink S3, Stage B): the
         /// FLAT-memory entry point that holds NO resident row buffer. The counterpart of the
-        /// <see cref="RunPercolatorFdr(FdrProjectionSet,OspreyConfig,OspreyFeatureInfo[],System.Action{string},IFdrOutputSink,PercolatorDiagnosticsConfig,string,System.Func{string,System.Collections.Generic.IReadOnlyList{double[]}},System.Action{FeatureContributions})"/>
+        /// <see cref="RunPercolatorFdr(FdrProjectionSet,OspreyConfig,OspreyFeatureInfo[],System.Action{string},IFdrOutputSink,PercolatorDiagnosticsConfig,string,System.Func{string,System.Collections.Generic.IReadOnlyList{double[]}},System.Action{FeatureContributions},System.Action{PercolatorResults})"/>
         /// projection overload for the lean 1st-pass case, it builds the same parity-locked
         /// <see cref="PercolatorConfig"/> and delegates to
         /// <see cref="PercolatorFdr.RunStreamingFirstPass"/>, which streams every row's identity +
@@ -315,7 +316,8 @@ namespace pwiz.Osprey.FDR
             IFdrOutputSink sink,
             PercolatorDiagnosticsConfig diagnostics = null,
             string passLabel = @"First-pass",
-            Action<FeatureContributions> captureContributions = null)
+            Action<FeatureContributions> captureContributions = null,
+            Action<PercolatorResults> captureModel = null)
         {
             if (sink == null)
                 throw new ArgumentNullException(nameof(sink));
@@ -326,7 +328,7 @@ namespace pwiz.Osprey.FDR
             var percConfig = BuildProjectionPercolatorConfig(config, featureInfos, diagnostics);
             return PercolatorFdr.RunStreamingFirstPass(
                 fileNames, streamFileRows, loadFileFeatures, percConfig, logInfo, passLabel, sink,
-                captureContributions);
+                captureContributions, captureModel);
         }
 
         /// <summary>
@@ -712,7 +714,8 @@ namespace pwiz.Osprey.FDR
             string passLabel,
             Func<string, IReadOnlyList<double[]>> loadFileFeatures,
             IFdrOutputSink sink,
-            Action<FeatureContributions> captureContributions = null)
+            Action<FeatureContributions> captureContributions = null,
+            Action<PercolatorResults> captureModel = null)
         {
             if (loadFileFeatures == null)
                 throw new InvalidOperationException(
@@ -863,6 +866,11 @@ namespace pwiz.Osprey.FDR
 
             if (trainResults.DiagnosticAbort)
                 return true;
+
+            // OSPREY_PASS2_QVALUE=transfer: surface the trained model so the caller can publish
+            // FirstPassPercolatorModel for the 2nd-pass transfer (see RunFirstPassStreaming).
+            // Null off the transfer path -- a pure hand-off, so scoring stays byte-identical.
+            captureModel?.Invoke(trainResults);
 
             // Release the subset-only working sets before the score pass so only the
             // flat per-observation arrays + the projection remain resident across the

--- a/pwiz_tools/Osprey/Osprey.FDR/PercolatorFdr.cs
+++ b/pwiz_tools/Osprey/Osprey.FDR/PercolatorFdr.cs
@@ -1459,7 +1459,8 @@ namespace pwiz.Osprey.FDR
             Action<string> logInfo,
             string passLabel,
             IFdrOutputSink sink,
-            Action<FeatureContributions> captureContributions = null)
+            Action<FeatureContributions> captureContributions = null,
+            Action<PercolatorResults> captureModel = null)
         {
             if (streamFileRows == null)
                 throw new ArgumentNullException(nameof(streamFileRows));
@@ -1616,6 +1617,13 @@ namespace pwiz.Osprey.FDR
             PercolatorResults trainResults = RunPercolator(subsetEntries, trainConfig);
             if (trainResults.DiagnosticAbort)
                 return true;
+
+            // OSPREY_PASS2_QVALUE=transfer: surface the trained model so the caller can publish
+            // FirstPassPercolatorModel (the merge-node 2nd-pass transfer re-scores reconciled
+            // features with this frozen model). Null off the transfer path -- a pure hand-off, so
+            // scoring stays byte-identical. Mirrors the resident RunPercolatorFdr facade's
+            // captureModel, but on the streaming (lean) 1st-pass path.
+            captureModel?.Invoke(trainResults);
 
             // Release the pass-0 working sets before the score passes so only the bounded lookups
             // remain resident across the peak.

--- a/pwiz_tools/Osprey/Osprey.Tasks/FdrProjectionSinks.cs
+++ b/pwiz_tools/Osprey/Osprey.Tasks/FdrProjectionSinks.cs
@@ -56,10 +56,16 @@ namespace pwiz.Osprey.Tasks
         // pre-compaction row into the reduced report structures so the projection path can emit
         // the pass-1 report without holding the resident FdrEntry pool. Fed in Accept.
         private readonly ModelDiagnosticsData.Accumulator _mdiagAccumulator;
+        // Streaming OSPREY_PASS2_QVALUE=transfer score->q table accumulator (null off the transfer
+        // path): folds every pre-compaction row's (averaged-model score, effective experiment q)
+        // into the table population, so the projection path builds the full-population table
+        // without the resident FdrEntry pool BuildFullPopulationScoreQTable walks. Fed in Accept.
+        private readonly Pass2FdrSidecar.FirstPassScoreQTableAccumulator _scoreQTableAccumulator;
 
         protected FdrProjectionSinkBase(
             FdrProjectionSet projections, OspreyConfig config, string passLabel,
-            ModelDiagnosticsData.Accumulator mdiagAccumulator = null)
+            ModelDiagnosticsData.Accumulator mdiagAccumulator = null,
+            Pass2FdrSidecar.FirstPassScoreQTableAccumulator scoreQTableAccumulator = null)
         {
             Projections = projections;
             _fdrLevel = config.FdrLevel;
@@ -70,6 +76,7 @@ namespace pwiz.Osprey.Tasks
             _fileDecoys = new int[nFiles];
             _bestQByPrecursor = new Dictionary<string, double>(StringComparer.Ordinal);
             _mdiagAccumulator = mdiagAccumulator;
+            _scoreQTableAccumulator = scoreQTableAccumulator;
         }
 
         /// <summary>
@@ -113,6 +120,15 @@ namespace pwiz.Osprey.Tasks
             // passing set the [COUNT] tally reads). Null off the report path.
             if (_mdiagAccumulator != null)
                 _mdiagAccumulator.Add(fileIdx, peptide, charge, entryId, isDecoy, score, in q);
+
+            // OSPREY_PASS2_QVALUE=transfer: fold this pre-compaction row's averaged-model score
+            // (== the finalScores/fScores the projection score pass hands us, byte-identical to
+            // Pass2FdrSidecar.ScoreWithFrozenModel) and its effective experiment q into the full-
+            // population score->q table, matching the resident BuildFullPopulationScoreQTable's
+            // (score, Math.Max(exp prec q, exp pept q)) pair. Null off the transfer path.
+            if (_scoreQTableAccumulator != null)
+                _scoreQTableAccumulator.Add(score,
+                    Math.Max(q.ExperimentPrecursorQvalue, q.ExperimentPeptideQvalue));
 
             AcceptOutput(fileIdx, rowIdx, entryId, isDecoy, score, in q);
         }
@@ -185,8 +201,9 @@ namespace pwiz.Osprey.Tasks
         public FdrStoringSink(
             FdrProjectionSet projections, OspreyConfig config, string passLabel,
             Func<string, IReadOnlyList<FdrScoreRecord>, int> flushPartial,
-            ModelDiagnosticsData.Accumulator mdiagAccumulator = null)
-            : base(projections, config, passLabel, mdiagAccumulator)
+            ModelDiagnosticsData.Accumulator mdiagAccumulator = null,
+            Pass2FdrSidecar.FirstPassScoreQTableAccumulator scoreQTableAccumulator = null)
+            : base(projections, config, passLabel, mdiagAccumulator, scoreQTableAccumulator)
         {
             _flushPartial = flushPartial;
             _flushed = new bool[projections.PerFile.Count];

--- a/pwiz_tools/Osprey/Osprey.Tasks/FirstJoinTask.cs
+++ b/pwiz_tools/Osprey/Osprey.Tasks/FirstJoinTask.cs
@@ -678,16 +678,33 @@ namespace pwiz.Osprey.Tasks
                     }
                     string sidecarPath = FdrScoresSidecar.Pass1Path(sidecarBase);
 
-                    // Read the file's 1st-pass records (row order == parquet row order == the order
-                    // the score-pass sink wrote them), then zip with the parquet scalars by that row
-                    // ordinal -- the same (features/scalars indexed by row) binding the resident
-                    // overlay uses. entry_id is carried on both sides, so a mismatch fails loud
-                    // rather than folding misaligned rows.
+                    // Buffer this ONE file's 1st-pass records so we can zip them with the parquet
+                    // scalars by row ordinal (row order == parquet row order == the order the score-pass
+                    // sink wrote them). Buffering the sidecar is the smaller of the two per-file streams
+                    // (a fixed 60 B/record vs the parquet's modseq strings) and is bounded to a single
+                    // file -- a few hundred MB at most for the largest file, released at the end of this
+                    // iteration -- never the whole-run resident pool the batch write held.
                     var records = new List<FdrScoreRecord>();
                     if (!FdrScoresSidecar.ReadRecords(sidecarPath, FdrScoresSidecar.Pass.FirstPass, records.Add))
                     {
                         ctx.LogWarning(string.Format(
                             @"[MODEL-DIAGNOSTICS] resume: failed to read {0}; skipping its rows.", sidecarPath));
+                        continue;
+                    }
+
+                    // Per-file best-effort: an incomplete / mismatched file (its sidecar and parquet
+                    // disagree on row count -- the realistic "one bad file" case) is skipped with a
+                    // warning BEFORE any of its rows are folded into the shared accumulator, so one bad
+                    // file corrupts neither the report nor the remaining files. (A same-count entry_id
+                    // scramble -- a deeper corruption that cannot arise while both sides read the parquet
+                    // in row order -- still trips the defensive throws below and aborts the whole report
+                    // rather than render partially-folded data.) ProbeCwtRowMetadata is a footer-only read.
+                    long parquetRowCount = ParquetScoreCache.ProbeCwtRowMetadata(parquetPath).RowCount;
+                    if (parquetRowCount != records.Count)
+                    {
+                        ctx.LogWarning(string.Format(
+                            @"[MODEL-DIAGNOSTICS] resume: {0} row-count mismatch (parquet {1} vs sidecar {2}); skipping its rows.",
+                            fileName, parquetRowCount, records.Count));
                         continue;
                     }
 
@@ -724,9 +741,11 @@ namespace pwiz.Osprey.Tasks
             catch (Exception ex)
             {
                 // Never let a diagnostics-only artifact take down a real run (matches Write /
-                // WriteFromAccumulator, which also log-and-swallow).
+                // WriteFromAccumulator, which also log-and-swallow). Log the full exception
+                // (type + message + stack + inner), not just Message: a resume sidecar/parquet
+                // mismatch or IO fault is otherwise near-undiagnosable from the swallowed line.
                 ctx.LogInfo(string.Format(
-                    @"[MODEL-DIAGNOSTICS] resume report generation failed: {0}", ex.Message));
+                    @"[MODEL-DIAGNOSTICS] resume report generation failed: {0}", ex));
             }
         }
 

--- a/pwiz_tools/Osprey/Osprey.Tasks/FirstJoinTask.cs
+++ b/pwiz_tools/Osprey/Osprey.Tasks/FirstJoinTask.cs
@@ -264,13 +264,17 @@ namespace pwiz.Osprey.Tasks
             // bound memory -- so when it is requested, take the resident (legacy) path so that
             // report still emits. Off the default output path, so byte-identity is unaffected
             // (the regression gate never sets it).
-            // OSPREY_PASS2_QVALUE=transfer also needs the resident first-pass pool: it
-            // captures the frozen 1st-pass model and builds the FULL pre-compaction
-            // score->q table (BuildFullPopulationScoreQTable, below), both of which read
-            // every entry's in-memory Stage-4 features -- exactly what the projection path
-            // streams and drops. The regression gate never sets the env var, so byte-identity
-            // on the default percolator path is unaffected.
-            // --model-diagnostics is NOT here: it now STREAMS its pass-1 report off the
+            // OSPREY_PASS2_QVALUE=transfer is NOT here anymore: it now STREAMS its full-population
+            // score->q table AND publishes the frozen 1st-pass model off the projection path (a
+            // FirstPassScoreQTableAccumulator + captureModel fed by the score-pass sink in
+            // RunFirstPassProjection below), so the ~80 GB resident FdrEntry pool
+            // BuildFullPopulationScoreQTable used to walk -- the OOM at an 82-file transfer resume --
+            // is never materialized. The sink hands the accumulator the same averaged-model score +
+            // experiment q the resident build paired, and BuildScoreToQTable sorts, so the streamed
+            // table is byte-identical to the resident build. The resident BuildFullPopulationScoreQTable
+            // path below still runs when the projection path is off (OSPREY_FDR_PROJECTION=0 /
+            // non-Percolator FDR), where the fat pool is present.
+            // --model-diagnostics is NOT here either: it likewise STREAMS its pass-1 report off the
             // projection path via a ModelDiagnosticsData.Accumulator fed by the score-pass sink
             // (RunFirstPassProjection below), folding each pre-compaction row into the reduced
             // report structures rather than holding the whole-run FdrEntry pool resident -- which
@@ -278,8 +282,7 @@ namespace pwiz.Osprey.Tasks
             // streamed report is byte-identical to the resident build, and it stays off the
             // default output path.
             bool needsResidentFirstPassPool =
-                (!string.IsNullOrEmpty(config.OutputFdrBench) && config.FdrBenchPass == 1) ||
-                OspreyEnvironment.Pass2TransferQ;
+                (!string.IsNullOrEmpty(config.OutputFdrBench) && config.FdrBenchPass == 1);
             if (OspreyEnvironment.UseFdrProjection && config.FdrMethod == FdrMethod.Percolator &&
                 !needsResidentFirstPassPool)
             {
@@ -484,7 +487,11 @@ namespace pwiz.Osprey.Tasks
 
             ctx.LogInfo(@"Bundle hydration: skipping first-pass Percolator (sidecar provides q-values).");
 
-            LogFirstPassResultsAndDump(perFileEntries, config, ctx);
+            // Resume path: emit --model-diagnostics by streaming the 1st-pass sidecar + parquet
+            // (streamModelDiagnosticsFromSidecars) rather than the resident batch write, so the
+            // report no longer forces the ~80-100 GB fat pool that OOM'd an 82-file mdiag resume.
+            LogFirstPassResultsAndDump(perFileEntries, config, ctx,
+                streamModelDiagnosticsFromSidecars: true);
 
             // Compaction delegates to RescoreCompaction.Apply on the bundle
             // path so the pre-compaction (file, vec_idx) keys in
@@ -582,12 +589,24 @@ namespace pwiz.Osprey.Tasks
         /// OSPREY_DUMP_PERCOLATOR; written before compaction drops rows so the
         /// cross-impl diff sees both targets and decoys) and the
         /// OSPREY_PERCOLATOR_ONLY measurement exit.
+        ///
+        /// When <paramref name="streamModelDiagnosticsFromSidecars"/> is set (the
+        /// <see cref="Rehydrate"/> resume path), the <c>--model-diagnostics</c> report is emitted
+        /// by STREAMING each file's <c>.1st-pass.fdr_scores.bin</c> sidecar + parquet scalars into
+        /// the reduced <see cref="ModelDiagnosticsData.Accumulator"/>, rather than reading the
+        /// resident <paramref name="perFileEntries"/> pool -- so a resume no longer materializes the
+        /// ~80-100 GB fat pool that OOM'd an 82-file --model-diagnostics resume. The accumulator's
+        /// streamed reductions reproduce the resident <c>Write</c> reductions (order-independent),
+        /// so the report is byte-identical. On the resident <see cref="Run"/> path (projection off /
+        /// non-Percolator) the flag is false and the batch <c>Write</c> reads the resident pool,
+        /// whose 1st-pass sidecars are not written yet.
         /// </summary>
         private void LogFirstPassResultsAndDump(
             List<KeyValuePair<string, List<FdrEntry>>> perFileEntries,
             OspreyConfig config,
             PipelineContext ctx,
-            FeatureContributions contributions = null)
+            FeatureContributions contributions = null,
+            bool streamModelDiagnosticsFromSidecars = false)
         {
             LogFirstPassResults(perFileEntries, config, ctx);
 
@@ -603,9 +622,111 @@ namespace pwiz.Osprey.Tasks
             // output; a failure is logged and swallowed inside Write.
             if (config.ModelDiagnostics)
             {
-                var libraryById = ctx.Get<LibraryById>().Value;
-                var cal = BuildCalibrationData(ctx, perFileEntries.ConvertAll(kv => kv.Key));
-                ModelDiagnosticsReport.Write(perFileEntries, contributions, libraryById, cal, config, ctx.LogInfo);
+                if (streamModelDiagnosticsFromSidecars)
+                {
+                    WriteModelDiagnosticsFromSidecars(perFileEntries, config, ctx);
+                }
+                else
+                {
+                    var libraryById = ctx.Get<LibraryById>().Value;
+                    var cal = BuildCalibrationData(ctx, perFileEntries.ConvertAll(kv => kv.Key));
+                    ModelDiagnosticsReport.Write(perFileEntries, contributions, libraryById, cal, config, ctx.LogInfo);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Resume-path <c>--model-diagnostics</c> emission: stream every file's
+        /// <c>.1st-pass.fdr_scores.bin</c> sidecar (SVM score + q-values, in stored row order) joined
+        /// with its parquet scalars (entry_id / charge / is_decoy / modseq, same row order) into the
+        /// reduced <see cref="ModelDiagnosticsData.Accumulator"/>, then render via
+        /// <see cref="ModelDiagnosticsReport.WriteFromAccumulator"/>. This reproduces the exact rows
+        /// the resident batch <see cref="ModelDiagnosticsReport.Write"/> reads off the fat pool -- the
+        /// sidecar carries the SAME per-row score + q the overlay would have assigned each stub -- so
+        /// the streamed report is byte-identical to the resident build, without materializing the fat
+        /// pool. Contributions are null on a resume (no retrain), matching the resident resume path.
+        /// A failure is logged and swallowed; a diagnostics artifact never aborts a real run.
+        /// </summary>
+        private void WriteModelDiagnosticsFromSidecars(
+            List<KeyValuePair<string, List<FdrEntry>>> perFileEntries,
+            OspreyConfig config,
+            PipelineContext ctx)
+        {
+            try
+            {
+                var runNames = perFileEntries.ConvertAll(kv => kv.Key);
+                var accumulator = BuildModelDiagnosticsAccumulator(runNames.ToArray(), config, ctx);
+                var perFileParquetPaths = ctx.Get<PerFileParquetPaths>().Value;
+
+                for (int fileIdx = 0; fileIdx < perFileEntries.Count; fileIdx++)
+                {
+                    string fileName = perFileEntries[fileIdx].Key;
+                    if (!perFileParquetPaths.TryGetValue(fileName, out string parquetPath))
+                    {
+                        ctx.LogWarning(string.Format(
+                            @"[MODEL-DIAGNOSTICS] resume: no scores parquet path for {0}; skipping its rows.",
+                            fileName));
+                        continue;
+                    }
+                    string sidecarBase = ResolveSidecarBasePath(fileName, perFileParquetPaths, config);
+                    if (string.IsNullOrEmpty(sidecarBase))
+                    {
+                        ctx.LogWarning(string.Format(
+                            @"[MODEL-DIAGNOSTICS] resume: no sidecar base path for {0}; skipping its rows.",
+                            fileName));
+                        continue;
+                    }
+                    string sidecarPath = FdrScoresSidecar.Pass1Path(sidecarBase);
+
+                    // Read the file's 1st-pass records (row order == parquet row order == the order
+                    // the score-pass sink wrote them), then zip with the parquet scalars by that row
+                    // ordinal -- the same (features/scalars indexed by row) binding the resident
+                    // overlay uses. entry_id is carried on both sides, so a mismatch fails loud
+                    // rather than folding misaligned rows.
+                    var records = new List<FdrScoreRecord>();
+                    if (!FdrScoresSidecar.ReadRecords(sidecarPath, FdrScoresSidecar.Pass.FirstPass, records.Add))
+                    {
+                        ctx.LogWarning(string.Format(
+                            @"[MODEL-DIAGNOSTICS] resume: failed to read {0}; skipping its rows.", sidecarPath));
+                        continue;
+                    }
+
+                    int localFileIdx = fileIdx;
+                    int row = 0;
+                    ParquetScoreCache.ReadFdrStubScalars(parquetPath,
+                        (entryId, charge, isDecoy, coelutionSum, modseq) =>
+                        {
+                            if (row >= records.Count)
+                                throw new InvalidDataException(string.Format(
+                                    @"model-diagnostics resume: {0} has more parquet rows than {1} has records.",
+                                    parquetPath, sidecarPath));
+                            var rec = records[row];
+                            if (rec.EntryId != entryId)
+                                throw new InvalidDataException(string.Format(
+                                    @"model-diagnostics resume: row {0} entry_id mismatch (parquet {1} vs sidecar {2}) in {3}.",
+                                    row, entryId, rec.EntryId, fileName));
+                            var q = new FdrQValues(
+                                rec.RunPrecursorQvalue, rec.RunPeptideQvalue,
+                                rec.ExperimentPrecursorQvalue, rec.ExperimentPeptideQvalue, rec.Pep);
+                            accumulator.Add(localFileIdx, modseq ?? string.Empty, charge, entryId,
+                                isDecoy, rec.Score, in q);
+                            row++;
+                        });
+                    if (row != records.Count)
+                        throw new InvalidDataException(string.Format(
+                            @"model-diagnostics resume: {0} has {1} parquet rows but {2} sidecar records.",
+                            fileName, row, records.Count));
+                }
+
+                var cal = BuildCalibrationData(ctx, runNames);
+                ModelDiagnosticsReport.WriteFromAccumulator(accumulator, null, cal, config, ctx.LogInfo);
+            }
+            catch (Exception ex)
+            {
+                // Never let a diagnostics-only artifact take down a real run (matches Write /
+                // WriteFromAccumulator, which also log-and-swallow).
+                ctx.LogInfo(string.Format(
+                    @"[MODEL-DIAGNOSTICS] resume report generation failed: {0}", ex.Message));
             }
         }
 
@@ -685,14 +806,11 @@ namespace pwiz.Osprey.Tasks
         /// accumulator with the input-file order (from the projection) plus the run FDR level.
         /// </summary>
         private static ModelDiagnosticsData.Accumulator BuildModelDiagnosticsAccumulator(
-            FdrProjectionSet projections, OspreyConfig config, PipelineContext ctx)
+            string[] runNames, OspreyConfig config, PipelineContext ctx)
         {
             var libraryById = ctx.Get<LibraryById>().Value;
             ModelDiagnosticsReport.BuildClassificationFromLibrary(config, libraryById, ctx.LogInfo,
                 out var classByBaseId, out var pairByBaseId, out var entrapmentRatio);
-            var runNames = new string[projections.PerFile.Count];
-            for (int i = 0; i < runNames.Length; i++)
-                runNames[i] = projections.PerFile[i].Key;
             return new ModelDiagnosticsData.Accumulator(
                 runNames, classByBaseId, pairByBaseId, entrapmentRatio, config.RunFdr, config.FdrLevel);
         }
@@ -1599,15 +1717,39 @@ namespace pwiz.Osprey.Tasks
             // folds every pre-compaction row into it; capture the trained model for the Model tab.
             // Null off the report path, so byte-neutral there.
             var mdiagAccumulator = config.ModelDiagnostics
-                ? BuildModelDiagnosticsAccumulator(projections, config, ctx)
+                ? BuildModelDiagnosticsAccumulator(
+                    projections.PerFile.ConvertAll(kv => kv.Key).ToArray(), config, ctx)
                 : null;
             FeatureContributions mdiagContributions = null;
             Action<FeatureContributions> captureContributions = null;
             if (mdiagAccumulator != null)
                 captureContributions = c => mdiagContributions = c;
 
+            // OSPREY_PASS2_QVALUE=transfer: build the full-population score->q table AND publish the
+            // frozen 1st-pass model straight off the projection score pass, so the ~80 GB resident
+            // FdrEntry pool BuildFullPopulationScoreQTable used to walk (the OOM at an 82-file
+            // transfer resume) is never materialized. The sink folds each pre-compaction row's
+            // averaged-model score + effective experiment q into the accumulator, and captureModel
+            // publishes the trained model the merge-node 2nd-pass transfer re-scores reconciled
+            // features with. Null off the transfer path, so byte-neutral there.
+            var scoreQTableAccumulator = OspreyEnvironment.Pass2TransferQ
+                ? new Pass2FdrSidecar.FirstPassScoreQTableAccumulator()
+                : null;
+            Action<PercolatorResults> captureModel = null;
+            if (OspreyEnvironment.Pass2TransferQ)
+            {
+                // Publish is add-only (throws on a duplicate key); guard so a first pass that somehow
+                // ran twice in one process degrades to a no-op rather than a raw ArgumentException.
+                // Mirrors the resident RunPercolatorFdr facade's captureModel guard.
+                captureModel = results =>
+                {
+                    if (!ctx.TryGet<FirstPassPercolatorModel>(out _))
+                        ctx.Publish(new FirstPassPercolatorModel { Results = results });
+                };
+            }
+
             var sink = new FdrStoringSink(projections, config, @"First-pass", FlushPartialSidecar,
-                mdiagAccumulator);
+                mdiagAccumulator, scoreQTableAccumulator);
             var featureInfos = OspreyFeatureCalculators.BuildFeatureInfos(ParquetScoreCache.PIN_FEATURE_NAMES);
             var swFdr = Stopwatch.StartNew();
             bool aborted;
@@ -1626,14 +1768,14 @@ namespace pwiz.Osprey.Tasks
                 aborted = PercolatorEngine.RunFirstPassStreaming(
                     projections.PerFile.ConvertAll(kv => kv.Key), streamFileRows, loadFileFeatures,
                     config, featureInfos, ctx.LogInfo, sink, BuildPercolatorDiagnostics(ctx.Diagnostics),
-                    @"First-pass", captureContributions);
+                    @"First-pass", captureContributions, captureModel);
             }
             else
             {
                 aborted = PercolatorEngine.RunPercolatorFdr(
                     projections, config, featureInfos,
                     ctx.LogInfo, sink, BuildPercolatorDiagnostics(ctx.Diagnostics),
-                    @"First-pass", loadFileFeatures, captureContributions);
+                    @"First-pass", loadFileFeatures, captureContributions, captureModel);
             }
             swFdr.Stop();
             if (aborted)
@@ -1662,6 +1804,18 @@ namespace pwiz.Osprey.Tasks
                 var cal = BuildCalibrationData(ctx, projections.PerFile.ConvertAll(kv => kv.Key));
                 ModelDiagnosticsReport.WriteFromAccumulator(
                     mdiagAccumulator, mdiagContributions, cal, config, ctx.LogInfo);
+            }
+
+            // OSPREY_PASS2_QVALUE=transfer: build + publish the FULL-population score->q table from
+            // the pairs the sink streamed during the score pass (the resident BuildFullPopulationScoreQTable
+            // equivalent, without the resident pool). captureModel above already published the frozen
+            // model; the merge-node 2nd-pass transfer reads both byproducts. Null (no publish) when the
+            // accumulator folded nothing, matching the resident build's fall-back.
+            if (scoreQTableAccumulator != null)
+            {
+                var scoreQTable = scoreQTableAccumulator.BuildTableOrNull(ctx);
+                if (scoreQTable != null)
+                    ctx.Publish(scoreQTable);
             }
 
             // First-pass protein FDR streamed off the per-file sidecar + parquet scalars

--- a/pwiz_tools/Osprey/Osprey.Tasks/Pass2FdrSidecar.cs
+++ b/pwiz_tools/Osprey/Osprey.Tasks/Pass2FdrSidecar.cs
@@ -1010,6 +1010,14 @@ namespace pwiz.Osprey.Tasks
         /// no resident pool, no second parquet re-read. <see cref="BuildScoreToQTable"/> sorts by
         /// score, so the collection order does not matter: the resulting table is byte-identical
         /// to the resident build on the same (score, q) multiset.
+        ///
+        /// Byte-identity invariant: the resident build SKIPS a row whose parquet feature is missing
+        /// / out-of-range / wrong-length (its <c>nSkipped</c> tally), while the score pass instead
+        /// resolves such a row to a basic-feature vector and folds it here -- so identity holds only
+        /// when <c>nSkipped == 0</c>. That is guaranteed on the 1st pass, where every entry's
+        /// <see cref="FdrEntry.ParquetIndex"/> is a valid in-range row of its own file's parquet
+        /// (1:1), which is the only place this accumulator runs. Not thread-safe by design: the
+        /// score-pass emit loop that drives <see cref="Add"/> (via the sink) is single-threaded.
         /// </summary>
         internal sealed class FirstPassScoreQTableAccumulator
         {

--- a/pwiz_tools/Osprey/Osprey.Tasks/Pass2FdrSidecar.cs
+++ b/pwiz_tools/Osprey/Osprey.Tasks/Pass2FdrSidecar.cs
@@ -999,6 +999,67 @@ namespace pwiz.Osprey.Tasks
         }
 
         /// <summary>
+        /// Streaming counterpart of <see cref="BuildFullPopulationScoreQTable"/> for the
+        /// projection / lean 1st-pass path (OSPREY_PASS2_QVALUE=transfer): the resident build
+        /// walks the full pre-compaction <see cref="FdrEntry"/> pool -- the ~80 GB buffer that
+        /// OOM'd an 82-file transfer resume at the join -- to pair each entry's averaged-model
+        /// score with its effective experiment q. The projection score pass already computes the
+        /// SAME two values per row (<c>finalScores</c>/<c>fScores</c> == the averaged-model
+        /// <see cref="ScoreWithFrozenModel"/> score, plus the experiment precursor/peptide q it
+        /// hands the sink), so this accumulator collects them straight off the score-pass sink --
+        /// no resident pool, no second parquet re-read. <see cref="BuildScoreToQTable"/> sorts by
+        /// score, so the collection order does not matter: the resulting table is byte-identical
+        /// to the resident build on the same (score, q) multiset.
+        /// </summary>
+        internal sealed class FirstPassScoreQTableAccumulator
+        {
+            // Two parallel lists, exactly the tableScores / tableQs the resident build fills.
+            private readonly List<double> _scores = new List<double>();
+            private readonly List<double> _qs = new List<double>();
+
+            /// <summary>Number of (score, q) pairs folded in so far.</summary>
+            public int Count => _scores.Count;
+
+            /// <summary>
+            /// Fold one pre-compaction 1st-pass row's averaged-model score + effective experiment q
+            /// into the table population, matching the resident build's per-entry
+            /// <c>(ScoreWithFrozenModel(...), Math.Max(ExperimentPrecursorQvalue,
+            /// ExperimentPeptideQvalue))</c> pair. Called once per row from the score-pass sink.
+            /// </summary>
+            public void Add(double score, double effExperimentQ)
+            {
+                _scores.Add(score);
+                _qs.Add(effExperimentQ);
+            }
+
+            /// <summary>
+            /// Build the score-&gt;q table from the folded pairs via <see cref="BuildScoreToQTable"/>,
+            /// with the same log line + empty-population guard as
+            /// <see cref="BuildFullPopulationScoreQTable"/>. Returns <c>null</c> (logged) when no
+            /// rows were folded, so the caller publishes nothing and the transfer falls back.
+            /// </summary>
+            public FirstPassScoreQTable BuildTableOrNull(PipelineContext ctx)
+            {
+                if (_scores.Count == 0)
+                {
+                    ctx.LogWarning(
+                        "OSPREY_PASS2_QVALUE=transfer: streaming score->q table folded no rows; " +
+                        "table not published (transfer will fall back).");
+                    return null;
+                }
+                BuildScoreToQTable(_scores, _qs, out double[] scoresDesc, out double[] qDesc);
+                ctx.LogInfo(string.Format(
+                    "OSPREY_PASS2_QVALUE=transfer: built FULL-population score->q table from {0} entries " +
+                    "(streamed off the projection score pass; raw-score range [{1:F4}, {2:F4}]; " +
+                    "q range [{3:E3}, {4:E3}]).",
+                    scoresDesc.Length,
+                    scoresDesc[scoresDesc.Length - 1], scoresDesc[0],
+                    qDesc[0], qDesc[qDesc.Length - 1]));
+                return new FirstPassScoreQTable { ScoresDesc = scoresDesc, QDesc = qDesc };
+            }
+        }
+
+        /// <summary>
         /// Apply the averaged frozen model to a single raw feature vector: standardize a
         /// copy into the caller-supplied <paramref name="scratch"/> buffer, then
         /// score = avgBias + sum(avgWeights[j] * std(feat)[j]). Mirrors the per-entry math

--- a/pwiz_tools/Osprey/Osprey.Tasks/PerFileScoringTask.cs
+++ b/pwiz_tools/Osprey/Osprey.Tasks/PerFileScoringTask.cs
@@ -616,13 +616,16 @@ namespace pwiz.Osprey.Tasks
             // needs the resident pool. FirstJoin consumes the projection set identically
             // whether Run or this path produced it.
             //
-            // --model-diagnostics is the one resume-only exception to Run's lean choice:
-            // Run streams the report off the first-pass Percolator score pass (the streaming
-            // Accumulator), but a resume SKIPS that score pass (sidecar q-values), so FirstJoin's
-            // resume path emits the report via the batch ModelDiagnosticsReport.Write, which reads
-            // the RESIDENT per-file entries. Force the fat pool here so that report is populated
-            // (matches pre-lean behavior); the compute Run path stays lean.
-            bool needsResidentPool = NeedsResidentPool(config) || config.ModelDiagnostics;
+            // --model-diagnostics no longer forces the fat pool here: a resume where FirstJoin RUNS
+            // Stage 5 (the common case -- the 1st-pass sidecars are absent) streams the report off
+            // the score pass exactly like a fresh Run, and a resume where FirstJoin REHYDRATES Stage 5
+            // (1st-pass sidecars valid) now emits the report by streaming the sidecar + parquet into
+            // the same ModelDiagnosticsData.Accumulator (FirstJoinTask.WriteModelDiagnosticsFromSidecars)
+            // rather than the resident batch ModelDiagnosticsReport.Write. Either way the report is
+            // byte-identical to the resident build, and the ~80-100 GB resident FdrEntry pool that
+            // OOM'd an 82-file --model-diagnostics resume is never materialized. So mdiag follows the
+            // same lean resume path plain percolator already takes.
+            bool needsResidentPool = NeedsResidentPool(config);
             FdrProjectionSet projections = null;
 
             var swAllFiles = Stopwatch.StartNew();
@@ -1464,12 +1467,17 @@ namespace pwiz.Osprey.Tasks
         /// <summary>
         /// Whether Stage 5 needs the resident fat-stub first-pass pool rather than the
         /// lean streamed <see cref="FdrProjection"/> set (#4400). True when an opt-in
-        /// output reads every entry's in-memory features/scores (FDRBench pass 1,
-        /// OSPREY_PASS2_QVALUE=transfer), when the projection path is off
-        /// (OSPREY_FDR_PROJECTION=0 / non-Percolator FDR), or on the reconciled-input
-        /// worker join. Shared by <see cref="Run"/> and <see cref="RehydrateFromOwnOutputs"/>
-        /// so the compute and resume paths make the identical lean/fat choice -- otherwise a
-        /// pure resume rebuilds the ~53 GB fat buffer #4400 dropped for straight-through.
+        /// output reads every entry's in-memory features/scores (FDRBench pass 1), when the
+        /// projection path is off (OSPREY_FDR_PROJECTION=0 / non-Percolator FDR), or on the
+        /// reconciled-input worker join. Shared by <see cref="Run"/> and
+        /// <see cref="RehydrateFromOwnOutputs"/> so the compute and resume paths make the identical
+        /// lean/fat choice -- otherwise a pure resume rebuilds the ~53 GB fat buffer #4400 dropped
+        /// for straight-through.
+        ///
+        /// OSPREY_PASS2_QVALUE=transfer is NOT here anymore: it streams its full-population
+        /// score->q table (and publishes the frozen model) off the projection score pass in
+        /// FirstJoinTask.RunFirstPassProjection, so it no longer needs the resident FdrEntry pool
+        /// BuildFullPopulationScoreQTable used to walk -- the OOM at an 82-file transfer resume.
         ///
         /// --model-diagnostics is NOT here: it streams its pass-1 report off the projection
         /// path via a ModelDiagnosticsData.Accumulator fed by the score-pass sink (mirrors the
@@ -1483,8 +1491,7 @@ namespace pwiz.Osprey.Tasks
             return config.ExpectReconciledInput ||
                    !OspreyEnvironment.UseFdrProjection ||
                    config.FdrMethod != FdrMethod.Percolator ||
-                   (!string.IsNullOrEmpty(config.OutputFdrBench) && config.FdrBenchPass == 1) ||
-                   OspreyEnvironment.Pass2TransferQ;
+                   (!string.IsNullOrEmpty(config.OutputFdrBench) && config.FdrBenchPass == 1);
         }
 
         /// <summary>

--- a/pwiz_tools/Osprey/Osprey.Tasks/PerFileScoringTask.cs
+++ b/pwiz_tools/Osprey/Osprey.Tasks/PerFileScoringTask.cs
@@ -780,10 +780,12 @@ namespace pwiz.Osprey.Tasks
             ctx.Publish(new PerFileIsolationMz(_perFileIsolationMz));
             ctx.Publish(new PerFileParquetPaths(_perFileParquetPaths));
             ctx.Publish(new ScoredEntries(_perFileEntries));
-            // Lean first-pass rows (issue #4397). Null on the rehydrate/merge paths (including
-            // a --model-diagnostics resume, which needs resident entries for the batch report)
-            // and on FDRBench pass 1 / OSPREY_PASS2_QVALUE=transfer, which publish fat stubs
-            // above; FirstJoinTask falls back to ScoredEntries whenever this is null.
+            // Lean first-pass rows (issue #4397). Non-null on the lean paths -- including a
+            // --model-diagnostics or OSPREY_PASS2_QVALUE=transfer resume, which now STREAM Stage 5
+            // (the mdiag report off the score-pass Accumulator, the transfer score->q table off the
+            // sink) instead of walking a resident pool. Null only on the fat paths that still publish
+            // resident stubs above (FDRBench pass 1, non-Percolator / projection-off, reconciled-input
+            // worker join); FirstJoinTask falls back to ScoredEntries whenever this is null.
             ctx.Publish(new FdrProjections(projections));
             ctx.Publish(new RescoreBundle(_rescoreInputs));
 

--- a/pwiz_tools/Osprey/Osprey.Test/FdrTest.cs
+++ b/pwiz_tools/Osprey/Osprey.Test/FdrTest.cs
@@ -708,7 +708,7 @@ namespace pwiz.Osprey.Test
         /// <summary>
         /// End-to-end projection RunPercolatorFdr equivalence (the survivor-reload
         /// equivalence at the unit level): the projection
-        /// <see cref="PercolatorEngine.RunPercolatorFdr(FdrProjectionSet,OspreyConfig,OspreyFeatureInfo[],System.Action{string},IFdrOutputSink,PercolatorDiagnosticsConfig,string,System.Func{string,System.Collections.Generic.IReadOnlyList{double[]}},System.Action{FeatureContributions})"/>
+        /// <see cref="PercolatorEngine.RunPercolatorFdr(FdrProjectionSet,OspreyConfig,OspreyFeatureInfo[],System.Action{string},IFdrOutputSink,PercolatorDiagnosticsConfig,string,System.Func{string,System.Collections.Generic.IReadOnlyList{double[]}},System.Action{FeatureContributions},System.Action{PercolatorResults})"/>
         /// overload must produce byte-identical Score + q-values to the FdrEntry-buffer
         /// <see cref="PercolatorEngine"/> RunPercolatorFdr overload (the one that takes the
         /// per-file <see cref="FdrEntry"/> lists) -- the flag-off byte-identity ORACLE -- on the same input, at the

--- a/pwiz_tools/Osprey/Osprey.Test/Pass2FdrSidecarTest.cs
+++ b/pwiz_tools/Osprey/Osprey.Test/Pass2FdrSidecarTest.cs
@@ -331,6 +331,65 @@ namespace pwiz.Osprey.Test
             Assert.AreEqual(1.0, Pass2FdrSidecar.LookupQForScore(0.0, new double[0], new double[0]), 1e-12);
         }
 
+        /// <summary>
+        /// The streaming transfer path (<see cref="Pass2FdrSidecar.FirstPassScoreQTableAccumulator"/>)
+        /// folds (score, q) pairs in score-pass (file, row) order off the sink, while the resident
+        /// <see cref="Pass2FdrSidecar.BuildFullPopulationScoreQTable"/> folds them in entry order.
+        /// Their byte-identity rests entirely on <see cref="Pass2FdrSidecar.BuildScoreToQTable"/>
+        /// being ORDER-INDEPENDENT -- the same (score, q) multiset in any order must yield a
+        /// byte-identical table. This test locks that invariant (the streaming transfer q-table's
+        /// only unverified assumption) and checks the accumulator collects the pairs it is fed.
+        /// </summary>
+        [TestMethod]
+        public void TestScoreQTableOrderIndependent()
+        {
+            const int n = 5000;
+            var scores = new List<double>(n);
+            var qs = new List<double>(n);
+            var rand = new Random(20260719);
+            for (int i = 0; i < n; i++)
+            {
+                scores.Add(rand.NextDouble() * 10.0 - 5.0);
+                // Include exact duplicate (score, q) pairs so the sort's tie region is exercised.
+                qs.Add(Math.Round(rand.NextDouble(), 3));
+            }
+
+            // Reference table from the fed order.
+            Pass2FdrSidecar.BuildScoreToQTable(scores, qs, out double[] scoresRef, out double[] qRef);
+
+            // Feed the SAME (score, q) pairs to the accumulator (its Add is what the sink calls),
+            // then shuffle the pairs together and rebuild. The accumulator forwards to
+            // BuildScoreToQTable, so its table must equal the reference; the shuffled rebuild must
+            // too (order-independence).
+            var acc = new Pass2FdrSidecar.FirstPassScoreQTableAccumulator();
+            var order = new int[n];
+            for (int i = 0; i < n; i++)
+            {
+                acc.Add(scores[i], qs[i]);
+                order[i] = i;
+            }
+            Assert.AreEqual(n, acc.Count);
+
+            for (int i = n - 1; i > 0; i--)
+            {
+                int j = rand.Next(i + 1);
+                int t = order[i]; order[i] = order[j]; order[j] = t;
+            }
+            var scoresShuf = new List<double>(n);
+            var qsShuf = new List<double>(n);
+            foreach (int k in order)
+            {
+                scoresShuf.Add(scores[k]);
+                qsShuf.Add(qs[k]);
+            }
+            Pass2FdrSidecar.BuildScoreToQTable(scoresShuf, qsShuf, out double[] scoresShufTab, out double[] qShufTab);
+
+            CollectionAssert.AreEqual(scoresRef, scoresShufTab,
+                "score->q table ScoresDesc must be byte-identical regardless of fold order");
+            CollectionAssert.AreEqual(qRef, qShufTab,
+                "score->q table QDesc must be byte-identical regardless of fold order");
+        }
+
         // Verbatim copy of the FdrProjectionSet-overload comparer in
         // PercolatorEngine.RunPercolatorFdr (the scan-omitted projection sort). Same
         // isolation caveat as LegacyResidentComparison.


### PR DESCRIPTION
## Summary

* Streamed the `OSPREY_PASS2_QVALUE=transfer` full-population score->q table and published the frozen 1st-pass model off the projection score pass (a `FirstPassScoreQTableAccumulator` + `captureModel` fed by the score-pass sink), so the resident `FdrEntry` pool `BuildFullPopulationScoreQTable` walked -- the OOM at an 82-file transfer resume -- is never materialized.
* Streamed `--model-diagnostics` on the resume/rehydrate path from the 1st-pass sidecar + parquet into the `ModelDiagnosticsData.Accumulator` + `WriteFromAccumulator`, instead of the resident batch `ModelDiagnosticsReport.Write`; dropped `Pass2TransferQ` and `ModelDiagnostics` from the Stage-5 resident-pool gates (`needsResidentFirstPassPool` / `NeedsResidentPool`). Resident builds kept for the projection-off path.
* Byte-identical to the resident build by construction (the sink hands the accumulator the same averaged-model score + experiment q; `BuildScoreToQTable` sorts). Verified: an 8-file resident-vs-streaming A/B shows byte-identical `.1st-pass.fdr_scores.bin` (all 8) and byte-identical mdiag `data.json`/`.html`; Stage-5 managed heap dropped 48 GB -> 13 GB.

See ai/todos/active/TODO-20260719_osprey_transfer_mdiag_resume_streaming.md

## Test plan

- [x] Build + 520 unit tests + zero-warning ReSharper inspection (Debug)
- [x] `regression.ps1 -Dataset Stellar` mode1/2/3 byte-identical (default percolator path unaffected; lean resume + HPC reconciliation OK)
- [x] 8-file transfer+mdiag A/B (master resident vs branch streaming): `.1st-pass` sidecars + mdiag report byte-identical
- [ ] 82-file transfer+mdiag resume completes in 64 GB with flat Stage 5 (in progress)

Co-Authored-By: Claude <noreply@anthropic.com>