### PR TITLE
Warned on unrecognized rows during --import-peak-boundaries

### DIFF
--- a/pwiz_tools/Skyline/CommandLine.cs
+++ b/pwiz_tools/Skyline/CommandLine.cs
@@ -737,44 +737,40 @@ namespace pwiz.Skyline
         /// </summary>
         private void WarnUnrecognizedPeakBoundaries(PeakBoundaryImporter importer)
         {
-            WarnUnrecognizedItems(importer.UnrecognizedPeptides, importer.UnrecognizedPeptideLines, p => p,
+            WarnUnrecognizedItems(importer.UnrecognizedPeptides, p => p,
                 SkylineResources.CommandLine_ImportPeakBoundaries_Warning__The_following_peptide_in_the_peak_boundaries_file_was_not_recognized_and_was_ignored_,
                 SkylineResources.CommandLine_ImportPeakBoundaries_Warning__The_following__0__peptides_in_the_peak_boundaries_file_were_not_recognized_and_were_ignored_);
-            WarnUnrecognizedItems(importer.UnrecognizedFiles, importer.UnrecognizedFileLines, f => f,
+            WarnUnrecognizedItems(importer.UnrecognizedFiles, f => f,
                 SkylineResources.CommandLine_ImportPeakBoundaries_Warning__The_following_file_or_replicate_name_in_the_peak_boundaries_file_was_not_recognized_and_was_ignored_,
                 SkylineResources.CommandLine_ImportPeakBoundaries_Warning__The_following__0__file_or_replicate_names_in_the_peak_boundaries_file_were_not_recognized_and_were_ignored_);
-            WarnUnrecognizedItems(importer.UnrecognizedChargeStates, importer.UnrecognizedChargeStateLines, c => c.PrintLine(' '),
+            WarnUnrecognizedItems(importer.UnrecognizedChargeStates, c => c.PrintLine(' '),
                 SkylineResources.CommandLine_ImportPeakBoundaries_Warning__The_following_peptide__file__and_charge_state_combination_was_not_recognized_and_was_ignored_,
                 SkylineResources.CommandLine_ImportPeakBoundaries_Warning__The_following__0__peptide__file__and_charge_state_combinations_were_not_recognized_and_were_ignored_);
         }
 
         /// <summary>
         /// Writes a count-headed warning followed by up to <c>maxItemsToShow</c> of the offending values
-        /// (then an ellipsis when truncated), mirroring the bounded list the GUI shows. Each value is
-        /// prefixed with the input-file line it first appeared on, from <paramref name="lineNumbers"/>.
+        /// (then an ellipsis when truncated), mirroring the bounded list the GUI shows. <paramref name="items"/>
+        /// maps each unrecognized value to the input-file line it first appeared on; the earliest rows are
+        /// shown first (dictionary order is arbitrary) so the list reliably points at the user's first bad rows.
         /// </summary>
-        private void WarnUnrecognizedItems<TItem>(ICollection<TItem> items, IDictionary<TItem, long> lineNumbers,
-            Func<TItem, string> printLine, string singularHeader, string pluralHeaderFormat)
+        private void WarnUnrecognizedItems<TItem>(IDictionary<TItem, long> items, Func<TItem, string> printLine,
+            string singularHeader, string pluralHeaderFormat)
         {
             if (items.Count == 0)
                 return;
             const int maxItemsToShow = 10;
             _out.WriteLine(items.Count == 1 ? singularHeader : string.Format(pluralHeaderFormat, items.Count));
-            // Show the earliest offending rows first (HashSet order is arbitrary) so the bounded list
-            // reliably points at the user's first bad rows and the cited line numbers read in order.
-            long LineOf(TItem item) => lineNumbers.TryGetValue(item, out var line) ? line : long.MaxValue;
             int shown = 0;
-            foreach (var item in items.OrderBy(LineOf))
+            foreach (var item in items.OrderBy(pair => pair.Value))
             {
                 if (shown++ == maxItemsToShow)
                 {
                     _out.WriteLine(@"...");
                     break;
                 }
-                var text = printLine(item);
-                if (lineNumbers.TryGetValue(item, out var lineNumber))
-                    text = string.Format(SkylineResources.CommandLine_ImportPeakBoundaries_Warning__line__0____1_, lineNumber, text);
-                _out.WriteLine(text);
+                _out.WriteLine(SkylineResources.CommandLine_ImportPeakBoundaries_Warning__line__0____1_,
+                    item.Value, printLine(item.Key));
             }
         }
 

--- a/pwiz_tools/Skyline/CommandLine.cs
+++ b/pwiz_tools/Skyline/CommandLine.cs
@@ -724,7 +724,58 @@ namespace pwiz.Skyline
                 var modifiedDocument = importer.ModifyDocument(SrmDocument.DOCUMENT_TYPE.none,
                     commandArgs.ImportPeakBoundariesPath, progressMonitor, lineCount);
                 ModifyDocument(DocumentModifier.FromResult(_doc, modifiedDocument));
+                WarnUnrecognizedPeakBoundaries(importer);
             }, SkylineResources.CommandLine_ImportPeakBoundaries_Error__Failed_importing_peak_boundaries_);
+        }
+
+        /// <summary>
+        /// Reports each row the peak-boundary importer skipped (unrecognized peptide, file name, or
+        /// peptide/file/charge-state combination) as a console warning. The GUI surfaces these through a
+        /// dialog (see <see cref="FileUI.PeakBoundaryImporterUI"/>); the command line has no dialog, so
+        /// without this an --import-peak-boundaries file that matches nothing imports silently and still
+        /// reports success, leaving the user no way to tell "applied" from "matched nothing".
+        /// </summary>
+        private void WarnUnrecognizedPeakBoundaries(PeakBoundaryImporter importer)
+        {
+            WarnUnrecognizedItems(importer.UnrecognizedPeptides, importer.UnrecognizedPeptideLines, p => p,
+                SkylineResources.CommandLine_ImportPeakBoundaries_Warning__The_following_peptide_in_the_peak_boundaries_file_was_not_recognized_and_was_ignored_,
+                SkylineResources.CommandLine_ImportPeakBoundaries_Warning__The_following__0__peptides_in_the_peak_boundaries_file_were_not_recognized_and_were_ignored_);
+            WarnUnrecognizedItems(importer.UnrecognizedFiles, importer.UnrecognizedFileLines, f => f,
+                SkylineResources.CommandLine_ImportPeakBoundaries_Warning__The_following_file_or_replicate_name_in_the_peak_boundaries_file_was_not_recognized_and_was_ignored_,
+                SkylineResources.CommandLine_ImportPeakBoundaries_Warning__The_following__0__file_or_replicate_names_in_the_peak_boundaries_file_were_not_recognized_and_were_ignored_);
+            WarnUnrecognizedItems(importer.UnrecognizedChargeStates, importer.UnrecognizedChargeStateLines, c => c.PrintLine(' '),
+                SkylineResources.CommandLine_ImportPeakBoundaries_Warning__The_following_peptide__file__and_charge_state_combination_was_not_recognized_and_was_ignored_,
+                SkylineResources.CommandLine_ImportPeakBoundaries_Warning__The_following__0__peptide__file__and_charge_state_combinations_were_not_recognized_and_were_ignored_);
+        }
+
+        /// <summary>
+        /// Writes a count-headed warning followed by up to <c>maxItemsToShow</c> of the offending values
+        /// (then an ellipsis when truncated), mirroring the bounded list the GUI shows. Each value is
+        /// prefixed with the input-file line it first appeared on, from <paramref name="lineNumbers"/>.
+        /// </summary>
+        private void WarnUnrecognizedItems<TItem>(ICollection<TItem> items, IDictionary<TItem, long> lineNumbers,
+            Func<TItem, string> printLine, string singularHeader, string pluralHeaderFormat)
+        {
+            if (items.Count == 0)
+                return;
+            const int maxItemsToShow = 10;
+            _out.WriteLine(items.Count == 1 ? singularHeader : string.Format(pluralHeaderFormat, items.Count));
+            // Show the earliest offending rows first (HashSet order is arbitrary) so the bounded list
+            // reliably points at the user's first bad rows and the cited line numbers read in order.
+            long LineOf(TItem item) => lineNumbers.TryGetValue(item, out var line) ? line : long.MaxValue;
+            int shown = 0;
+            foreach (var item in items.OrderBy(LineOf))
+            {
+                if (shown++ == maxItemsToShow)
+                {
+                    _out.WriteLine(@"...");
+                    break;
+                }
+                var text = printLine(item);
+                if (lineNumbers.TryGetValue(item, out var lineNumber))
+                    text = string.Format(SkylineResources.CommandLine_ImportPeakBoundaries_Warning__line__0____1_, lineNumber, text);
+                _out.WriteLine(text);
+            }
         }
 
         private bool RefineDocument(CommandArgs commandArgs)

--- a/pwiz_tools/Skyline/FileUI/PeakBoundaryImporterUI.cs
+++ b/pwiz_tools/Skyline/FileUI/PeakBoundaryImporterUI.cs
@@ -36,11 +36,11 @@ namespace pwiz.Skyline.FileUI
         public static bool UnrecognizedPeptidesCancel(this PeakBoundaryImporter importer, IWin32Window parent)
         {
             const int itemsToShow = 10;
-            if (!ShowMissingMessage(parent, itemsToShow, importer.UnrecognizedPeptides, p => p.ToString(), PeptideMessages))
+            if (!ShowMissingMessage(parent, itemsToShow, importer.UnrecognizedPeptides.Keys, p => p.ToString(), PeptideMessages))
                 return false;
-            if (!ShowMissingMessage(parent, itemsToShow, importer.UnrecognizedFiles, f => f.ToString(), FileMessages))
+            if (!ShowMissingMessage(parent, itemsToShow, importer.UnrecognizedFiles.Keys, f => f.ToString(), FileMessages))
                 return false;
-            if (!ShowMissingMessage(parent, itemsToShow, importer.UnrecognizedChargeStates, c => c.PrintLine(' '), ChargeMessages))
+            if (!ShowMissingMessage(parent, itemsToShow, importer.UnrecognizedChargeStates.Keys, c => c.PrintLine(' '), ChargeMessages))
                 return false;
             return true;
         }
@@ -105,7 +105,7 @@ namespace pwiz.Skyline.FileUI
             }
         }
 
-        private static bool ShowMissingMessage<TItem>(IWin32Window parent, int maxItems, HashSet<TItem> items,
+        private static bool ShowMissingMessage<TItem>(IWin32Window parent, int maxItems, ICollection<TItem> items,
             Func<TItem, string> printLine, Func<int, MissingMessageLines> getMessageLines)
         {
             if (items.Any())

--- a/pwiz_tools/Skyline/Model/ImportPeakBoundaries.cs
+++ b/pwiz_tools/Skyline/Model/ImportPeakBoundaries.cs
@@ -44,27 +44,20 @@ namespace pwiz.Skyline.Model
         public SrmDocument Document { get; private set; }
         public int CountMissing { get; private set; }
         public List<string> AnnotationsAdded { get; private set; }
-        public HashSet<string> UnrecognizedPeptides { get; private set; }
-        public HashSet<string> UnrecognizedFiles { get; private set; }
-        public HashSet<UnrecognizedChargeState> UnrecognizedChargeStates { get; private set; }
-
-        // First input-file line on which each unrecognized item appeared, so callers (e.g. the command
-        // line) can point the user at the offending row. Populated alongside the sets above; the sets stay
-        // the deduped source of truth the GUI and audit log already consume.
-        public Dictionary<string, long> UnrecognizedPeptideLines { get; private set; }
-        public Dictionary<string, long> UnrecognizedFileLines { get; private set; }
-        public Dictionary<UnrecognizedChargeState, long> UnrecognizedChargeStateLines { get; private set; }
+        // Each unrecognized item mapped to the first input-file line it appeared on, so callers (e.g. the
+        // command line) can point the user at the offending row. The keys are the deduped set of
+        // unrecognized items the GUI and audit log consume (via .Keys).
+        public Dictionary<string, long> UnrecognizedPeptides { get; private set; }
+        public Dictionary<string, long> UnrecognizedFiles { get; private set; }
+        public Dictionary<UnrecognizedChargeState, long> UnrecognizedChargeStates { get; private set; }
 
         public PeakBoundaryImporter(SrmDocument document)
         {
             Document = document;
             AnnotationsAdded = new List<string>();
-            UnrecognizedFiles = new HashSet<string>();
-            UnrecognizedPeptides = new HashSet<string>();
-            UnrecognizedChargeStates = new HashSet<UnrecognizedChargeState>();
-            UnrecognizedPeptideLines = new Dictionary<string, long>();
-            UnrecognizedFileLines = new Dictionary<string, long>();
-            UnrecognizedChargeStateLines = new Dictionary<UnrecognizedChargeState, long>();
+            UnrecognizedFiles = new Dictionary<string, long>();
+            UnrecognizedPeptides = new Dictionary<string, long>();
+            UnrecognizedChargeStates = new Dictionary<UnrecognizedChargeState, long>();
         }
 
         public struct UnrecognizedChargeState : IEquatable<UnrecognizedChargeState>
@@ -311,10 +304,10 @@ namespace pwiz.Skyline.Model
 
             var docPair = SrmDocumentPair.Create(originalDocument, modifiedDocument.Document, documentType);
             var allInfo = new List<MessageInfo>();
-            AddMessageInfo(allInfo, MessageType.removed_unrecognized_peptide, docPair.OldDocumentType, UnrecognizedPeptides);
+            AddMessageInfo(allInfo, MessageType.removed_unrecognized_peptide, docPair.OldDocumentType, UnrecognizedPeptides.Keys);
             AddMessageInfo(allInfo, MessageType.removed_unrecognized_file, docPair.OldDocumentType,
-                UnrecognizedFiles.Select(AuditLogPath.Create));
-            AddMessageInfo(allInfo, MessageType.removed_unrecognized_charge_state, docPair.OldDocumentType, UnrecognizedChargeStates);
+                UnrecognizedFiles.Keys.Select(AuditLogPath.Create));
+            AddMessageInfo(allInfo, MessageType.removed_unrecognized_charge_state, docPair.OldDocumentType, UnrecognizedChargeStates.Keys);
 
             var auditLogEntry = AuditLogEntry.CreateSimpleEntry(MessageType.imported_peak_boundaries,
                     docPair.OldDocumentType,
@@ -485,8 +478,8 @@ namespace pwiz.Skyline.Model
                 }
                 if (null == pepPaths)
                 {
-                    if (UnrecognizedPeptides.Add(modifiedPeptideString))
-                        UnrecognizedPeptideLines[modifiedPeptideString] = linesRead;
+                    if (!UnrecognizedPeptides.ContainsKey(modifiedPeptideString))
+                        UnrecognizedPeptides[modifiedPeptideString] = linesRead;
                     continue;
                 }
                 Adduct charge;
@@ -554,8 +547,8 @@ namespace pwiz.Skyline.Model
                 }
                 if (fileMatch == null)
                 {
-                    if (UnrecognizedFiles.Add(fileIdentity))
-                        UnrecognizedFileLines[fileIdentity] = linesRead;
+                    if (!UnrecognizedFiles.ContainsKey(fileIdentity))
+                        UnrecognizedFiles[fileIdentity] = linesRead;
                     continue;
                 }
                 var chromSet = fileMatch.Chromatograms;
@@ -626,8 +619,8 @@ namespace pwiz.Skyline.Model
                 if (!foundSample)
                 {
                     var unrecognizedChargeState = new UnrecognizedChargeState(charge, fileIdentity, modifiedPeptideString);
-                    if (UnrecognizedChargeStates.Add(unrecognizedChargeState))
-                        UnrecognizedChargeStateLines[unrecognizedChargeState] = linesRead;
+                    if (!UnrecognizedChargeStates.ContainsKey(unrecognizedChargeState))
+                        UnrecognizedChargeStates[unrecognizedChargeState] = linesRead;
                 }
             }
             // Remove peaks from the document that weren't in the file.

--- a/pwiz_tools/Skyline/Model/ImportPeakBoundaries.cs
+++ b/pwiz_tools/Skyline/Model/ImportPeakBoundaries.cs
@@ -46,8 +46,15 @@ namespace pwiz.Skyline.Model
         public List<string> AnnotationsAdded { get; private set; }
         public HashSet<string> UnrecognizedPeptides { get; private set; }
         public HashSet<string> UnrecognizedFiles { get; private set; }
-        public HashSet<UnrecognizedChargeState> UnrecognizedChargeStates { get; private set; } 
-        
+        public HashSet<UnrecognizedChargeState> UnrecognizedChargeStates { get; private set; }
+
+        // First input-file line on which each unrecognized item appeared, so callers (e.g. the command
+        // line) can point the user at the offending row. Populated alongside the sets above; the sets stay
+        // the deduped source of truth the GUI and audit log already consume.
+        public Dictionary<string, long> UnrecognizedPeptideLines { get; private set; }
+        public Dictionary<string, long> UnrecognizedFileLines { get; private set; }
+        public Dictionary<UnrecognizedChargeState, long> UnrecognizedChargeStateLines { get; private set; }
+
         public PeakBoundaryImporter(SrmDocument document)
         {
             Document = document;
@@ -55,6 +62,9 @@ namespace pwiz.Skyline.Model
             UnrecognizedFiles = new HashSet<string>();
             UnrecognizedPeptides = new HashSet<string>();
             UnrecognizedChargeStates = new HashSet<UnrecognizedChargeState>();
+            UnrecognizedPeptideLines = new Dictionary<string, long>();
+            UnrecognizedFileLines = new Dictionary<string, long>();
+            UnrecognizedChargeStateLines = new Dictionary<UnrecognizedChargeState, long>();
         }
 
         public struct UnrecognizedChargeState : IEquatable<UnrecognizedChargeState>
@@ -475,7 +485,8 @@ namespace pwiz.Skyline.Model
                 }
                 if (null == pepPaths)
                 {
-                    UnrecognizedPeptides.Add(modifiedPeptideString);
+                    if (UnrecognizedPeptides.Add(modifiedPeptideString))
+                        UnrecognizedPeptideLines[modifiedPeptideString] = linesRead;
                     continue;
                 }
                 Adduct charge;
@@ -543,7 +554,8 @@ namespace pwiz.Skyline.Model
                 }
                 if (fileMatch == null)
                 {
-                    UnrecognizedFiles.Add(fileIdentity);
+                    if (UnrecognizedFiles.Add(fileIdentity))
+                        UnrecognizedFileLines[fileIdentity] = linesRead;
                     continue;
                 }
                 var chromSet = fileMatch.Chromatograms;
@@ -613,7 +625,9 @@ namespace pwiz.Skyline.Model
                 }
                 if (!foundSample)
                 {
-                    UnrecognizedChargeStates.Add(new UnrecognizedChargeState(charge, fileIdentity, modifiedPeptideString));
+                    var unrecognizedChargeState = new UnrecognizedChargeState(charge, fileIdentity, modifiedPeptideString);
+                    if (UnrecognizedChargeStates.Add(unrecognizedChargeState))
+                        UnrecognizedChargeStateLines[unrecognizedChargeState] = linesRead;
                 }
             }
             // Remove peaks from the document that weren't in the file.

--- a/pwiz_tools/Skyline/SkylineResources.designer.cs
+++ b/pwiz_tools/Skyline/SkylineResources.designer.cs
@@ -938,7 +938,76 @@ namespace pwiz.Skyline {
                 return ResourceManager.GetString("CommandLine_ImportPeakBoundaries_Importing_peak_boundaries_from__0_", resourceCulture);
             }
         }
-        
+
+        /// <summary>
+        ///   Looks up a localized string similar to Warning: The following {0} file or replicate names in the peak boundaries file were not recognized and were ignored:.
+        /// </summary>
+        public static string CommandLine_ImportPeakBoundaries_Warning__The_following__0__file_or_replicate_names_in_the_peak_boundaries_file_were_not_recognized_and_were_ignored_ {
+            get {
+                return ResourceManager.GetString("CommandLine_ImportPeakBoundaries_Warning__The_following__0__file_or_replicate_names" +
+                        "_in_the_peak_boundaries_file_were_not_recognized_and_were_ignored_", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Warning: The following {0} peptide, file, and charge state combinations were not recognized and were ignored:.
+        /// </summary>
+        public static string CommandLine_ImportPeakBoundaries_Warning__The_following__0__peptide__file__and_charge_state_combinations_were_not_recognized_and_were_ignored_ {
+            get {
+                return ResourceManager.GetString("CommandLine_ImportPeakBoundaries_Warning__The_following__0__peptide__file__and_char" +
+                        "ge_state_combinations_were_not_recognized_and_were_ignored_", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Warning: The following {0} peptides in the peak boundaries file were not recognized and were ignored:.
+        /// </summary>
+        public static string CommandLine_ImportPeakBoundaries_Warning__The_following__0__peptides_in_the_peak_boundaries_file_were_not_recognized_and_were_ignored_ {
+            get {
+                return ResourceManager.GetString("CommandLine_ImportPeakBoundaries_Warning__The_following__0__peptides_in_the_peak_bo" +
+                        "undaries_file_were_not_recognized_and_were_ignored_", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Warning: The following file or replicate name in the peak boundaries file was not recognized and was ignored:.
+        /// </summary>
+        public static string CommandLine_ImportPeakBoundaries_Warning__The_following_file_or_replicate_name_in_the_peak_boundaries_file_was_not_recognized_and_was_ignored_ {
+            get {
+                return ResourceManager.GetString("CommandLine_ImportPeakBoundaries_Warning__The_following_file_or_replicate_name_in_t" +
+                        "he_peak_boundaries_file_was_not_recognized_and_was_ignored_", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Warning: The following peptide, file, and charge state combination was not recognized and was ignored:.
+        /// </summary>
+        public static string CommandLine_ImportPeakBoundaries_Warning__The_following_peptide__file__and_charge_state_combination_was_not_recognized_and_was_ignored_ {
+            get {
+                return ResourceManager.GetString("CommandLine_ImportPeakBoundaries_Warning__The_following_peptide__file__and_charge_s" +
+                        "tate_combination_was_not_recognized_and_was_ignored_", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Warning: The following peptide in the peak boundaries file was not recognized and was ignored:.
+        /// </summary>
+        public static string CommandLine_ImportPeakBoundaries_Warning__The_following_peptide_in_the_peak_boundaries_file_was_not_recognized_and_was_ignored_ {
+            get {
+                return ResourceManager.GetString("CommandLine_ImportPeakBoundaries_Warning__The_following_peptide_in_the_peak_boundar" +
+                        "ies_file_was_not_recognized_and_was_ignored_", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to line {0}: {1}.
+        /// </summary>
+        public static string CommandLine_ImportPeakBoundaries_Warning__line__0____1_ {
+            get {
+                return ResourceManager.GetString("CommandLine_ImportPeakBoundaries_Warning__line__0____1_", resourceCulture);
+            }
+        }
+
         /// <summary>
         ///   Looks up a localized string similar to {0} -&gt; {1}  Note: The file has already been imported. Ignoring....
         /// </summary>

--- a/pwiz_tools/Skyline/SkylineResources.resx
+++ b/pwiz_tools/Skyline/SkylineResources.resx
@@ -361,6 +361,27 @@
   <data name="CommandLine_ImportPeakBoundaries_Importing_peak_boundaries_from__0_" xml:space="preserve">
     <value>Importing peak boundaries from {0}</value>
   </data>
+  <data name="CommandLine_ImportPeakBoundaries_Warning__The_following__0__file_or_replicate_names_in_the_peak_boundaries_file_were_not_recognized_and_were_ignored_" xml:space="preserve">
+    <value>Warning: The following {0} file or replicate names in the peak boundaries file were not recognized and were ignored:</value>
+  </data>
+  <data name="CommandLine_ImportPeakBoundaries_Warning__The_following__0__peptide__file__and_charge_state_combinations_were_not_recognized_and_were_ignored_" xml:space="preserve">
+    <value>Warning: The following {0} peptide, file, and charge state combinations were not recognized and were ignored:</value>
+  </data>
+  <data name="CommandLine_ImportPeakBoundaries_Warning__The_following__0__peptides_in_the_peak_boundaries_file_were_not_recognized_and_were_ignored_" xml:space="preserve">
+    <value>Warning: The following {0} peptides in the peak boundaries file were not recognized and were ignored:</value>
+  </data>
+  <data name="CommandLine_ImportPeakBoundaries_Warning__The_following_file_or_replicate_name_in_the_peak_boundaries_file_was_not_recognized_and_was_ignored_" xml:space="preserve">
+    <value>Warning: The following file or replicate name in the peak boundaries file was not recognized and was ignored:</value>
+  </data>
+  <data name="CommandLine_ImportPeakBoundaries_Warning__The_following_peptide__file__and_charge_state_combination_was_not_recognized_and_was_ignored_" xml:space="preserve">
+    <value>Warning: The following peptide, file, and charge state combination was not recognized and was ignored:</value>
+  </data>
+  <data name="CommandLine_ImportPeakBoundaries_Warning__The_following_peptide_in_the_peak_boundaries_file_was_not_recognized_and_was_ignored_" xml:space="preserve">
+    <value>Warning: The following peptide in the peak boundaries file was not recognized and was ignored:</value>
+  </data>
+  <data name="CommandLine_ImportPeakBoundaries_Warning__line__0____1_" xml:space="preserve">
+    <value>line {0}: {1}</value>
+  </data>
   <data name="CommandLine_ImportResultsFile__0______1___Note__The_file_has_already_been_imported__Ignoring___" xml:space="preserve">
     <value>{0} -&gt; {1}  Note: The file has already been imported. Ignoring...</value>
   </data>

--- a/pwiz_tools/Skyline/Test/CommandLinePeakBoundaryTest.cs
+++ b/pwiz_tools/Skyline/Test/CommandLinePeakBoundaryTest.cs
@@ -23,9 +23,11 @@ using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using System.Text.RegularExpressions;
 using System.Xml.Serialization;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using pwiz.Common.SystemUtil;
+using pwiz.Skyline;
 using pwiz.Skyline.Model;
 using pwiz.Skyline.Model.DocSettings;
 using pwiz.Skyline.Model.Results.Scoring;
@@ -330,6 +332,112 @@ namespace pwiz.SkylineTest
 
             // 20. Peak boundaries file does not exist
             TestPeakBoundariesNotFound(originalDocumentPath);
+        }
+
+        /// <summary>
+        /// A peak-boundaries file that references an unknown file, peptide, or charge state imports those
+        /// rows as no-ops. Through the CLI that used to be completely silent (success, no output), so a
+        /// file that matched nothing looked identical to one that applied. Verify each skipped category now
+        /// produces a Warning line, that a clean import produces none, and that the list is bounded.
+        /// </summary>
+        [TestMethod]
+        public void TestCommandLineImportPeakBoundaryWarnings()
+        {
+            TestFilesDir = new TestFilesDir(TestContext, TEST_ZIP_PATH);
+            var cult = LocalizationHelper.CurrentCulture;
+            var cultI = CultureInfo.InvariantCulture;
+            string csvSep = TextUtil.CsvSeparator.ToString(cultI);
+            var originalDocumentPath = TestFilesDir.GetTestPath("Chrom05.sky");
+
+            // A fully valid row: peptide, file, and charge all present in Chrom05.sky
+            string[] baseValues =
+            {
+                "TPEVDDEALEK", "Q_2012_0918_RJ_13.raw", (4.0).ToString(cult), (3.5).ToString(cult),
+                (4.5).ToString(cult), 2.ToString(cult), 0.ToString(cult)
+            };
+            string headerRow = string.Join(csvSep, PeakBoundaryImporter.STANDARD_FIELD_NAMES.Take(baseValues.Length));
+
+            string BuildFile(params string[][] rows)
+            {
+                var lines = new List<string> { headerRow };
+                lines.AddRange(rows.Select(r => string.Join(csvSep, r)));
+                return TextUtil.LineSeparate(lines.ToArray());
+            }
+
+            string[] WithField(PeakBoundaryImporter.Field field, string value)
+            {
+                var values = (string[]) baseValues.Clone();
+                values[(int) field] = value;
+                return values;
+            }
+
+            // A clean import warns about nothing
+            string cleanOutput = ImportPeakBoundariesText(originalDocumentPath, BuildFile(baseValues));
+            Assert.AreEqual(0, FindErrorLines(cleanOutput).Count());
+            foreach (var warning in new[]
+                     {
+                         SkylineResources.CommandLine_ImportPeakBoundaries_Warning__The_following_file_or_replicate_name_in_the_peak_boundaries_file_was_not_recognized_and_was_ignored_,
+                         SkylineResources.CommandLine_ImportPeakBoundaries_Warning__The_following_peptide_in_the_peak_boundaries_file_was_not_recognized_and_was_ignored_,
+                         SkylineResources.CommandLine_ImportPeakBoundaries_Warning__The_following_peptide__file__and_charge_state_combination_was_not_recognized_and_was_ignored_
+                     })
+            {
+                StringAssert.DoesNotMatch(cleanOutput, new Regex(Regex.Escape(warning)));
+            }
+
+            // The single data row sits on line 2 (line 1 is the header), so every warning below cites line 2.
+            // Unrecognized file name -> file warning (single item -> singular header)
+            AssertWarns(originalDocumentPath, BuildFile(WithField(PeakBoundaryImporter.Field.filename, "Q_2012_0918_RJ_15.raw")),
+                SkylineResources.CommandLine_ImportPeakBoundaries_Warning__The_following_file_or_replicate_name_in_the_peak_boundaries_file_was_not_recognized_and_was_ignored_,
+                "Q_2012_0918_RJ_15.raw", 2);
+
+            // Unrecognized peptide -> peptide warning
+            AssertWarns(originalDocumentPath, BuildFile(WithField(PeakBoundaryImporter.Field.modified_peptide, "PEPTIDER")),
+                SkylineResources.CommandLine_ImportPeakBoundaries_Warning__The_following_peptide_in_the_peak_boundaries_file_was_not_recognized_and_was_ignored_,
+                "PEPTIDER", 2);
+
+            // Valid peptide and file but a charge state not in the document -> charge-state warning. The listed
+            // value is the peptide/file/charge triplet; assert the peptide+file prefix (charge rendering aside).
+            AssertWarns(originalDocumentPath, BuildFile(WithField(PeakBoundaryImporter.Field.charge, 5.ToString(cult))),
+                SkylineResources.CommandLine_ImportPeakBoundaries_Warning__The_following_peptide__file__and_charge_state_combination_was_not_recognized_and_was_ignored_,
+                "TPEVDDEALEK Q_2012_0918_RJ_13.raw", 2);
+
+            // More than ten unrecognized peptides -> plural header (with the count) and a bounded, ellipsized list
+            const string aminoAcids = "RKASTNQVWY LG"; // 12 valid one-letter residues (space skipped below)
+            var manyRows = aminoAcids.Where(c => c != ' ')
+                .Select(c => WithField(PeakBoundaryImporter.Field.modified_peptide, "PEPTIDE" + c)).ToArray();
+            Assert.AreEqual(12, manyRows.Length);
+            string manyOutput = ImportPeakBoundariesText(originalDocumentPath, BuildFile(manyRows));
+            Assert.AreEqual(0, FindErrorLines(manyOutput).Count());
+            StringAssert.Contains(manyOutput, string.Format(
+                SkylineResources.CommandLine_ImportPeakBoundaries_Warning__The_following__0__peptides_in_the_peak_boundaries_file_were_not_recognized_and_were_ignored_,
+                manyRows.Length));
+            Assert.IsTrue(SplitLines(manyOutput).Any(line => line == @"..."),
+                "Expected an ellipsis line truncating the unrecognized-peptide list");
+            // Exactly ten items are shown (the bound), each a "line N: PEPTIDE..." entry. Build the matcher
+            // from the resource string so it stays valid when the "line {0}: {1}" text is localized.
+            string lineFormat = SkylineResources.CommandLine_ImportPeakBoundaries_Warning__line__0____1_;
+            string linePattern = "^" + Regex.Escape(lineFormat)
+                .Replace(Regex.Escape("{0}"), @"\d+")
+                .Replace(Regex.Escape("{1}"), @"PEPTIDE\w+") + "$";
+            int shownItems = SplitLines(manyOutput).Count(line => Regex.IsMatch(line, linePattern));
+            Assert.AreEqual(10, shownItems);
+            // Earliest rows first: the first data row (line 2) is shown, the last (line 13) is truncated away
+            string firstResiduePeptide = "PEPTIDE" + aminoAcids.First(c => c != ' ');
+            string lastResiduePeptide = "PEPTIDE" + aminoAcids.Last(c => c != ' ');
+            StringAssert.Contains(manyOutput, string.Format(lineFormat, 2, firstResiduePeptide));
+            StringAssert.DoesNotMatch(manyOutput, new Regex(Regex.Escape(string.Format(lineFormat, 13, lastResiduePeptide))));
+        }
+
+        private static void AssertWarns(string documentPath, string importText, string expectedHeader,
+            string expectedItemValue, long expectedLine)
+        {
+            string output = ImportPeakBoundariesText(documentPath, importText);
+            // A skipped row is a warning, not an error: the import still succeeds
+            Assert.AreEqual(0, FindErrorLines(output).Count());
+            StringAssert.Contains(output, expectedHeader);
+            // The offending value is listed prefixed with the input-file line it appeared on
+            StringAssert.Contains(output, string.Format(
+                SkylineResources.CommandLine_ImportPeakBoundaries_Warning__line__0____1_, expectedLine, expectedItemValue));
         }
 
         private static ReportSpec MakeReportSpec()


### PR DESCRIPTION
## Summary

* `SkylineCmd --import-peak-boundaries` now reports every peak-boundary row it skips as unrecognized (unknown peptide, file name, or peptide/file/charge-state combination) as a bounded `Warning:` on the console, mirroring the GUI dialog. Previously such rows were silent no-ops, so a file that matched nothing looked identical to one that applied cleanly.
* Each listed value is prefixed with the input-file line it first appeared on (e.g. `line 4: PEPTIDER`); the earliest rows are shown first and the list is bounded to 10 items plus an ellipsis.
* The file-identity warning reads "file or replicate name" so a replicate-keyed no-match (from #4350) is labeled accurately.
* Non-fatal: warnings only, exit code unchanged. The importer, GUI path, and audit log are untouched — line numbers are recorded in additive, CLI-only dictionaries.

Reported by James.

Fixes #4439

## Example

Given a boundaries file with one valid row plus an unknown file (line 3), two unknown peptides (lines 4-5), and a charge state not in the document (line 6):

```
PeptideModifiedSequence,FileName,MinStartTime,MaxEndTime,PrecursorCharge
TPEVDDEALEK,Q_2012_0918_RJ_13.raw,26.17,26.92,2
FFVAPFPEVFGK,Q_2012_0918_RJ_99.raw,30.0,31.0,3
PEPTIDER,Q_2012_0918_RJ_13.raw,20.0,21.0,2
ELVISLIVESK,Q_2012_0918_RJ_13.raw,22.0,23.0,2
TPEVDDEALEK,Q_2012_0918_RJ_13.raw,26.17,26.92,7
```

`SkylineCmd --import-peak-boundaries` now prints:

```
Importing peak boundaries from demo_boundaries.csv
Warning: The following 2 peptides in the peak boundaries file were not recognized and were ignored:
line 4: PEPTIDER
line 5: ELVISLIVESK
Warning: The following file or replicate name in the peak boundaries file was not recognized and was ignored:
line 3: Q_2012_0918_RJ_99.raw
Warning: The following peptide, file, and charge state combination was not recognized and was ignored:
line 6: TPEVDDEALEK Q_2012_0918_RJ_13.raw 7
Saving file...
```

The valid row (line 2) still applied. Before this change the run printed only `Importing...` then `saved`, with no indication that four rows were skipped.

## Test plan

- [x] TestCommandLineImportPeakBoundaryWarnings - new; asserts each category warns with the cited line, a clean import warns about nothing, and the >10 case shows exactly 10 earliest-first line-prefixed items plus an ellipsis (en-US + fr-FR)
- [x] TestCommandLineImportPeakBoundary, TestImportPeakBoundary - unchanged, still green
- [x] CodeInspection - green
- [x] Full ReSharper solution inspection (Debug, CI-parity) - 0 warnings / 0 errors in changed files
- [x] Fresh-context self-review - clean (one LOW applied: earliest-first ordering)

Co-Authored-By: Claude <noreply@anthropic.com>