### PR TITLE
Fixed intermittent failures in TestSetItemMcpConnector and TestJsonToolServer

### DIFF
--- a/pwiz_tools/Skyline/TestFunctional/NativeFileDialogTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/NativeFileDialogTest.cs
@@ -144,8 +144,9 @@ namespace pwiz.SkylineTestFunctional
                     using var dlg = new System.Windows.Forms.OpenFileDialog();
                     dlg.Multiselect = true;
                     dlg.InitialDirectory = Path.GetTempPath();
-                    if (dlg.ShowDialog(SkylineWindow) == System.Windows.Forms.DialogResult.OK)
-                        selectedFiles = dlg.FileNames;
+                    AssertEx.AreEqual(System.Windows.Forms.DialogResult.OK, dlg.ShowDialog(SkylineWindow),
+                        @"The multiselect Open dialog was not accepted.");
+                    selectedFiles = dlg.FileNames;
                 },
                 // Navigate to the folder (confirmed through GetControls) and select the files by name.
                 fileDialog => SelectFilesInOpenDialog(fileDialog, selectDir, fileNames));
@@ -182,12 +183,10 @@ namespace pwiz.SkylineTestFunctional
             WaitForCondition(() => string.IsNullOrEmpty(dlg.GetFormValue(@"File name")),
                 @"The Open dialog did not clear the file-name box after navigating.");
 
-            // The box is empty and settled, so the names hold: type them and open in one go.
+            // The box is empty and settled, so the names hold: type them and open in one go. Nothing waits for the
+            // dialog to go away here -- the RunLongNativeDlg this runs inside already does.
             dlg.EnterPath(quotedNames);
             dlg.Accept();
-            if (!TryWaitForCondition(() => !dlg.IsOpen))
-                Assert.Fail(@"The Open dialog did not open the selected files (file-name box holds [" +
-                            dlg.GetFormValue(@"File name") + @"], showing folder [" + dlg.GetFormValue(@"Address") + @"]).");
         }
 
         // Whether the Open dialog is showing the given folder -- read from its "Address" control with get_value, the

--- a/pwiz_tools/Skyline/TestUtil/McpConnectorTest.cs
+++ b/pwiz_tools/Skyline/TestUtil/McpConnectorTest.cs
@@ -28,6 +28,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using pwiz.Skyline;
 using pwiz.Skyline.Properties;
 using pwiz.Skyline.ToolsUI;
+using pwiz.Skyline.Util.Extensions;
 using SkylineTool;
 
 namespace pwiz.SkylineTestUtil
@@ -220,9 +221,14 @@ namespace pwiz.SkylineTestUtil
 
         private string ResolveNow(Func<FormInfo, bool> predicate, string description)
         {
-            var id = McpConnector.GetOpenForms().FirstOrDefault(predicate)?.Id;
-            Assert.IsNotNull(id, "Expected {0} to be open already, but it was not.", description);
-            return id;
+            var openForms = McpConnector.GetOpenForms();
+            var match = openForms.FirstOrDefault(predicate);
+            if (match == null)
+            {
+                Assert.Fail("Expected {0} to be open, but it was not. Open forms: {1}", description, TextUtil.SpaceSeparate(openForms.Select(form=>form.Id)));
+            }
+
+            return match.Id;
         }
 
         /// <summary>

--- a/pwiz_tools/Skyline/ToolsUI/JsonUiService.cs
+++ b/pwiz_tools/Skyline/ToolsUI/JsonUiService.cs
@@ -784,7 +784,9 @@ namespace pwiz.Skyline.ToolsUI
                 var dockState = form.DockState;
                 if (dockState == DockState.Hidden || dockState == DockState.Unknown)
                     continue;
-                result.Add(StandaloneWindow.NewStandaloneWindow(form.Handle, cancellationToken));
+                var window = StandaloneWindow.NewStandaloneWindow(form.Handle, cancellationToken);
+                if (window != null)
+                    result.Add(window);
             }
             return result;
         }

--- a/pwiz_tools/Skyline/ToolsUI/JsonUiService.cs
+++ b/pwiz_tools/Skyline/ToolsUI/JsonUiService.cs
@@ -453,8 +453,12 @@ namespace pwiz.Skyline.ToolsUI
                 openForms = topLevelWindows.Concat(GetDockedForms(cancellationToken))
                     .Select(form => form.GetFormInfo()).ToArray();
             }));
-            asyncResult?.AsyncWaitHandle.WaitOne(MAIN_THREAD_TIMEOUT_MILLIS);
-            return openForms ?? topLevelWindows.Select(form => form.GetFormInfo()).ToArray();
+            if (true == asyncResult?.AsyncWaitHandle.WaitOne(MAIN_THREAD_TIMEOUT_MILLIS))
+            {
+                Assume.IsNotNull(openForms);
+                return openForms;
+            }
+            return topLevelWindows.Select(form => form.GetFormInfo()).ToArray();
         }
 
         // How long to give the main thread to describe the forms before describing them here instead. A thread that is

--- a/pwiz_tools/Skyline/ToolsUI/NativeDialog.cs
+++ b/pwiz_tools/Skyline/ToolsUI/NativeDialog.cs
@@ -86,8 +86,6 @@ namespace pwiz.Skyline.ToolsUI
         /// <summary>A native dialog never closes itself -- it stands there until it is dismissed. (Windows has no
         /// native equivalent of a LongWaitDlg here: every "#32770" the connector meets is a stop.)</summary>
         public override bool IsTransient => false;
-        /// <summary>Whether the dialog window is still visible.</summary>
-        public override bool IsOpen => User32.IsWindowVisible(Hwnd);
         /// <summary>A native dialog is never a progress form reporting work in flight.</summary>
         public override bool IsProgressing => false;
         /// <summary>The dialog's message body (its Static-control text) else its caption.</summary>

--- a/pwiz_tools/Skyline/ToolsUI/NativeDialog.cs
+++ b/pwiz_tools/Skyline/ToolsUI/NativeDialog.cs
@@ -91,11 +91,6 @@ namespace pwiz.Skyline.ToolsUI
         /// <summary>The dialog's message body (its Static-control text) else its caption.</summary>
         public override string DetailedMessage => NativeBodyText(Hwnd) ?? User32.GetWindowTextNoBlock(Hwnd);
 
-        /// <summary>Wraps a raw modal window handle (one with no managed Form) as a generic native dialog, for the
-        /// modal-watch's Win32-only queries. NOT classified as a file dialog -- see <see cref="Create"/>.</summary>
-        public static NativeDialog MakeNativeDialog(IntPtr handle, CancellationToken cancellationToken) =>
-            new NativeDialog(handle, cancellationToken);
-
         // The message body of a native dialog box (a Win32 #32770, e.g. a system message box), read from its child
         // controls, or null when none is found. The body is a "Static" control with text -- the icon's Static has
         // none -- so among the Static children with non-empty text, take the LONGEST, so the message wins over any

--- a/pwiz_tools/Skyline/ToolsUI/StandaloneWindow.cs
+++ b/pwiz_tools/Skyline/ToolsUI/StandaloneWindow.cs
@@ -1,6 +1,5 @@
 using pwiz.Common.SystemUtil.PInvoke;
 using pwiz.Skyline.Util;
-using pwiz.Skyline.Util.Extensions;
 using SkylineTool;
 using System;
 using System.Collections.Generic;
@@ -148,27 +147,31 @@ namespace pwiz.Skyline.ToolsUI
                 User32.GetWindowThreadProcessId(hwnd, out var windowProcessId);
                 if (windowProcessId != processId)
                     continue;
-                if (Control.FromHandle(hwnd) is Form form)
+
+                switch (Control.FromHandle(hwnd))
                 {
-                    // A managed form is showing when WINFORMS says it is, not when Windows has got round to setting
-                    // WS_VISIBLE. Form.SetVisibleCore puts the form in Application.OpenForms and flips Form.Visible
-                    // up front, then builds the child controls and runs OnLoad, and only THEN calls ShowWindow -- so
-                    // throughout that gap IsWindowVisible would drop a dialog every other reading (Application.
-                    // OpenForms, and so the tests' FindOpenForm) already reports as up. Form.Visible is a state-bit
-                    // read, so it is safe from this thread like the rest of the walk.
-                    if (form.Visible)
-                        yield return StandaloneForm.Create(form, hwnd, cancellationToken);
-                }
-                else if (User32.IsWindowVisible(hwnd))
-                {
-                    // A non-managed top-level window is only a window the connector can drive when it is a native
-                    // DIALOG. The process has other unmanaged top-level windows (message-only and helper windows,
-                    // each with no caption), and wrapping those would list them as forms with the id "Dialog:" that
-                    // nothing can resolve. Create returns null for anything that is not a "#32770", and picks the
-                    // subclass that drives the ones that are (Open / Save / folder browser).
-                    var dialog = NativeDialog.Create(hwnd, cancellationToken);
-                    if (dialog != null)
-                        yield return dialog;
+                    case Form form:
+                        if (form.Visible)
+                        {
+                            var standaloneForm = StandaloneForm.Create(form, hwnd, cancellationToken);
+                            if (standaloneForm != null)
+                            {
+                                yield return standaloneForm;
+                            }
+                        }
+
+                        break;
+                    case { }:
+                        // A child control is not a top-level window to drive, so skip it.
+                        break;
+                    default:
+                        if (User32.IsWindowVisible(hwnd))
+                        {
+                            var nativeDialog = NativeDialog.Create(hwnd, cancellationToken);
+                            if (nativeDialog != null)
+                                yield return nativeDialog;
+                        }
+                        break;
                 }
             }
         }
@@ -178,19 +181,25 @@ namespace pwiz.Skyline.ToolsUI
         // is a native window, which NativeDialog.Create classifies. CLASSIFY, do not just wrap: the kind is half of
         // the FormId, so a window enumerated here must come back with the same id it has anywhere else (a Save
         // dialog is "SaveFileDialog:Save As" here as well as in GetOpenDialogs) -- otherwise the id a wait reports
-        // in ActionResult.FormId would not resolve. Create returns null for a window that is not a dialog at all,
-        // which is then driven generically.
+        // in ActionResult.FormId would not resolve.
+        //
+        // NULL when the window is not one the connector can drive: a child control, or an unmanaged window that is
+        // not a dialog. Callers enumerate windows they did not choose -- the process has plenty of unmanaged
+        // top-level windows (tooltips, message-only and helper windows, each with no caption) -- so "not one of
+        // ours" is an ordinary result rather than an error, and there is nothing a caller could do with an
+        // exception about it anyway.
         internal static StandaloneWindow NewStandaloneWindow(IntPtr hwnd, CancellationToken cancellationToken)
         {
             switch (Control.FromHandle(hwnd))
             {
                 case Form form:
                     return StandaloneForm.Create(form, hwnd, cancellationToken);
-                case { } control:
-                    throw new ArgumentException(new LlmInstruction($@"{control.GetType().Name} is not a form"));
+                case { }:
+                    return null;    // a child control is not a top-level window to drive
                 default:
-                    return NativeDialog.Create(hwnd, cancellationToken)
-                           ?? NativeDialog.MakeNativeDialog(hwnd, cancellationToken);
+                    // Null for anything that is not a "#32770"; picks the subclass that drives the ones that are
+                    // (Open / Save / folder browser), else the generic dialog.
+                    return NativeDialog.Create(hwnd, cancellationToken);
             }
         }
 
@@ -207,15 +216,25 @@ namespace pwiz.Skyline.ToolsUI
             }).ToList();
         }
 
-        /// <summary>Every modal dialog currently open in this process, each wrapped as the connector window abstraction
-        /// that drives it. A single Win32 enumeration (<see cref="EnumModalWindowHandles"/>) is the sole source, so
-        /// managed and native modals are discovered the same way (see <see cref="NewStandaloneWindow"/>). Going
-        /// handle -> Form avoids reading Form.Handle (which trips the cross-thread check) and needs no Form/handle
-        /// pairing, so it is safe off the UI thread -- both the enumeration and Control.FromHandle are a lookup,
-        /// never a UI touch.</summary>
+        /// <summary>Every modal dialog currently open in this process THAT THE CONNECTOR CAN DRIVE, each wrapped as
+        /// the abstraction that drives it. A single Win32 enumeration (<see cref="EnumModalWindowHandles"/>) is the
+        /// sole source, so managed and native modals are discovered the same way. Going handle -> Form avoids
+        /// reading Form.Handle (which trips the cross-thread check) and needs no Form/handle pairing, so it is safe
+        /// off the UI thread -- both the enumeration and Control.FromHandle are a lookup, never a UI touch.
+        ///
+        /// <para>A window this cannot classify is SKIPPED rather than wrapped generically, because this list is what
+        /// makes a connector action stop and report "the operation did not complete because this dialog is open".
+        /// Stopping for a window we cannot drive helps nobody: there is no verb that would dismiss it, so the client
+        /// is stuck either way -- and it is worse than doing nothing, because <see cref="EnumModalWindowHandles"/>
+        /// recognizes a modal only by the shape of its window (visible, enabled, owner disabled), which any
+        /// transient unmanaged helper window can wear for an instant. That is what made TestJsonToolServer fail
+        /// intermittently in nightly, reporting a dialog with the unresolvable id "Dialog:" that had already
+        /// vanished by the time the failure was logged.</para></summary>
         public static IEnumerable<StandaloneWindow> GetModalDialogs(CancellationToken cancellationToken)
         {
-            return EnumModalWindowHandles().Select(hwnd => NewStandaloneWindow(hwnd, cancellationToken));
+            return EnumModalWindowHandles()
+                .Select(hwnd => NewStandaloneWindow(hwnd, cancellationToken))
+                .Where(modal => modal != null);
         }
 
         /// <summary>Whether the window is a modal dialog blocking its owner -- visible and enabled, with an owner

--- a/pwiz_tools/Skyline/ToolsUI/StandaloneWindow.cs
+++ b/pwiz_tools/Skyline/ToolsUI/StandaloneWindow.cs
@@ -98,10 +98,6 @@ namespace pwiz.Skyline.ToolsUI
         /// the caller, who must drive it. A transient one is ridden through -- waiting for it is the right thing to
         /// do, because it will finish on its own.</para></summary>
         public abstract bool IsTransient { get; }
-        /// <summary>Whether the form/dialog is still on screen (a managed form: not disposed, handle created and
-        /// visible; a native dialog: its window is visible). Must be read on the owning UI thread for a managed
-        /// form. Its negation is "dismissed".</summary>
-        public abstract bool IsOpen { get; }
         /// <summary>Whether this is a progress form actively reporting work in flight (an
         /// <see cref="ILongWaitForm"/> mid-operation). It is what tells the message-loop watchdog that a wait is
         /// getting somewhere -- work IS advancing -- rather than stuck; false for a native dialog.</summary>
@@ -140,7 +136,7 @@ namespace pwiz.Skyline.ToolsUI
                 UiActions.GetOptions.CallNow(FindElement(controlId, UiActions.GetOptions)));
         }
 
-        /// <summary>Every top-level window of this process that is a managed Form (visible) or a native modal dialog,
+        /// <summary>Every top-level window of this process that is an open managed Form or a native modal dialog,
         /// each wrapped as the connector window abstraction that drives it. Enumerated purely from Win32 + a
         /// Control.FromHandle lookup, so it is safe on any thread. Top-level only -- a form docked inside the main
         /// window is a child window and does not appear here (JsonUiService.GetOpenFormElements adds those).</summary>
@@ -150,13 +146,20 @@ namespace pwiz.Skyline.ToolsUI
             foreach (var hwnd in User32.EnumWindows())
             {
                 User32.GetWindowThreadProcessId(hwnd, out var windowProcessId);
-                if (windowProcessId != processId || !User32.IsWindowVisible(hwnd))
+                if (windowProcessId != processId)
                     continue;
-                if (Control.FromHandle(hwnd) is Form)
+                if (Control.FromHandle(hwnd) is Form form)
                 {
-                    yield return NewStandaloneWindow(hwnd, cancellationToken);
+                    // A managed form is showing when WINFORMS says it is, not when Windows has got round to setting
+                    // WS_VISIBLE. Form.SetVisibleCore puts the form in Application.OpenForms and flips Form.Visible
+                    // up front, then builds the child controls and runs OnLoad, and only THEN calls ShowWindow -- so
+                    // throughout that gap IsWindowVisible would drop a dialog every other reading (Application.
+                    // OpenForms, and so the tests' FindOpenForm) already reports as up. Form.Visible is a state-bit
+                    // read, so it is safe from this thread like the rest of the walk.
+                    if (form.Visible)
+                        yield return StandaloneForm.Create(form, hwnd, cancellationToken);
                 }
-                else
+                else if (User32.IsWindowVisible(hwnd))
                 {
                     // A non-managed top-level window is only a window the connector can drive when it is a native
                     // DIALOG. The process has other unmanaged top-level windows (message-only and helper windows,

--- a/pwiz_tools/Skyline/ToolsUI/UiElement.cs
+++ b/pwiz_tools/Skyline/ToolsUI/UiElement.cs
@@ -930,7 +930,6 @@ namespace pwiz.Skyline.ToolsUI
         // A LongWaitDlg is the one form that closes ITSELF -- when the work it reports on finishes. Every other form
         // stands there until it is dismissed.
         public override bool IsTransient => Form is LongWaitDlg;
-        public override bool IsOpen => !Form.IsDisposed && Form.IsHandleCreated && Form.Visible;
         public override bool IsProgressing => Form is ILongWaitForm { IsBusy: true };
         public override string DetailedMessage => (Form as CommonFormEx)?.DetailedMessage ?? Form.Text;
 


### PR DESCRIPTION
## Summary

* Fixed the intermittent `TestSetItemMcpConnector` failure ("Expected a form of type DefineAnnotationDlg to be open already, but it was not"). `Form.Visible` can disagree with `User32.IsWindowVisible`, so `GetTopLevelWindows` now uses `Form.Visible` once it knows the window is a managed form, and keeps the Win32 check only for native windows. The test harness sees a form as open through the managed `FormUtil.OpenForms` list, so the connector has to agree with the managed view for a form it has already identified.
* Fixed the intermittent `TestJsonToolServer` failure ("The operation did not complete because this dialog is open: Dialog:"). A connector action was aborting for windows that were never dialogs. `EnumModalWindowHandles` recognizes a modal only by the shape of its window -- visible, enabled, owner disabled -- which a transient unmanaged helper window such as a tooltip can wear for an instant, and the modal path then wrapped anything at all as a generic native dialog. Only windows the connector can actually drive now count: a managed `Form`, or a `"#32770"` that `NativeDialog.Create` recognizes.
* Removed `NativeDialog.MakeNativeDialog`, the permissive fallback that wrapped any window unconditionally. It was reachable only from the modal path, so it is dead once that path classifies properly, and leaving it there invites the same bug back.
* Made `NewStandaloneWindow` return null rather than throw for a window that is not one the connector can drive, and had `GetTopLevelWindows` and the modal path share it. The two paths had diverged: the enumeration path already skipped unrecognized windows, with a comment predicting exactly the unresolvable `"Dialog:"` id that the modal path went on to produce.
* Reported the open form ids when a "right now" resolver finds nothing, so the next such failure says what WAS open.
* Removed the unused `IsOpen` member and the test wait that depended on it.

## Why aborting for an unrecognized window is wrong

If the connector cannot classify a window, there is no verb that would dismiss it, so an MCP client is stuck whether we abort or not. Aborting only converts "a window appeared briefly" into a failed operation.

The evidence came from the diagnostics added in #4458, which fired on two agents (BRENDANX-DT1 and BRENDANX-UW5) on their first night in nightly. Both dumps showed no dialog open at the moment of failure, none three seconds later, and no thread parked in a modal loop -- so the window the connector stopped for had already vanished by the time the failure was logged.

## Test plan

- [x] Solution builds
- [x] CodeInspection - passes
- [x] Connector and native-dialog tests exercised locally while developing the modal-gate change (48 executions, 0 failures); the full suite runs in TeamCity

Co-Authored-By: Claude <noreply@anthropic.com>
