### PR TITLE
Fixed NullReferenceException in chromatogram totals graph on stale selection

### DIFF
--- a/pwiz_tools/Skyline/Controls/Graphs/GraphChromatogram.cs
+++ b/pwiz_tools/Skyline/Controls/Graphs/GraphChromatogram.cs
@@ -2098,6 +2098,14 @@ namespace pwiz.Skyline.Controls.Graphs
                     infoPrimary.Transform(Transform);
 
                     var peptideDocNode = (PeptideDocNode) DocumentUI.FindNode(_groupPaths[i].Parent);
+                    if (peptideDocNode == null)
+                    {
+                        // The peptide for this cached path is no longer present in the current
+                        // document (a document change can leave the tree selection referencing a
+                        // removed node until the next update catches up). Skip it; the following
+                        // update will redraw against the current selection.
+                        continue;
+                    }
                     int iColor = GetColorIndex(peptideDocNode, nodeGroup, countLabelTypes);
                     Color color = COLORS_GROUPS[iColor % COLORS_GROUPS.Count];
 

--- a/pwiz_tools/Skyline/Controls/Graphs/GraphChromatogram.cs
+++ b/pwiz_tools/Skyline/Controls/Graphs/GraphChromatogram.cs
@@ -2046,6 +2046,15 @@ namespace pwiz.Skyline.Controls.Graphs
                 if (chromGroupInfo == null)
                     continue;
 
+                // Skip a group whose cached path no longer resolves to a peptide in the current
+                // document (a document change can briefly leave the tree selection referencing a
+                // removed node until the next update catches up). Checked before any peak work so a
+                // skipped group cannot influence auto-zoom; the next update redraws against the
+                // current selection.
+                var peptideDocNode = (PeptideDocNode) DocumentUI.FindNode(_groupPaths[i].Parent);
+                if (peptideDocNode == null)
+                    continue;
+
                 ChromFileInfoId fileId = chromatograms.FindFile(chromGroupInfo);
 
                 // Collect the chromatogram info for the transition children
@@ -2097,15 +2106,6 @@ namespace pwiz.Skyline.Controls.Graphs
                     // Apply any transform the user has chosen
                     infoPrimary.Transform(Transform);
 
-                    var peptideDocNode = (PeptideDocNode) DocumentUI.FindNode(_groupPaths[i].Parent);
-                    if (peptideDocNode == null)
-                    {
-                        // The peptide for this cached path is no longer present in the current
-                        // document (a document change can leave the tree selection referencing a
-                        // removed node until the next update catches up). Skip it; the following
-                        // update will redraw against the current selection.
-                        continue;
-                    }
                     int iColor = GetColorIndex(peptideDocNode, nodeGroup, countLabelTypes);
                     Color color = COLORS_GROUPS[iColor % COLORS_GROUPS.Count];
 

--- a/pwiz_tools/Skyline/TestFunctional/ChromGraphTransformTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/ChromGraphTransformTest.cs
@@ -19,6 +19,7 @@
 
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using pwiz.MSGraph;
 using pwiz.Skyline.Controls.Graphs;
@@ -57,6 +58,71 @@ namespace pwiz.SkylineTestFunctional
                     }
                 }
             }
+
+            TestStaleSelection();
+        }
+
+        /// <summary>
+        /// Regression test for exception report skyline.ms #75292: a NullReferenceException in
+        /// GraphChromatogram.GetColorIndex while displaying peptide totals. While a document change
+        /// is being dispatched, the chromatogram graph can update with its cached transition-group
+        /// paths still referencing a peptide that is no longer in the current document, so
+        /// DocumentUI.FindNode(path.Parent) returns null. The graph must tolerate the transient
+        /// stale path rather than crash.
+        /// </summary>
+        private void TestStaleSelection()
+        {
+            var doc = SkylineWindow.Document;
+            var peptideGroup = doc.MoleculeGroups.First(g => g.Peptides.Any());
+            var peptide = peptideGroup.Peptides.First();
+
+            // Show the peptide totals chromatogram - the DisplayTotals path that resolves a color
+            // per transition group via DocumentUI.FindNode.
+            RunUI(() =>
+            {
+                SkylineWindow.SelectedPath = new IdentityPath(peptideGroup.Id, peptide.Id);
+                SkylineWindow.SetDisplayTypeChrom(DisplayTypeChrom.total);
+            });
+            WaitForGraphs();
+
+            var graphChrom = FindOpenForm<GraphChromatogram>();
+            Assert.IsNotNull(graphChrom);
+
+            // The race between the document-change dispatch and the tree selection cannot be
+            // triggered deterministically through the public UI, so seed the equivalent stale state
+            // directly: leave _nodeGroups untouched (so the UpdateGroups reference-equality
+            // short-circuit keeps the graph's cached chromatograms and preserves the paths we seed
+            // below) but point the cached paths at a peptide that is absent from the document,
+            // exactly as FindNode would fail to resolve after the peptide was removed.
+            RunUI(() =>
+            {
+                var nodeGroupsField = typeof(GraphChromatogram).GetField(@"_nodeGroups",
+                    BindingFlags.Instance | BindingFlags.NonPublic);
+                var groupPathsField = typeof(GraphChromatogram).GetField(@"_groupPaths",
+                    BindingFlags.Instance | BindingFlags.NonPublic);
+                Assert.IsNotNull(nodeGroupsField);
+                Assert.IsNotNull(groupPathsField);
+
+                var nodeGroups = (TransitionGroupDocNode[]) nodeGroupsField.GetValue(graphChrom);
+                Assert.IsNotNull(nodeGroups);
+                Assert.IsTrue(nodeGroups.Length > 0);
+
+                var stalePaths = nodeGroups
+                    .Select(g => new IdentityPath(peptideGroup.Id, new Peptide(@"ELVISLIVES"), g.Id))
+                    .ToArray();
+                groupPathsField.SetValue(graphChrom, stalePaths);
+
+                // Before the fix this threw NullReferenceException in GetColorIndex.
+                graphChrom.UpdateUI();
+            });
+            WaitForGraphs();
+
+            // The graph survived the stale selection without throwing. Every group shared the
+            // absent peptide, so all were skipped - a deterministic 0 curves. This also guards
+            // against a future false-green: if the seeded paths were ever discarded (e.g. the
+            // short-circuit stopped preserving them), the curves would reappear and this would fail.
+            var graphControl = (MSGraphControl) graphChrom.Controls.Find(@"graphControl", true).First();
+            Assert.AreEqual(0, GetChromatogramCount(graphControl.GraphPane));
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary

* Fixed a `NullReferenceException` in `GraphChromatogram.GetColorIndex` while displaying peptide totals. `DisplayTotals` now skips a transition group whose cached path no longer resolves to a peptide in the current document, instead of dereferencing null.
* The crash is a transient race: during a document-change dispatch the graph can update while the tree selection still references a just-removed peptide, so `DocumentUI.FindNode(path.Parent)` returns null. The unguarded deref was introduced in #2450 (2023) when `GetColorIndex` began taking a `PeptideDocNode`. The fix matches the existing null tolerance already in `IsCacheCurrent`.

Reported via skyline.ms exception #75292 (26.1.0.057).

## Test plan

- [x] TestChromGraphTotal (ChromGraphTransformTest) — added `TestStaleSelection()` that seeds the stale path and asserts no throw plus 0 rendered curves; red/green verified (reproduces the exact NRE without the guard)
- [x] CodeInspection test — passes
- [x] Full-solution ReSharper inspection — no issues in changed regions

## Cherry-pick note

This crash exists in the 26.1 release (the report is from 26.1.0.057) and the buggy code predates the release branch. We are in post-release patch mode (`Skyline/skyline_26_1` takes critical fixes only), so cherry-picking is a maintainer judgment call — flagging it here rather than auto-labeling.

Co-Authored-By: Claude <noreply@anthropic.com>
