### PR TITLE
Gave the three native-file-dialog tests extra leak iterations instead of muting the heap check

### DIFF
--- a/pwiz_tools/Skyline/TestRunner/Program.cs
+++ b/pwiz_tools/Skyline/TestRunner/Program.cs
@@ -114,32 +114,15 @@ namespace TestRunner
             // with no potential for infinite looping on a detected leak.
             {"TestLibraryExplorer", new ExpandedLeakCheck()},
             {"TestLibraryExplorerAsSmallMolecules", new ExpandedLeakCheck()},
-            // Every one of these shows the native common file dialog, and the growth they report is
-            // Windows', not Skyline's. Diffing the process heap's block-size histogram across a
-            // pass-1 run names it: the blocks that accumulate hold Explorer's cached DirectUI view
-            // markup ("<duixml>", "ViewHost", "ProperTreeModule", "DetailsContainer") plus the
-            // navigated path's own strings, one set per dialog shown. That is the shell view of the
-            // modern Explorer-hosted IFileDialog, cached per instance on a UI thread that lives for
-            // the whole process, so nothing gives it back until CoUninitialize at exit.
-            // The growth SATURATES rather than leaking without bound: on a long-lived thread the
-            // marginal cost decays to ~2 KB by the 40th dialog. (Legacy comdlg32 really is
-            // dead-linear at ~29 KB/dialog, but Skyline never takes that path -- AutoUpgradeEnabled
-            // is never set false, and ShowHelp/ShowReadOnly are never set at all.)
-            // It is the dialog and not the connector: TestSetItemMcpConnector drives the same
-            // connector with the same polling but opens no native dialog, and it converges and
-            // passes while sharing none of the block sizes above.
-            // So these tests do settle -- they just need more runs than the default 24 to get
-            // there. TestPrmMcpConnector sits right at the 20 KB threshold at 24 iterations
-            // (26.6 KB one run, 13.8 KB the next) and falls to -20.5 KB by 48. x4 rather than the
-            // default x2 because the nightly machines are further up the curve than the box this
-            // was measured on: on 2026-07-23/24 they reported 26-71 KB where this machine reported
-            // 13-27 KB. Extra iterations are only CONSUMED when a test has not settled (the loop
-            // exits as soon as the trailing deltas pass), so a generous ceiling costs nothing on a
-            // machine that converges early.
-            // Tradeoff to know about: because the per-run delta is a wide distribution straddling
-            // the threshold, a longer ceiling also gives a genuinely leaking test more chances to
-            // exit on a lucky trailing window. That is the price of keeping the heap check ON here;
-            // muting these tests would give up the detection entirely.
+            // These show the native common file dialog, and what grows is Windows' shell cache, not
+            // Skyline: a heap block-size diff finds Explorer's cached DirectUI view for the modern
+            // IFileDialog, one set per dialog, held on a UI thread that lives for the whole process.
+            // It saturates (~2 KB/dialog by the 40th), so these tests do settle -- they just need
+            // more than the default 24 runs. x4 because the nightly machines sit further up the
+            // curve than the box this was measured on; the extra iterations are only consumed when a
+            // test has not settled, so they cost nothing where it converges early. Muting instead
+            // would give up heap-leak detection here entirely.
+            // See ai/todos/active/TODO-20260723_native_dialog_leak_iterations.md for the evidence.
             {"TestNativeFileDialog", new ExpandedLeakCheck(LeakCheckIterations * 4)},
             {"TestNativeMessageBox", new ExpandedLeakCheck(LeakCheckIterations * 4)},
             {"TestPrmMcpConnector", new ExpandedLeakCheck(LeakCheckIterations * 4)},

--- a/pwiz_tools/Skyline/TestRunner/Program.cs
+++ b/pwiz_tools/Skyline/TestRunner/Program.cs
@@ -114,6 +114,24 @@ namespace TestRunner
             // with no potential for infinite looping on a detected leak.
             {"TestLibraryExplorer", new ExpandedLeakCheck()},
             {"TestLibraryExplorerAsSmallMolecules", new ExpandedLeakCheck()},
+            // Every one of these shows the native common file dialog. In a Terminal Services (RDP)
+            // session -- the state nightly agents sit in -- Windows grows the process heap on each
+            // show, filling its shell caches. That growth SATURATES rather than leaking: a bare
+            // SaveFileDialog loop with no Skyline code in it starts near 16 KB/dialog and decays to
+            // ~2-4 KB by the 250th, with individual stretches giving memory back. Measured on these
+            // tests, the trailing deltas do settle -- they just need more runs than the default 24
+            // to get there, which is what these extra iterations buy: TestPrmMcpConnector sits right
+            // at the 20 KB threshold at 24 iterations (26.6 KB one run, 13.8 KB the next) and falls
+            // to -20.5 KB by 48. Muting the heap check instead would give up heap-leak detection for
+            // these tests entirely.
+            // x4 rather than the default x2 because the nightly machines are further up the curve
+            // than the box this was measured on: on 2026-07-23/24 they reported 26-71 KB for these
+            // tests where this machine reported 13-27 KB. Extra iterations are only CONSUMED when a
+            // test has not yet settled (the loop exits as soon as the trailing deltas pass), so a
+            // generous ceiling costs nothing on a machine that converges early.
+            {"TestNativeFileDialog", new ExpandedLeakCheck(LeakCheckIterations * 4)},
+            {"TestNativeMessageBox", new ExpandedLeakCheck(LeakCheckIterations * 4)},
+            {"TestPrmMcpConnector", new ExpandedLeakCheck(LeakCheckIterations * 4)},
         };
 
         //  These tests only need to be run once, regardless of language, so they get turned off in pass 0 after a single invocation

--- a/pwiz_tools/Skyline/TestRunner/Program.cs
+++ b/pwiz_tools/Skyline/TestRunner/Program.cs
@@ -114,32 +114,35 @@ namespace TestRunner
             // with no potential for infinite looping on a detected leak.
             {"TestLibraryExplorer", new ExpandedLeakCheck()},
             {"TestLibraryExplorerAsSmallMolecules", new ExpandedLeakCheck()},
-            // Every one of these shows the native common file dialog. In a Terminal Services (RDP)
-            // session -- the state nightly agents sit in -- Windows grows the process heap on each
-            // show, filling its shell caches. That growth SATURATES rather than leaking: a bare
-            // SaveFileDialog loop with no Skyline code in it starts near 16 KB/dialog and decays to
-            // ~2-4 KB by the 250th, with individual stretches giving memory back. Measured on these
-            // tests, the trailing deltas do settle -- they just need more runs than the default 24
-            // to get there, which is what these extra iterations buy: TestPrmMcpConnector sits right
-            // at the 20 KB threshold at 24 iterations (26.6 KB one run, 13.8 KB the next) and falls
-            // to -20.5 KB by 48. Muting the heap check instead would give up heap-leak detection for
-            // these tests entirely.
-            // x4 rather than the default x2 because the nightly machines are further up the curve
-            // than the box this was measured on: on 2026-07-23/24 they reported 26-71 KB for these
-            // tests where this machine reported 13-27 KB. Extra iterations are only CONSUMED when a
-            // test has not yet settled (the loop exits as soon as the trailing deltas pass), so a
-            // generous ceiling costs nothing on a machine that converges early.
+            // Every one of these shows the native common file dialog, and the growth they report is
+            // Windows', not Skyline's. Diffing the process heap's block-size histogram across a
+            // pass-1 run names it: the blocks that accumulate hold Explorer's cached DirectUI view
+            // markup ("<duixml>", "ViewHost", "ProperTreeModule", "DetailsContainer") plus the
+            // navigated path's own strings, one set per dialog shown. That is the shell view of the
+            // modern Explorer-hosted IFileDialog, cached per instance on a UI thread that lives for
+            // the whole process, so nothing gives it back until CoUninitialize at exit.
+            // The growth SATURATES rather than leaking without bound: on a long-lived thread the
+            // marginal cost decays to ~2 KB by the 40th dialog. (Legacy comdlg32 really is
+            // dead-linear at ~29 KB/dialog, but Skyline never takes that path -- AutoUpgradeEnabled
+            // is never set false, and ShowHelp/ShowReadOnly are never set at all.)
+            // It is the dialog and not the connector: TestSetItemMcpConnector drives the same
+            // connector with the same polling but opens no native dialog, and it converges and
+            // passes while sharing none of the block sizes above.
+            // So these tests do settle -- they just need more runs than the default 24 to get
+            // there. TestPrmMcpConnector sits right at the 20 KB threshold at 24 iterations
+            // (26.6 KB one run, 13.8 KB the next) and falls to -20.5 KB by 48. x4 rather than the
+            // default x2 because the nightly machines are further up the curve than the box this
+            // was measured on: on 2026-07-23/24 they reported 26-71 KB where this machine reported
+            // 13-27 KB. Extra iterations are only CONSUMED when a test has not settled (the loop
+            // exits as soon as the trailing deltas pass), so a generous ceiling costs nothing on a
+            // machine that converges early.
+            // Tradeoff to know about: because the per-run delta is a wide distribution straddling
+            // the threshold, a longer ceiling also gives a genuinely leaking test more chances to
+            // exit on a lucky trailing window. That is the price of keeping the heap check ON here;
+            // muting these tests would give up the detection entirely.
             {"TestNativeFileDialog", new ExpandedLeakCheck(LeakCheckIterations * 4)},
             {"TestNativeMessageBox", new ExpandedLeakCheck(LeakCheckIterations * 4)},
             {"TestPrmMcpConnector", new ExpandedLeakCheck(LeakCheckIterations * 4)},
-            // Shows no native dialog at all. It cancels a 50,000-row grid paste at a
-            // NONDETERMINISTIC point (the assertion is only that fewer than all the properties
-            // landed), so how much work -- and allocation -- happens before the cancel takes effect
-            // varies with machine speed and timing, which makes its heap delta spiky rather than
-            // leaking. It is listed here for the same reason as the tests above (it was still
-            // running at 20+ iterations on the nightly machines, i.e. not settling inside the
-            // default 24), but at the normal x2 since its spikiness is not the dialog cache.
-            {"TestMcpConnectorBackgroundDialog", new ExpandedLeakCheck()},
         };
 
         //  These tests only need to be run once, regardless of language, so they get turned off in pass 0 after a single invocation

--- a/pwiz_tools/Skyline/TestRunner/Program.cs
+++ b/pwiz_tools/Skyline/TestRunner/Program.cs
@@ -132,6 +132,14 @@ namespace TestRunner
             {"TestNativeFileDialog", new ExpandedLeakCheck(LeakCheckIterations * 4)},
             {"TestNativeMessageBox", new ExpandedLeakCheck(LeakCheckIterations * 4)},
             {"TestPrmMcpConnector", new ExpandedLeakCheck(LeakCheckIterations * 4)},
+            // Shows no native dialog at all. It cancels a 50,000-row grid paste at a
+            // NONDETERMINISTIC point (the assertion is only that fewer than all the properties
+            // landed), so how much work -- and allocation -- happens before the cancel takes effect
+            // varies with machine speed and timing, which makes its heap delta spiky rather than
+            // leaking. It is listed here for the same reason as the tests above (it was still
+            // running at 20+ iterations on the nightly machines, i.e. not settling inside the
+            // default 24), but at the normal x2 since its spikiness is not the dialog cache.
+            {"TestMcpConnectorBackgroundDialog", new ExpandedLeakCheck()},
         };
 
         //  These tests only need to be run once, regardless of language, so they get turned off in pass 0 after a single invocation


### PR DESCRIPTION
## Summary

Gives `TestNativeFileDialog`, `TestNativeMessageBox` and `TestPrmMcpConnector` four times the
default leak-check iteration ceiling. `MutedHeapMemoryLeakTestNames` stays empty -- the heap
check remains enforced for these tests.

Reopened and rebased on master now that #4458 and #4474 are merged. Changes since it was closed:

* Dropped the `TestMcpConnectorBackgroundDialog` entry. #4458 reworked that test to create one
  window instead of ~100,000, and it now converges in 8 passes on all four agents that have
  reported (UW7 -16.8 KB, DEV6 -33.3 KB, DEV4 -24 KB), so it does not need an override.
* Removed the Terminal Services framing. The session headers added by #4458 falsify it:
  BRENDANX-DT1 reports `TerminalServerSession=False` and still leaks all three tests.
* Named the growth instead of inferring it. Diffing the process heap's block-size histogram
  across a pass-1 run shows the accumulating blocks hold Explorer's cached DirectUI view markup
  (`<duixml>`, `ViewHost`, `ProperTreeModule`, `DetailsContainer`) plus the navigated path's own
  strings, one set per dialog shown -- the shell view of the modern Explorer-hosted `IFileDialog`,
  cached per instance on a UI thread that lives for the whole process.

## Why extra iterations rather than muting

The growth saturates. On a long-lived thread the marginal cost decays to ~2 KB by the 40th dialog.
Legacy comdlg32 is genuinely dead-linear at ~29 KB/dialog, but Skyline never takes that path:
`AutoUpgradeEnabled` is never set false and `ShowHelp`/`ShowReadOnly` are never set at all.

It is the dialog and not the connector. `TestSetItemMcpConnector` drives the same connector with
the same 30 ms polling and the same startup but opens no native dialog; it converges and passes,
and shares none of the block sizes above.

## The objection this PR was closed on

The closing comment gave two reasons. The first -- that the growth is dead linear with no plateau,
so extra iterations only delay the same failure -- rested on the "unbounded" reading of 25 samples
that CORRECTION 3 in the TODO later withdrew as an over-extrapolation.

The second still stands and is worth stating plainly: a test given 96 passes has more chances to
exit on a lucky trailing window, which can turn a real leak into a reported pass. The per-run delta
here is a wide distribution straddling the 20 KB threshold, so that is a real risk, not a
theoretical one. It is the price of keeping the heap check enabled for these tests at all; muting
them would give up the detection outright.

A per-test heap *threshold* override would be the better instrument -- it would keep a fixed
iteration count while still catching a gross leak -- but TestRunner has only mute lists and
iteration overrides today. Worth considering as a follow-up if these tests keep flagging.

## Alternative that was tested and rejected

Pre-saturating the shell cache inside the test (showing the dialog N extra times per run) was
measured on `TestNativeMessageBox`: 2 dialogs/run failed 2/2 (28.9, 36.0 KB), 8 dialogs/run passed
2/2 (11.7, 18.4 KB), 16 dialogs/run failed 2/3 (8.5, 20.5 KB heap, and one run that passed the heap
check at 0.0 KB but tripped the total-memory threshold at 179.6 KB). It shifts the mean without
removing the variance, and trades the heap threshold for the memory one. It also takes the test
from 1-2 s to 8 s per execution, on every execution rather than only during pass 1.

## Test plan

- [x] Solution builds
- [x] CodeInspection passes
- [x] Verified on this machine with the override in place: TestNativeFileDialog -39.9 KB (25
      iterations), TestNativeMessageBox -62.2 KB (24), TestPrmMcpConnector +14.8 KB (25). PRM
      converged on pass 25, one past the old 24 ceiling that would have failed it.
- [x] Three further trials of each, plus a disconnected-session run (`tsdiscon`) where PRM needed
      pass 27 and TestNativeFileDialog pass 28 -- both of which the old ceiling would have failed

Co-Authored-By: Claude <noreply@anthropic.com>
