### PR TITLE
Added progress reporting to Osprey calibration window scoring

### DIFF
--- a/pwiz_tools/Osprey/Osprey.Tasks/Calibrator.cs
+++ b/pwiz_tools/Osprey/Osprey.Tasks/Calibrator.cs
@@ -25,6 +25,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Threading;
 using System.Threading.Tasks;
 using pwiz.Osprey.Chromatography;
 using pwiz.Osprey.Core;
@@ -1560,41 +1561,52 @@ namespace pwiz.Osprey.Tasks
             var snrByEntryId = new ConcurrentDictionary<uint, double>();
             var matchRts = new ConcurrentDictionary<uint, KeyValuePair<double, double>>();
 
-            Parallel.ForEach(entriesByWindow, new ParallelOptions
+            // Calibration scoring is the one long determinate loop that still ran silent: the
+            // surrounding [TIMING]/[COUNT] lines are filtered out of normal output
+            // (OspreyOutput.IsMachineParseable), so a normal run showed nothing between
+            // "Running RT calibration..." and the pass summary -- ~40 s per file, ~50 min
+            // across an 82-file run.
+            int windowsDone = 0;
+            using (var progress = new ProgressReporter(
+                       "Scoring calibration windows", entriesByWindow.Count, "  "))
             {
-                MaxDegreeOfParallelism = config.NThreads
-            },
-            () => resolution.CreateScorer(),
-            (kvp, loopState, localScorer) =>
-            {
-                // Load, RT-sort, and preprocess this window's spectra so the XCorr cache
-                // aligns with the RT-sorted spectra order used for scoring.
-                var windowSpectra = windowIndex.LoadWindow(kvp.Key);
-                windowSpectra.Sort((a, b) => a.RetentionTime.CompareTo(b.RetentionTime)); // Array.Sort OK: calibration RT-only sort tie behaviour
-                // s_calXcorrScorer is shared across the window-parallel bodies here, so
-                // PreprocessSpectrumForXcorrF32 MUST remain stateless (a pure function of its
-                // input spectrum) -- adding per-call scratch state on the scorer would race.
-                var windowPreprocessed = new float[windowSpectra.Count][];
-                for (int i = 0; i < windowSpectra.Count; i++)
-                    windowPreprocessed[i] = s_calXcorrScorer.PreprocessSpectrumForXcorrF32(windowSpectra[i]);
-
-                foreach (var entry in kvp.Value)
-                {
-                    var match = ScoreResolvedCalibrationEntry(
-                        entry, windowSpectra, windowPreprocessed, ms1Spectra, context,
-                        rtSlope, rtIntercept, tolerance, calibrationModel, localScorer,
-                        out double entrySnr, out double entryLibRt, out double entryMeasuredRt);
-                    if (match != null)
+                Parallel.ForEach(entriesByWindow, new ParallelOptions
                     {
-                        matches.Add(match);
-                        snrByEntryId[entry.Id] = entrySnr;
-                        matchRts[entry.Id] = new KeyValuePair<double, double>(
-                            entryLibRt, entryMeasuredRt);
-                    }
-                }
-                return localScorer;
-            },
-            localScorer => { });
+                        MaxDegreeOfParallelism = config.NThreads
+                    },
+                    () => resolution.CreateScorer(),
+                    (kvp, loopState, localScorer) =>
+                    {
+                        // Load, RT-sort, and preprocess this window's spectra so the XCorr cache
+                        // aligns with the RT-sorted spectra order used for scoring.
+                        var windowSpectra = windowIndex.LoadWindow(kvp.Key);
+                        windowSpectra.Sort((a, b) => a.RetentionTime.CompareTo(b.RetentionTime)); // Array.Sort OK: calibration RT-only sort tie behaviour
+                        // s_calXcorrScorer is shared across the window-parallel bodies here, so
+                        // PreprocessSpectrumForXcorrF32 MUST remain stateless (a pure function of its
+                        // input spectrum) -- adding per-call scratch state on the scorer would race.
+                        var windowPreprocessed = new float[windowSpectra.Count][];
+                        for (int i = 0; i < windowSpectra.Count; i++)
+                            windowPreprocessed[i] = s_calXcorrScorer.PreprocessSpectrumForXcorrF32(windowSpectra[i]);
+
+                        foreach (var entry in kvp.Value)
+                        {
+                            var match = ScoreResolvedCalibrationEntry(
+                                entry, windowSpectra, windowPreprocessed, ms1Spectra, context,
+                                rtSlope, rtIntercept, tolerance, calibrationModel, localScorer,
+                                out double entrySnr, out double entryLibRt, out double entryMeasuredRt);
+                            if (match != null)
+                            {
+                                matches.Add(match);
+                                snrByEntryId[entry.Id] = entrySnr;
+                                matchRts[entry.Id] = new KeyValuePair<double, double>(
+                                    entryLibRt, entryMeasuredRt);
+                            }
+                        }
+                        progress.Report(Interlocked.Increment(ref windowsDone));
+                        return localScorer;
+                    },
+                    localScorer => { });
+            }
             swScoring.Stop();
             _ctx.LogInfo(string.Format(
                 "[TIMING] Calibration pass {0} scoring: {1:F2}s ({2} matches)",


### PR DESCRIPTION
## Summary

* Osprey's RT calibration scored silently for ~40 s per file — ~50 minutes of dead air across an 82-file run, with nothing between `Running RT calibration...` and the pass summary.
* The window was not uninstrumented: `[TIMING] Calibration pass N scoring` and `[COUNT]` lines already exist, but `OspreyOutput` filters machine-parseable prefixes (`[TIMING]`/`[COUNT]`/`[BENCH]`/`[STAGE-WALL]`) out of normal output, so a non-verbose run showed none of them.
* Wraps the calibration window-scoring `Parallel.ForEach` in a `ProgressReporter`, reporting per completed window. This was the last long determinate loop in the pipeline without one.
* Log-only change: search results are byte-identical.

Before:

```
[2026/07/25 22:23:51]  Running RT calibration...
[2026/07/25 22:24:35]  Calibration pass 1: 588 RT calibration points (from 808 peptides at 1% FDR)
```

After:

```
[2026/07/26 07:22:03]  Running RT calibration...
[2026/07/26 07:22:03]    Scoring calibration windows...
[2026/07/26 07:22:05]      0%
[2026/07/26 07:22:06]      29%
[2026/07/26 07:22:07]      48%
[2026/07/26 07:22:08]      87%
[2026/07/26 07:22:08]      100%
[2026/07/26 07:22:09]  Calibration pass 1: 2388 RT calibration points (from 3803 peptides at 1% FDR)
```

`ProgressReporter`'s 30 s heartbeat also bounds the worst case on slower files, matching the intended ceiling for progress output.

## Test plan

- [x] Osprey unit suite — 535/535 pass
- [x] Zero-warning code inspection
- [x] `regression.ps1 -Dataset Stellar` — mode1 (vs golden), mode3 (HPC chain), mode2 (resume) all PASS; blib byte-identical at 45,064,192 bytes
- [x] Single-file runtime check — percent lines now fill the former gap (output above)

Co-Authored-By: Claude <noreply@anthropic.com>