### PR TITLE
Passed the window list through lParam so EnumWindows uses a static callback

### DIFF
--- a/pwiz_tools/Shared/CommonUtil/SystemUtil/PInvoke/User32.cs
+++ b/pwiz_tools/Shared/CommonUtil/SystemUtil/PInvoke/User32.cs
@@ -209,12 +209,34 @@ namespace pwiz.Common.SystemUtil.PInvoke
         [DllImport("user32.dll")]
         private static extern bool EnumChildWindows(IntPtr hWndParent, EnumWindowsProc lpEnumFunc, IntPtr lParam);
 
+        // ONE delegate for the life of the process. A lambda here would allocate a new delegate on every call and
+        // the marshaller builds a native thunk for each, which is measurable churn for calls this hot (the
+        // connector enumerates windows on every GetOpenForms). A static method cannot capture the list to fill,
+        // so the list travels through the enumeration's lParam -- which Windows hands back to the callback
+        // untouched -- as a GCHandle, unwrapped below. Keeping no state here also makes these thread-safe:
+        // concurrent enumerations each carry their own list and cannot collide.
+        private static readonly EnumWindowsProc COLLECT_WINDOW_HANDLES = CollectWindowHandle;
+
+        private static bool CollectWindowHandle(IntPtr hwnd, IntPtr lParam)
+        {
+            ((List<IntPtr>) GCHandle.FromIntPtr(lParam).Target).Add(hwnd);
+            return true;    // true keeps the enumeration going
+        }
+
         /// <summary>The handles of all top-level windows, in z-order (top to bottom) -- callers use LINQ over these
         /// rather than an enumeration callback.</summary>
         public static IEnumerable<IntPtr> EnumWindows()
         {
             var handles = new List<IntPtr>();
-            EnumWindows((hwnd, lparam) => { handles.Add(hwnd); return true; }, IntPtr.Zero);
+            var listHandle = GCHandle.Alloc(handles);
+            try
+            {
+                EnumWindows(COLLECT_WINDOW_HANDLES, GCHandle.ToIntPtr(listHandle));
+            }
+            finally
+            {
+                listHandle.Free();
+            }
             return handles;
         }
 
@@ -222,7 +244,15 @@ namespace pwiz.Common.SystemUtil.PInvoke
         public static IEnumerable<IntPtr> EnumChildWindows(IntPtr parent)
         {
             var handles = new List<IntPtr>();
-            EnumChildWindows(parent, (hwnd, lparam) => { handles.Add(hwnd); return true; }, IntPtr.Zero);
+            var listHandle = GCHandle.Alloc(handles);
+            try
+            {
+                EnumChildWindows(parent, COLLECT_WINDOW_HANDLES, GCHandle.ToIntPtr(listHandle));
+            }
+            finally
+            {
+                listHandle.Free();
+            }
             return handles;
         }
 
@@ -230,7 +260,15 @@ namespace pwiz.Common.SystemUtil.PInvoke
         public static IEnumerable<IntPtr> EnumThreadWindows(uint threadId)
         {
             var handles = new List<IntPtr>();
-            EnumThreadWindows((int) threadId, (hwnd, lp) => { handles.Add(hwnd); return true; }, IntPtr.Zero);
+            var listHandle = GCHandle.Alloc(handles);
+            try
+            {
+                EnumThreadWindows((int) threadId, COLLECT_WINDOW_HANDLES, GCHandle.ToIntPtr(listHandle));
+            }
+            finally
+            {
+                listHandle.Free();
+            }
             return handles;
         }
 


### PR DESCRIPTION
## Summary

* `User32.EnumWindows()` / `EnumChildWindows()` / `EnumThreadWindows()` each allocated a **new closure delegate on every call**. The P/Invoke marshaller builds a native thunk for each delegate it marshals, so this is native churn on a very hot path — the connector enumerates windows on every `GetOpenForms`, and `DialogWatcher`'s wait loop polls it continuously.
* All three enumerations take an `lParam` that Windows passes back to the callback untouched. This uses it: a `GCHandle` to the list travels through `lParam`, and the callback becomes a `static` method that unwraps it — so **one delegate instance serves the whole process**.
* Each wrapper does `GCHandle.Alloc(handles)` → passes `GCHandle.ToIntPtr(...)` → `Free()` in a `finally`. A normal (unpinned) handle is correct: the handle's token is passed, not the object address, so nothing needs pinning.
* Also makes the three wrappers **thread-safe** — better than a `[ThreadStatic]` list, since the callback keeps no state at all and each call carries its own list. That matters here: the connector enumerates from the pipe/test thread while the UI thread is busy.

Found while investigating the native-dialog heap leak (#4453). It is **not** that leak — far too small to explain it — but it is real and worth fixing on its own.

## Measured

Real `pwiz.CommonUtil` path, 20,000 calls:

| | growth | shape |
|---|---:|---|
| before (per-call lambda) | 76 KB | drifting, noisy (93 -> 51 -> 76 KB) |
| after (static + lParam) | 4 KB | flat; plateaued at 8k calls |

A probe compiled against the built assembly saw 127,400 handles across 200 enumerations (~637 windows each), confirming the enumeration still returns the same results.

## Test plan

- [x] Full solution builds with no errors or warnings
- [x] TestNativeMessageBox
- [x] TestNativeFileDialog
- [x] TestMcpConnectorBackgroundDialog
- [x] TestMcpConnectorFormThreading
- [x] TestAlertWatch
- [x] TestJsonToolServer

(All of these depend on window enumeration returning correct results, so they would break immediately if the `GCHandle` unwrapping were wrong.)

Co-Authored-By: Claude <noreply@anthropic.com>
