### PR TITLE
Waited for the native file dialog to finish opening before typing into it

### DIFF
--- a/pwiz_tools/Skyline/TestFunctional/NativeMessageBoxTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/NativeMessageBoxTest.cs
@@ -81,6 +81,9 @@ namespace pwiz.SkylineTestFunctional
             fileDialogId = actionResult.FormId;
             Assert.IsNotNull(fileDialogId);
             Assert.AreEqual(modalNestingCount, GetModalNestingCount(fileDialogId));
+            // The id is reported as soon as the window exists, which is before the shell has shown the file-name
+            // field; typing into it in that window throws "The file dialog is still opening".
+            WaitForNativeFileDialogReady(fileDialogId);
             AssertComplete(McpConnector.SetFormValue(fileDialogId, @"FileName", savePath));
             actionResult = McpConnector.DismissWithAcceptButton(fileDialogId);
             Assert.IsFalse(actionResult.Completed);

--- a/pwiz_tools/Skyline/TestPerf/DiaFragPipeTutorialTest.cs
+++ b/pwiz_tools/Skyline/TestPerf/DiaFragPipeTutorialTest.cs
@@ -93,7 +93,7 @@ namespace TestPerf
         {
             // File > Open opens the native Open dialog, so the menu click does not complete -- take the dialog
             // straight from the action's ActionResult.FormId.
-            var openDlg = ResolveModal(McpConnector.ClickMainMenuItem(
+            var openDlg = ResolveNativeFileDialog(McpConnector.ClickMainMenuItem(
                 MenuPath<SkylineWindow>("fileToolStripMenuItem", "openMenuItem")));
             McpConnector.SetFormValue(openDlg, "FileName",
                 GetTestPath(Path.Combine("backup", "skyline_files", "fragpipe.sky")));

--- a/pwiz_tools/Skyline/TestPerf/DiaToSrmTutorialTest.cs
+++ b/pwiz_tools/Skyline/TestPerf/DiaToSrmTutorialTest.cs
@@ -312,7 +312,7 @@ namespace TestPerf
         {
             // Import Document opens the native Open dialog (a dialog), so it does not complete; resolve it from the
             // menu action's ActionResult, then accept it to import.
-            var importDlg = ResolveModal(McpConnector.ClickMainMenuItem(MenuPath<SkylineWindow>(
+            var importDlg = ResolveNativeFileDialog(McpConnector.ClickMainMenuItem(MenuPath<SkylineWindow>(
                 "fileToolStripMenuItem", "importToolStripMenuItem", "importDocumentMenuItem")));
             McpConnector.SetFormValue(importDlg, "FileName", GetTestPath("PRTC.sky"));
             McpConnector.DismissWithAcceptButton(importDlg);
@@ -427,7 +427,7 @@ namespace TestPerf
 
             // Save As opens the native Save dialog (a dialog), so the menu-item verb does not complete -- resolve the
             // dialog from its ActionResult.FormId.
-            var saveDlg = ResolveModal(McpConnector.ClickMainMenuItem(
+            var saveDlg = ResolveNativeFileDialog(McpConnector.ClickMainMenuItem(
                 MenuPath<SkylineWindow>("fileToolStripMenuItem", "saveAsMenuItem")));
             McpConnector.SetFormValue(saveDlg, "FileName", GetTestPath("DIA_to_SRM_Tutorial-filtered.sky"));
             McpConnector.DismissWithAcceptButton(saveDlg);
@@ -493,7 +493,7 @@ namespace TestPerf
 
             // Save As opens the native Save dialog (a dialog), so the menu-item verb does not complete -- resolve the
             // dialog from its ActionResult.FormId.
-            var saveDlg = ResolveModal(McpConnector.ClickMainMenuItem(
+            var saveDlg = ResolveNativeFileDialog(McpConnector.ClickMainMenuItem(
                 MenuPath<SkylineWindow>("fileToolStripMenuItem", "saveAsMenuItem")));
             McpConnector.SetFormValue(saveDlg, "FileName", GetTestPath("SRM_targets.sky"));
             McpConnector.DismissWithAcceptButton(saveDlg);

--- a/pwiz_tools/Skyline/TestUtil/McpConnectorTest.cs
+++ b/pwiz_tools/Skyline/TestUtil/McpConnectorTest.cs
@@ -99,7 +99,51 @@ namespace pwiz.SkylineTestUtil
         /// caller knows it triggered a file dialog rather than a folder dialog.
         /// </summary>
         protected string WaitForNativeFileDialog() =>
-            ResolveWhenOpen(form => form.IsNative);
+            WaitForNativeFileDialogReady(ResolveWhenOpen(form => form.IsNative));
+
+        /// <summary>
+        /// Resolves the native file dialog a connector action just opened -- straight from its
+        /// <see cref="ActionResult"/>, for a verb whose own gesture blocks in the dialog and so names it (a menu
+        /// click that shows Open/Save As) -- and waits until it is ready to be typed into. The
+        /// <see cref="ResolveModal"/> counterpart for a file dialog, and the one to use for it: ResolveModal alone
+        /// returns the instant the window is reported, which is too early (see
+        /// <see cref="WaitForNativeFileDialogReady"/>).
+        /// </summary>
+        protected string ResolveNativeFileDialog(ActionResult actionResult) =>
+            WaitForNativeFileDialogReady(ResolveModal(actionResult));
+
+        /// <summary>
+        /// Waits until the native file dialog with the given id has finished opening -- i.e. the shell has created
+        /// and shown its file-name field -- and returns that id.
+        ///
+        /// <para>A native dialog becomes discoverable (its window exists, GetOpenForms reports it, and it
+        /// classifies as a file dialog) a moment BEFORE the shell has finished showing and populating it. Setting
+        /// the file name in that window fails with "The file dialog is still opening", because
+        /// <see cref="NativeFileDialog.FileNameTextBox"/> deliberately does NOT block polling for the field -- it
+        /// throws a retryable instruction so the wait lives with the DRIVER rather than inside the primitive that
+        /// every caller shares. This is that wait, for the driver that is a test.</para>
+        ///
+        /// <para>Readiness is the file-name box appearing in GetControls under its
+        /// <see cref="NativeFileDialog.FILE_NAME_FIELD"/> label -- the same field EnterPath needs, and listed only
+        /// once it is visible, so this waits for exactly the condition that would otherwise throw.</para>
+        /// </summary>
+        protected string WaitForNativeFileDialogReady(string formId)
+        {
+            WaitForCondition(() =>
+            {
+                try
+                {
+                    return McpConnector.GetControls(formId)
+                        ?.Any(control => Equals(control.Path.Text, NativeFileDialog.FILE_NAME_FIELD)) ?? false;
+                }
+                catch (InvalidOperationException)
+                {
+                    // The dialog can be momentarily unreadable while the shell is still bringing it up.
+                    return false;
+                }
+            }, @"The native file dialog did not finish opening.");
+            return formId;
+        }
 
         /// <summary>
         /// Waits for the native Browse-For-Folder dialog (enumerated by GetOpenForms with IsNative=true) and

--- a/pwiz_tools/Skyline/ToolsUI/NativeFileDialog.cs
+++ b/pwiz_tools/Skyline/ToolsUI/NativeFileDialog.cs
@@ -60,7 +60,7 @@ namespace pwiz.Skyline.ToolsUI
                 if (child is NativeLabel)
                     continue;
                 yield return child is NativeTextBox textBox && textBox.Hwnd == fileNameEdit
-                    ? new NativeTextBox(fileNameEdit, CancellationToken, @"File name")
+                    ? new NativeTextBox(fileNameEdit, CancellationToken, FILE_NAME_FIELD)
                     : child;
             }
             var addressBar = FindDescendant(ADDRESS_BAR_CLASS, ADDRESS_BAR_ID);
@@ -92,6 +92,11 @@ namespace pwiz.Skyline.ToolsUI
             throw new InvalidOperationException(LlmInstruction.Format(
                 @"Tried to set file path to '{0}' but it says '{1}'", path, actual));
         }
+
+        /// <summary>The label the file-name box is presented under, so a caller can read/set it by name (see
+        /// <see cref="EnumerateChildren"/>). Ours, not the shell's, so it is the same in every UI language -- which
+        /// is also what lets a driver wait for the field to exist by looking for this name in GetControls.</summary>
+        public const string FILE_NAME_FIELD = @"File name";
 
         /// <summary>The control id of this dialog's file-name Edit -- 1148 for the Open dialog's classic combo,
         /// 1001 for the Save dialog's DirectUI-hosted field.</summary>


### PR DESCRIPTION
## Summary

* `TestNativeMessageBox` failed in nightly on BSPRATT-UW2 with `InvalidOperationException: The file dialog is still opening. Wait a moment and try again.` (`NativeFileDialog.get_FileNameTextBox` ← `EnterPath` ← `SetValue` ← `NativeMessageBoxTest.cs:83`).
* A native dialog becomes discoverable — its window exists, `GetOpenForms` reports it, and it classifies as a file dialog — a moment **before** the shell has finished showing and populating it. The test took the dialog id and immediately set the file name, before the file-name Edit existed.
* `NativeFileDialog.FileNameTextBox` **deliberately** does not block polling for the field ("the wait lives with the DRIVER, not inside the primitive both drivers share… a single tool call never sits inside a 30-second sleep"), so adding a retry inside `SetValue` would violate that contract. The wait belongs in the test driver, and that is where this puts it.

Two discovery patterns were both racy — and the failing one had **no wait at all**:

| pattern | sites | wait before |
|---|---|---|
| `WaitForNativeFileDialog()` | 4 | the WINDOW only |
| `ResolveModal(ClickMainMenuItem(...))` | 4 | **none** |

## Changes

* `NativeFileDialog.FILE_NAME_FIELD` — extracted the `"File name"` label to a public const so product code and the test-side wait cannot drift. It is our label, not the shell's, so it is identical in every UI language (the failing run was French).
* `McpConnectorTest.WaitForNativeFileDialogReady(formId)` — waits until the file-name box appears in `GetControls` under that label: exactly the field `EnterPath` needs, and listed only once visible.
* `WaitForNativeFileDialog()` folds that wait in, fixing all 4 sites of the first pattern with no call-site change.
* `McpConnectorTest.ResolveNativeFileDialog(actionResult)` — the `ResolveModal` counterpart for a file dialog (resolve + wait); converted the 4 sites of the second pattern, plus an explicit wait in `NativeMessageBoxTest` step 2 where the id is used for other assertions first.

Only the 4 `ResolveModal` calls whose id is then used with `SetFormValue(..., "FileName", ...)` were converted — the other 7 in those files open **managed** dialogs, which have no file-name field and would wait forever.

## Test plan

- [x] Full solution builds with no errors or warnings
- [x] TestNativeMessageBox — the test that failed in nightly
- [x] TestNativeFileDialog
- [x] TestPrmMcpConnector
- [x] TestJsonToolServer
- [x] TestAlertWatch

(2 languages x 2 iterations. A wrong readiness label would hang the wait until timeout, so passing also confirms the predicate matches.)

**Caveat**: the original race did not reproduce locally — it failed on a nightly/RDP machine — so local passes cannot prove the race is gone. The fix makes the precondition explicit rather than relying on timing; nightly is the real confirmation.

Co-Authored-By: Claude <noreply@anthropic.com>
