### PR TITLE
Osprey clean-up: removed 3 permanently-skipped tests, fixed the coverage harness resume leg, quieted the VulnerablePackage warning

### DIFF
--- a/pwiz_tools/Osprey/Osprey.IO/Osprey.IO.csproj
+++ b/pwiz_tools/Osprey/Osprey.IO/Osprey.IO.csproj
@@ -10,6 +10,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <!-- ReSharper disable once VulnerablePackage -->
     <PackageReference Include="Parquet.Net" Version="4.25.0" />
     <PackageReference Include="System.Data.SQLite.Core" Version="1.0.118" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />

--- a/pwiz_tools/Osprey/Osprey.Scoring/PeakShapeCalculators.cs
+++ b/pwiz_tools/Osprey/Osprey.Scoring/PeakShapeCalculators.cs
@@ -231,8 +231,8 @@ namespace pwiz.Osprey.Scoring
     /// A truly scale-free sharpness would normalize the slope by the apex
     /// (<c>slope / apex</c>) and stay linear. That is a feature redesign, not a
     /// conditioning change, and it moves the discovery set, so it needs its own
-    /// entrapment validation. It is tracked in the team's sibling pwiz-ai repo (NOT in
-    /// this one) at todos/backlog/brendanx67/TODO-osprey_scale_free_sharpness.md.
+    /// entrapment validation. Tracked as issue #4466, together with the per-run
+    /// intensity normalization it pairs with.
     ///
     /// This is the ONE peak-shape feature whose raw value can genuinely be negative:
     /// the apex is the override/CWT-supplied apex (see <see cref="PeakApexCalc"/>), NOT

--- a/pwiz_tools/Osprey/Osprey.Test/CwtCandidateCodecTest.cs
+++ b/pwiz_tools/Osprey/Osprey.Test/CwtCandidateCodecTest.cs
@@ -1,7 +1,7 @@
 /*
  * Original author: Brendan MacLean <brendanx .at. uw.edu>,
  *                  MacCoss Lab, Department of Genome Sciences, UW
- * AI assistance: Claude Code (Claude Opus 4.7) <noreply .at. anthropic.com>
+ * AI assistance: Claude Code (Claude Opus 5) <noreply .at. anthropic.com>
  *
  * Based on osprey (https://github.com/MacCossLab/osprey)
  *   by Michael J. MacCoss, MacCoss Lab, Department of Genome Sciences, UW
@@ -173,266 +173,102 @@ namespace pwiz.Osprey.Test
         }
 
         /// <summary>
-        /// Cross-impl CWT-candidate value parity: decode the cwt_candidates
-        /// columns from both the Rust and C# .scores.parquet files for
-        /// Stellar file 20, index by entry_id, and assert every candidate
-        /// field is bit-identical for entries present in both. The Stage
-        /// 1-4 entry sets do not have to match exactly (a known row-count
-        /// divergence ~0.5% exists today, masked in the harness because
-        /// both impls load the same Rust-written parquet via
-        /// <c>--input-scores</c>). What matters for Stage 6 reconciliation
-        /// parity is that for every entry both impls did score, the CWT
-        /// candidate lists are byte-identical -- otherwise the planner
-        /// would diverge.
+        /// Round-trip CWT candidates through the real parquet writer and
+        /// reader: write scored entries carrying known candidate lists,
+        /// then read them back with
+        /// <see cref="ParquetScoreCache.LoadCwtCandidatesFromParquet"/> and
+        /// assert every field survives bit-exactly and each row keeps its
+        /// own list. This gates the codec's wiring into the cwt_candidates
+        /// parquet column (the encode/decode pair plus the per-row list
+        /// boundaries) with no dependency on external run output, so it
+        /// runs everywhere the rest of the suite does.
         /// </summary>
         [TestMethod]
-        public void TestCwtCandidateCrossImplParity()
+        public void TestCwtCandidatesRoundTripThroughParquet()
         {
-            string baseDir = StellarBaseDir();
-            string csPath = System.IO.Path.Combine(baseDir,
-                @"Ste-2024-12-02_HeLa_4mz_sDIA_400-900_20.scores.cs.parquet");
-            string rustPath = System.IO.Path.Combine(baseDir,
-                @"Ste-2024-12-02_HeLa_4mz_sDIA_400-900_20.scores.rust.parquet");
-            if (!System.IO.File.Exists(csPath) || !System.IO.File.Exists(rustPath))
+            string dir = System.IO.Path.Combine(System.IO.Path.GetTempPath(),
+                @"osprey_cwt_parquet_" + System.Guid.NewGuid().ToString(@"N"));
+            System.IO.Directory.CreateDirectory(dir);
+            try
             {
-                Assert.Inconclusive(@"Both Stellar 20 cs+rust parquets must be present");
-                return;
-            }
-            var csCands = ParquetScoreCache.LoadCwtCandidatesFromParquet(csPath);
-            var rustCands = ParquetScoreCache.LoadCwtCandidatesFromParquet(rustPath);
-            var csStubs = ParquetScoreCache.LoadFdrStubsFromParquet(csPath);
-            var rustStubs = ParquetScoreCache.LoadFdrStubsFromParquet(rustPath);
-            Assert.AreEqual(csStubs.Count, csCands.Count, @"cs stub/cwt count mismatch");
-            Assert.AreEqual(rustStubs.Count, rustCands.Count, @"rust stub/cwt count mismatch");
-
-            // Index CWT lists by entry_id for cross-impl matching.
-            var csByEntry = new Dictionary<uint, List<CwtCandidate>>(csStubs.Count);
-            for (int i = 0; i < csStubs.Count; i++)
-                csByEntry[csStubs[i].EntryId] = csCands[i];
-            var rustByEntry = new Dictionary<uint, List<CwtCandidate>>(rustStubs.Count);
-            for (int i = 0; i < rustStubs.Count; i++)
-                rustByEntry[rustStubs[i].EntryId] = rustCands[i];
-
-            int bothScored = 0;       // entry present in both parquets
-            int bothCwt = 0;          // entry has CWT candidates on BOTH sides
-            int countMismatch = 0;    // bothCwt subset where counts differ
-            int valueMismatch = 0;    // bothCwt subset, equal counts, value diff
-            string firstCountDiff = null;
-            string firstValueDiff = null;
-            foreach (var kvp in csByEntry)
-            {
-                List<CwtCandidate> rustList;
-                if (!rustByEntry.TryGetValue(kvp.Key, out rustList))
-                    continue;
-                bothScored++;
-                var csList = kvp.Value;
-                // The pre-existing Stage 1-4 CWT-detection divergence drops
-                // primary-CWT peaks on one side for ~3% of common entries
-                // (those entries fall through to median-polish or ref-XIC
-                // fallback paths that don't capture CWT candidates). To
-                // isolate the codec/scoring-loop value parity from that
-                // upstream issue, this test compares only entries where
-                // BOTH sides captured CWT data.
-                if (csList.Count == 0 || rustList.Count == 0)
-                    continue;
-                bothCwt++;
-                if (csList.Count != rustList.Count)
+                // Ids out of order so the write's canonical (entry_id, charge,
+                // scan_number) sort runs, and a deliberate mix of list lengths
+                // (two, zero, one) so a per-row boundary mismap surfaces as a
+                // count mismatch rather than a silent pass.
+                var entries = new List<FdrEntry>
                 {
-                    countMismatch++;
-                    if (firstCountDiff == null)
-                    {
-                        firstCountDiff = string.Format(
-                            @"entry_id {0}: cs has {1} candidates, rust has {2}",
-                            kvp.Key, csList.Count, rustList.Count);
-                    }
-                    continue;
-                }
-                for (int k = 0; k < csList.Count; k++)
-                {
-                    string d = FieldsBitDiff(csList[k], rustList[k]);
-                    if (d != null)
-                    {
-                        valueMismatch++;
-                        if (firstValueDiff == null)
-                        {
-                            firstValueDiff = string.Format(@"entry_id {0} candidate {1}: {2}",
-                                kvp.Key, k, d);
-                        }
-                        break;
-                    }
-                }
+                    MakeEntry(3,
+                        NewCandidate(31.5, 31.0, 32.0, 1.5e6, 42.5, 8.25),
+                        // Boundary value that locks the byte-exact path through
+                        // BitConverter (the ryu/R formatter ambiguity from the
+                        // Stage 5 percolator dump).
+                        NewCandidate(0.097751617431640625, 0.5, 1.5, 1.0, 1.0, -1.5)),
+                    MakeEntry(1),
+                    MakeEntry(2, NewCandidate(20.25, 20.0, 20.5, 7.5e5, 13.0, 3.125)),
+                };
+
+                string path = System.IO.Path.Combine(dir, @"cwt.scores.parquet");
+                ParquetScoreCache.WriteScoresParquet(path, entries, null, null, @"f.mzML");
+
+                // Rows come back in the canonical entry_id order the write
+                // imposed: 1 (none), 2 (one), 3 (two).
+                var loaded = ParquetScoreCache.LoadCwtCandidatesFromParquet(path);
+                Assert.IsNotNull(loaded);
+                Assert.AreEqual(entries.Count, loaded.Count, @"row count");
+                Assert.AreEqual(0, loaded[0].Count, @"entry 1 candidate count");
+                Assert.AreEqual(1, loaded[1].Count, @"entry 2 candidate count");
+                Assert.AreEqual(2, loaded[2].Count, @"entry 3 candidate count");
+
+                AssertCandidateBitEqual(entries[2].CwtCandidates[0], loaded[1][0], @"entry2[0]");
+                AssertCandidateBitEqual(entries[0].CwtCandidates[0], loaded[2][0], @"entry3[0]");
+                AssertCandidateBitEqual(entries[0].CwtCandidates[1], loaded[2][1], @"entry3[1]");
             }
-            Assert.IsTrue(bothCwt > 0, @"No entries with CWT data on both sides");
-            // Stage 1-4 cross-impl parity is gated at 1e-6 absolute tolerance
-            // (Test-Features.ps1) -- not bit-identical. peak_area in particular
-            // shows max diff ~4.4e-9 between impls. The CwtCandidate area
-            // field is computed by the same trapezoidal sum and inherits the
-            // same drift, so ~2% of both-CWT entries currently show ULP-level
-            // CwtCandidate field diffs. This test allows the same ~3% headroom
-            // so the codec/scoring-loop wiring is gated separately from the
-            // upstream Stage 1-4 ULP drift; widening beyond that will fail.
-            // See ai/todos/active/TODO-20260428_osprey_sharp_stage6.md for
-            // the open question on whether to chase the root cause.
-            Assert.AreEqual(0, countMismatch,
-                string.Format(
-                    @"{0}/{1} both-CWT entries have count diff. First: {2}",
-                    countMismatch, bothCwt, firstCountDiff));
-            const double VALUE_DIFF_TOLERANCE = 0.03;
-            double valueDiffFrac = (double)valueMismatch / bothCwt;
-            Assert.IsTrue(valueDiffFrac < VALUE_DIFF_TOLERANCE,
-                string.Format(@"{0}/{1} ({2:P2}) both-CWT entries have value diff (>{3:P0} threshold). First: {4}",
-                    valueMismatch, bothCwt, valueDiffFrac, VALUE_DIFF_TOLERANCE, firstValueDiff));
-        }
-
-        private static string FieldsBitDiff(CwtCandidate cs, CwtCandidate rust)
-        {
-            string d = BitDiff("apex_rt", cs.ApexRt, rust.ApexRt) ??
-                       BitDiff("start_rt", cs.StartRt, rust.StartRt) ??
-                       BitDiff("end_rt", cs.EndRt, rust.EndRt) ??
-                       BitDiff("area", cs.Area, rust.Area) ??
-                       BitDiff("snr", cs.Snr, rust.Snr) ??
-                       BitDiff("coelution_score", cs.CoelutionScore, rust.CoelutionScore);
-            return d;
-        }
-
-        private static string BitDiff(string name, double cs, double rust)
-        {
-            long csBits = System.BitConverter.DoubleToInt64Bits(cs);
-            long rustBits = System.BitConverter.DoubleToInt64Bits(rust);
-            if (csBits == rustBits)
-                return null;
-            return string.Format(@"{0}: cs={1:G17} (0x{2:x16}) rust={3:G17} (0x{4:x16})",
-                name, cs, csBits, rust, rustBits);
-        }
-
-        /// <summary>
-        /// End-to-end validation: read the latest C#-written
-        /// <c>.scores.cs.parquet</c> from the Stellar single-file test data
-        /// and assert the cwt_candidates column is populated. Confirms the
-        /// scoring-loop CWT capture path actually wrote candidates to the
-        /// parquet. Skipped when the file is missing.
-        /// </summary>
-        [TestMethod]
-        public void TestCsScoringPopulatesCwtCandidates()
-        {
-            string path = System.IO.Path.Combine(StellarBaseDir(),
-                @"Ste-2024-12-02_HeLa_4mz_sDIA_400-900_20.scores.cs.parquet");
-            if (!System.IO.File.Exists(path))
+            finally
             {
-                Assert.Inconclusive(@"C# scores parquet not present: " + path);
-                return;
+                System.IO.Directory.Delete(dir, true);
             }
-            var allCandidates = ParquetScoreCache.LoadCwtCandidatesFromParquet(path);
-            Assert.IsNotNull(allCandidates);
-            Assert.IsTrue(allCandidates.Count > 0, @"Expected at least one parquet row");
-            int nonEmpty = 0;
-            int totalCandidates = 0;
-            foreach (var lst in allCandidates)
-            {
-                if (lst.Count == 0) continue;
-                nonEmpty++;
-                totalCandidates += lst.Count;
-            }
-            // After the scoring-loop change, a typical Stellar single-file
-            // Stage 4 run produces tens of thousands of FdrEntry rows with
-            // 1..top_n_peaks (default 5) CWT candidates each. Expect at
-            // least 50% of rows to have at least one candidate.
-            double frac = (double)nonEmpty / allCandidates.Count;
-            Assert.IsTrue(frac > 0.5,
-                string.Format(@"Only {0}/{1} rows ({2:P0}) have CWT candidates -- "
-                              + "scoring loop may not be populating them",
-                              nonEmpty, allCandidates.Count, frac));
-            Assert.IsTrue(totalCandidates > 0, @"Expected some decoded candidates");
         }
 
-        /// <summary>
-        /// End-to-end validation: read a real Rust-written .scores.parquet and
-        /// assert <see cref="pwiz.Osprey.IO.ParquetScoreCache.LoadCwtCandidatesFromParquet"/>
-        /// returns sensible CWT data. Skipped automatically when the
-        /// reference parquet is not present (so the test stays portable),
-        /// but locally validates byte-level decode compatibility against
-        /// the current Rust write path.
-        /// </summary>
-        [TestMethod]
-        public void TestLoadCwtCandidatesFromRustParquet()
+        private static CwtCandidate NewCandidate(double apexRt, double startRt, double endRt,
+            double area, double snr, double coelutionScore)
         {
-            string baseDir = System.Environment.GetEnvironmentVariable(@"OSPREY_TEST_BASE_DIR")
-                             ?? DefaultTestBaseDir();
-            string path = System.IO.Path.Combine(baseDir, @"astral",
-                @"_stage6_planning", @"Astral",
-                @"Ast-2024-12-05_HeLa_3mzDIA_6mIIT_400-900_49.scores.parquet");
-            if (!System.IO.File.Exists(path))
+            return new CwtCandidate
             {
-                Assert.Inconclusive(@"Reference parquet not present: " + path);
-                return;
-            }
-            var allCandidates = ParquetScoreCache.LoadCwtCandidatesFromParquet(path);
-            Assert.IsNotNull(allCandidates);
-            Assert.IsTrue(allCandidates.Count > 0, @"Expected at least one parquet row");
-            int nonEmpty = 0;
-            int totalCandidates = 0;
-            int candidatesWithSensibleApex = 0;
-            foreach (var lst in allCandidates)
-            {
-                if (lst.Count == 0)
-                    continue;
-                nonEmpty++;
-                totalCandidates += lst.Count;
-                foreach (var c in lst)
-                {
-                    // Astral RT range for this dataset is roughly 0..120 min.
-                    // A sensible decode produces apex RTs in that range; a
-                    // wrong byte order (e.g. big-endian f64 read as little)
-                    // produces values around 1e308 from the bit pattern.
-                    if (c.ApexRt > 0 && c.ApexRt < 200)
-                        candidatesWithSensibleApex++;
-                    // Boundary ordering invariant: start <= apex <= end.
-                    Assert.IsTrue(c.StartRt <= c.ApexRt + 1e-6,
-                        @"start_rt > apex_rt: " + c.StartRt + @" > " + c.ApexRt);
-                    Assert.IsTrue(c.ApexRt <= c.EndRt + 1e-6,
-                        @"apex_rt > end_rt: " + c.ApexRt + @" > " + c.EndRt);
-                }
-            }
-            Assert.IsTrue(nonEmpty > 0, @"Expected at least one entry with CWT candidates");
-            Assert.IsTrue(totalCandidates > 0, @"Expected at least one decoded candidate");
-            // If decoding succeeded, the vast majority of apex values
-            // should be in the dataset's measured RT range. Use 95% to
-            // tolerate the rare candidate with an extreme value.
-            double sensibleFraction = (double)candidatesWithSensibleApex / totalCandidates;
-            Assert.IsTrue(sensibleFraction > 0.95,
-                string.Format(@"Only {0}/{1} candidates have apex_rt in [0, 200] min",
-                    candidatesWithSensibleApex, totalCandidates));
+                ApexRt = apexRt,
+                StartRt = startRt,
+                EndRt = endRt,
+                Area = area,
+                Snr = snr,
+                CoelutionScore = coelutionScore,
+            };
         }
 
-        /// <summary>
-        /// Resolve the Stellar test data directory via the
-        /// <c>OSPREY_TEST_BASE_DIR</c> environment variable used by
-        /// <c>ai/scripts/Osprey/Dataset-Config.ps1</c>, falling back
-        /// to <see cref="DefaultTestBaseDir"/> for the default developer
-        /// setup. Tests that read parquets call
-        /// <c>Assert.Inconclusive</c> when the resolved file is missing,
-        /// keeping the suite portable to environments without the test
-        /// dataset.
-        /// </summary>
-        private static string StellarBaseDir()
+        private static FdrEntry MakeEntry(uint entryId, params CwtCandidate[] candidates)
         {
-            string baseDir = System.Environment.GetEnvironmentVariable(@"OSPREY_TEST_BASE_DIR")
-                             ?? DefaultTestBaseDir();
-            return System.IO.Path.Combine(baseDir, @"stellar");
+            return new FdrEntry
+            {
+                EntryId = entryId,
+                Charge = 2,
+                ScanNumber = entryId * 10,
+                ApexRt = entryId + 0.5,
+                StartRt = entryId + 0.1,
+                EndRt = entryId + 0.9,
+                ModifiedSequence = @"PEPTIDE" + entryId,
+                Features = new double[ParquetScoreCache.NUM_PIN_FEATURES],
+                CwtCandidates = new List<CwtCandidate>(candidates),
+            };
         }
 
-        /// <summary>
-        /// Default test-data root when <c>OSPREY_TEST_BASE_DIR</c> is not
-        /// set. Maps the Windows <c>D:\test\osprey-runs</c> developer layout
-        /// to its WSL/drvfs equivalent <c>/mnt/d/test/osprey-runs</c> on
-        /// Linux, so the parquet-dependent tests run out of the box under
-        /// WSL without requiring the env var to be set manually.
-        /// </summary>
-        private static string DefaultTestBaseDir()
+        private static void AssertCandidateBitEqual(CwtCandidate expected, CwtCandidate actual,
+            string label)
         {
-            return System.IO.Path.DirectorySeparatorChar == '/'
-                ? @"/mnt/d/test/osprey-runs"
-                : @"D:\test\osprey-runs";
+            AssertBitEqual(expected.ApexRt, actual.ApexRt, label + @" ApexRt");
+            AssertBitEqual(expected.StartRt, actual.StartRt, label + @" StartRt");
+            AssertBitEqual(expected.EndRt, actual.EndRt, label + @" EndRt");
+            AssertBitEqual(expected.Area, actual.Area, label + @" Area");
+            AssertBitEqual(expected.Snr, actual.Snr, label + @" Snr");
+            AssertBitEqual(expected.CoelutionScore, actual.CoelutionScore,
+                label + @" CoelutionScore");
         }
 
         private static void AssertBitEqual(double expected, double actual, string label)

--- a/pwiz_tools/Osprey/Osprey.Test/CwtCandidateCodecTest.cs
+++ b/pwiz_tools/Osprey/Osprey.Test/CwtCandidateCodecTest.cs
@@ -225,7 +225,11 @@ namespace pwiz.Osprey.Test
             }
             finally
             {
-                System.IO.Directory.Delete(dir, true);
+                // Best-effort: a teardown throw (parquet handle still open on
+                // Windows) would replace the real assertion failure with an
+                // IOException. Matches the cleanup in IOTest.
+                try { System.IO.Directory.Delete(dir, true); }
+                catch (System.IO.IOException) { }
             }
         }
 

--- a/pwiz_tools/Osprey/Osprey.Test/CwtCandidateCodecTest.cs
+++ b/pwiz_tools/Osprey/Osprey.Test/CwtCandidateCodecTest.cs
@@ -24,7 +24,6 @@
 using System.Collections.Generic;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using pwiz.Osprey.Core;
-using pwiz.Osprey.IO;
 
 namespace pwiz.Osprey.Test
 {
@@ -37,6 +36,19 @@ namespace pwiz.Osprey.Test
     /// coelution_score). Stage 6 reconciliation depends on this round-trip
     /// for cross-impl byte parity of the .scores.parquet cwt_candidates
     /// column.
+    ///
+    /// Scope: this class stays pure byte-array assertions, no parquet and no
+    /// disk. The codec's wiring INTO the cwt_candidates parquet column - per-row
+    /// list boundaries, ParquetIndex alignment, the null/empty blob
+    /// normalization, multi-row-group framing - is covered by
+    /// IOTest.TestCwtCandidatesRoundTripThroughParquet, which lives beside the
+    /// rest of the ParquetScoreCache coverage.
+    ///
+    /// Not covered anywhere at unit level: that the scoring loop actually
+    /// populates FdrEntry.CwtCandidates. PerFileScoringTask is not unit-testable
+    /// today, so that path is gated only by the committed regression golden - if
+    /// candidates stopped being written, Stage 6 planning would shift and the
+    /// golden would diverge.
     /// </summary>
     [TestClass]
     public class CwtCandidateCodecTest
@@ -170,109 +182,6 @@ namespace pwiz.Osprey.Test
             var decoded = CwtCandidateCodec.Decode(bytes);
             Assert.AreEqual(2, decoded.Count);
             Assert.AreEqual(7.0, decoded[1].ApexRt);
-        }
-
-        /// <summary>
-        /// Round-trip CWT candidates through the real parquet writer and
-        /// reader: write scored entries carrying known candidate lists,
-        /// then read them back with
-        /// <see cref="ParquetScoreCache.LoadCwtCandidatesFromParquet"/> and
-        /// assert every field survives bit-exactly and each row keeps its
-        /// own list. This gates the codec's wiring into the cwt_candidates
-        /// parquet column (the encode/decode pair plus the per-row list
-        /// boundaries) with no dependency on external run output, so it
-        /// runs everywhere the rest of the suite does.
-        /// </summary>
-        [TestMethod]
-        public void TestCwtCandidatesRoundTripThroughParquet()
-        {
-            string dir = System.IO.Path.Combine(System.IO.Path.GetTempPath(),
-                @"osprey_cwt_parquet_" + System.Guid.NewGuid().ToString(@"N"));
-            System.IO.Directory.CreateDirectory(dir);
-            try
-            {
-                // Ids out of order so the write's canonical (entry_id, charge,
-                // scan_number) sort runs, and a deliberate mix of list lengths
-                // (two, zero, one) so a per-row boundary mismap surfaces as a
-                // count mismatch rather than a silent pass.
-                var entries = new List<FdrEntry>
-                {
-                    MakeEntry(3,
-                        NewCandidate(31.5, 31.0, 32.0, 1.5e6, 42.5, 8.25),
-                        // Boundary value that locks the byte-exact path through
-                        // BitConverter (the ryu/R formatter ambiguity from the
-                        // Stage 5 percolator dump).
-                        NewCandidate(0.097751617431640625, 0.5, 1.5, 1.0, 1.0, -1.5)),
-                    MakeEntry(1),
-                    MakeEntry(2, NewCandidate(20.25, 20.0, 20.5, 7.5e5, 13.0, 3.125)),
-                };
-
-                string path = System.IO.Path.Combine(dir, @"cwt.scores.parquet");
-                ParquetScoreCache.WriteScoresParquet(path, entries, null, null, @"f.mzML");
-
-                // Rows come back in the canonical entry_id order the write
-                // imposed: 1 (none), 2 (one), 3 (two).
-                var loaded = ParquetScoreCache.LoadCwtCandidatesFromParquet(path);
-                Assert.IsNotNull(loaded);
-                Assert.AreEqual(entries.Count, loaded.Count, @"row count");
-                Assert.AreEqual(0, loaded[0].Count, @"entry 1 candidate count");
-                Assert.AreEqual(1, loaded[1].Count, @"entry 2 candidate count");
-                Assert.AreEqual(2, loaded[2].Count, @"entry 3 candidate count");
-
-                AssertCandidateBitEqual(entries[2].CwtCandidates[0], loaded[1][0], @"entry2[0]");
-                AssertCandidateBitEqual(entries[0].CwtCandidates[0], loaded[2][0], @"entry3[0]");
-                AssertCandidateBitEqual(entries[0].CwtCandidates[1], loaded[2][1], @"entry3[1]");
-            }
-            finally
-            {
-                // Best-effort: a teardown throw (parquet handle still open on
-                // Windows) would replace the real assertion failure with an
-                // IOException. Matches the cleanup in IOTest.
-                try { System.IO.Directory.Delete(dir, true); }
-                catch (System.IO.IOException) { }
-            }
-        }
-
-        private static CwtCandidate NewCandidate(double apexRt, double startRt, double endRt,
-            double area, double snr, double coelutionScore)
-        {
-            return new CwtCandidate
-            {
-                ApexRt = apexRt,
-                StartRt = startRt,
-                EndRt = endRt,
-                Area = area,
-                Snr = snr,
-                CoelutionScore = coelutionScore,
-            };
-        }
-
-        private static FdrEntry MakeEntry(uint entryId, params CwtCandidate[] candidates)
-        {
-            return new FdrEntry
-            {
-                EntryId = entryId,
-                Charge = 2,
-                ScanNumber = entryId * 10,
-                ApexRt = entryId + 0.5,
-                StartRt = entryId + 0.1,
-                EndRt = entryId + 0.9,
-                ModifiedSequence = @"PEPTIDE" + entryId,
-                Features = new double[ParquetScoreCache.NUM_PIN_FEATURES],
-                CwtCandidates = new List<CwtCandidate>(candidates),
-            };
-        }
-
-        private static void AssertCandidateBitEqual(CwtCandidate expected, CwtCandidate actual,
-            string label)
-        {
-            AssertBitEqual(expected.ApexRt, actual.ApexRt, label + @" ApexRt");
-            AssertBitEqual(expected.StartRt, actual.StartRt, label + @" StartRt");
-            AssertBitEqual(expected.EndRt, actual.EndRt, label + @" EndRt");
-            AssertBitEqual(expected.Area, actual.Area, label + @" Area");
-            AssertBitEqual(expected.Snr, actual.Snr, label + @" Snr");
-            AssertBitEqual(expected.CoelutionScore, actual.CoelutionScore,
-                label + @" CoelutionScore");
         }
 
         private static void AssertBitEqual(double expected, double actual, string label)

--- a/pwiz_tools/Osprey/Osprey.Test/IOTest.cs
+++ b/pwiz_tools/Osprey/Osprey.Test/IOTest.cs
@@ -2532,6 +2532,129 @@ namespace pwiz.Osprey.Test
         }
 
         /// <summary>
+        /// CWT-candidate column round-trip through the real writer and reader: the
+        /// per-row candidate lists come back bit-identical, keep their own row via the
+        /// running <see cref="FdrEntry.ParquetIndex"/>, and survive a multi-row-group
+        /// write. Covers <see cref="CwtCandidateCodec"/>'s wiring into the
+        /// cwt_candidates column, which the codec's own unit tests cannot reach
+        /// because they never touch parquet.
+        ///
+        /// A row with a NULL candidate list is included deliberately: the writer
+        /// normalizes null and empty alike to a 4-byte zero-count blob (never a null
+        /// cell) to match Rust, and nothing else exercises the null branch.
+        /// </summary>
+        [TestMethod]
+        public void TestCwtCandidatesRoundTripThroughParquet()
+        {
+            string dir = Path.Combine(Path.GetTempPath(),
+                "osprey_cwt_parquet_" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(dir);
+            try
+            {
+                // Ids out of order so the write's canonical sort runs; candidate-list
+                // lengths deliberately mixed (2 / none / 1 / null) so a per-row boundary
+                // mismap surfaces as a count mismatch instead of a silent pass.
+                var byId = new Dictionary<uint, List<CwtCandidate>>
+                {
+                    { 5, new List<CwtCandidate> {
+                        NewCwtCandidate(51.5, 51.0, 52.0, 1.5e6, 42.5, 8.25),
+                        // Boundary value that pins the byte-exact BitConverter path
+                        // (the ryu/R formatter ambiguity from the Stage 5 dump).
+                        NewCwtCandidate(0.097751617431640625, 0.5, 1.5, 1.0, 1.0, -1.5) } },
+                    { 2, new List<CwtCandidate>() },
+                    { 9, new List<CwtCandidate> {
+                        NewCwtCandidate(90.25, 90.0, 90.5, 7.5e5, 13.0, 3.125) } },
+                    { 1, null },
+                };
+
+                var entries = new List<FdrEntry>();
+                foreach (uint id in new uint[] { 5, 2, 9, 1 })
+                {
+                    var e = MakeStreamEntry(id, id * 100.0);
+                    e.CwtCandidates = byId[id];
+                    entries.Add(e);
+                }
+
+                string path = Path.Combine(dir, "cwt.scores.parquet");
+                // Cap 2 -> ceil(4/2) = 2 row groups, so the reader's per-group append
+                // loop is exercised rather than a single-group degenerate case.
+                ParquetScoreCache.RowGroupRowCapForTest = 2;
+                ParquetScoreCache.WriteScoresParquet(path, entries, null, null, "f.mzML");
+                ParquetScoreCache.RowGroupRowCapForTest = null;
+
+                // Full entries carry both ParquetIndex and CwtCandidates, so one load
+                // checks the candidate values AND that each list landed on the row its
+                // running index claims (the alignment defect that once made every
+                // lookup return row 0's list).
+                var reloaded = ParquetScoreCache.LoadFullFdrEntries(path);
+                Assert.AreEqual(entries.Count, reloaded.Count, "row count");
+                for (int i = 0; i < reloaded.Count; i++)
+                {
+                    Assert.AreEqual((uint)i, reloaded[i].ParquetIndex,
+                        "ParquetIndex must be the running row position");
+                }
+
+                // The column-only reader must agree row-for-row with the full load.
+                var columnOnly = ParquetScoreCache.LoadCwtCandidatesFromParquet(path);
+                Assert.AreEqual(reloaded.Count, columnOnly.Count, "cwt column row count");
+
+                foreach (var row in reloaded)
+                {
+                    var expected = byId[row.EntryId] ?? new List<CwtCandidate>();
+                    var actual = row.CwtCandidates ?? new List<CwtCandidate>();
+                    string label = "entry " + row.EntryId;
+                    Assert.AreEqual(expected.Count, actual.Count, label + " candidate count");
+                    // Null and empty must both decode to an empty list, never null:
+                    // the writer emits the 4-byte zero-count blob for each.
+                    Assert.IsNotNull(row.CwtCandidates, label + " list must not be null");
+                    Assert.AreEqual(expected.Count, columnOnly[(int)row.ParquetIndex].Count,
+                        label + " column-only candidate count");
+                    for (int k = 0; k < expected.Count; k++)
+                    {
+                        AssertCwtCandidateBitEqual(expected[k], actual[k],
+                            label + " candidate " + k);
+                    }
+                }
+            }
+            finally
+            {
+                ParquetScoreCache.RowGroupRowCapForTest = null;
+                try { Directory.Delete(dir, true); } catch (IOException) { }
+            }
+        }
+
+        private static CwtCandidate NewCwtCandidate(double apexRt, double startRt, double endRt,
+            double area, double snr, double coelutionScore)
+        {
+            return new CwtCandidate
+            {
+                ApexRt = apexRt,
+                StartRt = startRt,
+                EndRt = endRt,
+                Area = area,
+                Snr = snr,
+                CoelutionScore = coelutionScore,
+            };
+        }
+
+        private static void AssertCwtCandidateBitEqual(CwtCandidate expected, CwtCandidate actual,
+            string label)
+        {
+            AssertBitEqual(expected.ApexRt, actual.ApexRt, label + " ApexRt");
+            AssertBitEqual(expected.StartRt, actual.StartRt, label + " StartRt");
+            AssertBitEqual(expected.EndRt, actual.EndRt, label + " EndRt");
+            AssertBitEqual(expected.Area, actual.Area, label + " Area");
+            AssertBitEqual(expected.Snr, actual.Snr, label + " Snr");
+            AssertBitEqual(expected.CoelutionScore, actual.CoelutionScore, label + " CoelutionScore");
+        }
+
+        private static void AssertBitEqual(double expected, double actual, string label)
+        {
+            Assert.AreEqual(BitConverter.DoubleToInt64Bits(expected),
+                BitConverter.DoubleToInt64Bits(actual), label + " bit mismatch");
+        }
+
+        /// <summary>
         /// Stage-6 streaming reconciled transfer: streaming the original parquet
         /// group-by-group with an overlay map + gap-fill list
         /// (<see cref="ParquetScoreCache.StreamReconciledScoresParquet"/>) is logically

--- a/pwiz_tools/Osprey/Regression/RegressionData.ps1
+++ b/pwiz_tools/Osprey/Regression/RegressionData.ps1
@@ -174,3 +174,40 @@ function Get-RegressionData {
     & $Log ("data ready: {0}" -f $t.ExtractedRoot)
     return $t.ExtractedRoot
 }
+
+<#
+.SYNOPSIS
+    Invalidate the Stage 5 join + blib so a re-run resumes (the rehydrate
+    paths fire) rather than recomputing from spectra.
+
+.DESCRIPTION
+    Shared by regression.ps1 (mode 2) and the ai-side cumulative-coverage
+    harness so there is ONE definition of what "resume" invalidates. The
+    patterns key off the task Name values the C# tasks stamp into their
+    validity sidecars -- FirstJoinTask.Name is "FirstPassFDR" and
+    MergeNodeTask.Name is "SecondPassFDR", NOT the class names. A private
+    copy of this function once used the class names, matched zero files,
+    and silently produced a run that never resumed.
+
+    Deleting nothing is therefore treated as a hard failure: if the tokens
+    ever drift from the C# Name values again, this throws instead of
+    yielding a green "resume" leg that only re-ran the merge.
+
+.PARAMETER WorkDir
+    The straight-through run directory to invalidate in place.
+#>
+function Invoke-ResumeInvalidation {
+    param([Parameter(Mandatory=$true)][string]$WorkDir)
+
+    $targets = Get-ChildItem -Path $WorkDir -File | Where-Object {
+        $_.Name -like '*.FirstPassFDR.osprey.task' -or
+        $_.Name -eq 'output.blib' -or $_.Name -eq 'output.blib.SecondPassFDR.osprey.task'
+    }
+    if (-not $targets) {
+        throw (("Invoke-ResumeInvalidation matched no files in '{0}'. The resume leg " +
+                "would not have resumed. Expected '*.FirstPassFDR.osprey.task' (FirstJoinTask.Name) " +
+                "and 'output.blib' + 'output.blib.SecondPassFDR.osprey.task' (MergeNodeTask.Name); " +
+                "check those Name values have not changed.") -f $WorkDir)
+    }
+    $targets | Remove-Item -Force
+}

--- a/pwiz_tools/Osprey/regression.ps1
+++ b/pwiz_tools/Osprey/regression.ps1
@@ -292,16 +292,12 @@ function Compare-DirFingerprint {
     return $changed
 }
 
-# Invalidate the Stage 5 join + blib so a re-run resumes (rehydrate paths fire)
-# rather than recomputing from spectra. Mirrors the proven repro from
+# Invoke-ResumeInvalidation (invalidate the Stage 5 join + blib so a re-run
+# resumes rather than recomputing from spectra) now lives in
+# Regression\RegressionData.ps1, dot-sourced above, so the ai-side
+# cumulative-coverage harness shares one definition instead of keeping a copy
+# that can drift. Mirrors the proven repro from
 # TODO-20260605_ospreysharp_resume_reconciled_rt.
-function Invoke-ResumeInvalidation {
-    param([string]$WorkDir)
-    Get-ChildItem -Path $WorkDir -File | Where-Object {
-        $_.Name -like '*.FirstPassFDR.osprey.task' -or
-        $_.Name -eq 'output.blib' -or $_.Name -eq 'output.blib.SecondPassFDR.osprey.task'
-    } | Remove-Item -Force
-}
 
 # --- mode 3: HPC 4-task worker chain ------------------------------------------
 # Low-level runner for a single --task phase: CWD = its own scratch dir so the


### PR DESCRIPTION
## Summary

A deliberate clean-up batch - small, orthogonal friction items that are individually too minor for their own PR and too unrelated to ride along with a feature, so they never land otherwise.

* **Removed the 3 permanently-skipped unit tests.** All were in `CwtCandidateCodecTest`, skipping via `Assert.Inconclusive` on parquet files that are not in the repo - resolved from `OSPREY_TEST_BASE_DIR`, defaulting to the transient Test-PerfGate scratch dir. They could never run in CI, and locally ran only if an earlier ad-hoc run happened to leave the exact file behind, which is worse than a plain skip. The two Rust cross-impl parity tests are dropped (that parity is covered far more strongly by `regression.ps1` at 1e-9 and `Compare-EndToEnd-Crossimpl.ps1`; the removed one was not even strict, allowing 3% value mismatch). Suite is now **535 / 535 with no skips**.
* **Replaced the third with a self-contained round-trip in `IOTest`**, beside the rest of the `ParquetScoreCache` coverage, reusing its `MakeStreamEntry` fixture. It covers a null candidate list (gating the writer's null-to-zero-blob normalization), multi-row-group framing, and `ParquetIndex` row alignment - none of which the removed tests gated on every run.
* **Fixed the cumulative-coverage harness resume leg, which never resumed.** `Measure-CumulativeCoverage.ps1` carried a private copy of `Invoke-ResumeInvalidation` keyed on task CLASS names, but tasks stamp their `Name` values (`FirstJoinTask.Name` is `FirstPassFDR`, `MergeNodeTask.Name` is `SecondPassFDR`). Both globs matched zero files, so it deleted only `output.blib` while leaving its validity sidecar intact - a state no supported path produces, which broke rehydrate. The function now lives once in `Regression/RegressionData.ps1`, shared with `regression.ps1`, and **hard-fails when it matches nothing** rather than silently reporting a green resume leg.
* **Quieted the `VulnerablePackage` inspection** on Parquet.Net so Visual Studio is clean. The two transitive advisories it flags are tracked in #4462 (they also affect Skyline, whose vendored copies no package auditing can see).

## Test plan

- [x] Unit suite: **535 total, 535 passed, 0 skipped** (was 537 / 534 / 3)
- [x] `Build-Osprey.ps1 -RunInspection` - 0 errors, 0 warnings
- [x] `regression.ps1 -Dataset Stellar` - **mode1 (vs golden) PASS, mode2 (resume==straight) PASS, mode3 (HPC chain==straight) PASS**; all three blibs 45,064,192 bytes. Mode 2 is the leg that exercises the relocated invalidation, and it also confirms master's resume path was never broken
- [x] New test verified non-vacuous: the reader leaves `CwtCandidates` null for a null cell and non-null for a zero blob, so reverting the writer's normalization fails it
- [x] Resume tokens verified directly against the run dir that failed: old patterns matched **0** files, new patterns **6**

See ai/todos/active/TODO-20260725_osprey_cwt_candidate_test_skips.md

Co-Authored-By: Claude <noreply@anthropic.com>