### PR TITLE
Added operation-ordered Osprey algorithm documentation

### DIFF
--- a/pwiz_tools/Osprey/docs/01-decoy-generation.md
+++ b/pwiz_tools/Osprey/docs/01-decoy-generation.md
@@ -1,0 +1,343 @@
+# 01. Decoy Generation (C#)
+
+> Pipeline stage: Stage 1 (Library preparation). C# port of Rust docs/01-decoy-generation.md. Corresponds to Rust osprey decoy generation (`osprey-scoring` `DecoyGenerator`, `osprey-core` library-decoy marking/pairing, `osprey-io` pairing manifest).
+
+Osprey builds a target/decoy library for FDR control using the target-decoy
+competition approach. Decoys are either **generated** by Osprey from the target
+library (enzyme-aware sequence reversal with a cycling fallback) or **supplied**
+by the input library (DIA-NN / EncyclopeDIA / Carafe output) and marked + paired
+in a post-load step. This stage runs inside `PerFileScoringTask` immediately
+after the library is loaded and before any scoring.
+
+The relevant C# types:
+
+- `Osprey.Scoring/DecoyGenerator.cs` — `DecoyGenerator`, `Enzyme` enum, reversal /
+  cycling / fragment recalculation.
+- `Osprey.Core/LibraryEntry.cs` — `LibraryEntry`, `DECOY_ID_BIT`,
+  `LooksLikeLibraryDecoy`.
+- `Osprey.IO/LibraryDecoyMarker.cs` — `ApplyLibraryDecoyMarking` (prefix / column marking).
+- `Osprey.Core/LibraryDecoyPairing.cs` — `PairLibraryDecoysByComposition` (composition fallback).
+- `Osprey.IO/DecoyPairingManifest.cs` — FDRBench manifest pairing + protein-ID substitution.
+- `Osprey.Tasks/PerFileScoringTask.cs` — the dispatch that ties it all together.
+
+## Dispatch: generate vs. mark-and-pair
+
+`PerFileScoringTask.LoadLibraryAndBuildDecoys` (`Osprey.Tasks/PerFileScoringTask.cs:700`)
+chooses one of three paths after `LibraryLoader.Load`:
+
+```
+librarySuppliesDecoys = config.DecoysInLibrary || config.DecoyMethod == FromLibrary   // :716
+```
+
+1. **`--task SecondPassFDR` (`config.ExpectReconciledInput`)** — decoys are not
+   rebuilt; the reconciled Parquet already carries both target and decoy FDR rows.
+   `decoys = new List<LibraryEntry>()` (`PerFileScoringTask.cs:746`). Skipping the
+   rebuild saves ~45s on Astral 1-file.
+2. **Generated decoys (default)** — `!librarySuppliesDecoys`:
+   `DecoyGenerator.GenerateAllWithCollisionDetection(...)` is called and the target
+   list is replaced with the collision-filtered `validTargets`
+   (`PerFileScoringTask.cs:750-752`).
+3. **Library-supplied decoys** — `MarkSuppliedDecoys` runs first (before the target
+   count is taken, `PerFileScoringTask.cs:718-719`), then `TryPairSuppliedDecoys`
+   (`PerFileScoringTask.cs:757`). A failure here returns `false` with `ExitCode = 1`.
+
+`DecoyMethod.FromLibrary` is treated as a synonym for `DecoysInLibrary = true`
+(`PerFileScoringTask.cs:716-717`); the comment there notes it historically fell
+through to Reverse generation, which was a bug.
+
+Generated and supplied decoys are concatenated onto the (valid) targets into
+`fullLibrary` (`PerFileScoringTask.cs:767-769`), then indexed by `Id` into
+`libraryById` (`PerFileScoringTask.cs:793-795`).
+
+## Generated decoys
+
+### Enzyme-aware sequence reversal
+
+`DecoyGenerator.ReverseSequence` (`Osprey.Scoring/DecoyGenerator.cs:292`) reverses
+a peptide while preserving one terminal residue so tryptic specificity survives:
+
+- **C-terminus-preserving enzymes** (`Enzyme.Trypsin`, `Enzyme.LysC`,
+  `Enzyme.Unspecific`; `EnzymeExtensions.PreservesCTerminus`, `DecoyGenerator.cs:56`):
+  positions `0..len-2` are reversed and position `len-1` is held fixed
+  (`DecoyGenerator.cs:306-317`). `PEPTIDEK` → `EDITPEPK` (K stays at C-terminus).
+- **N-terminus-preserving enzymes** (`Enzyme.LysN`, `Enzyme.AspN`): position 0 is
+  held fixed and `1..len-1` are reversed (`DecoyGenerator.cs:318-329`).
+- Sequences of length ≤ 2 are returned unchanged with an identity position mapping
+  (`DecoyGenerator.cs:295-301`).
+
+`ReverseSequence` returns a `positionMapping` array where
+`positionMapping[newPos] = oldPos`, used to remap modifications and fragment masses.
+
+There is a `DecoyGenerator.DetectEnzyme` helper (`DecoyGenerator.cs:100`) that
+infers the enzyme from the C-terminal residue (K/R → Trypsin, else N-terminal
+K → LysN, D → AspN, else Unspecific). **Note:** the batch path
+`GenerateAllWithCollisionDetection` does **not** call it — each worker constructs
+`new DecoyGenerator()` (`DecoyGenerator.cs:208`), which defaults to `Enzyme.Trypsin`
+(C-terminus preserved). So the production decoy path treats every peptide as
+C-terminus-preserving regardless of its actual terminal residue. This is fine for
+tryptic reference libraries (Stellar/Astral) and is the behavior the cross-impl
+byte-parity gate locks in.
+
+### Collision detection and cycling fallback
+
+`DecoyGenerator.GenerateAllWithCollisionDetection`
+(`Osprey.Scoring/DecoyGenerator.cs:175`) mirrors the Rust
+`generate_all_with_collision_detection` and implements the pyXcorrDIA multi-strategy
+approach:
+
+1. Build a `HashSet<string>` (ordinal) of all non-decoy target **stripped**
+   sequences for collision detection (`DecoyGenerator.cs:185-190`).
+2. Generate decoys in parallel with `Parallel.For` (matches Rust `par_iter`;
+   `DecoyGenerator.cs:198`). Targets that are already decoys or have no fragments
+   are skipped (`kind = 0`, `DecoyGenerator.cs:201-205`).
+3. **Reversal first** (`kind = 1`): accept the reversed sequence if it differs from
+   the original **and** is not already a target sequence
+   (`DecoyGenerator.cs:212-220`).
+4. **Cycling fallback** (`kind = 2`): try cycle lengths `1..min(len, 10)` via
+   `CycleSequence(seq, cycleLength, ...)`; accept the first cycled sequence that is
+   both distinct from the original and not a target (`DecoyGenerator.cs:222-236`).
+5. **Exclude** (`kind = 3`): if no unique decoy can be produced, drop the target
+   from the analysis (`DecoyGenerator.cs:238`).
+
+Results are collected sequentially to preserve order (`DecoyGenerator.cs:242-253`),
+so `validTargets` and `decoys` stay index-aligned and deterministic. Counters track
+reversed / cycled / excluded / skipped; the summary is logged as
+`Generated N decoys from M targets (K excluded due to collisions)`
+(`DecoyGenerator.cs:255-257`).
+
+`CycleSequence` (`DecoyGenerator.cs:346`) rotates the internal residues by
+`cycleLength % middleLen` while preserving the same terminus as reversal
+(`DecoyGenerator.cs:360-388`), producing e.g. `PEPTIDEK` → `EPTIDEPK` (shift 1, K
+fixed).
+
+The instance method `DecoyGenerator.Generate` (`DecoyGenerator.cs:123`) is a
+simpler single-entry API: it reverses, and if `reversed == original` cycles by 1,
+but does **not** check the reversed sequence against the target database. The
+production pipeline uses the batch `GenerateAllWithCollisionDetection`, not
+`Generate`.
+
+### Fragment m/z recalculation (b ↔ y swap)
+
+Because reversal moves residues, fragment m/z values must be recomputed.
+`RecalculateFragments` (`DecoyGenerator.cs:443`, static wrapper
+`RecalculateFragmentsStatic` at `:436`) walks the target's fragments and:
+
+- **b-ion → y-ion**, ordinal `N - ordinal` (`DecoyGenerator.cs:470-473`).
+- **y-ion → b-ion**, ordinal `N - ordinal` (`DecoyGenerator.cs:475-478`).
+- **Any other `IonType`** (A/C/X/Z/Precursor/Internal/Immonium/Unknown from
+  `Osprey.Core/FragmentAnnotation.cs:62`) is copied verbatim with its original m/z
+  and annotation (`DecoyGenerator.cs:480-490`). The Rust doc only discusses b/y; the
+  C# code preserves non-b/y fragments unchanged.
+- New ordinals outside `1..seqLen` are dropped (`DecoyGenerator.cs:492-493`).
+
+The swapped annotation carries over the original **charge** and **neutral loss**
+(loss code + custom mass) from the target fragment; only `IonType` and `Ordinal`
+change (`DecoyGenerator.cs:502-512`).
+
+`CalculateFragmentMz` (`DecoyGenerator.cs:519`) computes masses from first
+principles against the `STANDARD_AA_MASSES` monoisotopic table
+(`DecoyGenerator.cs:68-77`) with `PROTON_MASS = 1.007276` and `H2O_MASS = 18.010565`
+(`DecoyGenerator.cs:79-80`):
+
+- b-ion: sum of residues `[0, ordinal)` + proton (`DecoyGenerator.cs:529-531`,
+  `:559-561`).
+- y-ion: sum of residues `[seqLen-ordinal, seqLen)` + H2O + proton
+  (`DecoyGenerator.cs:533-535`, `:562-564`).
+- Per-residue modification mass deltas are added by new position via `modMasses`
+  (`DecoyGenerator.cs:552-554`).
+- Neutral loss is subtracted when present (`DecoyGenerator.cs:567-568`).
+- Final m/z: `(mass + (charge-1)*proton) / charge` (`DecoyGenerator.cs:570`).
+
+This matches the Rust `calculate_fragment_mz` pseudocode step for step, including
+the constants.
+
+### Modification remapping
+
+`RemapModifications` (`DecoyGenerator.cs:405`, static wrapper
+`RemapModificationsStatic` at `:398`) builds a reverse map `old_pos → new_pos` from
+the position mapping and moves each modification to its new position, copying
+`Position`, `UnimodId`, `MassDelta`, `Name` (`DecoyGenerator.cs:408-429`). Mods whose
+original position isn't in the mapping are dropped. Because the amino-acid
+composition and the modification set are unchanged (only positions move), the
+**precursor m/z is conserved** — the decoy `LibraryEntry` is constructed with the
+target's `PrecursorMz` and `Charge` verbatim (`DecoyGenerator.cs:268-274`), so decoys
+compete fairly with targets at the precursor level.
+
+### Decoy identity stamped on generated decoys
+
+`BuildDecoyFromSequence` (`DecoyGenerator.cs:265`) constructs each decoy with:
+
+- `Id = target.Id | 0x80000000u` — high bit set (`DecoyGenerator.cs:269`). The
+  constant is `LibraryEntry.DECOY_ID_BIT = 0x80000000u`
+  (`Osprey.Core/LibraryEntry.cs:43`); `base_id = Id & 0x7FFFFFFF` recovers the
+  paired target.
+- `IsDecoy = true` (`DecoyGenerator.cs:276`).
+- `ModifiedSequence = "DECOY_" + target.ModifiedSequence` (`DecoyGenerator.cs:271`).
+- Each protein accession prefixed `"DECOY_"` (`DecoyGenerator.cs:281-283`).
+- Gene names, RT, and `RtCalibrated` copied from the target
+  (`DecoyGenerator.cs:275`, `:284`).
+
+For Osprey-generated decoys the target/decoy pairing is exact by construction (the
+decoy inherits the target's `base_id`).
+
+## Library-supplied decoys
+
+When `DecoysInLibrary` is set, Osprey runs three post-load steps: marking, pairing
+(manifest + composition), and (with a manifest) protein-ID substitution.
+
+### Step 1: decoy marking
+
+`LibraryDecoyMarker.ApplyLibraryDecoyMarking`
+(`Osprey.IO/LibraryDecoyMarker.cs:88`, called from
+`PerFileScoringTask.MarkSuppliedDecoys` at `PerFileScoringTask.cs:830`) marks
+decoys from two OR'd signals:
+
+- **DIA-NN `Decoy` column**: the TSV loader sets `IsDecoy` at load time
+  (`Osprey.IO/DiannTsvLoader.cs:107`, `:201-209`). `ParseDecoyFlag`
+  (`DiannTsvLoader.cs:687`) accepts `1`, `true`, `yes`, `y`, `t` case-insensitively
+  (ASCII-only lowering to match Rust `to_ascii_lowercase`; `DiannTsvLoader.cs:707`);
+  everything else including `0`/empty/garbage is a target. Entries already flagged
+  by the loader just get `DECOY_ID_BIT` canonicalized onto their `Id` and count in
+  `MarkingStats.NViaColumn` (`LibraryDecoyMarker.cs:101-111`).
+- **Protein-accession prefix scan**: `LibraryEntry.LooksLikeLibraryDecoy`
+  (`Osprey.Core/LibraryEntry.cs:87`) returns true if any protein accession starts
+  (case-insensitively) with a configured prefix; matches get `IsDecoy = true` +
+  `DECOY_ID_BIT` and count in `MarkingStats.NViaPrefix`
+  (`LibraryDecoyMarker.cs:113-118`).
+
+Marking is idempotent (`LibraryDecoyMarker.cs:106`). The log breaks the count down:
+`Library-decoy mode: N flagged (X via Decoy column, Y via protein-accession prefix)`
+(`PerFileScoringTask.cs:837-839`).
+
+### Step 2: target-decoy pairing (hybrid manifest + composition fallback)
+
+`TryPairSuppliedDecoys` (`PerFileScoringTask.cs:852`) pairs each decoy with a target
+so their `base_id`s match — required for SVM competition, LDA calibration, and CV
+fold grouping (see 07-fdr-control.md, 16-determinism.md).
+
+First, a **hard guard**: if there are no library decoys at all,
+`TryPairSuppliedDecoys` errors and exits with code 1 (`PerFileScoringTask.cs:866-876`).
+This "no decoys" check runs **before** manifest application, matching Rust
+v26.6.0 (`bcd7249`); the comment notes a manifest can therefore not rescue a load
+where the prefix scan misses every decoy (`PerFileScoringTask.cs:855-865`).
+
+- **Stage 2a — manifest-based** (when `--decoy-pairing-manifest` is set):
+  `DecoyPairingManifest.FromTsv` (`Osprey.IO/DecoyPairingManifest.cs:146`) parses an
+  FDRBench 5-column TSV (`sequence`, `decoy`, `proteins`, `peptide_type`,
+  `peptide_pair_index`); required columns are `sequence`/`peptide_type`/
+  `peptide_pair_index` (`proteins` optional; `DecoyPairingManifest.cs:168-189`).
+  `ApplyToLibrary` (`DecoyPairingManifest.cs:264`) buckets entries by
+  `(pair_index, partition, charge, is_target_side)` where partition 0 =
+  target↔decoy and 1 = p_target↔p_decoy (`DecoyPairingManifest.cs:423-428`), sorts
+  each bucket by `(Sequence, Id)` and zips target/decoy 1:1
+  (`DecoyPairingManifest.cs:354-389`). The manifest is **authoritative for
+  classification**: any entry whose sequence appears as `decoy`/`p_decoy` gets
+  `IsDecoy = true` + `DECOY_ID_BIT` even if the prefix scan missed it (the Carafe
+  prefix-stripping failure mode; `DecoyPairingManifest.cs:325-334`, counted in
+  `NNewlyMarkedDecoy`). Paired decoys get `Id = targetId | DECOY_ID_BIT`
+  (`DecoyPairingManifest.cs:394-400`). Manifest read failure errors out with
+  exit code 1 (`PerFileScoringTask.cs:899-906`).
+- **Stage 2b — composition fallback** (always runs):
+  `LibraryDecoyPairing.PairLibraryDecoysByComposition`
+  (`Osprey.Core/LibraryDecoyPairing.cs:120`, called at `PerFileScoringTask.cs:940`)
+  indexes unclaimed targets by `(stripped_accession, charge, sorted_AA_composition)`
+  (`LibraryDecoyPairing.cs:131-153`), strips a configured decoy prefix from each
+  decoy accession (`StripDecoyPrefix`, `LibraryDecoyPairing.cs:282`), and matches
+  the first unclaimed target with the same key. Determinism: buckets and the decoy
+  scan order are sorted by `(Sequence, Id)`; a decoy's accessions are sorted
+  ordinally and the first unclaimed target match wins
+  (`LibraryDecoyPairing.cs:155-223`). Paired decoys get
+  `Id = targetId | DECOY_ID_BIT` (`LibraryDecoyPairing.cs:226-232`). This recovers
+  any decoy that preserves AA composition (reversal, Carafe randomized shuffles).
+
+The chained pass shares a `PairingState` (`Osprey.Core/LibraryDecoyPairing.cs:86`)
+of `ClaimedTargets` / `PairedDecoys` so the composition pass never re-claims a
+manifest-paired target (`PerFileScoringTask.cs:880`, `:939-941`).
+
+### Pairing gate (min fraction)
+
+The breakdown is logged as
+`Library-decoy pairing: paired A/B decoys (P%); manifest=M, composition=C; U unpaired decoys, V unpaired targets`
+(`PerFileScoringTask.cs:950-956`). If `PairingStats.PairedFraction <
+config.DecoyPairMinFraction` (default **0.80**), Osprey logs an error and exits with
+code 1 rather than run with broken competition (`PerFileScoringTask.cs:957-970`).
+`PairedFraction` returns 1.0 when there are no decoys
+(`Osprey.Core/LibraryDecoyPairing.cs:73-76`).
+
+### Step 3: protein-ID substitution from the manifest
+
+When the manifest's `proteins` column is non-empty and disagrees with the library's
+stored `ProteinIds`, `ApplyToLibrary` replaces `entry.ProteinIds` with the
+manifest's clean source-protein list (`DecoyPairingManifest.cs:312-317`,
+applied at `:339-343`), counted in `NProteinsReplaced` and logged as
+`manifest replaced protein_ids on N library entries`
+(`PerFileScoringTask.cs:909-916`). This restores correct protein parsimony /
+picked-protein FDR (see 08-protein-parsimony.md) for Carafe libraries that stamp a
+per-peptide `_pepNNNNN` suffix into `ProteinID`. Empty / `-` proteins column is a
+no-op — the library wins (`DecoyPairingManifest.cs:222-231`).
+
+## Flags and switches
+
+All flags parsed in `Osprey/OspreyCommandArgs.cs`; defaults in
+`Osprey.Core/OspreyConfig.cs`.
+
+| Flag / config | Default | Effect on this stage |
+|---|---|---|
+| `--decoys-in-library` (`config.DecoysInLibrary`) | off (`false`) | Trust decoys already in the library instead of generating them; runs mark + pair. Sets the flag to true (`OspreyCommandArgs.cs:192-193`). Hard error if no decoys are recognized. |
+| `config.DecoyMethod` | `Reverse` (`OspreyConfig.cs:138`) | Enum `{Reverse, Shuffle, FromLibrary}` (`OspreyConfig.cs:400-405`). `FromLibrary` is treated as a synonym for `DecoysInLibrary` (`PerFileScoringTask.cs:716`). **No `--decoy-method` CLI flag exists** — only `Reverse` (default, via generation) and `FromLibrary` (via `--decoys-in-library`) are reachable. `Shuffle` is in the enum but not implemented (see divergences). |
+| `config.DecoyPrefixes` | `["DECOY_", "rev_", "decoy_"]` (`OspreyConfig.cs:159-164`) | Case-insensitive protein-accession prefixes used by marking and by composition-fallback stripping. No CLI flag; config-file only. |
+| `config.DecoyPairMinFraction` | `0.80` (`OspreyConfig.cs:173`) | Minimum fraction of decoys that must pair with a target in library-decoy mode; below it Osprey errors out. Config-file only. |
+| `--decoy-pairing-manifest <manifest.tsv>` (`config.DecoyPairingManifestPath`) | unset (`null`) | FDRBench 5-column manifest for authoritative pairing + classification + protein-ID substitution (`OspreyCommandArgs.cs:194-195`). Requires `--decoys-in-library`; setting it without that flag is rejected during validation (`OspreyCommandArgs.cs:504-512`). |
+| `--write-pin` (`config.WritePin`) | off (`false`) | Writes PIN files for external tools (`OspreyCommandArgs.cs:196-197`). Does not change decoy content; downstream of this stage. |
+
+Generation is not otherwise flag-gated: with none of the above set, Osprey
+generates reverse decoys with the cycling fallback (the default path). No decoy
+env vars are read by this stage. Fragment tolerance / resolution flags
+(`--resolution`, `--fragment-tolerance`) affect scoring, not decoy construction.
+
+## Divergences from the Rust documentation
+
+- **[STALE-RUST-DOC] `Shuffle` decoy method is not implemented** — The Rust
+  "Configuration" section lists `decoy_method: Shuffle` as an option. The C#
+  `DecoyMethod` enum defines `Shuffle` (`Osprey.Core/OspreyConfig.cs:403`), but
+  `GenerateAllWithCollisionDetection` always performs reversal + cycling regardless
+  of `config.DecoyMethod` (it only logs the value; `Osprey.Scoring/DecoyGenerator.cs:182`,
+  `:210-236`). No code branch consumes `Shuffle`, and there is no CLI flag to select
+  it. Rust almost certainly behaves the same (both treat Shuffle as aspirational);
+  the reference datasets use reversal. Severity: minor.
+
+- **[INTENTIONAL-CSHARP-DESIGN] Batch generation always uses Trypsin, not
+  per-peptide enzyme detection** — The Rust doc presents a 4-enzyme table
+  (Trypsin/Lys-C/Lys-N/Asp-N) and enzyme-aware terminal preservation. The C#
+  `DetectEnzyme` helper exists (`DecoyGenerator.cs:100`) but the production batch
+  path constructs `new DecoyGenerator()` per worker, defaulting to `Enzyme.Trypsin`
+  / C-terminus preservation, and never calls `DetectEnzyme`
+  (`DecoyGenerator.cs:208`). Every peptide is reversed as if C-terminus-preserving.
+  Correct for tryptic reference libraries and locked in by the byte-parity gate;
+  the Rust batch generator is expected to do the same. Severity: info.
+
+- **[INTENTIONAL-CSHARP-DESIGN] Non-b/y fragments preserved verbatim on reversal** —
+  The Rust doc's ion-swap discussion covers only b↔y. C# `RecalculateFragments`
+  copies A/C/X/Z/Precursor/Internal/Immonium/Unknown fragments through with their
+  original m/z rather than recomputing (`DecoyGenerator.cs:480-490`). For standard
+  b/y DIA-NN libraries this is a no-op. Severity: info.
+
+- **[INTENTIONAL-CSHARP-DESIGN] Native managed pairing infrastructure** — The
+  library-decoy marking (`LibraryDecoyMarker`), composition pairing
+  (`LibraryDecoyPairing`), and FDRBench manifest reader (`DecoyPairingManifest`) are
+  pure managed C# with deterministic `(Sequence, Id)` sorting, replacing the Rust
+  crate equivalents (`osprey_core::types`, `osprey_io::pairing`). Behavior and the
+  logged breakdown match the Rust doc's "Library-supplied decoys" section (marking,
+  hybrid pairing, protein substitution, the 80% min-fraction gate). Severity: info.
+
+Everything else in the Rust doc — enzyme-aware reversal preserving the cleavage
+terminus, the position mapping, first-principles b/y mass recalculation with
+`PROTON = 1.007276` / `H2O = 18.010565`, modification remapping, precursor-mass
+conservation, `is_decoy` + `DECOY_ID_BIT (0x80000000)` + `DECOY_` prefixes on
+protein accessions and modified sequence, collision detection via reversal →
+cycling (lengths 1..10) → exclusion, the DIA-NN `Decoy`-column parsing rules, and
+the manifest/composition hybrid pairing with the `decoy_pair_min_fraction` hard
+gate — is implemented in the C# code as described and verified at the cited
+`file:line` locations. See 07-fdr-control.md for how paired `base_id`s feed
+target-decoy competition, 08-protein-parsimony.md for the protein-ID substitution
+payoff, and 16-determinism.md for the deterministic sort guarantees.

--- a/pwiz_tools/Osprey/docs/02-xcorr-scoring.md
+++ b/pwiz_tools/Osprey/docs/02-xcorr-scoring.md
@@ -1,0 +1,357 @@
+# 02. XCorr Scoring (C#)
+
+> Pipeline stage: Stage 3/4 (XCorr primitive). C# port of Rust docs/04-xcorr-scoring.md. Corresponds to Rust osprey XCorr scoring.
+
+XCorr (cross-correlation) is the Comet/SEQUEST spectral-similarity primitive. In
+the C# port it is implemented in `Osprey.Scoring/SpectralScorer.cs` and consumed
+in two places: the calibration candidate scorer (`Osprey.Tasks/Calibrator.cs`,
+always unit-resolution bins) and the apex-spectrum feature calculators
+(`Osprey.Scoring/XcorrCalculators.cs`, feature 6 `xcorr` and feature 17
+`sg_weighted_xcorr`). The arithmetic matches Comet's fast-XCorr exactly; the
+port's only real differences are infrastructure (managed scalar loops instead of
+BLAS, and a sparse HRAM cache instead of a dense `float[]`).
+
+The scoring form is the same as Comet's: **the experimental spectrum is
+preprocessed (bin + sqrt + windowing + flanking subtraction); the theoretical
+spectrum is never preprocessed** — XCorr simply sums the preprocessed
+experimental values at the library fragment bin positions and scales by `0.005`.
+
+---
+
+## Step 0: Binning parameters (`Osprey.Core/BinConfig.cs`)
+
+Both spectra are binned with Comet's `BIN` macro, implemented as
+`BinConfig.MzToBin` (`BinConfig.cs:96`):
+
+```csharp
+public readonly int MzToBin(double mz)
+{
+    return (int)(mz * InverseBinWidth + OneMinusOffset);
+}
+```
+
+`OneMinusOffset = 1.0 - BinOffset`, so this is `(int)(mz / bin_width + (1 -
+offset))`, identical to the Rust `BIN` macro.
+
+| Parameter | Unit resolution (`BinConfig.UnitResolution`, `BinConfig.cs:42`) | HRAM (`BinConfig.HRAM`, `BinConfig.cs:73`) |
+|-----------|------------------------------------|--------------------------------------------|
+| `BinWidth` | `1.0005079` Da | `0.02` Da |
+| `BinOffset` | `0.4` (so `OneMinusOffset = 0.6`) | `0.0` (so `OneMinusOffset = 1.0`) |
+| `MaxMz` | `2000.0` | `2000.0` |
+| `NBins` | `(int)(2000 * (1/1.0005079) + 0.6) + 1 = 2000` | `(int)(2000/0.02 + 1.0) + 1 = 100002` |
+
+`BinConfig.ForResolution(ResolutionMode)` (`BinConfig.cs:65`) selects HRAM vs
+unit; everything else in this stage is resolution-agnostic once the `BinConfig`
+is chosen. See `04-calibration.md` for how `--resolution auto` resolves to a
+`ResolutionMode`.
+
+---
+
+## Step 1: Experimental spectrum preprocessing (`SpectralScorer.cs`)
+
+The full Comet fast-XCorr preprocessing pipeline lives in `XcorrAtScan`
+(`SpectralScorer.cs:396`) and its cache-building siblings. The five documented
+steps map 1:1 onto the C# code, all in `f64`:
+
+### 1a. Bin + square-root transform (`SpectralScorer.cs:419`)
+
+```csharp
+for (int i = 0; i < spectrum.Mzs.Length; i++)
+{
+    int bin = _binConfig.MzToBin(spectrum.Mzs[i]);
+    if (bin >= 0 && bin < n)
+        binned[bin] += Math.Sqrt(spectrum.Intensities[i]);   // sqrt, accumulated
+}
+```
+
+Intensities are `float`; `Math.Sqrt` widens to `double` first, matching Rust
+`(intensity as f64).sqrt()` (comment at `SpectralScorer.cs:616-618`). Multiple
+peaks in the same bin **accumulate** (`+=`).
+
+### 1b. Windowing normalization (`ApplyWindowingNormalizationD`, `SpectralScorer.cs:522`)
+
+Comet's `MakeCorrData`: 10 equal-width windows, each normalized so its max
+becomes `50.0`, with a global 5%-of-base-peak noise floor.
+
+```csharp
+const int numWindows = 10;
+int windowSize = (n / numWindows) + 1;
+double threshold = globalMax * 0.05;               // 5% noise floor
+...
+double normFactor = 50.0 / windowMax;
+if (spectrum[i] > threshold)
+    result[i] = spectrum[i] * normFactor;          // else stays 0
+```
+
+Constants (`10`, `50.0`, `0.05`) and the `(n/10)+1` window size match the Rust
+`apply_windowing_normalization` exactly.
+
+### 1c. Flanking-bin subtraction / fast XCorr (`ApplySlidingWindowD`, `SpectralScorer.cs:573`)
+
+Prefix-sum O(n) implementation, offset 75, normalizing over 150 flanking bins
+(excluding the center):
+
+```csharp
+const int offset = XCORR_WINDOW_OFFSET;            // 75, SpectralScorer.cs:36
+double normFactor = 1.0 / (2 * offset);            // 1/150
+
+prefix[0] = 0.0;
+for (int i = 0; i < n; i++)
+    prefix[i + 1] = prefix[i] + spectrum[i];
+
+for (int i = 0; i < n; i++)
+{
+    int left  = Math.Max(0, i - offset);
+    int right = Math.Min(n, i + offset + 1);
+    double windowSum = prefix[right] - prefix[left];
+    double sumExcludingCenter = windowSum - spectrum[i];
+    result[i] = spectrum[i] - sumExcludingCenter * normFactor;
+}
+```
+
+This is the same prefix-sum recurrence the Rust doc calls the "optimized O(n)"
+path (offset 75, norm `1/150`, center excluded, edges clamped without
+renormalization).
+
+---
+
+## Step 2: Theoretical spectrum — no preprocessing, O(n_fragments) lookup
+
+The C# port never materializes a dense theoretical unit vector in production.
+XCorr is computed as the Comet lookup form: sum the preprocessed experimental
+value at each library fragment's bin. The three overloads
+(`XcorrFromPreprocessed` for `double[]` and `float[]`, and `XcorrFromSparse`)
+are structurally identical (`SpectralScorer.cs:186`, `:234`, `:273`):
+
+```csharp
+double xcorrRaw = 0.0;
+for (int f = 0; f < entry.Fragments.Count; f++)
+{
+    int bin = _binConfig.MzToBin(entry.Fragments[f].Mz);
+    if (bin >= 0 && bin < n && !visitedBins[bin])   // dedup: count a bin once
+    {
+        visitedBins[bin] = true;
+        xcorrRaw += preprocessed[bin];
+    }
+}
+...
+return xcorrRaw * XCORR_SCALING;                     // 0.005, SpectralScorer.cs:37
+```
+
+**Fragment-bin dedup (`visitedBins`)**: if two fragments map to the same bin,
+the bin contributes **once**. This reproduces the dense-vector semantics
+(`theoretical[bin] = 1.0` set idempotently) and is covered by
+`TestXcorrFragmentBinDedup` (`ScoringTest.cs:382`). The visited flags are reset
+in O(n_visited) after scoring so the shared `bool[]` can be reused across
+candidates without a per-call `NBins` allocation.
+
+The only dense theoretical-vector code path is the test-only `XCorr(double[]
+observedBins, double[] libraryBins)` (`SpectralScorer.cs:66`), which does a full
+dense dot product and is exercised by `TestXcorrPerfectMatch` /
+`TestXcorrNoMatch`. Production never calls it.
+
+### Scaling factor (`0.005`)
+
+`XCORR_SCALING = 0.005` (`SpectralScorer.cs:37`), applied once at the end of
+every overload. Matches Comet.
+
+---
+
+## Step 3: Per-window preprocessing cache (`ResolutionStrategy.cs`)
+
+During the search, all spectra in a DIA window are preprocessed **once** and
+reused across every candidate, exactly as the Rust doc's per-window optimization
+describes. The C# port routes this through `IResolutionStrategy`
+(`ResolutionStrategy.cs:66`) so pipeline code never branches on resolution:
+
+- **`UnitStrategy.PreprocessWindowSpectra`** (`ResolutionStrategy.cs:119`):
+  preprocesses each spectrum with `PreprocessSpectrumForXcorrF32`, then widens
+  the `float[]` losslessly into a `double[]` (`WindowXcorrCache.Doubles`). The
+  comment notes this pure-f32 preprocess matches Rust upstream.
+- **`HramStrategy.PreprocessWindowSpectra`** (`ResolutionStrategy.cs:170`):
+  stores each spectrum as a `SparseXcorrSpectrum` (`WindowXcorrCache.Sparse`)
+  rather than a dense `float[NBins]`.
+
+`ScoreXcorr` (`ResolutionStrategy.cs:143` / `:192`) dispatches on the cache type:
+unit reads `preprocessed.Doubles[i]` via `XcorrFromPreprocessed`; HRAM reads
+`preprocessed.Sparse[i]` via `XcorrFromSparse`, falling back to a live
+`XcorrAtScan` with a rented scratch when no cache row exists.
+
+### Sparse HRAM cache (`SparseXcorrSpectrum.cs`, issue #4398)
+
+The dense HRAM cache would be `float[100002]` (~391 KB) per spectrum; with ~2,000
+spectra per Astral window across `NThreads` concurrent windows this reached
+tens of GB. `SparseXcorrSpectrum` instead retains only the ~1–3K nonzero windowed
+bins plus a prefix sum over them (~20 B per retained peak), and recovers each
+probed bin's flanking-subtracted value on demand in `CenteredAt`
+(`SparseXcorrSpectrum.cs:93`):
+
+```csharp
+double windowSum = PrefixBelow(right) - PrefixBelow(left);
+double sumExcludingCenter = windowSum - v;
+double centered = v - sumExcludingCenter * _normFactor;   // _normFactor = 1/(2*offset)
+return (float)centered;                                    // narrow to f32, as dense cache did
+```
+
+Because IEEE-754 `x + 0.0 == x` exactly and intensities are non-negative, a
+prefix accumulated over only the nonzero bins equals the dense prefix bit-for-bit
+(`SparseXcorrSpectrum.cs:44-53`). The final `(float)` narrowing is deliberate:
+the dense path stored `float` and widened back on read, so the sparse path must
+narrow identically or every HRAM XCorr drifts from the golden.
+`TestSparseXcorrCacheMatchesDenseCache` (`ScoringTest.cs:1292`) asserts
+`XcorrFromSparse == XcorrFromPreprocessed(dense)` to 0.0 tolerance.
+
+### Scratch pooling (`XcorrScratchPool.cs`)
+
+To avoid per-call LOH allocation of the `NBins` f64 work buffers (`Binned`,
+`Windowed`, `Prefix`, `Preprocessed`, `VisitedBins`), a `XcorrScratchPool`
+(`XcorrScratchPool.cs:72`) rents/returns `XcorrScratch` sets. `Return` re-zeros
+only the two accumulator buffers (`Binned`, `VisitedBins`); the fully-overwritten
+buffers are left dirty. This pool is threaded into `ScoreXcorr` and is the
+subject of the performance gate (`XcorrCalc` doc comment, `XcorrCalculators.cs:48`).
+
+---
+
+## Step 4: Feature calculators (`XcorrCalculators.cs`)
+
+### Feature 6 — `xcorr` (`XcorrCalc`, `XcorrCalculators.cs:53`)
+
+A single apex-spectrum XCorr, delegated straight to the resolution strategy:
+
+```csharp
+return context.Resolution.ScoreXcorr(
+    context.PreprocessedXcorr, peakData.ApexGlobalIndex, peakData.ApexSpectrum,
+    peakData.Candidate, context.Scorer, context.XcorrScratchPool);
+```
+
+The cache is indexed at the **window-global apex index**
+(`peakData.ApexGlobalIndex = WindowStartIndex + candidate-local apex`), a
+different index space from the SG sweep (documented as an "INDEX TRAP" at
+`XcorrCalculators.cs:37`). Higher is better (`IsReversedScore == false`).
+
+### Feature 17 — `sg_weighted_xcorr` (`SgXcorrCalc` / `SgWeightedSweep`, `XcorrCalculators.cs:104`)
+
+A Savitzky-Golay quadratic-smoothed XCorr over the apex ±2 spectra. Weights are
+`[-3/35, 12/35, 17/35, 12/35, -3/35]` (`XcorrCalculators.cs:109`, matching Rust
+`sg_weights`). The sweep runs offsets −2..+2 strictly left-to-right, calling
+`ScoreXcorr` per offset (`XcorrCalculators.cs:152`):
+
+```csharp
+for (int offset = -2; offset <= 2; offset++)
+{
+    double weight = SG_WEIGHTS[offset + 2];
+    if (!peakData.TryGetApexOffsetSpectrum(offset, out var s, out int globalIdx))
+        continue;                                   // asymmetric edge skip, no renormalization
+    sgXcorr += resolution.ScoreXcorr(preprocessedXcorr, globalIdx, s, candidate, scorer, pool) * weight;
+    sgCosine += ComputeCosineAtScan(candidate, s, config) * weight;
+}
+```
+
+The sweep is computed **once** per candidate and shared with feature 18
+(`sg_weighted_cosine`) via `context.AddInfo`/`TryGetInfo`, guaranteeing both
+features use the identical offset loop, boundary skip, and index mapping. Near a
+window edge, out-of-range offsets are `continue`'d (not added as zero) and the
+partial sum is left un-renormalized, matching Rust.
+
+Both feature 6 and feature 17 are among the 21 PIN features used for FDR (see
+`03-spectral-scoring.md` and `07-fdr-control.md`); neither is behind a flag.
+
+---
+
+## Step 5: Calibration XCorr — always unit resolution (`Calibrator.cs`)
+
+Calibration scores each candidate against its apex spectrum with a scorer that is
+**hardcoded to unit-resolution bins** regardless of the data's resolution mode:
+
+```csharp
+internal static readonly SpectralScorer s_calXcorrScorer =
+    new SpectralScorer(BinConfig.UnitResolution());   // Calibrator.cs:72
+```
+
+Window spectra are preprocessed once with `PreprocessSpectrumForXcorrF32`
+(widened to `double[][]`, `Calibrator.cs:563-572`) and each candidate's apex
+XCorr is the O(n_fragments) lookup (`Calibrator.cs:1189`):
+
+```csharp
+double xcorrApex = (windowPreprocessed != null && apexWindowIdx < windowPreprocessed.Length)
+    ? s_calXcorrScorer.XcorrFromPreprocessed(windowPreprocessed[apexWindowIdx], entry)
+    : s_calXcorrScorer.XcorrAtScan(apexSpectrum, entry);
+```
+
+This matches the Rust doc's "Calibration: Always Unit Resolution Bins" section
+(~2000 bins even for HRAM data, for ~50× faster calibration scoring). HRAM bins
+are used only in the main-search feature-extraction path (Step 3/4).
+
+---
+
+## Flags and switches
+
+XCorr has no dedicated on/off flag — feature 6 (`xcorr`) and feature 17
+(`sg_weighted_xcorr`) are always computed and always in the 21-feature PIN set.
+The flags that change XCorr behavior for this stage:
+
+| Flag / env var | Default | Effect on XCorr |
+|----------------|---------|-----------------|
+| `--resolution {unit\|hram\|auto}` | `auto` | Selects `BinConfig` for the **feature-extraction** XCorr: unit (`1.0005079` Da, offset `0.4`, ~2000 bins) or HRAM (`0.02` Da, offset `0.0`, ~100002 bins). `auto` is resolved during calibration. Calibration XCorr ignores this and always uses unit bins (`Calibrator.cs:72`). |
+| `--fragment-tolerance <v>` / `--fragment-unit {ppm\|mz}` | `ppm`; unit-res forces `mz 0.5` | **Does not affect XCorr.** XCorr matches by bin index, not ppm tolerance. Tolerance only affects the sibling cosine kernels (`ComputeCosineAtScan`, `LibCosine`) and XIC extraction. |
+| `--no-prefilter` | prefilter enabled (`PrefilterEnabled = true`) | Does not change the XCorr math; only affects which candidates reach scoring. |
+| `OSPREY_DIAG_XCORR_SCAN` (env var) | unset | When set to a scan number, `XcorrAtScan` (`SpectralScorer.cs:453`) appends a per-scan diagnostic dump (`cs_xcorr_diag.txt`) with `binned`/`windowed`/`preprocessed` sums and per-fragment bin lookups, for cross-impl bisection. Zero overhead when unset. |
+
+There is **no** XCorr-specific config in `OspreyConfig`; the constants
+(`XCORR_WINDOW_OFFSET = 75`, `XCORR_SCALING = 0.005`, 10 windows, `50.0`, 5%
+threshold) are compile-time and match Comet/Rust.
+
+---
+
+## Divergences from the Rust documentation
+
+- **[INTENTIONAL-CSHARP-DESIGN] Managed scalar loops, no BLAS/SIMD** — Rust doc
+  says XCorr dot products dispatch to BLAS `sdot` via `ndarray::ArrayView1::dot()`
+  for contiguous f32 slices. The C# port cannot use BLAS; every XCorr is a
+  managed scalar loop, and in fact the production path never forms a dense
+  theoretical vector at all — it uses the O(n_fragments) sum-at-fragment-bins
+  form (`XcorrFromPreprocessed`/`XcorrFromSparse`). Results are bit-identical.
+  Evidence: `Osprey.Scoring/SpectralScorer.cs:186`, `:273`;
+  `Osprey.Tasks/Calibrator.cs:1189`. Severity: info.
+
+- **[INTENTIONAL-CSHARP-DESIGN] Sparse HRAM cache instead of dense `Vec<Vec<f32>>`**
+  — Rust doc stores each window spectrum's preprocessed XCorr as a dense
+  `float[NBins]` (`~391 KB` at HRAM). The C# port stores a `SparseXcorrSpectrum`
+  (~20 B per retained peak) and recovers each probed bin's flanking-subtracted
+  value on demand, bit-identically (proven by `x + 0.0 == x` in IEEE-754 and a
+  final `(float)` narrowing that reproduces the dense cache). This is C#-side
+  issue #4398, not described in the Rust doc. Evidence:
+  `Osprey.Scoring/SparseXcorrSpectrum.cs:55`, `:93`;
+  `Osprey.Scoring/ResolutionStrategy.cs:170`. Severity: info.
+
+- **[STALE-RUST-DOC] Simplified O(n_fragments) snippet omits fragment-bin dedup**
+  — The Rust doc's "feature extraction" pseudocode sums `preprocessed[bin]` for
+  every fragment with no dedup, which would double-count two fragments falling in
+  the same bin. The dense-vector form the same doc presents (`theoretical[bin] =
+  1.0`) inherently dedups, so the actual behavior requires dedup. The C# code
+  deduplicates via `visitedBins` and has a regression test for it, matching the
+  dense semantics rather than the simplified snippet. Evidence:
+  `Osprey.Scoring/SpectralScorer.cs:198`; `Osprey.Test/ScoringTest.cs:382`.
+  Severity: minor.
+
+- **[INTENTIONAL-CSHARP-DESIGN] Precision split: unit-res f64, HRAM f32-narrowed**
+  — The C# port keeps the unit-resolution / calibration cache in full `f64`
+  (`WindowXcorrCache.Doubles`) but narrows each HRAM centered value to `float`
+  (mirroring the Rust HRAM code's f32 cache, not spelled out in the doc). The
+  narrowing is required for parity with the Rust HRAM path, so behavior matches
+  the Rust *code*; the doc simply does not discuss the precision boundary.
+  Evidence: `Osprey.Scoring/ResolutionStrategy.cs:119` (f64 unit) vs
+  `Osprey.Scoring/SparseXcorrSpectrum.cs:113` (f32 HRAM). Severity: info.
+
+Everything else verified to match the Rust documentation step for step: Comet
+`BIN` macro (`BinConfig.cs:96`), unit/HRAM bin parameters, sqrt binning with
+in-bin accumulation, 10-window/`50.0`/5%-threshold windowing normalization
+(`SpectralScorer.cs:522`), offset-75 prefix-sum flanking subtraction with norm
+`1/150` (`SpectralScorer.cs:573`), the `0.005` scaling (`SpectralScorer.cs:37`),
+the theoretical-spectrum-not-preprocessed lookup form, per-window preprocess-once
+optimization (`ResolutionStrategy.cs:119`/`:170`), and calibration always using
+unit-resolution bins (`Calibrator.cs:72`).
+
+See `03-spectral-scoring.md` for the surrounding 21 PIN features,
+`04-calibration.md` for resolution selection, and `17-vectorization.md` for the
+BLAS-vs-managed performance discussion.

--- a/pwiz_tools/Osprey/docs/03-spectral-scoring.md
+++ b/pwiz_tools/Osprey/docs/03-spectral-scoring.md
@@ -1,0 +1,363 @@
+# 03. Spectral Scoring & the 21 PIN Features (C#)
+
+> Pipeline stage: Stage 3/4 (scoring). C# port of Rust docs/03-spectral-scoring.md. Corresponds to Rust osprey spectral scoring (calibration XCorr/E-value/isotope) and main-search 21-PIN-feature co-elution scoring.
+
+This document covers the two distinct scoring regimes in the C# Osprey port:
+
+1. **Calibration-phase spectral scoring** (Stage 3): XCorr + LibCosine + top-fragment
+   matching + isotope cosine, combined by a 4-feature LDA for target-decoy
+   competition that yields calibration points. See also `04-calibration.md`.
+2. **Main-search scoring** (Stage 4): fragment-XIC co-elution analysis producing the
+   **21 PIN features** consumed by the Percolator SVM in `07-fdr-control.md`.
+
+The XCorr primitive that both regimes share is documented in depth in
+`02-xcorr-scoring.md`; peak detection (which drives the main search) is in
+`06-peak-detection.md`.
+
+---
+
+## Part A — Calibration-phase spectral scoring (Stage 3)
+
+### A.1 XCorr scorer construction — always unit-resolution bins
+
+Calibration builds the scorer with **unit-resolution binning regardless of the
+data's resolution mode**, matching the Rust doc's "always 2001 bins" note.
+
+- `Osprey.Tasks/Calibrator.cs:73` — `new SpectralScorer(BinConfig.UnitResolution())`.
+- `Osprey.Scoring/SpectralScorer.cs:52` — the parameterless ctor defaults to
+  `BinConfig.UnitResolution()`.
+- `Osprey.Core/BinConfig.cs:42` — unit config: `binWidth = 1.0005079`, `offset = 0.4`,
+  `maxMz = 2000.0`, `NBins = (int)(maxMz/binWidth + 0.6) + 1`. This evaluates to
+  **2000 bins**, not the 2001 the Rust doc rounds to (see Divergences).
+
+The Comet fast-XCorr preprocessing (bin sqrt intensities → 10-window normalization
+to max 50 with a 5% global-max threshold → sliding-window subtraction with
+`offset = 75`, `scale = 0.005`) lives in `SpectralScorer.cs`:
+`PreprocessSpectrumForXcorr` (`:92`), `ApplyWindowingNormalizationD` (`:522`),
+`ApplySlidingWindowD` (`:573`), and the per-scan form `XcorrAtScan` (`:396`). The
+theoretical spectrum is NOT preprocessed — `XcorrFromPreprocessed` (`:186`) simply
+sums the preprocessed observed values at each fragment bin (deduping repeated bins
+via a visited-bin array) and scales by `0.005`. This exactly matches the Rust doc's
+"Comet does NOT preprocess the theoretical spectrum" invariant.
+
+### A.2 LibCosine at apex
+
+`SpectralScorer.LibCosine` (`SpectralScorer.cs:669`) matches each library fragment to
+the closest observed peak within tolerance, applies `sqrt` intensity preprocessing to
+both, and returns the clamped `[0,1]` cosine (`CosineAngle`, `:731`). The value is
+stored on `CalibrationMatch.LibcosineApex`.
+
+### A.3 Fragment matching / MS2 mass errors
+
+The calibration match struct (`Osprey.Scoring/CalibrationScorer.cs:34`,
+`CalibrationMatch`) carries `Top6MatchedApex`, `XcorrScore`, `Ms2MassErrors[]`, and
+`Ms1Error?`. These feed MS2/MS1 mass calibration for the main search (see
+`04-calibration.md`). The Rust doc's "top-3 fragment matching by binary search" and
+the closest-peak-by-mz tie-break are realized in the main-search apex matcher
+(`ApexMatchCalculators.cs:107`, strict `<` keeps the lower-index peak on a distance
+tie — the same `match_fragments` semantics).
+
+### A.4 Isotope cosine (MS1 quality)
+
+`CalibrationMatch.IsotopeCosine` holds the isotope-envelope cosine computed from the
+peptide's exact elemental composition (`IsotopeDistribution.PeptideIsotopeCosine`,
+reused by main-search feature 14 — see A.6 / B). This is only meaningful when MS1
+spectra are present.
+
+### A.5 LDA discriminant & target-decoy competition (4 features)
+
+`CalibrationScorer.TrainAndScoreCalibration` (`CalibrationScorer.cs:84`) is the C#
+port of Rust `train_and_score_calibration`. The 4-feature matrix
+(`ExtractFeatureMatrix`, `:581`) normalizes exactly as the Rust doc lists:
+
+| LDA feature | Source field | Normalization | Evidence |
+|-------------|--------------|---------------|----------|
+| correlation | `CorrelationScore` | `clamp(x/6.0, 0, 1)` | `CalibrationScorer.cs:590` |
+| libcosine   | `LibcosineApex`    | `clamp(x, 0, 1)`     | `:591` |
+| top6 matched| `Top6MatchedApex`  | `clamp(x/6.0, 0, 1)` | `:592` |
+| xcorr       | `XcorrScore`       | `clamp(x/3.0, 0, 1)` | `:593` |
+
+Training is iterative non-negative CV LDA (`TrainLdaWithNonNegativeCv`, `:227`):
+best-single-feature baseline → up to 3 iterations of 3-fold stratified-by-peptide CV,
+average fold weights, clip negatives, renormalize, keep the best-passing iteration,
+early-stop after 2 non-improvements. Target-decoy competition
+(`CompeteCalibrationPairs`, `:150`) groups by `entry_id & 0x7FFFFFFF`, and **ties go
+to the decoy** (strict `>` in favor of target, `:197`) — the conservative rule the
+Rust doc specifies. Winners are q-valued via `QValueCalculator.ComputeQValues` and
+filtered at 1% FDR.
+
+### A.6 E-value — NOT computed in C#
+
+The Rust doc describes a Comet-style E-value from the XCorr survival function,
+"computed and stored but not used for FDR." **The C# `CalibrationMatch` has no
+`evalue` field** (`CalibrationScorer.cs:34-56`) and no survival-function fit exists in
+the port. Because the LDA discriminant (not the E-value) drives competition, output
+parity is unaffected. See Divergences.
+
+---
+
+## Part B — Main-search scoring: the 21 PIN features (Stage 4)
+
+The main search does NOT use XCorr+E-value. It runs fragment-XIC co-elution analysis
+and computes a **21-element PIN feature vector** per candidate peak, which is written
+to the `.scores.parquet` cache and consumed by the SVM.
+
+### B.1 Pipeline order
+
+```
+AnalysisPipeline / PerFileScoring task
+  └─ ScoringPipeline.RunCoelutionScoring          (ScoringPipeline.cs:65)
+       ├─ context.Resolution.CreateScorer()        resolution-mode bins (Unit or HRAM)
+       ├─ apply MS2 calibration to a LOCAL spectra copy   (:104-129)
+       ├─ group spectra by isolation-window key     (:132)
+       ├─ compute GLOBAL rt tolerance (3*MAD*1.4826) + rt sigma (5*MAD*1.4826)  (:159-187)
+       └─ Parallel.For over isolation windows       (:269)
+            └─ CoelutionScorer.ScoreWindow          (CoelutionScorer.cs:70)
+                 ├─ find candidates whose precursor m/z ∈ window   (:106)
+                 ├─ PreprocessWindowSpectra (per-window XCorr cache) (:130)
+                 └─ for each candidate: ScoreCandidate (:180)
+                      ├─ PeakDataExtractor.TryExtract   (prefilter, XICs, CWT peaks, apex)
+                      ├─ publish Tukey median-polish byproduct
+                      └─ run the 21 OspreyFeatureCalculators → double[21]
+```
+
+Windows run in parallel (`MaxDegreeOfParallelism = config.NThreads`,
+`ScoringPipeline.cs:271`); per-window results are placed into a fixed-index array and
+flattened in **window order** (`:301`) so the parquet byte stream is reproducible
+regardless of completion order.
+
+### B.2 Per-candidate data production — `PeakDataExtractor`
+
+`PeakDataExtractor.TryExtract` (`Osprey.Scoring/PeakDataExtractor.cs`) is the producer
+seam mirroring Skyline's results layer. In order:
+
+1. **Expected RT** = `rtCalibration.Predict(candidate.RetentionTime)`
+   (`PeakDataExtractor.cs:97`); scan range from the global RT tolerance (`:100-108`).
+   A range shorter than 5 scans is rejected.
+2. **Signal pre-filter** (`:117-143`): require ≥2 of the top-6 fragments present in
+   ≥3 of 4 consecutive scans (`FragmentMath.HasTopNFragmentMatch`). Gated by
+   `config.PrefilterEnabled` (default true; `--no-prefilter` disables) and **skipped
+   for boundary overrides** (the Stage-6 rescore path already decided to score here).
+3. **XIC extraction** (`TopFragmentExtractor.ExtractFragmentXics`, `:146`); `< 2` XICs
+   rejects the candidate.
+4. **CWT peak detection** (3-tier CWT + fallbacks, `DetectCandidatePeaks`, `:169`) —
+   see `06-peak-detection.md`.
+5. **Best-peak ranking** (`:185-217`):
+   `rank = coelution × exp(-dt²/(2σ²)) × ln(1 + apex_intensity)`, where
+   `dt = |peak_apex_rt − expected_rt|` and σ is the **unclamped** `5×MAD×1.4826`
+   Gaussian sigma (floor 0.1 min). This RT penalty is essential for FDR calibration
+   (it stops wrong-RT interferers from winning on coelution alone).
+6. **Reference XIC** = highest total-intensity fragment, **last on tie** (`>=`, seed
+   `-1.0`, `:204-212`) — deliberately matching Rust's `max_by` returning the last
+   equal element.
+
+Boundary-override scoring (Stage-6 multi-charge consensus / reconciliation / gap-fill)
+enters through the same `TryExtract` with `overrideBounds` set, which skips the
+prefilter and CWT and maps the supplied `(apex, start, end)` RTs to scan indices. See
+`11-boundary-overrides.md`.
+
+### B.3 The 21 calculators — order is the parity contract
+
+`OspreyFeatureCalculators` (`Osprey.Scoring/OspreyFeatureCalculators.cs:41`) holds the
+ordered calculator array; **the array index IS the PIN feature index** and the parquet
+column order. `CoelutionScorer.ScoreCandidate` invokes `Get(0..20).Calculate(...)`
+explicitly (`CoelutionScorer.cs:254-274`). The names match
+`ParquetScoreCache.PIN_FEATURE_NAMES` (`Osprey.IO/ParquetScoreCache.cs:51`).
+
+| # | PIN name | Family / tier | Direction (`IsReversedScore`) | C# calculator (file) |
+|---|----------|---------------|-------------------------------|----------------------|
+| 0 | `fragment_coelution_sum` | Coelution (detailed) | higher | `FragmentCoelutionSumCalc` (CoelutionCalculators.cs:107) |
+| 1 | `fragment_coelution_max` | Coelution | higher | `FragmentCoelutionMaxCalc` (:122) |
+| 2 | `n_coeluting_fragments` | Coelution | higher | `NCoelutingFragmentsCalc` (:137) |
+| 3 | `peak_apex` | Peak shape (detailed) | higher | `PeakApexCalc` (PeakShapeCalculators.cs:116) |
+| 4 | `peak_area` | Peak shape | higher | `PeakAreaCalc` (:136) |
+| 5 | `peak_sharpness` | Peak shape | higher | `PeakSharpnessCalc` (:168) |
+| 6 | `xcorr` | Apex spectrum | higher | `XcorrCalc` (XcorrCalculators.cs:53) |
+| 7 | `consecutive_ions` | Apex spectrum | higher | `ConsecutiveIonsCalc` (ApexMatchCalculators.cs:146) |
+| 8 | `explained_intensity` | Apex spectrum | higher | `ExplainedIntensityCalc` (:218) |
+| 9 | `mass_accuracy_deviation_mean` | Apex spectrum | (signed; false by convention) | `MassAccuracyMeanCalc` (:240) |
+| 10 | `abs_mass_accuracy_deviation_mean` | Apex spectrum | lower | `AbsMassAccuracyMeanCalc` (:269) |
+| 11 | `rt_deviation` | Summary | (signed; false) | `RtDeviationCalc` (RtDeviationCalculators.cs:33) |
+| 12 | `abs_rt_deviation` | Summary | lower | `AbsRtDeviationCalc` (:52) |
+| 13 | `ms1_precursor_coelution` | MS1 (detailed) | higher | `Ms1PrecursorCoelutionCalc` (Ms1Calculators.cs:40) |
+| 14 | `ms1_isotope_cosine` | MS1 (detailed) | higher | `Ms1IsotopeCosineCalc` (:71) |
+| 15 | `median_polish_cosine` | Median polish | higher | `MedianPolishCosineCalc` (MedianPolishCalculators.cs:56) |
+| 16 | `median_polish_residual_ratio` | Median polish | lower | `MedianPolishResidualRatioCalc` (:73) |
+| 17 | `sg_weighted_xcorr` | Apex ±2 spectra | higher | `SgXcorrCalc` (XcorrCalculators.cs:245) |
+| 18 | `sg_weighted_cosine` | Apex ±2 spectra | higher | `SgCosineCalc` (:267) |
+| 19 | `median_polish_min_fragment_r2` | Median polish | higher | `MedianPolishMinFragmentR2Calc` (MedianPolishCalculators.cs:92) |
+| 20 | `median_polish_residual_correlation` | Median polish | lower | `MedianPolishResidualCorrelationCalc` (:109) |
+
+Note the array is populated out of numeric order in the source (slots 17/18 are set
+alongside slot 6 because they share the XCorr machinery, and the median-polish slots
+15/16/19/20 are set together), but each is assigned to its correct PIN index
+(`OspreyFeatureCalculators.cs:53-88`).
+
+### B.4 Feature-family details (verified)
+
+**Coelution (0–2)** — `CoelutionStats.Compute` (`CoelutionCalculators.cs:50`) does one
+`i<j` pairwise pass of `ScoringMath.PearsonCorrelationInRange` over
+`[peak.StartIndex, peak.EndIndex]`. NaN pairs are **skipped** (not zeroed); `max`
+seeds `-Infinity` and is only adopted when a valid pair exists (else 0). A fragment is
+"coeluting" when its mean pairwise correlation is `> 0`. All three features come from
+this single cached pass.
+
+**Peak shape (3–5)** — `PeakShapeReference` (`PeakShapeCalculators.cs:42`) selects the
+reference XIC as highest-total-intensity, **last on tie** (`>=`, seed `-1.0`).
+`peak_apex` is a direct lookup of the CWT/override apex value (NOT a recomputed local
+max, `:124`). `peak_area` is left-to-right trapezoidal integration over `[start, end)`
+(`:144`). `peak_sharpness` is the mean of left/right slopes (`:176`), with strict
+`dt > 1e-10` guards.
+
+**xcorr (6)** — `XcorrCalc.Calculate` (`XcorrCalculators.cs:61`) routes through
+`context.Resolution.ScoreXcorr` at the **window-global** apex index
+(`ApexGlobalIndex`). Unit reads the f64 dense cache; HRAM reads the sparse cache
+(`SparseXcorrSpectrum.CenteredAt`, bit-identical to the old dense f32 cache — issue
+#4398). See `02-xcorr-scoring.md` and `17-vectorization.md`.
+
+**Apex-match (7–10)** — `ApexFragmentMatchSet.Compute` (`ApexMatchCalculators.cs:62`)
+does ONE closest-peak-by-mz pass over the apex MS2 spectrum:
+- `explained_intensity` = matched / total apex intensity (0 when total ≤ 1e-12).
+- `mass_accuracy_deviation_mean` = signed mean fragment mass error (0 on no match).
+- `abs_mass_accuracy_deviation_mean` = mean abs error, **falling back to the live
+  calibrated `FragmentTolerance.Tolerance` (NOT 0.0) on no match** (`:282`) — a 0.0
+  fallback historically caused ~65 divergent Astral rows.
+- `consecutive_ions` (7) is a SEPARATE boolean `SpectralScorer.HasMatch` pass keyed by
+  ion type + ordinal (`:154`), returning the longest consecutive b- or y-ion run.
+
+**RT deviation (11–12)** — `apex_rt − expected_rt` and its absolute value
+(`RtDeviationCalculators.cs:45`, `:60`). NaN propagates by design (no fallback).
+
+**MS1 (13–14)** — HRAM-only. The producer (`PeakDataExtractor`) emits the MS1
+precursor XIC / reference XIC and the apex isotope envelope only when the resolution
+strategy reports `HasMs1Features` (`ResolutionStrategy.cs:163` HRAM=true, `:112`
+Unit=false). `ms1_precursor_coelution` is the Pearson correlation of the two MS1
+chromatograms (`< 3` samples → 0.0; NaN → 0.0, `Ms1Calculators.cs:52-57`).
+`ms1_isotope_cosine` gates on the M0 peak (`envelope[1] > 0`) then calls
+`IsotopeDistribution.PeptideIsotopeCosine` on the **unmodified** `Candidate.Sequence`
+(`:79-92`). For Unit-resolution runs both are exactly 0.0.
+
+**Median polish (15,16,19,20)** — the Tukey median-polish fit is published **by the
+harness** (`CoelutionScorer.ScoreCandidate:242`, `TukeyMedianPolish.Compute` with 10
+iterations, 0.01 tol) because its bisection dump lives in the exe layer. XICs are
+cropped to the peak range (`peakLen >= 3`) first. The four calculators read the
+`MedianPolishByproduct` and apply family defaults when the fit is null:
+`cosine` → 0.0, `residual_ratio` → **1.0** (NOT 0.0), `min_fragment_r2` → 0.0,
+`residual_correlation` → 0.0 (`MedianPolishCalculators.cs:56-123`).
+
+**SG-weighted (17,18)** — `SgWeightedSweep.Compute` (`XcorrCalculators.cs:130`) sweeps
+offsets `-2..+2` with Savitzky-Golay quadratic weights `[-3,12,17,12,-3]/35`. Out-of-
+range offsets at window edges are **skipped, not zero-filled, and not renormalized**
+(matches Rust). `sg_weighted_xcorr` accumulates per-scan `ScoreXcorr × weight`;
+`sg_weighted_cosine` accumulates a mass-range-filtered sqrt-intensity L2-normalized
+cosine (`ComputeCosineAtScan`, `:177` — a distinct kernel from
+`SpectralScorer.LibCosine`). The candidate-local index is bound-checked against the
+window length before mapping to the window-global index — a different index convention
+from feature 6 (documented as an "INDEX TRAP" in the source).
+
+### B.5 Byproduct caching
+
+`OspreyScoringContext` (`Osprey.Scoring/OspreyScoringContext.cs:44`) mirrors Skyline's
+`PeakScoringContext`: a typed byproduct cache (`AddInfo`/`TryGetInfo`) lets one
+producer publish an intermediate (coelution stats, peak-shape reference, apex-match
+set, SG sweep, median-polish fit) that its sibling calculators read. The context is
+reused across candidates with `ClearByproducts` between them
+(`CoelutionScorer.cs:208`).
+
+### B.6 FdrEntry assembly & post-scoring dedup
+
+`BuildFdrEntry` (`CoelutionScorer.cs:395`) sets both `CoelutionSum` and `Score` to
+`features[0]` (the raw coelution sum is the pre-SVM ranking score), serializes the full
+library fragment list and the reference-XIC slice, and stores the top-N CWT candidates
+for Stage-6 reconciliation. After scoring, `ScoringPipeline` runs two dedup passes:
+`DeduplicateDoubleCounting` (`:324`; drops same-class entries whose top-6 fragments
+overlap ≥50% within ±5 spectra, keeping the higher coelution sum) and
+`DeduplicatePairs` (`:526`; one best target + one best decoy per `base_id`, sorted by
+EntryId for determinism). See `07-fdr-control.md` and `16-determinism.md`.
+
+---
+
+## Flags and switches
+
+Flags affecting THIS stage (defaults from `Osprey.Core/OspreyConfig.cs` /
+`Osprey/OspreyCommandArgs.cs`):
+
+| Flag / field | Default | Effect on scoring |
+|--------------|---------|-------------------|
+| `--resolution {unit\|hram\|auto}` | `auto` | Selects `UnitStrategy` vs `HramStrategy` (`ResolutionStrategy.cs:97`). Unit = 2000 f64 bins, no MS1 features; HRAM = ~100K sparse bins, MS1 features 13/14 active. **Calibration always uses unit bins regardless.** |
+| `--fragment-tolerance <v>` | resolution-dependent | Fragment match window for apex-match, cosine, prefilter, LibCosine. |
+| `--fragment-unit {ppm\|mz}` | `ppm` (unit-res forces `mz` 0.5) | Tolerance unit; also the reporting unit for mass-error features 9/10. |
+| `--no-prefilter` (`PrefilterEnabled`) | `true` (prefilter ON) | When set, disables the 2-of-top-6-in-3-of-4-scans signal prefilter (`PeakDataExtractor.cs:117`). Prefilter is always skipped for boundary-override rescoring. |
+| `--threads <count>` | all cores | INNER parallelism: `MaxDegreeOfParallelism` over isolation windows (`ScoringPipeline.cs:271`). Affects speed only, not results. |
+| `--parallel-files [N]` | off (sequential) | OUTER parallelism across files; no effect on per-candidate feature values. |
+| RT calibration `MinRtTolerance` / `MaxRtTolerance` / `FallbackRtTolerance` | config | Clamp the scan-window half-width; the Gaussian rank sigma uses the UNCLAMPED `5×MAD×1.4826` (`ScoringPipeline.cs:170-187`). |
+| `Reconciliation.TopNPeaks` | config | How many CWT candidates `BuildFdrEntry` captures for Stage-6 (`CoelutionScorer.cs:328`). |
+
+Diagnostic env vars for this stage (shared with Rust for cross-impl bisection):
+
+| Env var | Effect |
+|---------|--------|
+| `OSPREY_DIAG_XCORR_SCAN` | Dumps XCorr internals for a matching scan to `cs_xcorr_diag.txt` (`SpectralScorer.cs:453`). |
+| `OSPREY_DIAG_SEARCH_ENTRY_IDS` | Dumps per-entry search XIC data (`ScoringPipeline.cs:224`, `PeakDataExtractor.cs:154`). |
+| `OSPREY_MAX_SCORING_WINDOWS` | Caps the number of scored windows for profiling (`ScoringPipeline.cs:240`). |
+| `OSPREY_DUMP_LDA_SCORES` | Calibration LDA score dump (calibration path). |
+
+The **isotope-cosine LDA feature toggle** for calibration is the `useIsotopeFeature`
+argument to `TrainAndScoreCalibration` (`CalibrationScorer.cs:84`), driven by MS1
+presence rather than a CLI flag.
+
+---
+
+## Divergences from the Rust documentation
+
+- **[UNVERIFIED] E-value not computed in the C# calibration path** - Rust doc says a
+  Comet-style E-value is computed from the XCorr survival function and stored on the
+  calibration match ("computed but not used for FDR"). The C# `CalibrationMatch` has no
+  `evalue` field and no survival-function fit exists in the port.
+  Evidence: `Osprey.Scoring/CalibrationScorer.cs:34-56` (struct has no evalue),
+  `SpectralScorer.cs` (no survival function). Because competition uses the LDA
+  discriminant, not the E-value, output parity is unaffected. Whether the current Rust
+  *code* still computes/stores E-value could not be checked here; likely
+  STALE-RUST-DOC or an intentional drop of dead output. Severity: info.
+
+- **[STALE-RUST-DOC] Unit-resolution bin count is 2000, not 2001** - Rust doc repeatedly
+  says calibration uses "2001 bins (1.0005 m/z)". The C# `BinConfig.UnitResolution()`
+  computes `NBins = (int)(2000/1.0005079 + 0.6) + 1 = 2000`.
+  Evidence: `Osprey.Core/BinConfig.cs:42-59`; confirmed by the test comment "unit
+  resolution: 2000 bins" at `Osprey.Test/ScoringTest.cs:1087`. The Rust code produces
+  the same 2000 (bit-identical parity per README); "2001" is a doc approximation.
+  Severity: info.
+
+- **[INTENTIONAL-CSHARP-DESIGN] Only the 21 PIN features are computed; the ~26 non-PIN
+  scores are not** - The Rust doc's "Spectral Scores at Apex (15 features)" and
+  "Co-Elution Features (11 features)" tables list `hyperscore`, `dot_product`(+`_smz`,
+  `_top4..6`), `fragment_coverage`, `sequence_coverage`, `elution_weighted_cosine`,
+  `fragment_coelution_min`, `n_fragment_pairs`, `fragment_corr_0..5`, etc. The C#
+  calculator pass computes exactly the 21 PIN features and nothing else; the leftover
+  fields still exist on `CoelutionFeatureSet` but are never populated by the scoring
+  pass.
+  Evidence: `OspreyFeatureCalculators.cs:36-44` ("Scores the Rust engine computes but
+  excludes from the 21 PIN features are intentionally NOT here"); `CoelutionScorer.cs:253-274`
+  builds only a `double[21]`; `Osprey.Core/CoelutionFeatureSet.cs:30-128` still declares
+  the unused fields. The Rust doc itself notes "21 PIN features (out of ~47 computed)",
+  so this is a deliberate port simplification, not a behavioral output difference.
+  Severity: minor.
+
+- **[INTENTIONAL-CSHARP-DESIGN] MS1 features gated by resolution strategy, not a config
+  flag** - The Rust doc treats MS1 isotope/precursor-coelution as always-on when MS1
+  scans exist. In C# they are strictly HRAM-only: `UnitStrategy.HasMs1Features` is
+  `false` so the producer emits no MS1 chromatogram/envelope and features 13/14 are
+  exactly 0.0.
+  Evidence: `ResolutionStrategy.cs:112` (Unit false) vs `:163` (HRAM true);
+  `Ms1Calculators.cs:37-38` ("HRAM-only"). This matches the Rust engine's behavior;
+  the doc simply doesn't foreground the resolution gate. Severity: info.
+
+Otherwise the C# main-search feature computation matches the Rust documentation step
+for step: the pipeline order (calibrated local spectra → per-window parallel scoring →
+prefilter → CWT peak ranking with the Gaussian RT penalty → 21-feature calculator pass
+→ dedup), the Comet XCorr preprocessing invariants (no theoretical preprocessing;
+window normalization to 50 at 5% threshold; sliding-window offset 75; scale 0.005), the
+closest-peak-by-mz tie-breaks, the last-on-tie reference-XIC selection, the calibration
+4-feature LDA with decoy-favoring ties at 1% FDR, and the shared
+`compute_features_at_peak`/`run_search` boundary-override design (see
+`11-boundary-overrides.md`) were all verified against the C# source.

--- a/pwiz_tools/Osprey/docs/04-calibration.md
+++ b/pwiz_tools/Osprey/docs/04-calibration.md
@@ -1,0 +1,445 @@
+# 04. Calibration (C#)
+
+> Pipeline stage: Stage 3 (Calibration / recalibration). C# port of Rust docs/04-calibration.md. Corresponds to Rust osprey joint RT + MS1/MS2 m/z calibration.
+
+Osprey performs joint calibration of retention time (RT), MS1 (precursor) m/z, and
+MS2 (fragment) m/z from a single set of high-confidence peptide matches discovered
+by a co-elution search. The calibration tightens the RT and mass windows used by
+the main search (Stage 4) and is persisted to a `.calibration.json` sidecar for
+reuse. In the C# port this stage is owned by `Osprey.Tasks/Calibrator.cs`, invoked
+once per input file from `PerFileScoringTask.RunCalibrationForFile`
+(`Osprey.Tasks/PerFileScoringTask.cs:1671`).
+
+The three calibrations share a single discovery phase: a windowed co-elution search
+scored with a 4-feature LDA, followed by paired target-decoy competition at 1% FDR
+and an S/N >= 5.0 quality gate. The surviving targets provide
+`(library_rt, measured_rt)` pairs for the LOESS RT fit and MS1/MS2 mass-error
+samples for the m/z calibrations.
+
+Entry method:
+`Calibrator.RunCalibration(library, spectra, ms1Spectra, context, out ms1Cal, out ms2Cal, out numSampledPrecursors, out initialRtTolerance)`
+(`Osprey.Tasks/Calibrator.cs:117`). It is a direct port of Rust's
+`run_calibration_discovery_windowed` in `osprey/src/pipeline.rs`.
+
+---
+
+## Step 1 — RT range analysis and linear pre-fit mapping
+
+`Calibrator.cs:142-190`. Before any scoring, the calibrator computes the library
+target RT range and the mzML spectrum RT range, then decides whether the two RT
+scales are "similar":
+
+```
+rangesSimilar = libRtRange > 0 && mzmlRtRange > 0 &&
+    max(libRtRange/mzmlRtRange, mzmlRtRange/libRtRange) < 2.0 &&
+    |libMinRt - mzmlMinRt| < libRtRange * 0.5
+```
+
+- **Scales similar**: identity mapping (`rtSlope = 1`, `rtIntercept = 0`), initial
+  RT tolerance = `mzmlRtRange * 0.2` (20% of the gradient).
+- **Scales differ**: a linear mapping `measured ≈ slope·lib + intercept` is fit from
+  the two bounding boxes (`Calibrator.cs:178-184`), and the initial tolerance widens
+  to `mzmlRtRange * 0.5` (50%).
+
+The chosen wide tolerance is returned via `initialRtTolerance` (the "before" number
+in the console calibration summary).
+
+## Step 2 — Stratified library sampling
+
+`Calibrator.SampleLibraryForCalibration` (`Calibrator.cs:756`), a direct port of Rust
+`sample_library_for_calibration`. This is the first randomized/selected step in the
+whole pipeline, so it must match Rust bit-for-bit for the two tools to calibrate on
+the same peptides.
+
+- If the library has `<= sampleSize` targets, all entries are used (sampling
+  skipped). Otherwise a **2D stratified grid** over `(RT × precursor_mz)` is built.
+- `binsPerAxis = max(5, ceil(sqrt(sampleSize) / 2))` (`Calibrator.cs:781`). For the
+  default 100,000 sample this is 159, a 159×159 grid.
+- Each target is assigned to its grid cell (`Calibrator.cs:808-818`); occupied cells
+  are counted and `perCell = sampleSize / nOccupied` (`Calibrator.cs:827`).
+- **First pass**: from each occupied cell, take `perCell` targets using a
+  deterministic stride `(cellOffset + j*stride) % cell.Count`; each sampled target
+  drags in its paired decoy via `decoyMap[target.Id]`
+  (`Calibrator.cs:842-874`).
+- **Second (top-up) pass**: if fewer than `sampleSize` unique targets were collected,
+  loop the occupied cells again adding unsampled entries until the quota is met
+  (`Calibrator.cs:877-910`).
+
+The sampler is seeded with `43UL` (`Calibrator.cs:197`) to match Rust's
+`42 + attempt` on the first (and, in the C# port, only) calibration attempt.
+Paired target/decoy linkage is by `base_id = entry_id & 0x7FFFFFFF`; decoy IDs are
+`target_id | 0x80000000` (`Calibrator.cs:774-777`).
+
+## Step 3 — Two-pass discovery loop
+
+`RunCalibration` runs the scoring/FDR/LOESS pass up to twice via
+`RunCalibrationScoringPass` (`Calibrator.cs:376`):
+
+- **Pass 1** (`Calibrator.cs:254`) uses the linear pre-fit mapping and the wide
+  initial tolerance; its LOESS floor is `config.RtCalibration.MinCalibrationPoints`
+  (default 200).
+- **Pass 2** (`Calibrator.cs:312`) re-scores the *same* sampled entries but predicts
+  the expected RT from pass 1's LOESS fit and uses a much tighter tolerance; its
+  floor drops to `ABSOLUTE_MIN_CALIBRATION_POINTS = 50` (`Calibrator.cs:60`).
+
+Each pass performs the following, in order.
+
+### 3a. Co-elution scoring per entry
+
+`ScoreCalibrationEntry` (`Calibrator.cs:926`), run in parallel over sampled entries
+(`ScoreCalibrationMatches`, `Calibrator.cs:609`, `MaxDegreeOfParallelism =
+config.NThreads`):
+
+1. Find the isolation window containing the entry's precursor m/z. The window index
+   is `round(precursorMz * 10)`; neighbour keys and a linear-scan fallback handle
+   rounding collisions (`Calibrator.cs:948-975`).
+2. Compute `expectedRt`: pass 1 uses `lib_rt·slope + intercept`; pass 2 uses
+   `calibrationModel.Predict(lib_rt)` (`Calibrator.cs:983-985`).
+3. Filter window spectra to those within `|rt - expectedRt| <= tolerance` that also
+   pass the top-N fragment prefilter `FragmentMath.HasTopNFragmentMatch`
+   (`Calibrator.cs:1029-1038`). Require at least `MIN_COELUTION_SPECTRA = 3`
+   candidates (`Calibrator.cs:53-55, 1040`).
+4. Extract XICs for the top `CAL_TOP_N_FRAGMENTS = 6` most intense library fragments
+   (`TopFragmentExtractor.ExtractTopNFragmentXics`, `Calibrator.cs:1057`).
+5. Detect candidate peaks with **CWT consensus peak detection**
+   (`CwtPeakDetector.DetectConsensusPeaks`, `Calibrator.cs:1072`). If CWT returns no
+   consensus peaks, fall back to `PeakDetector.DetectAllXicPeaks` on the single
+   highest-intensity reference XIC (`Calibrator.cs:1079-1102`). See
+   `06-peak-detection.md`.
+6. Score each candidate peak by the **sum of pairwise Pearson correlations** between
+   fragment XICs over the peak's index range and keep the best
+   (`ScorePeaksByCorrelation`, `Calibrator.cs:1225`; ties go to the last peak to
+   match Rust's `max_by`). Reject if `bestCorrSum < MIN_COELUTION_CORR_SCORE = 0.5`
+   (`Calibrator.cs:54, 1111`).
+7. Locate the apex as the argmax of the reference XIC within the peak bounds
+   (`Calibrator.cs:1144-1158`); `measuredRt = apexRt`.
+8. Compute S/N on the reference fragment's raw intensities
+   (`PeakDetector.ComputeSnr`, `Calibrator.cs:1163`).
+9. At the apex spectrum, compute the four LDA features (below) plus MS2 fragment mass
+   errors (`CollectMs2FragmentErrors`, `Calibrator.cs:1195`) and the MS1 precursor
+   mass error (`ComputeMs1MassError`, `Calibrator.cs:1198`).
+
+The result is a `CalibrationMatch` (`Osprey.Scoring/CalibrationScorer.cs:34`)
+carrying the four raw features, `Ms2MassErrors`, and optional `Ms1Error`.
+
+### 3b. The four LDA features
+
+`CalibrationScorer.ExtractFeatureMatrix` (`CalibrationScorer.cs:581`) normalizes
+exactly four features to roughly `[0,1]`:
+
+| Feature | C# field | Normalization |
+|---------|----------|---------------|
+| Co-elution correlation sum | `CorrelationScore` | `/ 6.0`, clamped `[0,1]` |
+| Spectral similarity at apex | `LibcosineApex` | already `[0,1]` |
+| Top-6 fragments matched at apex | `Top6MatchedApex` | `/ 6.0`, clamped |
+| Comet-style XCorr | `XcorrScore` | `/ 3.0`, clamped |
+
+Hyperscore, S/N, and isotope cosine are deliberately excluded. The XCorr uses a
+dedicated **unit-resolution** scorer regardless of instrument mode
+(`Calibrator.s_calXcorrScorer = new SpectralScorer(BinConfig.UnitResolution())`,
+`Calibrator.cs:72`; preprocessed per window by `PreprocessWindowsForXcorr`,
+`Calibrator.cs:563`).
+
+### 3c. LDA training + target-decoy competition
+
+`CalibrationScorer.TrainAndScoreCalibration` (`CalibrationScorer.cs:84`), a port of
+Rust `train_and_score_calibration`. Matches are first sorted deterministically by
+`(base_id, entry_id)` (`Calibrator.cs:431-439`). Training procedure
+(`TrainLdaWithNonNegativeCv`, `CalibrationScorer.cs:227`):
+
+1. Pick the best single feature at 1% FDR as the baseline (relaxes to 5% FDR if no
+   target passes, `CalibrationScorer.cs:254-277`).
+2. For up to `MAX_ITERATIONS = 3`:
+   - 3-fold CV **grouped by peptide sequence** so all charge states of a peptide (and
+     targets vs. decoys, handled independently) stay together
+     (`CreateStratifiedFoldsByPeptide`, `CalibrationScorer.cs:409`).
+   - Per fold: select high-confidence train targets (`SelectPositiveTrainingSet`,
+     progressively relaxing 1% → 5/10/25/50% until `MIN_POSITIVE_EXAMPLES = 50`),
+     combine with all train decoys, fit `LinearDiscriminant.Fit`.
+   - Average fold weights, **clip negatives to zero**, renormalize to unit length
+     (`AverageWeights`, `CalibrationScorer.cs:346-370`).
+   - Score all data with the consensus weights; track the best iteration; stop after
+     2 consecutive non-improvements (`CalibrationScorer.cs:379-395`).
+3. Return the best iteration's scores (may be the baseline).
+
+Competition is paired: `CompeteCalibrationPairs` (`CalibrationScorer.cs:150`) groups
+by `base_id`, keeps the best target and best decoy, and competes them with strict
+`>` so **ties go to the decoy** (conservative). Only winners enter the q-value walk;
+q-values use `QValueCalculator.ComputeQValues` on the winners sorted by score
+descending. See `07-fdr-control.md`.
+
+### 3d. S/N quality filter → RT points
+
+`CollectCalibrationPoints` (`Calibrator.cs:651`) keeps only non-decoy winners with
+`QValue <= CAL_FDR_THRESHOLD (0.01)` **and** `snr >= MIN_SNR_FOR_RT_CAL = 5.0`
+(`Calibrator.cs:53, 675`). Their `(libRt, measuredRt)` pairs are the LOESS input. If
+fewer than the pass's `minLoessPoints` survive, the pass returns null
+(`Calibrator.cs:479-485`).
+
+### 3e. Mass calibration aggregation
+
+`AggregateMassCalibrations` (`Calibrator.cs:706`) collects MS1 and MS2 errors from
+the *same* surviving targets (FDR + S/N passing). MS2 errors are flattened across all
+matched fragments; MS1 errors are the single M+0 precursor error per match.
+`MzCalibration.CalculateSingleLevel` (`MzCalibration.cs:233`) computes mean, median,
+sample SD (n-1 denominator, two left-to-right passes), and
+`AdjustedTolerance = |mean| + 3·SD`. The unit ("ppm" vs "Th") is taken from
+`config.FragmentTolerance.Unit` (`Calibrator.cs:737`).
+
+### 3f. LOESS fit
+
+`RunCalibrationScoringPass` builds an `RTCalibratorConfig` and calls
+`RTCalibrator.Fit` (`Calibrator.cs:501-519`; `RTCalibration.cs:100`):
+
+- `Bandwidth = config.RtCalibration.LoessBandwidth` (default 0.3)
+- `Degree = 1` (local linear)
+- `MinPoints = min(20, n)`
+- `RobustnessIterations = 2`
+- `OutlierRetention = 1.0` (LDA + S/N already filtered, so no percentile trim)
+- `ClassicalRobustIterations = OspreyEnvironment.LoessClassicalRobust` (default true)
+
+The fit sorts by `(libraryRt, measuredRt)` with a stable LINQ `OrderBy/ThenBy`
+(`RTCalibration.cs:126-129`) — critical because multi-charge peptides share a library
+RT and an unstable sort would diverge from Rust. See "RT Calibration internals" below.
+
+## Step 4 — Two-pass refinement gating and acceptance
+
+`RunCalibration` (`Calibrator.cs:287-366`), mirroring Rust `pipeline.rs`:
+
+1. Compute pass 1's tolerance from its robust spread:
+   `madTolerance = MAD · 1.4826 · 3.0`, clamped to
+   `[MinRtTolerance, MaxRtTolerance]` (`Calibrator.cs:290-293`).
+2. **Refine only if the tolerance narrowed >= 2×**:
+   `pass1Tolerance < initialTolerance * 0.5` (`Calibrator.cs:306`). If pass 1 was
+   already tight, pass 2 is skipped.
+3. Run pass 2 with the narrowed tolerance and pass 1's LOESS model.
+4. **Accept the refined calibration only if `pass2.RSquared >= pass1.RSquared * 0.99`**
+   (`Calibrator.cs:337`). On acceptance, pass 2's RT calibration and MS1/MS2 mass
+   calibrations replace pass 1's; otherwise pass 1 is kept
+   (`Calibrator.cs:348-366`).
+
+`numSampledPrecursors` is reported as pass 1's total scored match count (before any
+q/S-N filtering), matching Rust's `accumulated_matches.len()` (`Calibrator.cs:285`).
+
+---
+
+## RT Calibration internals (`RTCalibration.cs`, `LoessRegression.cs`)
+
+### LOESS fitting
+
+`LoessRegression.Fit` (`LoessRegression.cs:239`):
+
+1. Stable sort by `(x, y)` (`LoessRegression.cs:259-262`).
+2. Initial unweighted fit (`LoessFitInternal`), then `RobustnessIterations`
+   bisquare-weighted refits.
+3. Per iteration: `s = 6 · median(|residual|)`; weight `(1 - u²)²` for `|u| < 1`
+   else 0, with `u = |r|/s` (`LoessRegression.cs:300-322`). The `(1-u²)²` is written
+   as `t*t` (not `Math.Pow`) so the bisquare weight is bit-identical to Rust's
+   `powi(2)`.
+4. Each local fit uses the `k = ceil(bandwidth·n)` nearest neighbours (two-pointer
+   expansion, `FindKNearestSorted`), tricube distance weights, and a weighted 2×2
+   linear solve (`LoessFitInternal`, `LoessRegression.cs:401-470`). The local fits are
+   parallelized with `Parallel.For` (each output index is independent) to close the
+   gap with Rust's auto-vectorized serial loop.
+
+**Classical vs legacy robust iterations**
+(`LoessRegression.cs:229-237, 291-298`): when `classicalRobust` is true (production
+default via the env var), residuals are recomputed from the current fit at the top of
+each iteration (Cleveland 1979). When false, the initial-fit residuals are reused
+across all iterations (legacy single-refresh). Toggle with
+`OSPREY_LOESS_CLASSICAL_ROBUST=0`.
+
+### Prediction and interpolation
+
+`LoessModel.Predict` (`LoessRegression.cs:59`): binary-search the sorted x for the
+bracketing pair, linear-interpolate the fitted values; linearly extrapolate outside
+the range. **Duplicate library RTs** (`|x1 - x0| < 1e-12`) average the two fitted
+values instead of dividing by zero (`LoessRegression.cs:77-78`) — the NaN fix the
+Rust doc calls out.
+
+### Local RT tolerance
+
+`RTCalibration.LocalTolerance(libraryRt, factor, minTolerance)`
+(`RTCalibration.cs:251`) interpolates the smoothed absolute residual at a query RT
+(`InterpolateAbsResidual` + `SmoothedAbsResidual` over ±2 neighbours,
+`RTCalibration.cs:378-413`) and returns `max(localResidual · factor, minTolerance)`.
+**This method exists and is unit-tested, but the main search does not use it for
+candidate selection** — see the Divergences section.
+
+### Statistics
+
+`RTCalibration.Stats()` (`RTCalibration.cs:258`) reports `NPoints`, `ResidualSD`,
+`MeanResidual`, `MaxResidual`, `RSquared`, `P20/P80AbsResidual`, and `MAD` (median of
+absolute residuals). `PercentileValue` uses round-half-away-from-zero to match Rust's
+`f64::round` (`LoessRegression.cs:367-380`). The final search-window half-width the
+main search actually uses is defined once by
+`RTCalibration.SearchWindowHalfWidth(mad, min, max) = clamp(3·mad·1.4826, min, max)`
+(`RTCalibration.cs:318`), shared by the scoring path, the JSON, and the console
+summary.
+
+---
+
+## Mass Calibration internals (`MzCalibration.cs`)
+
+- **Unit-aware**: HRAM instruments report errors in ppm, unit-resolution instruments
+  in Th. `MzCalibrationResult.Unit` carries the string; `ToleranceUnit.Mz`
+  corresponds to Th (`MzCalibration.cs:200, 235`).
+- **MS1 (precursor) error**: `ComputeMs1MassError` (`Calibrator.cs:1298`) finds the
+  nearest MS1 to the apex RT (`ScoringTaskShared.FindNearestMs1`), extracts the M+0
+  isotope peak with `IsotopeEnvelope.Extract` using the isotope spacing
+  `NEUTRON_MASS = 1.002868` Da (`Osprey.Core/IsotopeEnvelope.cs:31`), and reports the
+  error in the fragment-tolerance unit so MS1 and MS2 share a unit.
+- **MS2 (fragment) error**: `CollectMs2FragmentErrors` (`Calibrator.cs:1268`) matches
+  the top-6 library fragments to the apex spectrum within the fragment tolerance and
+  records each closest-peak error.
+- **Statistics**: mean (systematic offset), median, sample SD (n-1), and
+  `AdjustedTolerance = |mean| + 3·SD` (`MzCalibration.cs:280-316`).
+
+---
+
+## Applying calibration in the main search
+
+Stage 4 consumes the calibration in `Osprey.Scoring/ScoringPipeline.cs`:
+
+- **MS2 spectrum correction** (`ScoringPipeline.cs:104-129`): when
+  `ms2Calibration.Calibrated`, every spectrum's m/z array is copied and corrected via
+  `MzCalibration.ApplyCalibration` (`MzCalibration.cs:147`): PPM
+  `corrected = observed - observed·mean/1e6`; Th `corrected = observed - mean`. The
+  spectra are copied (not mutated in place) so repeated `run_search` calls do not
+  apply the offset cumulatively.
+- **Calibrated fragment tolerance** (`ScoringPipeline.cs:193-214`):
+  `MzCalibration.CalibratedTolerance` returns `max(3·SD, floor)` where the floor is
+  `1.0 ppm` (HRAM) or `0.05 Th` (unit) (`MzCalibration.cs:193-211`). Falls back to the
+  configured base tolerance when uncalibrated.
+- **RT tolerance** (`ScoringPipeline.cs:145-187`): a single **global** tolerance is
+  used, not a per-entry local tolerance —
+  `SearchWindowHalfWidth(mad, MinRtTolerance, MaxRtTolerance)` = `clamp(3·mad·1.4826,
+  min, max)`. The MAD is preferentially read from the persisted first-pass
+  `rt_calibration.mad` (`context.OriginalRtMad`), falling back to the in-memory
+  calibration's stats MAD. A separate **unclamped** RT sigma `max(5·mad·1.4826, 0.1)`
+  drives the Gaussian RT penalty during CWT peak ranking. When no RT calibration
+  exists, `FallbackRtTolerance` (2.0 min) is used.
+- **RT prediction of candidates**: `PeakDataExtractor` predicts each candidate's
+  expected RT via `rtCalibration.Predict(candidate.RetentionTime)`
+  (`Osprey.Scoring/PeakDataExtractor.cs:98`).
+
+---
+
+## Calibration caching (`CalibrationIO.cs`, `CalibrationParams.cs`)
+
+After discovery, `PerFileScoringTask.RunCalibrationForFile`
+(`PerFileScoringTask.cs:1700-1738`) serializes a `CalibrationParams` (metadata +
+MS1/MS2 `MzCalibrationJson` + `RTCalibrationJson` with the full LOESS `model_params`)
+to `{inputStem}.calibration.json` next to the input (or in the resolved output dir).
+`CalibrationIO.SaveCalibration` writes atomically via `FileSaver`
+(`CalibrationIO.cs:42`). On resume, `PerFileScoringTask` reloads the JSON and
+reconstructs the model with `RTCalibration.FromModelParams`
+(`PerFileScoringTask.cs:1055, 1303`, `RTCalibration.cs:359`), skipping discovery. The
+JSON stores `(library_rts, fitted_rts, abs_residuals)` triples so the curve is
+rebuilt by interpolation without re-fitting.
+
+The persisted `RTCalibrationJson` also records `mad`, `p20_abs_residual`, and
+`rt_search_window_halfwidth` (`CalibrationParams.cs:296-363`) so the main search and
+console report the same window number (issue #4364).
+
+---
+
+## Flags and switches
+
+| Flag / config / env var | Default | Effect on this stage |
+|---|---|---|
+| `RtCalibration.Enabled` (config) | `true` | Master switch. When false, discovery is skipped and the main search uses `FallbackRtTolerance` with raw library RTs (`PerFileScoringTask.cs:1668`). No dedicated CLI flag. |
+| `RtCalibration.LoessBandwidth` | `0.3` | Fraction of points per local LOESS fit (`Calibrator.cs:503`). |
+| `RtCalibration.MinCalibrationPoints` | `200` | Pass-1 LOESS floor; below it, calibration fails to fallback (`Calibrator.cs:259, 479`). |
+| `RtCalibration.RtToleranceFactor` | `3.0` | Multiplier on the residual/MAD spread. Note: the search path multiplies `MAD·1.4826` by a hardcoded `3.0` in `SearchWindowHalfWidth`, not this config field. |
+| `RtCalibration.FallbackRtTolerance` | `2.0` min | RT tolerance when calibration is disabled or fails (`ScoringPipeline.cs:185`). |
+| `RtCalibration.MinRtTolerance` | `0.5` min | Lower clamp on the search RT window (`ScoringPipeline.cs:176`) and on the pass tolerances (`Calibrator.cs:291-293`). |
+| `RtCalibration.MaxRtTolerance` | `3.0` min | Upper clamp (hard cap) on the search RT window. |
+| `RtCalibration.CalibrationSampleSize` | `100000` | Target sampled entries; `0` = use all (`Calibrator.cs:197, 759`). |
+| `RtCalibration.CalibrationRetryFactor` | `2.0` | Present on the config but **unused** by the C# `Calibrator` (see Divergences). |
+| `--resolution {unit\|hram\|auto}` | `auto` | Selects the main-search scorer and the mass-error unit context; the calibration XCorr is always unit-resolution regardless (`Calibrator.cs:72`). |
+| `--fragment-tolerance` / `--fragment-unit` | ppm; forced `mz 0.5` at unit resolution | Base fragment tolerance used before calibration and as the fallback when uncalibrated (`ScoringPipeline.cs:192`). Also sets the mass-error unit ("ppm"/"Th"). |
+| `PrecursorTolerance` (config, ppm) | `10.0` | Window for MS1 M+0 isotope extraction (`Calibrator.cs:1305-1308`). |
+| `OSPREY_LOESS_CLASSICAL_ROBUST` (env) | on (unset ⇒ classical) | `0` reverts LOESS to legacy single-refresh residuals (`OspreyEnvironment.cs:72`, `LoessRegression.cs:291-298`). |
+| `OSPREY_EXIT_AFTER_CALIBRATION` (env) | off | Exit after Stage 3, skipping the main search (`OspreyEnvironment.cs:79`). |
+| `OSPREY_LOAD_CALIBRATION=<path>` (env) | unset | Load a Rust-produced `.calibration.json` instead of computing; used for cross-impl bisection (`PerFileScoringTask.cs:1623-1667`). |
+
+### Diagnostic env vars (shared with Rust; each has a `*_ONLY` abort variant)
+
+`OSPREY_DUMP_CAL_SAMPLE` (sampled entry IDs + grid contents, `Calibrator.cs:203, 833`),
+`OSPREY_DUMP_CAL_WINDOWS` (per-entry window selection, `Calibrator.cs:403`),
+`OSPREY_DUMP_CAL_MATCH` (per-entry match info, `Calibrator.cs:413`),
+`OSPREY_DUMP_LDA_SCORES` (per-entry discriminant + q-value, `Calibrator.cs:464`),
+`OSPREY_DUMP_LOESS_INPUT` (the `(libRt, measuredRt)` pairs actually fed to the
+accepted fit, `Calibrator.cs:274, 343`), `OSPREY_DUMP_MS2_CAL_ERRORS`
+(`Calibrator.cs:731`), and the per-entry XIC trace via
+`OSPREY_DIAG_XIC_ENTRY_ID` / `OSPREY_DIAG_XIC_PASS` (`Calibrator.cs:1060`). `--write-pin`
+also forces the cal-sample dump (`Calibrator.cs:203`).
+
+---
+
+## Divergences from the Rust documentation
+
+- **[STALE-RUST-DOC] RT candidate selection uses a global tolerance, not per-entry
+  local tolerance** - The Rust doc's "RT Candidate Selection" section says the main
+  search filters candidates by `local_tolerance(library_rt, factor=3.0, min=0.1)`.
+  The C# main search instead uses one global window `clamp(3·MAD·1.4826, MinRt, MaxRt)`
+  for every entry, matching Rust `run_search` (pipeline.rs:8141-8194). The
+  `RTCalibration.LocalTolerance` method is ported and unit-tested but is not wired
+  into candidate selection. Evidence: `Osprey.Scoring/ScoringPipeline.cs:145-176`,
+  `Osprey.Chromatography/RTCalibration.cs:251`. Severity: minor.
+
+- **[STALE-RUST-DOC] Global RT tolerance is MAD-based, not `residual_sd · factor`** -
+  The Rust doc says the global fallback tolerance is `max(residual_sd ·
+  rt_tolerance_factor, min_rt_tolerance)`. Both the C# port and current Rust code
+  prefer `3 · MAD · 1.4826` (robust SD) and only fall back to the `residual_sd ·
+  factor` form when no MAD is available. Evidence:
+  `Osprey.Tasks/Calibrator.cs:290`, `Osprey.Scoring/ScoringPipeline.cs:170-177`
+  (Rust: pipeline.rs:1307, 8143-8151). Severity: minor.
+
+- **[STALE-RUST-DOC] `min_rt_tolerance` default is 0.5 min, not 0.1 min** - The Rust
+  doc's Configuration/"Local RT Tolerance" sections state `min_rt_tolerance = 0.1`
+  (6 s). Both the C# config default and the current Rust `default_min_rt_tolerance()`
+  are `0.5` min. Evidence: `Osprey.Core/RTCalibrationConfig.cs:50` (Rust:
+  config.rs:771). Severity: minor.
+
+- **[STALE-RUST-DOC] Calibration cache filename is `<stem>.calibration.json`, not
+  `<stem>.osprey_calibration.json`** - The Rust doc's "Calibration Caching" section
+  shows `sample.mzML → sample.osprey_calibration.json`. Both the C# port and the Rust
+  code produce `sample.calibration.json`. Evidence:
+  `Osprey.Chromatography/CalibrationIO.cs:91` (Rust: io.rs:149). Severity: info.
+
+- **[UNVERIFIED] No sample-expansion retry loop or graduated linear-fit fallback** -
+  The Rust doc's "Library Sampling" section (3 attempts: `sample_size`, ×`retry_factor`,
+  then ALL entries) and Rust `pipeline.rs:1178-1250` (a retry loop plus a
+  `MIN_LINEAR_FIT_POINTS` graduated linear fit and an RT-span leverage check) describe
+  a robustness path for sparse libraries. The C# `Calibrator` samples exactly once
+  (seed 43) and enforces `MinCalibrationPoints` (200) as the pass-1 floor; if unmet it
+  returns null and the search falls back to `FallbackRtTolerance` — there is no
+  retry-expansion, no `MIN_LINEAR_FIT_POINTS` graduated fit, and no RT-span check. The
+  `CalibrationRetryFactor` config field exists but is never read. On the certified
+  Stellar/Astral reference datasets the first 100K sample always clears 200 confident
+  peptides, so the retry path is never exercised and cross-impl parity holds; on a
+  small or sparse library the C# port would fail calibration where Rust recovers.
+  Evidence: `Osprey.Tasks/Calibrator.cs:196-197, 259, 261-267, 479-485`. Severity:
+  major. A human should confirm whether the retry/graduated-fit omission is an
+  intentional simplification or a genuine port gap for small-library inputs.
+
+- **[INTENTIONAL-CSHARP-DESIGN] Calibration XCorr is managed unit-bin code, not BLAS
+  sdot** - The Rust doc's LDA feature table describes the XCorr feature as "Comet-style
+  XCorr (unit resolution, BLAS sdot)". The C# port has no BLAS; it uses a managed
+  `SpectralScorer(BinConfig.UnitResolution())` with an f32 preprocess path (chosen to
+  match Rust's native f32 XCorr and to avoid .NET LOH pressure from 100K-bin arrays).
+  Numerically equivalent at F10 rounding. Evidence:
+  `Osprey.Tasks/Calibrator.cs:72, 563`. Severity: info. See `17-vectorization.md`.
+
+Everything else verified matches the Rust documentation: stratified grid sampling
+(bins, per-cell stride, top-up pass, paired decoys), the 4 LDA features and their
+normalizations, 3-fold peptide-grouped CV with non-negative clipped weights, paired
+target-decoy competition with ties-to-decoy, the S/N >= 5.0 gate, LOESS parameters
+(bandwidth 0.3, degree 1, 2 robustness iterations, tricube/bisquare weights,
+`s = 6·MAD`), duplicate-RT averaging, the two-pass refinement gate
+(`< 0.5× initial`) and acceptance criterion (`R² >= 0.99×`), MS1 M+0 extraction with
+1.002868 Da spacing, MS2 top-6 fragment errors, mass statistics (`|mean| + 3·SD`,
+sample SD), the PPM/Th spectrum-correction formulas, the calibrated-tolerance floors
+(1.0 ppm / 0.05 Th), and the JSON schema (`model_params` triples).

--- a/pwiz_tools/Osprey/docs/05-rt-alignment.md
+++ b/pwiz_tools/Osprey/docs/05-rt-alignment.md
@@ -1,0 +1,188 @@
+# 05. RT Alignment (C#)
+
+> Pipeline stage: Stage 3 calibration + reconciliation consensus RT. C# port of Rust docs/14-rt-alignment.md. Corresponds to Rust osprey RT alignment & consensus library RT.
+
+This document describes how the C# Osprey port aligns retention times across runs and computes a consensus library RT for each peptide. The consensus library RT is the run-independent anchor that drives cross-run reconciliation (see `10-cross-run-reconciliation.md`) and forced-integration boundary imputation (see `11-boundary-overrides.md`).
+
+## Problem
+
+Retention times drift across runs (LC system, gradient, column conditioning, matrix effects). A peptide might apex at RT=25.3 in file1 and RT=25.8 in file2. To reconcile peak boundaries across runs the port needs a **run-independent representation** of where each peptide elutes: the consensus library RT.
+
+## RT spaces
+
+The port works in three RT spaces, exactly as the Rust doc describes:
+
+| Space | Description | C# representation |
+|-------|-------------|-------------------|
+| **Library RT** | RT from the spectral library (predicted/measured on a reference system) | `LibraryEntry.RetentionTime` |
+| **Measured RT** | RT observed in a specific run | `FdrEntry.ApexRt` |
+| **Consensus library RT** | Weighted median library RT across all high-confidence detections | `PeptideConsensusRT.ConsensusLibraryRt` |
+
+The key invariant is unchanged: **library RT space is run-independent**. Measured apex RTs are mapped back to library RT space (`RTCalibration.InversePredict`), aggregated with a robust weighted median, and then mapped forward again per-run (`RTCalibration.Predict`) to predict where a peptide should elute in any file.
+
+## LOESS calibration primitive
+
+Both the initial (Stage 3) and refined (Stage 6) calibrations are fitted by the same LOESS engine.
+
+- `LoessRegression.Fit` (`Osprey.Chromatography/LoessRegression.cs:239`) fits local weighted linear regressions: tricube distance weights (`Tricube`, `LoessRegression.cs:383`), bisquare robustness iterations (`Bisquare`, `LoessRegression.cs:393`), 2 robustness iterations by default.
+- The inner fit (`LoessFitInternal`, `LoessRegression.cs:401`) is parallelized with `Parallel.For` over output indices — the C# port's replacement for the Rust auto-vectorized serial loop (see `17-vectorization.md`). Each fitted point solves a weighted 2x2 normal-equation system.
+- `LoessModel` (`LoessRegression.cs:35`) stores the sorted x-values and fitted y-values and serves prediction by linear interpolation (`Predict`, `LoessRegression.cs:59`) with linear extrapolation outside the fitted range.
+- `RTCalibrator.Fit` (`Osprey.Chromatography/RTCalibration.cs:100`) wraps the LOESS fit, adds optional outlier removal, computes residuals/`ResidualSD`, and produces an `RTCalibration`.
+
+Cross-impl determinism details that are load-bearing for bit-identity: the outer sort in `RTCalibrator.Fit` is a stable `OrderBy(x).ThenBy(y)` (`RTCalibration.cs:126`) rather than an unstable `Array.Sort`, so duplicate library RTs (multi-charge peptides share a library RT) do not scramble the paired y-values; the bisquare weight is computed as `t*t` not `Math.Pow(t,2)` (`LoessRegression.cs:315`) to match Rust `powi(2)` at the last ULP; and `PercentileValue` rounds half-away-from-zero (`LoessRegression.cs:377`) to match Rust `f64::round`.
+
+### Robustness-iteration mode flag
+
+`RTCalibratorConfig.ClassicalRobustIterations` (`RTCalibration.cs:63`) selects between two robustness behaviors: when `true` (the shipped default), absolute residuals are recomputed from the current fit each iteration (classical Cleveland 1979); when `false`, residuals from the initial fit are reused. Both the initial calibration (`Calibrator.cs:508`) and the refit (`CalibrationRefit.cs:97`) read `OspreyEnvironment.LoessClassicalRobust` for this flag so the two calibrations use the same mode. Default is `true`, matching Rust `calibration_ml.rs` v26.3.1+; override with `OSPREY_LOESS_CLASSICAL_ROBUST=0` on both tools together.
+
+## Step 1 — Initial calibration (Stage 3)
+
+Initial calibration happens during per-file calibration discovery, driven by `Calibrator.RunCalibration` (`Osprey.Tasks/Calibrator.cs:117`), a port of Rust `run_calibration_discovery_windowed`. This produces the forward LOESS mapping `library_rt -> measured_rt`. The full discovery scoring (sampling, LDA target-decoy competition, S/N filtering, mass calibration) is documented in `04-calibration.md`; here we focus on the LOESS RT curve it emits.
+
+Discovery is a **two-pass** refinement (`Calibrator.cs:254`-`366`):
+
+1. **Pass 1** scores stratified-sampled entries with a linear pre-fit RT mapping and a wide initial tolerance, then fits a LOESS `RTCalibration` from the LDA + S/N surviving targets (`Calibrator.cs:254`).
+2. **Pass 2** re-scores using pass 1's LOESS curve to predict expected RT with a much tighter tolerance `3 * MAD * 1.4826` clamped to `[MinRtTolerance, MaxRtTolerance]` (`Calibrator.cs:290`-`293`), refits, and is accepted only if R^2 does not degrade by more than 1% (`Calibrator.cs:337`). Otherwise pass 1's calibration is kept.
+
+The LOESS config used at this stage (`Calibrator.cs:501`) sets `Bandwidth = config.RtCalibration.LoessBandwidth` (default 0.3), `Degree = 1`, `RobustnessIterations = 2`, and importantly **`OutlierRetention = 1.0`** — outlier removal is disabled because the LDA 1% FDR gate and the `S/N >= 5.0` filter (`MIN_SNR_FOR_RT_CAL`, `Calibrator.cs:53`) have already cleaned the point set.
+
+Minimum-point gating: pass 1 requires `config.RtCalibration.MinCalibrationPoints` LOESS input points (`Calibrator.cs:259`, default 200 — `RTCalibrationConfig.cs:41`); pass 2 requires `ABSOLUTE_MIN_CALIBRATION_POINTS = 50` (`Calibrator.cs:60`). The inner `RTCalibrator` requires only `Math.Min(20, libRts.Length)` (`Calibrator.cs:505`).
+
+## Step 2 — Inverse calibration
+
+The LOESS calibration also supports inverse prediction: mapping a measured RT back to library RT space. `RTCalibration.InversePredict` (`RTCalibration.cs:238`) delegates to `LoessModel.InversePredict` (`LoessRegression.cs:90`), which checks that the fitted curve is monotonically non-decreasing and, if so, binary-searches the fitted y-values and linearly interpolates the corresponding x. If the fit is non-monotonic it falls back to the nearest fitted value (`LoessRegression.cs:129`). Inverse prediction is what converts each run's measured apex RT into a comparable library RT for consensus aggregation.
+
+## Step 3 — Consensus library RT (Stage 6)
+
+Consensus RTs are computed by `ConsensusRts.Compute` (`Osprey.FDR/Reconciliation/ConsensusRts.cs:70`), invoked from `Stage6Planner.ComputeConsensusRts` (`Osprey.Tasks/Stage6Planner.cs:150`). Cross-file consensus only runs when `perFileEntries.Count > 1` (`Stage6Planner.cs:172`); single-file runs return an empty consensus and skip refit + reconciliation entirely.
+
+The algorithm:
+
+1. **Select qualifying target peptides** (`ConsensusRts.cs:93`-`105`). A target detection qualifies via `Qualifies` (`ConsensusRts.cs:242`):
+   - `RunPrecursorQvalue <= consensusFdr` is a **hard precondition**, AND
+   - `RunPeptideQvalue <= consensusFdr` OR (protein rescue) `proteinFdrThreshold > 0 && RunProteinQvalue <= proteinFdrThreshold`.
+   Protein FDR can only rescue borderline *peptide-level* evidence; it cannot rescue a detection with poor precursor-level evidence, because the consensus RT is driven by each detection's own apex.
+2. **Collect paired decoy peptides** by `base_id` linkage: `EntryId & 0x7FFFFFFF` (`ConsensusRts.cs:102`,`115`). A decoy sequence is included if its base_id matches a qualifying target's base_id. This works for both Osprey-generated reverse decoys and library-supplied (Carafe / FDRBench-manifest) decoys whose modified sequence carries no `DECOY_` prefix.
+3. **Collect detections** for each consensus peptide (`ConsensusRts.cs:124`-`152`) as `(fileName, apexRt, score, peakWidth = EndRt - StartRt, coelutionSum)`. Targets contribute only qualifying detections; decoys contribute all detections of paired decoy sequences.
+4. **Map to library RT space and weight** (`ConsensusRts.cs:167`-`191`): `libraryRt = cal.InversePredict(apexRt)` per file. A detection is dropped if the library RT is non-finite or `coelutionSum <= 0`. The weight is `sigmoid(SVM score)` floored at `1e-6`: `Math.Max(1e-6, 1/(1+exp(-score)))` (`ConsensusRts.cs:178`).
+5. **Weighted medians** (`ConsensusRts.cs:196`-`197`): `ConsensusLibraryRt` is the `WeightedMedian` of `(libraryRt, weight)` pairs; `MedianPeakWidth` is the `WeightedMedian` of `(peakWidth, weight)` pairs. `WeightedMedian` (`ConsensusRts.cs:264`) sorts by value ascending and returns the first value whose cumulative weight crosses half the total.
+6. **Within-peptide RT MAD** (`ConsensusRts.cs:203`-`214`): when `>= 3` detections contribute, `ApexLibraryRtMad` is set to the median absolute deviation of the per-run library RTs from the consensus. This is the peptide's own reproducibility in library space and feeds the reconciliation tolerance (Step 5).
+7. **Deterministic output sort** (`ConsensusRts.cs:231`): targets before decoys, then ordinal by modified sequence.
+
+### Why sigmoid(SVM score) weighting
+
+A wrong-peak detection with a negative SVM score gets weight ~0.02 and cannot poison the median; strong detections with positive scores dominate. This is more discriminating than raw co-elution magnitude because it uses the trained model's judgment of detection quality. The `coelutionSum > 0` sanity filter is retained as a floor.
+
+### Output record
+
+`PeptideConsensusRT` (`Osprey.FDR/Reconciliation/PeptideConsensusRT.cs:33`):
+
+```csharp
+public class PeptideConsensusRT {
+    string ModifiedSequence;    // peptide-level grouping
+    bool   IsDecoy;             // computed independently for targets and decoys
+    double ConsensusLibraryRt;  // sigmoid-weighted median in library RT space
+    double MedianPeakWidth;     // sigmoid-weighted median peak width (min, measured space)
+    int    NRunsDetected;       // number of runs contributing a detection
+    double? ApexLibraryRtMad;   // within-peptide RT MAD (library space); null if < 3 detections
+}
+```
+
+### Target-decoy separation
+
+Targets and decoys receive independent consensus RTs — decoy consensus is computed from decoy detections only (`ConsensusRts.cs:130`-`133`) so no target information leaks into the decoy null, preserving fair second-pass target-decoy competition.
+
+### Cross-impl bisection trace
+
+When `OSPREY_DUMP_INV_PREDICT` is set, `ConsensusRts.Compute` populates an `InvPredictRecord` list (`InvPredictRecord.cs:35`) with the `(fileName, modifiedSequence, isDecoy, apexRt, libraryRt, weight)` of every contributing detection (`ConsensusRts.cs:182`). The `Stage6Planner` drives the dump via the diagnostics sink (`Stage6Planner.cs:167`,`180`). This localizes any `ConsensusLibraryRt` divergence to either the loaded apex RT (Parquet decode) or the LOESS inverse-interpolation step.
+
+## Step 4 — Refined calibration (Stage 6)
+
+During reconciliation the per-file calibration is **refit** from FDR-controlled consensus peptides by `CalibrationRefit.Refit` (`Osprey.FDR/Reconciliation/CalibrationRefit.cs:48`), called per file from `Stage6Planner.RefitCalibrations` (`Stage6Planner.cs:214`).
+
+- **Points**: `(consensus_library_rt -> measured_apex_rt)` for target peptides in this run whose `EffectiveExperimentQvalue(FdrLevel.Both) <= consensusFdr` and that have a consensus RT (`CalibrationRefit.cs:69`-`79`). Note this refit gate is **experiment-level** (`EffectiveExperimentQvalue`), distinct from the run-level precursor hard gate used to *select* consensus peptides in Step 3.
+- **LOESS config** (`CalibrationRefit.cs:92`): `Bandwidth = 0.3`, `OutlierRetention = 1.0` (no outlier removal — all points are FDR-controlled; LOESS robustness iterations still downweight stragglers), `MinPoints = MIN_CONSENSUS_POINTS = 20` (`CalibrationRefit.cs:39`), `ClassicalRobustIterations = OspreyEnvironment.LoessClassicalRobust`.
+- **Fallback**: fewer than 20 usable points, or a fit exception, returns `null` (`CalibrationRefit.cs:81`,`104`) and the original first-pass calibration is used downstream.
+
+This produces a tighter calibration because all points are high-confidence FDR-controlled detections and the consensus library RTs are more consistent than first-pass library RTs.
+
+## Step 5 — Predicting expected measured RT and the reconciliation tolerance
+
+Reconciliation planning (`ReconciliationPlanner.Plan`, `Osprey.FDR/Reconciliation/ReconciliationPlanner.cs:65`) uses the consensus RTs and refined calibrations to decide, per (file, entry), whether to keep the current peak, switch to a stored CWT candidate, or force an integration window.
+
+### Expected measured RT
+
+For each entry in the consensus set that passed experiment-FDR (or its paired decoy, keyed by `(base_id, charge)` — `ReconciliationPlanner.cs:131`-`143`,`209`), the expected RT is `cal.Predict(consensusEntry.ConsensusLibraryRt)` (`ReconciliationPlanner.cs:212`), where `cal` is the refined calibration if present, else the original first-pass calibration (`ReconciliationPlanner.cs:155`-`157`).
+
+### RT tolerance — within-peptide MAD, not cross-peptide calibration MAD
+
+This is the most substantive difference from the Rust `14-rt-alignment.md` text (which describes a single global `max(0.1, 3.0 * MAD * 1.4826)` derived from the refined calibration's cross-peptide residuals). The C# port — matching the current Rust code — instead derives the tolerance primarily from **within-peptide** reproducibility:
+
+1. **Global within-peptide MAD** (`ReconciliationPlanner.cs:96`-`118`): the median of all target peptides' `ApexLibraryRtMad` values (per-peptide, library space, `>= 3` detections). If no peptide qualifies (e.g. a 2-replicate experiment), it falls back to `FALLBACK_GLOBAL_MAD_LIB = 0.05` min (`ReconciliationPlanner.cs:44`).
+2. **Per-file cross-peptide ceiling** (`ReconciliationPlanner.cs:166`-`183`): a *sigma-clipped* MAD of the refined calibration's absolute residuals (`SigmaClippedMad`, `ReconciliationPlanner.cs:299`) converted to `3 * MAD * 1.4826`, floored at `MIN_RT_TOLERANCE = 0.1` min, and further **capped by** the original first-pass calibration MAD so each pass can only tighten. Sigma-clipping (`SIGMA_CLIP_MIN_SURVIVORS = 20`) prevents wrong-peak residuals from inflating the ceiling.
+3. **Final per-peptide tolerance** (`ReconciliationPlanner.cs:188`): `min( max(globalWithinPeptideMadLib * 1.4826 * 3.0, 0.1), fileCalToleranceCeiling )`.
+
+Rationale (from the Rust docstring the C# comments cite): after cross-run alignment, within-peptide scatter is roughly peptide-independent (instrument/LC reproducibility) and the cross-peptide median is a far more stable estimator than any single peptide's 3-5-replicate MAD. Using a global (not per-query-position) tolerance also eliminates the self-fulfilling-prophecy feedback loop the Rust doc warns about, where a wrong-apex detection inflates the local tolerance at its own RT and then passes the proximity check. On Stellar this typically drops the tolerance from ~0.3 min (cross-peptide) to ~0.1 min (within-peptide).
+
+### Reconcile action
+
+`ReconciliationPlanner.DetermineAction` (`ReconciliationPlanner.cs:248`), a port of Rust `determine_reconcile_action`, uses **apex proximity** (not boundary containment):
+
+- If `|apexRt - expectedMeasuredRt| <= rtTolerance` -> `ReconcileAction.Keep` (implicit; not stored).
+- Else pick the stored CWT candidate whose apex is closest to `expectedMeasuredRt` and within tolerance -> `ReconcileAction.UseCwtPeak` (`ReconciliationPlanner.cs:280`).
+- Else -> `ReconcileAction.ForcedIntegration(expectedRt, halfWidth)` where `halfWidth = consensusEntry.MedianPeakWidth / 2.0` (`ReconciliationPlanner.cs:225`,`288`).
+
+## Step 6 — Peak width for imputation
+
+When no CWT candidate exists at the expected RT, `MedianPeakWidth` becomes the forced-integration window: `forced_start = expected_rt - halfWidth`, `forced_end = expected_rt + halfWidth` (`ReconciliationPlanner.cs:288`, consumed downstream in `11-boundary-overrides.md`). The width is the sigmoid-weighted median across confident detections, so the imputed window matches the peptide's typical chromatographic width.
+
+## Stage ordering
+
+`Stage6Planner.Plan` (`Stage6Planner.cs:80`) runs the four planning phases in Rust pipeline order:
+
+1. Multi-charge consensus per file (independent; see `09-multi-charge-consensus.md`).
+2. Cross-run consensus RTs (`ComputeConsensusRts`).
+3. Per-file calibration refit (`RefitCalibrations`), which depends on (2).
+4. Reconciliation planning (`PlanReconciliation`), which depends on (2) and (3).
+
+## Flags and switches
+
+| Flag / field / env var | Default | Effect on this stage |
+|------------------------|---------|----------------------|
+| `ReconciliationConfig.ConsensusFdr` (config field) | `0.01` (`ReconciliationConfig.cs:39`) | FDR threshold for selecting consensus peptides (Step 3) and for the refit experiment-FDR gate (Step 4). Not exposed as a dedicated CLI flag; uses the default. |
+| `ReconciliationConfig.Enabled` | `true` (`ReconciliationConfig.cs:33`) | Enables inter-replicate reconciliation for multi-file runs. |
+| `ReconciliationConfig.TopNPeaks` | `5` (`ReconciliationConfig.cs:36`) | CWT candidate peaks stored per precursor for reconciliation planning. |
+| `--protein-fdr <t>` -> `OspreyConfig.EffectiveProteinFdr` | `0.01` (default threshold; machinery always runs) | When passed as `proteinFdrThreshold` to `ConsensusRts.Compute` (`Stage6Planner.cs:176`), enables protein-FDR rescue of borderline peptide-level detections in consensus selection. |
+| `--experiment-fdr <t>` | `0.01` | Sets the experiment-level FDR threshold; passing precursors (any q-level) are the ones reconciliation includes per file. |
+| `RTCalibrationConfig.LoessBandwidth` | `0.3` (`RTCalibrationConfig.cs:38`) | LOESS bandwidth for both initial and refined RT calibration. |
+| `RTCalibrationConfig.MinCalibrationPoints` | `200` (`RTCalibrationConfig.cs:41`) | Minimum LOESS input points for initial-calibration pass 1. |
+| `RTCalibrationConfig.MinRtTolerance` / `MaxRtTolerance` | `0.5` / `3.0` min (`RTCalibrationConfig.cs:50`,`59`) | Clamp on the initial-calibration search tolerance (`3*MAD*1.4826`). Distinct from the reconciliation `MIN_RT_TOLERANCE = 0.1` floor. |
+| `CalibrationRefit.MIN_CONSENSUS_POINTS` (const) | `20` (`CalibrationRefit.cs:39`) | Minimum consensus points to attempt a per-file refit. |
+| `ReconciliationPlanner.FALLBACK_GLOBAL_MAD_LIB` (const) | `0.05` min (`ReconciliationPlanner.cs:44`) | Within-peptide MAD fallback when no peptide has `>= 3` detections. |
+| `ReconciliationPlanner.MIN_RT_TOLERANCE` (const) | `0.1` min (`ReconciliationPlanner.cs:40`) | Floor on the reconciliation RT tolerance. |
+| `ReconciliationPlanner.SIGMA_CLIP_MIN_SURVIVORS` (const) | `20` (`ReconciliationPlanner.cs:54`) | Minimum survivors before the sigma-clipped ceiling falls back to the unclipped median. |
+| `OSPREY_LOESS_CLASSICAL_ROBUST` (env) | `1`/true (`OspreyEnvironment.cs:72`) | Robustness-iteration mode for all LOESS fits. Set to `0` on both tools together to validate legacy behavior. |
+| `OSPREY_DUMP_INV_PREDICT` (`+ _ONLY`) (env) | off | Dumps the per-detection `(apex_rt, library_rt, weight)` inverse-prediction trace (`Stage6Planner.cs:167`). `_ONLY` exits after the dump. |
+| `OSPREY_DUMP_CONSENSUS` (`+ _ONLY`) | off | Dumps the consensus RT table (`Stage6Planner.cs:202`). |
+| `OSPREY_DUMP_REFIT` / `OSPREY_DUMP_LOESS_FIT` (`+ _ONLY`) | off | Dumps refined-calibration state (`Stage6Planner.cs:231`,`238`). |
+| `OSPREY_DUMP_RECONCILIATION` (`+ _ONLY`) | off | Dumps the per-(file,entry) reconciliation action plan (`Stage6Planner.cs:306`). |
+
+## Divergences from the Rust documentation
+
+- **[STALE-RUST-DOC] Consensus weight is sigmoid(SVM score), not coelution_sum** - Rust doc says the weighted median uses `coelution_sum` as the weight for both consensus library RT and median peak width; C# weights by `sigmoid(SVM score)` floored at `1e-6`, keeping `coelution_sum > 0` only as a sanity filter. This matches the current Rust code (the Rust CLAUDE.md records "Consensus weighting: sigmoid(SVM score), not coelution_sum"), so parity is preserved and the doc is out of date. Evidence: `Osprey.FDR/Reconciliation/ConsensusRts.cs:178`. Severity: minor.
+
+- **[STALE-RUST-DOC] Median peak width is a weighted median, not a simple median** - Rust doc computes `median_peak_width` via `simple_median([...])`; C# uses the same sigmoid-weighted `WeightedMedian` as the RT (a consequence of the weighting change above). Evidence: `Osprey.FDR/Reconciliation/ConsensusRts.cs:197`. Severity: minor.
+
+- **[STALE-RUST-DOC] Consensus selection gate is a run-level precursor hard precondition plus peptide/protein rescue, not "experiment-level FDR"** - Rust doc says consensus peptides are those "passing experiment-level FDR at consensus_fdr". C# `Qualifies` requires `RunPrecursorQvalue <= consensusFdr` as a hard gate, then `RunPeptideQvalue <= consensusFdr` OR protein rescue — all run-level. This matches the current Rust code (Rust CLAUDE.md: "Consensus qualification gate: precursor q-value is a hard precondition"). Evidence: `Osprey.FDR/Reconciliation/ConsensusRts.cs:242`-`250`. Severity: minor.
+
+- **[STALE-RUST-DOC] Reconciliation RT tolerance uses within-peptide MAD (with a sigma-clipped cross-peptide ceiling), not a single cross-peptide calibration MAD** - Rust doc gives `rt_tolerance = max(0.1, 3.0 * MAD * 1.4826)` from the refined calibration's cross-peptide residuals. C# derives the tolerance from the global median of per-peptide within-library-space apex MADs, floors it at 0.1, and caps it by a sigma-clipped per-file calibration MAD that is itself capped by the original first-pass MAD. This matches the current Rust code (Rust CLAUDE.md: "Reconciliation RT tolerance: within-peptide MAD, not cross-peptide calibration MAD"). Evidence: `Osprey.FDR/Reconciliation/ReconciliationPlanner.cs:96`-`190`,`299`. Severity: major.
+
+- **[STALE-RUST-DOC] Decoy pairing is by base_id linkage, not DECOY_ prefix stripping** - Rust doc describes decoy consensus computed "from decoy detections only" and the older Rust implementation stripped a `DECOY_` prefix. C# links paired decoys via `EntryId & 0x7FFFFFFF`, which also recognizes library-supplied decoys (Carafe / FDRBench manifest) whose modified sequence carries no prefix. The target/decoy-independence property the doc requires is preserved. Evidence: `Osprey.FDR/Reconciliation/ConsensusRts.cs:102`,`115`. Severity: info.
+
+- **[INTENTIONAL-CSHARP-DESIGN] Parallelized LOESS inner fit instead of BLAS/auto-vectorization** - The Rust code relies on an auto-vectorized serial inner loop; the C# port parallelizes the per-point fit with `Parallel.For` and uses direct `t*t` / away-from-zero rounding to preserve bit-identity. Numerical results match; only the execution strategy differs. Evidence: `Osprey.Chromatography/LoessRegression.cs:420`. See `17-vectorization.md`. Severity: info.
+
+- **[INTENTIONAL-CSHARP-DESIGN] Initial-calibration minimum-point gate differs from the doc's "50"** - Rust `14-rt-alignment.md` lists "Minimum points: 50" for initial calibration. In the C# discovery path pass 1 requires `MinCalibrationPoints` (default 200) and pass 2 requires 50 (`ABSOLUTE_MIN_CALIBRATION_POINTS`); the inner `RTCalibrator` requires only 20. The "50" figure corresponds to `RTStratifiedSampler.MinCalibrationPoints` and the pass-2 floor, not the pass-1 gate. This is a Stage 3 detail; see `04-calibration.md`. Evidence: `Osprey.Tasks/Calibrator.cs:60`,`259`; `Osprey.Core/RTCalibrationConfig.cs:41`. Severity: minor.
+
+- **[FLAG-GATED] `OSPREY_TRACE_PEPTIDE` per-peptide trace not present in this stage of the C# port** - Rust documents an `OSPREY_TRACE_PEPTIDE` env var that emits `[trace]` lines inside `compute_consensus_rts` and `plan_reconciliation`. The C# reconciliation code exposes structured *dump* diagnostics instead (`OSPREY_DUMP_INV_PREDICT`, `OSPREY_DUMP_CONSENSUS`, `OSPREY_DUMP_RECONCILIATION`); no `OSPREY_TRACE_PEPTIDE` handling was found under `Osprey.FDR/Reconciliation` or `Osprey.Tasks`. A human should confirm whether the peptide trace exists elsewhere in the C# port before relying on it. Evidence: no match for `TRACE_PEPTIDE` in the C# tree. See `18-peptide-trace.md`. Severity: info.
+
+Verified against the Rust doc step for step: the three RT spaces, forward/inverse LOESS prediction, two-pass initial calibration, per-file consensus refit at bandwidth 0.3 / retention 1.0 / min-20, weighted-median consensus with independent target/decoy sets, `predict(consensus_library_rt)` for expected RT, apex-proximity reconcile action, and `median_peak_width/2` forced-integration window all match. The behavioral deltas above are all cases where the C# port tracks the *current* Rust code and the Rust `14-rt-alignment.md` prose is stale.

--- a/pwiz_tools/Osprey/docs/06-peak-detection.md
+++ b/pwiz_tools/Osprey/docs/06-peak-detection.md
@@ -1,0 +1,516 @@
+# 06. CWT Peak Detection (C#)
+
+> Pipeline stage: Stage 4 (main first-pass search). C# port of Rust docs/05-peak-detection.md. Corresponds to Rust osprey CWT consensus peak detection (`osprey-chromatography/src/cwt.rs`, `lib.rs`, `pipeline.rs::run_search`).
+
+This document describes how the C# Osprey port detects chromatographic peaks in
+fragment-ion chromatograms (XICs), selects the winning peak among candidates, and
+turns that peak into the boundaries, apex, area, and S/N that feed FDR scoring
+(`see 03-spectral-scoring.md`) and, ultimately, the .blib output (`see
+13-blib-output-schema.md`). It also folds in the intent of the historical Rust
+design spec `docs/DIA-PeakDetectionPlan.md` as context and calls out where that
+early plan was superseded.
+
+The port keeps the pipeline byte-identical to Rust on the Stellar
+(`--resolution unit`) and Astral (`--resolution hram`) reference datasets, so
+almost every routine below is a deliberate line-for-line translation, including
+the tie-break and float-order details that make cross-impl parity hold. Those
+details are noted where they matter.
+
+---
+
+## Where this runs in the pipeline
+
+Peak detection is invoked per isolation window, per candidate precursor, from the
+coelution scoring engine:
+
+- `Osprey.Scoring/ScoringPipeline.cs` computes the per-file RT tolerance and RT
+  penalty sigma once, then dispatches windows in parallel to
+  `CoelutionScorer.ScoreWindow` (`ScoringPipeline.cs:277`).
+- `Osprey.Scoring/CoelutionScorer.cs::ScoreWindow` (`CoelutionScorer.cs:70`)
+  sorts the window spectra, finds candidate library entries, preprocesses XCorr,
+  and calls `ScoreCandidate` for each candidate.
+- `Osprey.Scoring/PeakDataExtractor.cs::TryExtract` (`PeakDataExtractor.cs:63`) is
+  the detection half of Rust `run_search`: it picks the scan range, extracts
+  XICs, runs the 3-tier peak detector, rank-selects the winning peak, and
+  publishes the peak-data view.
+- The wavelet math lives in `Osprey.Chromatography/CwtPeakDetector.cs`; the
+  legacy Savitzky-Golay detector and shared area/SNR helpers live in
+  `Osprey.Chromatography/PeakDetector.cs`; the additive-model decomposition lives
+  in `Osprey.Scoring/TukeyMedianPolish.cs`.
+
+The same peak-detection code is also used by the calibration pass (`see
+04-calibration.md`) to find calibration matches, and by Stage 6 reconciliation
+re-scoring through the boundary-override path (`see 11-boundary-overrides.md`).
+
+---
+
+## Step 0: RT search window vs apex acceptance (the decouple)
+
+`PeakDataExtractor.FindScanRange` (`PeakDataExtractor.cs:491`) chooses which
+scans feed the detector. For the normal (non-override) search path the
+extraction half-width is deliberately **wider** than the apex-acceptance
+tolerance:
+
+```
+xicHalfWidth = rtTolerance + max(rtTolerance, 0.1)   // PeakDataExtractor.cs:518
+scan i is in range when |windowRts[i] - expectedRt| <= xicHalfWidth
+```
+
+`expectedRt` is the calibration-predicted RT (`rtCalibration.Predict`,
+`PeakDataExtractor.cs:97`). `rtTolerance` is the per-file global tolerance
+`3 * MAD * 1.4826` clamped to `[MinRtTolerance, MaxRtTolerance]` = `[0.5, 3.0]`
+min (`RTCalibration.SearchWindowHalfWidth`, `RTCalibration.cs:318`;
+`ScoringPipeline.cs:175`).
+
+The apex-acceptance filter is applied later, during rank scoring: a detected
+peak whose apex RT lies farther than `rtTolerance` from `expectedRt` is dropped
+(`PeakDataExtractor.cs:256-259`). This is exactly the decouple the Rust doc
+describes: the wider window lets CWT see both tails of a peak whose apex has
+drifted toward the acceptance edge (so boundaries are not truncated to
+`start == apex`), while the apex filter preserves first-pass selectivity. The C#
+comment at `PeakDataExtractor.cs:248-255` cites the same Rust commit (885339b)
+and rationale.
+
+The comparison uses the abs-diff form `Math.Abs(windowRts[i] - expectedRt) <=
+xicHalfWidth`, not a precomputed `rtHi` compare, because the two arithmetic
+chains round differently in the last bit and a single boundary spectrum slipping
+in or out of the window cascades through CWT detection into a different apex pick
+(`PeakDataExtractor.cs:483-489`).
+
+Before detection, a signal pre-filter (gated by `PrefilterEnabled`, default true)
+requires at least 2 of the top-6 fragments present in at least 3 of 4 consecutive
+scans, skipping noise-only candidates (`PeakDataExtractor.cs:117-143`). It is
+bypassed on the boundary-override path.
+
+---
+
+## Step 1: Fragment XIC extraction
+
+`TopFragmentExtractor.ExtractFragmentXics` (`PeakDataExtractor.cs:146`) extracts
+the top fragment XICs within `[startScan, endScan]` using the configured fragment
+tolerance. Each XIC is an `Osprey.Chromatography/CwtPeakDetector.cs::XicData`
+holding a fragment index and parallel `RetentionTimes` / `Intensities` arrays on
+the shared window scan axis. Fewer than 2 XICs aborts the candidate
+(`PeakDataExtractor.cs:162`).
+
+---
+
+## Step 2: CWT consensus peak detection
+
+`CwtPeakDetector.DetectConsensusPeaks(xics, minConsensusHeight = 0.0)`
+(`CwtPeakDetector.cs:511`) is the primary detector. It requires at least 2 XICs
+of at least 5 scans each, all the same length, and at least one non-zero
+intensity, else returns an empty list (`CwtPeakDetector.cs:515-547`).
+
+### 2a. Scale estimation
+
+`EstimateScale` (`CwtPeakDetector.cs:161`) measures the FWHM of each fragment XIC
+that has signal (apex found via last-on-tie `>=`, half-max crossings via linear
+interpolation), takes the median FWHM, and converts to a Gaussian sigma:
+
+```
+sigma = medianFWHM / 2.355        (FWHM_TO_SIGMA = 2.355)
+clamp to [MIN_SCALE=2.0, MAX_SCALE=20.0]
+fallback DEFAULT_SCALE = 4.0 when no FWHM can be measured
+```
+
+The apex uses `>=` (last equal element) deliberately to match Rust
+`Iterator::max_by` tie semantics; a strict `>` would diverge on flat tops
+(`CwtPeakDetector.cs:171-189`).
+
+### 2b. Mexican Hat kernel
+
+`MexicanHatKernel(sigma, kernelRadius)` (`CwtPeakDetector.cs:85`) builds the
+Ricker wavelet — the negative normalized second derivative of a Gaussian:
+
+```
+psi(t) = (2 / (sqrt(3*sigma) * pi^(1/4))) * (1 - (t/sigma)^2) * exp(-t^2 / (2*sigma^2))
+```
+
+followed by a zero-mean (DC-offset) correction so the kernel gives zero response
+to a constant signal (`CwtPeakDetector.cs:99-107`). Kernel radius is
+`min(ceil(5*sigma), nScans/2)` (`CwtPeakDetector.cs:551`), so the ~99.99%
+energy-capture radius is capped by the available scans. (`MIN_KERNEL_POINTS = 11`
+is declared but the detector uses the radius formula directly.)
+
+### 2c. Convolution and pointwise-median consensus
+
+Each XIC is convolved with the kernel using direct "same"-size, zero-padded
+convolution (`Convolve`, `CwtPeakDetector.cs:122`). `ConsensusMedianCwt`
+(`CwtPeakDetector.cs:265`) then takes the pointwise **median** of the per-fragment
+CWT coefficients at each scan. The median (not mean) is the interference-rejection
+mechanism: a peak-like shape must be present in the majority of transitions for
+the consensus to rise.
+
+### 2d. Apex detection and boundaries (zero-crossing ±2σ with valley guard)
+
+`FindPeaks` (`CwtPeakDetector.cs:298`) collects consensus local maxima above
+`minConsensusHeight` (interior plus both endpoints), then sorts them by consensus
+coefficient descending via `OrderByDescending` — LINQ's stable sort is used
+specifically because `Array.Sort` is an unstable introsort and would reorder ties
+relative to Rust's stable `slice::sort_by` (`CwtPeakDetector.cs:334-344`).
+
+For each apex:
+
+1. Walk out to zero-crossings of the consensus signal (`leftZc`, `rightZc`;
+   `CwtPeakDetector.cs:353-359`). For a Gaussian these sit near ±σ (~68% area).
+2. Estimate asymmetric sigma from the zero-crossing distances and set targets
+   `apex ± COVERAGE_FACTOR * max(sigma, 1)` where `COVERAGE_FACTOR = 2.0`, giving
+   ~95% coverage (`CwtPeakDetector.cs:362-372`).
+3. **Valley guard**: extend from each zero-crossing toward the target while
+   tracking a running minimum of the raw reference signal; if the reference rises
+   more than `VALLEY_THRESHOLD = 0.05 * refApex` above that running minimum, stop
+   at the valley minimum — this prevents bleeding into an adjacent peak
+   (`CwtPeakDetector.cs:374-416`).
+4. Require at least 3 scans (`CwtPeakDetector.cs:419`).
+5. Recompute the apex as the max of the **reference signal** within the
+   boundaries (last-on-tie `>=`), and compute `area` (trapezoidal) and
+   `signal_to_noise` from that reference signal (`CwtPeakDetector.cs:430-445`).
+
+The reference signal here is the **sum** of the raw fragment intensities
+(`refSignal`, built at `CwtPeakDetector.cs:562-568`). Consensus CWT coefficients
+are used only for detection and boundaries; all quantitative values come from raw
+intensities. Peaks are returned sorted by consensus coefficient descending.
+
+The output type is `Osprey.Core/XICPeakBounds.cs` (`apex_rt`, `apex_intensity`,
+`apex_index`, `start_rt`, `end_rt`, `start_index`, `end_index`, `area`,
+`signal_to_noise`) — field-for-field the Rust `XICPeakBounds` struct.
+
+---
+
+## Step 3: Fallback chain
+
+`PeakDataExtractor.DetectCandidatePeaks` (`PeakDataExtractor.cs:543`) applies the
+three-tier priority the Rust doc lists, in order:
+
+1. CWT consensus (`DetectConsensusPeaks`, above).
+2. If empty: peak detection on the Tukey median-polish elution profile via
+   `PeakDetector.DetectAllXicPeaks(profile, 0.01, 5.0)`
+   (`PeakDataExtractor.cs:566-583`).
+3. If still empty: `DetectAllXicPeaks` on the highest-total-intensity fragment XIC
+   (`PeakDataExtractor.cs:585-602`).
+
+`DetectAllXicPeaks` (`PeakDetector.cs:334`) is the legacy Savitzky-Golay detector:
+5-point SG smoothing `[-3,12,17,12,-3]/35` with negative clamp
+(`SmoothSavitzkyGolay`, `PeakDetector.cs:296`), local maxima above `minHeight`
+(stable `OrderByDescending`), DIA-NN-style valley boundary walks
+(`WalkBoundaryLeft/Right`, `PeakDetector.cs:452,480`: stop at 20%-of-signal
+threshold or at a valley below 50% of apex and 50% of the rising neighbor), and
+asymmetric FWHM capping at `apex ± 2 * half-width` (`ComputeAsymmetricHalfWidths`,
+`PeakDetector.cs:515`). S/N uses 5 raw flanking points each side
+(`ComputeSnr`, `PeakDetector.cs:224`).
+
+---
+
+## Step 4: Reference XIC selection
+
+The reference XIC used for apex/area/SNR recompute and for the reconciliation
+CWT-candidate list is the single fragment with the highest total intensity,
+selected with last-on-tie `>=` (`PeakDataExtractor.cs:204-213`). The `>=` is
+load-bearing for parity: Rust's `max_by` returns the last equal element, and
+using strict `>` here diverged ~33k Stellar entries on tied fragments.
+
+---
+
+## Step 5: Peak selection among candidates (RT-penalized rank score)
+
+Detection returns candidate peaks; selection picks one. For each candidate peak
+that passes the apex-acceptance filter (Step 0), `PeakDataExtractor.cs:262-289`
+computes:
+
+```
+coelutionScore = mean pairwise Pearson correlation of fragment intensities
+                 within [start_index, end_index]              (PeakDataExtractor.cs:262-278)
+rtPenalty      = exp(-(rtResidual^2) / (2 * rtSigma^2))       (PeakDataExtractor.cs:280)
+intensityWeight= ln(1 + refApexIntensity)                     (PeakDataExtractor.cs:287)
+rankScore      = coelutionScore * rtPenalty * intensityWeight (PeakDataExtractor.cs:289)
+```
+
+The highest `rankScore` wins, compared with IEEE-754 total-order semantics
+(`TotalOrder.Greater`, `PeakDataExtractor.cs:300`) so signed-zero ties (when
+`intensityWeight = 0`) resolve the same way Rust's `f64::total_cmp` resolves them.
+
+This is where the C# implementation (matching the current Rust *code*) is richer
+than the Rust *doc*: the doc's Stage 2 describes selection as pure mean pairwise
+correlation. The C# adds:
+
+- a **Gaussian RT penalty** so a strong interferer at the wrong RT cannot beat the
+  correct peak on coelution alone (this penalty is the peak-selection quality that
+  the Rust CLAUDE.md notes is critical for protein-FDR calibration), and
+- a **log-intensity tiebreaker** so the main peak wins over its own shoulder when
+  coelution scores are nearly equal.
+
+The RT penalty sigma is computed once per file as **unclamped** `5 * MAD * 1.4826`
+with a 0.1 min floor (`ScoringPipeline.cs:177`), distinct from the scan-window
+`rtTolerance` which is `3 * MAD * 1.4826` clamped to `[0.5, 3.0]`. Keeping the two
+values separate is what makes ranking bit-identical to Rust regardless of the
+config clamp (`ScoringPipeline.cs:150-157`).
+
+### Post-selection apex/area/SNR recompute
+
+For non-override entries the winning peak's apex is recomputed over
+`ref_xic[start..end]` (the single highest-intensity fragment, last-on-tie `>=`),
+and `area` / `signal_to_noise` are recomputed from that same slice
+(`PeakDataExtractor.cs:375-420`). This discards the consensus-signal apex (which
+used the summed reference) so the persisted `bounds_area` / `bounds_snr` stay
+consistent with the ref-XIC boundary — the C# comment documents ~32k `peak_apex`
+and ~560 `bounds_area` rows that diverged before this recompute was added.
+
+### Calibration-path minimum correlation
+
+In the calibration pass, `Osprey.Tasks/Calibrator.cs:54` defines
+`MIN_COELUTION_CORR_SCORE = 0.5`: a calibration match is rejected if no candidate
+peak reaches that mean-correlation floor, matching the Rust `batch.rs` threshold.
+The main first-pass search (`PeakDataExtractor`) does not apply a hard correlation
+floor at detection — coelution enters the SVM as feature 0.
+
+### Optional: learned linear pick model (opt-in)
+
+The product-form `rankScore` above is the **default** pick — it is the
+Rust-parity / regression-golden path, so it is what the reference datasets are
+frozen against. An opt-in alternative replaces that product with a **frozen
+standardized linear model** over the same terms plus the per-candidate
+median-polish library cosine (`PickLdaModel.Score`, `PeakDataExtractor.cs:330`;
+`Osprey.Scoring/PickLdaModel.cs`):
+
+```
+rank = w0*z(coelution) + w1*z(ln_intensity) + w2*z(rt_penalty) + w3*z(median_polish)
+z(x) = (x - mean) / scale          (a zero scale contributes 0 for that term)
+```
+
+The argmax and `TotalOrder` tie-break are unchanged, so only the ranking scalar
+differs. Selection precedence, resolved once at process start
+(`Osprey.Core/OspreyEnvironment.cs`; `PeakDataExtractor.cs:231-239`):
+
+1. `OSPREY_PICK_LDA_MODEL` set to an existing JSON file → that model (test / retrain override);
+2. else `OSPREY_PICK_LDA` set and not `0` → the hardcoded resolution-keyed model
+   (`PickLdaModel.ForResolution` — Stellar weights for unit resolution, Astral for HRAM);
+3. else (**default**) → the legacy product pick.
+
+A model JSON must list `features` as `[coelution, ln_intensity, rt_penalty,
+median_polish]` in that exact order (positional weights; `LoadFromEnv` throws a
+`FormatException` otherwise). Models are trained offline from an
+`OSPREY_PICK_DUMP_CANDIDATES` per-candidate capture — see
+[peak-model-training.md](peak-model-training.md) for the capture → train →
+promote recipe and the score equations. The Rust reference carries the identical
+model and loader (`crates/osprey/src/pick_lda.rs`), kept in lock-step for parity.
+
+---
+
+## Step 6: Tukey median polish (scoring features)
+
+After the winning peak is chosen, `CoelutionScorer.ScoreCandidate` crops the XICs
+to `[start..end]` and runs `TukeyMedianPolish.Compute(peakXics, peakRts,
+maxIter = 10, tol = 0.01)` (`CoelutionScorer.cs:242`).
+
+`TukeyMedianPolish.Compute` (`TukeyMedianPolish.cs:103`) decomposes the
+`fragment × scan` matrix in ln space into `overall + rowEffects + colEffects +
+residuals`, treating zero-intensity cells as NaN (missing) via `NanMedian`. Each
+iteration does a row sweep then a column sweep, updating `overall`, and checks
+`max|new - old| < tol` after both sweeps (`TukeyMedianPolish.cs:146-237`). The
+linear-space elution profile is `exp(overall + colEffects[s])`.
+
+Four PIN features are derived from the decomposition (indices per
+`CoelutionScorer.cs:269-273`, computed by the `OspreyFeatureCalculators`):
+
+- `median_polish_cosine` — `LibCosine` (`TukeyMedianPolish.cs:291`): sqrt-space
+  cosine of row effects vs library fragment intensities.
+- `median_polish_residual_ratio` — `ResidualRatio` (`TukeyMedianPolish.cs:344`):
+  `sum|obs - pred| / sum(obs)` in linear space.
+- `median_polish_min_fragment_r2` — `MinFragmentR2` (`TukeyMedianPolish.cs:385`).
+- `median_polish_residual_correlation` — `ResidualCorrelation`
+  (`TukeyMedianPolish.cs:428`): mean pairwise Pearson of residuals.
+
+In this C# port the median polish is used **only** for these scoring features (and
+as fallback-detector input in Step 3). It does **not** supply the peak boundaries
+written to output — those come from the CWT/detected peak (see Step 7 and the
+divergences).
+
+---
+
+## Step 7: Building the FdrEntry (boundaries, area, S/N, candidates)
+
+`CoelutionScorer.BuildFdrEntry` (`CoelutionScorer.cs:395`) assembles the
+`FdrEntry` from the winning peak:
+
+- `StartRt` / `EndRt` = `windowRts[startScan + bestPeak.Start/EndIndex]`
+  (`CoelutionScorer.cs:462-463`) — i.e. the **CWT/detected peak boundaries**.
+- `ApexRt` / `ScanNumber` = the apex spectrum's RT and scan.
+- `BoundsArea` = `bestPeak.Area`, `BoundsSnr` = `bestPeak.SignalToNoise`
+  (`CoelutionScorer.cs:473-474`).
+- `CoelutionSum` and `Score` are seeded from feature 0 (mean pairwise coelution).
+- `FragmentMzs` / `FragmentIntensities` serialize the **full** library fragment
+  list, and `ReferenceXic{Rts,Intensities}` slice the reference XIC across
+  `[start..end]` for the reconciled `.scores.parquet` write-back.
+
+### Stage 6 CWT-candidate capture
+
+`CoelutionScorer.CaptureCwtCandidates` (`CoelutionScorer.cs:321`) keeps the
+top-`N` peaks (`ReconciliationConfig.TopNPeaks`, default 5;
+`ReconciliationConfig.cs:36`) ranked by penalized `rankScore`, each with its
+apex/area/SNR recomputed over the reference-XIC slice, storing the **raw**
+coelution score (not the RT-penalized rank) as `CoelutionScore`. These become the
+`CwtCandidate` list (`Osprey.Core/CwtCandidate.cs`) serialized into the parquet
+`cwt_candidates` column (6 little-endian f64 per candidate,
+`CwtCandidateCodec`) for cross-run reconciliation (`see
+10-cross-run-reconciliation.md`). The override path leaves this list empty,
+matching Rust.
+
+---
+
+## Boundary-override path (Stage 6 re-scoring)
+
+When `context.BoundaryOverrides` supplies an `(apex, start, end)` RT triple for a
+candidate (`PeakDataExtractor.cs:87-92`), peak detection and the signal pre-filter
+are skipped. `FindScanRange` uses the override bounds plus a margin
+(`max(0.2, peakWidth)` each side) for SNR context (`PeakDataExtractor.cs:499-514`),
+and `BuildOverridePeaks` (`PeakDataExtractor.cs:614`) constructs a single synthetic
+`XICPeakBounds` by mapping the RT triple onto the reference-XIC axis via
+lower-bound binary search with Rust `partition_point` / `saturating_sub`
+semantics. Override entries also skip the apex-acceptance filter and the
+post-selection apex recompute. See `11-boundary-overrides.md`.
+
+---
+
+## MS1 data production (HRAM only)
+
+On HRAM runs `PeakDataExtractor.ProduceMs1Data` (`PeakDataExtractor.cs:697`)
+builds the precursor chromatogram (nearest-MS1 sampling, missing scans skipped),
+its co-sampled reference fragment chromatogram, and the apex isotope envelope,
+feeding the `ms1_precursor_coelution` and `ms1_isotope_cosine` features. On
+unit-resolution runs no MS1 data is produced and both features evaluate to 0.0
+(`context.Resolution.HasMs1Features` gate, `PeakDataExtractor.cs:453`).
+
+---
+
+## Flags and switches
+
+| Flag / config / env var | Default | Effect on this stage |
+|---|---|---|
+| `--no-prefilter` (`OspreyConfig.PrefilterEnabled`) | `true` (prefilter on) | When on, the 2-of-top-6-in-3-of-4-scans signal pre-filter (`PeakDataExtractor.cs:117`) drops noise-only candidates before XIC extraction. `--no-prefilter` scores every candidate. |
+| `--fragment-tolerance` / `--fragment-unit` | `ppm`; unit-resolution forces `mz 0.5` | Fragment match tolerance for XIC extraction and the pre-filter. |
+| `--resolution {unit\|hram\|auto}` | `auto` | Selects the resolution strategy; HRAM enables the MS1 chromatogram/isotope features produced here, unit resolution disables them. |
+| `MinRtTolerance` / `MaxRtTolerance` (`RTCalibrationConfig`) | `0.5` / `3.0` min | Clamp on the scan-window `rtTolerance = 3*MAD*1.4826` (`RTCalibration.SearchWindowHalfWidth`). The XIC extraction half-width is `rtTolerance + max(rtTolerance, 0.1)`; the apex-acceptance filter uses `rtTolerance`. The RT-penalty sigma (`5*MAD*1.4826`, floor 0.1) is deliberately **not** clamped. |
+| `FallbackRtTolerance` (`RTCalibrationConfig`) | used when no RT calibration | Sets both `rtTolerance` and `rtSigma` when calibration is absent (`ScoringPipeline.cs:185-186`). |
+| `ReconciliationConfig.TopNPeaks` | `5` | Number of CWT candidates captured per entry for reconciliation (`CoelutionScorer.cs:328`). `0` captures none. |
+| `--task PerFileRescoring` (Stage 6) | off | Activates the boundary-override path: detection skipped, bounds taken from the supplied triple (`see 11-boundary-overrides.md`). |
+| `OSPREY_PICK_LDA` | unset (product pick) | Replaces the default product-form pick with the hardcoded resolution-keyed learned linear model (`PickLdaModel.ForResolution`). Off by default. |
+| `OSPREY_PICK_LDA_MODEL` | unset | Path to a frozen JSON pick model that overrides the built-in model; its `features` order is validated on load. See [peak-model-training.md](peak-model-training.md). |
+| `OSPREY_PICK_DUMP_CANDIDATES` | unset | Dumps one row per CWT candidate (the raw pick terms) to `<stem>.pick_candidates.tsv` for offline pick-model training. Byte-identical / zero cost when unset. |
+| `OSPREY_DIAG_XIC_ENTRY_ID` / `OSPREY_DIAG_XIC_PASS` | unset | Dumps the per-entry search XIC and CWT peak list (`PeakDataExtractor.cs:154-160`, `312-347`). |
+| `OSPREY_DUMP_CWT_PATH` (CWT-path row) | unset | Emits detection counters (n CWT peaks, n scored, success) per entry (`PeakDataExtractor.cs:466-471`). |
+| `OSPREY_TRACE_PEPTIDE` | unset | Per-peptide `[trace]` lines through CWT scoring and downstream stages (`see 18-peptide-trace.md`). |
+
+Compile-time constants (not CLI-exposed): `COVERAGE_FACTOR = 2.0`,
+`VALLEY_THRESHOLD = 0.05`, `MIN_SCALE = 2.0`, `MAX_SCALE = 20.0`,
+`DEFAULT_SCALE = 4.0`, `FWHM_TO_SIGMA = 2.355` (`CwtPeakDetector.cs:44-69`);
+SG `peak_boundary = 5.0` and `minHeight = 0.01` in the fallback calls
+(`PeakDataExtractor.cs:581,601`).
+
+---
+
+## Testing
+
+- `Osprey.Test/ChromatographyTest.cs` — kernel zero-mean / symmetry / positive
+  center, convolution same-length and delta response, scale estimation (known
+  peak and all-zero fallback to 4.0), consensus single Gaussian, two separated
+  peaks, and interference rejection; trapezoidal area and the simple
+  `PeakDetector.Detect`.
+- `Osprey.Test/PeakDetectorTest.cs` — `Detect` end-of-series and min-width,
+  `FindBestPeak`, the Savitzky-Golay smoother (constant preservation, negative
+  clamp, short-series passthrough), and the full `DetectAllXicPeaks` valley/FWHM
+  path.
+
+These are MSTest ports of the Rust `#[cfg(test)]` cases listed in the Rust doc.
+The standing cross-impl parity gate (`regression.ps1`, `see 19-testing.md`)
+compares Stage 7 output and the .blib, which transitively exercises this stage on
+the reference datasets.
+
+---
+
+## Divergences from the Rust documentation
+
+- **[INTENTIONAL — opt-in, off by default] Learned linear pick model** - Beyond
+  the product-form pick the Rust algorithm doc describes, both implementations
+  now carry an opt-in frozen linear pick model (`OSPREY_PICK_LDA` /
+  `OSPREY_PICK_LDA_MODEL`; `Osprey.Scoring/PickLdaModel.cs`, Rust
+  `crates/osprey/src/pick_lda.rs`, kept in lock-step). It is **off by default**,
+  so the reference-dataset parity path (the product pick) is unchanged; when
+  enabled it substitutes only the ranking scalar (argmax + `TotalOrder` tie-break
+  unchanged). The Rust `docs/05-peak-detection.md` predates this feature. Trained
+  offline — see [peak-model-training.md](peak-model-training.md). Evidence:
+  `Osprey.Scoring/PeakDataExtractor.cs:231-239,330`. Severity: info.
+
+- **[STALE-RUST-DOC] Peak selection uses an RT-penalized rank score, not pure
+  correlation** - Rust doc §"Peak Selection" (Stage 2) says the peak with the
+  highest mean pairwise fragment correlation wins. C# ranks by
+  `coelution * exp(-dt^2 / (2*sigma^2)) * ln(1 + apex_intensity)` — a Gaussian RT
+  penalty and a log-intensity tiebreaker on top of correlation. The C# comments
+  attribute this to Rust `pipeline.rs:6685-6760` (RT penalty) and commit 4d0119d
+  (intensity tiebreaker), and the Rust CLAUDE.md itself calls the RT penalty
+  critical for protein-FDR calibration, so the Rust *code* has this and the doc is
+  behind. Evidence: `Osprey.Scoring/PeakDataExtractor.cs:289`. Severity: minor.
+
+- **[STALE-RUST-DOC] Median-polish iteration/convergence parameters** - Rust doc
+  §"Tukey Median Polish / Algorithm" specifies 20 iterations and a `1e-4`
+  convergence tolerance. The C# main-search call site uses `maxIter = 10`,
+  `tol = 0.01`, with a comment that this "Matches Rust pipeline.rs:5198-5212"
+  (i.e. the Rust code was changed and the doc's 20 / 1e-4 is the old
+  default). The `Compute` method's own XML default is still documented as
+  20 / 1e-4, but the actual call overrides it. Evidence:
+  `Osprey.Scoring/CoelutionScorer.cs:242`; defaults at
+  `Osprey.Scoring/TukeyMedianPolish.cs:100-101`. Severity: minor.
+
+- **[UNVERIFIED] Blib peak boundaries come from the CWT/detected peak, not
+  median-polish FWHM** - Rust doc §"Peak Boundaries for Blib Output" gives a
+  priority list where Tukey median-polish FWHM (`apex ± 1.96σ`) is priority 1 and
+  CWT boundaries are the fallback. In the C# scoring path the `FdrEntry.StartRt /
+  EndRt` written for output are the CWT/detected `bestPeak` boundaries; median
+  polish is consumed only for the four scoring features, never for output bounds.
+  Evidence: `Osprey.Scoring/CoelutionScorer.cs:462-463` (bounds from `bestPeak`);
+  median-polish use confined to `CoelutionScorer.cs:242,269-273`. Because the
+  README asserts the .blib is cross-impl bit-identical, the Rust code most likely
+  also writes CWT bounds (making the doc stale), but the C# BLIB writer
+  (`Osprey.IO/BlibWriter.cs`) was not read here to confirm no median-polish
+  boundary is re-derived downstream. A human should confirm the RetentionTimes
+  `startTime`/`endTime` source in the blib writer. Severity: minor.
+
+- **[STALE-RUST-DOC] Scale-space / ridge-tracking search is aspirational (design
+  spec)** - The historical `DIA-PeakDetectionPlan.md` §5.2 proposes wrapping
+  detection in a loop over scales `[2, 4, 8, 16]` with ridge tracking across
+  scales, and §Phase 2 proposes an `S/N < 3` consensus threshold. Neither is
+  implemented: C# estimates a **single** data-driven scale from the median FWHM
+  (`CwtPeakDetector.EstimateScale`) and calls `DetectConsensusPeaks` with
+  `minConsensusHeight = 0.0` (accept any positive consensus peak). The later
+  `05-peak-detection.md` doc already reflects the single-scale reality; only the
+  earlier plan is aspirational. Evidence: `Osprey.Chromatography/CwtPeakDetector.cs:161,551`;
+  call at `Osprey.Scoring/PeakDataExtractor.cs:560`. Severity: info.
+
+- **[STALE-RUST-DOC] No linear-baseline background subtraction on integrated
+  area** - `DIA-PeakDetectionPlan.md` §4.4 (Quantitation) proposes trapezoidal AUC
+  minus a linear baseline connecting the start/end intensities. The C# area is a
+  plain trapezoidal integral of the raw reference signal with no baseline
+  subtraction (`PeakDetector.TrapezoidalArea`), consistent with the current
+  `05-peak-detection.md` guidance that XIC area is a relative measure and must not
+  be used for quantification (Skyline quantifies within the provided boundaries).
+  Evidence: `Osprey.Chromatography/PeakDetector.cs:178-191`. Severity: info.
+
+- **[STALE-RUST-DOC] Consensus aggregation is median, not the sum shown in the
+  plan's sample code** - `DIA-PeakDetectionPlan.md` §4.3 sums per-transition CWTs
+  in its illustrative Rust (`consensus = consensus + cwt`), noting in a comment
+  that the real implementation should use the median. C# uses the pointwise median
+  (`ConsensusMedianCwt`), matching the production `05-peak-detection.md` doc.
+  Evidence: `Osprey.Chromatography/CwtPeakDetector.cs:265`. Severity: info.
+
+Otherwise the C# implementation matches the Rust `05-peak-detection.md`
+description step for step: the Mexican Hat kernel formula and zero-mean
+correction, data-driven scale with the same clamps and 4.0 fallback, same-size
+zero-padded convolution, pointwise-median consensus, zero-crossing + ±2σ boundary
+extension with the 5%-of-apex valley guard, reference-signal apex/area/S/N,
+`XICPeakBounds` output fields, the 3-tier fallback chain, the legacy SG detector
+(SG smoothing, valley walks, asymmetric FWHM capping, flanking-point S/N), the
+median-polish decomposition and its four features, and the extraction-vs-apex
+window decouple with its wider extraction window and post-detection apex filter.
+The parity-critical tie-breaks (last-on-tie `>=` for apex/reference selection,
+stable `OrderByDescending` for peak sorting, `TotalOrder` compares for signed-zero
+ranks) are all present and documented in-code.

--- a/pwiz_tools/Osprey/docs/07-fdr-control.md
+++ b/pwiz_tools/Osprey/docs/07-fdr-control.md
@@ -1,0 +1,437 @@
+# 07. FDR Control (C#)
+
+> Pipeline stage: Stage 5 (first-pass) & Stage 7 (second-pass). C# port of Rust docs/07-fdr-control.md. Corresponds to Rust osprey FDR control.
+
+This document describes how the C# Osprey port controls the false discovery rate
+(FDR) of peptide/precursor identifications. It is a native managed reimplementation
+of the Rust `osprey-fdr` + `osprey-ml` crates: there is **no Python dependency, no
+external Mokapot subprocess, and no PIN-file round-trip on the default path**. The
+default engine is a native linear-SVM Percolator that trains and scores entirely
+in-process. See `08-protein-parsimony.md` for protein-level FDR (parsimony +
+picked-protein), and `10-cross-run-reconciliation.md` for how Stage 6 reconciliation
+feeds the second FDR pass.
+
+Primary C# code:
+
+| File | Role |
+|------|------|
+| `Osprey.FDR/PercolatorEngine.cs` | Orchestration: build `PercolatorEntry` input, dispatch, write results back onto stubs, best-of-runs clamp |
+| `Osprey.FDR/PercolatorFdr.cs` | Native Percolator: standardize, subsample, fold assignment, SVM training, Granholm calibration, PEP, q-values |
+| `Osprey.FDR/PercolatorEntryBuilder.cs` | Build the flat `PercolatorEntry` list from `FdrEntry` stubs |
+| `Osprey.FDR/FdrController.cs` | Simple target-decoy competition (used by `--fdr-method simple`) |
+| `Osprey.FDR/FdrProjection.cs`, `FdrProjectionOutput.cs` | Thin peak-buffer projection path (issue #4355) driving the identical SVM core |
+| `Osprey.ML/LinearSvmClassifier.cs` | L2-regularized linear SVM via dual coordinate descent + grid search for C |
+| `Osprey.ML/PepEstimator.cs` | Posterior error probability (KDE + isotonic/PAVA), Sage-derived |
+| `Osprey.ML/QValueCalculator.cs`, `MlMath.cs` | Conservative q-value helpers and math primitives |
+| `Osprey.Core/FdrEntry.cs` | The FDR result stub with the six q-value fields + `EffectiveRunQvalue`/`EffectiveExperimentQvalue` |
+| `Osprey.Tasks/FirstJoinTask.cs` | Stage 5 first-pass FDR driver (HPC `--task FirstPassFDR`) |
+| `Osprey.Tasks/Pass2FdrSidecar.cs`, `MergeNodeTask.cs` | Stage 7 second-pass FDR driver (HPC `--task SecondPassFDR`) |
+
+---
+
+## Overview: pipeline order
+
+The FDR stage runs twice in the two-pass architecture:
+
+```text
+Stage 5 (first pass, after per-file coelution scoring):
+  1. Each observation carries a 21-feature PIN vector (see 03-spectral-scoring.md),
+     cached per file in .scores.parquet; the resident buffer is a lightweight FdrEntry stub.
+  2. Build a flat PercolatorEntry list (one per observation) from the stubs.
+  3. Dispatch by --fdr-method:
+       percolator (default) -> native streaming linear-SVM Percolator
+       gbdt                 -> same Percolator framework, GBDT classifier per fold (C#-only)
+       simple               -> direct target-decoy competition on coelution_sum
+  4. Native Percolator produces four q-value levels (run/experiment x precursor/peptide),
+     PEP, and a combined SVM score; write them back onto the FdrEntry stubs.
+  5. Best-of-runs clamp on experiment q-values.
+  6. (Optional) first-pass protein FDR gate; compaction drops non-passing stubs.
+
+Stage 6: cross-run reconciliation re-scores moved / gap-filled peaks (10-cross-run-reconciliation.md).
+
+Stage 7 (second pass, authoritative):
+  7. Re-run the identical Percolator core over the reconciled entries, write
+     .2nd-pass.fdr_scores.bin sidecars, reload stubs with the fresh q-values.
+  8. Re-apply the best-of-runs clamp (Stage 6 reset the run q-values of moved peaks).
+  9. Second-pass protein FDR (authoritative) + blib output.
+```
+
+The two passes call the **same** `PercolatorEngine.RunPercolatorFdr` core (with
+`passLabel` `"First-pass"` vs `"Second-pass"`), so training, calibration, and q-value
+math are shared source (`PercolatorEngine.cs:59`, `Pass2FdrSidecar.cs:521`).
+
+---
+
+## Step 1 — FDR input: `FdrEntry` stubs and the `PercolatorEntry` list
+
+After per-file coelution scoring, each observation is represented by an
+`FdrEntry` stub (`Osprey.Core/FdrEntry.cs:33`): `EntryId`, `ParquetIndex`,
+`IsDecoy`, `Charge`, `ScanNumber`, RT bounds, `CoelutionSum`, `Score`, the six
+q-value fields, `Pep`, and the interned `ModifiedSequence`. The heavy 21-feature
+vector is *not* held resident on the streaming path — it is reloaded on demand from
+`.scores.parquet` by `ParquetIndex` (`FirstJoinTask.cs` `loadFileFeatures`
+delegate).
+
+Target/decoy pairing uses the high bit of `EntryId`: `base_id = EntryId & 0x7FFFFFFF`
+(`PercolatorFdr.cs:258`, `BASE_ID_MASK = 0x7FFFFFFF`). A target and its paired decoy
+share `base_id`; the decoy has the high bit set.
+
+`PercolatorEntryBuilder.Build` (`PercolatorEngine.cs:105`) emits exactly one
+`PercolatorEntry` per stub in nested `(file, entry)` order. Results are later zipped
+back **by position** — the former psm_id-keyed re-join was removed as redundant
+(`PercolatorEngine.ApplyPercolatorResults`, `PercolatorEngine.cs:404`). Before
+building, each file's entries are sorted by `(EntryId, Charge, ScanNumber,
+ParquetIndex)` so the SVM working-set order is canonical across Rust and C#
+(`PercolatorEngine.cs:82`).
+
+---
+
+## Step 2 — Dispatch by FDR method
+
+`FirstJoinTask.cs` switches on `config.FdrMethod`:
+
+- `FdrMethod.Percolator` (default) → `PercolatorEngine.RunPercolatorFdr` (linear SVM)
+- `FdrMethod.Gbdt` → the **same** Percolator framework with a gradient-boosted-tree
+  classifier swapped in per fold (`--fdr-method gbdt`; C#-only, see below)
+- `FdrMethod.Simple` → `PercolatorEngine.RunSimpleFdr`
+- any other value → falls back to `RunSimpleFdr` with a warning
+
+`--fdr-method` accepts `percolator | gbdt | simple` (`OspreyCommandArgs.cs:120`; the
+deprecated alias `fasttree` also parses → `Gbdt`). `FdrMethod.Mokapot` exists in the
+enum but **is not reachable from the CLI** — there is no Mokapot runner, no PIN-writing
+pre-competition, and no external subprocess in the C# port. See Divergences.
+
+### Simple FDR (`--fdr-method simple`)
+
+`PercolatorEngine.RunSimpleFdr` (`PercolatorEngine.cs:350`) runs
+`FdrController.CompeteAndFilter` per file, scoring directly by `e.CoelutionSum`
+(PIN feature 0, `fragment_coelution_sum`) with no ML reranking and no ROC-AUC feature
+selection. Passing targets get `RunPrecursorQvalue = RunPeptideQvalue =
+ExperimentPrecursorQvalue = ExperimentPeptideQvalue = FdrAtThreshold`; everything else
+stays at the `1.0` default. This is a baseline path; the default is Percolator.
+
+### GBDT FDR (`--fdr-method gbdt`) — C#-only, no Rust counterpart
+
+`gbdt` reuses the **entire** Percolator scaffold documented below — feature
+standardization, 3-fold peptide-grouped CV, semi-supervised positive-set iteration,
+cross-fold score calibration, PEP, and the four q-value levels — and swaps only the
+per-fold classifier: `GradientBoostedTrees` (`Osprey.ML/GradientBoostedTrees.cs`)
+instead of the linear SVM. It is a pure-managed second-order (Newton) boosting
+implementation with the XGBoost regularized objective (logistic loss, per-leaf L2/L1,
+min split gain, row/column subsampling, histogram split finding), made deterministic
+with `XorShift64` and single-threaded float accumulation.
+
+Two structural differences from the SVM path (`PercolatorFdr.TrainFoldGbt`): there is
+**no `GridSearchC`** (trees have no cost parameter), and iteration selection is
+**honest** — because trees grow monotonically the in-sample passing count would always
+pick the most-overfit round, so the best iteration is chosen on a held-out inner split
+(`OSPREY_GBT_INNER_FOLDS`, default 5). Full-population scoring averages fold **scores**
+(trees can't be weight-averaged). The default iteration cap is `OSPREY_GBT_MAX_ITERATIONS`
+= 30 (vs the SVM's fixed 10); hyperparameters are overridable via `OSPREY_GBT_*`
+(gamma / lambda / alpha / max-depth / n-trees / min-child-weight / learning-rate /
+subsample / colsample).
+
+**This method has no Rust counterpart** — grepping the Rust crates for
+`gbdt`/`GradientBoost` returns nothing. It is a C# addition *beyond* the reference
+engine, so it carries no cross-impl parity claim; `--fdr-method percolator` remains the
+default and the parity-gated path.
+
+---
+
+## Step 3 — Native Percolator (default)
+
+`PercolatorFdr.RunPercolator` (`PercolatorFdr.cs:264`) implements the semi-supervised
+Percolator of Käll et al. (2007). Both targets and their paired decoys enter — no
+upstream competition. The C# port is **streaming-only**: the former sub-threshold
+"direct" branch that trained on all entries was removed to match Rust's streaming-only
+change, so C# and Rust fit the standardizer on the identical best-per-precursor subset
+at every scale (`PercolatorEngine.DispatchSvm`, `PercolatorEngine.cs:336`;
+`RunPercolatorStreaming`, `PercolatorEngine.cs:473`).
+
+### 3a. Standardize features
+
+`FeatureStandardizer.FitTransform` standardizes every feature to zero mean / unit
+variance (`PercolatorFdr.cs:292`). On the streaming path the standardizer is fit on the
+**training subset**, not the full population (`RunPercolatorStreaming`).
+
+### 3b. Best-per-precursor dedup + peptide-grouped subsample
+
+`PercolatorFdr.BuildTrainingSubset` (called at `PercolatorFdr.cs:338` and from both
+streaming callers) does two things, keeping target/decoy pairs and all charge states of
+a peptide together:
+
+1. **Best-per-precursor**: `SelectBestPerPrecursor` picks the single best-scoring
+   observation per `(base_id, isDecoy)` across all files, ranked by `CoelutionSum`
+   (byte-identical to `Features[0]` on the first pass). With N files this avoids the SVM
+   seeing the same precursor's pair N times. This dedup applies on *all* multi-file
+   inputs — the comment at `PercolatorFdr.cs:320` notes Rust was patched to match.
+2. **Subsample**: if the dedup set still exceeds `MaxTrainSize` (default **300000**,
+   `PercolatorConfig` ctor `PercolatorFdr.cs:123`), `SubsampleByPeptideGroup` samples
+   whole peptide groups using the same XOR-shift PRNG seed (default **42**) and
+   peptide-key sort order as Rust.
+
+The learned model is later applied to **all** entries, not just the subset.
+
+### 3c. Fold assignment
+
+`CreateStratifiedFoldsByPeptide` (`PercolatorFdr.cs:390`) assigns 3 folds
+(`NFolds = 3`) grouping by target peptide via `base_id`, so all charge states and the
+paired decoy of a peptide land in the same fold. This enforces the critical invariant:
+splitting pairs across folds would let unpaired targets auto-win competition in a
+training fold and make the SVM too permissive.
+
+### 3d. Best initial feature
+
+`FindBestInitialFeature` (`PercolatorFdr.cs:411`) scores every entry by each single
+standardized feature (ascending only) and counts targets passing after paired
+competition; the feature with the most passing targets seeds iteration 0. If zero pass at
+the train FDR, it relaxes to 5% (`PercolatorFdr.cs:414`). The chosen feature name is
+logged via `config.FeatureInfos`.
+
+### 3e. Iterative SVM training per fold
+
+Folds train in parallel via `OspreyParallel.For` (explicit dedicated threads, chosen over
+TPL because the TaskReplicator throttled effective parallelism) — `PercolatorFdr.cs:488`.
+Each fold runs `TrainFold` up to `MaxIterations = 10` iterations:
+
+1. Select the positive training set: targets passing `TrainFdr` on the current scores;
+   if fewer than `MIN_POSITIVE = 50` (`PercolatorFdr.cs:259`) pass, relax progressively.
+2. Build the SVM set: selected targets (positive) + all decoys (negative).
+3. Grid-search C over `CValues = {0.001, 0.01, 0.1, 1.0, 10.0, 100.0}`
+   (`PercolatorFdr.cs:122`) via inner CV each iteration.
+4. Train an L2-regularized linear SVM by dual coordinate descent
+   (`LinearSvmClassifier.cs`).
+5. Score, count passing targets, track the best model; stop after 2 non-improving
+   iterations.
+
+The selected per-fold C is reported on the console (`PercolatorFdr.cs:516`).
+
+### 3f. Score all entries
+
+Held-out CV entries are scored by their fold's model; entries outside the training subset
+are scored by the **average** of all fold models (`PercolatorFdr.cs:565-627`). On the
+streaming path this is done by `ScorePopulationAndComputeFdr` /
+`ScoreProjectionAndComputeFdrInPlace`, which average the fold weights + bias and apply
+`standardizer` + averaged model to every entry, reloading features one file at a time
+(`PercolatorFdr.cs:760`, `PercolatorFdr.cs:1110`).
+
+### 3g. Granholm score calibration between folds
+
+`CalibrateScoresBetweenFolds` (`PercolatorFdr.cs:2105`) linearly normalizes each fold's
+scores per Granholm et al. (2012): the score at the FDR threshold maps to 0 and the median
+decoy score maps to -1, via `(score - thresholdScore) / (thresholdScore - medianDecoy)`
+(`PercolatorFdr.cs:2149-2154`).
+
+### 3h. Posterior error probability (PEP)
+
+`PepEstimator.FitDefault` (`Osprey.ML/PepEstimator.cs:67`) fits PEP on the competition
+**winners only** using KDE for the target/decoy score densities, Bayes' rule for
+`P(decoy | score)`, and isotonic regression (PAVA) for monotonicity (default 1000 bins,
+`DEFAULT_N_BINS`). Non-winners get `Pep = 1.0`. For byte-exact cross-impl parity the
+winner arrays are re-sorted **base_id-ascending** before the fit, because the KDE sum is
+non-associative (`ComputeStreamingCompetitionQvalues`, `PercolatorFdr.cs:977`). PEP is
+Sage-derived (MIT-licensed header at `PepEstimator.cs:31`), the same origin as the Rust
+implementation.
+
+### 3i. Q-values at four levels
+
+All q-values use the conservative `(decoys + 1) / targets` estimate with a backward
+monotonicity sweep (`ComputeQvaluesCore`, `PercolatorFdr.cs:1881`,
+`decoyOffset = 1` for conservative). The four levels
+(`ScorePopulationAndComputeFdr` / `ComputeStreamingCompetitionQvalues`,
+`PercolatorFdr.cs:998-1019`):
+
+| Level | Scope | Method |
+|-------|-------|--------|
+| Run precursor | within each file, per precursor | `ComputePerRunPrecursorQvalues` |
+| Run peptide | within each file, best precursor per peptide | `ComputePerRunPeptideQvalues` |
+| Experiment precursor | across files, best obs per precursor | `ComputeExperimentPrecursorQvalues` |
+| Experiment peptide | across files, best obs per peptide | `ComputeExperimentPeptideQvalues` |
+
+**Single-file shortcut**: when only one file is present, experiment q-values are a clone
+of the run q-values (`PercolatorFdr.cs:682`, `PercolatorFdr.cs:1008`) — no separate
+aggregation.
+
+### 3j. Best-of-runs clamp on experiment q-values
+
+Experiment-level FDR competes each precursor's single best observation against a thinner
+de-duplicated decoy null, so the raw experiment q can fall **below** every per-run q,
+producing reported peptides with no run-level ID line. The clamp floors each entry's
+experiment q up to its own best (min-over-runs) **combined** run q
+(`runBoth = max(runPrecursorQ, runPeptideQ)`, i.e. `FdrLevel.Both`):
+
+```text
+ExperimentPrecursorQvalue <- max(ExperimentPrecursorQvalue, min-over-runs runBoth)  [by EntryId]
+ExperimentPeptideQvalue   <- max(ExperimentPeptideQvalue,   min-over-runs runBoth)  [by (ModifiedSequence, IsDecoy)]
+```
+
+Both floors key on the target/decoy-specific identity (never the shared `base_id` or bare
+sequence), so a decoy's good run cannot lower its paired target's floor. Two identical
+implementations exist: the memory-bounded flat form `ClampExperimentQToBestRunFlat`
+runs in-pass over the score arrays (`PercolatorFdr.cs:1040`); the resident overload
+`PercolatorEngine.ClampExperimentQToBestRun` (`PercolatorEngine.cs:864`) is re-applied
+after Stage 6 reconciliation in `MergeNodeTask`, because reconciliation resets the run
+q-values of moved and gap-filled peaks (issue #4390).
+
+---
+
+## Step 4 — Dual precursor + peptide FDR (the effective q-value)
+
+A precursor must pass at **both** the precursor level (`ModifiedSequence` + `Charge`) and
+the peptide level (`ModifiedSequence` only). This is the `FdrLevel.Both` selection —
+`max(precursor_q, peptide_q)` — implemented in `FdrEntry.EffectiveRunQvalue` /
+`EffectiveExperimentQvalue` (`FdrEntry.cs:136`, `FdrEntry.cs:154`):
+
+```csharp
+case FdrLevel.Precursor: return RunPrecursorQvalue;
+case FdrLevel.Peptide:   return RunPeptideQvalue;
+case FdrLevel.Both:      return Math.Max(RunPrecursorQvalue, RunPeptideQvalue);
+```
+
+Which level actually gates the reported output is controlled by `--fdr-level`
+(default **Precursor** — see Flags). Note that the best-of-runs clamp above always floors
+by run-**Both** regardless of `--fdr-level`, so "reported ⇒ some run has an ID line" holds
+even under precursor-level control (`PercolatorEngine.cs:850` comment).
+
+---
+
+## Step 5 — Two-level FDR and multi-file observation propagation
+
+- **Run-level FDR**: each file scored independently; controls the per-file FDR.
+- **Experiment-level FDR**: the single best-scoring observation per precursor
+  (`ModifiedSequence` + `Charge`) across all files competes; controls the experiment-wide
+  FDR.
+
+After experiment-level FDR determines passing precursors, all per-file target
+observations for those precursors are carried into the blib output with the best
+experiment q-value propagated to each, so a precursor seen in 3 of 5 files yields 3 blib
+entries (each with its own RT boundaries). See `13-blib-output-schema.md` for the nullable
+`retentionTime` ID-line semantics.
+
+---
+
+## Step 6 — Second pass (Stage 7)
+
+`Pass2FdrSidecar` / `MergeNodeTask` (`--task SecondPassFDR`) reload the reconciled
+`.scores.parquet` entries and re-run the identical Percolator core with `passLabel =
+"Second-pass"` (`Pass2FdrSidecar.cs:521`), writing per-file `.2nd-pass.fdr_scores.bin`
+sidecars so reruns can skip SVM training. Only `FdrMethod.Percolator` is supported in the
+merge-node second pass — any other method throws
+(`Pass2FdrSidecar.cs:530`). The second-pass q-values are authoritative for blib output;
+the best-of-runs clamp is re-applied afterward.
+
+---
+
+## Step 7 — Protein-level FDR (brief; see `08-protein-parsimony.md`)
+
+Protein parsimony always runs. Two-pass picked-protein FDR (Savitski 2015) writes
+`FdrEntry.RunProteinQvalue` (first pass, `ProteinFdr.cs:826`) and
+`FdrEntry.ExperimentProteinQvalue` (second pass, authoritative, `ProteinFdr.cs:781`).
+The ranking score is the maximum peptide SVM discriminant per group; protein-level PEP is
+intentionally not computed. **However**, unlike Rust, the C# `FdrLevel` enum has no
+`Protein` variant, so protein q-values are computed and reported in the protein report but
+**cannot gate the blib output** from the CLI — see Divergences.
+
+---
+
+## Flags and switches
+
+All defaults are from `Osprey.Core/OspreyConfig.cs` and `Osprey/OspreyCommandArgs.cs`.
+
+| Flag / field | Default | Effect on this stage |
+|--------------|---------|----------------------|
+| `--fdr-method {percolator\|gbdt\|simple}` | `percolator` (`OspreyConfig.cs:188`) | Selects the FDR engine. `gbdt` swaps a gradient-boosted-tree classifier into the Percolator framework (**C#-only**; `fasttree` is a deprecated alias). `mokapot` exists in the enum but is **not accepted** by the CLI (`OspreyCommandArgs.cs:120`). |
+| `OSPREY_GBT_MAX_ITERATIONS` / `OSPREY_GBT_*` | `30` / classifier defaults | Iteration cap and hyperparameters for `--fdr-method gbdt` (max-depth, n-trees, learning-rate, subsample, λ/α/γ, min-child-weight, inner folds). Ignored by the SVM path. |
+| `--fdr-level {precursor\|peptide\|both}` | `precursor` (`OspreyConfig.cs:284`) | Which q-value gates reported output via `EffectiveRunQvalue`/`EffectiveExperimentQvalue`. `protein` is **not** a valid value (`OspreyCommandArgs.cs:138`). |
+| `--run-fdr <threshold>` | `0.01` (`OspreyConfig.cs:120`) | Run-level q-value threshold; also the Percolator `TrainFdr`/`TestFdr` (`PercolatorEngine.cs:302`). |
+| `--experiment-fdr <threshold>` | `0.01` (`OspreyConfig.cs:123`) | Experiment-level q-value threshold. |
+| `--reconciliation-compaction-fdr <threshold>` | `0.01` (`OspreyConfig.cs:135`) | Peptide q-value gate for first-pass compaction; loosen (e.g. 0.05) to broaden the reconciliation pool. Protein rescue is additive. |
+| `--protein-fdr <threshold>` | unset → `EffectiveProteinFdr = 0.01` (`OspreyConfig.cs:271`) | Protein machinery **always runs** regardless; this only sets the passing-group threshold. |
+| `--shared-peptides {all\|razor\|unique}` | `all` (`OspreyConfig.cs:274`) | Protein-level shared-peptide handling (see `08-protein-parsimony.md`). |
+| `--write-pin` | off (`OspreyCommandArgs.cs:196`) | Writes PIN files for external tools; diagnostic only — the FDR engine does not consume them. |
+| `--fdrbench <tsv>` | off (`OspreyCommandArgs.cs:179`) | Emit an FDRBench-compatible input TSV (entrapment true-FDR). Level taken from `--fdr-level`. |
+| `--fdrbench-per-run` | off (`OspreyCommandArgs.cs:181`) | One row per (precursor, run) with run-level q-values; default is one row per precursor with experiment q-values. |
+| `--fdrbench-pass {1\|2\|both}` | `2` (`OspreyCommandArgs.cs:183`) | Which pass to emit: 2 = post-compaction second-pass survivors; 1 = full pre-compaction first-pass pool; both = both with `.pass1`/`.pass2` suffixes. |
+| `--model-diagnostics` | off | Also collects per-feature target/decoy histograms + feature-contribution report (`CollectFeatureHistograms`, `PercolatorEngine.cs:310`); forces the resident first-pass pool. Byte-neutral when off. |
+| `--task {PerFileScoring\|FirstPassFDR\|PerFileRescoring\|SecondPassFDR}` | (single-process) | HPC split. `FirstPassFDR`/`SecondPassFDR` are the CLI names; the internal `HpcTask` enum values are `PerFileScoring, FirstJoin, PerFileRescore, MergeNode` (`OspreyConfig.cs:388`). See `15-hpc-scoring-split.md`. |
+
+Internal Percolator constants (not CLI-exposed; `PercolatorConfig` ctor
+`PercolatorFdr.cs:115`): `MaxIterations = 10`, `NFolds = 3`, `Seed = 42`,
+`CValues = {0.001,0.01,0.1,1,10,100}`, `MaxTrainSize = 300000`.
+
+**Diagnostic env vars** (Stage 5 dumps, carried in via `PercolatorDiagnosticsConfig`,
+never read directly by the engine): `OSPREY_DUMP_STANDARDIZER`, `OSPREY_DUMP_PERC_INPUT`,
+`OSPREY_DUMP_SUBSAMPLE`, `OSPREY_DUMP_SVM_WEIGHTS`, each with an `*_ONLY` variant that
+aborts after the dump (`PercolatorFdr.cs:302-534`). `OSPREY_DUMP_LDA_SCORES` affects the
+calibration LDA, not Percolator.
+
+---
+
+## Divergences from the Rust documentation
+
+- **[INTENTIONAL-CSHARP-DESIGN] Native managed Percolator replaces external Mokapot** -
+  Rust doc says three FDR methods exist (native Percolator, external Mokapot via
+  `pip install mokapot` + PIN files + subprocess, and Simple) and documents Mokapot's
+  two-step `--save_models`/`--load_models`/`--aggregate` flow, ROC-AUC pre-competition,
+  and `--subset_max_train` memory logic. C# ships only the native Percolator and Simple:
+  `--fdr-method` accepts `percolator | simple`; the `FdrMethod.Mokapot` enum value is
+  never wired to the CLI and there is no MokapotRunner, no PIN round-trip on the default
+  path, and no Python dependency. Evidence: `Osprey/OspreyCommandArgs.cs:120`,
+  `Osprey.Core/OspreyConfig.cs:422`. Behavior/outputs of the retained engine match Rust.
+  Severity: info.
+
+- **[INTENTIONAL-CSHARP-DESIGN] No `FdrLevel::Protein`; `--fdr-level protein` is
+  unreachable in C#** - Rust doc §"FDR Filtering Level" documents four modes
+  `{precursor, peptide, protein, both}` and `--fdr-level protein` output filtering that
+  reads `experiment_protein_qvalue`. The C# `FdrLevel` enum has only
+  `{Precursor, Peptide, Both}` (`OspreyConfig.cs:411`) and `--fdr-level` accepts only
+  `precursor | peptide | both` (`OspreyCommandArgs.cs:138`).
+  `FdrEntry.EffectiveRunQvalue`/`EffectiveExperimentQvalue` have no `Protein` case and
+  would throw `ArgumentOutOfRangeException` on one (`FdrEntry.cs:136`). Protein q-values
+  are still computed and written to the protein report, but there is **no CLI path to
+  gate the blib output by protein-level FDR**. Two stale in-code comments still reference
+  "`--fdr-level protein` output filtering" (`OspreyConfig.cs:258`, `MergeNodeTask.cs:157`)
+  even though the mode is unreachable. Evidence: `Osprey.Core/OspreyConfig.cs:411`,
+  `Osprey/OspreyCommandArgs.cs:138`, `Osprey.Core/FdrEntry.cs:136`. Severity: major.
+
+- **[STALE-RUST-DOC] Default `--fdr-level` is Precursor, not Peptide** - Rust doc §"FDR
+  Filtering Level" states the default is `Peptide` ("`fdr_level: Peptide  # default`").
+  C# defaults to `FdrLevel.Precursor`, and its own comment states this matches the current
+  Rust `FdrLevel::default() = Precursor` and that a prior `Both` default was a
+  cross-impl-corrupting bug. The Rust doc's "Peptide default" prose is stale relative to
+  the Rust config. Evidence: `Osprey.Core/OspreyConfig.cs:284`. Severity: minor.
+
+- **[C#-ONLY ADDITION] `gbdt` FDR method exists only in C#** - The C# `FdrMethod`
+  enum is `{Percolator, Mokapot, Simple, Gbdt}` and `--fdr-method gbdt` (deprecated
+  alias `fasttree`) selects a gradient-boosted-tree classifier inside the Percolator
+  framework (`Osprey.ML/GradientBoostedTrees.cs`; see "GBDT FDR" above). **The Rust
+  reference has no GBDT scorer** — grepping the Rust crates for `gbdt`/`GradientBoost`
+  returns nothing — so this is a C# addition *beyond* the reference engine, not a port,
+  and carries no cross-impl parity claim. `--fdr-method percolator` remains the default
+  and the parity-gated path. Evidence: `Osprey.Core/OspreyConfig.cs:446-455`,
+  `Osprey/OspreyCommandArgs.cs:120`. Severity: info.
+
+- **[UNVERIFIED] Simple FDR scores on `coelution_sum`, not a ROC-AUC-selected best
+  feature** - Rust doc §"Simple FDR" says the method "applies target-decoy competition
+  directly on the best single feature (selected by ROC AUC)". The C# `RunSimpleFdr` scores
+  directly by `e.CoelutionSum` (PIN feature 0) with no ROC-AUC selection
+  (`PercolatorEngine.cs:359`). Whether the current Rust Simple path also just uses
+  `coelution_sum` (making the doc stale) or truly selects by ROC AUC was not confirmed
+  against Rust source. Simple is a non-default baseline method. Evidence:
+  `Osprey.FDR/PercolatorEngine.cs:350`. Severity: minor.
+
+- **[INTENTIONAL-CSHARP-DESIGN] Streaming-only, matching Rust's v26.7.0 change** - The
+  Rust doc notes the direct (non-streaming) path was removed in v26.7.0 and Percolator
+  "always streams". C# matches: `DispatchSvm` always takes the streaming path and the
+  in-code comments state the former sub-threshold direct branch was removed for parity
+  (`PercolatorEngine.cs:336`, `PercolatorEngine.cs:256`). This is agreement, recorded for
+  completeness. Evidence: `Osprey.FDR/PercolatorEngine.cs:336`. Severity: info.
+
+Everything else verified matches the Rust documentation step for step: the semi-supervised
+linear-SVM algorithm (standardize → best-per-precursor dedup → peptide-grouped subsample
+at 300K → 3-fold peptide-grouped CV → iterative training with C grid search and
+`MIN_POSITIVE = 50` relaxation → Granholm cross-fold calibration → KDE+isotonic PEP on
+winners → four-level conservative `(decoys+1)/targets` q-values), the base_id `0x7FFFFFFF`
+pairing, the dual precursor+peptide `max` rule, the best-of-runs experiment clamp, the
+single-file experiment shortcut, multi-file observation propagation, and the two-pass
+(Stage 5 / Stage 7) architecture with `.2nd-pass.fdr_scores.bin` sidecars.

--- a/pwiz_tools/Osprey/docs/08-protein-parsimony.md
+++ b/pwiz_tools/Osprey/docs/08-protein-parsimony.md
@@ -1,0 +1,357 @@
+# 08. Protein Parsimony & Picked-Protein FDR (C#)
+
+> Pipeline stage: Stage 5 & 7 (protein FDR). C# port of Rust docs/16-protein-parsimony.md. Corresponds to Rust osprey protein parsimony + two-pass picked-protein FDR.
+
+Protein parsimony resolves the peptide-to-protein mapping from the spectral
+library into a minimal set of protein groups that can explain the observed
+peptides. In the C# port the **parsimony machinery always runs** (it is not
+gated by any flag), because the resulting peptide-to-group mapping feeds
+protein-aware compaction, reconciliation consensus selection, and the
+picked-protein FDR passes. The `--protein-fdr` flag is a **threshold only**: even
+when it is omitted the config falls back to `EffectiveProteinFdr = 0.01`
+(`Osprey.Core/OspreyConfig.cs:271`) and the two protein-FDR passes still execute.
+
+The whole stage is a native managed C# port of `osprey-fdr/src/protein.rs`. There
+is no external dependency and no Python component. The two public entry points
+are `ProteinFdr` (the pure algorithm, `Osprey.FDR/ProteinFdr.cs`) and
+`ProteinFdrEngine` (the Tasks-layer orchestration facade,
+`Osprey.FDR/ProteinFdrEngine.cs`).
+
+See `07-fdr-control.md` for the peptide/precursor FDR that produces the SVM
+discriminant scores and q-values this stage consumes, and
+`10-cross-run-reconciliation.md` for how the first-pass protein q-values are used
+as a consensus rescue gate.
+
+---
+
+## Data types
+
+`Osprey.FDR/ProteinFdr.cs` defines the value types used throughout:
+
+- `ProteinGroup` (`ProteinFdr.cs:44`): `Id` (uint), `Accessions` (list of
+  protein accessions sharing an identical peptide set), `UniquePeptides` and
+  `SharedPeptides` (both `HashSet<string>` of modified sequences).
+- `ProteinParsimonyResult` (`ProteinFdr.cs:69`): `Groups` +
+  `PeptideToGroupMap` (`Dictionary<string, List<uint>>`).
+- `PeptideScore` (`ProteinFdr.cs:87`): per-peptide `Score` (best SVM
+  discriminant), `IsDecoy`, and `BestQvalue` (best/lowest run-level **peptide**
+  q-value across files — the Savitski target-side gate).
+- `ProteinFdrResult` (`ProteinFdr.cs:113`): `GroupQvalues` and `GroupScores`
+  (target winners only) + `PeptideQvalues`. There is intentionally **no**
+  `GroupPep` field — protein-level PEP is not computed (matches Rust).
+
+Protein membership comes from `LibraryEntry.ProteinIds`
+(`Osprey.Core/LibraryEntry.cs:54`), a `List<string>` of accessions carried on
+each library entry alongside `ModifiedSequence` and the `IsDecoy` flag
+(`LibraryEntry.cs:56`).
+
+---
+
+## Step 1 — Bipartite graph (target entries only)
+
+`ProteinFdr.BuildProteinParsimony` (`ProteinFdr.cs:215`) walks the full library
+and builds two dictionaries, `peptideToProteins` and `proteinToPeptides`
+(`ProteinFdr.cs:220-248`). For each entry it:
+
+- Skips decoys: `if (entry.IsDecoy) continue;` (`ProteinFdr.cs:226`).
+- Skips undetected peptides when a detected set is supplied:
+  `if (detectedPeptides != null && !detectedPeptides.Contains(entry.ModifiedSequence)) continue;`
+  (`ProteinFdr.cs:228`). The detected set is the peptides passing the relevant
+  peptide-level FDR gate (see the two passes below).
+- Adds an edge for every accession in `entry.ProteinIds`
+  (`ProteinFdr.cs:230-247`). A peptide with an **empty** `ProteinIds` list
+  contributes no edges and therefore never appears in any group — matching the
+  Rust "empty protein_ids excluded" edge case.
+
+## Step 2 — Identical-set merging
+
+Proteins whose detected peptide set is identical are indistinguishable and are
+collapsed into a single group. The C# code builds a canonical set key by sorting
+each protein's peptides ordinally and joining with `|`, then bucketing
+accessions by that key (`peptideSetToAccessions`, `ProteinFdr.cs:250-265`). The
+sort is only used to form the key; because equal peptide strings are
+byte-identical, tie order cannot change the key.
+
+## Step 3 — Subset elimination
+
+A group whose peptide set is a strict subset of another group's is dropped. The
+naive form is O(groups² × peptides); the C# port uses a **rarest-peptide
+candidate scan** (issue #4357, `ProteinFdr.cs:288-377`):
+
+1. Groups are sorted by peptide-count descending (`ProteinFdr.cs:288`).
+2. A global `peptideGroupCount` is built (`ProteinFdr.cs:314-323`).
+3. For each group, the **rarest** peptide (the pivot minimizing the candidate
+   list) is chosen (`ProteinFdr.cs:335-345`); any proper superset must contain
+   it. Only already-retained groups sharing that pivot are tested with
+   `peptideSet.Count < larger.Key.Count && peptideSet.IsSubsetOf(larger.Key)`
+   (`ProteinFdr.cs:354`).
+4. Non-subset groups are appended to `retained` and indexed incrementally
+   (`ProteinFdr.cs:362-376`).
+
+The code comment documents that this drops exactly the same groups in exactly
+the same order as the pairwise scan — byte-identical grouping, near-linear time
+(Stellar 3-file dropped from 6.3 s to ~0.5 s). `HashSet<string>` is used instead
+of `SortedSet` because `IsSubsetOf` is the hot path (`ProteinFdr.cs:275`).
+
+## Step 4 — Group IDs and unique/shared classification
+
+Group IDs are assigned by retained order: `gid = (uint)idx`
+(`ProteinFdr.cs:383-385`). The peptide→groups map is populated, then each peptide
+is classified (`ProteinFdr.cs:410-423`):
+
+- Count == 1 → added to that group's `UniquePeptides` (proteotypic).
+- Count ≥ 2 → added to every group's `SharedPeptides`.
+
+> **Determinism note.** The retained order — and hence `Id` — derives from
+> `HashSet`/`Dictionary` iteration order, which is not cross-impl stable. The
+> port therefore never relies on `Id` for a cross-impl-visible tiebreak; the
+> picked-FDR winner sort uses a sorted-accessions string instead (see Step 3 of
+> ComputeProteinFdr). See `16-determinism.md`.
+
+## Step 5 — Shared-peptide mode
+
+Controlled by `--shared-peptides {all|razor|unique}`
+(`SharedPeptideMode` enum, `OspreyConfig.cs:444-448`; default `All`,
+`OspreyConfig.cs:274`). Handled in the `switch` at `ProteinFdr.cs:426`:
+
+| Mode | C# behavior | Location |
+|------|-------------|----------|
+| `All` (default) | No reassignment. Shared peptides stay mapped to all their groups and can contribute to each group's best-peptide score. | `ProteinFdr.cs:428-430` |
+| `Razor` | Each shared peptide is reassigned to a single group (most unique peptides, tiebreak lowest group ID), moved into that group's `UniquePeptides`, removed from all others, and its `PeptideToGroupMap` entry rewritten to the single winner. | `ProteinFdr.cs:432-467` |
+| `Unique` | Shared peptides are removed from every group's `SharedPeptides` and deleted from `PeptideToGroupMap` entirely, so they never contribute to any protein score. | `ProteinFdr.cs:469-486` |
+
+> **Razor caveat.** The C# razor is a *per-shared-peptide* greedy in dictionary
+> iteration order, **not** the group-centric iterative set-cover the Rust code
+> and doc describe. This is a genuine divergence — see
+> [Divergences](#divergences-from-the-rust-documentation). Razor is behind a
+> non-default flag and is not exercised by the bit-identical reference gates
+> (which run `All` mode).
+
+---
+
+## How parsimony feeds protein FDR — the two passes
+
+When protein FDR runs (always, per above), the parsimony graph is rebuilt once
+per pass on the same library and same shared-peptide mode, but the peptide score
+pool differs. Both passes share the same picked-protein core,
+`ProteinFdr.ComputeProteinFdr` (`ProteinFdr.cs:536`).
+
+### Collecting best-peptide scores
+
+`ProteinFdr.CollectBestPeptideScores` (`ProteinFdr.cs:726`) reduces the
+per-file `FdrEntry` pool to one `PeptideScore` per modified sequence, keeping the
+**max** SVM `Score` and the **min** `RunPeptideQvalue` across all files
+(`ProteinFdr.cs:735-750`). This is per-peptide **best** — never a sum. A
+projection-buffer overload exists for the lean `FdrProjection` path
+(`ProteinFdr.cs:850`), documented as byte-identical because max/min are
+order-independent.
+
+### The picked-protein core (`ComputeProteinFdr`, Savitski 2015)
+
+1. **Per-group max SVM score on each side** (`ProteinFdr.cs:549-590`). Iterating
+   `PeptideToGroupMap` (keyed by target modified sequence):
+   - **Target side is gated**: a peptide contributes only if
+     `!tps.IsDecoy && tps.BestQvalue <= qvalueGate` (`ProteinFdr.cs:556`). The
+     gate is the peptide-level q-value, per Savitski's "proteins we would report"
+     convention.
+   - **Decoy side is not gated**: the decoy peptide is looked up as
+     `DECOY_ + peptide` and every decoy contributes its score
+     (`ProteinFdr.cs:573-589`). Gating decoys would collapse the null (most
+     losing decoys have q = 1.0).
+2. **Pairwise picking** (`ProteinFdr.cs:599-626`). Each group yields exactly one
+   winner: target if `t >= d` (ties to target), else decoy. A sorted-accessions
+   `SortKey` is carried on each winner for a deterministic tiebreak
+   (`ProteinFdr.cs:605-607`).
+3. **Cumulative FDR** (`ProteinFdr.cs:632-651`). Winners are sorted by score
+   descending, tiebreak `SortKey` ascending (cross-impl deterministic, unlike the
+   HashMap-derived `GroupId`). Then `q = min(1.0, cumDecoys / cumTargets)` at each
+   rank.
+4. **Backward monotonicity sweep** (`ProteinFdr.cs:653-670`): lower score →
+   non-decreasing q. Only **target** winners are written to `GroupQvalues` /
+   `GroupScores`; decoy winners are statistical machinery only.
+5. **Peptide propagation** (`ProteinFdr.cs:687-700`): each peptide's q-value is
+   the **min** (best) q across the groups it belongs to; peptides whose only
+   groups lost the pair stay at 1.0.
+
+Ranking is by raw SVM discriminant (`FdrEntry.Score`), never by q-value or PEP —
+the class doc (`ProteinFdr.cs:496-534`) reproduces the Rust rationale that q/PEP
+collapse the decoy null.
+
+### First pass — pre-compaction, gating (`run_protein_qvalue`)
+
+`ProteinFdr.RunFirstPassProteinFdr` (`ProteinFdr.cs:804`), wrapped by
+`ProteinFdrEngine.RunFirstPass` (`ProteinFdrEngine.cs:61`), is invoked from
+`FirstJoinTask` **unconditionally** after first-pass peptide FDR and before
+compaction (`Osprey.Tasks/FirstJoinTask.cs:305-313`; the comment confirms it is
+"not gated on --protein-fdr").
+
+- Detected set = targets with `RunPeptideQvalue <= config.RunFdr`
+  (`ProteinFdr.cs:816`) — peptide-level, symmetric with Rust
+  `pipeline.rs` (`e.run_peptide_qvalue <= config.run_fdr`).
+- `CollectBestPeptideScores` runs over the **full pre-compaction**
+  `perFileEntries` (targets and decoys, regardless of whether their base_id
+  passed precursor FDR), giving a symmetric target+decoy null.
+- Picked-protein FDR runs at the **1× Savitski gate** `config.RunFdr`
+  (`ProteinFdr.cs:824`).
+- Only `RunProteinQvalue` is set (`setRun: true, setExperiment: false`,
+  `ProteinFdr.cs:828`) via `PropagateProteinQvalues` (`ProteinFdr.cs:765`).
+
+`RunProteinQvalue` then feeds protein-aware compaction and the reconciliation
+consensus rescue gate (`10-cross-run-reconciliation.md`).
+
+### Second pass — post-reconciliation, authoritative (`experiment_protein_qvalue`)
+
+`ProteinFdrEngine.RunSecondPass` (`ProteinFdrEngine.cs:145`) is invoked from
+`MergeNodeTask` (`Osprey.Tasks/MergeNodeTask.cs:255`) after second-pass peptide
+FDR, on the compacted + reconciled + rescored pool.
+
+- Detected set = targets with
+  `EffectiveExperimentQvalue(peptideGateLevel) <= config.ExperimentFdr`
+  (`ProteinFdrEngine.cs:171-183`), where `peptideGateLevel = config.FdrLevel`
+  (default `Precursor`). The long comment (`ProteinFdrEngine.cs:155-171`)
+  explains this deliberately mirrors Rust's `config.fdr_level` gate, with Rust's
+  `Protein → Peptide` remap being a no-op in C# because the C# `FdrLevel` enum
+  has no `Protein` variant.
+- Parsimony rebuilt (`ProteinFdrEngine.cs:192`), picked-protein FDR again at
+  `config.RunFdr` (1×, `ProteinFdrEngine.cs:203`; the comment notes a previous 2×
+  gate was a corrected divergence).
+- Both `RunProteinQvalue` and `ExperimentProteinQvalue` are propagated
+  (`PropagateProteinQvalues(..., true, true)`, `ProteinFdrEngine.cs:227`).
+
+`ExperimentProteinQvalue` is the authoritative protein q-value on `FdrEntry`
+(`Osprey.Core/FdrEntry.cs:50`, default 1.0 at `:129`).
+
+### When `--protein-fdr` is not set
+
+Because `EffectiveProteinFdr` always resolves to a value
+(`OspreyConfig.cs:271`) and both passes run unconditionally, parsimony and the
+protein q-values are always computed. What the flag changes is only the numeric
+threshold used when counting/reporting passing groups
+(`ProteinFdrEngine.cs:209-217`). Compaction still adds the protein rescue rule
+against `RunProteinQvalue <= EffectiveProteinFdr`.
+
+---
+
+## Edge cases (verified against C#)
+
+- **Empty `ProteinIds`**: peptide contributes no graph edges
+  (`ProteinFdr.cs:230`), never appears in `PeptideToGroupMap`, cannot pass
+  protein filtering.
+- **Decoy library entries**: excluded from the target parsimony graph
+  (`ProteinFdr.cs:226`); handled by the picked-protein pass via the `DECOY_`
+  prefix pairing (`ProteinFdr.cs:203`, `:574`).
+- **Peptides not in the detected set**: skipped when a detected set is provided
+  (`ProteinFdr.cs:228`).
+
+---
+
+## Diagnostics
+
+There is no persistent production protein report writer in the examined C# code
+path (no `*.proteins.csv` / `protein_groups.tsv` emitter). What exists are
+env-var-gated cross-impl bisection dumps in
+`Osprey/OspreyFileDiagnostics.cs`:
+
+- `WriteStage6ProteinFdrDump` → `cs_stage6_protein_fdr.tsv`
+  (`OspreyFileDiagnostics.cs:1918`), gated by `OSPREY_DUMP_PROTEIN_FDR`
+  (`:333`); `OSPREY_PROTEIN_FDR_ONLY` exits after the dump (`:336`).
+- `WriteStage7ProteinFdrDump` → `cs_stage7_protein_fdr.tsv`
+  (`OspreyFileDiagnostics.cs:1983`), gated by `OSPREY_DUMP_STAGE7_PROTEIN_FDR`
+  (`:348`); `OSPREY_STAGE7_PROTEIN_FDR_ONLY` exits after it (`:351`).
+- `WriteBestPeptideScoresDump` and `WriteStage7WinnersDump` are fired from
+  inside `ProteinFdr` when `FdrDiagnostics.DumpBestPeptideScores` /
+  `DumpStage7Winners` are set (`ProteinFdr.cs:677-682`, `:756-757`).
+
+The stage-7 dump sorts rows by group q-value then sorted accessions
+(`OspreyFileDiagnostics.cs:2020-2026`) for cross-impl comparison.
+
+---
+
+## Flags and switches
+
+| Flag / field | Default | Effect on this stage |
+|---|---|---|
+| `--protein-fdr <threshold>` | unset → `EffectiveProteinFdr = 0.01` (`OspreyConfig.cs:265,271`) | **Threshold only.** Parsimony + both protein-FDR passes always run regardless (`FirstJoinTask.cs:305`, `MergeNodeTask.cs:255`). The flag sets the q-value cutoff used when counting passing groups and the additive compaction rescue rule. |
+| `--shared-peptides {all\|razor\|unique}` | `all` (`OspreyConfig.cs:274`) | Selects the Step-5 shared-peptide policy (`ProteinFdr.cs:426-486`). `all` = contribute to every group; `razor` = single-group assignment; `unique` = drop shared peptides. Parsed at `OspreyCommandArgs.cs:158-177`. |
+| `--fdr-level {precursor\|peptide\|both}` | `precursor` (`OspreyConfig.cs:284`) | Sets `config.FdrLevel`, which is the **second-pass** detected-peptide gate level (`ProteinFdrEngine.cs:171`). The CLI does **not** accept `protein` (`OspreyCommandArgs.cs:138-157`) and the enum has no `Protein` variant (`OspreyConfig.cs:411-416`). |
+| `--run-fdr <v>` | 0.01 | Used as the 1× Savitski picked-protein gate in both passes (`ProteinFdr.cs:824`, `ProteinFdrEngine.cs:203`) and as the first-pass detected-peptide gate (`ProteinFdr.cs:816`). |
+| `--experiment-fdr <v>` | 0.01 | Second-pass detected-peptide gate cutoff (`ProteinFdrEngine.cs:178`). |
+| `OSPREY_DUMP_PROTEIN_FDR` / `_ONLY` | off | Emit `cs_stage6_protein_fdr.tsv` (first pass) and optionally exit (`OspreyFileDiagnostics.cs:333-336`). |
+| `OSPREY_DUMP_STAGE7_PROTEIN_FDR` / `_ONLY` | off | Emit `cs_stage7_protein_fdr.tsv` (second pass) and optionally exit (`:348-351`). |
+
+There is no `--decoy` or protein-report flag specific to this stage; decoy
+pairing uses the fixed `DECOY_` prefix constant (`ProteinFdr.cs:203`).
+
+---
+
+## Divergences from the Rust documentation
+
+- **[PORT-ERROR] Razor mode is a per-peptide greedy, not the iterative
+  group-centric set cover** - Rust doc §"Razor: Iterative Greedy Set Cover"
+  (and the Rust code, `crates/osprey-fdr/src/protein.rs:197-266`) sorts shared
+  peptides alphabetically, then repeatedly selects the *group* with the most
+  unique peptides that still owns any unassigned shared peptide and claims **all**
+  of that group's remaining shared peptides in one batch — explicitly
+  path-independent. C# instead iterates shared peptides in `Dictionary` order and
+  assigns each individually to its current best group, mutating unique counts
+  in-place as it goes (`ProteinFdr.cs:432-467`). The C# collection is **not**
+  sorted (`ProteinFdr.cs:434-439`). These algorithms diverge on cascading
+  topologies: e.g. G0 unique {A,B} shared {X,Y}, G1 unique {C,D,E} shared {X},
+  G2 unique {F} shared {Y} — Rust always yields X→G1, Y→G0, but the C# result
+  flips to X→G0 when the dictionary happens to process Y before X (Y lifts G0 to
+  3 unique, then X ties G0=G1 and the lowest-ID tiebreak picks G0). Rust's
+  `test_shared_peptides_razor_cascading_assignment` pins the group-centric
+  result. Evidence: `Osprey.FDR/ProteinFdr.cs:432-467`. Severity: minor (razor is
+  the non-default `--shared-peptides razor`; the reference bit-identical gates run
+  `All` mode, so this path is unverified by the golden tests; `All` and `Unique`
+  match Rust exactly).
+
+- **[INTENTIONAL-CSHARP-DESIGN] No `--fdr-level protein` / no protein-level
+  output filtering** - Rust doc §"Second Pass" states
+  `experiment_protein_qvalue` "feeds `--fdr-level protein` filtering." The C#
+  `FdrLevel` enum has only `{Precursor, Peptide, Both}` (`OspreyConfig.cs:411-416`)
+  and the CLI parser rejects `protein`, accepting only `precursor|peptide|both`
+  (`OspreyCommandArgs.cs:138-157`). `ExperimentProteinQvalue` is still computed
+  and propagated (`ProteinFdrEngine.cs:227`), but there is no reachable path to
+  filter the output by it. The `RunSecondPass` comment
+  (`ProteinFdrEngine.cs:165-170`) documents this as a deliberate no-op remap.
+  Evidence: `Osprey.Core/OspreyConfig.cs:411-416`, `Osprey/OspreyCommandArgs.cs:138-157`.
+  Severity: minor.
+
+- **[UNVERIFIED] No production protein report** - Rust doc §"Implementation"
+  lists `write_protein_report()` emitting `*.proteins.csv` with gene names, PEP,
+  and q-values. No equivalent production writer was found in the C# path
+  (grep for `proteins.csv`/`protein_groups`/`ProteinReport` returned no
+  emitter); only the env-var-gated diagnostic dumps
+  `cs_stage6_protein_fdr.tsv` / `cs_stage7_protein_fdr.tsv` exist
+  (`Osprey/OspreyFileDiagnostics.cs:1918`, `:1983`). A human should confirm
+  whether a protein report writer lives outside the files reviewed here (lab
+  memory references a `protein_groups.tsv` / `stats.tsv` feature that this
+  checkout's protein-FDR code does not surface). Severity: minor.
+
+- **[STALE-RUST-DOC] Second-pass detected set gates on `config.fdr_level`, not
+  "peptide FDR"** - Rust doc §"Second Pass" step 1 says the second parsimony is
+  built "from peptides passing second-pass **peptide** FDR." Both the C# code
+  (`ProteinFdrEngine.cs:171-183`) and current Rust
+  (`pipeline.rs`, referenced in the C# comment) actually gate on
+  `EffectiveExperimentQvalue(config.FdrLevel)`, which is **precursor**-level by
+  default. C# and Rust agree; the doc's "peptide" wording is stale. Evidence:
+  `Osprey.FDR/ProteinFdrEngine.cs:171`. Severity: info.
+
+Verified as matching the Rust documentation and Rust code: parsimony always runs
+regardless of `--protein-fdr` (threshold-only, `FirstJoinTask.cs:305`,
+`OspreyConfig.cs:271`); decoy and empty-protein exclusion from the target graph
+(`ProteinFdr.cs:226,230`); identical-set merging and strict-subset elimination
+(`ProteinFdr.cs:250-377`, byte-identical drop order); `All` and `Unique`
+shared-peptide modes (`ProteinFdr.cs:428-486`); two-pass architecture with
+first-pass on the full pre-compaction pool writing `RunProteinQvalue` and
+second-pass writing `ExperimentProteinQvalue` (`ProteinFdr.cs:804-835`,
+`ProteinFdrEngine.cs:145-230`); per-protein scoring by **single best peptide**
+max SVM discriminant, not a sum (`ProteinFdr.cs:549-590`,
+`CollectBestPeptideScores` max/min at `:735-750`); gated target side / ungated
+decoy side (`ProteinFdr.cs:556` vs `:573`); pairwise picking, cumulative FDR with
+sorted-accessions tiebreak, backward monotonicity sweep, and min-across-groups
+peptide propagation (`ProteinFdr.cs:599-700`); no protein-level PEP
+(`ProteinFdrResult` has no `GroupPep`, `ProteinFdr.cs:113`); and the 1× Savitski
+gate at `config.RunFdr` in both passes (`ProteinFdr.cs:824`,
+`ProteinFdrEngine.cs:203`).

--- a/pwiz_tools/Osprey/docs/09-multi-charge-consensus.md
+++ b/pwiz_tools/Osprey/docs/09-multi-charge-consensus.md
@@ -1,0 +1,166 @@
+# 09. Multi-Charge Consensus (C#)
+
+> Pipeline stage: Stage 5 (post-FDR consensus). C# port of Rust docs/06-multi-charge-consensus.md. Corresponds to Rust osprey `select_post_fdr_consensus`.
+
+## Problem
+
+A peptide elutes at one retention time regardless of ionization charge state. In DIA, different charge states of the same peptide (e.g. `PEPTIDEK` at 2+ and 3+) have different precursor m/z and fall into **different DIA isolation windows**. Those windows are scored by independent parallel work, so each charge state finds its chromatographic peak on its own — and they can land on different peaks. If 2+ is detected at RT 25.3 and 3+ at RT 27.1, one of them is on the wrong peak. Forcing all charge states of a peptide to share one apex and one integration window improves accuracy and downstream quantification consistency.
+
+Because charge states live in different windows, cross-charge agreement cannot be reached inside the per-window scoring loop. Osprey resolves it in a **post-FDR** step: it picks a consensus leader per peptide, then re-scores the disagreeing charge states at the leader's boundaries via the same forced-integration (boundary-override) path used by reconciliation.
+
+## Where this runs in the pipeline
+
+Multi-charge consensus is **Phase 1 of Stage 6 planning**, and it is the first planning phase to run — before cross-run consensus RTs, before the calibration refit, before reconciliation planning. See `Osprey.Tasks/Stage6Planner.cs:80` (`Plan`) and `Stage6Planner.cs:106` (`ComputeMultiChargeConsensus`, "runs first per Rust pipeline.rs:3217").
+
+Execution order (C# task graph):
+
+```text
+Stage 4  Per-file scoring (PerFileScoringTask)          -> per-file .scores.parquet
+Stage 5  First-pass FDR (FirstJoinTask / FirstPassFDR)  -> run-level q-values on FdrEntry stubs
+   |         (compaction drops non-passing entries here)
+   v
+Stage 6  Planning (Stage6Planner, invoked from FirstJoinTask):
+           Phase 1  MultiChargeConsensus.SelectRescoreTargets  <-- THIS DOC
+           Phase 2  ConsensusRts.Compute        (cross-run, multi-file only)
+           Phase 3  RefitCalibrations
+           Phase 4  ReconciliationPlanner        (cross-run, multi-file only)
+   |
+   v
+Stage 6  Re-scoring (PerFileRescoreTask / PerFileRescoring):
+           merge consensus + reconciliation targets (reconciliation wins on conflict)
+           re-score via RunCoelutionScoring with BoundaryOverrides
+   |
+   v
+Stage 7  Second-pass FDR (MergeNode / SecondPassFDR)   -> final q-values
+```
+
+The consensus selection itself is a pure, side-effect-free function; the re-scoring that acts on its output is shared with cross-run reconciliation (see 10-cross-run-reconciliation.md) and the forced-integration mechanism (see 11-boundary-overrides.md).
+
+Note on grouping vs. the Rust doc's four-line sketch: the Rust doc labels consensus "Step 4 / post first-pass FDR." In the C# port the same relationship holds — `SelectRescoreTargets` reads `RunPrecursorQvalue`, which is only populated after first-pass FDR — and consensus is invoked from `FirstJoinTask` (the first-pass FDR task) after compaction. `FirstJoinTask.cs:146` and `Stage6Planner.cs:115` are the two call sites (compute path and bundle-rehydrate path); both pass `config.RunFdr` as the threshold.
+
+## Algorithm
+
+The whole selection is `MultiChargeConsensus.SelectRescoreTargets(entries, fdrThreshold)` in `Osprey.FDR/Reconciliation/MultiChargeConsensus.cs:51`. It returns a list of `(int Index, double Apex, double Start, double End)` rescore targets — the index is the position in the per-file `entries` list, and the RT triple is the consensus leader's window.
+
+### Step 1: Group by modified sequence
+
+`MultiChargeConsensus.cs:58-68` builds a `Dictionary<string, List<int>>` keyed by `FdrEntry.ModifiedSequence` using `StringComparer.Ordinal`. Grouping by modified sequence naturally separates:
+
+- **Different charge states** of one peptide (same `ModifiedSequence`, different `Charge`) — these land in the same group and are the whole point of the step.
+- **Targets from decoys** — decoys carry a `DECOY_` prefix in `ModifiedSequence`, so `DECOY_PEPTIDEK` and `PEPTIDEK` are distinct keys (verified by `ReconciliationTest.cs:1164` `TestMultiChargeDecoyAndTargetAreSeparateGroups`).
+- **Different peptides** — distinct keys, independent groups (`ReconciliationTest.cs` covers this via separate-peptide cases).
+
+Groups with a single member are skipped (`MultiChargeConsensus.cs:74-75`) — nothing to reconcile.
+
+### Step 2: Select the consensus leader
+
+For each multi-member group, `PickBestPassing` (`MultiChargeConsensus.cs:105`) chooses the leader:
+
+1. **FDR gate**: only entries with `RunPrecursorQvalue <= fdrThreshold` are eligible (`MultiChargeConsensus.cs:115`). If no charge state passes, the group contributes nothing (`bestIdx < 0`, `MultiChargeConsensus.cs:78-79`). This matches the Rust "only FDR-passing charge states can lead" rule and the "skip groups where no charge passes" optimization (`ReconciliationTest.cs:1057` `TestMultiChargeNoPassingEntryInGroupSkipped`).
+   - Note the gate is specifically `RunPrecursorQvalue`, not the effective `max(precursor, peptide)` q-value — this is the run-level precursor q-value from first-pass FDR.
+2. **Ranking**: among passing entries, the highest `FdrEntry.Score` (the raw SVM discriminant) wins (`MultiChargeConsensus.cs:123-130`). The SVM score is preferred over `coelution_sum` because it folds in all 21 PIN features (see 03-spectral-scoring.md).
+3. **Tie-break**: on an exact score tie, the lower `RunPrecursorQvalue` wins (`MultiChargeConsensus.cs:138`); on a *full* tie (equal score AND equal q-value) the **later** entry wins, because the comparison uses `<=` (`entry.RunPrecursorQvalue <= bestQvalue`). This deliberately mirrors Rust `max_by`, which returns the last element among equal maxima (comment cites `pipeline.rs:7665-7679`). A `MultiChargeConsensusTest.cs:53` test (`TestConsensusLeaderTieBreakPrefersLastEntry`) pins this exact behavior and would fail if the code reverted to a strict `<`.
+
+The leader's `ApexRt`, `StartRt`, `EndRt` become the consensus window (`MultiChargeConsensus.cs:81-83`).
+
+### Step 3: Mark divergent charge states for re-scoring
+
+`MultiChargeConsensus.cs:84-94` computes the match tolerance and flags outliers:
+
+- `consensusWidth = EndRt - StartRt`
+- `rtMatchTolerance = Math.Max(MIN_RT_MATCH_TOLERANCE, consensusWidth / 2.0)` where `MIN_RT_MATCH_TOLERANCE = 0.1` min (`MultiChargeConsensus.cs:43`). So the tolerance is half the consensus peak width, floored at 0.1 min — identical to the Rust "within half the consensus peak width (minimum 0.1 min)."
+- For each non-leader in the group, if `|ApexRt - consensusApex| > rtMatchTolerance` it is added as a rescore target `(idx, consensusApex, consensusStart, consensusEnd)`; otherwise it already agrees and is left alone (no target emitted, entry kept as-is downstream).
+
+Worked example matching the Rust doc: leader window `[24.8, 25.9]` gives width 1.1, tolerance `max(0.1, 0.55) = 0.55`; a 2+ apex at 25.3 (`diff 0.0`) is kept, a 3+ apex at 27.1 (`diff 1.8 > 0.55`) becomes a rescore target pinned to `(25.3, 24.8, 25.9)`. Test coverage: `ReconciliationTest.cs:1091` (`TestMultiChargeWrongApexChargeIsRescoreTarget`), `:1074` (same-apex → no rescore), `:1113` (three charges, only the divergent one rescored).
+
+### Step 4: Merge with reconciliation and re-score via boundary overrides
+
+The consensus targets are merged with cross-run reconciliation actions in `PerFileRescoreTask.TryAssembleRescoreTargets` (`Osprey.Tasks/PerFileRescoreTask.cs:879`). Both are folded into one `Dictionary<int, (Apex, Start, End)>` keyed by entry index:
+
+```
+foreach consensus target:      combinedTargets[idx] = (apex, start, end)   // PerFileRescoreTask.cs:905-906
+foreach reconciliation target: combinedTargets[idx] = (apex, start, end)   // PerFileRescoreTask.cs:907-908
+```
+
+Because reconciliation is applied second, **reconciliation wins on conflict** when both want to re-score the same entry — the inter-replicate boundary is more authoritative than the intra-file multi-charge boundary (`PerFileRescoreTask.cs:869-873`). This matches the Rust "reconciliation wins" rule.
+
+`BuildScoringSubset` (`PerFileRescoreTask.cs:1066`) then turns the combined index map into `BoundaryOverrides` keyed by `entry_id` (`FdrEntry.EntryId`, `PerFileRescoreTask.cs:1079-1080`) plus a subset `List<LibraryEntry>` containing only the entries to re-score. The overrides are attached to the `ScoringContext` (`PerFileRescoreTask.cs:733`) and consumed by the scoring engine.
+
+Inside scoring, `PeakDataExtractor.cs:87-92` detects a boundary override for a candidate and, when present:
+
+- **Skips the signal pre-filter** — `config.PrefilterEnabled && !overrideBounds.HasValue` (`PeakDataExtractor.cs:117`); the caller has already decided to score here.
+- **Skips CWT peak detection** — a synthetic peak is built from the override triple instead of running the 3-tier CWT (`PeakDataExtractor.cs:165-167` and the override branch of `FindScanRange`/`DetectCandidatePeaks`).
+- **Maps the RT triple to XIC scan indices** via the override-shaped `FindScanRange` (`PeakDataExtractor.cs:104`).
+- **Computes all features at those boundaries**, same feature calculators as first-pass.
+- **Drops the entry when there is no signal** at the consensus RT: too few scans in range (`PeakDataExtractor.cs:79-80`, `:107-108`) or fewer than 2 fragment XICs (`PeakDataExtractor.cs:162-163`) all return `false`, so the entry produces no re-scored result and is excluded.
+
+See 11-boundary-overrides.md for the full forced-integration path.
+
+## Why "best SVM score wins"
+
+The C# ranking uses the trained SVM discriminant (`FdrEntry.Score`) among FDR-passing charge states, matching the Rust rationale: the SVM score integrates all 21 discriminative features and a charge state parked on an interference peak scores lower than one on the true peak. Alternatives (highest `coelution_sum`, highest apex intensity, closest-to-expected-RT, majority vote) are the same alternatives the Rust doc lists and rejects.
+
+## Shared peak boundaries at blib output (Stage 7)
+
+The consensus leader above re-scores *divergent* charge states during Stage 6. A
+separate, final step at blib-write time (`MergeNodeTask.BuildSharedBoundaries`)
+makes **all** charge states of one peptide in one file report the **same** RT
+window in the `.blib` `RetentionTimes` rows: per `(modified_sequence, fileName)`
+the window is taken from the entry with the **minimum run q-value**.
+
+On a run-q **tie** — e.g. two charge states both gap-filled at `q = 1.0` — the
+winner is broken deterministically by **lowest charge**
+(`rq < existing || (rq == existing && e.Charge < existingCharge)`), *not* by
+in-memory entry order. This tie-break is load-bearing for parity: the C# side
+iterates per-file entries in memory order while Rust iterates parquet row order,
+so without the explicit lowest-charge rule the two implementations could keep
+different charges' windows and the blib `RetentionTimes` `startTime`/`endTime`
+would diverge (it fixed a 20-row Astral transfer-compete divergence). Both impls
+now apply the identical *(lower run q-value, then lower charge)* rule. Pinned by
+`MultiChargeConsensusTest.TestSharedBoundariesTieBrokenByLowestCharge`.
+
+## Determinism
+
+- Grouping uses a `Dictionary` (unordered iteration), but this does not affect output: each group's leader is chosen deterministically by `PickBestPassing` (a total order over score then q-value then position), and the emitted targets are consumed by index into keyed dictionaries (`combinedTargets` keyed by entry index at `PerFileRescoreTask.cs:906`, `BoundaryOverrides` keyed by `entry_id` at `PerFileRescoreTask.cs:1080`), so target-list order is immaterial.
+- The re-scored entries themselves flow back through `RunCoelutionScoring`, which carries its own deterministic ordering; the reconciled write-back preserves `ParquetIndex` so post-compaction Vec position never corrupts the Parquet row mapping (`PerFileRescoreTask.cs:1101-1105`).
+
+See 16-determinism.md.
+
+## Scope
+
+- **Post-FDR**: consensus needs `RunPrecursorQvalue`, which exists only after first-pass FDR; only FDR-passing charge states can lead.
+- **Per-file**: `SelectRescoreTargets` is called once per file over that file's `entries` list (`Stage6Planner.cs:112-116`), so consensus is computed within each file independently.
+- **Targets and decoys separately**: enforced by grouping on `ModifiedSequence` (the `DECOY_` prefix separates them).
+- **Merged with reconciliation**: consensus and reconciliation rescore targets share one `RunCoelutionScoring` pass per file; reconciliation wins conflicts (`PerFileRescoreTask.cs:869-908`).
+
+### What stays unchanged
+
+- CWT peak detection in the first-pass per-precursor loop (see 06-peak-detection.md) — consensus only overrides it for re-scored entries.
+- All 21 PIN features and Percolator scoring (see 03-spectral-scoring.md, 07-fdr-control.md).
+- FDR control, blib output, everything downstream.
+
+## Flags and switches
+
+This stage has no dedicated on/off CLI flag — multi-charge consensus always runs as Phase 1 of Stage 6 planning. The flags that affect its inputs and behavior:
+
+| Flag / env var | Default | Effect on this stage |
+|---|---|---|
+| `--run-fdr <q>` | `0.01` (`OspreyConfig.RunFdr`) | The `fdrThreshold` passed to `SelectRescoreTargets` (`Stage6Planner.cs:115`, `FirstJoinTask.cs:146`). Gates which charge states are eligible to lead (`RunPrecursorQvalue <= threshold`) and, implicitly, whether a group produces any rescore target at all. |
+| `--no-prefilter` | prefilter ON (`PrefilterEnabled = true`) | Only relevant to the re-scoring pass: with the prefilter on it is still skipped for boundary-override candidates (`PeakDataExtractor.cs:117`), so this flag does not change consensus re-scoring behavior; it affects only free (non-override) scoring. |
+| `--reconciliation-compaction-fdr`, `--experiment-fdr`, reconciliation flags | see 08/10 docs | Do not gate consensus selection itself, but reconciliation targets computed later are merged with (and override) consensus targets in the shared re-scoring pass. |
+| `OSPREY_DUMP_MULTICHARGE=1` | off | Diagnostic. Writes `cs_stage6_multicharge.tsv` (per-file entries + selected rescore targets) for cross-impl bisection (`Stage6Planner.cs:124-134`, `OspreyFileDiagnostics.cs:261-264`). |
+| `OSPREY_MULTICHARGE_ONLY=1` | off | Diagnostic. Exits after the multicharge dump (`Stage6Planner.cs:135-136`, `OspreyFileDiagnostics.cs:266-267`). |
+
+`MIN_RT_MATCH_TOLERANCE = 0.1` min is a compile-time constant (`MultiChargeConsensus.cs:43`), not a flag.
+
+## Divergences from the Rust documentation
+
+- **[STALE-RUST-DOC] Re-scoring engine is `RunCoelutionScoring`, not `run_search()`** - Rust doc says entries are re-scored "via `run_search()` with `boundary_overrides`." C# has no `run_search`; the boundary-override re-scoring is `RunCoelutionScoring` with `ScoringContext.BoundaryOverrides`, driven from `PerFileRescoreTask`. Behavior is equivalent (skip prefilter, skip CWT, force integration at the consensus window). Evidence: `Osprey.Scoring/PeakDataExtractor.cs:82-167`, `Osprey.Tasks/PerFileRescoreTask.cs:733`. Severity: info.
+
+- **[INTENTIONAL-CSHARP-DESIGN] Consensus is a pure selection function separated from re-scoring** - The Rust doc describes one `select_post_fdr_consensus()` that both selects and hands off to re-scoring. The C# port splits this: `MultiChargeConsensus.SelectRescoreTargets` is a pure function returning `(Index, Apex, Start, End)` targets, and the merge-with-reconciliation + boundary-override re-scoring lives in `PerFileRescoreTask.TryAssembleRescoreTargets`/`BuildScoringSubset`. Same overall algorithm, cleaner separation for the .NET task graph. Evidence: `MultiChargeConsensus.cs:51`, `PerFileRescoreTask.cs:879,1066`. Severity: info.
+
+- **[STALE-RUST-DOC] "Percolator/Mokapot scoring" — C# has no Mokapot** - Rust "What stays unchanged" lists "Percolator/Mokapot scoring." The C# port uses a native managed Percolator SVM only; Mokapot is not wired to the CLI. This does not affect consensus logic. Evidence: see 07-fdr-control.md. Severity: info.
+
+- **[STALE-RUST-DOC] FDR gate is `RunPrecursorQvalue`, doc says generic "FDR threshold"** - The Rust doc phrases the eligibility gate as "passing the FDR threshold" without naming the q-value. C# gates specifically on `RunPrecursorQvalue <= fdrThreshold` (run-level precursor q-value), not the effective `max(precursor, peptide)` q-value. The C# source comment confirms this matches the Rust code at `pipeline.rs:7665-7679`, so the doc is merely less specific than the implementation. Evidence: `MultiChargeConsensus.cs:115`. Severity: info.
+
+Otherwise the C# implementation matches the Rust documentation step for step: group by modified sequence (`MultiChargeConsensus.cs:58`), best-SVM-score-among-FDR-passing leader with last-wins-on-full-tie (`:105-149`), half-peak-width tolerance floored at 0.1 min (`:84-85`), rescore targets pinned to the leader's window (`:93`), reconciliation-wins merge (`PerFileRescoreTask.cs:905-908`), and boundary-override re-scoring that skips prefilter + CWT and drops entries with no signal (`PeakDataExtractor.cs:82-167`).

--- a/pwiz_tools/Osprey/docs/10-cross-run-reconciliation.md
+++ b/pwiz_tools/Osprey/docs/10-cross-run-reconciliation.md
@@ -1,0 +1,238 @@
+# 10. Cross-Run Reconciliation (C#)
+
+> Pipeline stage: Stage 5 (plan) / Stage 6 (apply). C# port of Rust docs/10-cross-run-reconciliation.md. Corresponds to Rust osprey cross-run peak reconciliation (`crates/osprey/src/reconciliation.rs`).
+
+Cross-run reconciliation aligns peak integration boundaries across replicate files so that the same peptide is quantified at a consistent chromatographic position in every run. It runs after first-pass (run-level) FDR and before the final experiment-level FDR, and only applies to multi-file experiments. The C# port keeps the algorithm identical to Rust but splits it across two HPC stages joined by a per-file `<stem>.reconciliation.json` envelope:
+
+- **Stage 5 — planning** (`Osprey.Tasks/Stage6Planner.cs`, driven by `FirstJoinTask` / `--task FirstPassFDR`): computes consensus RTs, refits per-file calibration, and produces the Keep / UseCwtPeak / ForcedIntegration action plan plus gap-fill targets. Writes them to `reconciliation.json`.
+- **Stage 6 — apply** (`Osprey.Tasks/PerFileRescoreTask.cs`, `--task PerFileRescoring`): re-scores the flagged entries at the planned boundaries.
+- **Stage 7 — second-pass FDR** (`MergeNodeTask`, `--task SecondPassFDR`): recomputes experiment-level q-values on the reconciled pool.
+
+The core planning/consensus code lives in `Osprey.FDR/Reconciliation/`. See also 09-multi-charge-consensus.md (the sibling post-FDR alignment that shares the same rescore pass), 07-fdr-control.md (the two FDR passes bracketing reconciliation), 08-protein-parsimony.md (first-pass protein q-values used as a rescue gate), 11-boundary-overrides.md (the rescore mechanism), and 15-hpc-scoring-split.md (the `--task` worker split).
+
+---
+
+## Problem
+
+Without reconciliation, each file's per-window search finds peaks independently using CWT peak detection and pairwise coelution scoring. For a given peptide the search may confidently find the correct peak in most runs but select a co-eluting interferer, a noise spike, or an isomer in one or more runs where the signal is weaker.
+
+The first line of defense is RT-penalized peak selection during the first-pass search (a Gaussian RT penalty × log-intensity weight applied to CWT candidate ranking). That lives in the scoring stage, not here — see 06-peak-detection.md. Reconciliation is the second line of defense: it uses the high-confidence runs to establish where a peptide actually elutes, then goes back to files where the selected peak is wrong and either switches to an alternate CWT candidate at that RT or imputes the integration boundaries at the expected position.
+
+---
+
+## Algorithm Overview
+
+The four planning phases run in `Stage6Planner.Plan` (`Osprey.Tasks/Stage6Planner.cs:80`), in this order:
+
+```text
+After per-run (first-pass) FDR:
+  1. MultiChargeConsensus.SelectRescoreTargets  — intra-file multi-charge leaders (09-multi-charge-consensus.md)
+  2. ConsensusRts.Compute                        — sigmoid(score)-weighted median library RT across runs
+  3. CalibrationRefit.Refit                      — tighter per-run LOESS from consensus points
+  4. ReconciliationPlanner.Plan                  — Keep | UseCwtPeak | ForcedIntegration per entry
+  (then) GapFillTargetIdentifier.Identify        — precursors missing from a file (FirstJoinTask)
+  (then) PerFileRescoreTask                       — re-score via boundary overrides (Stage 6)
+  (then) MergeNodeTask                            — second-pass experiment-level FDR (Stage 7)
+```
+
+Cross-run consensus, refit, and reconciliation planning only run when there is more than one file: `ConsensusRts.Compute` is called only when `perFileEntries.Count > 1` (`Stage6Planner.cs:171-178`); with a single file the consensus list is empty and phases 3-4 degenerate to no work, leaving multi-charge consensus rescore as the only Stage 6 work. Multi-charge consensus (phase 1) runs unconditionally.
+
+---
+
+## Step 1: Consensus Peptide Selection
+
+`ConsensusRts.Compute` (`Osprey.FDR/Reconciliation/ConsensusRts.cs:70`) selects the peptides whose detections drive the consensus RT. The qualification gate is `ConsensusRts.Qualifies` (`ConsensusRts.cs:242-250`):
+
+1. A detection must **not** be a decoy.
+2. Its **per-entry run precursor q-value** must be `<= consensusFdr` (default 0.01). This is a **hard gate** (`ConsensusRts.cs:246`) — protein FDR cannot rescue poor precursor evidence.
+3. EITHER its run peptide-level q-value is `<= consensusFdr`, OR (protein-rescue) `proteinFdrThreshold > 0` AND its first-pass run protein q-value is `<= proteinFdrThreshold` (`ConsensusRts.cs:248-249`). The threshold passed in is `config.EffectiveProteinFdr` (`Stage6Planner.cs:176`); when protein FDR is disabled it is 0 and the rescue branch is off.
+
+### Why precursor-level evidence is a hard gate
+
+Consensus RT is driven by each surviving entry's own `ApexRt`. If a detection qualified only because its protein group was strong (but the entry itself has a weak/wrong-peak apex), that wrong apex would be pulled into the weighted median and could shift the consensus toward an interferer. Requiring `RunPrecursorQvalue <= consensusFdr` first prevents strong proteins' wrong-peak charge-state detections from poisoning the charge-agnostic consensus RT. This mirrors the Rust regression case (Stellar, DAQVVGMTTTGAAK) documented in the source Rust doc; the C# port applies the identical gate.
+
+### Paired decoys via base_id linkage
+
+Paired decoys are included so the second FDR pass sees fair competition. The C# port pairs decoys by **base_id** (`EntryId & 0x7FFFFFFF`), not by stripping a `DECOY_` prefix from the modified sequence (`ConsensusRts.cs:93-118`). This is deliberate: the prefix-strip approach only works for Osprey-generated reverse decoys and silently misses library-supplied decoys (Carafe / FDRBench manifest) whose modified sequence carries no prefix. Qualifying target base_ids are recorded (`ConsensusRts.cs:102`), then any decoy sharing a qualifying base_id contributes all of its detections (`ConsensusRts.cs:115-116`). Target and decoy consensus RTs are computed independently to avoid information leakage.
+
+---
+
+## Step 2: Consensus Library RT
+
+For each consensus peptide, its qualifying detections across all files are collected as `(FileName, ApexRt, Score, PeakWidth, CoelutionSum)` where `PeakWidth = EndRt - StartRt` (`ConsensusRts.cs:143-150`). Each measured `ApexRt` is mapped back to library RT space using the run's inverse calibration: `cal.InversePredict(det.ApexRt)` (`ConsensusRts.cs:171`).
+
+The **consensus library RT** is the **weighted median** of these library RTs (`ConsensusRts.WeightedMedian`, `ConsensusRts.cs:264-287` — cumulative-weight median over value-sorted pairs). Weights come from the SVM discriminant score through a sigmoid, floored at 1e-6:
+
+```text
+weight = max(1e-6, 1 / (1 + exp(-score)))     // ConsensusRts.cs:178
+```
+
+The SVM score is the strongest per-detection quality signal (it is what FDR ranks on). A detection with positive score dominates the weighted median; a detection with negative score (interferer-like) contributes near-zero weight. The 1e-6 floor guarantees a non-zero total weight even when every score is very negative.
+
+Two sanity filters run before a detection reaches the median (`ConsensusRts.cs:172`): the inverse-predicted library RT must be finite, and `CoelutionSum > 0` (rejects anti-correlated "noise integration" detections). Per-peptide peak widths are aggregated with the same sigmoid-score weighted median (`ConsensusRts.cs:180, 197`), so `MedianPeakWidth` reflects high-quality detections' peak shapes.
+
+The result is a `PeptideConsensusRT` (`Osprey.FDR/Reconciliation/PeptideConsensusRT.cs`) carrying `ModifiedSequence`, `IsDecoy`, `ConsensusLibraryRt`, `MedianPeakWidth`, `NRunsDetected`, and `ApexLibraryRtMad`.
+
+### Within-peptide MAD
+
+`ApexLibraryRtMad` is the median absolute deviation of a peptide's library-space apex RTs across replicates, computed only when `NRunsDetected >= 3` (otherwise null — a MAD on 2 points is not robust) (`ConsensusRts.cs:203-214`). It captures the LC/instrument reproducibility floor and feeds the planner's global RT tolerance (Step 4).
+
+### Charge-agnostic grouping (multi-charge / GPF)
+
+Consensus keys are `(ModifiedSequence, IsDecoy)` — **charge is not part of the key** (`ConsensusRts.cs:137`). All detections of a peptide across every file and charge state contribute to one shared `PeptideConsensusRT`. A peptide's 2⁺ in file1 and 3⁺ in file2 reinforce each other, and gas-phase fractionation (where different charge states land in different files) is handled automatically because the cross-run consensus IS the multi-charge alignment. The per-file `MultiChargeConsensus.SelectRescoreTargets` (09-multi-charge-consensus.md) handles the standard-DIA intra-file case and is effectively a no-op under GPF.
+
+### Determinism
+
+The consensus list is sorted `(IsDecoy, ModifiedSequence ordinal)` before returning (`ConsensusRts.cs:231-237`), giving deterministic output regardless of input file order.
+
+---
+
+## Step 3: Calibration Refit
+
+`CalibrationRefit.Refit` (`Osprey.FDR/Reconciliation/CalibrationRefit.cs:48`) refits each run's LOESS RT calibration from `(consensus_library_rt → measured_apex_rt)` pairs, using **target** peptides in that run whose **experiment-level** q-value at `FdrLevel.Both` is `<= consensusFdr` (`CalibrationRefit.cs:73`).
+
+The refit configuration (`CalibrationRefit.cs:92-98`):
+- `Bandwidth = 0.3`
+- `OutlierRetention = 1.0` — outlier removal disabled (these are FDR-controlled detections; LOESS robustness iterations still downweight stragglers)
+- `MinPoints = MIN_CONSENSUS_POINTS = 20`
+- `ClassicalRobustIterations = OspreyEnvironment.LoessClassicalRobust` — mirrors the Stage 4 initial calibration so refit fitted values stay cross-impl identical
+
+If fewer than 20 consensus points exist for a run, or the fit throws, `Refit` returns null and that run falls back to its original first-pass calibration (`CalibrationRefit.cs:81-82, 104-110`; consumed at `Stage6Planner.cs:222-225` and `ReconciliationPlanner.cs:156-157`).
+
+---
+
+## Step 4: Reconciliation Planning
+
+`ReconciliationPlanner.Plan` (`Osprey.FDR/Reconciliation/ReconciliationPlanner.cs:65`) assigns each entry a `ReconcileAction`. For each entry it predicts `expectedRt = cal.Predict(consensusEntry.ConsensusLibraryRt)` from the refined (or fallback original) calibration (`ReconciliationPlanner.cs:212`), then compares apex proximity via `DetermineAction`.
+
+### The three actions
+
+`ReconcileAction` (`Osprey.FDR/Reconciliation/ReconcileAction.cs`) is a discriminated union with a private constructor and three nested subclasses:
+
+| Action | Condition (`ReconciliationPlanner.DetermineAction`, `ReconciliationPlanner.cs:248-291`) | What happens |
+|--------|------------------------------------------------------------------------------------------|--------------|
+| **Keep** (singleton `ReconcileAction.Keep`) | `\|apexRt - expectedRt\| <= rtTolerance` | No change; omitted from the returned map (implicit absence). |
+| **UseCwtPeak** | A stored CWT candidate has `\|cand.ApexRt - expectedRt\| <= rtTolerance` | Switch to the candidate whose apex is **closest** to expectedRt. Carries `CandidateIndex`, `StartRt`, `ApexRt`, `EndRt`. |
+| **ForcedIntegration** | Neither current peak nor any CWT candidate is within tolerance | Integrate at `expectedRt ± halfWidth`, where `halfWidth = MedianPeakWidth / 2` (`ReconciliationPlanner.cs:225`). |
+
+`DetermineAction` uses **apex proximity**, not boundary containment: a wrong-apex peak with a wide trailing edge spanning the expected RT is correctly rejected. CWT candidate selection also picks the closest apex, not merely any candidate whose boundaries overlap (`ReconciliationPlanner.cs:259-285`). Only non-Keep actions are stored, keyed `(fileName, entryIndex)` (`ReconciliationPlanner.cs:227-229`).
+
+### Entry preconditions
+
+Two filters run before an entry is planned:
+1. The entry's `(ModifiedSequence, IsDecoy)` must be in the consensus map (`ReconciliationPlanner.cs:200-202`).
+2. The entry's `(EntryId & 0x7FFFFFFF, Charge)` must be in `passingBaseIds` — precursors where the minimum of the four q-values (run/experiment × precursor/peptide) clears `experimentFdr` (`ReconciliationPlanner.cs:131-144, 209`). Reconciliation must include a passing precursor (and its paired decoy, matched by base_id) in every file to keep per-file boundaries self-consistent. Note the planner receives `config.Reconciliation.ConsensusFdr` as its `experimentFdr` argument (`Stage6Planner.cs:285`), which defaults to 0.01.
+
+### RT tolerance: global within-peptide MAD
+
+`rtTolerance` is driven by the experiment's **within-peptide** RT reproducibility, not cross-peptide calibration residuals:
+
+```text
+globalWithinPeptideMadLib = median over target consensus peptides with ApexLibraryRtMad set
+                            of their per-peptide ApexLibraryRtMad          // ReconciliationPlanner.cs:96-118
+peptideTolerance = min( max(globalWithinPeptideMadLib * 1.4826 * 3.0, 0.1),
+                        fileCalToleranceCeiling )                          // ReconciliationPlanner.cs:188-190
+```
+
+Constants: `MIN_RT_TOLERANCE = 0.1`, `MAD_TO_SIGMA = 1.4826`, `SIGMA_FACTOR = 3.0` (`ReconciliationPlanner.cs:40, 47, 50`). When no target peptide has `>= 3` detections (e.g. a 2-replicate experiment), the global MAD falls back to `FALLBACK_GLOBAL_MAD_LIB = 0.05` (`ReconciliationPlanner.cs:44, 108`).
+
+Using a single global number (the median across all peptides) avoids the self-fulfilling-prophecy failure of a per-point local tolerance, where a wrong-apex peptide inflates the tolerance at its own RT. Per-peptide MADs are still computed and stored on `PeptideConsensusRT` for diagnostics but are not the primary tolerance.
+
+### Per-file safety ceiling (sigma-clipped)
+
+The per-file calibration MAD is retained as a ceiling so a pathologically tight global MAD cannot force every peak to be re-scored (`ReconciliationPlanner.cs:166-183`):
+
+```text
+rawMad         = cal.Stats().MAD
+clipThreshold  = rawMad * 1.4826 * 3.0
+clippedMad     = SigmaClippedMad(cal.AbsResiduals, clipThreshold)   // ReconciliationPlanner.cs:299-322
+refinedTol     = max(clippedMad * 1.4826 * 3.0, 0.1)
+cap            = max(originalCal.MAD * 1.4826 * 3.0, 0.1)           // each pass can only tighten
+ceiling        = min(refinedTol, cap)
+```
+
+`SigmaClippedMad` filters absolute residuals at the clip threshold and returns the median of the survivors, falling back to the unclipped median if fewer than `SIGMA_CLIP_MIN_SURVIVORS = 20` remain (`ReconciliationPlanner.cs:299-322`). This sigma-clipping is more detailed than the plain "per-file calibration MAD ceiling" the Rust prose describes; the code comment ties it to the Rust docstring at `reconciliation.rs:570-607`, so the two implementations agree (see Divergences).
+
+### CWT candidates
+
+CWT candidates were stored during the first-pass search (default 5 per precursor, `ReconciliationConfig.TopNPeaks`) and persisted in the per-file Parquet score cache. During planning they are loaded selectively via `CwtCandidateLoader.Load` (`Stage6Planner.cs:267`), keyed per entry by `ParquetIndex` (`ReconciliationPlanner.cs:214-218`) — avoiding a full re-extraction. `ForcedIntegration` is the last resort when no stored candidate's apex lands within tolerance.
+
+---
+
+## Step 5: Re-Scoring via Boundary Overrides (Stage 6)
+
+`PerFileRescoreTask` (`Osprey.Tasks/PerFileRescoreTask.cs`) applies the plan. It reuses the same coelution scoring path as the first pass with a `BoundaryOverrides` map, so re-scoring inherits parallel window processing and per-window XCorr preprocessing (see 11-boundary-overrides.md and 02-xcorr-scoring.md).
+
+1. **Merge targets** (`TryAssembleRescoreTargets`, `PerFileRescoreTask.cs:879-932`): multi-charge consensus targets and reconciliation targets are merged into one per-file map keyed by entry index. On conflict, **reconciliation wins** — its inter-replicate boundary is more authoritative (`PerFileRescoreTask.cs:904-908`).
+2. **Build boundary overrides** (`GroupReconciliationActionsByFile`, `PerFileRescoreTask.cs:997-1037`): `UseCwtPeak → (ApexRt, StartRt, EndRt)`; `ForcedIntegration → (ExpectedRt, ExpectedRt - HalfWidth, ExpectedRt + HalfWidth)`. The `BuildScoringSubset` step (`PerFileRescoreTask.cs:1066`) keys these by `EntryId` and subsets the library to only the entries being re-scored.
+3. **Call the search** with `context.BoundaryOverrides` set (`PerFileRescoreTask.cs:733`). Entries with an override skip the pre-filter and CWT peak detection, map RT boundaries to XIC scan indices, and recompute all 21 PIN features at the override boundaries.
+4. **Write back** the re-scored entries into the reconciled Parquet, keyed by `ParquetIndex` to survive first-pass compaction.
+
+Files are processed **sequentially** at the file level because each file loads spectra (~1-2 GB) plus its Parquet entries; parallel file loading would OOM. Parallelism is within a file, across isolation windows.
+
+---
+
+## Step 6: Second-Pass FDR (Stage 7)
+
+After reconciliation and gap-fill, `MergeNodeTask` (`--task SecondPassFDR`) recomputes experiment-level q-values on the updated pool (features recomputed at consensus-aligned boundaries) using the same native Percolator SVM FDR pipeline as the first pass. These are the final experiment-level q-values written to the blib. See 07-fdr-control.md.
+
+---
+
+## Gap-Fill
+
+If a precursor passed run-level FDR in one replicate but was never scored in another, reconciliation alone would leave that file with no integration and the blib missing a per-file boundary. `GapFillTargetIdentifier.Identify` (`Osprey.FDR/Reconciliation/GapFillTargetIdentifier.cs:68`) closes this hole.
+
+### Identification
+
+It builds the set of passing precursors `(ModifiedSequence, Charge)` — any target whose minimum of the four q-values is `<= experimentFdr` (`GapFillTargetIdentifier.cs:98-111`; called with `config.Reconciliation.ConsensusFdr` at `FirstJoinTask.cs:947`). For each file it finds passing precursors absent from that file's entries (`GapFillTargetIdentifier.cs:144-155`) and emits a `GapFillTarget` (`Osprey.FDR/Reconciliation/GapFillTarget.cs`) carrying `TargetEntryId` / `DecoyEntryId` (from the library lookup), `ExpectedRt` = `cal.Predict(consensusLibraryRt)`, `HalfWidth` = `MedianPeakWidth / 2`, and `ModifiedSequence` / `Charge` (`GapFillTargetIdentifier.cs:186-197`). Target and decoy are emitted together for symmetric competition. Results are sorted by `TargetEntryId` for deterministic, byte-parity JSON output (`GapFillTargetIdentifier.cs:207`).
+
+### Isolation-window m/z filter (GPF-aware)
+
+Forcing an integration at every missing precursor is wrong for gas-phase fractionation, where a file physically cannot observe an m/z its isolation windows don't select. A candidate survives only if its library precursor m/z falls inside at least one of the target file's `(Lo, Hi)` intervals, with a **strict** upper bound `precursorMz >= Lo && precursorMz < Hi` (`GapFillTargetIdentifier.cs:165-181`). When a file has no stored isolation scheme (null or empty list), the filter is disabled for that file — a graceful fallback to "fill every missing precursor" rather than dropping everything (`GapFillTargetIdentifier.cs:140-142, 165`).
+
+### Scoring
+
+Surviving gap-fill targets are re-scored by the same `PerFileRescoreTask` boundary-override path as reconciliation, using `(ExpectedRt - HalfWidth, ExpectedRt, ExpectedRt + HalfWidth)`, and feed into the second-pass FDR.
+
+---
+
+## The reconciliation.json envelope (Stage 5 → Stage 6)
+
+Because the C# port runs as HPC stages, the Stage 5 plan is serialized per-file to `<stem>.reconciliation.json` (`Osprey.IO/ReconciliationFile.cs`) and read back by the Stage 6 worker. The envelope (schema `format_version = 3`) carries the non-Keep actions split into two homogeneous arrays (`use_cwt_peak_actions`, `forced_integration_actions`), `gap_fill_targets`, the `refined_rt_calibration`, the join-wide `file_stems` and `first_pass_base_ids`, and `library_hash` / `search_hash` for cache validation. All doubles route through `RoundtripDoubleConverter` and the file is normalized to LF with a trailing newline so it is byte-identical to the Rust `serde_json` output. This envelope has no counterpart in the Rust doc, which describes reconciliation as an in-process step; it is the port's HPC-split infrastructure (see 14-intermediate-files.md, 15-hpc-scoring-split.md).
+
+---
+
+## Flags and switches
+
+| Flag / field | Default | Effect on this stage |
+|--------------|---------|----------------------|
+| `ReconciliationConfig.Enabled` (`Osprey.Core/ReconciliationConfig.cs:33`) | `true` | Master switch. `FirstJoinTask.cs:387` and `PerFileRescoreTask.cs:158, 963` gate reconciliation on it. **There is no CLI flag to toggle it** — no `--no-reconciliation`; only a config/YAML `Reconciliation.Enabled = false` disables it. `--task FirstPassFDR` requires it enabled (`Program.cs:395-396`). |
+| `ReconciliationConfig.ConsensusFdr` (`ReconciliationConfig.cs:39`) | `0.01` | The consensus qualification threshold (Step 1 hard precursor gate + peptide/protein rescue), the refit experiment-q gate, the planner `experimentFdr` (`Stage6Planner.cs:285`), and the gap-fill passing threshold (`FirstJoinTask.cs:947`). |
+| `ReconciliationConfig.TopNPeaks` (`ReconciliationConfig.cs:36`) | `5` | Number of CWT candidate peaks stored per precursor for later UseCwtPeak selection. |
+| `--reconciliation-compaction-fdr <threshold>` (`OspreyCommandArgs.cs:116-117`) | `0.01` | Peptide-q gate for first-pass compaction, which sets the pool reconciliation operates on. Loosen (e.g. 0.05) to broaden the reconciliation pool. Not the consensus gate itself. |
+| `--protein-fdr <threshold>` (`config.EffectiveProteinFdr`, passed at `Stage6Planner.cs:176`) | protein machinery always runs; threshold 0.01 | Enables the Step 1 protein-rescue branch for borderline peptide-level evidence. When 0 / disabled, the rescue branch is off (`ConsensusRts.cs:249`). |
+| `--experiment-fdr <threshold>` | `0.01` | The second-pass (Stage 7) experiment FDR threshold; not consumed by planning itself. |
+| `OspreyEnvironment.LoessClassicalRobust` (`CalibrationRefit.cs:97`) | `true` | Must match Stage 4 initial calibration; drives refit robustness iterations for cross-impl parity. |
+| `OSPREY_DUMP_INV_PREDICT` (+ `_ONLY`) | off | Diagnostic: dumps one `InvPredictRecord` per consensus detection (apex_rt, library_rt, weight) for cross-impl bisection (`Stage6Planner.cs:168-184`). |
+| `OSPREY_DUMP_CONSENSUS`, `OSPREY_DUMP_RECONCILIATION`, `OSPREY_DUMP_MULTICHARGE`, `OSPREY_DUMP_LOESS_FIT`, `OSPREY_DUMP_REFIT` (+ each `_ONLY`) | off | Stage 6 cross-impl bisection dumps for each planning phase (`Stage6Planner.cs`). |
+| `OSPREY_TRACE_PEPTIDE` | off | Per-peptide trace through consensus, planning, and gap-fill (18-peptide-trace.md). |
+
+---
+
+## Divergences from the Rust documentation
+
+- **[INTENTIONAL-CSHARP-DESIGN] HPC stage split with a JSON envelope** - Rust doc describes reconciliation as an in-process step inside `run_analysis` (consensus → refit → plan → re-score → second-pass FDR, all in memory). C# splits it into Stage 5 planning (`Stage6Planner`/`FirstJoinTask`), a serialized `<stem>.reconciliation.json` handoff (`Osprey.IO/ReconciliationFile.cs`, `format_version` 3), Stage 6 apply (`PerFileRescoreTask`), and Stage 7 second-pass FDR (`MergeNodeTask`). Behavior/outputs match; the envelope is byte-parity with Rust. Evidence: Osprey.IO/ReconciliationFile.cs:52-107; Osprey.Tasks/Stage6Planner.cs:48-100. Severity: info.
+
+- **[STALE-RUST-DOC] `--no-reconciliation` CLI flag not present in C#** - Rust doc (Configuration section) says "CLI flag: `--no-reconciliation` disables it entirely." The C# CLI has no such argument; the only reconciliation-related CLI flag is `--reconciliation-compaction-fdr`. Reconciliation can only be disabled via the config object's `Reconciliation.Enabled = false`, not from the command line. Evidence: Osprey/OspreyCommandArgs.cs:116-117 (only reconciliation CLI arg); Osprey.Core/ReconciliationConfig.cs:33 (config-only switch). Severity: minor.
+
+- **[STALE-RUST-DOC] Worked example still uses `coelution_sum` weighting** - Rust doc's "Example" section (and the Algorithm Overview arrow diagram) computes the weighted median with `weight = coelution_sum`, while the current algorithm — stated correctly elsewhere in the same Rust doc's Step 2 — uses `sigmoid(SVM score)`. C# uses `max(1e-6, sigmoid(score))`, matching current Rust code, not the stale example. Evidence: Osprey.FDR/Reconciliation/ConsensusRts.cs:178. Severity: info.
+
+- **[STALE-RUST-DOC] Planner passing-precursor precondition not described** - Rust doc Step 4 says the planner runs "For each scored entry (target or decoy)" with no mention of a per-entry FDR gate. C# (and, per the code comment, current Rust `reconciliation.rs:560-576`) additionally requires the entry's `(base_id, charge)` to be in `passingBaseIds` — precursors where `min(run/exp × precursor/peptide q) <= experimentFdr` — before an action is assigned. Evidence: Osprey.FDR/Reconciliation/ReconciliationPlanner.cs:131-144, 209. Severity: minor.
+
+- **[STALE-RUST-DOC] Ceiling is a sigma-clipped MAD, not a plain calibration MAD** - Rust doc describes the per-file safety ceiling only as "the calibration-MAD-based ceiling." C# computes it as a sigma-clipped median of the refined absolute residuals (clip at `MAD×1.4826×3`, fall back to unclipped median if fewer than 20 survive), then caps it by the original first-pass calibration MAD so each pass can only tighten. The code comment ties this to Rust docstring `reconciliation.rs:570-607`, so the implementations agree; only the Rust prose is simplified. Evidence: Osprey.FDR/Reconciliation/ReconciliationPlanner.cs:166-183, 299-322. Severity: minor.
+
+- **[INTENTIONAL-CSHARP-DESIGN] Decoy pairing by base_id, not DECOY_ prefix** - Rust doc says paired decoys are matched by "DECOY_ prefix, any matching modified_sequence." C# pairs by `EntryId & 0x7FFFFFFF` so library-supplied decoys (Carafe / FDRBench manifest) with no prefix are still recognized; the prefix-strip path would silently miss them. The code comment states this mirrors current Rust `compute_consensus_rts`, so this is the shared current behavior, more general than the doc's prose. Evidence: Osprey.FDR/Reconciliation/ConsensusRts.cs:93-118; ReconciliationPlanner.cs:120-144. Severity: info.
+
+- **[INTENTIONAL-CSHARP-DESIGN] Second-pass FDR engine is native Percolator only** - Rust doc Step 6 says "the same Percolator/Mokapot/Simple FDR pipeline applies." The C# port has no Python Mokapot dependency; second-pass FDR runs the native managed Percolator SVM (or `simple`). The `FdrMethod` enum still lists Mokapot but the CLI only accepts `percolator | simple`. Evidence: MergeNodeTask (`--task SecondPassFDR`); see 07-fdr-control.md. Severity: info.
+
+Everything else verified matches step for step: the hard run-precursor-q consensus gate (`ConsensusRts.cs:246`), the protein-FDR rescue branch (`ConsensusRts.cs:248-249`), sigmoid(score) weighted median with a 1e-6 floor and a `CoelutionSum > 0` filter (`ConsensusRts.cs:172-197`), within-peptide MAD requiring ≥3 detections (`ConsensusRts.cs:203-214`), the global-within-peptide-MAD RT tolerance with a 0.1-min floor and 3σ×1.4826 factor (`ReconciliationPlanner.cs:96-190`), apex-proximity (not boundary-containment) Keep/UseCwtPeak/ForcedIntegration selection picking the closest CWT candidate (`ReconciliationPlanner.cs:248-291`), calibration refit at 20-point minimum with outlier removal disabled (`CalibrationRefit.cs:39, 92-98`), the GPF isolation-window m/z filter with a strict upper bound and graceful fallback (`GapFillTargetIdentifier.cs:165-181`), single-file skip (`Stage6Planner.cs:171-178`), reconciliation-wins-on-conflict merge (`PerFileRescoreTask.cs:904-908`), and deterministic sorting of consensus and gap-fill output (`ConsensusRts.cs:231-237`, `GapFillTargetIdentifier.cs:207`).

--- a/pwiz_tools/Osprey/docs/11-boundary-overrides.md
+++ b/pwiz_tools/Osprey/docs/11-boundary-overrides.md
@@ -1,0 +1,383 @@
+# 11. Boundary Overrides & Rescore (C#)
+
+> Pipeline stage: Stage 6 (per-file rescore + gap-fill). C# port of Rust docs/13-boundary-overrides.md. Corresponds to Rust osprey `run_search(boundary_overrides)` / `run_rescore`.
+
+This document describes how the C# port re-scores previously-scored entries at
+caller-supplied RT boundaries — the mechanism Rust exposes as the
+`boundary_overrides` parameter of `run_search()`. In C# the override triple flows
+through a `ScoringContext.BoundaryOverrides` map into the same
+`ScoringPipeline.RunCoelutionScoring` path the first-pass search uses, so
+re-scored entries get features on exactly the same scale as first-pass entries.
+Stage 6 is driven by `PerFileRescoreTask` (`--task PerFileRescoring`), planned by
+`Stage6Planner`, and consumes the plan produced by cross-run reconciliation
+(see 10-cross-run-reconciliation.md) and multi-charge consensus (see
+09-multi-charge-consensus.md).
+
+## Overview: the C# override channel
+
+Rust threads an `Option<&HashMap<u32, (f64, f64, f64)>>` parameter into
+`run_search()`. C# has no extra parameter on the scoring entry point; instead the
+override map is carried on the scoring context:
+
+- `ScoringContext.BoundaryOverrides` is an
+  `IReadOnlyDictionary<uint, (double Apex, double Start, double End)>` keyed by
+  `LibraryEntry.Id` / `FdrEntry.EntryId` (`Osprey.Scoring/ScoringContext.cs:58`).
+- `ScoringPipeline.RunCoelutionScoring(...)` is the `run_search` equivalent
+  (`Osprey.Scoring/ScoringPipeline.cs:65`). It takes the same context whether it
+  is first-pass scoring or Stage 6 re-scoring.
+- Inside per-candidate peak extraction, `PeakDataExtractor.TryExtract` looks up
+  the candidate id in `context.BoundaryOverrides`
+  (`Osprey.Scoring/PeakDataExtractor.cs:88`). A hit switches the candidate onto
+  the override peak-construction path; a miss uses the normal CWT detection path.
+
+This is the same design the Rust doc describes: first-pass search and every
+re-scoring path (multi-charge consensus, cross-run reconciliation, gap-fill
+forced integration) share one code path; only the source of the boundaries
+differs.
+
+## Where the override triples come from
+
+Stage 6 planning (`Stage6Planner.Plan`, `Osprey.Tasks/Stage6Planner.cs:80`) runs
+four phases in Rust order (multi-charge consensus, cross-run consensus RTs,
+per-file calibration refit, reconciliation planning). Three of those feed
+override boundaries into the rescore:
+
+### 1. Multi-charge consensus (forced boundaries)
+
+`Stage6Planner.ComputeMultiChargeConsensus`
+(`Osprey.Tasks/Stage6Planner.cs:106`) calls
+`MultiChargeConsensus.SelectRescoreTargets(entries, config.RunFdr)` per file. When
+a peptide has FDR-passing detections at several charge states, the best
+SVM-scoring charge defines the consensus `(apex, start, end)`; the other charge
+states are re-scored there. These land in
+`PerFileConsensusTargets` keyed by file name.
+
+### 2. UseCwtPeak (stored CWT candidate)
+
+`ReconcileAction.UseCwtPeak` — during reconciliation planning
+(`Stage6Planner.PlanReconciliation`, `Osprey.Tasks/Stage6Planner.cs:258`), if the
+current peak's apex is not at the expected consensus RT but a stored CWT
+candidate is, the planner switches to that candidate's `(start, apex, end)`. CWT
+candidates are stored during the first-pass search (up to
+`ReconciliationConfig.TopNPeaks`, default 5, `Osprey.Core/ReconciliationConfig.cs:36`)
+in the per-file `.scores.parquet` and loaded selectively by `CwtCandidateLoader`.
+
+### 3. ForcedIntegration (imputed boundaries)
+
+`ReconcileAction.ForcedIntegration` — when no stored CWT candidate contains the
+expected RT, the planner imputes boundaries from the expected RT and half the
+median peak width: `(expected_rt, expected_rt - half_width, expected_rt +
+half_width)`. `GroupReconciliationActionsByFile`
+(`Osprey.Tasks/PerFileRescoreTask.cs:1016-1021`) expands the stored
+`ExpectedRt`/`HalfWidth` into the `(apex, start, end)` triple exactly as the Rust
+doc specifies.
+
+The `UseCwtPeak` / `ForcedIntegration` split is modeled as a discriminated union
+`ReconcileAction` in `Osprey.FDR/Reconciliation`; the planner never emits a
+`Keep` action into the map (Keep is the implicit default and is absent from the
+persisted arrays).
+
+A fourth source — **gap-fill** — is C#-specific to this stage's write-up but is
+part of the same reconciliation machinery (see the Gap-fill section below).
+
+## Merging consensus and reconciliation targets per file
+
+`TryAssembleRescoreTargets` (`Osprey.Tasks/PerFileRescoreTask.cs:879`) builds one
+combined override map per file:
+
+1. Multi-charge consensus targets are inserted first
+   (`PerFileRescoreTask.cs:905-906`).
+2. Reconciliation targets are inserted second and **overwrite on conflict**
+   (`PerFileRescoreTask.cs:907-908`) — reconciliation wins because the
+   inter-replicate boundary carries more information (refined calibration +
+   cross-run consensus RT). This matches the Rust doc's "reconciliation wins on
+   conflict" rule.
+3. Gap-fill targets are collected separately (they append new rows rather than
+   re-scoring existing ones).
+
+A single `RunCoelutionScoring` call per file then processes all override entries
+together, so spectra are loaded only once per file.
+
+## The per-file rescore loop
+
+`PerFileRescoreTask.Run` (`Osprey.Tasks/PerFileRescoreTask.cs:185`) pulls the
+planning byproducts through the typed pipeline registry
+(`ctx.Get<CompactedEntries>()`, `ctx.Get<ReconciliationActions>()`,
+`ctx.Get<PerFileConsensusTargets>()`, `ctx.Get<PerFileGapFillForRescore>()`, etc.)
+and dispatches into `ExecuteRescore` (`PerFileRescoreTask.cs:491`). Per file,
+`RescoreOneFile` (`PerFileRescoreTask.cs:644`) does:
+
+1. **Resume probe** — `TryResumeRescoredFile` skips a file whose
+   `.scores-reconciled.parquet` + resume sidecar are already valid, overlaying the
+   reconciled boundaries in place (`PerFileRescoreTask.cs:827`).
+2. **Assemble targets** — `TryAssembleRescoreTargets` (consensus + reconciliation
+   dedup + gap-fill); bails on no-work files.
+3. **Build the scoring subset** — `BuildScoringSubset`
+   (`PerFileRescoreTask.cs:1066`) turns `combinedTargets` into a
+   `boundary_overrides` map keyed by `EntryId` and a library subset containing
+   only the entries being re-scored.
+4. **Reload spectra** — `LoadSpectraForRescore` (`PerFileRescoreTask.cs:1485`)
+   prefers the `.spectra.bin` cache, falling back to re-parsing the mzML.
+5. **Reload mass calibrations** — `LoadMassCalibrations`
+   (`PerFileRescoreTask.cs:1531`) reads the sibling `.calibration.json` for MS2/MS1
+   m/z calibration and the first-pass RT MAD. This is a hard requirement: a
+   missing/unreadable calibration sidecar throws (no silent uncalibrated
+   fallback).
+6. **Pick RT calibration** — refined (Stage 6 refit) wins, first-pass falls back
+   (`PerFileRescoreTask.cs:712-713`).
+7. **Score the subset** — a fresh `ScoringContext` carries
+   `BoundaryOverrides = boundaryOverrides` and `OriginalRtMad`
+   (`PerFileRescoreTask.cs:732-735`); `RunCoelutionScoring(..., passLabel:
+   "Re-scoring")` re-scores.
+8. **Overlay results** — `OverlayRescoredEntries` (`PerFileRescoreTask.cs:1119`)
+   writes each re-scored `FdrEntry` back onto the per-file stub by `EntryId`,
+   preserving `ParquetIndex` and resetting the discriminant fields to Rust
+   `to_fdr_entry` defaults (Score 0.0, all six q-values 1.0, Pep 1.0) so Stage 7
+   second-pass Percolator recomputes them.
+9. **Gap-fill two-pass** — `RunGapFillTwoPass` (see below).
+10. **Write-back** — `WriteReconciledAndStamp` (`PerFileRescoreTask.cs:944`) writes
+    the reconciled parquet and stamps the resume sidecar only on success.
+
+## How overrides work inside the scorer (step by step)
+
+`PeakDataExtractor.TryExtract` (`Osprey.Scoring/PeakDataExtractor.cs:63`) mirrors
+the detection half of `run_search`. With `overrideBounds` set:
+
+### Step 1: Override detection
+
+`context.BoundaryOverrides.TryGetValue(candidate.Id, out var bnd)` sets a nullable
+`overrideBounds` triple (`PeakDataExtractor.cs:87-92`). The rest of the method
+branches on `overrideBounds.HasValue`.
+
+### Step 2: RT range selection
+
+`FindScanRange` (`PeakDataExtractor.cs:491`) uses the override boundaries ± a
+margin rather than expected-RT ± tolerance:
+
+```
+peakWidth = max(0.1, End - Start)
+margin    = max(0.2, peakWidth)
+rtLo = Start - margin ; rtHi = End + margin
+```
+
+Scans with `windowRts[i]` in `[rtLo, rtHi]` define `[startScan, endScan]`. This is
+byte-equivalent to the Rust `target_start - margin .. target_end + margin`
+window.
+
+### Step 3: Pre-filter skip
+
+The top-fragment signal pre-filter runs only when
+`config.PrefilterEnabled && !overrideBounds.HasValue`
+(`PeakDataExtractor.cs:117`). Override entries skip it entirely — the caller has
+already decided these boundaries must be scored.
+
+### Step 4: RT to XIC index mapping (synthetic peak)
+
+Instead of CWT peak detection, `DetectCandidatePeaks`
+(`PeakDataExtractor.cs:543`) routes overrides to `BuildOverridePeaks`
+(`PeakDataExtractor.cs:614`), which maps the target RTs onto the reference XIC's
+RT axis with `ScoringMath.BinarySearchLowerBound` (Rust `partition_point`
+semantics):
+
+- `startIdx = lowerBound(rt, Start)`, then `startIdx--` (Rust `saturating_sub(1)`),
+  clamped to `len-1`.
+- `endIdx = lowerBound(rt, End)`, clamped to `len-1`.
+- `apexIdx = lowerBound(rt, Apex)`, refined to the nearer neighbor, then clamped
+  to `[startIdx, endIdx]`.
+
+The reference XIC is the highest total-intensity fragment selected with `>=`
+(last-wins on ties) to match Rust `max_by` tie behavior — a deliberately
+documented parity point (`PeakDataExtractor.cs:618-639`).
+
+A single synthetic `XICPeakBounds` is returned with `Area` from
+`PeakDetector.TrapezoidalArea` and `SignalToNoise` from `PeakDetector.ComputeSnr`.
+The apex-acceptance RT filter that gates normal peaks
+(`PeakDataExtractor.cs:258`) is bypassed for overrides.
+
+### Step 5: Feature computation
+
+From the synthetic peak, the scorer computes all 21 PIN features through the same
+calculators the first-pass path uses (see 03-spectral-scoring.md), sharing the
+per-window pre-processed XCorr vectors. No separate re-scoring code path exists.
+
+### Early return on insufficient data
+
+`BuildOverridePeaks` returns `null` (candidate dropped) when the reference XIC has
+fewer than 3 points (`if (last < 2) return null;`, `PeakDataExtractor.cs:643`) or
+the mapped range is too narrow (`if (endIdx <= startIdx + 1) return null;`,
+`PeakDataExtractor.cs:663`) — the same two guards the Rust doc lists.
+
+## Gap-fill two-pass (Phase 2)
+
+For peptides that pass FDR in sibling replicates but were not detected in this
+file, `RunGapFillTwoPass` (`Osprey.Tasks/PerFileRescoreTask.cs:1337`) runs two
+passes over target-only gap-fill entries (decoys are intentionally excluded —
+see the method's doc comment for the exact-duplicate-row rationale):
+
+1. **CWT pass** — a cloned config with `PrefilterEnabled = false` and **no**
+   boundary overrides, so CWT picks peaks freely
+   (`passLabel: "Gap-fill scoring"`, `PerFileRescoreTask.cs:1370-1385`). Hits are
+   appended as new stubs with `ParquetIndex = uint.MaxValue` and score-reset
+   fields.
+2. **Forced-integration pass** — for targets the CWT pass missed, an override map
+   `(ExpectedRt, ExpectedRt - HalfWidth, ExpectedRt + HalfWidth)` re-scores at the
+   imputed window (`passLabel: "Gap-fill forced integration"`,
+   `PerFileRescoreTask.cs:1444-1453`). These land through the same override path
+   as reconciliation `ForcedIntegration`.
+
+Counts flow into `RescoreStats.TotalGapCwt` / `TotalGapForced`.
+
+## Search-label progress phases
+
+`RunCoelutionScoring` takes a `passLabel` argument
+(`Osprey.Scoring/ScoringPipeline.cs:74`) that names the progress phase; the
+reporter renders `"{passLabel} isolation windows"` and defaults to `"Scoring"`
+when null (`ScoringPipeline.cs:266`). The C# phase labels are:
+
+| Phase | C# `passLabel` | Rust `search_label` |
+|-------|----------------|---------------------|
+| First-pass search | (null) -> `Scoring` | `Scoring` |
+| Consensus + reconciliation re-score | `Re-scoring` | `Re-scoring` |
+| Gap-fill CWT pass | `Gap-fill scoring` | `Gap-fill CWT` |
+| Gap-fill forced pass | `Gap-fill forced integration` | `Gap-fill forced` |
+
+Under `--parallel-files`, each file's rescore is divided into three equal
+progress segments (reload spectra / re-score subset / write reconciled parquet),
+advanced via `MultiProgressReporter.Current?.BeginSegment()`
+(`PerFileRescoreTask.cs:103`, `:693`, `:742`, `:789`).
+
+## Reconciled parquet write-back
+
+`ReconciledParquetWriter.Write` (`Osprey.Tasks/ReconciledParquetWriter.cs:54`)
+reads the original Stage 4 `.scores.parquet`, replaces the re-scored rows,
+appends gap-fill rows, and writes a **separate** `.scores-reconciled.parquet`
+sibling (the original stays intact for crash-resume safety). The footer metadata
+stamps `osprey.reconciled = "true"` and `osprey.reconciliation_hash` alongside
+`osprey.version`, `osprey.search_hash`, and `osprey.library_hash`
+(`ReconciledParquetWriter.cs:200-204`), which the downstream `--task
+SecondPassFDR` merge node validates.
+
+Note: six per-row blob columns (`fragment_mzs`, `fragment_intensities`,
+`reference_xic_rts`, `reference_xic_intensities`, `bounds_area`, `bounds_snr`) are
+currently written null/zero — a tracked follow-up noted in
+`RescoreWorker.cs:64-71`, not a boundary-override algorithm difference.
+
+## Worker mode, hydration, and compaction
+
+`RescoreWorker.Run` (`Osprey/RescoreWorker.cs:80`) is now a thin alias for
+`new AnalysisPipeline().Run(config)` (Phase C): the `--task PerFileRescoring`
+worker reuses the canonical pipeline, and the upstream boundary state is
+rehydrated lazily rather than hand-assembled.
+
+- `RescoreHydration.HydrateForRescore` (`Osprey.Tasks/RescoreHydration.cs:166`)
+  loads pre-compaction `FdrEntry` stubs from each `.scores.parquet`, overlays the
+  `.1st-pass.fdr_scores.bin` v3 sidecar (SVM scores + 4 q-values + PEP +
+  `RunProteinQvalue`), and parses each `reconciliation.json` envelope into the
+  action map + refined calibration + gap-fill targets + join-wide
+  `first_pass_base_ids` (v3).
+- `RescoreCompaction.Apply` (`Osprey.Tasks/RescoreCompaction.cs:113`) reproduces
+  the in-process first-pass compaction: it keeps exactly the join-wide
+  `GlobalFirstPassBaseIds` set (hard-fails if absent), **unioned** with the
+  base_ids of every reconciliation-action target so cross-file-rescued entries
+  survive. Compaction is keyed by `base_id` (`0x7FFFFFFF` mask) so a target and
+  its paired decoy stay together, and the action map is re-keyed to
+  post-compaction indices.
+
+## Flags and switches
+
+This stage has no dedicated boundary-override CLI flag; the override triples are
+computed by Stage 6 planning. The flags that affect this stage:
+
+| Flag / field | Default | Effect on this stage |
+|--------------|---------|----------------------|
+| `--task {PerFileScoring\|FirstPassFDR\|PerFileRescoring\|SecondPassFDR}` | (in-process, all stages) | `PerFileRescoring` runs this stage as a standalone worker (internal `HpcTask.PerFileRescore`). `SecondPassFDR` (`HpcTask.MergeNode`) rehydrates reconciled parquets instead of re-scoring. |
+| `--input-scores <paths\|dir>` | — | Supplies the boundary `.scores.parquet` files the worker rescores; drives `IsIncluded` (`PerFileRescoreTask.cs:123`). |
+| `--reconciliation-compaction-fdr <v>` | 0.01 (`OspreyConfig.ReconciliationCompactionFdr`) | First-pass compaction predicate applied upstream in FirstJoin; determines which entries survive into the rescore set. |
+| `ReconciliationConfig.Enabled` | true | Gates reconciliation planning + `reconciliation.json` inputs (`PerFileRescoreTask.cs:158`). Disabling leaves only multi-charge consensus rescore. |
+| `ReconciliationConfig.ConsensusFdr` | 0.01 (`ReconciliationConfig.cs:39`) | Threshold for consensus peptide selection, calibration refit, and reconciliation planning (`Stage6Planner.cs`). Not a CLI flag; config field. |
+| `ReconciliationConfig.TopNPeaks` | 5 (`ReconciliationConfig.cs:36`) | CWT candidates stored per precursor at first-pass; the pool `UseCwtPeak` overrides are drawn from. |
+| `--no-prefilter` (`PrefilterEnabled`) | true | Only affects non-override entries; override entries always skip the pre-filter (`PeakDataExtractor.cs:117`). The gap-fill CWT pass forces prefilter off regardless (`PerFileRescoreTask.cs:1375`). |
+| `--parallel-files [N]` | off (sequential) | Runs per-file rescores concurrently under `EffectiveFileParallelism` (`PerFileRescoreTask.cs:547`); output is byte-identical to sequential (gated by regression.ps1). |
+| `--threads <count>` | all cores | Inner window parallelism per file; divided across concurrent files under `--parallel-files` (`PerFileRescoreTask.cs:684`). |
+| `--protein-fdr <v>` | optional (`EffectiveProteinFdr`) | Feeds the protein-rescue gate into consensus RT computation (`Stage6Planner.cs:176`), affecting which entries become reconciliation targets. |
+
+Diagnostic env vars that dump this stage (each with a `*_ONLY=1` early-exit
+variant): `OSPREY_DUMP_MULTICHARGE`, `OSPREY_DUMP_CONSENSUS`,
+`OSPREY_DUMP_INV_PREDICT`, `OSPREY_DUMP_LOESS_FIT`, `OSPREY_DUMP_REFIT`,
+`OSPREY_DUMP_RECONCILIATION`, `OSPREY_DUMP_RESCORED`, plus the per-entry
+`OSPREY_DIAG_SEARCH_ENTRY_IDS` search-XIC dump and `OSPREY_DUMP_CWT_PATH`
+(`Stage6Planner.cs`, `PerFileRescoreTask.cs:297`, `PeakDataExtractor.cs:154`).
+`OSPREY_TRACE_PEPTIDE` per-peptide tracing is documented in 18-peptide-trace.md.
+
+## Divergences from the Rust documentation
+
+- **[INTENTIONAL-CSHARP-DESIGN] Override map carried on the context, not a
+  function parameter** - Rust doc says `run_search()` takes a
+  `boundary_overrides: Option<&HashMap<...>>` parameter; C# has no such parameter
+  on `RunCoelutionScoring` and instead carries the map on
+  `ScoringContext.BoundaryOverrides`, read inside `PeakDataExtractor.TryExtract`.
+  Behavior is identical (same lookup, same override path).
+  Evidence: `Osprey.Scoring/ScoringContext.cs:58`,
+  `Osprey.Scoring/PeakDataExtractor.cs:88`. Severity: info.
+
+- **[INTENTIONAL-CSHARP-DESIGN] Optional file-level parallelism on the rescore
+  loop** - The Rust doc (and Rust CLAUDE.md memory-architecture notes) describe
+  reconciliation re-scoring as strictly sequential across files (`iter_mut`, one
+  ~3 GB spectra load at a time), relying only on window-level parallelism inside
+  `run_search`. C# keeps that window-level parallelism but additionally runs whole
+  files concurrently under `--parallel-files` / `EffectiveFileParallelism`, with
+  a per-file GC drop skipped in the parallel case. Output is byte-identical
+  (regression.ps1-gated); this is an added performance option, not an algorithm
+  change. Evidence: `Osprey.Tasks/PerFileRescoreTask.cs:547-584`, `:809-810`.
+  Severity: minor.
+
+- **[STALE-RUST-DOC] Gap-fill two-pass not covered by the boundary-override
+  doc** - Rust docs/13 documents only the three override types (consensus,
+  UseCwtPeak, ForcedIntegration). The C# rescore also runs a gap-fill two-pass
+  (CWT-free-pick pass + forced-integration pass) for peptides missing from a
+  file, driven through the same override channel. This is part of the
+  reconciliation machinery both implementations share (Rust
+  `identify_gap_fill_targets`); the boundary-override doc simply predates/omits
+  it. Evidence: `Osprey.Tasks/PerFileRescoreTask.cs:1337-1477`. Severity: info.
+
+- **[STALE-RUST-DOC] Gap-fill progress labels differ cosmetically** - Rust doc
+  lists progress labels `Gap-fill CWT` and `Gap-fill forced`; C# uses
+  `Gap-fill scoring` and `Gap-fill forced integration`. Console-string only; no
+  effect on outputs. Evidence: `Osprey.Tasks/PerFileRescoreTask.cs:1385`, `:1453`.
+  Severity: info.
+
+- **[INTENTIONAL-CSHARP-DESIGN] Reconciled parquet written to a separate
+  sibling** - The Rust doc frames re-scoring as updating the per-file cache in
+  place. C# writes a separate `.scores-reconciled.parquet` (leaving the original
+  Stage 4 parquet intact) for crash-resume safety, stamping
+  `osprey.reconciled` / `osprey.reconciliation_hash` in the footer. Content of the
+  re-scored rows matches; only the output file layout differs.
+  Evidence: `Osprey.Tasks/ReconciledParquetWriter.cs:54`, `:200-204`,
+  `Osprey.Tasks/PerFileRescoreTask.cs:145-151`. Severity: minor.
+
+- **[UNVERIFIED] Six per-row blob columns written null/zero in the reconciled
+  parquet** - `RescoreWorker`'s summary states `fragment_mzs`,
+  `fragment_intensities`, `reference_xic_rts`, `reference_xic_intensities`,
+  `bounds_area`, and `bounds_snr` are currently written null/zero, tracked as a
+  follow-up. This is a serialization gap in the reconciled parquet, not in the
+  boundary-override scoring itself (features and RT boundaries are computed and
+  written). A human should confirm whether any downstream consumer reads those
+  six columns off the reconciled parquet. Evidence: `Osprey/RescoreWorker.cs:64-71`.
+  Severity: minor.
+
+Verified to match the Rust doc step for step: the single shared scoring path for
+first-pass and re-scoring; override detection by entry id; the
+override-window ± margin RT range (`max(0.1, End-Start)`, `max(0.2, width)`);
+pre-filter skip for overrides; `partition_point`-equivalent RT-to-index mapping
+with `saturating_sub(1)` on start and nearest-neighbor apex refinement; the two
+early-return guards (`ref_xic.len() < 3`, `end_index <= start_index + 1`);
+consensus-first / reconciliation-wins merge order; and one `RunCoelutionScoring`
+call per file so spectra load once.
+
+See 10-cross-run-reconciliation.md for the full reconciliation algorithm,
+09-multi-charge-consensus.md for consensus leader selection, 05-rt-alignment.md
+for how expected/consensus RTs are computed, 02-xcorr-scoring.md for per-window
+XCorr preprocessing, 07-fdr-control.md for the second-pass FDR that consumes the
+re-scored features, 14-intermediate-files.md for the `.scores-reconciled.parquet`
+/ `reconciliation.json` / `.calibration.json` / `.spectra.bin` sidecars, and
+15-hpc-scoring-split.md for the `--task` worker fan-out.

--- a/pwiz_tools/Osprey/docs/12-second-pass-fdr.md
+++ b/pwiz_tools/Osprey/docs/12-second-pass-fdr.md
@@ -1,0 +1,120 @@
+# 12. Second-Pass FDR (C#)
+
+> Pipeline stage: Stage 7 (merge node). C#-originated; the Rust reference is
+> porting these modes back (maccoss/osprey#57), so there is no Rust `docs/` source
+> for this document. Corresponds to `Osprey.Tasks/Pass2FdrSidecar.cs`,
+> `Osprey.FDR/FrozenModelScorer.cs`, `Osprey.FDR/PercolatorFdr.cs`.
+
+After cross-run reconciliation (see [10-cross-run-reconciliation.md](10-cross-run-reconciliation.md))
+re-scores moved / gap-filled peaks, the merge node recomputes FDR over the
+reconciled entries to produce the **authoritative** experiment-level q-values that
+gate the `.blib` output. This is the "second pass." The FDR *framework* is the
+same one documented in [07-fdr-control.md](07-fdr-control.md); what differs is
+**how the null is built** for the second pass, selected by `OSPREY_PASS2_QVALUE`.
+
+The driver is `Pass2FdrSidecar.ComputeAndPersist`: it reloads the reconciled PIN
+features, runs one of the modes below, writes a `<stem>.2nd-pass.fdr_scores.bin`
+sidecar per file, and reloads the fresh q-values onto the post-compaction stubs.
+
+## Why a second-pass null is a problem
+
+First-pass compaction drops precursors that did not pass run-level FDR in any
+replicate (it frees ~21 GB on a 240-file experiment). That compacted pool is
+**decoy-depleted** — many decoys were dropped with the non-passing targets — so
+simply *retraining* a Percolator SVM on it estimates the null from a thin,
+biased decoy population and reports **anti-conservative** (optimistic) q-values.
+The frozen modes below avoid retraining on the depleted pool.
+
+## `OSPREY_PASS2_QVALUE` modes
+
+`OspreyEnvironment` parses the flag; an unrecognized token normalizes to
+`percolator` with a warning.
+
+| Mode | Retrain? | Null population | Level |
+|------|----------|-----------------|-------|
+| `percolator` (default) | **yes** | reconciled + compacted pool | precursor + peptide |
+| `transfer` | no | pass-1 q carried through; only moved peaks re-mapped | precursor + peptide |
+| `transfer-compete` | no (frozen model) | fresh full-population target-decoy competition | precursor |
+| `protein-compact` | no (frozen model) | competition constrained to the protein stratum | precursor |
+
+### `percolator` (default)
+
+Retrains the second-pass Percolator SVM and recomputes a target/decoy null on the
+reconciled + compacted pool (`ComputePass2Resident` → `FirstJoinTask.RunPercolatorFdr`).
+This is the historical path; the decoy-depletion caveat above applies, which is
+why the frozen modes were added.
+
+### `transfer`
+
+No retrain. Pass-1 q-values are carried through unchanged, and **only the per-run
+q-value of reconciliation-moved peaks** is re-mapped through each file's own
+score→run-q table (`TransferPerRunQ` → `BuildScoreToQTable`, equal-count quantile
+bins + PAVA isotonic; `LookupQForScore`). The experiment q is frozen by the
+best-peak anchor. Each survivor is classified Unchanged / Moved / GapFill, with
+bit-exact score equality as the "Moved" discriminator.
+
+### `transfer-compete` (frozen model)
+
+Scores the reconciled **targets and decoys** with the **frozen 1st-pass model**
+(no retrain), then recomputes q-values and PEP by a **fresh full-population
+target-decoy competition** — a non-depleted null, because both sides are scored on
+the same frozen scale (`ComputePass2TransferCompeteFull` with `stratumBaseIds ==
+null` → `PercolatorFdr.ComputeFullPopulationPrecursorFdrStreaming`, one file
+resident at a time). Precursor-level only.
+
+### `protein-compact` (frozen model)
+
+Identical to `transfer-compete` but the competition is **constrained to the
+protein stratum** — the `base_id`s of proteins that had ≥2 peptides pass first-pass
+protein FDR, admitted as target+decoy pairs (the stratum is built by first-pass
+protein parsimony; see [08-protein-parsimony.md](08-protein-parsimony.md)).
+Off-stratum survivors keep their first-pass q-values, so the report is
+`pass-1 ∪ stratum-passers`. Constraining the competition to a biologically
+pre-filtered set reduces the multiple-testing burden (independent filtering,
+Bourgon 2010).
+
+## Frozen vs. retrain
+
+- **Frozen** applies the captured first-pass model — fold weights/biases +
+  standardizer for the SVM, or the fold GBT ensembles — to the reconciled
+  features with **no new training**. It routes through `FrozenModelScorer`
+  (`TryCreate` averages fold weights or takes the tree ensemble; `Score` goes
+  through `PercolatorFdr.ScoreStandardizedRow`, so it is classifier-agnostic and
+  works for `--fdr-method gbdt` too). The model is captured on the streaming
+  first pass via the `captureModel` hook.
+- **Retrain** trains a fresh SVM/GBDT on the post-reconciliation pool (the default
+  `percolator` mode, or the `OSPREY_PROTEIN_COMPACT_RETRAIN` A/B toggle).
+
+`OSPREY_PROTEIN_COMPACT_RETRAIN` is a diagnostic A/B lever: with `protein-compact`
+it **skips** the frozen-model + stratum competition and instead retrains the
+second pass over the stratum-expanded compacted pool, isolating the
+frozen-vs-retrain calibration difference for the entrapment oracle.
+
+## Fail-fast
+
+An **explicitly requested** frozen mode never silently degrades to the
+anti-conservative retrain. If the frozen model, the required sidecars, or the
+protein stratum are absent (e.g. a warm rerun that loaded cached SVM scores and
+skipped first-pass training, or a present-but-corrupt first-pass sidecar),
+`Pass2FdrSidecar` aborts with a `ConfigError` and actionable guidance rather than
+reporting looser FDR than a cold run under the same flag. The default
+(`percolator`) path is unaffected.
+
+## Flags and switches
+
+| Flag / env var | Default | Effect |
+|---|---|---|
+| `OSPREY_PASS2_QVALUE` | `percolator` | Selects the second-pass q-value mode: `percolator` \| `transfer` \| `transfer-compete` \| `protein-compact`. Unrecognized → `percolator` + warning. |
+| `OSPREY_PROTEIN_COMPACT_RETRAIN` | off (frozen) | With `protein-compact`, retrain the second pass instead of using the frozen model + stratum competition (A/B lever). |
+| `OSPREY_FDR_PROJECTION` | on | Streams the FDR peak via the thin `FdrProjection` slice; the frozen modes stream one file at a time so routing them does not hold all features resident. |
+
+## Divergences from the Rust documentation
+
+- **[C#-ORIGINATED] The pass-2 frozen q-value modes originated in C#** - The Rust
+  algorithm doc set has no second-pass-FDR document because these modes
+  (`transfer`, `transfer-compete`, `protein-compact`, and the frozen-model
+  machinery) were developed in the C# implementation first; the Rust reference is
+  porting them back in maccoss/osprey#57. The default `percolator` mode matches the
+  long-standing two-pass behavior both implementations share. Parity for the frozen
+  modes is therefore tracked **C# → Rust** rather than Rust → C#. Evidence:
+  `Osprey.Tasks/Pass2FdrSidecar.cs`, `Osprey.FDR/FrozenModelScorer.cs`. Severity: info.

--- a/pwiz_tools/Osprey/docs/13-blib-output-schema.md
+++ b/pwiz_tools/Osprey/docs/13-blib-output-schema.md
@@ -1,0 +1,148 @@
+# 13. BLIB Output Schema (C#)
+
+> Pipeline stage: Output (Stage 7). C# port of Rust docs/08-blib-output-schema.md. Corresponds to Rust osprey BiblioSpec (.blib) output.
+
+Osprey emits its final results as a **BiblioSpec (`.blib`)** SQLite database — the spectral-library format Skyline consumes for chromatogram extraction, ID lines, and quantification. The C# port writes this file with a hand-rolled managed SQLite writer (`System.Data.SQLite`), not by shelling out to ProteoWizard's C++ BiblioSpec. It mirrors the schema and byte conventions of Skyline's own `BlibData`/`BlibDb` writer closely enough to be byte-identical to the Rust output on the reference datasets.
+
+Two layers are involved:
+
+- **`Osprey.IO/BlibWriter.cs`** — the low-level SQLite layer: schema creation, prepared-statement inserts, zlib compression, sequence cleanup, finalize. One instance == one `.blib` file.
+- **`Osprey.Tasks/BlibOutputWriter.cs`** — the Stage 7 sequencer that composes rows from the passing-precursor lookup tables and drives `BlibWriter`. It is invoked once from `Osprey.Tasks/MergeNodeTask.cs:365` (the `MergeNode` / `SecondPassFDR` HPC worker — see 15-hpc-scoring-split.md).
+
+Reading back (for library input, and for round-trip tests) is `Osprey.IO/BlibLoader.cs`.
+
+---
+
+## Overview
+
+The blib contains standard BiblioSpec tables (Skyline-compatible) plus five Osprey extension tables:
+
+```text
+Standard BiblioSpec tables (BlibWriter.CreateSchema, BlibWriter.cs:723-886)
+  LibInfo, ScoreTypes, IonMobilityTypes, SpectrumSourceFiles,
+  RefSpectra, RefSpectraPeaks, RefSpectraPeakAnnotations,
+  Modifications, Proteins, RefSpectraProteins, RetentionTimes
+
+Osprey extension tables (same CreateSchema block)
+  OspreyMetadata, OspreyPeakBoundaries, OspreyRunScores,
+  OspreyExperimentScores, OspreyCoefficients
+```
+
+The C# schema declares two columns the Rust doc's table listings omit: `SpectrumSourceFiles.workflowType TINYINT` and `ScoreTypes.probabilityType VARCHAR(128)` (BlibWriter.cs:750, 737). Both exist for BiblioSpecLite compatibility with Skyline.
+
+---
+
+## Pipeline-order walkthrough
+
+Stage 7 blib emission runs entirely inside `BlibOutputWriter.Write(...)` (BlibOutputWriter.cs:53-97). The gating (which precursors pass, and which run is "best" per precursor) is done by the caller and handed in as pre-built lookup tables; this stage only composes rows.
+
+### Step 1 — Create the file with WAL journaling
+
+`new BlibWriter(path)` deletes any existing file, opens a fresh SQLite connection, and sets `PRAGMA journal_mode=WAL` + `PRAGMA synchronous=NORMAL` (BlibWriter.cs:88-106). The write happens to a `FileSaver` sibling temp; `saver.Commit()` atomically renames it into `config.OutputBlib` only after `FinalizeDatabase()` has checkpointed and torn down the WAL (BlibOutputWriter.cs:73-96). This is why `FinalizeDatabase()` must be the last writer call.
+
+### Step 2 — Schema + seed rows
+
+`CreateSchema()` (BlibWriter.cs:723) creates all 16 tables in one batch, then seeds:
+
+- **`LibInfo`**: one row, `libLSID = urn:lsid:osprey:blib:<guid>`, `createTime = datetime('now')`, `numSpecs = 0` (updated at finalize), `majorVersion = 1`, `minorVersion = 11` (constants `BLIB_MAJOR_VERSION`/`BLIB_MINOR_VERSION`, BlibWriter.cs:39-40).
+- **`ScoreTypes`**: the full ProteoWizard BiblioSpec score-type enumeration, IDs 0-20 (BlibWriter.cs:899-922). ID 1 = `PERCOLATOR QVALUE`, ID 14 = `MORPHEUS SCORE`, **ID 19 = `GENERIC Q-VALUE`** with `probabilityType = PROBABILITY_THAT_IDENTIFICATION_IS_INCORRECT`. Osprey stamps every spectrum with score type **19** (`SCORE_TYPE_GENERIC_QVALUE`, BlibWriter.cs:41).
+- **`IonMobilityTypes`**: 0=none, 1=driftTime(msec), 2=inverseK0(Vsec/cm^2), 3=compensation(V) (BlibWriter.cs:936-951).
+
+`PrepareStatements()` (BlibWriter.cs:114) then compiles one reusable `SQLiteCommand` per insert kind so the tight per-spectrum loops avoid re-parsing SQL.
+
+### Step 3 — Source files
+
+`CreateSourceFiles` (BlibOutputWriter.cs:103-115) adds one `SpectrumSourceFiles` row per input file via `AddSourceFile` (BlibWriter.cs:263). Column semantics:
+
+- `fileName = <fileStem>.mzML` (the spectrum source; `kvp.Key` is the file stem).
+- `idFileName = Path.GetFileName(config.LibrarySource.Path)` — the **library** basename, i.e. the "ID source". Skyline expects the ID source to be the library file, not a copy of the spectrum path.
+- `cutoffScore = fdrThreshold = config.RunFdr` (default 0.01, BlibOutputWriter.cs:62,112).
+- `workflowType = 1` (hard-coded, BlibWriter.cs:267).
+
+The path stored is a bare `<stem>.mzML` filename, not a computed relative path with `../` segments.
+
+### Step 4 — Parallel fragment pre-compression
+
+`PrecompressSpectra` (BlibOutputWriter.cs:121-153) pulls the **library theoretical fragments** (b/y ions) for each passing precursor from the in-memory library (`libraryById[entry.EntryId].Fragments`), packs m/z as little-endian `f64` and intensity as little-endian `f32`, and zlib-compresses them in parallel via `BlibWriter.CompressMzs` / `CompressIntensities` (static, thread-safe). These are the library predicted fragments, **not** observed DIA peaks — Skyline uses them to build XICs for the correct transitions. The compressed blobs are held per-index so the sequential emit loop stays deterministic.
+
+Compression detail (BlibWriter.cs:980-1008): Osprey uses **DotNetZip `Ionic.Zlib` at level 6** — the same library and level as Skyline's `pwiz.Skyline.Util.Extensions.UtilDB.Compress` — rather than `System.IO.Compression.DeflateStream`, which emits a subtly different byte stream on small inputs and would break byte parity with both Rust (`flate2` stock-zlib backend) and Skyline's `BlibData`. If the compressed output is not smaller than the raw bytes, the raw bytes are stored (BlibWriter.cs:1005-1007); the reader detects this by comparing blob length to the expected uncompressed size.
+
+### Step 5 — RefSpectra + child rows (sequential, one per passing precursor)
+
+`EmitSpectrumRows` (BlibOutputWriter.cs:159-260) iterates the best-per-precursor entries in order. For each:
+
+- **`AddSpectrumPrecompressed`** (BlibWriter.cs:311) inserts the `RefSpectra` row and its `RefSpectraPeaks` blob row. Before insert it runs `StripFlankingChars` (removes `_`, `.`, `-`, and `K.PEPTIDE.R`-style flanks, bracket-aware; BlibWriter.cs:635) and `ConvertUnimodToMass` (rewrites `[UniMod:4]` → `[+57.0215]` using the built-in `UNIMOD_MASSES` table, BlibWriter.cs:653, 46-65). Fixed column values: `prevAA`/`nextAA = '-'`, `ionMobility`/`ccs`/`highEnergyOffset = 0.0`, `ionMobilityType = 0`, `moleculeName`/`chemicalFormula`/`precursorAdduct`/`inchiKey`/`otherKeys = ''` (empty strings, BlibWriter.cs:127-131).
+  - `retentionTime`/`startTime`/`endTime` = the cross-charge **shared** apex/start/end if the peptide was detected at multiple charges in this file (`sharedBounds`, BlibOutputWriter.cs:208-218), else the entry's own boundaries.
+  - `copies = nRunsDetected` (count of runs this precursor was detected in, BlibOutputWriter.cs:198-204).
+  - `score = scoreQvalue`, the **experiment-precursor q-value** (min across observations, `bestExpPrecursorQ`, BlibOutputWriter.cs:190-193). This is a raw q-value (lower = better), consistent with score type 19 being a "probability the ID is incorrect". `scoreType = 19`.
+- **`AddModifications`** (BlibWriter.cs:399): one `Modifications` row per mod, `position` converted from internal **0-based to 1-based** (`mod.Position + 1`, BlibWriter.cs:403), `mass = MassDelta`. Verified by `Osprey.Test/IOTest.cs:107` (`TestBlibModifications1Based`).
+- **`AddProteinMapping`** (BlibWriter.cs:414): de-duplicates accessions via `_proteinCache`, inserting `Proteins` + `RefSpectraProteins` rows.
+- **`WriteRetentionTimes`** (see Step 6).
+- **Osprey extension rows** (BlibOutputWriter.cs:247-258): `AddPeakBoundaries` (best-run start/end/apex + `IntegratedArea = entry.BoundsArea`, `ApexIntensity = 0.0` placeholder), `AddRunScores` (`RunQValue = EffectiveRunQvalue(Both)`, `DiscriminantScore`/`PosteriorErrorProb = 0.0` placeholders), `AddExperimentScores` (`ExperimentQValue = scoreQvalue`, `NRunsDetected`, `NRunsSearched = perFileEntries.Count`).
+
+### Step 6 — RetentionTimes: nullable retentionTime for Skyline ID lines
+
+`WriteRetentionTimes` (BlibOutputWriter.cs:279-339) emits one `RetentionTimes` row for **every run where this precursor was detected** (`entriesByPrecursor[key]` observations). The `retentionTime` column drives whether Skyline draws an ID line:
+
+- If the run's `EffectiveRunQvalue(Both) <= fdrThreshold` → `retentionTime = apex RT` (ID line shown).
+- Otherwise → `retentionTime = NULL` (`DBNull.Value` in `AddRetentionTime`, BlibWriter.cs:446-447): Skyline uses `startTime`/`endTime` for quantification boundaries but shows no ID line ("integrate here, but not an independent identification").
+
+The C# adds a **fallback the Rust doc does not describe**: if *no* run passes run-level FDR, the run with the lowest `run_qvalue` still gets `retentionTime` populated (`bestRunFile`, BlibOutputWriter.cs:288-313), so every `RefSpectra` has at least one ID line. `bestSpectrum = 1` for the observation whose file equals the best-precursor file, else 0. `score = runQ`. Cross-charge shared boundaries are applied here too.
+
+### Step 7 — Metadata
+
+`WriteMetadata` (BlibOutputWriter.cs:264-272) writes four `OspreyMetadata` key/value rows (via `INSERT OR REPLACE`): `osprey_version`, `search_mode = coelution`, `run_fdr`, `experiment_fdr`.
+
+### Step 8 — Finalize
+
+`FinalizeDatabase()` (BlibWriter.cs:561-579): updates `LibInfo.numSpecs` to the `RefSpectra` count, creates 10 indices (the 7 the Rust doc lists plus `idx_expscores_refid`, `idx_coefficients_refid`, `idx_rettimes_refid`), then `PRAGMA wal_checkpoint(TRUNCATE)` + `PRAGMA journal_mode=DELETE` to merge and remove the WAL sidecars so the atomic rename in Step 1 moves a single self-contained file.
+
+### OspreyCoefficients (reserved, zero rows)
+
+`AddCoefficient` exists (BlibWriter.cs:547) but is never called from the pipeline (only `MergeNodeTask`/`BlibOutputWriter` drive the writer, and neither calls it). The `OspreyCoefficients` table is created and indexed but written with zero rows — the per-scan XIC time series is not plumbed through Stage 7. This matches the Rust doc's "(optional)" label.
+
+---
+
+## Reading back (`BlibLoader.cs`)
+
+`BlibLoader.Load` (BlibLoader.cs:51) reads `RefSpectra` + `RefSpectraPeaks` (`LoadSpectra`) and `RefSpectraProteins`/`Proteins` (`LoadProteinMappings`). Peak blobs are decoded by `DecodeBlibPeaks` / `DecompressPeakBlobs` (BlibLoader.cs:320, 389), which try raw-first then zlib (`TryZlibDecompress` skips the 2-byte zlib header and inflates with `DeflateStream`, BlibLoader.cs:293), tolerate f32 or f64 intensities, and normalize intensity to the max. Modifications are re-parsed from the `peptideModSeq` string (not the `Modifications` table) by `ParseBlibModifications` + `IdentifyModification` (BlibLoader.cs:181, 238), which recognizes common mods by mass within `MOD_TOLERANCE = 0.01` and handles both mass-shift (`[+57.0]`) and absolute-mass (`[160.0]`) notation.
+
+---
+
+## Flags and switches
+
+This stage has no dedicated feature flags; it always runs when a `-o/--output` blib is produced. The values it stamps into the blib come from these config fields:
+
+| Flag / field | Default | Effect on this stage |
+|---|---|---|
+| `-o` / `--output <path>` | required | `config.OutputBlib` — the `.blib` written (BlibOutputWriter.cs:73). |
+| `-l` / `--library <path>` | required | `Path.GetFileName` becomes `SpectrumSourceFiles.idFileName` (BlibOutputWriter.cs:107). |
+| `-i` / `--input <mzML...>` | required | one `SpectrumSourceFiles` row each; `fileName = <stem>.mzML` (BlibOutputWriter.cs:112). |
+| `--run-fdr <v>` | 0.01 | `config.RunFdr` — `cutoffScore` and the ID-line threshold for `RetentionTimes.retentionTime` NULL-vs-apex (BlibOutputWriter.cs:62,297). Written to `OspreyMetadata.run_fdr`. |
+| `--experiment-fdr <v>` | 0.01 | Written to `OspreyMetadata.experiment_fdr` (BlibOutputWriter.cs:270). Experiment q-value (via the FDR stage) becomes `RefSpectra.score` and `OspreyExperimentScores.ExperimentQValue`. |
+| `--threads <count>` | all cores | `config.NThreads` — degree of parallelism for the fragment pre-compression pass (BlibOutputWriter.cs:82,131). Does not change output bytes. |
+| `--fdr-level {precursor\|peptide\|both}` | precursor | Governs which precursors pass upstream; within this stage `EffectiveRunQvalue(FdrLevel.Both)` is hard-coded for the ID-line decision regardless of the global level (BlibOutputWriter.cs:252,296,310). |
+
+There is no CLI switch to enable `OspreyCoefficients` output, to choose the score type, or to change the compression backend — all are fixed in code.
+
+---
+
+## Divergences from the Rust documentation
+
+- **[STALE-RUST-DOC] Score type is GENERIC Q-VALUE (19), not PERCOLATOR QVALUE (14)** - Rust doc says `ScoreTypes` ID 14 = `PERCOLATOR QVALUE` and `RefSpectra.scoreType = 14`; C# seeds the full ProteoWizard BiblioSpec score-type list (ID 1 = PERCOLATOR QVALUE, ID 14 = MORPHEUS SCORE, ID 19 = GENERIC Q-VALUE) and stamps every spectrum with `SCORE_TYPE_GENERIC_QVALUE = 19`. Evidence: Osprey.IO/BlibWriter.cs:41, BlibWriter.cs:899-922, BlibOutputWriter.cs:336. Severity: minor.
+- **[STALE-RUST-DOC] RefSpectra.score is a raw q-value, not `1 - q_value`** - Rust doc says `score = 1 - q_value` (higher is better); C# stores the raw experiment-precursor q-value (lower is better), consistent with score type 19's `PROBABILITY_THAT_IDENTIFICATION_IS_INCORRECT`. Evidence: Osprey.Tasks/BlibOutputWriter.cs:186-193,229. Severity: minor.
+- **[STALE-RUST-DOC] LibInfo minorVersion is 11, not 10** - Rust doc says `minorVersion = 10`; C# writes 11. Evidence: Osprey.IO/BlibWriter.cs:40. Severity: info.
+- **[STALE-RUST-DOC] idFileName is the library basename, not a copy of fileName** - Rust doc says `idFileName` = "Same as fileName"; C# sets `idFileName` to the library file basename (the ID source) and `fileName` to `<stem>.mzML`. Evidence: Osprey.Tasks/BlibOutputWriter.cs:107-113. Severity: minor.
+- **[STALE-RUST-DOC] cutoffScore is the run-FDR threshold, not 0.0** - Rust doc says `cutoffScore = 0.0`; C# passes `config.RunFdr` (default 0.01). Evidence: Osprey.Tasks/BlibOutputWriter.cs:62,112. Severity: info.
+- **[STALE-RUST-DOC] SpectrumSourceFiles stores a bare filename, not a computed relative path** - Rust doc describes computing relative paths (`../data/sample.mzML`) from the blib directory for WSL2/Windows portability; C# stores `<stem>.mzML` with no directory computation. Evidence: Osprey.Tasks/BlibOutputWriter.cs:112. Severity: minor.
+- **[STALE-RUST-DOC] Modifications.position is 1-based, not 0-indexed** - Rust doc says `position` is a "0-indexed position in sequence"; C# converts internal 0-based positions to 1-based on write (and a standing test asserts it). Byte-identical `.blib` parity with Rust implies the Rust code also writes 1-based, so the doc is stale. Evidence: Osprey.IO/BlibWriter.cs:399-408; Osprey.Test/IOTest.cs:107-149. Severity: minor.
+- **[STALE-RUST-DOC] Nullable-text columns are written as empty strings, not NULL** - Rust doc says `moleculeName`/`chemicalFormula`/`precursorAdduct`/`inchiKey`/`otherKeys` are NULL; C# inserts empty-string literals. Evidence: Osprey.IO/BlibWriter.cs:127-131. Severity: info.
+- **[STALE-RUST-DOC] RetentionTimes best-run ID-line fallback is undocumented** - Rust doc says `retentionTime` is NULL for any run not passing run-level FDR; C# additionally guarantees at least one ID line per RefSpectra by populating `retentionTime` on the lowest-`run_qvalue` run when no run passes. Evidence: Osprey.Tasks/BlibOutputWriter.cs:288-313. Severity: minor.
+- **[STALE-RUST-DOC] Osprey extension score/intensity fields are 0.0 placeholders** - Rust doc labels `OspreyRunScores.DiscriminantScore` a "Mokapot discriminant score", `PosteriorErrorProb` a PEP, and `OspreyPeakBoundaries.ApexIntensity` an intensity; C# writes 0.0 for all three (not plumbed through Stage 7), and there is no Mokapot in the C# port. Evidence: Osprey.Tasks/BlibOutputWriter.cs:249-254. Severity: minor.
+- **[STALE-RUST-DOC] OspreyMetadata key set differs** - Rust doc lists keys `osprey_version`, `rt_calibration_enabled`, `run_fdr`, `fdr_method`; C# writes `osprey_version`, `search_mode`, `run_fdr`, `experiment_fdr`. Evidence: Osprey.Tasks/BlibOutputWriter.cs:266-271. Severity: minor.
+- **[INTENTIONAL-CSHARP-DESIGN] Native managed SQLite writer, not ProteoWizard BiblioSpec** - The README frames the C# blib output as "reusing ProteoWizard BiblioSpec infrastructure"; in fact `BlibWriter` is a hand-rolled `System.Data.SQLite` writer that reuses only the BiblioSpec *schema* and Skyline's `BlibData`/`UtilDB` byte conventions (Ionic.Zlib level 6), not the C++ BiblioSpec code. Rust's `flate2` (stock-zlib backend) and this Ionic.Zlib path produce byte-identical `RefSpectraPeaks` blobs. Evidence: Osprey.IO/BlibWriter.cs:37, 980-1008. Severity: info.
+- **[INTENTIONAL-CSHARP-DESIGN] Extra schema columns and indices not in the Rust doc tables** - C# declares `SpectrumSourceFiles.workflowType` and `ScoreTypes.probabilityType`, and creates three indices beyond the Rust doc's seven (`idx_expscores_refid`, `idx_coefficients_refid`, `idx_rettimes_refid`), for BiblioSpecLite/Skyline compatibility. Evidence: Osprey.IO/BlibWriter.cs:737,750, 573-575. Severity: info.
+
+Everything else matches the Rust doc: the standard + extension table set, `RefSpectraPeaks` storing library theoretical fragments (f64 m/z / f32 intensity, zlib-with-raw-fallback), the nullable-`retentionTime` ID-line semantics, one `RetentionTimes` row per detected run, `copies = nRunsDetected`, `OspreyCoefficients` emitted with zero rows, and the write→finalize→atomic-rename flow. No `PORT-ERROR` was found: the C# implementation is internally consistent and (per the standing `Compare-Blib-Crossimpl.ps1` gate referenced in BlibWriter.cs) byte-identical to the Rust output, so the schema-value differences above reflect a stale Rust doc rather than a behavioral defect.
+
+See also 07-fdr-control.md (source of the run/experiment q-values written here), 11-boundary-overrides.md (the reconciled peak boundaries in `RefSpectra`/`RetentionTimes`/`OspreyPeakBoundaries`), 10-cross-run-reconciliation.md (per-file boundary imputation), and 15-hpc-scoring-split.md (the `MergeNode`/`SecondPassFDR` worker that invokes this stage).

--- a/pwiz_tools/Osprey/docs/14-intermediate-files.md
+++ b/pwiz_tools/Osprey/docs/14-intermediate-files.md
@@ -1,0 +1,583 @@
+# 14. Intermediate Files, Caches & Cache Invalidation (C#)
+
+> Pipeline stage: Cross-cutting (all stages). C# port of Rust docs/12-intermediate-files.md. Corresponds to Rust osprey intermediate file formats.
+
+The C# Osprey port writes the same family of per-file intermediate artifacts as the Rust
+tool, and — where cross-impl byte parity matters (spectra cache, scores parquet, FDR
+sidecars, reconciliation JSON) — it writes them byte-for-byte identically so a cache produced
+by one implementation is consumable by the other. This document describes each artifact as the
+C# code actually writes and reads it, the SHA-256 hashing that gates cache reuse, and the two
+resume mechanisms the port adds (a per-task `.osprey.task` validity sidecar and the
+`.scores-reconciled.parquet` split output) that have no exact Rust doc counterpart.
+
+## File overview
+
+| File pattern | Format | C# writer/reader | Purpose |
+|---|---|---|---|
+| `<stem>.calibration.json` | JSON (Newtonsoft) | `Osprey.Chromatography/CalibrationIO.cs` | RT + MS1/MS2 mass calibration parameters |
+| `<stem>.spectra.bin` | Custom binary v3 | `Osprey.IO/SpectraCache.cs` | Decoded MS1/MS2 spectra for fast reload |
+| `<stem>.scores.parquet` | Apache Parquet (ZSTD) | `Osprey.IO/ParquetScoreCache.cs` | Scored entries: 21 PIN features, fragments, CWT candidates + footer metadata |
+| `<stem>.scores-reconciled.parquet` | Apache Parquet (ZSTD) | `Osprey.Tasks/ReconciledParquetWriter.cs` | Stage 6 reconciled rewrite (separate file, not in-place) |
+| `<stem>.1st-pass.fdr_scores.bin` | Custom binary v3 | `Osprey.IO/FdrScoresSidecar.cs` | SVM score + 4 q-values + PEP + run_protein_qvalue after first-pass Percolator |
+| `<stem>.2nd-pass.fdr_scores.bin` | Custom binary v3 | `Osprey.IO/FdrScoresSidecar.cs` | Same record shape after second-pass Percolator |
+| `<stem>.reconciliation.json` | JSON (Newtonsoft) | `Osprey.IO/ReconciliationFile.cs` | Stage 5 planner output: actions, gap-fill targets, refined RT calibration |
+| `<output>.<TaskName>.osprey.task` | JSON (hand-rolled) | `Osprey.Tasks/TaskValiditySidecar.cs` | **C# addition**: per-(output, task) resume validity record |
+| `<lib>.<...>` library cache | Custom binary v2 | `Osprey.IO/LibraryCache.cs` | Parsed spectral library reload cache |
+| `<output>.blib` | SQLite (BiblioSpec) | `Osprey.IO/BlibWriter.cs` | Final output; see 13-blib-output-schema.md |
+
+All per-file artifact paths resolve their directory through `ArtifactPaths`
+(`Osprey.IO/ArtifactPaths.cs:47`), so `--output-dir` / `--cache-dir` / `--work-dir`
+redirection is applied atomically to every artifact.
+
+---
+
+## 0. Path resolution and safe writes (cross-cutting)
+
+### `ArtifactPaths` directory redirection
+
+`ArtifactPaths` (`Osprey.IO/ArtifactPaths.cs:47`) holds two process-wide static properties,
+`OutputDir` and `CacheDir`, both defaulting to `null` (write beside the input file — the
+historical default). `--work-dir` sets both; `--output-dir` / `--cache-dir` set them
+individually.
+
+- `ResolveOutputDir(inputPath)` (`ArtifactPaths.cs:77`) returns `OutputDir` when set, else the
+  input file's own directory. Used by the scores parquet, calibration JSON, FDR sidecars, and
+  reconciliation JSON.
+- `ResolveCacheDir(inputPath)` (`ArtifactPaths.cs:91`) resolves the `.spectra.bin` location:
+  explicit `CacheDir` → beside the data file if that directory is writable (probed once and
+  memoized, `ArtifactPaths.cs:112`) → `OutputDir`. The cache is settings-independent, so a
+  shared `CacheDir` lets many analyses reuse one parse.
+
+### Atomic writes via `FileSaver` (the C# stand-in for Rust `copy_and_verify`)
+
+Every cache writer stages through `Osprey.Core/FileSaver.cs`. The pattern is: construct a
+`FileSaver(finalPath)`, which allocates a **sibling** temp file in the *same directory*
+(`FileSaver.cs:68`); write to `saver.SafeName`; call `saver.Commit()`
+(`FileSaver.cs:92`) to delete any existing destination and `File.Move` the temp into place; on
+exception the `using` block's `Dispose()` (`FileSaver.cs:116`) deletes the temp without
+touching the destination. A crash mid-write therefore leaves either the previous content or no
+file — never a half-written destination a resume check could mistake for finished output.
+
+This is the C# realization of Rust's "safe NAS file writes / `copy_and_verify`" pattern.
+Because the temp is a sibling, the promote is an in-volume rename rather than a
+local-temp → NAS cross-volume copy, which sidesteps the truncation risk `copy_and_verify`
+guards against. Callers that use it: `ParquetScoreCache.WriteScoresParquet`
+(`ParquetScoreCache.cs:265`, `:457`), `SpectraCache.SaveSpectraCache` (`SpectraCache.cs:85`),
+`CalibrationIO.SaveCalibration` (`CalibrationIO.cs:50`), `FdrScoresSidecar.WriteInternal`
+(`FdrScoresSidecar.cs:366`) and `PatchRunProteinQvalues` (`FdrScoresSidecar.cs:257`),
+`ReconciliationFile.Save` (`ReconciliationFile.cs:203`), `LibraryCache.SaveCache`
+(`LibraryCache.cs:77`), and `TaskValiditySidecar.Write` (`TaskValiditySidecar.cs:130`).
+
+---
+
+## 1. Calibration JSON (`<stem>.calibration.json`)
+
+**C# source**: `Osprey.Chromatography/CalibrationIO.cs`, model types in
+`Osprey.Chromatography/CalibrationParams.cs`.
+
+`CalibrationIO.SaveCalibration` (`CalibrationIO.cs:42`) serializes a `CalibrationParams` with
+Newtonsoft `Formatting.Indented`; `LoadCalibration` (`CalibrationIO.cs:62`) deserializes it.
+The path is `<stem>.calibration.json` in `ArtifactPaths.ResolveOutputDir(inputFile)`
+(`CalibrationIO.cs:97`, assembled at the call site
+`PerFileScoringTask.cs:1736`).
+
+The schema mirrors Rust's `CalibrationMetadata` / `MzCalibration` / `RTCalibrationParams`
+(`CalibrationParams.cs` model classes carry the same `metadata` / `ms1_calibration` /
+`ms2_calibration` / `rt_calibration` / `second_pass_rt` JSON keys). The metadata block written
+by `ResolveCalibration` (`PerFileScoringTask.cs:1702`) populates
+`calibration_successful`, `num_confident_peptides`, `num_sampled_precursors`, `timestamp`, and
+the DIA `isolation_scheme` (so an HPC merge node with no mzML can rehydrate the gap-fill m/z
+filter, `PerFileScoringTask.cs:1758`).
+
+**How calibration is reused in C#.** The Rust doc says the calibration file is reused when its
+`search_hash` matches, and deleted+recomputed when the hash is missing/stale. The C# port does
+**not** implement that per-calibration-file check:
+
+- `CalibrationMetadata.SearchHash` exists as a field (`CalibrationParams.cs:125`, with
+  `NullValueHandling.Ignore`) to keep schema parity, but `ResolveCalibration` never assigns it,
+  so the C# `.calibration.json` omits the `search_hash` key entirely.
+- The only load path is `OSPREY_LOAD_CALIBRATION` (`PerFileScoringTask.cs:1623`, via
+  `OspreyEnvironment.LoadCalibrationPath`), an explicit cross-impl bisection hook that loads a
+  named JSON instead of computing. When it is unset and RT calibration is enabled, calibration
+  is always recomputed and re-saved.
+- Reuse-across-runs is instead handled one level up, at the *task* level, by the
+  `.osprey.task` validity sidecar (Section 8) whose key already folds the search + library
+  hashes: if that key matches, the whole `PerFileScoringTask` is skipped and no calibration
+  runs at all; if it does not, the task re-runs and rewrites the calibration JSON. Net effect
+  matches Rust (stale parameters ⇒ recalibrate) but the trigger is the task sidecar, not a
+  `search_hash` embedded in the calibration file.
+
+---
+
+## 2. Binary spectra cache (`<stem>.spectra.bin`)
+
+**C# source**: `Osprey.IO/SpectraCache.cs`. Path: `SpectraCache.GetCachePath` (`SpectraCache.cs:210`)
+= `<stem>.spectra.bin` in `ArtifactPaths.ResolveCacheDir(inputFile)`.
+
+A raw little-endian dump of decoded MS1 and MS2 spectra, written after the first parse and
+reloaded during Stage 6 reconciliation re-scoring to avoid re-parsing mzML.
+
+### Header and format (VERSION 3)
+
+The C# header is **larger than the 20-byte header in the Rust doc** because it adds a source
+fingerprint (`SpectraCache.cs:90`):
+
+```
+[magic:        8 bytes  "OSPRSPC\0"]
+[version:      uint32   = 3]
+[source_size:  uint64   source file length, 0 when unknown]
+[source_mtime: int64    source last-write time, Unix ms UTC, 0 when unknown]
+[n_ms2:        uint32]
+[n_ms1:        uint32]
+```
+
+Per-MS2 record: `scan_number:u32, retention_time:f64, precursor_mz:f64, iso_center:f64,
+iso_lower:f64, iso_upper:f64, n_peaks:u32, mzs:f64×n, intensities:f32×n`
+(`SpectraCache.cs:99`). Per-MS1 record drops the three precursor/isolation fields
+(`SpectraCache.cs:113`). Per-peak storage is 12 bytes (f64 m/z + f32 intensity), matching Rust.
+
+The Unix-ms mtime is deliberately not .NET ticks so that C# and Rust compute an *identical*
+fingerprint for the same file and can share one cache (`SpectraCache.cs:43`,
+`ComputeSourceFingerprint` at `SpectraCache.cs:227`).
+
+### Version-bump invalidation
+
+`LoadSpectraCache` (`SpectraCache.cs:132`) returns `null` (⇒ re-parse + rewrite) on: missing
+file, wrong magic, or `version != 3` (`SpectraCache.cs:152`). The version constant records its
+own history (`SpectraCache.cs:61`): v1→v2 (2026-05-09) because non-monotonic centroids are now
+sorted before caching; v2→v3 (2026-06-09) added the source fingerprint. Any older cache is
+rejected and repopulated.
+
+### Source-fingerprint invalidation
+
+When the stored `source_size != 0` and a `sourcePath` is supplied, the loader recomputes the
+fingerprint and rejects the cache if size or mtime changed (`SpectraCache.cs:162`). When the
+cache recorded no fingerprint, or the source is unavailable (e.g. a resume run whose mzML is not
+beside the cache), the check is skipped and the within-run cache is trusted.
+
+Safe to delete: yes — recreated on next run.
+
+---
+
+## 3. Scores parquet cache (`<stem>.scores.parquet`)
+
+**C# source**: `Osprey.IO/ParquetScoreCache.cs` (uses the managed `Parquet.Net` library, not a
+native Arrow/Parquet dependency). Path: `GetScoresPath` (`ParquetScoreCache.cs:1029`).
+
+Per-file cache of every scored entry (targets + decoys) with the 21 PIN feature columns, the
+binary blob columns, boundary columns, and a footer of key-value metadata. Written after Stage
+4 scoring, read selectively during FDR, reconciliation, and blib output.
+
+### Schema
+
+`BuildWriteSchema` (`ParquetScoreCache.cs:142`) writes 19 fixed columns followed by the 21 PIN
+feature columns. Column types are deliberately aligned with Rust: `entry_id` and `scan_number`
+are `UInt32`, `charge` is `UInt8`, so a C#-written parquet loads under Rust's strict downcasts
+and vice versa (`ParquetScoreCache.cs:90`). Pre-2026-04-19 C#-written parquets used `Int32` and
+must be regenerated.
+
+- **Identity (8)**: `entry_id`, `is_decoy`, `sequence`, `modified_sequence`, `charge`,
+  `precursor_mz`, `protein_ids` (nullable, `;`-joined), `file_name`.
+- **Boundary (6)**: `scan_number`, `apex_rt`, `start_rt`, `end_rt`, `bounds_area`, `bounds_snr`.
+- **Binary (5)**: `cwt_candidates`, `fragment_mzs`, `fragment_intensities`,
+  `reference_xic_rts`, `reference_xic_intensities`.
+- **Features (21)**: the names in `PIN_FEATURE_NAMES` (`ParquetScoreCache.cs:51`), all Float64,
+  in the exact Rust `get_pin_feature_names()` order.
+
+Rows are written in canonical sorted order `(entry_id, charge, scan_number)`
+(`ParquetScoreCache.cs:226`, `:351`) so per-side parquets have identical physical row layout
+regardless of which implementation wrote them. Compression is ZSTD
+(`writer.CompressionMethod = CompressionMethod.Zstd`, `ParquetScoreCache.cs:270`, `:462`).
+
+**Binary blob encoding.** The `FdrEntry` write overload (`ParquetScoreCache.cs:299`) encodes the
+blobs exactly as Rust: `fragment_mzs` / `reference_xic_*` as little-endian f64 with no length
+prefix (`EncodeF64Blob`, `ParquetScoreCache.cs:635`); `fragment_intensities` as little-endian
+f32 (`EncodeF32Blob`, `ParquetScoreCache.cs:660`); `cwt_candidates` via `CwtCandidateCodec`
+with a mandatory 4-byte count prefix so an empty candidate list is a zero-length blob, never a
+null cell (`ParquetScoreCache.cs:399`–`:422`). Length is recovered on read as `bytes /
+sizeof(element)`.
+
+> **Note:** the older `CoelutionScoredEntry` write overload (`ParquetScoreCache.cs:182`) still
+> writes the five binary columns as null placeholders (`ParquetScoreCache.cs:114`); populating
+> them there is marked a future sprint. The pipeline's actual per-file writes go through the
+> `FdrEntry` overload, which populates them.
+
+### Selective loaders
+
+Mirroring Rust's specialized loaders, the C# side never loads the full parquet unless needed:
+
+| Loader (`ParquetScoreCache.cs`) | Columns read | Purpose |
+|---|---|---|
+| `LoadFdrStubsFromParquet` (`:723`) | 10 identity/boundary scalars | Lightweight `FdrEntry` stubs for FDR; sets `ParquetIndex = row` |
+| `ReadFdrStubScalars` (`:788`) | 5 scalar columns, zero-alloc callback | Streams stub scalars for the first-pass FDR projection without materializing `FdrEntry`s |
+| `LoadCwtCandidatesFromParquet` (`:835`) | `cwt_candidates` only | Stage 6 reconciliation planning |
+| `LoadPinFeaturesFromParquet` (`:981`) | 21 feature columns | SVM re-scoring |
+| `LoadFullFdrEntries` (`:897`) | all scalar + feature + blob columns | Full rehydration for Stage 6 reconciled write-back |
+
+`ParquetIndex` bookkeeping is load-bearing: both write overloads and every loader assign
+`ParquetIndex` to the post-sort row so Stage 5's per-file CWT lookup indexes each entry's own
+candidate list. A code comment (`ParquetScoreCache.cs:364`) documents a bisected bug where the
+in-memory path once left `ParquetIndex = 0` and force-integrated nearly every entry.
+
+### Footer metadata and cache invalidation (SHA-256 hashes)
+
+Every scores parquet carries footer key-value metadata. For a Stage 4 write
+(`PerFileScoringTask.cs:228`):
+
+| Key | Value | Source |
+|---|---|---|
+| `osprey.version` | `OspreyVersion.Current` (Skyline `YEAR.ORDINAL.BRANCH.DOY`) | `OspreyVersion.cs` |
+| `osprey.search_hash` | SHA-256 hex | `SearchIdentity.SearchParameterHash()` |
+| `osprey.library_hash` | SHA-256 hex | `SearchIdentity.LibraryIdentityHash()` |
+| `osprey.reconciled` | `"false"` | literal |
+
+The Stage 6 reconciled rewrite (`ReconciledParquetWriter.BuildReconciliationMetadata`,
+`ReconciledParquetWriter.cs:192`) sets `osprey.reconciled = "true"` and adds
+`osprey.reconciliation_hash` = `SearchIdentity.ReconciliationParameterHash[ForStems]()`.
+
+**Hash recipes** (`Osprey.Core/SearchIdentity.cs`, must stay byte-identical to Rust
+`osprey-core/src/config.rs`):
+
+- `SearchParameterHash()` (`SearchIdentity.cs:60`): resolution mode; fragment + precursor
+  tolerance (value + unit); prefilter enabled; decoy method; decoys-in-library; sorted
+  lowercased decoy prefixes; decoy pairing manifest path (Rust `{:?}` `Some/None` escaping,
+  `SearchIdentity.cs:186`); decoy pair min fraction; all RT-calibration parameters (enabled,
+  fallback tolerance, tolerance factor, min/max tolerance, LOESS bandwidth, min calibration
+  points, sample size, retry factor); and `reconciliation.top_n_peaks`. Booleans lowercased,
+  invariant culture (`SearchIdentity.cs:69`) for cross-impl parity.
+- `LibraryIdentityHash()` (`SearchIdentity.cs:143`): library **file name (not path) + size +
+  mtime in Unix seconds** — a fast metadata check, no content hashing. Directory is deliberately
+  excluded so the same library hashes identically across OSes / HPC nodes.
+- `ReconciliationParameterHash()` (`SearchIdentity.cs:235`): the search hash, plus
+  `reconciliation.enabled`, `reconciliation.consensus_fdr`, `run_fdr`, and the sorted+deduped
+  input file stems. `ReconciliationParameterHashForStems` (`SearchIdentity.cs:262`) lets a
+  per-file Stage 6 worker pass the join-wide stem set read from `reconciliation.json`.
+
+**Validation on read.** `CheckParquetMetadata` (`ParquetScoreCache.cs:1190`) — a pure,
+unit-testable mirror of Rust's `check_parquet_metadata` — compares cached vs expected
+`osprey.version` (component-wise, hard-fail on any mismatch including the day-of-year build
+component, `ParquetScoreCache.cs:1216`), then `search_hash`, then `library_hash`, returning a
+descriptive error string or `null`. `ValidateScoresParquetGroup` (`ParquetScoreCache.cs:1256`)
+runs it over a set of parquets at the start of `--task FirstPassFDR`, and additionally, when
+`config.ExpectReconciledInput` (i.e. `--task SecondPassFDR`), requires every input carry
+`osprey.reconciled = "true"` (`ParquetScoreCache.cs:1292`).
+
+**No `CacheValidity` enum.** Rust models cache state with a tri-state
+`CacheValidity { ValidReconciled, ValidFirstPass, Stale }` and, on `Stale`, silently deletes and
+re-scores. The C# port has no such enum (the only reference is a stray comment at
+`ReconciledParquetWriter.cs:180`). Instead:
+
+- The HPC `--task` entry points call `ValidateScoresParquetGroup`, which **hard-fails with an
+  error** on any hash/version mismatch rather than silently deleting and re-scoring — a cache
+  whose compatibility cannot be verified is refused, not quietly discarded.
+- The in-process straight-through pipeline decides skip-vs-recompute per task via the
+  `.osprey.task` validity sidecar (Section 8), whose key folds the same search + library hashes.
+  A key mismatch re-runs the task and overwrites the parquet (net behavior matches Rust's
+  "stale ⇒ re-score", via a different mechanism).
+
+### Reconciled output is a separate file, not an in-place overwrite
+
+Stage 6 (`PerFileRescoreTask`) writes `<stem>.scores-reconciled.parquet`
+(`GetReconciledScoresPath`, `ParquetScoreCache.cs:1055`) rather than overwriting the Stage 4
+`.scores.parquet`. The `.scores-reconciled.parquet` suffix is appended **after** the `.scores`
+token so it is an unambiguous "Stage 6 output" signal (`ParquetScoreCache.cs:1036`).
+`EffectiveScoresPathFromScoresPath` (`ParquetScoreCache.cs:1103`) is the read-side contract: a
+post-Stage-6 reader consumes the reconciled sibling when it exists on disk, else the original —
+making the split-file design byte-equivalent to the former in-place overwrite while surviving a
+partial Stage 6 crash. This is a C# infrastructure refinement over the Rust doc's single-file
+model.
+
+---
+
+## 4. FDR score sidecars (`<stem>.{1st,2nd}-pass.fdr_scores.bin`)
+
+**C# source**: `Osprey.IO/FdrScoresSidecar.cs`; record shape `Osprey.IO/FdrScoreRecord.cs`.
+Paths: `Pass1Path` / `Pass2Path` (`FdrScoresSidecar.cs:139`, `:145`), routed through
+`ArtifactPaths.ResolveOutputDir`.
+
+Per-file persistence of FDR state at the Stage 5 → Stage 6 boundary (first pass) and after
+second-pass FDR. Carries the SVM discriminant plus every q-value needed for downstream filtering
+and protein-FDR-aware compaction.
+
+### Format (v3) — byte-identical to Rust
+
+`FdrScoresSidecar` writes a 32-byte header + fixed 60-byte records (`FdrScoresSidecar.cs:97`):
+
+```
+Header (32 bytes):
+  [0..8]   magic         = "OSPRYFDR"
+  [8]      version       = 3
+  [9]      pass          = 1 (first) | 2 (second)
+  [10..16] reserved (zero)
+  [16..24] entry_count   u64 LE
+  [24..32] reserved (zero)
+Record (60 bytes):
+  [0..4]   entry_id                     u32 LE
+  [4..12]  svm_score                    f64 LE
+  [12..20] run_precursor_qvalue         f64 LE
+  [20..28] run_peptide_qvalue           f64 LE
+  [28..36] experiment_precursor_qvalue  f64 LE
+  [36..44] experiment_peptide_qvalue    f64 LE
+  [44..52] pep                          f64 LE
+  [52..60] run_protein_qvalue           f64 LE
+```
+
+Field order and offsets are single-sourced in `WriteRecord` (`FdrScoresSidecar.cs:390`).
+The v2→v3 bump (dated 2026-05-02 in the C# comment, `FdrScoresSidecar.cs:82`) added
+`run_protein_qvalue` so a Stage 6 worker can reproduce the in-process compaction predicate
+`run_peptide_qvalue ≤ 0.01 OR run_protein_qvalue ≤ 0.01`; records are written pre-compaction but
+post first-pass protein FDR so the value is real, not the default 1.0. Cross-impl byte parity is
+checked by a harness via the `OSPREY_CROSS_IMPL_FDR_SIDECAR_OUT` hook (`FdrScoresSidecar.cs:43`).
+
+A two-phase write exists for the lean projection path (issue #4355): phase 1 writes records with
+a 1.0 placeholder `run_protein_qvalue`; `PatchRunProteinQvalues` (`FdrScoresSidecar.cs:247`)
+then streams the file one record at a time and overwrites only bytes `[52..60]` per entry_id,
+producing a file byte-identical to a single-phase write.
+
+### Validation and record→entry matching
+
+`TryRead` (`FdrScoresSidecar.cs:437`) rejects: missing file, wrong magic, `version != 3`, a
+`pass` byte that disagrees with `expectedPass`, and a file length that does not equal
+`32 + 60 × header_count` (with checked arithmetic to reject an overflowing count,
+`FdrScoresSidecar.cs:120`).
+
+**Records are matched to entries by `entry_id`, not by position** (`FdrScoresSidecar.cs:484`).
+This deliberately diverges from the Rust doc's stated "entry_count must match entries.len();
+per-record entry_id checked at load". The C# loader tolerates `header_count < entries.Count`
+(the first-pass sidecar is pre-gap-fill, the second-pass is post-compaction) by building an
+`entry_id → index` dictionary; it still rejects a record whose `entry_id` is absent from the
+caller's superset as corruption (`FdrScoresSidecar.cs:492`). `TryReadOverlay`
+(`FdrScoresSidecar.cs:527`) is the dictionary-input variant used by `--task SecondPassFDR`,
+which silently skips records not in the (already-compacted) caller dict. The class-summary
+comment at `FdrScoresSidecar.cs:74` still describes the older position-based matching and is
+stale relative to the method's actual entry_id join.
+
+Safe to delete: the second-pass file, yes. The first-pass file is a Stage 5 → Stage 6 boundary
+input; deleting it forces re-running the Stage 5 join.
+
+---
+
+## 5. Reconciliation boundary file (`<stem>.reconciliation.json`)
+
+**C# source**: `Osprey.IO/ReconciliationFile.cs`. Path: `PathForInput`
+(`ReconciliationFile.cs:216`) via `ArtifactPaths.ResolveOutputDir`.
+
+Per-file JSON written at the tail of Stage 5 and consumed by the Stage 6 per-file rescore
+worker. Together with the `<stem>.1st-pass.fdr_scores.bin` sidecar it is the Stage 5 → Stage 6
+boundary pair.
+
+### Cross-impl byte parity
+
+Field declaration order is **alphabetical at every nesting level** via explicit `[JsonProperty(...
+Order = N)]` attributes (`ReconciliationFile.cs:77`+), matching Rust's `serde_json`
+alphabetical emission. Every `double` is routed through `RoundtripDoubleConverter`
+(`ReconciliationFile.cs:185`, registered in the serializer settings) — the C# counterpart to
+Rust's canonical fixed-point f64 formatter — sidestepping the Newtonsoft-`R`/Grisu vs.
+Rust-`ryu` disagreement on small values. `Save` normalizes CRLF→LF and appends a trailing
+newline (`ReconciliationFile.cs:194`) so the bytes match serde_json's LF output.
+
+### Schema and version (v3, larger than the Rust doc's v1)
+
+The C# `CurrentFormatVersion = 3` (`ReconciliationFile.cs:75`) and the envelope carries two
+fields **absent from the Rust doc's v1 example**:
+
+- `file_stems` (v2, `ReconciliationFile.cs:77`): the join-wide file set, so a per-file Stage 6
+  worker can compute the reconciliation parameter hash the `--task SecondPassFDR` merge node
+  expects (hash is over all joined files, not the worker's single parquet).
+- `first_pass_base_ids` (v3, `ReconciliationFile.cs:84`): the join-wide set of base_ids that
+  survived first-pass compaction, sorted ascending. A per-file worker uses it to compact to
+  exactly the in-memory pipeline's set instead of a per-file subset.
+
+The remaining fields match the Rust doc: `forced_integration_actions`
+(`ForcedIntegrationEntry`), `format_version`, `gap_fill_targets` (`GapFillEntry`),
+`library_hash`, `refined_rt_calibration` (`RefinedRtCalibrationJson` — LOESS
+`abs_residuals`/`fitted_rts`/`library_rts`/`residual_sd`, reconstructed on the worker via
+`RTCalibration.FromModelParams`), `search_hash`, and `use_cwt_peak_actions`
+(`UseCwtPeakEntry`). As in Rust, `Keep` actions are not persisted and actions are split into two
+homogeneous arrays to avoid a discriminator field.
+
+### Validation
+
+`Load` (`ReconciliationFile.cs:113`) rejects a missing file, malformed JSON, any
+`format_version != 3` (`ReconciliationFile.cs:124`), a missing/empty `file_stems`
+(`ReconciliationFile.cs:138`), and a missing `first_pass_base_ids`
+(`ReconciliationFile.cs:150`) — all fail loudly to prevent a per-file worker from silently
+computing a single-file hash for a multi-file join. The C# comments note the Rust
+`reconciliation_io.rs` carries the matching fields to keep cross-impl byte parity.
+
+For the full HPC orchestration story see 15-hpc-scoring-split.md.
+
+---
+
+## 6. BiblioSpec output (`<output>.blib`)
+
+Final SQLite output; see 13-blib-output-schema.md. The C# port reuses ProteoWizard BiblioSpec
+infrastructure where possible (`Osprey.IO/BlibWriter.cs`).
+
+---
+
+## 7. Library reload cache (`<...>` library cache)
+
+**C# source**: `Osprey.IO/LibraryCache.cs`. Binary cache of a parsed spectral library for fast
+reload; magic `"OSPRLBR\0"`, `VERSION = 2` (`LibraryCache.cs:49`). v2 stamps the source
+library's `SearchIdentity.LibraryIdentityHash()` into the header immediately after the version
+(`LibraryCache.cs:84`). `LoadCache` returns a tri-state `LibraryCacheStatus`
+(`LibraryCache.cs:55`): `Invalid` (bad magic / wrong version), `IdentityMismatch` (stored hash
+≠ expected — the entries are *not* read, skipping a multi-GB load on a stale cache,
+`LibraryCache.cs:202`), or `Loaded`. This is the library-side analogue of the parquet
+`library_hash` invalidation. (Not called out as a distinct artifact in the Rust doc, which
+folds library identity into the parquet metadata check.)
+
+---
+
+## 8. Task validity sidecar (`<output>.<TaskName>.osprey.task`) — C# addition
+
+**C# source**: `Osprey.Tasks/TaskValiditySidecar.cs`. This artifact has **no Rust doc
+counterpart**; it is the resume-on-restart mechanism the C# port adds.
+
+For each produced output, a small hand-rolled JSON file is written next to it at
+`<output>.<TaskName>.osprey.task` (`TaskValiditySidecar.PathFor`, `TaskValiditySidecar.cs:80`).
+It records the producing task, the Osprey version, a `validity_key`, and the input paths
+(`TaskValiditySidecar.cs:98`). Example:
+
+```json
+{
+  "task": "PerFileScoring",
+  "version": "26.6.0",
+  "validity_key": "search=abc...;library=def...",
+  "inputs": ["/path/to/file.mzML", "/path/to/library.tsv"]
+}
+```
+
+The default `validity_key` is `search=<SearchParameterHash>;library=<LibraryIdentityHash>`
+(`OspreyTask.ValidityKey`, `OspreyTask.cs:173`); tasks with extra state (the rescore task)
+override to append `ReconciliationParameterHash`. On the next invocation the driver
+(`PerFileResumeDriver`) reads each output's sidecar and skips the producing task when
+`IsValid` (`TaskValiditySidecar.cs:144`) confirms the recorded key matches the current key;
+a missing/malformed/mismatched sidecar returns `false` ("can't tell ⇒ re-run", the conservative
+answer). The task-name in the filename disambiguates per-task records for tasks that once shared
+an output path (`TaskValiditySidecar.cs:71`). `Delete` (`TaskValiditySidecar.cs:169`) clears a
+sidecar when its task starts, so a crash mid-write cannot leave a stale "valid" marker.
+
+This is the C# equivalent of, and refinement over, Rust's implicit "skip-if-cache-valid"
+behavior: it makes resume explicit and per-task rather than inferring state from parquet footer
+hashes alone.
+
+---
+
+## Cleanup
+
+All intermediate files are safe to delete and are recreated on the next run:
+
+- `<stem>.spectra.bin` — recreated by re-parsing mzML.
+- `<stem>.scores.parquet` / `<stem>.scores-reconciled.parquet` — recreated by re-scoring.
+- `<stem>.{1st,2nd}-pass.fdr_scores.bin` — first-pass required by the Stage 6 worker; deleting
+  forces a Stage 5 re-join.
+- `<stem>.reconciliation.json` — deleting forces a Stage 5 re-join.
+- `<stem>.calibration.json` — small; worth keeping across runs with the same LC-MS setup, but in
+  C# recalibration is triggered by the task sidecar, not by this file's presence.
+- `<output>.<TaskName>.osprey.task` — deleting forces the task to re-run.
+
+---
+
+## Flags and switches
+
+Flags in this section affect where and whether the intermediate artifacts in this document are
+written or reused. Defaults from `Osprey/OspreyCommandArgs.cs` + `Osprey.Core/OspreyConfig.cs`.
+
+| Flag / env var | Default | Effect on this stage |
+|---|---|---|
+| `--work-dir <dir>` | unset (beside input) | Sets both `ArtifactPaths.OutputDir` and `CacheDir`; redirects every artifact |
+| `--output-dir <dir>` | unset | Sets `ArtifactPaths.OutputDir` (scores parquet, calibration JSON, FDR sidecars, reconciliation JSON) |
+| `--cache-dir <dir>` | unset | Sets `ArtifactPaths.CacheDir` (`.spectra.bin` only); a shared cache dir lets analyses reuse one parse |
+| `--task <T>` | unset (in-process) | `FirstPassFDR`/`SecondPassFDR` trigger `ValidateScoresParquetGroup`; `SecondPassFDR` sets `ExpectReconciledInput` (requires `osprey.reconciled = "true"`). See 15-hpc-scoring-split.md |
+| `--resolution {unit\|hram\|auto}` | `auto` | Folded into `SearchParameterHash` ⇒ changing it invalidates `.scores.parquet` and (via the task key) recalibration |
+| `--fragment-tolerance` / `--fragment-unit` | ppm; unit-res forces mz 0.5 | Folded into `SearchParameterHash` |
+| `--no-prefilter` | prefilter on | Folded into `SearchParameterHash` |
+| decoy flags (`--decoys-in-library`, `--decoy-pairing-manifest`, decoy method/prefixes/pair-min-fraction) | Reverse; DECOY_/rev_/decoy_; 0.80 | All folded into `SearchParameterHash` |
+| RT calibration params (bandwidth, tolerance factor, min/max tolerance, sample size, retry factor, min points, enabled) | see `RTCalibrationConfig` | Folded into `SearchParameterHash` |
+| `reconciliation.top_n_peaks` (config) | config default | Folded into `SearchParameterHash` |
+| `--run-fdr <v>` | 0.01 | Folded into `ReconciliationParameterHash` (⇒ `osprey.reconciliation_hash`) |
+| `reconciliation.enabled` / `reconciliation.consensus_fdr` (config) | enabled; 0.01 | Folded into `ReconciliationParameterHash` |
+| `--library <path>` | required | File name + size + mtime ⇒ `LibraryIdentityHash` ⇒ `osprey.library_hash` and the library reload cache identity |
+| `OSPREY_LOAD_CALIBRATION` (env) | unset | Loads a named `.calibration.json` instead of computing (cross-impl bisection hook) |
+| `OSPREY_EXIT_AFTER_CALIBRATION` (env) | unset | Exits after Stage 3, having written `.calibration.json` |
+| `OSPREY_CROSS_IMPL_FDR_SIDECAR_OUT` (env) | unset | Test hook for FDR sidecar byte-parity harness |
+
+The `.osprey.task` validity sidecar is written unconditionally (not behind a flag); it is the
+default resume mechanism.
+
+---
+
+## Divergences from the Rust documentation
+
+- **[INTENTIONAL-CSHARP-DESIGN] Safe writes use `FileSaver` sibling-temp rename, not
+  `copy_and_verify`** - Rust doc says all cache writers write to a local temp then
+  `copy_and_verify` to the final (NAS) destination; C# stages through a *same-directory* sibling
+  temp and `File.Move`s it into place. Evidence: `Osprey.Core/FileSaver.cs:68,92`; callers e.g.
+  `ParquetScoreCache.cs:265`, `SpectraCache.cs:85`. Same crash-safety guarantee; in-volume
+  rename rather than cross-volume copy. Severity: info.
+
+- **[INTENTIONAL-CSHARP-DESIGN] No `CacheValidity` enum; hash mismatch hard-fails instead of
+  silent delete-and-rescore** - Rust doc defines `CacheValidity { ValidReconciled, ValidFirstPass,
+  Stale }` and, on `Stale`, deletes the cache and re-scores from scratch. C# has no such enum;
+  `ValidateScoresParquetGroup` returns a descriptive error and aborts the `--task` run on any
+  version/hash mismatch, while the in-process pipeline decides skip-vs-recompute via the
+  `.osprey.task` sidecar. Evidence: `ParquetScoreCache.cs:1190,1256`;
+  `ReconciledParquetWriter.cs:180` (comment only). Severity: minor.
+
+- **[INTENTIONAL-CSHARP-DESIGN] `.osprey.task` validity sidecar (resume mechanism) has no Rust
+  doc counterpart** - The C# port adds a per-(output, task) JSON sidecar keyed on the search +
+  library (+ reconciliation) hashes to drive resume-on-restart; Rust infers reuse from parquet
+  footer hashes. Evidence: `Osprey.Tasks/TaskValiditySidecar.cs`; `Osprey.Tasks/OspreyTask.cs:173`.
+  Severity: info.
+
+- **[INTENTIONAL-CSHARP-DESIGN] Reconciled parquet is a separate `.scores-reconciled.parquet`,
+  not an in-place overwrite** - Rust doc's model rewrites `.scores.parquet` in place during Stage
+  6; C# writes a distinct sibling and selects it on read via
+  `EffectiveScoresPathFromScoresPath`, surviving a partial Stage 6 crash. Evidence:
+  `ParquetScoreCache.cs:1036,1055,1103`; `ReconciledParquetWriter.cs`. Severity: minor.
+
+- **[INTENTIONAL-CSHARP-DESIGN] FDR sidecar loader matches records by `entry_id`, tolerating
+  `count < entries.len()`** - Rust doc says `entry_count` must equal `entries.len()` and records
+  align positionally with an entry_id check. C# builds an `entry_id → index` map and applies
+  records by id, deliberately allowing a smaller pre-gap-fill / post-compaction sidecar over a
+  larger parquet stub list. Evidence: `FdrScoresSidecar.cs:437,484,492`. The class-summary comment
+  at `FdrScoresSidecar.cs:74` describing positional matching is internally stale. Severity: minor.
+
+- **[STALE-RUST-DOC] `reconciliation.json` is format_version 3 with `file_stems` and
+  `first_pass_base_ids`, not the doc's v1** - The Rust doc shows `"format_version": 1` and omits
+  both fields; the C# envelope requires v3 and both fields, and its comments state the Rust
+  `reconciliation_io.rs` carries the matching fields for byte parity — i.e. the Rust code evolved
+  past its own doc. Evidence: `ReconciliationFile.cs:75,77,84,124,138,150`. Severity: minor.
+
+- **[STALE-RUST-DOC] `.spectra.bin` header is v3 with a source fingerprint, not the doc's
+  20-byte v1** - The Rust doc's header shows `version = 1` and no size/mtime; C# writes v3 with
+  `source_size:u64` + `source_mtime:i64` (Unix ms) and invalidates on both version bump and
+  fingerprint change, computing the fingerprint as Unix-ms specifically to match Rust. Evidence:
+  `SpectraCache.cs:61,70,90,162`. The matching fingerprint implies the Rust code also advanced;
+  the doc did not. Severity: minor.
+
+- **[INTENTIONAL-CSHARP-DESIGN] Calibration reuse is not gated on a `search_hash` inside
+  `.calibration.json`** - Rust doc: the calibration file is reused when its `search_hash`
+  matches and deleted+recomputed when it is stale. C# never writes `search_hash` into the
+  calibration JSON (the field exists for schema parity but is unset), and reuse is instead the
+  task-level `.osprey.task` sidecar decision; the only direct-load path is the
+  `OSPREY_LOAD_CALIBRATION` bisection hook. Evidence: `PerFileScoringTask.cs:1702` (metadata
+  built without `SearchHash`), `CalibrationParams.cs:125`, `CalibrationIO.cs:42`. Net recalibrate-
+  on-stale behavior is preserved via the sidecar. Severity: minor.
+
+- **[UNVERIFIED] Mokapot / Python calibration report tooling** - The Rust doc references
+  `python scripts/evaluate_calibration.py` for calibration visualization. The C# port has no
+  Python dependency (it emits an HTML report via `--model-diagnostics`); whether an exact
+  equivalent of that specific script's output exists was not verified in this stage's code.
+  Evidence: absence in `Osprey.Chromatography/CalibrationIO.cs` and CLI. Severity: info.
+
+Verified as matching the Rust documentation: the `.scores.parquet` schema (19 fixed + 21 PIN
+feature columns, UInt32/UInt8 identity types, ZSTD, canonical `(entry_id, charge, scan_number)`
+row sort) and its footer keys (`osprey.version/search_hash/library_hash/reconciled/
+reconciliation_hash`); the binary blob encodings (f64/f32 little-endian, cwt count-prefixed);
+the FDR sidecar v3 32-byte header + 60-byte record layout and its field offsets; the search /
+library / reconciliation SHA-256 hash recipes (invariant culture, lowercase booleans, Rust
+`{:?}` escaping); and the reconciliation JSON alphabetical field order with roundtrip-stable f64
+formatting.

--- a/pwiz_tools/Osprey/docs/15-hpc-scoring-split.md
+++ b/pwiz_tools/Osprey/docs/15-hpc-scoring-split.md
@@ -1,0 +1,196 @@
+# 15. HPC Scoring Split (the four --task workers) (C#)
+
+> Pipeline stage: Cross-cutting (orchestration). C# port of Rust docs/18-hpc-scoring-split.md. Corresponds to Rust osprey `--no-join` / `--join-at-pass` HPC scoring split.
+
+For large experiments (hundreds to thousands of mzML files) the Osprey pipeline can be split into phases that scale very differently. The embarrassingly-parallel per-file phases (Stages 1-4 scoring, Stage 6 rescore) can fan out across N HPC nodes; the single-process join phases (Stage 5 first-pass FDR + reconciliation planning, Stages 7-8 merge) run once on a head node and require all-file evidence.
+
+The C# port implements this split as **four pipeline tasks** driven by a single `--task <Name>` CLI selector, rather than the Rust doc's `--no-join` / `--join-at-pass` / `--join-only` flag family. Each task is a subclass of `OspreyTask` (`Osprey.Tasks/OspreyTask.cs`), and the orchestration model is a per-task membership predicate walked by a driver loop (`Osprey/AnalysisPipeline.cs:99-112`) rather than a contiguous `[start..stop]` stage window.
+
+## Task-name mapping (CLI name vs internal enum)
+
+The CLI `--task` spelling and the internal `HpcTask` enum member differ for three of the four tasks. This is the single most important thing to keep straight when reading the code.
+
+| Pipeline stage | CLI `--task` name | `HpcTask` enum | `OspreyTask` subclass (`OspreyTask.Name`) |
+|---|---|---|---|
+| Stages 1-4 per-file scoring | `PerFileScoring` | `HpcTask.PerFileScoring` | `PerFileScoringTask` (`"PerFileScoring"`) |
+| Stage 5 first join | `FirstPassFDR` | `HpcTask.FirstJoin` | `FirstJoinTask` (`"FirstPassFDR"`) |
+| Stage 6 per-file rescore | `PerFileRescoring` | `HpcTask.PerFileRescore` | `PerFileRescoreTask` (`"PerFileRescoring"`) |
+| Stages 7-8 second join | `SecondPassFDR` | `HpcTask.MergeNode` | `MergeNodeTask` (`"SecondPassFDR"`) |
+
+- The enum is defined at `Osprey.Core/OspreyConfig.cs:388-394` as `{ PerFileScoring, FirstJoin, PerFileRescore, MergeNode }`.
+- The CLI-name ↔ enum mapping is `Program.ResolveTask` (`Osprey/Program.cs:291-317`) and its inverse `Program.TaskCliName` (`Osprey/Program.cs:326-335`).
+- The `OspreyTask.Name` strings (used in `[TASK]` log lines and `.osprey.task` sidecar naming) match the **CLI** spelling, not the enum: `PerFileScoringTask.Name => "PerFileScoring"`, `FirstJoinTask.Name => "FirstPassFDR"` (`Osprey.Tasks/FirstJoinTask.cs:71`), `PerFileRescoreTask.Name => "PerFileRescoring"` (`Osprey.Tasks/PerFileRescoreTask.cs:114`), `MergeNodeTask.Name => "SecondPassFDR"` (`Osprey.Tasks/MergeNodeTask.cs:49`).
+
+## Orchestration model: `--task` + membership predicates
+
+Instead of Rust's `--no-join` / `--join-at-pass=N` / `--join-only` flags, the C# entry point takes an optional `--task <Name>`, resolves it to an `HpcTask`, and derives three boolean config flags that the four tasks' `IsIncluded` predicates read (`Osprey/Program.cs:118-128`):
+
+```
+config.SelectedTask         = selectedTask;
+config.NoJoin               = task == PerFileScoring || task == PerFileRescore;
+config.StopAfterStage5      = task == FirstJoin;
+config.ExpectReconciledInput= task == MergeNode;
+```
+
+The pipeline is a fixed four-task list, `AnalysisPipeline.CanonicalPipeline()` (`Osprey/AnalysisPipeline.cs:139-148`), always in execution order `PerFileScoring → FirstJoin → PerFileRescore → MergeNode`. The driver loop (`Osprey/AnalysisPipeline.cs:99-112`):
+
+1. Skips any task whose `IsIncluded(ctx)` is false (excluded tasks lazy-rehydrate their state on demand if a downstream task reaches for it).
+2. Skips any included task whose declared `Outputs` already exist on disk with a matching `.osprey.task` validity-key sidecar (`ctx.CanRehydrate`).
+3. Otherwise runs the task via `RunTask` (`Osprey/AnalysisPipeline.cs:165-216`), which measures wall time, marks the task materialized, and writes output sidecars.
+
+Cross-task state flows through a typed byproduct registry (`PipelineContext.Get<T>()` / `Publish<T>()`), not constructor arguments. A `ctx.Get<T>()` cache miss lazily materializes the producing task through its `Rehydrate` (disk-load) path — this is what lets a worker that starts mid-pipeline pull the upstream state from the boundary files on disk.
+
+### Membership truth table
+
+The exact per-task membership per mode is pinned by `Osprey.Test/PipelineMembershipTest.cs:60-78`:
+
+| Mode | `PerFileScoring` | `FirstJoin` | `PerFileRescore` | `MergeNode` |
+|---|---|---|---|---|
+| straight-through (no `--task`, `-i mzML`) | run | run | run | run |
+| `--task PerFileScoring` (`NoJoin`) | run | – | – | – |
+| `--task FirstPassFDR` (`StopAfterStage5`) | rehydrate | run | – | – |
+| `--task PerFileRescoring` (`NoJoin`+`InputScores`) | rehydrate | rehydrate | run | – |
+| `--task SecondPassFDR` (`ExpectReconciledInput`) | rehydrate | (skipped) | rehydrate | run |
+| `--input-scores`, no `--task` (single-node full) | rehydrate | run | run | run |
+
+("rehydrate" = excluded from the driver loop but lazily materialized on demand from disk; "–" = never touched.) The predicates live in `PerFileScoringTask.IsIncluded` (`:84-88`), `FirstJoinTask.IsIncluded` (`:80-95`), `PerFileRescoreTask.IsIncluded` (`:123-130`), and `MergeNodeTask.IsIncluded` (`:57-64`).
+
+## Stage 1-4 — Per-file scoring (`--task PerFileScoring`)
+
+`PerFileScoringTask` (`Osprey.Tasks/PerFileScoringTask.cs`). Load the library + generate/pair decoys (`LoadLibraryAndDecoys`, `:695`), then score every input mzML (`Run`, `:173-421`). Each file's parse → RT/mass calibration → coelution scoring writes:
+
+- `<stem>.scores.parquet` — the per-file PIN-feature / fragment / CWT-candidate cache (`ParquetScoreCache.GetScoresPath`).
+- `<stem>.calibration.json` — RT + MS1/MS2 mass calibration (`CalibrationIO.CalibrationPathForInput`).
+- `<stem>.spectra.bin` — local mzML-decode fast-reload cache (not needed by joins).
+
+The parquet footer is stamped once against the unmutated outer config (`:226-232`) with `osprey.version`, `osprey.search_hash`, `osprey.library_hash`, and `osprey.reconciled = "false"`. Under `--task PerFileScoring` (`config.NoJoin` with no `--input-scores`) the task stops after writing the parquets and returns false with `ExitCode = 0` (`FinalizeAndCheck`, `:649-658`) — Stage 5+ is skipped, no blib is written. `--output` is accepted but not used (`Osprey/Program.cs:228-232` reports the real per-file parquet output instead of warning).
+
+Under `--task PerFileScoring` the task's `IsIncluded` requires **no** `--input-scores` (`:84-88`); `ValidateArgs` rejects `--task PerFileScoring --input-scores` (`Osprey/Program.cs:357-366`).
+
+`ProcessFile` always writes the parquet regardless of task, matching Rust's end-to-end behavior (the sidecar is needed by Stage 6 reconciliation to lazy-load CWT candidates).
+
+## Stage 5 — First join (`--task FirstPassFDR`)
+
+`FirstJoinTask` (`Osprey.Tasks/FirstJoinTask.cs`). Requires all per-file caches. `Run` (`:183-408`):
+
+1. Reads the pre-compaction shared entry buffer (`ctx.Get<ScoredEntries>()`, `:203`).
+2. Runs first-pass Percolator SVM FDR (`RunFdr` / `RunFirstPassProjection`, `:269-286`) with per-file PIN features streamed back on demand from each `.scores.parquet` (`loadFileFeatures`, `:244-249`).
+3. Runs first-pass picked-protein FDR on the full pre-compaction pool (`RunFirstPassProteinFdr`, `:309`) — unconditional, not gated on `--protein-fdr` (see 07-fdr-control.md, 08-protein-parsimony.md).
+4. Persists the per-file `<stem>.1st-pass.fdr_scores.bin` sidecars **before** compaction, so every stub carries its q-values (`WriteFdrScoresSidecars`, `:322`, `:827-858`).
+5. Compacts each file's stub list to the passing base_ids (`CompactFirstPass`, `:367`, `:657-720`): keep a base_id if `RunPeptideQvalue ≤ ReconciliationCompactionFdr` OR `RunProteinQvalue ≤ EffectiveProteinFdr`.
+6. Stage 6 **planning** (`PlanStage6`, `:387-392`, `:736-808`): multi-charge consensus, cross-run consensus RTs, per-file calibration refit, reconciliation planning, then writes each `<stem>.reconciliation.json` envelope (`WriteReconciliationFiles`, `:878-1039`).
+
+The boundary file pair per file is thus `<stem>.1st-pass.fdr_scores.bin` + `<stem>.reconciliation.json`. Each reconciliation.json carries `search_hash`, `library_hash`, the sorted join-wide file-stem set, and the global first-pass passing base_id set (`:970-996`), so a single-file Stage 6 worker can reconstruct the join-wide compaction set.
+
+Under `--task FirstPassFDR` (`config.StopAfterStage5`), `PlanStage6` writes the boundary pair and returns true with `ExitCode = 0` before Stage 6 rescore (`:775-797`). `IsIncluded` requires `--input-scores` with 2+ parquets (`ValidateArgs`, `Osprey/Program.cs:379-399`) and `Reconciliation.Enabled = true`.
+
+## Stage 6 — Per-file rescore (`--task PerFileRescoring`)
+
+`PerFileRescoreTask` (`Osprey.Tasks/PerFileRescoreTask.cs`). Consumes the boundary file pair + the per-file parquet and re-scores each file against the consensus + reconciliation boundaries, runs the gap-fill two-pass, and writes a **reconciled** parquet. `Run` (`:185-315`) reads the post-first-join buffer (`ctx.Get<CompactedEntries>()`, `:200`; demanding it materializes `FirstJoinTask`), self-gates on planning state (`didPlan` or a rescore bundle, and no 2nd-pass sidecar already present, `:232-247`), then calls `ExecuteRescore` (`:491-612`).
+
+`ExecuteRescore` runs the per-file loop `RescoreOneFile` (`:644-813`), which for each file with work: builds `boundary_overrides` keyed by entry_id + the subset library, reloads spectra (`.spectra.bin` → mzML fallback) and mass calibrations, picks the refined RT calibration (falling back to first-pass), re-scores via `ScoringPipeline.RunCoelutionScoring`, overlays the rescored entries in place, runs gap-fill, and writes the reconciled parquet. Rescore runs the files **in parallel** under the same `EffectiveFileParallelism` the scoring phase resolved (`:547-584`).
+
+Reconciled output goes to a **separate** `<stem>.scores-reconciled.parquet` sibling, leaving the Stage 4 `<stem>.scores.parquet` intact (`ParquetScoreCache.GetReconciledScoresPath`; `WriteReconciledAndStamp`, `:944-987`). Its footer carries `osprey.reconciled = "true"` plus `osprey.reconciliation_hash` (`Osprey.Tasks/ReconciledParquetWriter.cs:198-205`). This differs from the Rust doc, which says Stage 6 "rewrites each `<stem>.scores.parquet`" in place (see Divergences).
+
+Under `--task PerFileRescoring` (`config.NoJoin` + `--input-scores`), `IsIncluded` (`:123-130`) includes only this task; `PerFileScoringTask` and `FirstJoinTask` lazy-rehydrate the upstream state from the boundary files via `ctx.Demand`. `RescoreWorker.Run` (`Osprey/RescoreWorker.cs:80-91`) is now a thin alias that just calls `new AnalysisPipeline().Run(config)` — the hand-rolled worker path was collapsed into the canonical driver. `ValidateArgs` forbids `-i` (mzML paths are derived from the parquet stems) and requires `--library` + `--output` (`Osprey/Program.cs:368-377`).
+
+## Stages 7-8 — Second join / merge node (`--task SecondPassFDR`)
+
+`MergeNodeTask` (`Osprey.Tasks/MergeNodeTask.cs`). The terminal aggregator. `Run` (`:115-235`):
+
+1. Second-pass Percolator FDR whenever any reconciled parquet exists on disk (`AnyReconciledParquet`, `:284-294` — the C# analog of Rust's `total_rescored > 0`), via `Pass2FdrSidecar.ComputeAndPersist` (`:149`), which reloads reconciled features, reruns Percolator, writes `<stem>.2nd-pass.fdr_scores.bin`, and reloads them onto the stubs.
+2. Second-pass protein FDR — always runs (parsimony + picked-protein at `config.RunFdr`), `RunProteinFdr` (`:249-273`).
+3. Re-clamp experiment q to best run q (`PercolatorEngine.ClampExperimentQToBestRun`, `:177`).
+4. Write the BiblioSpecLite `.blib` (`WriteBlibOutput`, `:299-370`; see 13-blib-output-schema.md).
+
+Under `--task SecondPassFDR` (`config.ExpectReconciledInput`), `Rehydrate` (`:317-455`) hydrates from the reconciled parquets + sidecars **without** materializing `FirstJoinTask` (which would wrongly re-run Stage 5 Percolator on the reconciled parquets), applies its own compaction, and lets `MergeNodeTask.Run` do 2nd-pass FDR + protein FDR + blib. The strict reconciled-input gate asserts every `--input-scores` parquet carries `osprey.reconciled = "true"` (`ParquetScoreCache.ValidateScoresParquetGroup`, `Osprey.IO/ParquetScoreCache.cs:1292-1305`). `ValidateArgs` forbids `-i` and requires `--library` + `--output` (`Osprey/Program.cs:401-408`).
+
+`MergeNodeTask.Rehydrate` returns `true` as a no-op (`:113`): nothing consumes the merge node's state in-memory, so it is never demanded.
+
+## Full pipeline (default) and `--input-scores` full run
+
+With no `--task`, all four tasks run in one process (`straight-through` row of the truth table): output is identical to running the four workers in sequence over the same files. `--input-scores` with no `--task` (the `input-scores-full` row) runs Stages 5-8 in one process from existing per-file parquets — `PerFileScoringTask` is excluded (`IsIncluded` returns false when `InputScores` is non-empty, `:84-88`) and lazy-rehydrates the supplied scores instead of recomputing them.
+
+## `--input-scores` resolution and ordering
+
+`Program.ResolveInputScores` (`Osprey/Program.cs:446-483`), wired through `ARG_INPUT_SCORES` (`Osprey/OspreyCommandArgs.cs:208-220`):
+
+- A single **directory** argument is globbed **non-recursively** for `*.parquet`, then classified by suffix: `*.scores-reconciled.parquet` vs `*.scores.parquet` (`:459-465`).
+- **Reconciled wins per stem**: a stem with both files returns only the reconciled parquet (the authoritative later pass); a stem with only the original returns the original (`:469-472`).
+- The resulting list is **sorted Ordinal** (`:473`), so the file order is deterministic and stable across nodes.
+- Explicit path lists are passed through unchanged after existence validation (`:477-482`); repeated `--input-scores` flags accumulate and re-resolve (`OspreyCommandArgs.cs:211-218`).
+- Empty directory or missing explicit path throws (`:466-468`, `:479-480`).
+
+At pipeline entry, `AnalysisPipeline.Run` synthesizes `config.InputFiles` from the parquet stems once (`:76-83`, via `RescoreHydration.SyntheticInputFromParquet`) so every per-task accessor sees a populated `InputFiles` regardless of which task the run starts at.
+
+## Parquet footer hash validation
+
+The join steps are only safe if every input parquet was scored with the same library, search parameters, and a compatible binary version. `ParquetScoreCache.ValidateScoresParquetGroup` (`Osprey.IO/ParquetScoreCache.cs:1256-1308`) validates each parquet's footer before any work, delegating to `CheckParquetMetadata` (`:1190-1248`):
+
+| Metadata key | Covers | Failure mode |
+|---|---|---|
+| `osprey.version` | binary year/feature/patch/daily | hard-fail on any mismatch (`:1210-1227`) |
+| `osprey.search_hash` | search parameters (`config.Identity.SearchParameterHash()`) | mismatch → named error (`:1231-1236`) |
+| `osprey.library_hash` | library identity (`config.Identity.LibraryIdentityHash()`) | mismatch → named error (`:1240-1245`) |
+| `osprey.reconciled` | whether already reconciled | `--task SecondPassFDR` requires `"true"` (`:1292-1305`) |
+| `osprey.reconciliation_hash` | reconciliation params + sorted file set | written on reconciled parquets (`ReconciledParquetWriter.cs:195-204`) |
+
+On mismatch the run aborts before any FDR/reconciliation work, naming the offending file and which hash mismatched — mirroring the Rust doc's abort-early contract. This runs at the start of `--task FirstPassFDR` load (`PerFileScoringTask.LoadJoinOnlyScores`, `:1003-1006`). The same-task-resume skip is enforced separately by the `.osprey.task` validity-key sidecars (`OspreyTask.ValidityKey`, `OspreyTask.cs:173-176`), and per-file rescore-resume by `PerFileResumeDriver` (`TryResumeRescoredFile`, `:827-867`).
+
+## Persistent files per input
+
+| File | Written by | Consumed by |
+|---|---|---|
+| `<stem>.calibration.json` | Stage 1-2 | Stage 6 (inverse RT prediction + isolation windows) |
+| `<stem>.scores.parquet` | Stage 4 (`PerFileScoringTask`) | Stages 5-7 (stubs, PIN features, CWT candidates, blib plan) |
+| `<stem>.spectra.bin` | Stage 1-2 | local fast-reload only; no join depends on it |
+| `<stem>.1st-pass.fdr_scores.bin` | Stage 5 (`FirstJoinTask`) | Stage 6 worker (mandatory); skip-Percolator on rerun |
+| `<stem>.reconciliation.json` | Stage 5 (`FirstJoinTask`) | Stage 6 worker (mandatory) |
+| `<stem>.scores-reconciled.parquet` | Stage 6 (`PerFileRescoreTask`) | Stage 7 (`MergeNodeTask`) 2nd-pass FDR + blib |
+| `<stem>.2nd-pass.fdr_scores.bin` | Stage 7 (`MergeNodeTask`) | skip-Percolator on rerun |
+
+See 14-intermediate-files.md for the full cache formats.
+
+## Cross-implementation compatibility and bisection dumps
+
+The parquet cache and `reconciliation.json` boundary file are shared with Rust Osprey at each pipeline seam. Cross-impl byte-parity is validated via env-var-gated diagnostic dumps routed through `ctx.Diagnostics` (`Osprey.Diagnostics/IOspreyDiagnostics.cs`). The C# port exposes the Stage 5/6 dumps the Rust doc lists, including `OSPREY_DUMP_PERCOLATOR` (`DumpPercolator`, written pre-compaction so the diff sees targets + decoys, `FirstJoinTask.cs:551-554`), `OSPREY_DUMP_STANDARDIZER`, `OSPREY_DUMP_SUBSAMPLE`, `OSPREY_DUMP_SVM_WEIGHTS`, `OSPREY_DUMP_CALIBRATION`, `OSPREY_DUMP_PROTEIN_FDR`, `OSPREY_DUMP_CONSENSUS`, `OSPREY_DUMP_INV_PREDICT`, `OSPREY_DUMP_MULTICHARGE`, `OSPREY_DUMP_REFIT`, `OSPREY_DUMP_LOESS_FIT`, `OSPREY_DUMP_RECONCILIATION`, `OSPREY_DUMP_MP_INPUTS`, and the Stage 6 rescore dump `OSPREY_DUMP_RESCORED` (`PerFileRescoreTask.cs:297-313`). Each has an `_ONLY` companion that exits after writing. **`OSPREY_DUMP_PREDICT_RT` is declared but its scoring-hotspot call site is disabled** in the C# port for performance (`PerFileRescoreTask.cs:715-726`; see Divergences and 18-peptide-trace.md).
+
+## Safe concurrent writes
+
+All cache writers write to a local temp file and copy-and-verify to the final destination, so a mid-write process kill on a NAS/CIFS mount leaves no corrupt cache that a downstream stage must reject. See 16-determinism.md.
+
+## Flags and switches
+
+| Flag / field | Default | Effect on this stage |
+|---|---|---|
+| `--task {PerFileScoring\|FirstPassFDR\|PerFileRescoring\|SecondPassFDR}` | none (full pipeline in one process) | Selects one HPC worker; sets `NoJoin` / `StopAfterStage5` / `ExpectReconciledInput` (`Program.cs:126-128`). Resolved case-insensitively (`ResolveTask`). |
+| `--input-scores <paths\|dir>` | none | One or more `.scores.parquet` files or a single directory (globbed non-recursively, reconciled-wins-per-stem, Ordinal-sorted). Mutually exclusive with `-i/--input`. Consumed by `FirstPassFDR` / `PerFileRescoring` / `SecondPassFDR` and the `--input-scores`-only full run. |
+| `-i/--input <mzML...>` | none | Required by `PerFileScoring` and the default full pipeline; forbidden by `FirstPassFDR` / `PerFileRescoring` / `SecondPassFDR`. |
+| `-l/--library`, `-o/--output` | none | Required by every join/merge task. `--output` is accepted-but-unused by `--task PerFileScoring` (writes per-file parquets, not a blib). |
+| `--reconciliation-compaction-fdr <v>` | 0.01 | Peptide-q gate for Stage 5 compaction (`FirstJoinTask.cs:689`). |
+| `--protein-fdr <v>` | 0.01 (machinery always runs) | Protein-rescue gate for compaction (`EffectiveProteinFdr`, `FirstJoinTask.cs:693`) and the merge-node passing-group count. |
+| `Reconciliation.Enabled` (config) | true | Gates Stage 6 planning (`FirstJoinTask.cs:387`) and the `--task FirstPassFDR` requirement (`Program.cs:395-398`). |
+| `--parallel-files [N]` | sequential (off) | OUTER parallelism: number of input files scored/rescored at once. Both Stage 1-4 scoring and Stage 6 rescore fan out under the same resolved `EffectiveFileParallelism` (`RunPlan.cs:47`). Auto when the flag is given with no value. |
+| `--threads <count>` | all cores | INNER per-file main-search thread budget, divided across concurrently running files. |
+| `--work-dir` / `--output-dir` / `--cache-dir` | input file's own dir | Redirect where per-file artifacts (parquet, spectra, calibration, sidecars) are written (`ArtifactPaths`, `Program.cs:135-136`). |
+| `OSPREY_MAX_PARALLEL_FILES` (env) | unset | Back-compat cap on the resolved concurrent-file count (`FileParallelismResolver`). |
+| `OSPREY_DUMP_*` / `OSPREY_*_ONLY` (env) | unset | Env-var-gated cross-impl bisection dumps (see above); `_ONLY` exits after writing. Zero overhead when unset. |
+| Retired: `--no-join`, `--join-only`, `--join-at-pass=N`, `--parquet-compression` | — | Not recognized by the C# CLI; any such token fails fast in `ParseArgs` (`Program.cs:83-85`). |
+
+## Divergences from the Rust documentation
+
+- **[INTENTIONAL-CSHARP-DESIGN] CLI surface is `--task <Name>`, not `--no-join` / `--join-at-pass` / `--join-only`** - Rust doc says the HPC split is orchestrated by `--join-at-pass=<N>` with `--no-join` / `--join-only` modifiers; C# retired those flags and uses a single `--task {PerFileScoring|FirstPassFDR|PerFileRescoring|SecondPassFDR}` selector that derives the `NoJoin` / `StopAfterStage5` / `ExpectReconciledInput` membership flags. The unrecognized Rust flags fail fast. Evidence: `Osprey/Program.cs:86-128`, `Osprey/OspreyCommandArgs.cs:206-207`. Severity: major.
+
+- **[INTENTIONAL-CSHARP-DESIGN] Task names differ from the pipeline stage they run** - The CLI names describe the FDR pass (`FirstPassFDR`, `SecondPassFDR`) while the internal `HpcTask` enum and task classes describe the join topology (`FirstJoin`/`FirstJoinTask`, `MergeNode`/`MergeNodeTask`); `PerFileRescoring` ↔ `PerFileRescore`. A reader must map three of four names. Evidence: `Osprey.Core/OspreyConfig.cs:388-394`, `Osprey/Program.cs:326-335`. Severity: info.
+
+- **[INTENTIONAL-CSHARP-DESIGN] Stage 6 writes a separate `.scores-reconciled.parquet`, not an in-place rewrite** - Rust doc says Stage 6 "rewrites each `<stem>.scores.parquet`" with reconciled scores; C# writes a separate `<stem>.scores-reconciled.parquet` sibling and leaves the Stage 4 parquet intact (crash-safety: a partial Stage 6 crash cannot half-rewrite the Stage 4 output). `--input-scores` directory resolution then prefers the reconciled sibling per stem. Evidence: `Osprey.Tasks/PerFileRescoreTask.cs:163-177,944-954`, `Osprey/Program.cs:459-472`. Severity: minor.
+
+- **[INTENTIONAL-CSHARP-DESIGN] Orchestration is membership-predicate + lazy-rehydrate, not a stage window** - Rust doc frames each mode as "run stages X through Y, load the rest from disk"; C# implements a fixed four-task canonical pipeline where each task's `IsIncluded` decides participation and excluded/valid tasks lazy-rehydrate their state on demand through the typed byproduct registry. Behavior/outputs match the Rust modes (pinned by the membership truth table). Evidence: `Osprey/AnalysisPipeline.cs:99-148`, `Osprey.Test/PipelineMembershipTest.cs:55-93`. Severity: info.
+
+- **[INTENTIONAL-CSHARP-DESIGN] No `--parquet-compression` flag; C# writes ZSTD** - Rust doc documents `--parquet-compression snappy` on the scoring step for OspreySharp interop (Parquet.Net 3.x Snappy-only). The C# port has no such flag; its `ParquetScoreCache` writer uses `CompressionMethod.Zstd` unconditionally and reading auto-dispatches on per-column-chunk metadata. Cross-impl ZSTD/Snappy read compatibility is tracked as follow-up. Evidence: `Osprey.IO/ParquetScoreCache.cs:270,462`, `Osprey.Tasks/PerFileScoringTask.cs:1481`. Severity: minor.
+
+- **[FLAG-GATED] `OSPREY_DUMP_PREDICT_RT` is declared but disabled** - Rust doc lists `OSPREY_DUMP_PREDICT_RT` among the Stage 6 worker bisection dumps; the C# interface declares `DumpPredictRt`, but its per-file call site in the rescore loop is commented out as a scoring hotspot, so the dump produces nothing today. Evidence: `Osprey.Diagnostics/IOspreyDiagnostics.cs:80`, `Osprey.Tasks/PerFileRescoreTask.cs:715-726`. Severity: minor.
+
+- **[STALE-RUST-DOC] Stage 4 parquet footer omits `osprey.reconciliation_hash`** - Rust doc's hash table lists `osprey.reconciliation_hash` as parquet footer metadata generally; in C# the Stage 4 `.scores.parquet` footer carries only `version` / `search_hash` / `library_hash` / `reconciled = "false"`, and `reconciliation_hash` is written **only** on the Stage 6 reconciled parquet. This matches the semantic intent (the hash is meaningful only post-reconciliation) but the field is not present on every parquet. Evidence: `Osprey.Tasks/PerFileScoringTask.cs:226-232` vs `Osprey.Tasks/ReconciledParquetWriter.cs:198-205`. Severity: info.
+
+Verified as matching the Rust doc: the four-phase split (per-file scoring / first join / per-file rescore / second join) and which stages run vs load-from-disk in each mode; the boundary file pair (`<stem>.1st-pass.fdr_scores.bin` + `<stem>.reconciliation.json`); the SHA-256 footer-hash validation (version / search_hash / library_hash / reconciled) aborting early with a file-named error; the `--task SecondPassFDR` strict `reconciled = "true"` gate; the `--input-scores` directory being scanned non-recursively; the mutual-exclusion validation errors (`Program.ValidateArgs`); the reconciliation.json carrying `search_hash`/`library_hash`; the copy-and-verify safe-write pattern; and the env-var-gated cross-impl bisection dumps.

--- a/pwiz_tools/Osprey/docs/16-determinism.md
+++ b/pwiz_tools/Osprey/docs/16-determinism.md
@@ -1,0 +1,327 @@
+# 16. Determinism (C#)
+
+> Pipeline stage: Cross-cutting. C# port of Rust docs/09-determinism.md. Corresponds to Rust osprey determinism patterns.
+
+The C# Osprey port is designed to produce **bit-identical results** across runs
+on the same input, regardless of thread scheduling, `--threads`/`--parallel-files`
+count, or which .NET runtime target (net472 vs net8.0) executes it. This is the
+same guarantee the Rust tool makes, and it is enforced by the same standing
+oracle described at the end of this doc: `regression.ps1` compares whole `.blib`
+outputs (and a protein-FDR dump) at a `1e-9` tolerance. This document catalogs
+the determinism patterns the C# code actually uses, in the order the pipeline
+relies on them, and anchors each to concrete C# code.
+
+The determinism-critical invariant is broader than "same answer twice": the
+regression gate also requires that a **resumed** run (rehydrated from on-disk
+Parquet/sidecars) and a **distributed 4-`--task`** run reproduce the
+straight-through result exactly (see 14-intermediate-files.md and
+15-hpc-scoring-split.md). That means the deterministic entry ORDER established
+during scoring must survive a Parquet round-trip and a cross-process boundary,
+not just an in-memory sort.
+
+## Sources of non-determinism in the .NET port
+
+The Rust doc lists four hazards (HashMap iteration order, Rayon collection
+order, floating-point accumulation order, RNG). The C# port faces the direct
+.NET analogs:
+
+1. **`Dictionary<K,V>` / `HashSet<T>` iteration order** — .NET does not
+   guarantee iteration order, and for reference-type keys (notably `string`)
+   the per-process randomized hash seed makes `HashSet<string>` enumeration
+   order vary across processes. Every collect-from-dictionary site must sort
+   before use.
+2. **`Parallel.For` / PLINQ completion order** — results must be placed by
+   index or sorted afterward, never appended in completion order.
+3. **Floating-point accumulation order** — `a + (b + c)` differs from
+   `(a + b) + c`; SIMD lane reduction differs from a scalar left-fold. The port
+   holds these within the `1e-9` cross-impl gate (see "Float stability").
+4. **Random number generation** — all sampling/shuffling uses a fixed-seed
+   deterministic PRNG (`XorShift64`, seed 42).
+
+## Step 1 — Total ordering of doubles (`TotalOrder`)
+
+`Osprey.Core/TotalOrder.cs` is the C# equivalent of Rust's `f64::total_cmp`. It
+maps a `double` to a sign-flipped `long` key (`TotalOrder.Key`,
+`Osprey.Core/TotalOrder.cs:55`) so the natural `long` ordering reproduces the
+IEEE 754-2008 §5.10 total order: `-0.0` sorts below `+0.0` and NaNs order
+consistently. `TotalOrder.Comparer` (`:47`) pairs with LINQ
+`OrderBy`/`OrderByDescending` (stable per the .NET contract) to reproduce Rust's
+`sort_by(... .total_cmp(...))` byte-for-byte; `TotalOrder.Greater` (`:67`) is
+the boolean form used by the main-search peak-ranking tie-break. The header note
+records that this transform was relocated verbatim out of `AbstractScoringTask`
+(two former copies) with the arithmetic unchanged, so cross-impl parity is
+unaffected.
+
+## Step 2 — Deterministic parallel scoring (place-by-index, not append)
+
+The per-window main search runs under `Parallel.For`
+(`Osprey.Scoring/ScoringPipeline.cs:269`). Each window writes its result list to
+a pre-sized slot `windowResults[wIdx]` (`:290`) keyed by window index, and the
+final flatten iterates `wIdx` in order (`:301-305`). The comment at `:249-251`
+states the intent explicitly: "Per-window results land in `windowResults[wIdx]`
+so the final flatten is deterministic in window order regardless of completion
+order." This is the C# realization of the Rust "sort after parallel collection"
+pattern — implemented as an indexed scatter so no post-sort is even needed for
+the flatten itself.
+
+Within a window, spectra are sorted by `(RetentionTime, ScanNumber)` before XIC
+extraction (`Osprey.Scoring/CoelutionScorer.cs:97`), `ScanNumber` giving a unique
+total order so the sort never ties.
+
+## Step 3 — Sort after dictionary collection
+
+Every site that collects results out of a `Dictionary`/`HashSet` sorts into a
+stable key order before the values are used downstream:
+
+- **Target-decoy pair dedup**: after HashMap-based pairing, entries are sorted by
+  `EntryId` (`Osprey.Scoring/ScoringPipeline.cs:579`; the comment at `:567`
+  notes this makes order "deterministic regardless of Dictionary" enumeration).
+- **Competition winners** (`PercolatorFdr.CompeteAll`): winners are sorted by
+  **score descending, then `base_id` ascending**
+  (`Osprey.FDR/PercolatorFdr.cs:1599-1602`). `base_id` = `entry_id & 0x7FFFFFFF`
+  (`:258`) is unique per winner, so the secondary key makes the comparator total
+  — the note at `:1602` records that the unique `base_id` tie-break is what
+  licenses `Array.Sort` (an unstable sort) here.
+- **Best-per-precursor selection** result is sorted by entry index
+  (`Osprey.FDR/PercolatorFdr.cs:2604`).
+- **Protein picked-FDR winners** are sorted by score descending, tie-broken by a
+  canonical sorted-accessions `SortKey` string, not by the HashMap-order
+  `GroupId` (`Osprey.FDR/ProteinFdr.cs:628-636`).
+
+The double-counting dedup similarly re-sorts by `EntryId`
+(`Osprey.Scoring/ScoringPipeline.cs:579`), and the reconciliation CWT/forced
+lists sort by `EntryId` (`Osprey.Tasks/FirstJoinTask.cs:1143-1144`).
+
+## Step 4 — Deterministic fold assignment (round-robin over sorted peptide groups)
+
+Cross-validation fold assignment is **not** a hash-modulo of the sequence. Both
+the Percolator SVM and the calibration LDA build peptide groups keyed by the
+target sequence (via `base_id`), sort the distinct group keys with
+`StringComparer.Ordinal`, and round-robin `i % nFolds` over the sorted keys:
+
+- **Percolator SVM**: `PercolatorFdr.CreateStratifiedFoldsByPeptide`
+  (`Osprey.FDR/PercolatorFdr.cs:2453`) — groups by target peptide (`:2456-2490`),
+  `sortedKeys.Sort(StringComparer.Ordinal)` (`:2494`), `fold = i % nFolds`
+  (`:2499`).
+- **Calibration LDA**: `CalibrationScorer.CreateStratifiedFoldsByPeptide`
+  (`Osprey.Scoring/CalibrationScorer.cs:409`) — target and decoy groups sorted
+  by `string.CompareOrdinal` (`:435,:437`), each round-robined independently
+  (`:439-452`). The doc-comment at `:402-407` states it is a "Direct port of
+  `create_stratified_folds_by_peptide` in calibration_ml.rs" that "sorts each
+  group list by ordinal sequence, and assigns peptide groups to folds."
+
+This grouping keeps the cross-validation invariants: all charge states and the
+paired decoy of a peptide (same `base_id` → same target sequence group) go to the
+same fold, so target-decoy pairs are never split across the train/test boundary
+(see 07-fdr-control.md).
+
+Because the assignment is a pure function of the ordinal-sorted group keys, it is
+deterministic across runs and thread counts with **no** PRNG involvement.
+
+## Step 5 — Seeded PRNG (`XorShift64`, seed 42)
+
+The only randomness in the pipeline is training-subset shuffling, and it uses a
+fixed-seed deterministic PRNG. `XorShift64` (`Osprey.ML/LinearSvmClassifier.cs:266`)
+matches the Rust generator exactly (`x ^= x << 13; x ^= x >> 7; x ^= x << 17`).
+`PercolatorConfig.Seed` defaults to `42` (`Osprey.FDR/PercolatorFdr.cs:64,:121`),
+and is threaded through both the direct and streaming Percolator paths
+(`PercolatorEngine.cs:566,:797`). The SVM's per-iteration index permutation is a
+Fisher-Yates shuffle over the same PRNG (`LinearSvmClassifier.FisherYatesShuffle`,
+`:668`), whose header note states it "Matches the Rust implementation exactly."
+
+## Step 6 — Deterministic subsampling
+
+When the deduped training set exceeds `MaxTrainSize`, the peptide-grouped
+subsample is also deterministic: `SubsampleByPeptideGroup`
+(`Osprey.FDR/PercolatorFdr.cs:2611`) builds peptide groups, sorts the group keys
+with `StringComparison.Ordinal` (`:2654`), then applies a Fisher-Yates shuffle
+seeded from the same `seed` (`:2656-2666`) before greedily taking whole groups up
+to the budget and re-sorting the selected indices (`:2677`). Subsampling operates
+on whole `base_id` groups (targets + decoys + all charges together), not
+individual entries, preserving the cross-validation grouping invariant. The
+prior `SelectBestPerPrecursor` dedup (`:2569`) itself sorts its output
+(`:2604`), so the subsample input order is stable. `BuildTrainingSubset`
+(`:2522`) is the single owner both the direct and streaming Percolator paths call
+so they select **identical** subsets for identical input.
+
+## Step 7 — Float stability within the 1e-9 gate
+
+The port cannot use BLAS; the SVM hot loop is hand-vectorized with
+`System.Numerics.Vector<double>` (`Osprey.ML/LinearSvmClassifier.cs:516-604`,
+see 17-vectorization.md). This changes the floating-point reduction ORDER
+relative to Rust's strict scalar left-fold: the SIMD path accumulates per-lane
+partial sums (lane stride = `Vector<double>.Count`, 4 on AVX2, 8 on AVX-512, 2 on
+ARM NEON) then horizontal-sums via `Vector.Dot`. The extensive note at `:531-545`
+records the consequence precisely: per-op drift is sub-ULP, cumulative drift over
+the `n*iter` dot products at `p=21` features stays inside the `1e-9` cross-impl
+parity gate, but that headroom **implicitly assumes a lane-stride-stable
+runtime** — a production CPU/runtime swap that changes the lane stride shifts the
+divergence pattern, and the documented bisection is to force the scalar tail
+(set `vecSize > cols`) to confirm.
+
+Elsewhere the port keeps scalar left-fold sums (`MlMath.Norm`/`Mean`/`Std`,
+`Osprey.ML/MlMath.cs:39-71`; `FeatureStandardizer.Fit`,
+`Osprey.ML/LinearSvmClassifier.cs:314`) to match Rust's accumulation order. The
+port also avoids nondeterministic parallel float reduction: the SVM training and
+scoring reductions are per-row and per-lane deterministic, not a thread-order
+`Parallel` sum.
+
+## Step 8 — Canonical entry order across Parquet and process boundaries
+
+The deterministic entry order established during scoring must be reproduced after
+a rehydrate, because the resume and HPC-chain legs of the regression gate depend
+on it. The scoring task orders entries and writes them to the per-file
+`.scores.parquet` in that order; on any warm/resume path
+`PerFileRescoreTask.SortFileEntriesCanonical` (`Osprey.Tasks/PerFileRescoreTask.cs:1301`)
+re-imposes the exact `(EntryId, Charge, ScanNumber, ParquetIndex)` order a cold
+run establishes, with `ParquetIndex` as a unique terminal key so the sort never
+ties (`:1306-1315`). The comment at `:1287-1299` explains why this is applied to
+**every** file (even no-work files with no reconciled Parquet): otherwise
+`MergeNode`'s `BuildSharedBoundaries` could iterate a different order and, on a
+q-value tie between charge states, pick a different shared `(modseq, file)`
+boundary. Parquet preserves exact IEEE-754 values, so a rehydrated entry is
+bit-identical to the in-memory original (see 14-intermediate-files.md).
+
+The PEP estimator is fed a `base_id`-ascending-sorted union so its
+non-associative KDE sum is order-stable (`Osprey.FDR/PercolatorFdr.cs:934,:959-977`),
+and experiment-level q-values are propagated through a `base_id`-keyed map
+(`:2342-2352`) rather than dictionary iteration.
+
+## Step 9 — Razor shared-peptide assignment
+
+`SharedPeptideMode.Razor` (`Osprey.FDR/ProteinFdr.cs:432-467`, off by default —
+default is `All`) resolves each shared peptide to a single protein group. The C#
+implementation collects the shared peptides (`:434-439`) and, for each, picks the
+group with the most unique peptides (tie-break lowest `GroupId`), mutating the
+winning group's unique set as it goes (`:441-465`). See the divergence note below:
+this is a single-pass greedy, which differs from the iterative greedy set cover
+the Rust doc describes, and its input order derives from `HashSet<string>`
+enumeration. The default `All` mode and the `Unique` mode do no
+order-dependent reassignment. Protein parsimony grouping itself is made
+deterministic by ordinal-sorted set keys and a descending set-size sort with a
+canonical `SortKey` tie-break (`ProteinFdr.cs:255,:288,:628-636`); see
+08-protein-parsimony.md.
+
+## Step 10 — Outer file parallelism does not affect results
+
+`--parallel-files` (outer, across-files) and `--threads` (inner, per-file) change
+only scheduling, never output. `FileParallelismResolver.Resolve`
+(`Osprey.Core/FileParallelism.cs:122`) resolves a concurrent-file count from the
+CLI request, `OSPREY_MAX_PARALLEL_FILES`, free RAM, and core count, but each file
+is scored independently into its own Parquet cache in a deterministic order, and
+the join stages sort by stable keys. The reconciliation re-scoring per-file loop
+under `PerFileRescoreTask` (`Osprey.Tasks/PerFileRescoreTask.cs:576`) writes each
+file's result independently and the merge node re-imposes the canonical order
+(Step 8), so a run with `--parallel-files 8` and a sequential run produce
+identical blibs — which is exactly what the regression gate asserts.
+
+## The determinism oracle — `regression.ps1` at 1e-9
+
+`regression.ps1` (repo root of the Osprey C# tree) is the standing determinism
+gate; it has no Rust equivalent (the Rust project used inline unit tests). It
+runs the full pipeline on the Stellar (`--resolution unit`) and Astral
+(`--resolution hram`) reference datasets and enforces three complementary
+`1e-9`-tolerance comparisons (`regression.ps1:14-36,:114`):
+
+- **mode 1 — vs committed golden**: straight-through output compared to a
+  committed text golden (`osprey-regression.data`): the Stage 7 protein-FDR dump,
+  a deterministic precursor subset, and a full-set summary, all at `1e-9`
+  (`:16-20,:490-500`). This is the user-facing correctness gate; the golden is
+  refreshed only with `-CreateGolden` on a reviewed behavior change.
+- **mode 2 — resume == straight-through**: the Stage 5 join + blib are
+  invalidated and the same command re-run so the rehydrate paths fire; the resume
+  blib must equal the cold blib at `1e-9` (`:21-25,:524-543`). This is what makes
+  Step 8's canonical-order-after-rehydrate essential.
+- **mode 3 — HPC 4-task chain == straight-through**: the distributed
+  `PerFileScoring → FirstPassFDR → PerFileRescoring → SecondPassFDR` chain, each
+  phase rehydrating the prior phase's on-disk sidecars across a process boundary,
+  must equal the straight-through blib at `1e-9` (`:26-36,:502-522`).
+
+To keep the version metadata cell byte-stable across the daily version stamp, the
+gate pins `OSPREY_VERSION_OVERRIDE = 26.1.1.0` for every child process
+(`regression.ps1:133`). The default tolerance is `1e-9` (`:114`), tight enough
+that any real reordering of a float reduction or any nondeterministic collection
+order surfaces as a red gate.
+
+## Flags and switches
+
+This stage has no dedicated "make it deterministic" flag — determinism is
+unconditional. The switches below influence the mechanisms above; none of them
+changes the output, only scheduling or which order-sensitive algorithm runs.
+
+| Flag / env var / field | Default | Effect on this stage |
+|---|---|---|
+| `--threads <count>` | all cores | Inner per-file/per-window/per-fold thread budget. Results are place-by-index (Step 2) and sort-after-collect (Step 3), so thread count never changes the output. |
+| `--parallel-files [N]` | absent = Sequential | Outer across-files concurrency (`FileParallelism.cs:35-45`). Each file is scored independently; join stages sort by stable keys. Does not change output. |
+| `OSPREY_MAX_PARALLEL_FILES` | unset | Legacy back-compat cap on the outer file count when `--parallel-files` is absent (`FileParallelism.cs:153-165`). Scheduling only. |
+| Percolator `Seed` | `42` | Fixed PRNG seed for SVM shuffle + peptide-group subsample (`PercolatorFdr.cs:64,:121`). Not exposed as a CLI flag; the constant matches Rust's `seed=42`. |
+| `--shared-peptides {all\|razor\|unique}` | `all` | Selects the shared-peptide reassignment. `all` and `unique` are order-independent; `razor` runs the order-sensitive greedy in Step 9 (see divergence). |
+| `--fdr-method {percolator\|simple}` | `percolator` | `percolator` uses the seeded SVM (Steps 4-6); `simple` skips SVM training (no PRNG involved). |
+| `OSPREY_VERSION_OVERRIDE` | unset | Pins the `osprey_version` blib metadata cell so the golden compare stays byte-stable; set to `26.1.1.0` by the regression gate (`regression.ps1:133`). |
+| `-Tolerance` (regression.ps1) | `1e-9` | The determinism/parity tolerance the oracle enforces across all three modes (`regression.ps1:114`). |
+
+## Divergences from the Rust documentation
+
+- **[STALE-RUST-DOC] Fold assignment is round-robin over sorted peptide groups,
+  not a sequence hash** - The Rust doc (§6 "Deterministic Fold Assignment", and
+  the `calibration_ml.rs` row of the known-paths table) shows
+  `fold = hash(modified_sequence) % n_folds`. The C# code assigns folds by
+  round-robin (`i % nFolds`) over the **ordinal-sorted distinct peptide-group
+  keys**, with no hashing — and its own doc-comment says this is a direct port of
+  Rust `create_stratified_folds_by_peptide`, i.e. the Rust CODE also sorts and
+  round-robins. The doc's `hash % n_folds` phrasing is stale relative to both
+  implementations. Evidence: `Osprey.FDR/PercolatorFdr.cs:2492-2504`,
+  `Osprey.Scoring/CalibrationScorer.cs:402-452`. Severity: minor.
+
+- **[INTENTIONAL-CSHARP-DESIGN] `TotalOrder` bit-transform replaces `f64::total_cmp`**
+  - Rust calls the built-in `total_cmp`. The C# port has no such intrinsic, so it
+  reproduces the IEEE-754 total order via a sign-flipped `long` key paired with a
+  stable LINQ sort. The header note asserts the arithmetic is unchanged and
+  parity is unaffected. Evidence: `Osprey.Core/TotalOrder.cs:55-70`. Severity: info.
+
+- **[INTENTIONAL-CSHARP-DESIGN] SIMD lane-reduction order differs from Rust's
+  scalar left-fold** - The Rust doc treats float determinism as "use `total_cmp`
+  and sequential sums." The C# SVM hot loop reduces via `System.Numerics`
+  per-lane partial sums instead of a strict left-fold, a deliberate perf choice
+  (see 17-vectorization.md). Per-op drift is sub-ULP and stays inside the `1e-9`
+  gate at `p=21`, but the divergence pattern is lane-stride dependent (AVX2 vs
+  AVX-512 vs NEON). Evidence: `Osprey.ML/LinearSvmClassifier.cs:531-545`.
+  Severity: minor.
+
+- **[INTENTIONAL-CSHARP-DESIGN] The determinism oracle is a PowerShell gate, not
+  inline tests** - The Rust doc's "Testing" section names inline tests
+  (`test_deduplicate_pairs_deterministic`) and a manual `diff` of two blibs. The
+  C# port instead runs a standing `regression.ps1` gate that enforces
+  straight-through-vs-golden, resume-vs-straight, and HPC-chain-vs-straight all at
+  `1e-9`, covering rehydrate and cross-process determinism the Rust doc's manual
+  recipe does not. Evidence: `regression.ps1:14-36,:490-543`. Severity: info.
+
+- **[UNVERIFIED] Razor mode is a single-pass greedy, not the documented iterative
+  greedy set cover** - The Rust doc (§9) describes an *iterative greedy set cover*
+  that, each round, finds the globally-best group and claims **all** its
+  unassigned shared peptides in sorted order, and cites
+  `test_shared_peptides_razor_deterministic` (10 repeats, byte-identical). The C#
+  `SharedPeptideMode.Razor` instead iterates the shared peptides once, assigning
+  each to the currently-best group and mutating the unique-peptide counts as it
+  goes; the iteration order comes from `HashSet<string>`/`Dictionary<string,...>`
+  enumeration, which under .NET's randomized string hashing is not guaranteed
+  stable across processes. This differs algorithmically from the documented Rust
+  approach and could be order-sensitive. It is off the bit-identical reference
+  path (default `--shared-peptides all`; the `regression.ps1` gate does not
+  exercise `razor`), and I could not find a C# repeated-run razor determinism test
+  analogous to the Rust one, so I could not confirm whether the C# output is
+  actually order-dependent or merely a different-but-stable algorithm. A human
+  should add a repeat-run byte-identity test for `--shared-peptides razor` (and
+  confirm C#/Rust razor assignments match). Evidence:
+  `Osprey.FDR/ProteinFdr.cs:432-467`. Severity: major.
+
+Verified matching (no divergence): total-order float comparison
+(`TotalOrder.cs`), place-by-index parallel scoring
+(`ScoringPipeline.cs:249-305`), sort-after-dictionary-collection at every
+competition/dedup site (`PercolatorFdr.cs:1599-1602`, `ScoringPipeline.cs:579`,
+`ProteinFdr.cs:628-636`), fixed-seed `XorShift64`+Fisher-Yates matching Rust
+(`LinearSvmClassifier.cs:266,:668`), deterministic peptide-grouped subsample
+(`PercolatorFdr.cs:2611-2678`), and canonical entry order preserved across
+Parquet round-trip and the `--task` boundary
+(`PerFileRescoreTask.cs:1301-1315`), all enforced end-to-end by the `1e-9`
+`regression.ps1` oracle.

--- a/pwiz_tools/Osprey/docs/17-vectorization.md
+++ b/pwiz_tools/Osprey/docs/17-vectorization.md
@@ -1,0 +1,238 @@
+# 17. Vectorization (managed, no BLAS) (C#)
+
+> Pipeline stage: Cross-cutting (performance). C# port of Rust docs/15-blas-vectorization.md. Corresponds to Rust osprey BLAS/SIMD vectorization.
+
+## What this stage is about
+
+The Rust reference implementation accelerates its numerical hot paths with an external
+BLAS library (OpenBLAS, linked through `ndarray`'s `blas` feature) plus LLVM
+auto-vectorization of idiomatic iterator code. The C# port is a self-contained managed
+.NET assembly: it takes **no native BLAS dependency at all** and cannot rely on a
+Rust/LLVM auto-vectorizer. This document describes what the managed port actually does
+in each numeric hot path, where it uses `System.Numerics.Vector<T>` SIMD, and where it
+deliberately falls back to plain scalar loops -- and confirms that in every case the
+outputs stay bit-for-bit on the cross-impl parity gate.
+
+There is **no `--blas`, `--simd`, or `--no-vectorize` switch anywhere in the C# CLI.**
+Vectorization here is an implementation detail, not a user-facing feature. The only flags
+that touch this stage are the general performance/threading and resolution flags (see
+"Flags and switches").
+
+## The numeric hot paths, in pipeline order
+
+### 1. Calibration spectral scoring (Stage 3 discovery)
+
+Rust reformulates calibration-phase spectral matching as a single BLAS `sgemm`:
+`library_matrix (n_lib x n_bins) @ spectra_matrix.T (n_bins x n_spectra)` computes all
+pairwise cosine similarities at once, ~20x faster than pairwise scoring, using f32 to
+double SIMD throughput.
+
+The C# port **ports the data structures but not the all-pairs matrix multiply into the
+live pipeline**:
+
+- `PreprocessedLibrary` (Osprey.Scoring/BatchScorer.cs:46) stores library entries as a
+  `float[,]` row-major matrix (`n_entries x n_bins`), sqrt-preprocessed and L2-normalized
+  exactly like Rust (BatchScorer.cs:95-122). f32 is preserved for parity with the Rust
+  matrix dtype.
+- `PreprocessedSpectra` (BatchScorer.cs:129) does the same for spectra (BatchScorer.cs:145-200).
+- `BatchScorer.BatchXCorr` (BatchScorer.cs:248-267) is the "matrix multiply", but it is a
+  plain triple-nested scalar loop (`dot += library.Matrix[lib,b] * spectra.Matrix[spec,b]`),
+  explicitly labelled "Uses direct loops (no BLAS dependency)" (BatchScorer.cs:247) and
+  "Port of BatchScorer ... (simplified, no BLAS)" (BatchScorer.cs:205).
+
+However, `BatchXCorr` / `BatchScorer.FindBestMatches` are **not called anywhere in the
+analysis pipeline** -- their only references are inside `BatchScorer.cs` itself and the
+unit test `Osprey.Test/ScoringTest.cs:284`. The actual calibration discovery loop scores
+**per candidate**, not all-pairs:
+
+- `Calibrator.cs:1184` computes the apex LibCosine feature with
+  `SpectralScorer.LibCosine(apexSpectrum, entry, tolerance)` -- one library entry against
+  one apex spectrum.
+- `Calibrator.cs:1189-1191` computes the apex XCorr through
+  `SpectralScorer.XcorrFromPreprocessed` against a **per-window** preprocessed bin array
+  (`windowPreprocessed[apexWindowIdx]`) that is built once per isolation window and reused
+  across all candidates in that window -- the same "preprocess once, O(n_fragments) bin
+  lookup" strategy Rust reserves for the *main* search (see step 2), applied to
+  calibration too.
+- `CalibrationScorer.cs` (`CalibrationScorer.TrainAndScoreCalibration`,
+  CalibrationScorer.cs:84) consumes those per-candidate features.
+
+Net effect: the C# port never materializes the 2.5-million-cell all-pairs score matrix in
+production. It reaches the same calibration matches through per-candidate scoring plus
+per-window XCorr preprocessing. Outputs are bit-identical on the reference datasets; the
+BLAS `sgemm` reformulation is simply absent. See 04-calibration.md.
+
+### 2. Main-search XCorr (Stage 3/4 scoring primitive)
+
+Here the C# port and the Rust "Where BLAS is Not Used" section agree in architecture. Each
+precursor's XCorr is an individual sparse gather, not a matrix multiply:
+
+- Per isolation window, the sliding-window-subtracted Comet fast-XCorr bin vector is
+  prepared once and reused across every candidate in the window.
+- `SpectralScorer.XcorrFromPreprocessed(double[]/float[], entry, visitedBins)`
+  (SpectralScorer.cs:186-216 for f64, SpectralScorer.cs:234 for f32) walks only the
+  candidate's ~10-30 fragment bins (`MzToBin` lookup), summing `preprocessed[bin]` with a
+  de-dup guard (`visitedBins`). This is an O(n_fragments) sparse dot product, **not** an
+  O(n_bins) dense one and not a matmul -- exactly the Rust main-search design.
+- The `xcorr` feature calculator (XcorrCalc, Osprey.Scoring/XcorrCalculators.cs:53) and the
+  Savitzky-Golay apex+/-2 sweep (SgWeightedSweep, XcorrCalculators.cs:104) both route
+  through `IResolutionStrategy.ScoreXcorr`, which selects the f64 (Unit) or f32 (HRAM)
+  cache. The accumulation is a strict scalar left-to-right sum -- the doc-comment at
+  XcorrCalculators.cs:95-97 explicitly says "Do not vectorize or reorder" to preserve the
+  golden. See 02-xcorr-scoring.md.
+
+No SIMD is applied to XCorr; the gather is data-dependent and sparse, so vectorizing it
+would not help and would risk perturbing the f64 reduction order the parity gate depends
+on.
+
+### 3. HRAM XCorr cache: managed memory design (no Rust analogue)
+
+The managed runtime has a garbage collector and a Large Object Heap (LOH) that Rust does
+not. Two C# constructs exist purely to keep the XCorr hot path off the LOH allocator; they
+change nothing about the arithmetic:
+
+- `SparseXcorrSpectrum` (Osprey.Scoring/SparseXcorrSpectrum.cs:55, issue #4398) stores the
+  HRAM spectrum as its sparse pre-subtraction peaks + a prefix sum instead of a dense
+  `float[100001]` (391 KB, LOH) per spectrum. `CenteredAt(bin)` (SparseXcorrSpectrum.cs:93)
+  recovers the Comet fast-XCorr centered value on demand and **narrows to `float`** so it
+  matches the old dense f32 cache bit-for-bit (SparseXcorrSpectrum.cs:44-50 documents the
+  IEEE-754 `x + 0.0 == x` argument that makes the sparse prefix equal the dense prefix
+  element-for-element).
+- `XcorrScratchPool` / `XcorrScratch` (Osprey.Scoring/XcorrScratchPool.cs:41,72) is a
+  reuse pool of the f64 scratch buffers (Binned/Windowed/Prefix/Preprocessed/VisitedBins,
+  each `double[NBins]`) so repeated XCorr calls do not re-allocate ~800 KB LOH arrays. The
+  pool grows to its high-water mark (typically NThreads) and never shrinks. This is the
+  perf gate (see 19-testing.md, Test-PerfGate.ps1); the pool is threaded through every
+  `ScoreXcorr` call.
+
+Rust has no equivalent because it has no GC/LOH; these are INTENTIONAL-CSHARP-DESIGN
+infrastructure with identical outputs.
+
+### 4. SVM training: the one hand-vectorized SIMD path (Stage 5/7 FDR)
+
+This is the single place the C# port uses explicit SIMD, and it is the mirror-image of the
+Rust situation. Rust wrote idiomatic `w[..p].iter().zip(row).map(...).sum()` and let LLVM
+auto-vectorize it into AVX2/AVX-512 FMA. RyuJIT does **not** auto-vectorize the equivalent
+indexed scalar loop, so the C# dual-coordinate-descent SVM hand-vectorizes with
+`System.Numerics.Vector<double>`:
+
+- The `w . x_i` dot product (Osprey.ML/LinearSvmClassifier.cs:516-568) accumulates
+  per-lane partial sums in a `Vector<double>` then horizontal-sums with
+  `Vector.Dot(sumVec, Vector<double>.One)` (LinearSvmClassifier.cs:560), followed by a
+  scalar tail for the remaining `< vecSize` columns and the bias term.
+- The `w += d * x_i` weight update (LinearSvmClassifier.cs:589-602) uses the same lane
+  pattern (`(wv + dVec * xv).CopyTo(w, k2)`).
+- `Vector.Dot`/`Vector.One` (rather than `Vector.Sum`, which is .NET 7+) are used so the
+  code also compiles for the net472 target (LinearSvmClassifier.cs:557-559).
+
+Reduction-order caveat (LinearSvmClassifier.cs:531-545): the SIMD path accumulates
+`Vector<double>.Count` lane-partial sums (4 on AVX2, 8 on AVX-512, 2 on ARM NEON) whereas
+Rust does a strict scalar left-fold. Per-op drift is sub-ULP; on the reference data at
+p=21 features the cumulative drift stays inside the 1e-9 cross-impl parity gate. The
+comment explicitly warns that the gate's headroom assumes a lane-stride-stable runtime -- a
+future AVX2->AVX-512 swap shifts the lane stride and hence the exact divergence pattern; if
+parity ever breaches 1e-9 after such a swap, bisect by forcing the scalar tail
+(`vecSize > cols`). See 07-fdr-control.md and 16-determinism.md.
+
+### 5. ML matrix / linear-algebra ops: plain scalar loops (LDA calibration)
+
+The `osprey-ml` matrix ops are the small-matrix operations Rust also keeps off BLAS. The
+C# port implements them as straightforward scalar loops with no SIMD and no parallelism:
+
+- `Matrix.Dot` (Osprey.ML/Matrix.cs:235-254) and `Matrix.DotVector` (Matrix.cs:259-275)
+  are textbook triple/double scalar loops over a row-major `double[]`.
+- `Matrix.PowerMethod` (Matrix.cs:348) and `Matrix.Transpose` / `ExtractRows` are scalar.
+- `GaussSolver` (Osprey.ML/GaussSolver.cs:41) solves `Sw * x = Sb` for LDA via scalar
+  Gauss-Jordan elimination with partial pivoting (Echelon GaussSolver.cs:133, Reduce/
+  Backfill), plus the escalating-epsilon diagonal regularization (GaussSolver.cs:56-67).
+
+These matrices are tiny (e.g. LDA scatter is n_features x n_features), so SIMD/BLAS
+dispatch overhead would exceed any gain -- the same rationale the Rust doc gives for
+osprey-ml using manual loops. Both `Matrix.cs` and `GaussSolver.cs` carry a header noting
+they originate from Sage (`osprey-ml/src/matrix.rs`, `gauss.rs`).
+
+### 6. Pearson / cosine scalar kernels (feature computation)
+
+The pairwise-correlation and cosine feature kernels are all scalar single-pass reductions
+with fixed accumulation order for parity:
+
+- `PearsonCorrelation.Pearson` / `CoelutionSum` / `MeanPairwiseCorrelation`
+  (Osprey.Scoring/PearsonCorrelation.cs:38,104,72) -- scalar sums, no-variance guard at
+  `denom < 1e-30`.
+- `ScoringMath.PearsonOverRange` / `PearsonCorrelationInRange`
+  (Osprey.Scoring/ScoringMath.cs:60,89) -- range-windowed scalar Pearson (two independent
+  ports with different no-variance guards, deliberately not merged; ScoringMath.cs:38-51).
+- `SgWeightedSweep.ComputeCosineAtScan` (XcorrCalculators.cs:177) and
+  `SpectralScorer.CosineAngle` (SpectralScorer.cs:731) -- scalar sqrt-intensity L2 cosine.
+
+None are vectorized; the intent is exact reproduction of the Rust scalar reduction order.
+
+## Flags and switches
+
+There are **no vectorization-specific flags** in the C# CLI. BLAS is not present, SIMD is
+always on where the code uses it (SVM), and there is no way to disable it. The flags that
+indirectly affect this stage:
+
+| Flag / config | Default | Effect on this stage |
+| --- | --- | --- |
+| `--threads <count>` | all cores | INNER parallelism (per-window scoring, FDR). Vectorization is per-thread; more threads multiply the SIMD hot paths but do not change per-call arithmetic. |
+| `--parallel-files [N]` | off (sequential; no value = auto) | OUTER parallelism across files. Independent of vectorization. |
+| `--resolution {unit\|hram\|auto}` | auto | Selects the XCorr cache dtype: Unit reads the f64 `Doubles` cache, HRAM reads the f32-narrowed `SparseXcorrSpectrum` value (XcorrCalculators.cs:43-46). Determines whether step 2/3 run in f64 or f32, mirroring the Rust f32 batch choice. |
+| `--fragment-tolerance` / `--fragment-unit` | ppm (unit-resolution forces mz 0.5) | Governs bin/match tolerance in the scalar kernels above; not a vectorization control. |
+
+Environment variables: none specific to vectorization. (`OSPREY_DUMP_*` diagnostics touch
+calibration/scoring dumps but not the SIMD paths.)
+
+Config fields: `OspreyConfig` exposes no BLAS/SIMD toggle. The `BatchScorer` bin geometry
+(`DEFAULT_NUM_BINS = 2000`, `DEFAULT_MIN_MZ = 200.0`, `DEFAULT_BIN_WIDTH = 1.0005`,
+BatchScorer.cs:209-211) is a private constant, and `BatchScorer` is not on any pipeline
+path.
+
+## Divergences from the Rust documentation
+
+- **[INTENTIONAL-CSHARP-DESIGN] No BLAS/OpenBLAS dependency** - Rust doc says calibration
+  batch scoring is a single OpenBLAS `sgemm` call linked via `ndarray`'s `blas` feature ->
+  `blas-src` -> system OpenBLAS; the C# port is pure managed .NET with no native BLAS.
+  Evidence: Osprey.Scoring/BatchScorer.cs:205,247 ("simplified, no BLAS" / "Uses direct
+  loops (no BLAS dependency)"). Severity: info.
+
+- **[INTENTIONAL-CSHARP-DESIGN] All-pairs matrix multiply not used in the calibration
+  pipeline** - Rust doc says calibration computes ~2.5M cosine similarities as one matrix
+  multiply per window (`BatchScorer::score_all`, `library.matrix.dot(&spectra.matrix.t())`);
+  the C# `BatchScorer.BatchXCorr` port exists but is a scalar triple loop referenced only by
+  its own `FindBestMatches` and by `Osprey.Test/ScoringTest.cs:284`. The live calibration
+  loop scores per candidate (`SpectralScorer.LibCosine` + per-window
+  `XcorrFromPreprocessed`). Evidence: Osprey.Tasks/Calibrator.cs:1184,1189-1191;
+  BatchScorer.cs:248-267 (no pipeline caller). Severity: minor.
+
+- **[INTENTIONAL-CSHARP-DESIGN] Explicit SIMD only in the SVM, via System.Numerics** - Rust
+  doc frames SIMD as auto-vectorization by LLVM across the code; in the C# port RyuJIT does
+  not auto-vectorize, so the only hand-written SIMD is the SVM dot product / weight update
+  using `Vector<double>`, with a documented sub-ULP lane-reduction-order caveat kept inside
+  the 1e-9 gate. Evidence: Osprey.ML/LinearSvmClassifier.cs:516-568,589-602. Severity: minor.
+
+- **[INTENTIONAL-CSHARP-DESIGN] Managed LOH/GC avoidance infrastructure with no Rust
+  analogue** - Rust doc has nothing on GC because Rust has no GC; the C# port adds
+  `SparseXcorrSpectrum` (sparse pre-subtraction storage + on-demand f32 recovery, issue
+  #4398) and `XcorrScratchPool` (reuse pool for `double[NBins]` scratch) purely to keep the
+  XCorr hot path off the .NET Large Object Heap. Arithmetic and outputs are unchanged.
+  Evidence: Osprey.Scoring/SparseXcorrSpectrum.cs:55,93; Osprey.Scoring/XcorrScratchPool.cs:41,72.
+  Severity: info.
+
+- **[INTENTIONAL-CSHARP-DESIGN] osprey-ml matrix ops are scalar, no BLAS (matches Rust
+  intent)** - Rust doc states osprey-ml uses "manual loops with Rayon parallelization,
+  without BLAS"; the C# `Matrix.Dot`/`DotVector` and `GaussSolver` are scalar loops with no
+  SIMD and (unlike Rust) no Rayon-style parallelism -- acceptable because these matrices are
+  tiny. Evidence: Osprey.ML/Matrix.cs:235-275; Osprey.ML/GaussSolver.cs:133-230. Severity: info.
+
+- **[STALE-RUST-DOC] Bin-count off-by-one in the (unused) batch geometry** - Rust doc says
+  "2,001 bins spanning 200-2000 Da at 1.0005 Da width"; the C# `BatchScorer` default is
+  `DEFAULT_NUM_BINS = 2000`. Because `BatchScorer` is not on any pipeline path this has no
+  behavioral effect, and the live per-window XCorr uses its own `BinConfig`, not this
+  constant. Evidence: Osprey.Scoring/BatchScorer.cs:209-211. Severity: info.
+
+Verified: the C# port has no BLAS linkage; the only production numeric paths are the
+per-candidate/per-window scalar XCorr and cosine kernels, the hand-vectorized SVM
+(`Vector<double>`), and scalar osprey-ml matrix/Gauss-Jordan ops -- all producing outputs
+on the 1e-9 cross-impl parity gate. See 02-xcorr-scoring.md, 04-calibration.md,
+07-fdr-control.md, and 16-determinism.md.

--- a/pwiz_tools/Osprey/docs/18-peptide-trace.md
+++ b/pwiz_tools/Osprey/docs/18-peptide-trace.md
@@ -1,0 +1,275 @@
+# 18. Peptide Trace Diagnostics (C#)
+
+> Pipeline stage: Cross-cutting (diagnostics). C# port of Rust docs/18-peptide-trace.md. Corresponds to Rust osprey peptide-trace (`OSPREY_TRACE_PEPTIDE`).
+
+## Summary up front
+
+The Rust `OSPREY_TRACE_PEPTIDE` facility — an env-var-gated, `[trace]`-prefixed
+per-peptide log narrative keyed by `modified_sequence`, emitted at five pipeline
+stages — **has no equivalent in the C# port.** There is no `OSPREY_TRACE_PEPTIDE`
+env var, no `trace_set()` / `is_traced()` predicate, no `[trace]` log lines, and no
+`--trace-peptide` CLI flag anywhere under `pwiz_tools/Osprey`. This was verified by a
+repository-wide search (`OSPREY_TRACE_PEPTIDE`, `TracePeptide`, `is_traced`,
+`IsTraced`, `trace_set`, `[trace]` all return zero matches).
+
+What the C# port has instead is a **structured, byte-stable dump architecture** —
+the `IOspreyDiagnostics` seam gated by the `OSPREY_DUMP_*` / `OSPREY_DIAG_*` env-var
+family — built for a different purpose: cross-implementation byte-diff bisection
+against the Rust reference, not human-readable single-peptide storytelling. It
+overlaps the same five pipeline stages the Rust trace covers, but it keys on
+**`entry_id` (a `uint`)**, writes **TSV/txt files** (not log lines), and dumps
+**all entries** (or one selected `entry_id`) rather than a peptide-name subset.
+
+This document describes the C# diagnostics that a Skyline engineer would actually
+reach for to answer the per-peptide questions the Rust trace was designed for, then
+maps each Rust trace stage to its closest C# dump, and finally records the
+divergence precisely.
+
+## The C# diagnostics architecture (what replaces the trace)
+
+### The injection seam: `IOspreyDiagnostics`
+
+`Osprey.Diagnostics/IOspreyDiagnostics.cs:51` defines the pipeline-wide diagnostics
+interface. Its doc comment states the design intent directly: it is "the
+cross-implementation bisection diagnostics seam for the whole pipeline." Tasks in
+the library layer never reach a static dump surface; they emit dumps through an
+injected `ctx.Diagnostics?.X` reference (an `IOspreyDiagnostics`), so the task layer
+can live in a library that does not reference the top-level exe project. When
+diagnostics are off, the injected reference is `null` and every call site
+short-circuits through the null-conditional operator (`diag?.ShouldDump() ?? false`,
+`diag?.Write(...)`) — a single null check, no virtual dispatch, byte-identical to and
+as fast as diagnostics-off.
+
+The concrete sink is `Osprey/OspreyFileDiagnostics.cs:68`
+(`internal sealed class OspreyFileDiagnostics : IScoringDiagnostics, IOspreyDiagnostics`).
+It reads every `OSPREY_DUMP_*` / `OSPREY_DIAG_*` gate once at process start
+(`IsOne(...)`, `ParseNullableUint(...)`, etc.) into readonly properties, and owns
+the byte-stable file writers.
+
+### Bootstrap and the `-d` master switch
+
+`Osprey/OspreyDiagnostics.cs:39` is the exe-only bootstrap. `Initialize(bool forceDumps)`
+(`OspreyDiagnostics.cs:84`) is called once at pipeline entry:
+
+- If `forceDumps` is true (the `-d`/`--diagnostics` CLI flag), it turns on a bundle
+  of `OSPREY_DUMP_*` env vars in-process first (`s_forcedDumpBundle`,
+  `OspreyDiagnostics.cs:51`), so the sink picks them up exactly as an external env
+  var would.
+- It constructs an `OspreyFileDiagnostics` and keeps it as the live sink only if
+  `sink.AnyEnabled` (`OspreyFileDiagnostics.cs:410`) is true; otherwise the sink is
+  `null` and a production run carries no diagnostic state.
+
+`OspreyDiagnostics.Active` (`OspreyDiagnostics.cs:106`) exposes the sink as
+`IOspreyDiagnostics` (or `null`), which the driver injects into `PipelineContext`.
+
+### Shared logging / formatting helpers
+
+`Osprey.Diagnostics/OspreyDiagnosticsLog.cs:34` holds the stateless helpers the task
+layer can call without referencing the exe:
+
+- `LogAction` (`OspreyDiagnosticsLog.cs:40`) — the log hook the pipeline points at
+  its `LogInfo`, so `[COUNT]` / `[BISECT]` dump messages flow through the normal
+  logging channel.
+- `F10(double)` (`OspreyDiagnosticsLog.cs:49`) — round-half-to-even 10-decimal
+  formatter matching Rust `{:.10}`.
+- `ExitAfterDump(string)` (`OspreyDiagnosticsLog.cs:60`) — logs
+  `[BISECT] <var> set - aborting after dump` and calls `Environment.Exit(0)`, used
+  by the `*_ONLY` gates.
+
+The round-trip f64 formatter used by Stage 5+ dumps lives in
+`Osprey.Core/Diagnostics.cs:60` (`FormatF64Roundtrip`), which emits the shortest
+decimal that round-trips to the same f64 bit pattern — matching Rust's ryu-based
+`format!("{}", v)` byte-for-byte. This is the C# counterpart of Rust's
+`osprey_core::diagnostics` module and is covered by `Osprey.Test/DiagnosticsTest.cs`.
+
+## Mapping the five Rust trace stages to C# dumps
+
+The Rust trace emits at five stages. Here is where a C# engineer gets the
+equivalent information. All C# dumps are declared on `IOspreyDiagnostics`
+(`Osprey.Diagnostics/IOspreyDiagnostics.cs`) and implemented in
+`Osprey/OspreyFileDiagnostics.cs`.
+
+### 1. First-pass CWT peak scoring — Rust `[trace] ... CWT candidates`
+
+Closest C# dumps:
+
+- `OSPREY_DUMP_CWT_PATH` → `WriteCwtPathRow` / `CloseCwtPathDump`
+  (`IOspreyDiagnostics.cs:181`, gate `DumpCwtPath` at `OspreyFileDiagnostics.cs:248`).
+  Emits `cs_stage6_cwt_path.tsv`: per-(file, entry_id) counts of CWT peaks, final
+  peaks after median-polish and reference-XIC fallbacks, peaks that passed the
+  apex-acceptance filter, and a "scored" flag. This localizes *whether* CWT found a
+  peak for an entry and at which seam it was lost — the C# analog of the Rust trace's
+  "did CWT actually find the correct peak?" question, but as counts, not per-candidate
+  penalized-score rows.
+- `OSPREY_DIAG_SEARCH_ENTRY_IDS=<ids>` → `ShouldDumpSearchXicFor` / `WriteSearchXicDump`
+  (`IOspreyDiagnostics.cs:156`, `OspreyFileDiagnostics.cs:989`). For a comma-separated
+  set of `entry_id`s, dumps `cs_search_xic_entry_<ID>.txt` with the full extracted XIC,
+  candidate scans, and RT window during the main search. This is the deepest per-entry
+  view — it exposes the raw chromatogram the Rust trace's `coelution`/`apex`/`intensity`
+  fields summarize.
+
+The Rust trace's explicit per-candidate ranking table (rank 0..N with `coelution`,
+`rt_penalty`, `int_weight`, `penalized`) has no direct C# TSV equivalent; the C#
+side exposes the inputs (XIC) and the outcome counts (CWT path) rather than the
+intermediate penalized-score ledger.
+
+### 2. `compute_consensus_rts` — Rust `[trace] consensus ...`
+
+Closest C# dumps:
+
+- `OSPREY_DUMP_CONSENSUS` → `WriteStage6ConsensusDump` (`IOspreyDiagnostics.cs:195`,
+  gate `DumpConsensus` at `OspreyFileDiagnostics.cs:255`). Emits
+  `cs_stage6_consensus.tsv`: the per-peptide consensus-RT planning state at the start
+  of Stage 6 (`consensus_library_rt`, median peak width) — the C# analog of the Rust
+  trace's `consensus ... → consensus_library_rt=..., median_peak_width=...` summary line.
+- `OSPREY_DUMP_INV_PREDICT` → `WriteStage6InvPredictDump` (`IOspreyDiagnostics.cs:211`,
+  gate `DumpInvPredict` at `OspreyFileDiagnostics.cs:318`). Emits
+  `cs_stage6_inv_predict.tsv`: the per-detection `(apex_rt, library_rt, weight)` triples
+  flowing into `ConsensusRts.Compute`. This is the C# analog of the Rust trace's
+  per-detection `file=... apex_rt=... weight=...` rows — the weight is the
+  `sigmoid(SVM score)` weighted-median weight
+  (`Osprey.FDR/Reconciliation/ConsensusRts.cs:75,182`;
+  `Osprey.FDR/Reconciliation/InvPredictRecord.cs`).
+
+Note the C# `InvPredictRecord` is itself internally called a "cross-impl bisection
+trace" in its own doc comment (`InvPredictRecord.cs:27`) — but it is a structured
+TSV record keyed by the detection, not the `[trace]`-log facility from the Rust doc.
+
+### 3. `plan_reconciliation` — Rust `[trace] plan ...`
+
+Closest C# dump:
+
+- `OSPREY_DUMP_RECONCILIATION` → `WriteStage6ReconciliationDump`
+  (`IOspreyDiagnostics.cs:204`, gate `DumpReconciliation` at
+  `OspreyFileDiagnostics.cs:287`). Emits `cs_stage6_reconciliation.tsv`: the
+  per-(file, entry_id) `ReconcileAction` map produced by the reconciliation planner,
+  with the action variant plus apex / start / end / half-width fields — the C# analog
+  of the Rust trace's `→ <action>` (`Keep` / `UseCwtPeak` / `ForcedIntegration`) line.
+  See `11-boundary-overrides.md` and `10-cross-run-reconciliation.md` for the action
+  semantics.
+
+The Rust trace's tolerance-derivation narrative (`global_MAD`, `this_peptide_MAD`,
+`ceiling`, and the stored `cwt[i]` candidate rows) is not reproduced field-for-field
+in the C# TSV; the C# dump reports the chosen action and its integration window.
+
+### 4. Gap-fill identification — Rust `[trace] gap-fill: ...`
+
+The C# port folds gap-fill targets into the same Stage 6 planning path. The closest
+dumps are `OSPREY_DUMP_RECONCILIATION` (above) and `OSPREY_DUMP_MULTICHARGE` →
+`WriteStage6MultichargeDump` (`IOspreyDiagnostics.cs:197`, gate `DumpMulticharge` at
+`OspreyFileDiagnostics.cs:264`), which emits `cs_stage6_multicharge.tsv` — the per-file
+rescore targets. There is no dedicated `gap-fill` trace line; a missing-in-this-file
+target surfaces as a forced-integration `ReconcileAction` row rather than a distinct
+`gap-fill:` message.
+
+### 5. First-pass and second-pass FDR q-values — Rust `[trace] fdr(<stage>) ...`
+
+Closest C# dumps:
+
+- First pass: `OSPREY_DUMP_PERCOLATOR` → `WriteStage5PercolatorDump`
+  (`IOspreyDiagnostics.cs:191`, gate `DumpPercolator` at `OspreyFileDiagnostics.cs:150`).
+  Emits `cs_stage5_percolator.tsv`: per-precursor `score`, `pep`, and the four q-values
+  after first-pass Percolator FDR and before protein FDR / compaction.
+- Second pass: `OSPREY_DUMP_RESCORED` → `WriteStage6RescoredDump`
+  (`IOspreyDiagnostics.cs:193`, gate `DumpRescored` at `OspreyFileDiagnostics.cs:200`).
+  Emits `cs_stage6_rescored.tsv` with the same column shape after the Stage 6 rescore
+  (consensus + reconciliation overlay). Its doc comment states it "Mirrors Rust's
+  dump_stage6_rescored / OSPREY_DUMP_RESCORED gate."
+
+Together these give the C# analog of the Rust trace's `fdr(first-pass)` /
+`fdr(second-pass)` per-entry q-value lines — the disposition of a precursor at both
+passes — but as full-population TSVs keyed by entry, not per-peptide log lines. See
+`07-fdr-control.md`.
+
+## Per-entry selectors (the closest thing to "trace one peptide")
+
+Where the Rust trace narrows to a `modified_sequence`, the C# system narrows by
+identifier instead:
+
+- `OSPREY_DIAG_XIC_ENTRY_ID=<id>` + `OSPREY_DIAG_XIC_PASS={1,2}`
+  (`DiagXicEntryId`, `OspreyFileDiagnostics.cs:379`; `DiagXicPass`,
+  `OspreyFileDiagnostics.cs:386`) — dumps `cs_xic_entry_<ID>.txt` for one entry during
+  calibration scoring, then `Environment.Exit(0)` (`ShouldDumpCalXicFor` /
+  `WriteCalXicEntryDumpAndExit`, `OspreyFileDiagnostics.cs:880,895`).
+- `OSPREY_DIAG_SEARCH_ENTRY_IDS=<id,id,...>` (`DiagSearchEntryIds`,
+  `OspreyFileDiagnostics.cs:393`) — non-exiting per-entry search-XIC dump for a set of
+  entries.
+- `OSPREY_DIAG_MP_SCAN=<scan>` (`DiagMpScan`, `OspreyFileDiagnostics.cs:400`) — dumps
+  the median-polish inputs for one MS2 scan, additionally filtered "to a specific
+  DECOY_ALQFAQWWK target by historical convention." This is the only place a
+  peptide-name-like filter appears, and it is hardcoded, not user-supplied.
+
+The practical consequence: to trace "one peptide" in C#, an engineer first resolves
+its `entry_id` (from the library load order or a `cs_cal_*` dump), then sets the
+`OSPREY_DIAG_*` selector — a two-step, id-based workflow, versus the Rust trace's
+direct `OSPREY_TRACE_PEPTIDE=<modified_sequence>` name match.
+
+## Cache invalidation for a clean run
+
+The Rust doc's advice to delete per-file caches so the traced code paths actually
+execute applies to the C# port's dumps too: the `.scores.parquet` caches and
+`.1st-pass.fdr_scores.bin` / `.2nd-pass.fdr_scores.bin` FDR score sidecars let the
+C# pipeline shortcut past scoring and Percolator on reruns (skip-Percolator fast
+path). To force the Stage 4/5/6 producers to re-run and emit their dumps, clear the
+per-file caches first. See `14-intermediate-files.md` for the C# cache/sidecar layout
+and the `CacheValidity` invalidation rules.
+
+## Flags and switches
+
+This stage is diagnostics-only; nothing here changes search outputs. All gates
+default **off** (unset), so a production run carries no diagnostic state.
+
+| Flag / env var | Default | Effect on this stage |
+|---|---|---|
+| `-d` / `--diagnostics` (`OspreyCommandArgs.cs:283`) | off | Master switch: forces on the `OSPREY_DUMP_*` bundle (`OspreyDiagnostics.cs:51,84`) so the structured dumps are written. Sets `config.Diagnostics = true`. |
+| `--model-diagnostics` (`OspreyCommandArgs.cs:285`) | off | Writes a self-contained interactive HTML report of the trained scoring model and FDR calibration. Unrelated to per-peptide tracing. |
+| `OSPREY_DUMP_CWT_PATH` (`OspreyFileDiagnostics.cs:248`) | off | `cs_stage6_cwt_path.tsv` — per-(file, entry) CWT path counts (Rust trace stage 1 analog). |
+| `OSPREY_DIAG_SEARCH_ENTRY_IDS=<ids>` (`OspreyFileDiagnostics.cs:393`) | unset | `cs_search_xic_entry_<ID>.txt` per selected entry during main search (deepest per-entry XIC view). Non-exiting. |
+| `OSPREY_DUMP_CONSENSUS` (`OspreyFileDiagnostics.cs:255`) | off | `cs_stage6_consensus.tsv` — per-peptide consensus RT planning (Rust trace stage 2 analog). |
+| `OSPREY_DUMP_INV_PREDICT` (`OspreyFileDiagnostics.cs:318`) | off | `cs_stage6_inv_predict.tsv` — per-detection `(apex_rt, library_rt, weight)` into consensus (Rust trace stage 2 per-detection analog). |
+| `OSPREY_DUMP_RECONCILIATION` (`OspreyFileDiagnostics.cs:287`) | off | `cs_stage6_reconciliation.tsv` — per-entry `ReconcileAction` (Rust trace stage 3/4 analog). |
+| `OSPREY_DUMP_MULTICHARGE` (`OspreyFileDiagnostics.cs:264`) | off | `cs_stage6_multicharge.tsv` — per-file rescore targets. |
+| `OSPREY_DUMP_PERCOLATOR` (`OspreyFileDiagnostics.cs:150`) | off | `cs_stage5_percolator.tsv` — first-pass per-precursor score/pep/q-values (Rust trace stage 5 first-pass analog). |
+| `OSPREY_DUMP_RESCORED` (`OspreyFileDiagnostics.cs:200`) | off | `cs_stage6_rescored.tsv` — second-pass per-precursor score/pep/q-values (Rust trace stage 5 second-pass analog). |
+| `OSPREY_DIAG_XIC_ENTRY_ID=<id>` (`OspreyFileDiagnostics.cs:379`) | unset | `cs_xic_entry_<ID>.txt` for one entry during calibration; exits after dump. |
+| `OSPREY_DIAG_XIC_PASS={1,2}` (`OspreyFileDiagnostics.cs:386`) | 1 | Selects the calibration pass for the XIC dump. |
+| `OSPREY_DIAG_MP_SCAN=<scan>` (`OspreyFileDiagnostics.cs:400`) | unset | Dumps median-polish inputs for one scan (hardcoded DECOY_ALQFAQWWK filter). |
+| `OSPREY_<NAME>_ONLY=1` (per gate, e.g. `OSPREY_CONSENSUS_ONLY`) | off | Exit-after-dump companion for many gates; calls `ExitAfterDump` (`OspreyDiagnosticsLog.cs:60`). |
+| **`OSPREY_TRACE_PEPTIDE`** | **N/A** | **Not implemented in C#.** No env var, no CLI flag, no code path. See divergences below. |
+
+The full `OSPREY_DUMP_*` / `OSPREY_DIAG_*` roster (stages 1–7) is enumerated on
+`IOspreyDiagnostics` (`Osprey.Diagnostics/IOspreyDiagnostics.cs:53-109`) and gated in
+`OspreyFileDiagnostics.cs:84-423`; only the subset relevant to per-peptide behavior
+is tabulated here. The README documents the bisection env vars at
+`README.md:238-251`.
+
+## Divergences from the Rust documentation
+
+- **[INTENTIONAL-CSHARP-DESIGN] `OSPREY_TRACE_PEPTIDE` per-peptide trace facility is absent; replaced by a structured dump architecture** - Rust doc 17 says an env-var-gated `[trace]` log facility keyed by `modified_sequence` emits per-peptide narrative at five pipeline stages, with `OSPREY_TRACE_PEPTIDE=<seq>` matching bare modified sequences (and paired `DECOY_<target>` automatically), an `OnceLock`-guarded `is_traced()` probe, and `log_fdr_qvalues()` after each FDR pass. C# implements none of this: repository-wide search for `OSPREY_TRACE_PEPTIDE`, `TracePeptide`, `is_traced`/`IsTraced`, `trace_set`/`TraceSet`, and `[trace]` returns zero matches. Instead the C# port carries the `IOspreyDiagnostics` seam gated by the `OSPREY_DUMP_*` / `OSPREY_DIAG_*` family — a byte-stable, TSV/txt, `entry_id`-keyed dump system built for cross-impl bisection (its own doc comment: "the cross-implementation bisection diagnostics seam for the whole pipeline"). Evidence: `Osprey.Diagnostics/IOspreyDiagnostics.cs:51`; gates at `Osprey/OspreyFileDiagnostics.cs:84-423`; bootstrap `Osprey/OspreyDiagnostics.cs:39-107`; CLI `Osprey/OspreyCommandArgs.cs:283-285` (only `-d` and `--model-diagnostics`, no trace flag). Severity: major. Rationale for classification: diagnostics are output-neutral (they cannot change search results), and the C# port carries a deliberate, elaborate alternative diagnostics architecture serving the same five stages — this is an infrastructure design difference, not a behavioral port error. A reader wanting the Rust workflow will not find it; use the mapped `OSPREY_DUMP_*` dumps instead.
+
+- **[INTENTIONAL-CSHARP-DESIGN] Selection is by `entry_id`, not `modified_sequence`** - Rust doc 17 selects the peptide(s) to trace by bare `modified_sequence` (comma-separated), matching all charge states and the paired decoy automatically. The C# per-entry selectors key on numeric `entry_id` instead (`OSPREY_DIAG_XIC_ENTRY_ID`, `OSPREY_DIAG_SEARCH_ENTRY_IDS`) or MS2 scan number (`OSPREY_DIAG_MP_SCAN`), so narrowing to "one peptide" requires resolving its id first and does not auto-group charge states or paired decoys. Evidence: `Osprey/OspreyFileDiagnostics.cs:379,393,400`. Severity: minor.
+
+- **[INTENTIONAL-CSHARP-DESIGN] Dumps are byte-stable files diffed cross-impl, not interleaved `[trace]` log lines** - Rust doc 17 emits trace at `log::info!` sharing a `[trace]` prefix, interleaved with normal log output and grep-isolated, preserved in the log file. The C# dumps write dedicated TSV/txt files (e.g. `cs_stage6_consensus.tsv`) with round-half-to-even (`F10`, `OspreyDiagnosticsLog.cs:49`) and shortest-round-trip f64 (`FormatF64Roundtrip`, `Osprey.Core/Diagnostics.cs:60`) formatting so they can be SHA-256/numerically diffed against the Rust reference dumps; only `[COUNT]` / `[BISECT]` status lines flow to the log. Evidence: `Osprey/OspreyFileDiagnostics.cs:68-82` (LF newline discipline), `Osprey.Test/DiagnosticsTest.cs`. Severity: minor.
+
+- **[STALE-RUST-DOC] `OSPREY_DUMP_PREDICT_RT` producer is disabled in C#** - Not a Rust-doc-17 claim per se, but relevant to anyone tracing RT prediction per entry: the C# `OSPREY_DUMP_PREDICT_RT` gate throws `NotImplementedException` at sink construction because its per-candidate producer was removed from the scoring hotspot; the doc comment names exactly what to uncomment to restore it. Evidence: `Osprey/OspreyFileDiagnostics.cs:431-445`. Severity: info.
+
+### What was verified
+
+- Read Rust `docs/18-peptide-trace.md` in full (all five trace stages, enabling,
+  cache-invalidation, workflows, and the implementation table).
+- Confirmed by repository-wide search that no C# symbol implements
+  `OSPREY_TRACE_PEPTIDE`, `is_traced`, `trace_set`, or `[trace]` logging.
+- Read the C# diagnostics seam end-to-end: `IOspreyDiagnostics.cs`,
+  `OspreyDiagnosticsLog.cs`, `OspreyDiagnostics.cs`, `OspreyFileDiagnostics.cs`
+  (gates + per-entry XIC/consensus/reconciliation/FDR dump methods),
+  `Osprey.Core/Diagnostics.cs`, `Osprey.Core/OspreyEnvironment.cs`, and
+  `Osprey.Test/DiagnosticsTest.cs`.
+- Confirmed the CLI exposes only `-d`/`--diagnostics` and `--model-diagnostics` for
+  this area (`OspreyCommandArgs.cs:283-285`); no trace flag.
+
+See also: `14-intermediate-files.md` (caches and sidecars whose fast paths shortcut
+past traced/dumped producers), `10-cross-run-reconciliation.md` and
+`11-boundary-overrides.md` (consensus + `ReconcileAction` semantics),
+`07-fdr-control.md` (the first/second-pass q-values surfaced by the Percolator /
+Rescored dumps), and `19-testing.md` (the cross-impl bisection methodology the dump
+system feeds).

--- a/pwiz_tools/Osprey/docs/19-testing.md
+++ b/pwiz_tools/Osprey/docs/19-testing.md
@@ -1,0 +1,361 @@
+# 19. Testing & Standing Gates (C#)
+
+> Pipeline stage: Cross-cutting. C# port of Rust docs/11-testing.md. Corresponds to Rust osprey testing guide.
+
+This document describes how the C# Osprey port is tested. The Rust project put
+every test inline in `#[cfg(test)] mod tests` blocks in the source files and
+had no separate integration project (Rust 11-testing.md, "All tests are unit
+tests"). The C# port keeps that same unit-test-heavy philosophy but reorganizes
+it into a **separate MSTest project** (`Osprey.Test`) and adds two **standing
+CI gates that have no Rust equivalent**: an end-to-end golden/resume/HPC
+regression (`regression.ps1`) and an A/B performance gate (`Test-PerfGate.ps1`).
+A Skyline engineer reading this should come away knowing where the tests live,
+what actually enforces cross-impl parity, and how the two overnight gates work.
+
+---
+
+## 1. Test architecture: one MSTest project, not inline modules
+
+The C# tests live in a single project, `Osprey.Test`
+(`Osprey.Test/Osprey.Test.csproj:1`), which references all seven production
+projects (`Osprey.Test.csproj:43-51`: Core, ML, IO, Chromatography, Scoring,
+FDR, and the Osprey CLI). This is the structural inverse of Rust, where each
+crate carried its own `#[cfg(test)]` tests compiled into that crate.
+
+- **Framework**: MSTest v3.6.4 (`MSTest.TestAdapter` + `MSTest.TestFramework`,
+  `Osprey.Test.csproj:12-13`) on `Microsoft.NET.Test.Sdk` 17.12.0
+  (`Osprey.Test.csproj:11`). Tests are annotated with `[TestClass]` /
+  `[TestMethod]`, the Skyline-standard MSTest attributes.
+- **Multi-target**: the test project builds for both `net472` and `net8.0`. The
+  `net472` leg needs extra native/managed wiring the SDK gives `net8.0` for
+  free: an explicit `IronCompress` native `nironcompress.dll` copy for Parquet
+  Zstd (`Osprey.Test.csproj:17-36`) and an explicit `System.Memory` reference
+  (`Osprey.Test.csproj:38-41`). The production regression build runs the
+  `net8.0` binary (`regression.ps1:123`).
+- **Scale**: 41 `[TestClass]` types and **492 `[TestMethod]` tests** across the
+  `Osprey.Test/*.cs` files (measured). Rust 11-testing.md tabulates "~302
+  tests." The larger C# count reflects extra tests written specifically to lock
+  down cross-impl parity (Parquet/sidecar byte layout, codec round-trips, CLI
+  argument plumbing) that Rust did not need to guard against a second
+  implementation.
+- **Assertions**: tests use plain MSTest `Assert` / `CollectionAssert` /
+  `StringAssert` (measured: 1,314 `Assert.AreEqual`, 323 `Assert.IsTrue`, 41
+  `CollectionAssert.AreEqual`, etc.). There is **no `AssertEx` helper** and no
+  shared abstract base test class in `Osprey.Test` — unlike Skyline's `TestUtil`
+  `AssertEx`, this project does not reference Skyline test infrastructure.
+
+The largest test files by method count are `IOTest.cs` (64), `ProgramTests.cs`
+(62), `ReconciliationTest.cs` (46), `FdrTest.cs` (45), `MLTest.cs` (42), and
+`ScoringTest.cs` (40) — roughly mirroring the Rust per-crate distribution
+(chromatography/scoring/fdr/io heaviest).
+
+## 2. Tests by project (maps to Rust "Tests by Crate")
+
+Each production project has a corresponding `*Test.cs` (some split across
+several), porting the Rust crate's inline tests. The correspondence is direct:
+
+| C# project | C# test file(s) | Rust crate (Rust 11-testing.md) |
+|---|---|---|
+| `Osprey.Core` | `CoreTypesTest.cs` (24), `IsotopeDistributionTest.cs` (11), `OspreyConfigTest.cs` (2) | `osprey-core` (28) |
+| `Osprey.IO` | `IOTest.cs` (64), `DiannDecoyColumnTest.cs`, `CwtCandidateCodecTest.cs` (9), `CwtCandidateLoaderTest.cs` | `osprey-io` (26) |
+| `Osprey.Chromatography` | `ChromatographyTest.cs` (13), `CalibrationTest.cs` (20), `PeakDetectorTest.cs` (9) | `osprey-chromatography` (66) |
+| `Osprey.Scoring` | `ScoringTest.cs` (40), `OspreyFeatureCalculatorsTest.cs` (9), `FragmentSelectionTest.cs` (11), `IsotopeDistributionTest.cs` | `osprey-scoring` (70) |
+| `Osprey.FDR` | `FdrTest.cs` (45), `FdrControllerTest.cs`, `ReconciliationTest.cs` (46), `MultiChargeConsensusTest.cs`, `Pass2FdrSidecarTest.cs`, `PercolatorEntryBuilderTest.cs`, `ReconciledParquetWriterTest.cs`, `GapFillTargetIdentifierTest.cs`, `MedianPolishMetricsTest.cs` | `osprey-fdr` (41) |
+| `Osprey.ML` | `MLTest.cs` (42) | `osprey-ml` (30) |
+| `Osprey` (CLI) + `Osprey.Tasks` | `ProgramTests.cs` (62), `OspreyCommandArgsTests.cs` (6), `PipelineMembershipTest.cs`, `PerFileResumeDriverTest.cs`, `FileParallelismResolverTests.cs`, `MultiProgressReporterTest.cs`, `ArtifactPathsTest.cs` | `osprey` (main, 26–41) |
+
+The header comments make the porting explicit: `FdrTest.cs:25` "Ported from Rust
+test suite in osprey-fdr"; `ScoringTest.cs:36` "Tests for Osprey.Scoring, ported
+from osprey-scoring Rust tests"; `IOTest.cs:42` "Ported from osprey-io Rust
+tests." Like Rust, these are pure unit tests over synthetically constructed
+inputs (spectra, library entries, feature vectors) with no external data
+dependency.
+
+Additional C# test files with no direct Rust analog cover port-specific
+infrastructure: `ProgramTests.cs` (CLI `--task` argument validation and
+`--input-scores` directory expansion — see 15-hpc-scoring-split.md),
+`ByproductContextTest.cs`, `DiagnosticsTest.cs`, `ModelDiagnosticsDataTest.cs`
+(the `--model-diagnostics` HTML report), `FileSaverTest.cs` (the safe
+copy-and-verify NAS-write pattern), `DecoyPairingManifestTest.cs` and
+`EntrapmentPairingTest.cs` (decoy/entrapment pairing — see 01-decoy-generation.md).
+
+## 3. Parity-locked tests and the "translation-proof" register
+
+Because the C# code must be bit-identical to Rust (see 16-determinism.md), a
+class of C# tests goes beyond "does the answer look right" to "does this match
+Rust exactly." Three techniques appear:
+
+1. **Hand-computed reference values ported from the Rust test.** e.g.
+   `ScoringTest.cs:972` "Full XCorr pipeline verification: hand-computed
+   reference value"; the comment at `ScoringTest.cs:1073` notes "The f64 result
+   is what both C# and Rust (after the flip) should use." Comparisons are done
+   on the exact bit pattern where it matters: `IOTest.cs:2102-2115` compares
+   `BitConverter.DoubleToInt64Bits(...)` of every numeric field rather than an
+   approximate `AreEqual` with a tolerance.
+
+2. **Behavioral notes that encode a Rust semantic.** e.g. `ScoringTest.cs:613`
+   uses `>=` "to match Rust's `Iterator::max_by` which returns the [last]"
+   element on ties; `ScoringTest.cs:839` and the `CodeInspectionTest`
+   unstable-sort guard (section 4) both exist because .NET introsort reorders
+   ties differently than Rust's stable `slice::sort_by`.
+
+3. **Cross-impl byte-parity hooks.** Certain tests write a real on-disk artifact
+   (an FDR-score sidecar, a reconciliation sidecar) using hardcoded inputs that
+   are identical to the Rust sibling test's inputs, and — when an environment
+   variable points them at an output path — copy that artifact out so a harness
+   can byte-compare the C# and Rust outputs. The hook for the FDR-score sidecar
+   is `OspreyEnvironment.CrossImplFdrSidecarOut`
+   (`Osprey.Core/OspreyEnvironment.cs:104`, env var
+   `OSPREY_CROSS_IMPL_FDR_SIDECAR_OUT`), consumed at `IOTest.cs:2082-2083`; the
+   reconciliation sidecar hook is `CrossImplReconciliationOut`
+   (`OspreyEnvironment.cs:112`, env var `OSPREY_CROSS_IMPL_RECONCILIATION_OUT`).
+   `IOTest.cs:2064-2065` states the values "match Rust's
+   `fdr_scores_sidecar_v3_round_trip` exactly so the ... byte-parity gate
+   compares identical inputs on both sides." `ScoringTest.cs:1283-1286` similarly
+   requires the sparse HRAM cache to be "BIT-IDENTICAL to the dense f32 cache."
+
+Note: the phrase "translation-proof" is a description of intent, not a literal
+class or attribute name in the code; the mechanism is the ported reference
+values plus the byte-parity hooks above.
+
+## 4. Static-analysis gate: `CodeInspectionTest`
+
+`CodeInspectionTest.cs` (`Osprey.Test/CodeInspectionTest.cs:44`) is a C#-only
+test class with no Rust counterpart. Modeled on Skyline's
+`Test/CodeInspectionTest.cs` (`CodeInspectionTest.cs:32-36`) but scoped to the
+Osprey tree, it runs source-text static analysis over the production `*.cs`
+files (skipping `Osprey.Test`, `bin`, `obj` — `CodeInspectionTest.cs:53-58`) and
+fails the build on cross-impl-parity hazards. Two rules are implemented:
+
+- **`TestNoUnstableSort`** (`CodeInspectionTest.cs:85`): forbids `Array.Sort` and
+  `List<T>.Sort` in production code, because .NET introsort is **unstable** and
+  reorders equal-keyed elements differently from Rust's stable `slice::sort_by`,
+  silently diverging tie-ordering in scoring code (`CodeInspectionTest.cs:60-82`).
+  The fix is `OrderBy(...).ThenBy(...)` (LINQ stable sort) or an explicit index
+  permutation. A call that is provably tie-safe can be exempted with an inline
+  `// Array.Sort OK: <reason>` comment (`CodeInspectionTest.cs:94`). The canonical
+  incident cited is `ProteinFdr`'s `winners.Sort(...)` with a HashMap-order
+  tiebreak (`CodeInspectionTest.cs:66-70`) — see 08-protein-parsimony.md.
+- **`TestReconciliationPairsDecoysByBaseIdNotPrefix`**
+  (`CodeInspectionTest.cs:150`): forbids any `"DECOY_"` string literal in the
+  `Osprey.FDR/Reconciliation/` code (`CodeInspectionTest.cs:159`), enforcing that
+  reconciliation pairs a target with its decoy by `base_id`
+  (`entry_id & 0x7FFFFFFF`), never by stripping a modseq prefix — prefix
+  stripping misses library-supplied decoys that carry no prefix and biases
+  second-pass FDR (`CodeInspectionTest.cs:139-148`). Exemption tag:
+  `// DECOY_ pairing OK:`. See 10-cross-run-reconciliation.md and
+  01-decoy-generation.md.
+
+Both rules parse only the code portion of each line (a shared `IndexOfLineComment`
+string-literal-aware scanner, `CodeInspectionTest.cs:260`) so a comment that
+mentions the forbidden pattern does not trip the rule.
+
+## 5. Standing gate 1 — `regression.ps1` (golden + resume + HPC chain at 1e-9)
+
+`Osprey/../regression.ps1` (`regression.ps1:1`) is the overnight end-to-end
+correctness gate, wired to the scheduled TeamCity "Osprey Windows .NET
+Regression" config via `tctest.bat` (`regression.ps1:99`). It has **no Rust
+equivalent** — Rust shipped only inline unit tests. It builds the Release
+`net8.0` binary (`regression.ps1:201-206`), acquires real DIA data by
+downloading a Panorama zip into `<Downloads>\Perftests`
+(`regression.ps1:137,217-220`, TestPerf-style skip-if-present), and runs the
+full pipeline on two reference datasets — **Stellar** (unit resolution) and
+**Astral** (hram) — with inputs referenced read-only and all derived artifacts
+under a per-run timestamped `TestResults/regression-<stamp>` via `--work-dir`
+(`regression.ps1:142-145,229-231`). It then asserts a no-copy invariant that the
+read-only data dir is byte-for-byte untouched (`regression.ps1:277-293,477-481`).
+
+It runs three complementary correctness legs, all at a **1e-9 tolerance**
+(`regression.ps1:114`, `-Tolerance` default):
+
+- **mode 1 — straight-through vs a committed text golden**
+  (`regression.ps1:490-500`). Compares the Stage 7 protein-FDR dump (emitted via
+  `OSPREY_DUMP_STAGE7_PROTEIN_FDR`, `regression.ps1:244`), a deterministic
+  ~500-precursor subset, and a full-set summary against the committed
+  `osprey-regression.data/<dataset>/` capture. The golden is small committed text
+  (Stellar ~1.1 MB, Astral ~2.4 MB — `Regression/README.md:44-45`), versioned
+  with the code so an older tagged commit compares against its own baseline. The
+  subset is selected by `MD5(peptideModSeq|precursorCharge) % 120 == 0`
+  (`Regression/README.md:56`) — machine-independent. Refresh only on an
+  intentional reviewed change with `-CreateGolden` (`regression.ps1:48-50,483-488`).
+  Golden tables under `osprey-regression.data/*/tables/` include RefSpectra,
+  RetentionTimes, Peak­Boundaries, Osprey{Run,Experiment}Scores,
+  OspreyCoefficients, Proteins, PeakDigest (per-spectrum SHA-256), and
+  OspreyMetadata.
+- **mode 3 — HPC 4-task worker-chain self-consistency**
+  (`regression.ps1:502-522`, `Invoke-HpcChain` at `regression.ps1:338`). Runs the
+  distributed `--task` pipeline `PerFileScoring → FirstPassFDR → PerFileRescoring
+  → SecondPassFDR` (`regression.ps1:27-28`), each phase rehydrating the prior
+  phase's on-disk sidecars across a real process boundary (copied inputs, nothing
+  held in memory), and asserts the chain's final blib equals the straight-through
+  blib at 1e-9. This exercises the cross-process `--task` rehydrate paths that
+  mode 2 (in-process resume) does not. See 15-hpc-scoring-split.md for the task
+  worker semantics.
+- **mode 2 — resume vs straight-through self-consistency**
+  (`regression.ps1:524-543`). Copies the straight-through blib aside, invalidates
+  the Stage 5 join + blib (`Invoke-ResumeInvalidation`, `regression.ps1:298-304`),
+  re-runs the identical command so the rehydrate paths fire, and asserts the
+  resume blib equals the cold blib at 1e-9. The build is its own oracle — no
+  external baseline. See 14-intermediate-files.md for the cache/sidecar formats
+  that resume depends on.
+
+Version pinning: the daily build stamps a changing `YEAR.ORDINAL.BRANCH.DOY`
+version, but the golden compares the `osprey_version` metadata cell exactly, so
+the harness pins `OSPREY_VERSION_OVERRIDE = '26.1.1.0'` (`regression.ps1:133`,
+honored at `Osprey.Core/OspreyVersion.cs:93`) to keep the stamp deterministic.
+Any mismatch emits a TeamCity `buildProblem` and a non-zero exit
+(`regression.ps1:565-570`). The comparators (`Compare-BlibGolden`,
+`Compare-BlibFull`) live in `Regression/BlibGolden.ps1` with data acquisition in
+`Regression/RegressionData.ps1` — self-contained, with **no dependency on the
+sibling `ai/` checkout** (`regression.ps1:38-41`, `Regression/README.md:4-7`).
+
+Switches: `-Dataset {Stellar|Astral|All}` (`regression.ps1:103`), `-CreateGolden`,
+`-SkipResume` (mode-2 off), `-SkipHpcChain` (mode-3 off), `-NoBuild`, `-Threads`
+(default 16), `-TeamCity`, `-KeepOutput`, `-Tolerance` (default 1e-9).
+
+## 6. Standing gate 2 — `Test-PerfGate.ps1` (interleaved A/B wall-time)
+
+`ai/scripts/Osprey/Test-PerfGate.ps1` (`Test-PerfGate.ps1:1`) is the performance
+companion to gate 1, also with **no Rust equivalent**. Where `regression.ps1`
+asserts the OUTPUT is unchanged, this asserts the SPEED is not degraded by a
+refactor (`Test-PerfGate.ps1:9-11`). It does a **same-session A/B** of a branch
+build against a **pinned baseline worktree** (`C:\proj\pwiz-perfbase`, default
+`-BaselineRoot`, `Test-PerfGate.ps1:119`) so machine/thermal/SDK conditions are
+shared and cancel (`Test-PerfGate.ps1:16-20`). Key design points:
+
+- **Build both binaries fresh** in the same session unless `-SkipBuild`
+  (`Test-PerfGate.ps1:192-200`), and stage both into a common parent to remove
+  any PATH asymmetry (`Test-PerfGate.ps1:211-220`).
+- **Interleave with alternating order per repeat** (rep 1 baseline-first, rep 2
+  branch-first, …) so neither side is systematically the hotter later run
+  (`Test-PerfGate.ps1:391-400`), after discarding `-WarmupRuns` warm-ups
+  (`Test-PerfGate.ps1:388-390`).
+- **Pair each rep's baseline+branch and take the per-rep % delta; the median is
+  the headline** (`Get-PairedDelta`, `Test-PerfGate.ps1:424-437`;
+  judging at `Test-PerfGate.ps1:459-485`). Walls are parsed from the binary's
+  `[STAGE-WALL]` lines emitted under `--perf-stats` (`Test-PerfGate.ps1:320-331`).
+- **Hard-fail on TOTAL wall only** — median per-rep delta over `-TotalThresholdPct`
+  (default 4%, `Test-PerfGate.ps1:123`) AND every rep agreeing the branch was
+  slower (`Test-PerfGate.ps1:470-478`). Heavy stages (`stage1to4`, `stage6`,
+  `Test-PerfGate.ps1:160`) report as WARN, never fail — a refactor that moves time
+  between stages at equal total is not a regression (`Test-PerfGate.ps1:24-31`).
+
+Rust is not needed for the A/B (the interleaved same-session design already
+cancels the environment); it stays the optional change-immune anchor only when a
+flagged regression must be confirmed as code vs environment
+(`Test-PerfGate.ps1:36-38`). Cross-binary parallelism is controlled via
+`OSPREY_MAX_PARALLEL_FILES` rather than `--parallel-files`, because the pinned
+baseline predates that argument (`Test-PerfGate.ps1:79-84,296-306`).
+
+## Flags and switches
+
+This stage is driven by test-harness scripts and diagnostic environment
+variables rather than product CLI flags. The product `--task`,
+`--parallel-files`, `--threads`, `--protein-fdr`, and `--resolution` flags are
+exercised *by* the gates but documented in their own stage docs.
+
+`regression.ps1` parameters:
+
+| Switch | Default | Effect |
+|---|---|---|
+| `-Dataset` | `All` | `Stellar` (unit, fast), `Astral` (hram, large), or `All` |
+| `-CreateGolden` | off | Capture/refresh `osprey-regression.data/` instead of comparing (reviewed changes only) |
+| `-SkipResume` | off | Skip mode-2 resume self-consistency leg |
+| `-SkipHpcChain` | off | Skip mode-3 HPC 4-task worker-chain leg |
+| `-NoBuild` | off | Reuse existing Release binary |
+| `-Threads` | 16 | `--threads` per run |
+| `-TeamCity` | off | Emit TeamCity `progressMessage`/`buildProblem` |
+| `-KeepOutput` | off | Retain the run's scratch (default deletes as it goes) |
+| `-Tolerance` | `1e-9` | Numeric tolerance for all three legs |
+
+`Test-PerfGate.ps1` parameters:
+
+| Switch | Default | Effect |
+|---|---|---|
+| `-Dataset` | `Stellar` | `Stellar`, `Astral`, or `Both` |
+| `-Repeats` | 3 | Interleaved A/B repeats (median + band) |
+| `-WarmupRuns` | 1 | Discarded warm-ups before measured reps |
+| `-BaselineRoot` | `C:\proj\pwiz-perfbase` | Pinned baseline worktree |
+| `-BranchRoot` | auto (sibling `pwiz`) | Change-under-test worktree |
+| `-TotalThresholdPct` | 4.0 | Hard-fail total-wall threshold (every rep must agree) |
+| `-StageThresholdPct` | 5.0 | Heavy-stage WARN threshold (never fails) |
+| `-SkipBuild` | off | Reuse existing Release/net8.0 binaries |
+| `-Threads` | 16 | `--threads` per run |
+| `-MaxParallelFiles` | -1 (dataset default: 3 Stellar / 1 Astral) | Sets `OSPREY_MAX_PARALLEL_FILES` for both A/B legs |
+
+Environment variables that affect testing:
+
+| Env var | Where | Effect |
+|---|---|---|
+| `OSPREY_VERSION_OVERRIDE` | `OspreyVersion.cs:93`; set by `regression.ps1:133` | Pins the logical version string so the golden's `osprey_version` cell stays deterministic |
+| `OSPREY_CROSS_IMPL_FDR_SIDECAR_OUT` | `OspreyEnvironment.cs:104`; used `IOTest.cs:2082` | When set, the sidecar round-trip test copies its output there for a byte-compare against the Rust sibling test |
+| `OSPREY_CROSS_IMPL_RECONCILIATION_OUT` | `OspreyEnvironment.cs:112` | Same, for the reconciliation sidecar |
+| `OSPREY_DUMP_STAGE7_PROTEIN_FDR` | set by `regression.ps1:244` | Emits the Stage 7 protein-FDR dump that mode 1 diffs against the golden |
+| `OSPREY_MAX_PARALLEL_FILES` | `Test-PerfGate.ps1:303` | Cross-binary outer-parallelism control for the perf A/B (back-compat for the pinned baseline that predates `--parallel-files`) |
+
+The `CodeInspectionTest` exemption tags are inline-comment "flags," not CLI
+flags: `// Array.Sort OK: <reason>` (`CodeInspectionTest.cs:94`) and
+`// DECOY_ pairing OK: <reason>` (`CodeInspectionTest.cs:158`).
+
+## Divergences from the Rust documentation
+
+- **[INTENTIONAL-CSHARP-DESIGN] Separate MSTest project vs inline `#[cfg(test)]`** -
+  Rust doc says all tests are inline unit tests in `#[cfg(test)] mod tests`
+  blocks with no separate integration directory (Rust 11-testing.md lines 3,
+  657-659); C# collects all tests into one `Osprey.Test` MSTest project that
+  references every production project. Evidence: `Osprey.Test/Osprey.Test.csproj:43-51`,
+  41 `[TestClass]` / 492 `[TestMethod]`. Severity: info.
+
+- **[INTENTIONAL-CSHARP-DESIGN] Two standing CI gates have no Rust analog** -
+  Rust doc's "Running Tests" is `cargo test --all` plus `cargo fmt`/`cargo clippy`
+  (Rust 11-testing.md lines 34-42) with no end-to-end golden or perf gate. C#
+  adds `regression.ps1` (golden + resume + HPC-chain at 1e-9) and
+  `Test-PerfGate.ps1` (interleaved A/B wall-time). Evidence: `regression.ps1:1`,
+  `Test-PerfGate.ps1:1`. Severity: info.
+
+- **[INTENTIONAL-CSHARP-DESIGN] Static-analysis test enforcing cross-impl
+  determinism** - Rust needed no sort-stability guard (`slice::sort_by` is
+  stable) and no DECOY_-prefix guard as a test; C# adds `CodeInspectionTest`
+  because .NET introsort is unstable. Evidence: `CodeInspectionTest.cs:85` (unstable
+  sort), `CodeInspectionTest.cs:150` (decoy pairing). Severity: info.
+
+- **[STALE-RUST-DOC] Test count "~302"** - Rust 11-testing.md line 46 states
+  "Total: ~302 tests"; the C# port measures 492 `[TestMethod]` tests, and the
+  orchestration brief cited a "317-test" Rust model, so neither the round number
+  nor the exact figure is authoritative today. This is a moving count, not a
+  behavioral difference. Evidence: measured across `Osprey.Test/*.cs`. Severity: info.
+
+- **[STALE-RUST-DOC] Mokapot test coverage** - Rust 11-testing.md documents an
+  entire `osprey-fdr/src/mokapot.rs` test suite (PIN format, result parsing,
+  runner availability — lines 487-509) predicated on the external Python mokapot
+  tool. The C# port has a native managed Percolator SVM and no Python mokapot
+  dependency, so those Mokapot-specific tests do not exist in `Osprey.Test`
+  (the `FdrMethod` enum retains a `Mokapot` value but it is not wired to the CLI).
+  Evidence: `FdrTest.cs` tests the native Percolator path; no `MokapotTest.cs`
+  exists under `Osprey.Test/`. See 07-fdr-control.md. Severity: minor.
+
+- **[INTENTIONAL-CSHARP-DESIGN] Plain MSTest `Assert`, not `AssertEx`** - the
+  reconnaissance framing referred to "AssertEx + translation-proof tests"; the
+  actual `Osprey.Test` project uses plain MSTest `Assert`/`CollectionAssert`/
+  `StringAssert` with no `AssertEx` helper and no reference to Skyline's
+  `TestUtil`. "Translation-proof" is realized instead through ported hand-computed
+  reference values, `BitConverter.DoubleToInt64Bits` exact comparisons, and the
+  `OSPREY_CROSS_IMPL_*` byte-parity hooks. Evidence: no `AssertEx` in
+  `Osprey.Test/*.cs`; byte-parity hook at `IOTest.cs:2082`,
+  `OspreyEnvironment.cs:104`. Severity: info.
+
+- **[STALE-RUST-DOC] Regression README documents 2 legs; the script runs 3** -
+  `Regression/README.md:30-37` lists only mode 1 (golden) and mode 2 (resume),
+  but `regression.ps1` also runs mode 3 (HPC 4-task worker chain,
+  `regression.ps1:502-522`). This is an internal C#-side doc lag, not a Rust
+  divergence, noted here for accuracy. Evidence: `regression.ps1:24-36` (all three
+  modes in the synopsis) vs `Regression/README.md:22-39`. Severity: minor.
+
+Verified: I confirmed the MSTest project structure and references
+(`Osprey.Test.csproj`), the 41-class/492-method inventory, the plain-`Assert`
+usage, the two `CodeInspectionTest` rules and their exemption tags, the three
+regression legs and their 1e-9 tolerance and version pin, the cross-impl
+byte-parity env-var hooks in `OspreyEnvironment.cs` and their use in `IOTest.cs`,
+and the `Test-PerfGate.ps1` interleaved-A/B design and hard-fail-on-total logic.
+No product-behavior PORT-ERROR was found; all divergences are infrastructure or
+documentation differences.

--- a/pwiz_tools/Osprey/docs/20-command-line.md
+++ b/pwiz_tools/Osprey/docs/20-command-line.md
@@ -1,0 +1,247 @@
+# 20. Command-Line Reference (C#)
+
+> Reference doc (cross-cutting). The option tables below mirror the build-generated
+> help (`Osprey --help`, archived at `../Documentation/Help/en/CommandLine.html`),
+> which is generated from `Osprey/OspreyCommandArgs.cs` so it never drifts from the
+> binary. This doc adds curated **unit (Stellar)** and **HRAM (Astral)** examples and
+> ties each option back to the algorithm docs.
+
+Osprey reads DIA mzML files plus a spectral library and writes a BiblioSpecLite
+(`.blib`) library of FDR-controlled results that imports directly into Skyline. It
+runs as a standalone .NET 8 executable on Windows and Linux.
+
+```
+osprey -i <file1.mzML ...> -l <library.tsv|.blib> -o <output.blib> [options]
+```
+
+The three required inputs are `-i`/`--input` (one or more mzML), `-l`/`--library`
+(a DIA-NN TSV or `.blib`), and `-o`/`--output` (the result `.blib`). Everything else
+has a sensible default; `--resolution` is the one flag you will almost always set.
+
+---
+
+## Quick start
+
+### Unit resolution (e.g. Stellar)
+
+```bash
+# Single file, precursor + peptide FDR at 1%
+osprey -i sample.mzML -l hela.tsv -o results.blib --resolution unit
+
+# A replicate set, with protein-level FDR and a TSV report
+osprey -i rep1.mzML rep2.mzML rep3.mzML -l hela.blib -o results.blib \
+       --resolution unit --protein-fdr 0.01 --report results.tsv
+
+# Glob + keep derived artifacts and the spectra cache out of a read-only data dir
+osprey -i /data/stellar/*.mzML -l hela.tsv -o results.blib \
+       --resolution unit --work-dir /scratch/osprey_run
+```
+
+Unit resolution has no usable MS1 features, so the two MS1 PIN features evaluate to
+0.0 and the pick uses the Stellar-trained defaults where the learned pick is enabled
+(see [06-peak-detection.md](06-peak-detection.md)). Fragment tolerance is forced to
+`mz 0.5` at unit resolution regardless of `--fragment-tolerance`.
+
+### HRAM (e.g. Astral)
+
+```bash
+# Single file at high resolution (10 ppm fragment tolerance is the default)
+osprey -i sample.mzML -l predicted.tsv -o results.blib --resolution hram
+
+# A larger replicate set with protein FDR; score several files at once
+osprey -i /data/astral/*.mzML -l predicted.blib -o results.blib \
+       --resolution hram --protein-fdr 0.01 --parallel-files
+
+# Tighten the fragment tolerance to 8 ppm and write the model-diagnostics report
+osprey -i sample.mzML -l predicted.tsv -o results.blib \
+       --resolution hram --fragment-tolerance 8 --model-diagnostics
+```
+
+HRAM turns on the MS1 precursor-coelution and isotope-cosine features and selects the
+Astral-trained defaults for the learned pick. `--resolution auto` (the default) infers
+unit vs. HRAM from the data, but passing it explicitly is clearer for batch scripts.
+
+### Useful extras
+
+```bash
+# Broaden the reconciliation pool (looser peptide gate for first-pass compaction)
+osprey -i *.mzML -l lib.tsv -o out.blib --resolution hram --reconciliation-compaction-fdr 0.05
+
+# Razor shared-peptide rollup for protein inference
+osprey -i *.mzML -l lib.tsv -o out.blib --resolution hram --protein-fdr 0.01 --shared-peptides razor
+
+# Trust decoys already in the library instead of generating reverse decoys
+osprey -i *.mzML -l lib_with_decoys.tsv -o out.blib --resolution hram --decoys-in-library
+
+# Timestamped, memory-stamped log to a file (for perf visualization)
+osprey -i *.mzML -l lib.tsv -o out.blib --resolution hram --timestamp --memstamp --log-file run.log
+```
+
+---
+
+## Options
+
+Defaults and value lists are from `Osprey/OspreyCommandArgs.cs`; the parser accepts
+`--name value` (space-separated), short aliases (`-i`), and a positional mzML fallback.
+
+### General I/O
+
+| Option | Value | Effect |
+|--------|-------|--------|
+| `-i`, `--input` | `<file1.mzML ...>` | Input mzML file(s). Variadic; also accepts positional mzML paths. |
+| `-l`, `--library` | `<library.tsv\|.blib>` | Spectral library — DIA-NN TSV or BiblioSpec `.blib` (see [01-decoy-generation.md](01-decoy-generation.md), [14-intermediate-files.md](14-intermediate-files.md)). |
+| `-o`, `--output` | `<output.blib>` | Output `.blib` (see [13-blib-output-schema.md](13-blib-output-schema.md)). |
+| `--work-dir` | `<dir>` | Write derived artifacts **and** the spectra cache here, so the input data dir can be read-only. Default: beside the input. |
+| `--output-dir` | `<dir>` | Directory for derived artifacts (overrides `--work-dir`). |
+| `--cache-dir` | `<dir>` | Directory for the `.spectra.bin` cache (overrides `--work-dir`). |
+| `--report` | `<report.tsv>` | Also write a TSV report. |
+
+### Scoring & Tolerance
+
+| Option | Value | Default | Effect |
+|--------|-------|---------|--------|
+| `--resolution` | `unit \| hram \| auto` | `auto` | Resolution mode. Gates MS1 features and the default pick model; unit forces `mz 0.5` fragment tolerance. See [03-spectral-scoring.md](03-spectral-scoring.md), [06-peak-detection.md](06-peak-detection.md). |
+| `--fragment-tolerance` | `<value>` | `10` | Fragment m/z tolerance (ignored at unit resolution). |
+| `--fragment-unit` | `ppm \| mz` | `ppm` | Unit for `--fragment-tolerance`. |
+| `--no-prefilter` | — | prefilter on | Disable the coelution signal pre-filter (scores every candidate; ~30% slower). See [06-peak-detection.md](06-peak-detection.md). |
+
+### FDR & Protein Inference
+
+| Option | Value | Default | Effect |
+|--------|-------|---------|--------|
+| `--run-fdr` | `<threshold>` | `0.01` | Run-level FDR threshold (also the Percolator train/test FDR). See [07-fdr-control.md](07-fdr-control.md). |
+| `--experiment-fdr` | `<threshold>` | `0.01` | Experiment-level FDR threshold. |
+| `--reconciliation-compaction-fdr` | `<threshold>` | `0.01` | Peptide q-value gate for first-pass compaction; loosen (e.g. `0.05`) to broaden the reconciliation pool. See [10-cross-run-reconciliation.md](10-cross-run-reconciliation.md). |
+| `--protein-fdr` | `<threshold>` | off → 0.01 gate | Enable protein-level FDR at this threshold (parsimony always runs regardless). See [08-protein-parsimony.md](08-protein-parsimony.md). |
+| `--fdr-method` | `percolator \| gbdt \| simple` | `percolator` | FDR engine. `gbdt` is a **C#-only** gradient-boosted-tree classifier; `simple` is bare TDC. See [07-fdr-control.md](07-fdr-control.md). |
+| `--fdr-level` | `precursor \| peptide \| both` | `precursor` | Which q-value gates the reported output. (`protein` is not a valid value.) |
+| `--shared-peptides` | `all \| razor \| unique` | `all` | Shared-peptide handling for protein inference. See [08-protein-parsimony.md](08-protein-parsimony.md). |
+| `--fdrbench` | `<input.tsv>` | off | Write an FDRBench-compatible input TSV (every reported target with the raw SVM score) for entrapment true-FDR. Level follows `--fdr-level`. See [fractional-entrapment.md](fractional-entrapment.md). |
+| `--fdrbench-per-run` | — | off | With `--fdrbench`: one row per (precursor, run) using run-level q-values. |
+| `--fdrbench-pass` | `1 \| 2 \| both` | `2` | With `--fdrbench`: which pass to emit (2 = reported second-pass survivors; 1 = full pre-compaction first-pass pool). |
+
+### Decoys
+
+| Option | Value | Effect |
+|--------|-------|--------|
+| `--decoys-in-library` | — | Trust decoys already in the library instead of generating reverse decoys (hard error if none recognised). See [01-decoy-generation.md](01-decoy-generation.md). |
+| `--decoy-pairing-manifest` | `<manifest.tsv>` | FDRBench 5-column pairing manifest, used with `--decoys-in-library`. |
+| `--write-pin` | — | Write PIN files for external tools (diagnostic only; the engine does not consume them). |
+
+### Performance
+
+| Option | Value | Default | Effect |
+|--------|-------|---------|--------|
+| `--parallel-files` | `[<N>]` | one at a time | Files scored concurrently (OUTER). No value = auto from free RAM + cores; `<N>` = exactly N. **Single-node** mode — do not use under an HPC scheduler that already fans out. |
+| `--threads` | `<count>` | all cores | Per-file main-search threads (INNER), divided across concurrently-scored files. |
+
+### Distributed / HPC
+
+| Option | Value | Effect |
+|--------|-------|--------|
+| `--task` | `PerFileScoring \| FirstPassFDR \| PerFileRescoring \| SecondPassFDR` | Run exactly one pipeline task (one node = one task). Omit for the whole pipeline. See [15-hpc-scoring-split.md](15-hpc-scoring-split.md). |
+| `--input-scores` | `<paths\|dir>` | One or more `.scores.parquet` files, or a single directory (non-recursive). Mutually exclusive with `--input`. |
+
+### Logging
+
+| Option | Effect |
+|--------|--------|
+| `--timestamp` | Prefix each output line with `[yyyy/MM/dd HH:mm:ss]`. |
+| `--memstamp` | Prefix each line with managed + private memory in MB (pair with `--timestamp` for perf visualization). |
+| `--log-file <path>` | Write all output to a file instead of stderr. |
+| `--perf-stats` | Emit machine-parseable `[COUNT]`/`[TIMING]`/`[STAGE-WALL]` lines. |
+| `--verbose` | Show implementer-grade detail (e.g. per-fold Percolator iterations). |
+
+### Diagnostics & Info
+
+| Option | Effect |
+|--------|--------|
+| `-d`, `--diagnostics` | Write the cross-impl bisection dump bundle (`OSPREY_DUMP_*`). See [18-peptide-trace.md](18-peptide-trace.md). |
+| `--model-diagnostics` | Write a self-contained interactive HTML report of the trained scoring model and FDR calibration. |
+| `-h`, `--help` | Show help. Accepts a format: `[ascii\|unicode\|sections\|html\|<Section>]`. |
+| `-v`, `--version` | Show version. |
+
+---
+
+## Distributed execution (HPC)
+
+Run with no `--task` for the whole pipeline in one process. For distributed (HPC /
+workflow-engine) execution the pipeline splits at its join / fan-out boundaries into
+four single-task workers — **one node = one `--task`**:
+
+```
+PerFileScoring (split, per file) → FirstPassFDR (join, all files)
+    → PerFileRescoring (split, per file) → SecondPassFDR (merge node)
+```
+
+Pass the **same** `--library` and search options to every task; the parquet integrity
+check rejects inputs whose search/library hash does not match.
+
+```bash
+# split 1 — one process per mzML (writes <stem>.scores.parquet, <stem>.calibration.json beside each input)
+osprey --task PerFileScoring   -i s1.mzML -l hela.tsv -o out.blib --resolution unit --protein-fdr 0.01
+
+# join 1 — one process over ALL parquets (pass a DIRECTORY so order is deterministic)
+osprey --task FirstPassFDR     --input-scores ./scores_dir -l hela.tsv -o out.blib --resolution unit --protein-fdr 0.01
+#   writes beside each parquet: <stem>.1st-pass.fdr_scores.bin, <stem>.reconciliation.json
+
+# split 2 — one process per file (parquet + its two sidecars co-located)
+osprey --task PerFileRescoring --input-scores s1.scores.parquet -l hela.tsv -o out.blib --resolution unit --protein-fdr 0.01
+#   writes: <stem>.scores-reconciled.parquet
+
+# join 2 — one process over ALL reconciled parquets (writes out.blib)
+osprey --task SecondPassFDR     --input-scores ./reconciled_dir -l hela.tsv -o out.blib --resolution unit --protein-fdr 0.01
+```
+
+- `--input-scores` takes a **directory** (globbed and sorted internally) or an explicit
+  file list (consumed in the order given). First-join reconciliation is order-sensitive,
+  so for the join tasks pass a directory or a deterministically sorted list.
+- Rehydration sidecars must travel with their parquet into each worker's working
+  directory. Let the scheduler fan out (one file per split process) rather than
+  `--parallel-files`, which is the single-node multi-file mode.
+
+Full detail: [15-hpc-scoring-split.md](15-hpc-scoring-split.md).
+
+---
+
+## Environment variables
+
+Env vars are the escape hatch for experimental / diagnostic behavior that is not on the
+CLI; they are read once at process start. The ones most likely to matter:
+
+| Variable | What it does | Doc |
+|----------|--------------|-----|
+| `OSPREY_PICK_LDA` / `OSPREY_PICK_LDA_MODEL` | Turn on the learned linear pick model (built-in or a JSON file) | [06](06-peak-detection.md) |
+| `OSPREY_PICK_DUMP_CANDIDATES` | Dump per-candidate pick terms for offline model training | [peak-model-training.md](peak-model-training.md) |
+| `OSPREY_PASS2_QVALUE` | Second-pass q-value mode (`percolator` / `transfer` / `transfer-compete` / `protein-compact`) | [12](12-second-pass-fdr.md) |
+| `OSPREY_GBT_*` | GBDT hyperparameters (with `--fdr-method gbdt`) | [07](07-fdr-control.md) |
+| `OSPREY_DUMP_*` / `OSPREY_DIAG_*` | Cross-impl bisection dumps (also via `-d`) | [18](18-peptide-trace.md) |
+
+The full set is enumerated in the relevant algorithm docs; there is no single flat
+listing on the CLI by design (these are not user-facing knobs).
+
+---
+
+## Notes
+
+- **Exit codes.** A failing run returns a non-zero process exit code, so a workflow
+  engine can gate on it.
+- **`--help` formats.** `osprey --help html` writes the same reference as HTML;
+  `osprey --help <Section>` prints one group (e.g. `osprey --help "FDR & Protein Inference"`).
+- **Value validation.** Osprey's tokenizer does **not** reject values outside the listed
+  set — an unrecognized `--fdr-method` / `--fdr-level` value warns and falls back to the
+  default rather than erroring (this is why the deprecated `--fdr-method fasttree` alias
+  still resolves to `gbdt`).
+
+## Divergences from the Rust CLI
+
+The C# CLI is a redesign, not a flag-for-flag port; the output is unchanged. The
+recurring differences (all in [DIVERGENCES.md](DIVERGENCES.md)):
+
+- **HPC flags.** The Rust `--no-join` / `--join-at-pass` / `--join-only` family is
+  replaced by the single `--task {PerFileScoring|FirstPassFDR|PerFileRescoring|SecondPassFDR}`
+  selector. See [15-hpc-scoring-split.md](15-hpc-scoring-split.md).
+- **`--fdr-method`.** Adds the C#-only `gbdt`; Mokapot is not wired to the CLI (`percolator`
+  and `simple` only, plus `gbdt`). See [07-fdr-control.md](07-fdr-control.md).
+- **`--fdr-level`.** No `protein` value (the enum is `precursor | peptide | both`);
+  protein q-values are computed and reported but cannot gate the blib from the CLI.

--- a/pwiz_tools/Osprey/docs/DIVERGENCES.md
+++ b/pwiz_tools/Osprey/docs/DIVERGENCES.md
@@ -1,0 +1,370 @@
+# Osprey C# Port — Cross-Implementation Divergence Report
+
+This report consolidates every divergence found by the 18 per-document parity reviews of the C# port of Osprey against the Rust reference documentation (`00-overview.md` … `19-testing.md`). Each per-doc review compared the Rust algorithm doc against the actual C# source and classified every gap.
+
+## Executive summary
+
+Across all 18 algorithm documents the C# port is a faithful, parity-focused reproduction of the Rust engine: on the Stellar/Astral reference datasets it is bit-identical, enforced by the `regression.ps1` 1e-9 gate (golden + resume + HPC-chain legs) plus `OSPREY_CROSS_IMPL_*` byte-parity hooks. Of **110 catalogued divergences**, the overwhelming majority are either **documentation staleness** (the Rust prose lagging its own evolving Rust code, which the C# port correctly tracks) or **intentional C# infrastructure/CLI redesigns** that preserve output. There is exactly **one genuine PORT-ERROR** — the Razor shared-peptide assignment order in protein parsimony — and it sits off the default, bit-identical-tested path. **Eight items are UNVERIFIED** (the reviewer could not confirm one side against source and flagged them for a human to check). Nothing on the default analysis path was found to change output relative to Rust.
+
+### Count by classification
+
+| Classification | Count |
+|---|---:|
+| STALE-RUST-DOC | 49 |
+| INTENTIONAL-CSHARP-DESIGN | 50 |
+| UNVERIFIED | 8 |
+| FLAG-GATED | 2 |
+| PORT-ERROR | 1 |
+| **Total** | **110** |
+
+### Count by severity
+
+| Severity | Count |
+|---|---:|
+| major | 6 |
+| minor | 49 |
+| info | 55 |
+
+The 6 `major` items are: the sparse-library calibration retry omission (doc 04), the reconciliation RT-tolerance formula (doc 05, C# tracks current Rust — doc stale), the missing `FdrLevel::Protein` variant (doc 07), the `--task` CLI redesign (doc 15), the Razor determinism concern (doc 16), and the absence of the `OSPREY_TRACE_PEPTIDE` facility (doc 18). Only the first and fifth of those are substantive behavioral concerns; the rest are intentional redesigns or doc-lag.
+
+> **Numbering note.** This report was generated against the original doc numbering
+> (Rust-doc order); the detail sections below are grouped by algorithm topic. All
+> links point to the current **operation-order** C# doc numbers (see
+> [README.md](README.md) for the index). Doc-number references in prose use the new
+> numbering.
+
+> **Updates since generation (features added after this report).** `--fdr-method
+> gbdt` (doc 07) is a **C#-only** addition — the Rust reference has no GBDT scorer,
+> so it is not a divergence to reconcile. The opt-in learned peak-pick model (doc 06)
+> and the pass-2 frozen q-value modes (doc 12) postdate this report; both exist in
+> Rust too (the pick model in lock-step; the pass-2 modes ported C#→Rust in
+> maccoss/osprey#57) and are off the default parity-gated path. The one **PORT-ERROR**
+> below (P1, Razor rollup order) is tracked as ProteoWizard/pwiz#4441.
+
+---
+
+## Port errors and items to verify
+
+This is the section a maintainer should read first. It lists the **single PORT-ERROR** and all **8 UNVERIFIED** items — the divergences that either are, or might be, real behavioral differences from Rust.
+
+### PORT-ERROR (1)
+
+#### P1. Razor shared-peptide assignment is a per-peptide greedy, not Rust's iterative group-centric set cover
+- **Doc:** [08-protein-parsimony.md](08-protein-parsimony.md)
+- **Rust says:** Razor sorts shared peptides alphabetically, then repeatedly selects the *group* with the most unique peptides that still owns any unassigned shared peptide and claims **all** of that group's remaining shared peptides in one batch (`crates/osprey-fdr/src/protein.rs:197-266`); explicitly path-independent, pinned by `test_shared_peptides_razor_cascading_assignment`.
+- **C# does:** Iterates shared peptides in `Dictionary` (hash-insertion) order, unsorted, and assigns each individually to its current best group while mutating unique counts in place. Diverges on cascading topologies — e.g. `G0 u{A,B} s{X,Y}`, `G1 u{C,D,E} s{X}`, `G2 u{F} s{Y}`: Rust always yields `X→G1, Y→G0` but C# flips `X→G0` when `Y` is processed before `X`.
+- **C# evidence:** `Osprey.FDR/ProteinFdr.cs:432-467`
+- **Severity:** minor (non-default flag: default is `--shared-peptides all`; the Razor path is not covered by the All-mode reference gates).
+- **Recommended action:** Reimplement Razor as the iterative group-centric batch set cover with alphabetical shared-peptide ordering to match Rust, and port `test_shared_peptides_razor_cascading_assignment`. Note this is the same code region flagged as UNVERIFIED/major for determinism in doc 15 (U8 below) — fixing both together is natural: the sorted, group-batch algorithm is inherently path- and process-order-independent.
+
+### UNVERIFIED (8)
+
+#### U1. No sample-expansion retry loop or graduated linear-fit fallback for sparse libraries — **major**
+- **Doc:** [04-calibration.md](04-calibration.md)
+- **Rust says:** Library sampling uses 3 attempts (`sample_size`, `× retry_factor`, then ALL entries) plus a `MIN_LINEAR_FIT_POINTS` graduated linear fit and an RT-span leverage check for sparse libraries.
+- **C# does:** Samples exactly once (seed 43), enforces `MinCalibrationPoints` (200) as the pass-1 floor, and returns `null → fallback tolerance` when unmet; no retry expansion, no graduated linear fit, no RT-span check. `CalibrationRetryFactor` config exists but is never read. On the Stellar/Astral reference datasets the first 100K sample always clears 200 points so parity holds; **small/sparse libraries would fail where Rust recovers.**
+- **C# evidence:** `Osprey.Tasks/Calibrator.cs:196-197, 259, 261-267, 479-485`
+- **Recommended action:** This is the highest-value item to verify. Confirm whether any supported input library can fall below the 200-point floor; if so, port the retry-expansion loop + graduated linear-fit fallback. `CalibrationRetryFactor` being dead config is a tell that the port stopped short here.
+
+#### U2. Comet-style E-value not computed in the C# calibration path — info
+- **Doc:** [03-spectral-scoring.md](03-spectral-scoring.md)
+- **Rust says:** A Comet-style E-value is computed from the XCorr survival function and stored on the calibration match (computed but not used for FDR).
+- **C# does:** `CalibrationMatch` has no `evalue` field and no survival-function fit exists; only the LDA discriminant drives competition, so output parity is unaffected.
+- **C# evidence:** `Osprey.Scoring/CalibrationScorer.cs:34-56` (struct has no evalue field); no survival function in `SpectralScorer.cs`
+- **Recommended action:** Low priority — verify the Rust E-value is truly unused downstream (doc says so). If confirmed unused, close as a safe intentional omission.
+
+#### U3. Blib peak boundaries come from the CWT/detected peak, not median-polish FWHM — minor
+- **Doc:** [06-peak-detection.md](06-peak-detection.md)
+- **Rust says:** Rust doc gives a blib-boundary priority list where Tukey median-polish FWHM (apex ± 1.96σ) is priority 1 and CWT boundaries are fallback.
+- **C# does:** `FdrEntry.StartRt/EndRt` written for output are the CWT/detected `bestPeak` boundaries; median polish is consumed only for four scoring features. README asserts blib is bit-identical cross-impl, so Rust likely also writes CWT bounds (doc stale) — but `Osprey.IO/BlibWriter.cs` was not read to confirm no downstream re-derivation.
+- **C# evidence:** `Osprey.Scoring/CoelutionScorer.cs:462`
+- **Recommended action:** Read `BlibWriter.cs` and confirm boundaries are written straight from the CWT peak with no median-polish re-derivation. Given the byte-identical blib gate this is almost certainly doc-staleness, not a port error.
+
+#### U4. Simple FDR scores on `coelution_sum`, not a ROC-AUC-selected best feature — minor
+- **Doc:** [07-fdr-control.md](07-fdr-control.md)
+- **Rust says:** Simple applies target-decoy competition on the best single feature selected by ROC AUC.
+- **C# does:** `RunSimpleFdr` scores directly by `e.CoelutionSum` (PIN feature 0) with no ROC-AUC selection. Whether current Rust Simple also just uses `coelution_sum` was not confirmed against Rust source.
+- **C# evidence:** `Osprey.FDR/PercolatorEngine.cs:359`
+- **Recommended action:** Diff against current Rust `simple` FDR. `--fdr-method simple` is a non-default diagnostic path, so low urgency, but the ROC-AUC selection is easy to port if Rust still has it.
+
+#### U5. No production protein report writer (`*.proteins.csv`) found — minor
+- **Doc:** [08-protein-parsimony.md](08-protein-parsimony.md)
+- **Rust says:** `write_protein_report()` emits `*.proteins.csv` with gene names, PEP, and q-values.
+- **C# does:** No production protein report writer found in the reviewed path (grep for `proteins.csv`/`protein_groups`/`ProteinReport` returned no emitter); only env-var-gated diagnostic dumps `cs_stage6_protein_fdr.tsv`/`cs_stage7_protein_fdr.tsv` exist.
+- **C# evidence:** `Osprey/OspreyFileDiagnostics.cs:1918,1983`
+- **Recommended action:** Lab memory references a default-emitted `protein_groups.tsv` + `stats.tsv` (see MEMORY: "Osprey protein & summary reports"), so a writer likely lives outside the reviewed files. Confirm the emitter exists and matches Rust's report columns; if it genuinely does not exist, this is a missing feature.
+
+#### U6. Six per-row blob columns written null/zero in the reconciled parquet — minor
+- **Doc:** [11-boundary-overrides.md](11-boundary-overrides.md)
+- **Rust says:** The reconciled cache carries fragment/XIC/bounds blob columns.
+- **C# does:** `fragment_mzs`, `fragment_intensities`, `reference_xic_rts`, `reference_xic_intensities`, `bounds_area`, `bounds_snr` are written null/zero today (tracked follow-up); RT boundaries and the 21 features are still computed and written.
+- **C# evidence:** `Osprey/RescoreWorker.cs:64-71`
+- **Recommended action:** Confirm nothing downstream (blib, reports) reads these six columns off the *reconciled* parquet. If they are consumed anywhere, this is a real data-loss bug; if not, it's a benign tracked follow-up.
+
+#### U7. Python calibration report tooling (`evaluate_calibration.py`) has no verified C# equivalent — info
+- **Doc:** [14-intermediate-files.md](14-intermediate-files.md)
+- **Rust says:** Recommends `python scripts/evaluate_calibration.py` for calibration visualization.
+- **C# does:** No Python dependency; emits HTML via `--model-diagnostics`. Whether an exact equivalent of that script's output exists was not verified.
+- **C# evidence:** `Osprey.Chromatography/CalibrationIO.cs` (no report emit); CLI
+- **Recommended action:** Cosmetic/tooling only. Confirm `--model-diagnostics` HTML covers the calibration plots the Python script produced; no output-parity impact.
+
+#### U8. Razor mode may be order-sensitive across processes (single-pass greedy) — **major**
+- **Doc:** [16-determinism.md](16-determinism.md)
+- **Rust says:** Rust doc §9 describes an iterative greedy set cover that each round claims all of the globally-best group's unassigned shared peptides in sorted order, cited as path-independent (`test_shared_peptides_razor_deterministic`, 10 repeats byte-identical).
+- **C# does:** `SharedPeptideMode.Razor` iterates the shared peptides once, assigning each to the currently-best group and mutating unique-peptide counts as it goes; iteration order derives from `HashSet<string>`/`Dictionary` enumeration, which under .NET randomized string hashing is **not guaranteed stable across processes**. Off the default/bit-identical path (default `--shared-peptides all`; the regression gate does not exercise razor) and no C# repeat-run razor determinism test was found, so order-sensitivity is unconfirmed.
+- **C# evidence:** `Osprey.FDR/ProteinFdr.cs:432-467`
+- **Recommended action:** Same root cause as P1. Fixing Razor to the sorted group-batch algorithm removes both the assignment divergence and the process-order nondeterminism at once. Add a repeat-run determinism test mirroring `test_shared_peptides_razor_deterministic`.
+
+---
+
+## All divergences by document
+
+Legend — Classification: **STALE** = STALE-RUST-DOC, **INTENT** = INTENTIONAL-CSHARP-DESIGN, **FLAG** = FLAG-GATED, **PORT** = PORT-ERROR, **UNVER** = UNVERIFIED.
+
+### [01-decoy-generation.md](01-decoy-generation.md) — matches-with-notes
+
+| Classification | Title | Rust says | C# does | Evidence | Sev |
+|---|---|---|---|---|---|
+| STALE | Shuffle decoy method not implemented | `Shuffle` selectable alongside Reverse/FromLibrary | Enum has `Shuffle` but generator always reverse+cycles regardless of config (only logs it) | `OspreyConfig.cs:403`; `DecoyGenerator.cs:182,210-236` | minor |
+| INTENT | Batch generation always Trypsin | 4-enzyme table w/ enzyme-aware terminal preservation | `DetectEnzyme` exists but batch path always Trypsin/C-term-preserving; correct for tryptic libs | `DecoyGenerator.cs:100,208,306-317` | info |
+| INTENT | Non-b/y fragments preserved verbatim | Ion-swap covers only b↔y | Swaps b↔y + recomputes m/z; copies A/C/X/Z/etc through unchanged (no-op for b/y libs) | `DecoyGenerator.cs:480-490` | info |
+| INTENT | Native managed pairing/marking | Pairing in Rust `osprey_core`/`osprey_io` crates | Pure managed C# (`LibraryDecoyMarker`/`Pairing`/`Manifest`), deterministic sort, 80% gate matches | `LibraryDecoyMarker.cs:88`; `LibraryDecoyPairing.cs:120`; `DecoyPairingManifest.cs:264` | info |
+
+### [04-calibration.md](04-calibration.md) — matches-with-notes
+
+| Classification | Title | Rust says | C# does | Evidence | Sev |
+|---|---|---|---|---|---|
+| STALE | RT candidate selection uses global tolerance | Per-entry `local_tolerance(factor=3.0,min=0.1)` | One global window `clamp(3*MAD*1.4826,…)` for every entry (matches Rust `run_search`); `LocalTolerance` ported but unused | `ScoringPipeline.cs:145-176`; `RTCalibration.cs:251` | minor |
+| STALE | Global tolerance is MAD-based | `max(residual_sd*factor, min)` | Prefers `3*MAD*1.4826`, `residual_sd*factor` only as fallback (matches current Rust) | `Calibrator.cs:290`; `ScoringPipeline.cs:170-177` | minor |
+| STALE | `min_rt_tolerance` default 0.5 not 0.1 | Doc states 0.1 min | Default 0.5 min (matches current Rust default) | `RTCalibrationConfig.cs:50` | minor |
+| STALE | Cache filename `.calibration.json` | `<stem>.osprey_calibration.json` | `<stem>.calibration.json` (matches Rust `calibration_filename_for_input`) | `CalibrationIO.cs:91` | info |
+| UNVER | No retry loop / graduated linear fit (**U1**) | 3-attempt sampling + graduated linear fit + RT-span check | Single sample, hard 200-pt floor → fallback tol; sparse libs fail where Rust recovers | `Calibrator.cs:196-197,259,261-267,479-485` | major |
+| INTENT | Calibration XCorr is managed, not BLAS | Comet XCorr via BLAS `sdot` | Managed `SpectralScorer(UnitResolution())`, f32 preprocess; equivalent at F10 | `Calibrator.cs:72,563` | info |
+
+### [05-rt-alignment.md](05-rt-alignment.md) — matches-with-notes
+
+| Classification | Title | Rust says | C# does | Evidence | Sev |
+|---|---|---|---|---|---|
+| STALE | Consensus weight is sigmoid(SVM), not coelution_sum | Weight = `coelution_sum` | Weight = `sigmoid(score)` floored 1e-6, coelution>0 as filter (matches current Rust) | `ConsensusRts.cs:178` | minor |
+| STALE | Median peak width is weighted median | `simple_median` | Same sigmoid-weighted `WeightedMedian` | `ConsensusRts.cs:197` | minor |
+| STALE | Consensus gate is run-level precursor hard gate + rescue | Experiment-level FDR at `consensus_fdr` | `RunPrecursorQvalue≤fdr` hard gate then peptide OR protein rescue, all run-level (matches current Rust) | `ConsensusRts.cs:242-250` | minor |
+| STALE | Reconciliation tol: within-peptide MAD + sigma-clipped ceiling | `max(0.1, 3*MAD*1.4826)` cross-peptide, single global | Global median of per-peptide within-lib apex MADs, floored 0.1, capped by sigma-clipped per-file MAD (matches current Rust) | `ReconciliationPlanner.cs:96-190,299` | major |
+| STALE | Decoy pairing by base_id, not prefix | Decoy detections only (older stripped DECOY_) | Links via `EntryId & 0x7FFFFFFF`, recognizes prefix-less lib decoys | `ConsensusRts.cs:102,115` | info |
+| INTENT | Parallelized LOESS inner fit | Serial auto-vectorized loop | `Parallel.For` per-point fit, `t*t` + away-from-zero rounding keeps bit-identity | `LoessRegression.cs:420` | info |
+| INTENT | Initial min-point gate differs from doc's 50 | Initial calibration min points: 50 | Pass-1 200, pass-2 50, inner 20; the 50 = `RTStratifiedSampler`/pass-2 floor | `Calibrator.cs:60,259`; `RTCalibrationConfig.cs:41` | minor |
+| FLAG | `OSPREY_TRACE_PEPTIDE` trace absent in reconciliation | `[trace]` lines in consensus/plan | Structured `OSPREY_DUMP_*` dumps instead; no TRACE_PEPTIDE in tree | `Stage6Planner.cs:167,202,306` | info |
+
+### [03-spectral-scoring.md](03-spectral-scoring.md) — matches-with-notes
+
+| Classification | Title | Rust says | C# does | Evidence | Sev |
+|---|---|---|---|---|---|
+| UNVER | E-value not computed (**U2**) | Comet E-value from XCorr survival fn, stored (unused for FDR) | No `evalue` field, no survival fn; only LDA drives competition | `CalibrationScorer.cs:34-56` | info |
+| STALE | Unit-res bin count is 2000, not 2001 | 2001 bins (1.0005 m/z) | `UnitResolution()` = 2000 bins; confirmed by test comment | `BinConfig.cs:42-59`; `ScoringTest.cs:1087` | info |
+| INTENT | Only the 21 PIN features computed | ~47 scores incl hyperscore, dot_product variants, etc. | Exactly the 21 PIN features; unused fields never populated | `OspreyFeatureCalculators.cs:36-44`; `CoelutionScorer.cs:253-274` | minor |
+| INTENT | MS1 features gated by resolution, not MS1 presence | MS1 scoring available when MS1 present | Features 13/14 HRAM-only; `UnitStrategy.HasMs1Features=false` → exactly 0.0 at unit res | `ResolutionStrategy.cs:112/163`; `Ms1Calculators.cs:37-38` | info |
+
+### [02-xcorr-scoring.md](02-xcorr-scoring.md) — matches-with-notes
+
+| Classification | Title | Rust says | C# does | Evidence | Sev |
+|---|---|---|---|---|---|
+| INTENT | Managed scalar loops, no BLAS/SIMD, no dense vector | XCorr via BLAS `sdot`; calibration forms dense theoretical vector | Managed scalar loop; `O(n_fragments)` sum-at-bins form; bit-identical | `SpectralScorer.cs:186,273`; `Calibrator.cs:1189` | info |
+| INTENT | Sparse HRAM cache instead of dense `Vec<Vec<f32>>` | Dense `float[NBins]` (~391 KB) per window | `SparseXcorrSpectrum` (~20 B/peak), recovers flanking-subtracted value on demand, bit-identical (issue #4398) | `SparseXcorrSpectrum.cs:55,93`; `ResolutionStrategy.cs:170` | info |
+| STALE | Simplified snippet omits fragment-bin dedup | Pseudocode sums per-fragment with no dedup (would double-count) | Dedups via `visitedBins`; matches dense semantics. Covered by `TestXcorrFragmentBinDedup` | `SpectralScorer.cs:198`; `ScoringTest.cs:382` | minor |
+| INTENT | Precision split: unit-res f64, HRAM f32-narrowed | Doc silent on precision boundary | Unit/calibration cache f64; HRAM narrows to float, mirroring Rust HRAM f32 cache | `ResolutionStrategy.cs:119`; `SparseXcorrSpectrum.cs:113` | info |
+
+### [06-peak-detection.md](06-peak-detection.md) — matches-with-notes
+
+| Classification | Title | Rust says | C# does | Evidence | Sev |
+|---|---|---|---|---|---|
+| STALE | Peak selection uses RT-penalized rank score | Highest mean pairwise fragment correlation | `coelution * exp(-dt²/2σ²) * ln(1+apex)` — Gaussian RT penalty + log-intensity tiebreak (both impls have penalty; doc behind) | `PeakDataExtractor.cs:289` | minor |
+| STALE | Median-polish 10 iters / tol 0.01 | 20 iters / 1e-4 | Call site `maxIter=10, tol=0.01` (matches current Rust `pipeline.rs`; doc's 20/1e-4 is old default) | `CoelutionScorer.cs:242` | minor |
+| UNVER | Blib boundaries from CWT peak, not median-polish FWHM (**U3**) | Median-polish FWHM priority 1, CWT fallback | `StartRt/EndRt` = CWT `bestPeak` bounds; median polish only for 4 features; `BlibWriter.cs` not read to confirm | `CoelutionScorer.cs:462` | minor |
+| STALE | Scale-space/ridge-tracking is aspirational | Loop over scales [2,4,8,16] w/ ridge tracking, S/N<3 | Single data-driven scale from median FWHM, `minConsensusHeight=0.0`; only the old plan is aspirational | `CwtPeakDetector.cs:161` | info |
+| STALE | No linear-baseline background subtraction | Trapezoidal AUC minus linear baseline (plan §4.4) | Plain trapezoidal integral, no baseline (area is relative, not for quant) | `PeakDetector.cs:178` | info |
+| STALE | Consensus aggregation is median, not sum | Plan §4.3 sums per-transition CWTs | Pointwise `ConsensusMedianCwt` (matches production doc) | `CwtPeakDetector.cs:265` | info |
+
+### [09-multi-charge-consensus.md](09-multi-charge-consensus.md) — matches-with-notes
+
+| Classification | Title | Rust says | C# does | Evidence | Sev |
+|---|---|---|---|---|---|
+| STALE | Re-scoring engine is `RunCoelutionScoring` | Re-score via `run_search()` w/ boundary_overrides | No `run_search`; overrides via `ScoringContext.BoundaryOverrides` from `PerFileRescoreTask` (equivalent) | `PeakDataExtractor.cs:82-167`; `PerFileRescoreTask.cs:733` | info |
+| INTENT | Consensus is a pure selection function | One `select_post_fdr_consensus()` selects + hands off | `SelectRescoreTargets` pure; merge + override re-scoring separate in `PerFileRescoreTask` | `MultiChargeConsensus.cs:51`; `PerFileRescoreTask.cs:879,1066` | info |
+| STALE | No Mokapot scoring | Lists Percolator/Mokapot | Native Percolator SVM only; Mokapot not CLI-wired | see 08 | info |
+| STALE | FDR gate is `RunPrecursorQvalue` | Generic "FDR threshold" | Gates on `RunPrecursorQvalue≤fdr` specifically (matches Rust `pipeline.rs`) | `MultiChargeConsensus.cs:115` | info |
+
+### [07-fdr-control.md](07-fdr-control.md) — matches-with-notes
+
+| Classification | Title | Rust says | C# does | Evidence | Sev |
+|---|---|---|---|---|---|
+| INTENT | Native Percolator replaces external Mokapot | 3 methods incl Mokapot (Python subprocess, PIN round-trip) | Native Percolator + Simple only; `FdrMethod.Mokapot` enum never CLI-wired; no Python dep | `OspreyCommandArgs.cs:120`; `OspreyConfig.cs:422` | info |
+| INTENT | No `FdrLevel::Protein`; `--fdr-level protein` unreachable | Supports {precursor,peptide,protein,both}; protein filters blib | Enum {Precursor,Peptide,Both}; effective-qvalue throws on Protein; protein q computed/reported but can't gate blib; 2 stale in-code comments | `OspreyConfig.cs:411`; `OspreyCommandArgs.cs:138`; `FdrEntry.cs:136` | major |
+| STALE | Default `--fdr-level` is Precursor, not Peptide | Default Peptide | Defaults Precursor (matches Rust `FdrLevel::default()`; doc prose stale) | `OspreyConfig.cs:284` | minor |
+| STALE | No gbdt/FastTree method in either impl | Lab memory mentions Rust `--fdr-method gbdt` | No gbdt symbol anywhere; enum {Percolator,Mokapot,Simple}, CLI percolator\|simple | `OspreyConfig.cs:422`; `OspreyCommandArgs.cs:120` | info |
+| UNVER | Simple scores on coelution_sum, not ROC-AUC best feature (**U4**) | Best single feature by ROC AUC | Scores directly by `CoelutionSum`; Rust Simple behavior not confirmed | `PercolatorEngine.cs:359` | minor |
+| INTENT | Streaming-only Percolator (matches Rust v26.7.0) | Direct path removed v26.7.0 | `DispatchSvm` always streams; former direct branch removed for parity | `PercolatorEngine.cs:336` | info |
+
+### [08-protein-parsimony.md](08-protein-parsimony.md) — **diverges**
+
+| Classification | Title | Rust says | C# does | Evidence | Sev |
+|---|---|---|---|---|---|
+| **PORT** | Razor is per-peptide greedy, not group-centric set cover (**P1**) | Group-batch set cover, alphabetical, path-independent | Per-shared-peptide greedy in Dictionary order; flips assignments on cascading topologies | `ProteinFdr.cs:432-467` | minor |
+| INTENT | No `--fdr-level protein` / protein-level output filtering | `experiment_protein_qvalue` feeds protein filtering | Enum {Precursor,Peptide,Both}; CLI rejects protein; q computed/propagated but no filter path | `OspreyConfig.cs:411-416`; `OspreyCommandArgs.cs:138-157`; `ProteinFdrEngine.cs:165-170` | minor |
+| UNVER | No production protein report writer (**U5**) | `write_protein_report()` → `*.proteins.csv` | No emitter found; only env-gated diagnostic dumps; lab memory refs `protein_groups.tsv`/`stats.tsv` | `OspreyFileDiagnostics.cs:1918,1983` | minor |
+| STALE | Second-pass detected set gates on `config.fdr_level` | Gates on second-pass PEPTIDE FDR | Gates `EffectiveExperimentQvalue(FdrLevel)≤fdr` (precursor default); mirrors Rust `pipeline.rs`; doc stale | `ProteinFdrEngine.cs:171-183` | info |
+
+### [10-cross-run-reconciliation.md](10-cross-run-reconciliation.md) — matches-with-notes
+
+| Classification | Title | Rust says | C# does | Evidence | Sev |
+|---|---|---|---|---|---|
+| INTENT | HPC stage split with JSON envelope | In-process step inside `run_analysis` | Stage 5 plan / `reconciliation.json` v3 handoff / Stage 6 apply / Stage 7 FDR; envelope byte-parity | `ReconciliationFile.cs:52-107`; `Stage6Planner.cs:48-100` | info |
+| STALE | `--no-reconciliation` CLI flag absent | Flag disables reconciliation | No such arg; disable only via `Reconciliation.Enabled=false` | `OspreyCommandArgs.cs:116-117`; `ReconciliationConfig.cs:33` | minor |
+| STALE | Worked example still uses coelution_sum | Example weights by `coelution_sum` | `max(1e-6, sigmoid(score))` (matches current Rust + same doc's Step 2) | `ConsensusRts.cs:178` | info |
+| STALE | Planner passing-precursor precondition undocumented | "For each scored entry" no per-entry gate | Also requires `(base_id,charge)` in `passingBaseIds`; ties to Rust `reconciliation.rs:560-576` | `ReconciliationPlanner.cs:131-144,209` | minor |
+| STALE | Ceiling is sigma-clipped MAD, not plain | "calibration-MAD-based ceiling" | Sigma-clipped median of refined residuals, capped by first-pass MAD; ties to Rust docstring | `ReconciliationPlanner.cs:166-183,299-322` | minor |
+| INTENT | Decoy pairing by base_id, not prefix | Matched by DECOY_ prefix | Pairs by `EntryId & 0x7FFFFFFF`; recognizes prefix-less lib decoys | `ConsensusRts.cs:93-118`; `ReconciliationPlanner.cs:120-144` | info |
+| INTENT | Second-pass FDR is native Percolator only | "Percolator/Mokapot/Simple applies" | No Python Mokapot; native managed Percolator (or simple) | `MergeNodeTask.cs`; see 08 | info |
+
+### [11-boundary-overrides.md](11-boundary-overrides.md) — matches-with-notes
+
+| Classification | Title | Rust says | C# does | Evidence | Sev |
+|---|---|---|---|---|---|
+| INTENT | Override map on `ScoringContext`, not a param | `run_search()` takes `boundary_overrides` param | Rides on `ScoringContext.BoundaryOverrides`, looked up by candidate id | `ScoringContext.cs:58`; `PeakDataExtractor.cs:88` | info |
+| INTENT | Optional file-level parallelism added | Re-scoring strictly sequential across files | Keeps window parallelism + whole-file concurrency under `--parallel-files`; byte-identical | `PerFileRescoreTask.cs:547-584` | minor |
+| STALE | Gap-fill two-pass not in the doc | Only 3 override types documented | Also gap-fill two-pass (CWT + forced-integration) via same override channel | `PerFileRescoreTask.cs:1337-1477` | info |
+| STALE | Gap-fill progress labels differ | "Gap-fill CWT"/"Gap-fill forced" | "Gap-fill scoring"/"Gap-fill forced integration" (console string only) | `PerFileRescoreTask.cs:1385,1453` | info |
+| INTENT | Reconciled parquet is a separate sibling file | Updates `.scores.parquet` in place | Writes `.scores-reconciled.parquet`, stamps `osprey.reconciled` footer (crash-resume safety) | `ReconciledParquetWriter.cs:54,200-204` | minor |
+| UNVER | Six blob columns null/zero in reconciled parquet (**U6**) | Reconciled cache carries fragment/XIC/bounds blobs | 6 columns written null/zero (tracked follow-up); RT bounds + 21 features still written | `RescoreWorker.cs:64-71` | minor |
+
+### [13-blib-output-schema.md](13-blib-output-schema.md) — matches-with-notes
+
+| Classification | Title | Rust says | C# does | Evidence | Sev |
+|---|---|---|---|---|---|
+| STALE | Score type is GENERIC Q-VALUE (19), not PERCOLATOR (14) | ID 14, `scoreType=14` | Seeds full PWiz table; stamps `SCORE_TYPE_GENERIC_QVALUE=19` | `BlibWriter.cs:41,899-922`; `BlibOutputWriter.cs:336` | minor |
+| STALE | `RefSpectra.score` is raw q-value, not `1-q` | `score = 1 - q_value` | Raw experiment-precursor q-value (lower better), matches type 19 | `BlibOutputWriter.cs:186-193,229` | minor |
+| STALE | `minorVersion` is 11, not 10 | 10 | 11 (`BLIB_MINOR_VERSION`) | `BlibWriter.cs:40` | info |
+| STALE | `idFileName` is library basename | Same as `fileName` | Library basename; `fileName=<stem>.mzML` | `BlibOutputWriter.cs:107-113` | minor |
+| STALE | `cutoffScore` is run-FDR threshold, not 0.0 | 0.0 | `config.RunFdr` (default 0.01) | `BlibOutputWriter.cs:62,112` | info |
+| STALE | Stores bare filename, not relative path | Computes `../data/sample.mzML` | `<stem>.mzML`, no dir/relative computation | `BlibOutputWriter.cs:112` | minor |
+| STALE | `Modifications.position` is 1-based | 0-indexed | Converts 0→1-based on write; test asserts 4→5; byte-identical implies Rust also 1-based | `BlibWriter.cs:399-408`; `IOTest.cs:107-149` | minor |
+| STALE | Nullable-text columns empty strings, not NULL | 5 columns NULL | Empty-string literals | `BlibWriter.cs:127-131` | info |
+| STALE | RetentionTimes best-run ID-line fallback undocumented | RT NULL if run fails FDR | Fallback: lowest-q run still gets RT so every RefSpectra has an ID line | `BlibOutputWriter.cs:288-313` | minor |
+| STALE | Osprey extension score/intensity are 0.0 placeholders | DiscriminantScore/PEP/ApexIntensity real | 0.0 for all three (not plumbed; no Mokapot) | `BlibOutputWriter.cs:249-254` | minor |
+| STALE | OspreyMetadata key set differs | osprey_version, rt_calibration_enabled, run_fdr, fdr_method | osprey_version, search_mode=coelution, run_fdr, experiment_fdr | `BlibOutputWriter.cs:266-271` | minor |
+| INTENT | Native managed SQLite writer, not PWiz BiblioSpec | README frames as reusing PWiz BiblioSpec | Hand-rolled `System.Data.SQLite`, reuses only schema + Skyline Ionic.Zlib L6 convention (byte-identical to flate2) | `BlibWriter.cs:37,980-1008` | info |
+| INTENT | Extra schema columns/indices not in doc | Omits workflowType/probabilityType; 7 indices | Declares both columns, 3 extra indices for BiblioSpecLite/Skyline compat | `BlibWriter.cs:737,750,573-575` | info |
+
+### [14-intermediate-files.md](14-intermediate-files.md) — matches-with-notes
+
+| Classification | Title | Rust says | C# does | Evidence | Sev |
+|---|---|---|---|---|---|
+| INTENT | FileSaver sibling-temp rename, not copy_and_verify | Local temp + `copy_and_verify` to NAS | Same-dir sibling temp + `File.Move` promote; same crash-safety | `FileSaver.cs:68,92`; `ParquetScoreCache.cs:265` | info |
+| INTENT | No CacheValidity enum; hash mismatch hard-fails | `{ValidReconciled,ValidFirstPass,Stale}`; Stale→delete+rescore | Returns descriptive error + aborts on mismatch; resume via `.osprey.task` | `ParquetScoreCache.cs:1190,1256` | minor |
+| INTENT | `.osprey.task` resume sidecar has no Rust counterpart | Reuse inferred from footer hashes | Per-(output,task) JSON sidecar on search+library(+reconciliation) hashes | `TaskValiditySidecar.cs:80,98,144` | info |
+| INTENT | Reconciled parquet separate, not in-place | Stage 6 rewrites in place | `.scores-reconciled.parquet` sibling; survives partial Stage 6 crash | `ParquetScoreCache.cs:1036,1055,1103` | minor |
+| INTENT | FDR sidecar matches by entry_id, tolerates count mismatch | `entry_count == entries.len()`, positional | entry_id→index map; allows smaller sidecar over larger stub list; stale summary comment | `FdrScoresSidecar.cs:437,484,492,74` | minor |
+| STALE | `reconciliation.json` is format_version 3 | v1, omits file_stems/first_pass_base_ids | Requires v3 + both fields (Rust code evolved past its doc) | `ReconciliationFile.cs:75,77,84,124,138,150` | minor |
+| STALE | `.spectra.bin` header is v3 w/ fingerprint | v1 (20 bytes), no size/mtime | v3 w/ source_size+source_mtime (Unix ms), invalidates on fingerprint change | `SpectraCache.cs:61,70,90,162` | minor |
+| INTENT | Calibration reuse not gated on `search_hash` | Reused when search_hash matches | Never writes search_hash (field unset); reuse is `.osprey.task` decision | `PerFileScoringTask.cs:1702`; `CalibrationParams.cs:125` | minor |
+| UNVER | No verified equivalent to `evaluate_calibration.py` (**U7**) | Recommends Python calibration script | No Python dep; HTML via `--model-diagnostics`; exact equivalence unverified | `CalibrationIO.cs`; CLI | info |
+
+### [15-hpc-scoring-split.md](15-hpc-scoring-split.md) — matches-with-notes
+
+| Classification | Title | Rust says | C# does | Evidence | Sev |
+|---|---|---|---|---|---|
+| INTENT | CLI is `--task <Name>`, not `--no-join`/`--join-at-pass`/`--join-only` | Orchestrated by `--join-at-pass` + modifiers | Single `--task {PerFileScoring\|FirstPassFDR\|PerFileRescoring\|SecondPassFDR}`; old flags retired, fail fast | `Program.cs:86-128`; `OspreyCommandArgs.cs:206-207` | major |
+| INTENT | Task names differ from stage they run | Named by pass/join topology | CLI names by FDR pass; enum/classes by join topology | `OspreyConfig.cs:388-394`; `Program.cs:326-335` | info |
+| INTENT | Stage 6 separate `.scores-reconciled.parquet` | Rewrites `.scores.parquet` | Separate sibling; `--input-scores` prefers reconciled | `PerFileRescoreTask.cs:163-177,944-954` | minor |
+| INTENT | Membership-predicate + lazy-rehydrate, not stage window | Each mode runs stages X..Y | Fixed 4-task pipeline; `IsIncluded` + typed byproduct registry; pinned by truth table | `AnalysisPipeline.cs:99-148`; `PipelineMembershipTest.cs:55-93` | info |
+| INTENT | No `--parquet-compression`; ZSTD unconditional | `--parquet-compression snappy` for OspreySharp interop | Writes ZSTD; read auto-dispatches; cross-impl ZSTD/Snappy read compat is follow-up | `ParquetScoreCache.cs:270,462` | minor |
+| FLAG | `OSPREY_DUMP_PREDICT_RT` declared but disabled | Stage 6 worker bisection dump | `DumpPredictRt` declared; call site commented out (scoring hotspot) → produces nothing | `IOspreyDiagnostics.cs:80`; `PerFileRescoreTask.cs:715-726` | minor |
+| STALE | Stage 4 footer omits `osprey.reconciliation_hash` | Lists it among footer metadata | Stage 4 footer version/search/library/reconciled=false only; reconciliation_hash on Stage 6 parquet | `PerFileScoringTask.cs:226-232`; `ReconciledParquetWriter.cs:198-205` | info |
+
+### [16-determinism.md](16-determinism.md) — matches-with-notes
+
+| Classification | Title | Rust says | C# does | Evidence | Sev |
+|---|---|---|---|---|---|
+| STALE | Fold assignment is round-robin over sorted groups | `fold = hash(mod_seq) % n_folds` | Round-robin `i % nFolds` over ordinal-sorted keys, no hash (matches Rust `create_stratified_folds_by_peptide`) | `PercolatorFdr.cs:2492-2504`; `CalibrationScorer.cs:402-452` | minor |
+| INTENT | TotalOrder bit-transform replaces `total_cmp` | Built-in `f64::total_cmp` | IEEE-754 total order via sign-flipped long key + stable LINQ sort; arithmetic unchanged | `TotalOrder.cs:55-70` | info |
+| INTENT | SIMD lane-reduction order differs from scalar left-fold | Sequential scalar left-fold | Per-lane partials + horizontal sum; sub-ULP drift inside 1e-9 gate at p=21 | `LinearSvmClassifier.cs:531-545` | minor |
+| INTENT | Oracle is PowerShell regression gate, not inline tests | Inline tests + manual two-blib diff | `regression.ps1` 3 legs at 1e-9 (golden/resume/HPC-chain) | `regression.ps1:14-36,490-543` | info |
+| UNVER | Razor single-pass greedy may be order-sensitive (**U8**) | Iterative set cover, path-independent, 10-repeat test | Single-pass greedy over HashSet/Dictionary order; not process-stable under randomized string hashing; off default/tested path | `ProteinFdr.cs:432-467` | major |
+
+### [17-vectorization.md](17-vectorization.md) — matches-with-notes
+
+| Classification | Title | Rust says | C# does | Evidence | Sev |
+|---|---|---|---|---|---|
+| INTENT | No BLAS/OpenBLAS dependency | Calibration batch is one OpenBLAS `sgemm` | Pure managed; `BatchScorer` "simplified, no BLAS", scalar loops | `BatchScorer.cs:205,247` | info |
+| INTENT | All-pairs matmul not used in calibration | ~2.5M cosines as one matmul/window | `BatchXCorr` is scalar triple loop used only by test; live loop scores per candidate | `Calibrator.cs:1184,1189-1191`; `BatchScorer.cs:248-267` | minor |
+| INTENT | Explicit SIMD only in SVM | SIMD implicit via LLVM auto-vectorization | RyuJIT doesn't auto-vectorize; only SVM dot/weight hand-vectorized w/ `Vector<double>`; sub-ULP caveat inside gate | `LinearSvmClassifier.cs:516-568,589-602` | minor |
+| INTENT | Managed LOH/GC-avoidance infra, no Rust analogue | Rust has no GC | `SparseXcorrSpectrum` + `XcorrScratchPool` keep XCorr off LOH (issue #4398); outputs unchanged | `SparseXcorrSpectrum.cs:55,93`; `XcorrScratchPool.cs:41,72` | info |
+| INTENT | osprey-ml matrix ops scalar, no BLAS/parallelism | Manual loops w/ Rayon | `Matrix.Dot`/`GaussSolver` scalar, no SIMD/Rayon (matrices tiny) | `Matrix.cs:235-275`; `GaussSolver.cs:133-230` | info |
+| STALE | Bin-count off-by-one in unused batch geometry | 2001 bins 200-2000 Da | `DEFAULT_NUM_BINS=2000`; BatchScorer off any pipeline path, no effect | `BatchScorer.cs:209-211` | info |
+
+### [18-peptide-trace.md](18-peptide-trace.md) — **diverges**
+
+| Classification | Title | Rust says | C# does | Evidence | Sev |
+|---|---|---|---|---|---|
+| INTENT | `OSPREY_TRACE_PEPTIDE` facility absent; replaced by structured dumps | Env-gated `[trace]` log at 5 stages, keyed by modified_sequence, auto-matches decoy | None of it exists (zero matches for TRACE_PEPTIDE/is_traced/[trace]); `IOspreyDiagnostics` `OSPREY_DUMP_*`/`OSPREY_DIAG_*` byte-stable TSV dumps instead | `IOspreyDiagnostics.cs:51`; `OspreyFileDiagnostics.cs:84-423` | major |
+| INTENT | Peptide selection by entry_id, not modified_sequence | Bare modified_sequence, auto-groups charges + decoy | Keys on numeric entry_id or MS2 scan; no auto-group of charges/decoys | `OspreyFileDiagnostics.cs:379,393,400` | minor |
+| INTENT | Dumps are byte-stable files, not interleaved `[trace]` lines | `log::info!` `[trace]` interleaved, grep-isolated | Dedicated TSV/txt w/ F10 + shortest-round-trip f64 for SHA-256 diffing; only `[COUNT]`/`[BISECT]` to log | `OspreyFileDiagnostics.cs:68-82`; `Diagnostics.cs:60` | minor |
+| STALE | `OSPREY_DUMP_PREDICT_RT` producer disabled | RT prediction is traceable/dumpable | Gate throws `NotImplementedException`; producer removed from scoring hotspot; comment names what to uncomment | `OspreyFileDiagnostics.cs:431-445` | info |
+
+### [19-testing.md](19-testing.md) — matches-with-notes
+
+| Classification | Title | Rust says | C# does | Evidence | Sev |
+|---|---|---|---|---|---|
+| INTENT | Separate MSTest project vs inline `#[cfg(test)]` | Inline unit tests, no separate project | One `Osprey.Test` MSTest project (net472+net8.0), 41 classes / 492 methods | `Osprey.Test.csproj:43-51` | info |
+| INTENT | Two standing CI gates have no Rust analog | `cargo test` + fmt/clippy | `regression.ps1` (golden+resume+HPC at 1e-9) + `Test-PerfGate.ps1` (A/B wall-time) | `regression.ps1:1`; `Test-PerfGate.ps1:1` | info |
+| INTENT | Static-analysis test enforcing determinism | No such test (Rust `sort_by` stable) | `CodeInspectionTest` forbids `Array.Sort`/`List.Sort` + any `"DECOY_"` literal in reconciliation | `CodeInspectionTest.cs:85,150` | info |
+| STALE | Mokapot test suite absent | Full `mokapot.rs` test suite | Native Percolator, no Python dep, no `MokapotTest.cs`; `FdrTest.cs` exercises Percolator | `FdrTest.cs:25` | minor |
+| INTENT | Plain MSTest Assert, not AssertEx | N/A (recon framing assumed AssertEx) | Plain `Assert`/`CollectionAssert` (1,314 calls); parity via hand-computed refs + bit compares + `OSPREY_CROSS_IMPL_*` | `IOTest.cs:2082-2115`; `OspreyEnvironment.cs:104` | info |
+| STALE | Test count is stale/moving (~302 vs 492) | ~302 tests | 492 `[TestMethod]` measured | `Osprey.Test/*.cs` | info |
+| STALE | Regression README documents 2 legs, script runs 3 | N/A (C#-side doc lag) | README lists mode1/mode2; script also runs mode3 (HPC 4-task chain) | `regression.ps1:502-522` vs `Regression/README.md:30-39` | minor |
+
+---
+
+## Confirmed intentional design differences (the big ones at a glance)
+
+These are the deliberate, output-preserving architectural choices in the C# port that recur across many documents. None is a defect; they are recorded so a reader knows what to expect and does not re-flag them:
+
+1. **Native managed Percolator, no Mokapot.** The external Python Mokapot path (PIN round-trip, subprocess, `--save_models`/`--load_models`) is not wired to the C# CLI. `--fdr-method` accepts `percolator | gbdt | simple`. The `FdrMethod.Mokapot` enum value survives but is unreachable. (docs 07, 09, 10, 13, 19)
+
+2. **`gbdt` is a C#-only FDR method.** `--fdr-method gbdt` selects a gradient-boosted-tree classifier inside the Percolator framework (`GradientBoostedTrees.cs`); the linear-SVM Percolator remains the default. The Rust reference has **no** GBDT scorer, so this is a C# addition beyond the reference, not a divergence to reconcile. (doc 07)
+
+3. **`FdrLevel` has no `Protein` variant.** The enum is `{Precursor, Peptide, Both}`; `--fdr-level protein` is rejected. Protein q-values are still computed, propagated, and reported, but cannot gate blib output from the CLI. Two stale in-code comments still reference the removed mode. (docs 07, 08)
+
+4. **No BLAS/OpenBLAS; pure managed numerics.** XCorr and cosine are managed scalar loops; the only explicit SIMD is the SVM dual-coordinate descent (`System.Numerics.Vector<double>`). The calibration "one big `sgemm`/`dot`" matmul is replaced by per-candidate scoring. All results stay on the 1e-9 gate. Adds managed-only LOH/GC-avoidance infra (`SparseXcorrSpectrum`, `XcorrScratchPool`). (docs 02, 04, 17)
+
+5. **ProteoWizard/Skyline blib reuse is schema-only.** `BlibWriter` is a hand-rolled `System.Data.SQLite` writer that reuses the BiblioSpec schema and Skyline's Ionic.Zlib level-6 byte convention (byte-identical to Rust `flate2`), not the C++ BiblioSpec code. (doc 13)
+
+6. **MSTest project instead of inline Rust tests.** All tests live in one `Osprey.Test` MSTest project (492 `[TestMethod]`s ported crate-for-crate) plus two CI gates with no Rust analog: `regression.ps1` (golden + resume + HPC-chain at 1e-9) and `Test-PerfGate.ps1` (A/B wall-time), and a `CodeInspectionTest` that forbids unstable `Array.Sort`/`List.Sort` and stray `DECOY_` literals in reconciliation code. (docs 16, 19)
+
+7. **HPC task naming redesign.** The Rust `--no-join`/`--join-at-pass`/`--join-only` flag family is replaced by a single `--task {PerFileScoring|FirstPassFDR|PerFileRescoring|SecondPassFDR}` selector with `IsIncluded` membership predicates and lazy byproduct rehydration; boundary files stay byte-identical. Related: Stage 6 writes a separate `.scores-reconciled.parquet` sibling (crash-safety) rather than rewriting in place, and reconciliation is carried through a serialized `reconciliation.json` (format_version 3) envelope. (docs 10, 11, 14, 15)
+
+---
+
+## Document index
+
+Numbered in **operation order** (the current C# doc numbering).
+
+| # | Document | Parity status |
+|---|---|---|
+| 01 | [decoy-generation](01-decoy-generation.md) | matches-with-notes |
+| 02 | [xcorr-scoring](02-xcorr-scoring.md) | matches-with-notes |
+| 03 | [spectral-scoring](03-spectral-scoring.md) | matches-with-notes |
+| 04 | [calibration](04-calibration.md) | matches-with-notes |
+| 05 | [rt-alignment](05-rt-alignment.md) | matches-with-notes |
+| 06 | [peak-detection](06-peak-detection.md) | matches-with-notes |
+| 07 | [fdr-control](07-fdr-control.md) | matches-with-notes |
+| 08 | [protein-parsimony](08-protein-parsimony.md) | **diverges** |
+| 09 | [multi-charge-consensus](09-multi-charge-consensus.md) | matches-with-notes |
+| 10 | [cross-run-reconciliation](10-cross-run-reconciliation.md) | matches-with-notes |
+| 11 | [boundary-overrides](11-boundary-overrides.md) | matches-with-notes |
+| 12 | [second-pass-fdr](12-second-pass-fdr.md) | C#-originated (no Rust doc) |
+| 13 | [blib-output-schema](13-blib-output-schema.md) | matches-with-notes |
+| 14 | [intermediate-files](14-intermediate-files.md) | matches-with-notes |
+| 15 | [hpc-scoring-split](15-hpc-scoring-split.md) | matches-with-notes |
+| 16 | [determinism](16-determinism.md) | matches-with-notes |
+| 17 | [vectorization](17-vectorization.md) | matches-with-notes |
+| 18 | [peptide-trace](18-peptide-trace.md) | **diverges** |
+| 19 | [testing](19-testing.md) | matches-with-notes |

--- a/pwiz_tools/Osprey/docs/README.md
+++ b/pwiz_tools/Osprey/docs/README.md
@@ -12,6 +12,10 @@ is a one-to-one deep dive on a Rust source doc and **ends with a "Divergences fr
 the Rust documentation" section**; those are consolidated in
 [DIVERGENCES.md](DIVERGENCES.md).
 
+> **Just want to run it?** Jump to the [command-line reference](20-command-line.md)
+> — every flag with defaults, plus copy-paste examples for unit (Stellar) and HRAM
+> (Astral) datasets.
+
 ## Ordered index
 
 | # | Doc | What it covers |
@@ -35,6 +39,7 @@ the Rust documentation" section**; those are consolidated in
 | 17 | [vectorization](17-vectorization.md) | Performance-critical vectorization — the SIMD / BLAS-equivalent paths for XCorr and matrix operations. |
 | 18 | [peptide-trace](18-peptide-trace.md) | The per-peptide diagnostic dump facility (C# `OSPREY_DUMP_*` / `OSPREY_DIAG_*` in place of the Rust `OSPREY_TRACE_PEPTIDE`). |
 | 19 | [testing](19-testing.md) | The C# test suite and the standing gates: `regression.ps1` (straight-through correctness at 1e-9) and the cross-impl drift bridge against Rust. |
+| 20 | [command-line](20-command-line.md) | Full CLI option reference (every flag, default, and value list) with copy-paste unit (Stellar) and HRAM (Astral) examples and the four-task HPC split. |
 
 ## Supplementary
 

--- a/pwiz_tools/Osprey/docs/README.md
+++ b/pwiz_tools/Osprey/docs/README.md
@@ -1,0 +1,62 @@
+# Osprey (C#) algorithm documentation
+
+Deep-dive documentation of the algorithms in **Osprey**, the C# (.NET 8) port of
+Mike MacCoss's Rust [Osprey](https://github.com/maccoss/osprey) — a
+peptide-centric DIA search tool that scores fragment-XIC co-elution with rigorous
+FDR control and emits BiblioSpec `.blib` output directly consumable by Skyline.
+
+Unlike the Rust `docs/` set (numbered by when each algorithm was written), **this
+set is numbered by pipeline execution order** — read it top to bottom and you
+follow a run from library preparation through the `.blib` write. Each numbered doc
+is a one-to-one deep dive on a Rust source doc and **ends with a "Divergences from
+the Rust documentation" section**; those are consolidated in
+[DIVERGENCES.md](DIVERGENCES.md).
+
+## Ordered index
+
+| # | Doc | What it covers |
+|---|-----|----------------|
+| 01 | [decoy-generation](01-decoy-generation.md) | Enzyme-aware sequence reversal (cleavage residue preserved), fragment m/z recompute for b/y swaps, FDRBench decoy-pairing manifest. |
+| 02 | [xcorr-scoring](02-xcorr-scoring.md) | The Comet-style XCorr primitive: spectrum preprocessing, bin sizes, flanking-bin subtraction, the vectorized dot product. |
+| 03 | [spectral-scoring](03-spectral-scoring.md) | The 21 PIN features and how each is computed (pairwise coelution, peak shape, spectral-at-apex, mass accuracy, RT deviation, MS1, Tukey median polish, SG-weighted multi-scan). |
+| 04 | [calibration](04-calibration.md) | Per-file RT + MS1 + MS2 calibration: quick unit-resolution XCorr pass, LDA scoring, LOESS fit, mass-error stats, calibration-JSON caching. |
+| 05 | [rt-alignment](05-rt-alignment.md) | LOESS calibration + inverse prediction, weighted-median consensus library RT, peak imputation — the RT machinery shared by calibration and reconciliation. |
+| 06 | [peak-detection](06-peak-detection.md) | CWT consensus peak detection (Mexican Hat wavelet, pointwise median, ±2σ boundaries with valley guard), the product-form pick, and the opt-in learned linear pick model. |
+| 07 | [fdr-control](07-fdr-control.md) | First-pass two-level FDR (run + experiment): native Percolator SVM, the C#-only GBDT method, simple TDC, dual precursor+peptide q-values, PEP. |
+| 08 | [protein-parsimony](08-protein-parsimony.md) | Protein parsimony (bipartite graph, identical-set merging, subset elimination, razor) and picked-protein FDR; the first pass builds the **protein-compact stratum** used by second-pass FDR. |
+| 09 | [multi-charge-consensus](09-multi-charge-consensus.md) | Post-FDR sharing of peak boundaries across charge states; the best passing charge leads (lowest-charge tie-break), disagreeing charges re-scored at consensus boundaries. |
+| 10 | [cross-run-reconciliation](10-cross-run-reconciliation.md) | Consensus RT, per-file LOESS refit, and the per-entry reconciliation plan (Keep / UseCwtPeak / ForcedIntegration). |
+| 11 | [boundary-overrides](11-boundary-overrides.md) | How the search accepts override boundaries so consensus and reconciliation targets re-score on the same window / XCorr path as the first pass. |
+| 12 | [second-pass-fdr](12-second-pass-fdr.md) | Stage-7 second-pass FDR and the frozen-model q-value modes — transfer-compete and protein-compact — selected by `OSPREY_PASS2_QVALUE`. |
+| 13 | [blib-output-schema](13-blib-output-schema.md) | BiblioSpec SQLite schema plus Osprey extension tables and the nullable `retentionTime` convention for Skyline ID lines. |
+| 14 | [intermediate-files](14-intermediate-files.md) | On-disk caches / sidecars (calibration JSON, spectra cache, `.scores.parquet`, FDR sidecars), SHA-256 footer hashing, and the tiered memory architecture. |
+| 15 | [hpc-scoring-split](15-hpc-scoring-split.md) | The four `--task` workers, their input/output files, `--input-scores` ordering rules, and validity sidecars for HPC / NextFlow orchestration. |
+| 16 | [determinism](16-determinism.md) | Patterns that keep results bit-identical across runs: thread-order independence, float stability, cross-validation fold assignment. |
+| 17 | [vectorization](17-vectorization.md) | Performance-critical vectorization — the SIMD / BLAS-equivalent paths for XCorr and matrix operations. |
+| 18 | [peptide-trace](18-peptide-trace.md) | The per-peptide diagnostic dump facility (C# `OSPREY_DUMP_*` / `OSPREY_DIAG_*` in place of the Rust `OSPREY_TRACE_PEPTIDE`). |
+| 19 | [testing](19-testing.md) | The C# test suite and the standing gates: `regression.ps1` (straight-through correctness at 1e-9) and the cross-impl drift bridge against Rust. |
+
+## Supplementary
+
+| Doc | What it covers |
+|-----|----------------|
+| [DIVERGENCES.md](DIVERGENCES.md) | Consolidated cross-implementation parity report — every per-doc "Divergences from the Rust documentation" section in one place, classified (stale-doc / intentional-C# / port-error / unverified). |
+| [peak-model-training.md](peak-model-training.md) | Retraining the opt-in learned peak-pick model (06): feature capture → train → promote, with the score equations. |
+| [fractional-entrapment.md](fractional-entrapment.md) | Entrapment-based FDR-accuracy diagnostics (`--model-diagnostics`): why a fractional entrapment ratio still yields a valid FDP estimate. |
+
+## Cross-implementation status
+
+The C# port is end-to-end **bit-identical to the Rust reference** for Stages 1–7
+plus `.blib` output on the Stellar (`--resolution unit`) and Astral
+(`--resolution hram`) reference datasets, enforced by the `regression.ps1` 1e-9
+gate. Stages 1–4 PIN features are ULP-identical on Stellar; on Astral 19 of 21 are
+ULP, with `xcorr` and `sg_weighted_xcorr` drifting at ~1e-7 from the intrinsic f32
+HRAM preprocessed-bin cache. Stages 5–6 are byte-equal at every diagnostic dump,
+Stage 7 protein FDR matches at 1e-9, and the `.blib` matches at the SQL row +
+column level.
+
+A handful of features are **C#-only additions beyond the reference** (the
+`--fdr-method gbdt` classifier; the opt-in learned pick model, which also exists in
+Rust; the pass-2 frozen q-value modes, which the C# originated and Rust is porting
+back). Those are called out in the relevant docs and in
+[DIVERGENCES.md](DIVERGENCES.md); none changes the default, parity-gated path.

--- a/pwiz_tools/Osprey/docs/peak-model-training.md
+++ b/pwiz_tools/Osprey/docs/peak-model-training.md
@@ -1,0 +1,176 @@
+# Retraining the learned peak-pick model
+
+Osprey's optional learned peak pick (see [`06-peak-detection.md`](06-peak-detection.md))
+replaces the default product-form CWT candidate rank with a frozen linear model
+over four standardized terms. The weights are trained **offline** from feature
+dumps produced by a normal search, then copied back into the source as
+hard-coded constants. This note is the end-to-end recipe.
+
+There is no single wrapper script yet — the "infrastructure" is one environment
+variable (feature capture), one Python script (training), and a manual
+copy-into-source step (promotion). The three stages:
+
+```
+[C# Osprey run]                     [Python]                 [C# + Rust source]
+OSPREY_PICK_DUMP_CANDIDATES=1       pick_lda_train.py        StellarModel / AstralModel
+   -> per-file .tsv          -->       -> pick-model-*.json  -->  STELLAR_MODEL / ASTRAL_MODEL
+   pick_candidates.tsv              {features,weights,       (copied in verbatim; parity)
+                                     means,scales}
+```
+
+Models are trained **per platform / resolution**: unit resolution (Stellar) and
+HRAM (Astral) get separate models, so capture and train them independently.
+
+## Stage 1 — Capture the per-candidate features
+
+Setting `OSPREY_PICK_DUMP_CANDIDATES` to a non-empty / non-zero value makes the
+first-pass search write one row **per CWT candidate peak of every precursor —
+targets *and* paired decoys** — to a per-input-file TSV next to the work
+directory: `<work-dir>\<inputStem>.pick_candidates.tsv`
+(`Osprey.Core/OspreyEnvironment.cs`, `Osprey.Scoring/PickCandidateDump.cs`,
+`Osprey.Scoring/ScoringContext.cs`).
+
+```powershell
+$env:OSPREY_PICK_DUMP_CANDIDATES = "1"
+# Run first-pass per-file scoring on representative runs of ONE platform:
+Osprey -i run1.mzML run2.mzML ... -l library.blib --work-dir C:\capture\stellar --resolution unit
+```
+
+- The dump captures the **exact raw rank terms** the picker computes, so the
+  trainer learns on precisely the values inference will see. Row schema
+  (`PickCandidateDump.HeaderLine`):
+
+  | column | meaning |
+  |--------|---------|
+  | `base_id` | `Id & 0x7FFFFFFF` — precursor id shared by a target and its decoy |
+  | `is_decoy` | `(Id & 0x80000000) != 0` |
+  | `cand_index` | the rank-loop index of this candidate within the precursor |
+  | `coelution` | mean pairwise Pearson of fragments over the peak window |
+  | `ln_intensity` | `log(1 + apexIntensity)` |
+  | `rt_penalty` | `exp(-rtResidual² / 2σ²)` |
+  | `median_polish` | median-polish cosine vs. the library spectrum (1.0 on failure) |
+  | `apex_rt`, `start_rt`, `end_rt` | candidate peak bounds |
+  | `is_picked` | whether this candidate was the chosen (argmax) peak |
+
+- **Default OFF, zero cost when unset.** With the flag off, no per-candidate
+  median polish is computed and no file is written, so the hot loop is
+  byte-identical to a normal run. The dump is a diagnostic capture only.
+- **The files are large** — on Stellar the candidate set exceeds the CLR's
+  contiguous-string limit, which is why `Flush` streams row-by-row rather than
+  materializing one string. Expect multi-GB TSVs for a full run.
+- Put all of a platform's `*.pick_candidates.tsv` files in one directory; the
+  trainer globs the directory.
+
+## Stage 2 — Train (Python)
+
+```
+pwiz_tools/Osprey/pick_lda_train.py <platform> <capture_dir> <out_json> [holdout]
+```
+
+```bash
+python pick_lda_train.py stellar C:\capture\stellar  pick-model-stellar.json
+python pick_lda_train.py astral  C:\capture\astral   pick-model-astral.json
+
+# Optional 4th arg = holdout substring: files whose basename contains it are
+# EXCLUDED from training (leave-one-run-out cross-validation):
+python pick_lda_train.py stellar C:\capture\stellar  pick-model-stellar.json  run3
+```
+
+- **Dependencies:** `numpy` and `pyarrow`. (pyarrow parses the huge TSVs
+  efficiently; plain `csv` would be far slower.)
+- **The `<platform>` argument is just a label** written into the JSON's
+  `platform` field — it does not change the math.
+- **Algorithm** (mirrors the calibration LDA): seed the pick with coelution
+  only, then iterate:
+  1. score every candidate `rank = z·w` in standardized space and take the
+     argmax candidate per precursor (best peak);
+  2. run **paired target/decoy competition** — a target whose best-peak score
+     beats its paired decoy's best-peak score is a **positive**; all decoy
+     best-peaks are **negatives**;
+  3. fit a **non-negative Fisher LDA** over the four z-normalized terms
+     (within-class scatter `Sw` with a `1e-6` ridge; clamp weights to `≥ 0`
+     since all terms are positive-sense), L2-normalize `w`;
+  4. re-pick and repeat (≤ 10 iterations; stop when the positive count
+     stabilizes or the LDA degenerates).
+
+  `means`/`scales` are computed over **all** candidate rows and frozen into the
+  model, so inference standardizes each term with the same statistics training
+  used. The emitted JSON is exactly the schema the C# and Rust loaders consume:
+
+  ```json
+  { "features": ["coelution","ln_intensity","rt_penalty","median_polish"],
+    "weights": [w0,w1,w2,w3], "means": [m0,m1,m2,m3], "scales": [s0,s1,s2,s3] }
+  ```
+
+- **The precursor key must stay collision-free.** The trainer groups candidate
+  rows into precursors with a dense per-`(file, base_id)` index
+  (`key = pair_index*2 + is_decoy`), so `key // 2` recovers the target/decoy
+  pair regardless of how large `base_id` grows. (An earlier fixed multiplier
+  collided once `base_id` exceeded ~5M — see the Copilot-review fix on
+  pwiz #4446 / maccoss/osprey #57.)
+
+## Stage 3 — Validate, then promote
+
+**Validate without touching source.** Point the engine at the freshly trained
+JSON and A/B it against the current pick on a held-out run — this overrides the
+built-in model:
+
+```powershell
+$env:OSPREY_PICK_LDA_MODEL = "C:\...\pick-model-stellar.json"
+Osprey -i heldout.mzML -l library.blib -o out.blib --resolution unit
+```
+
+The loader (`Osprey.Scoring/PickLdaModel.cs`, `LoadFromEnv`) requires the JSON's
+`features` array to list `[coelution, ln_intensity, rt_penalty, median_polish]`
+in that exact order — a re-ordered or older-schema file fails loudly rather than
+silently applying weights to the wrong term.
+
+**Promote into the defaults** by copying the JSON `weights` / `means` / `scales`
+**verbatim** into the hard-coded models. Because of the C# ↔ Rust parity
+requirement, this must land in **both** trees:
+
+- C#: `Osprey.Scoring/PickLdaModel.cs` → `StellarModel` / `AstralModel`
+- Rust: `crates/osprey/src/pick_lda.rs` → `STELLAR_MODEL` / `ASTRAL_MODEL`
+
+(The "Values copied verbatim from pick-model-stellar.json / pick-model-astral.json"
+comment in `PickLdaModel.cs` marks exactly where.)
+
+### Selection precedence (what the picker actually uses)
+
+The picker resolves the model once, in this order
+(`Osprey.Core/OspreyEnvironment.cs`):
+
+1. `OSPREY_PICK_LDA_MODEL` set to an existing file → that JSON model (the
+   validation override);
+2. else `OSPREY_PICK_LDA` set and not `0` → the hard-coded resolution-keyed
+   model (Stellar for unit, Astral for HRAM);
+3. else (**default**) → the legacy pure product-form pick — the Rust-parity
+   pick that matches the committed regression golden.
+
+## Caveats
+
+- **Promoting weights does not change production behavior.** The learned model
+  is off by default; only `OSPREY_PICK_LDA` (or the JSON override) turns it on.
+  **Flipping it on by default is a separate, coordinated golden re-baseline** —
+  it moves the pick, so the committed regression golden must be regenerated and
+  cross-impl parity re-confirmed on Stellar + Astral.
+- **The `pick-model-*.json` files are developer-local training artifacts** and
+  are not committed; only the numeric literals copied into source live in the
+  repo.
+- **Capture representative data.** The model is only as good as the runs it was
+  trained on; use enough representative files per platform to get stable
+  positive counts (the trainer stops early and warns if positives are too few).
+- **Keep the two trees in lock-step.** Any change to the feature set, the
+  standardization, or the weights must be mirrored in both `PickLdaModel.cs` and
+  `pick_lda.rs`, or the implementations diverge.
+
+## Source map
+
+| Piece | File |
+|-------|------|
+| Dump flag + model env vars | `Osprey.Core/OspreyEnvironment.cs` |
+| Per-candidate dump writer | `Osprey.Scoring/PickCandidateDump.cs` |
+| Dump collector hook | `Osprey.Scoring/ScoringContext.cs` |
+| Trainer | `pick_lda_train.py` |
+| C# model loader + defaults | `Osprey.Scoring/PickLdaModel.cs` |
+| Rust model loader + defaults | `crates/osprey/src/pick_lda.rs` (maccoss/osprey) |


### PR DESCRIPTION
## Summary

* Added an operation-ordered Osprey algorithm & cross-implementation parity documentation set under `pwiz_tools/Osprey/docs`: **19 numbered docs** in pipeline-execution order, a `README.md` index, the `DIVERGENCES.md` Rust↔C# parity report, and a pick-model retraining guide.
* Ported from the Rust `maccoss/osprey` `docs/` set and **renumbered from Rust-doc order into pipeline-execution order** — e.g. protein parsimony (08) follows FDR control (07) because first-pass protein FDR builds the protein-compact stratum the pass-2 `protein-compact` mode consumes.
* Refreshed for the features merged in #4446: the opt-in **learned peak-pick model** (06), the **C#-only `--fdr-method gbdt`** (07), a new **second-pass-FDR** doc (12: frozen / transfer-compete / protein-compact), and the **lowest-charge shared-boundary tie-break** (09).
* **Documentation only — no code changes.**

Addresses #4475

## Notes for reviewers

* Each numbered doc ends with a "Divergences from the Rust documentation" section; `DIVERGENCES.md` consolidates all 110 catalogued items (classified stale-doc / intentional-C# / port-error / unverified).
* The one PORT-ERROR (razor `--shared-peptides razor` rollup order) is already tracked in #4441; the 8 UNVERIFIED parity items are listed as follow-ups in #4475.
* The four docs with fresh content this round are **06** (learned pick), **07** (GBDT), **09** (charge tie-break), and **12** (pass-2); the other 15 are the prior parity docs, unchanged except for renumbering.

## Test plan

- [x] All in-folder Markdown links resolve (link-checked)
- [x] Each doc's H1 title synced to its operation-order filename

Co-Authored-By: Claude <noreply@anthropic.com>
