### PR TITLE
osprey: Persisted the 1st-pass model so frozen 2nd-pass modes run in the merge node

### DIFF
--- a/pwiz_tools/Osprey/Osprey.ML/LinearSvmClassifier.cs
+++ b/pwiz_tools/Osprey/Osprey.ML/LinearSvmClassifier.cs
@@ -309,6 +309,24 @@ namespace pwiz.Osprey.ML
         public int NumFeatures { get { return _means.Length; } }
 
         /// <summary>
+        /// Reconstruct a standardizer from persisted means/stds -- e.g. reloading a
+        /// frozen 1st-pass model in a distributed SecondPassFDR merge node that did not
+        /// train pass 1 in-process. The arrays are exactly what <see cref="Means"/> and
+        /// <see cref="Stds"/> return, so a scorer built from the reloaded model
+        /// standardizes bit-identically to the in-process original.
+        /// </summary>
+        public static FeatureStandardizer FromMeansStds(double[] means, double[] stds)
+        {
+            if (means == null)
+                throw new ArgumentNullException(nameof(means));
+            if (stds == null)
+                throw new ArgumentNullException(nameof(stds));
+            if (means.Length != stds.Length)
+                throw new ArgumentException(@"means and stds must have the same length");
+            return new FeatureStandardizer(means, stds);
+        }
+
+        /// <summary>
         /// Compute mean and std for each feature column.
         /// </summary>
         public static FeatureStandardizer Fit(Matrix features)

--- a/pwiz_tools/Osprey/Osprey.Tasks/FirstJoinTask.cs
+++ b/pwiz_tools/Osprey/Osprey.Tasks/FirstJoinTask.cs
@@ -903,6 +903,32 @@ namespace pwiz.Osprey.Tasks
                 out var perFileGapFillForRescore,
                 ctx);
 
+            // Persist the trained 1st-pass model beside each file's reconciled sidecars so a
+            // distributed --task SecondPassFDR merge node -- or any resume that skips 1st-pass
+            // training -- can run the frozen 2nd-pass modes without re-training. Written
+            // per-file (identical copies) so the merge node finds it by the same input-file
+            // stem it uses for every other reconciled sidecar. Best-effort: a write failure
+            // must not fail the run (the merge node keeps its existing fail-fast when the
+            // sidecar is absent). Save() is a no-op for the GBDT / degenerate model.
+            if (ctx.TryGet<FirstPassPercolatorModel>(out var firstPassModel) && firstPassModel.Results != null)
+            {
+                int modelWrites = 0;
+                foreach (var kvp in perFileParquetPaths)
+                {
+                    try
+                    {
+                        if (FirstPassModelIO.Save(FirstPassModelIO.PathFor(kvp.Value, kvp.Key), firstPassModel.Results))
+                            modelWrites++;
+                    }
+                    catch (Exception ex)
+                    {
+                        ctx.LogWarning(@"Could not persist 1st-pass model sidecar for '" + kvp.Key + @"': " + ex.Message);
+                    }
+                }
+                if (modelWrites > 0)
+                    ctx.LogInfo(string.Format(@"Persisted 1st-pass model for frozen 2nd-pass reload ({0} file sidecar(s)).", modelWrites));
+            }
+
             if (config.StopAfterStage5)
             {
                 if (reconWriteFailures > 0)

--- a/pwiz_tools/Osprey/Osprey.Tasks/FirstPassModelIO.cs
+++ b/pwiz_tools/Osprey/Osprey.Tasks/FirstPassModelIO.cs
@@ -164,9 +164,20 @@ namespace pwiz.Osprey.Tasks
                 var dto = JsonConvert.DeserializeObject<ModelDto>(File.ReadAllText(path), settings);
                 if (dto == null || dto.SchemaVersion != 1 ||
                     dto.Means == null || dto.Stds == null || dto.Means.Length != dto.Stds.Length ||
+                    dto.NumFeatures != dto.Means.Length ||
                     dto.FoldWeights == null || dto.FoldWeights.Length == 0 ||
                     dto.FoldBiases == null || dto.FoldBiases.Length != dto.FoldWeights.Length)
                     return null;
+
+                // Each fold's linear weights must be present and match the feature width,
+                // or the frozen scorer would dereference null / index past the end while
+                // scoring on the merge node -- an opaque crash outside this method's
+                // documented null-on-unreadable contract.
+                foreach (var foldWeights in dto.FoldWeights)
+                {
+                    if (foldWeights == null || foldWeights.Length != dto.Means.Length)
+                        return null;
+                }
 
                 return new PercolatorResults
                 {

--- a/pwiz_tools/Osprey/Osprey.Tasks/FirstPassModelIO.cs
+++ b/pwiz_tools/Osprey/Osprey.Tasks/FirstPassModelIO.cs
@@ -1,0 +1,172 @@
+/*
+ * Original author: Brendan MacLean <brendanx .at. uw.edu>,
+ *                  MacCoss Lab, Department of Genome Sciences, UW
+ * AI assistance: Claude Code (Claude Opus 4.8) <noreply .at. anthropic.com>
+ *
+ * Based on osprey (https://github.com/MacCossLab/osprey)
+ *   by Michael J. MacCoss, MacCoss Lab, Department of Genome Sciences, UW
+ *
+ * Copyright 2026 University of Washington - Seattle, WA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Newtonsoft.Json;
+using pwiz.Osprey.Core;
+using pwiz.Osprey.FDR;
+using pwiz.Osprey.IO;
+using pwiz.Osprey.ML;
+
+namespace pwiz.Osprey.Tasks
+{
+    /// <summary>
+    /// Persists the trained 1st-pass Percolator model to a small join-wide JSON sidecar
+    /// so a distributed <c>--task SecondPassFDR</c> merge node -- or any resume that
+    /// skips 1st-pass training -- can run the frozen 2nd-pass modes
+    /// (OSPREY_PASS2_QVALUE=transfer / transfer-compete / protein-compact) without the
+    /// in-process <see cref="FirstPassPercolatorModel"/>. Without this the merge node hits
+    /// the <see cref="Pass2FdrSidecar"/> fail-fast ("a distributed SecondPassFDR merge node
+    /// that never trained pass 1").
+    ///
+    /// Only the slice <see cref="FrozenModelScorer"/> consumes is stored: the feature
+    /// standardizer (<see cref="FeatureStandardizer.Means"/>/<see cref="FeatureStandardizer.Stds"/>)
+    /// plus the per-fold linear weights and biases. Doubles route through
+    /// <see cref="RoundtripDoubleConverter"/> so a reloaded model scores BIT-IDENTICALLY to
+    /// the in-process original (the <see cref="FrozenModelScorer.TryCreate"/> fold-average is
+    /// applied to the same per-fold values either way).
+    ///
+    /// GBDT (<c>--fdr-method gbdt</c>) is NOT persisted here: the tree ensembles carry no
+    /// linear weights, so <see cref="Save"/> declines and a GBDT merge node keeps the prior
+    /// fail-fast behavior (unchanged) until tree serialization is added.
+    /// </summary>
+    internal static class FirstPassModelIO
+    {
+        private const string ModelSuffix = @".1st-pass.model.json";
+
+        /// <summary>Serializable slice of <see cref="PercolatorResults"/> the frozen scorer needs.</summary>
+        private sealed class ModelDto
+        {
+            public int SchemaVersion { get; set; }
+            public int NumFeatures { get; set; }
+            public double[] Means { get; set; }
+            public double[] Stds { get; set; }
+            public double[][] FoldWeights { get; set; }
+            public double[] FoldBiases { get; set; }
+        }
+
+        /// <summary>
+        /// Per-file model sidecar path <c>&lt;parquetDir&gt;/&lt;fileStem&gt;.1st-pass.model.json</c>,
+        /// sitting beside the file's other Stage-5 sidecars (<c>.calibration.json</c>,
+        /// <c>.1st-pass.fdr_scores.bin</c>, <c>.reconciliation.json</c>). Per-file (not
+        /// join-wide) so a distributed <c>--task SecondPassFDR</c> merge node finds it by the
+        /// SAME input-file-stem derivation it uses for every other reconciled sidecar -- the
+        /// model is identical across files, so any one copy serves. <paramref name="parquetPath"/>
+        /// is the file's score parquet; only its directory is used.
+        /// </summary>
+        public static string PathFor(string parquetPath, string fileStem)
+        {
+            string dir = Path.GetDirectoryName(Path.GetFullPath(parquetPath)) ?? string.Empty;
+            return Path.Combine(dir, fileStem + ModelSuffix);
+        }
+
+        /// <summary>
+        /// Load the model from the first per-file sidecar that exists among
+        /// <paramref name="perFileParquetPaths"/> (stem -&gt; score parquet path), or null when
+        /// none is present. The copies are identical, so the first hit is authoritative.
+        /// </summary>
+        public static PercolatorResults LoadFromAny(IReadOnlyDictionary<string, string> perFileParquetPaths)
+        {
+            if (perFileParquetPaths == null)
+                return null;
+            foreach (var kvp in perFileParquetPaths)
+            {
+                var model = Load(PathFor(kvp.Value, kvp.Key));
+                if (model != null)
+                    return model;
+            }
+            return null;
+        }
+
+        /// <summary>
+        /// Write the frozen-scorer slice of <paramref name="model"/> to <paramref name="path"/>.
+        /// Returns false (writing nothing) when the model has no linear weights or standardizer
+        /// -- the GBDT path, or an empty/degenerate model -- so the caller does not advertise a
+        /// sidecar the merge node cannot use.
+        /// </summary>
+        public static bool Save(string path, PercolatorResults model)
+        {
+            if (model?.Standardizer == null ||
+                model.FoldWeights == null || model.FoldWeights.Count == 0 ||
+                model.FoldBiases == null || model.FoldBiases.Count != model.FoldWeights.Count)
+                return false;
+
+            var dto = new ModelDto
+            {
+                SchemaVersion = 1,
+                NumFeatures = model.Standardizer.NumFeatures,
+                Means = model.Standardizer.Means,
+                Stds = model.Standardizer.Stds,
+                FoldWeights = model.FoldWeights.ToArray(),
+                FoldBiases = model.FoldBiases.ToArray(),
+            };
+
+            string parent = Path.GetDirectoryName(Path.GetFullPath(path));
+            if (!string.IsNullOrEmpty(parent))
+                Directory.CreateDirectory(parent);
+
+            var settings = new JsonSerializerSettings { Converters = { new RoundtripDoubleConverter() } };
+            string json = JsonConvert.SerializeObject(dto, Formatting.Indented, settings);
+            // LF + trailing newline, matching the reconciliation.json convention so the
+            // artifact is stable across platforms.
+            json = json.Replace("\r\n", "\n");
+            if (!json.EndsWith("\n", StringComparison.Ordinal))
+                json += "\n";
+
+            using (var saver = new FileSaver(path))
+            {
+                File.WriteAllText(saver.SafeName, json);
+                saver.Commit();
+            }
+            return true;
+        }
+
+        /// <summary>
+        /// Load a persisted model, or return null when <paramref name="path"/> is absent or
+        /// unreadable (the caller then fails fast exactly as it did before persistence existed).
+        /// The returned <see cref="PercolatorResults"/> carries only the scorer slice
+        /// (standardizer + per-fold weights/biases); <see cref="FrozenModelScorer.TryCreate"/>
+        /// needs nothing else.
+        /// </summary>
+        public static PercolatorResults Load(string path)
+        {
+            if (string.IsNullOrEmpty(path) || !File.Exists(path))
+                return null;
+
+            var settings = new JsonSerializerSettings { Converters = { new RoundtripDoubleConverter() } };
+            var dto = JsonConvert.DeserializeObject<ModelDto>(File.ReadAllText(path), settings);
+            if (dto?.Means == null || dto.Stds == null || dto.FoldWeights == null || dto.FoldBiases == null)
+                return null;
+
+            var model = new PercolatorResults
+            {
+                Standardizer = FeatureStandardizer.FromMeansStds(dto.Means, dto.Stds),
+                FoldWeights = new List<double[]>(dto.FoldWeights),
+                FoldBiases = new List<double>(dto.FoldBiases),
+            };
+            return model;
+        }
+    }
+}

--- a/pwiz_tools/Osprey/Osprey.Tasks/FirstPassModelIO.cs
+++ b/pwiz_tools/Osprey/Osprey.Tasks/FirstPassModelIO.cs
@@ -155,18 +155,30 @@ namespace pwiz.Osprey.Tasks
             if (string.IsNullOrEmpty(path) || !File.Exists(path))
                 return null;
 
-            var settings = new JsonSerializerSettings { Converters = { new RoundtripDoubleConverter() } };
-            var dto = JsonConvert.DeserializeObject<ModelDto>(File.ReadAllText(path), settings);
-            if (dto?.Means == null || dto.Stds == null || dto.FoldWeights == null || dto.FoldBiases == null)
-                return null;
-
-            var model = new PercolatorResults
+            // A corrupt or truncated sidecar must load as null (the documented "unreadable"
+            // contract) rather than throw and crash the merge node: a bad read/parse and a
+            // shape-invariant violation both fall back to the pre-persistence fail-fast.
+            try
             {
-                Standardizer = FeatureStandardizer.FromMeansStds(dto.Means, dto.Stds),
-                FoldWeights = new List<double[]>(dto.FoldWeights),
-                FoldBiases = new List<double>(dto.FoldBiases),
-            };
-            return model;
+                var settings = new JsonSerializerSettings { Converters = { new RoundtripDoubleConverter() } };
+                var dto = JsonConvert.DeserializeObject<ModelDto>(File.ReadAllText(path), settings);
+                if (dto == null || dto.SchemaVersion != 1 ||
+                    dto.Means == null || dto.Stds == null || dto.Means.Length != dto.Stds.Length ||
+                    dto.FoldWeights == null || dto.FoldWeights.Length == 0 ||
+                    dto.FoldBiases == null || dto.FoldBiases.Length != dto.FoldWeights.Length)
+                    return null;
+
+                return new PercolatorResults
+                {
+                    Standardizer = FeatureStandardizer.FromMeansStds(dto.Means, dto.Stds),
+                    FoldWeights = new List<double[]>(dto.FoldWeights),
+                    FoldBiases = new List<double>(dto.FoldBiases),
+                };
+            }
+            catch (Exception)
+            {
+                return null;
+            }
         }
     }
 }

--- a/pwiz_tools/Osprey/Osprey.Tasks/Pass2FdrSidecar.cs
+++ b/pwiz_tools/Osprey/Osprey.Tasks/Pass2FdrSidecar.cs
@@ -99,9 +99,13 @@ namespace pwiz.Osprey.Tasks
             // publish so the frozen dispatch below finds it instead of fail-fasting. No-op
             // when the model is already present, the mode is the default retrain, or the
             // sidecar is absent (the existing fail-fast then applies).
+            // protein-compact is intentionally NOT here: it also needs the
+            // ProteinCompactStratum, which is not yet persisted to the merge node
+            // (follow-up). Reloading only the model would log a misleading "reloaded"
+            // success and still fail-fast on the missing stratum. transfer /
+            // transfer-compete need the model alone.
             bool wantsFrozenModel = OspreyEnvironment.Pass2TransferQ ||
-                                    OspreyEnvironment.Pass2TransferCompete ||
-                                    (OspreyEnvironment.Pass2ProteinCompact && !OspreyEnvironment.Pass2ProteinCompactRetrain);
+                                    OspreyEnvironment.Pass2TransferCompete;
             if (wantsFrozenModel && !ctx.TryGet<FirstPassPercolatorModel>(out _))
             {
                 var reloaded = FirstPassModelIO.LoadFromAny(perFileParquetPaths);

--- a/pwiz_tools/Osprey/Osprey.Tasks/Pass2FdrSidecar.cs
+++ b/pwiz_tools/Osprey/Osprey.Tasks/Pass2FdrSidecar.cs
@@ -93,6 +93,25 @@ namespace pwiz.Osprey.Tasks
                     OspreyEnvironment.PASS2_QVALUE_TRANSFER));
             }
 
+            // Frozen 2nd-pass modes need the trained 1st-pass model. On a distributed
+            // --task SecondPassFDR merge node (or any resume that skipped 1st-pass training)
+            // it was never published in-process; reload it from the per-file sidecar and
+            // publish so the frozen dispatch below finds it instead of fail-fasting. No-op
+            // when the model is already present, the mode is the default retrain, or the
+            // sidecar is absent (the existing fail-fast then applies).
+            bool wantsFrozenModel = OspreyEnvironment.Pass2TransferQ ||
+                                    OspreyEnvironment.Pass2TransferCompete ||
+                                    (OspreyEnvironment.Pass2ProteinCompact && !OspreyEnvironment.Pass2ProteinCompactRetrain);
+            if (wantsFrozenModel && !ctx.TryGet<FirstPassPercolatorModel>(out _))
+            {
+                var reloaded = FirstPassModelIO.LoadFromAny(perFileParquetPaths);
+                if (reloaded != null)
+                {
+                    ctx.Publish(new FirstPassPercolatorModel { Results = reloaded });
+                    ctx.LogInfo(@"Reloaded persisted 1st-pass model sidecar for frozen 2nd-pass.");
+                }
+            }
+
             // When the projection 2nd-pass compute ran (flag on), this holds the scored
             // FdrProjectionSet -- non-null is the flag that the StreamingSink already
             // wrote each file's .2nd-pass.fdr_scores.bin + validity sidecar DURING the

--- a/pwiz_tools/Osprey/Osprey.Tasks/PipelineContext.cs
+++ b/pwiz_tools/Osprey/Osprey.Tasks/PipelineContext.cs
@@ -385,7 +385,7 @@ namespace pwiz.Osprey.Tasks
         /// is a loud exception at the next <see cref="Get{TInfo}"/>, not silent corruption.
         ///
         /// NOT for the <c>PerFileEntries</c> milestone family: the DEBUG republish guard
-        /// (<c>_consumedByproducts</c> / <see cref="AssertMilestoneConsumedBeforeRepublish{TInfo}"/>)
+        /// (<c>_consumedByproducts</c> / <c>AssertMilestoneConsumedBeforeRepublish</c>)
         /// is not updated here, so releasing a milestone and republishing over the same
         /// backing list would read stale state. Prefer <see cref="Consume{TInfo}"/>.
         /// </summary>

--- a/pwiz_tools/Osprey/Osprey.Test/FirstPassModelIoTest.cs
+++ b/pwiz_tools/Osprey/Osprey.Test/FirstPassModelIoTest.cs
@@ -89,7 +89,7 @@ namespace pwiz.Osprey.Test
                 Assert.IsNotNull(reloaded, @"reloaded model should not be null");
 
                 // Structural bit-parity.
-                AssertBitEqual(model.Standardizer.NumFeatures, reloaded.Standardizer.NumFeatures, @"NumFeatures");
+                Assert.AreEqual(model.Standardizer.NumFeatures, reloaded.Standardizer.NumFeatures, @"NumFeatures");
                 for (int i = 0; i < model.Standardizer.Means.Length; i++)
                 {
                     AssertBitEqual(model.Standardizer.Means[i], reloaded.Standardizer.Means[i], @"Means[" + i + @"]");

--- a/pwiz_tools/Osprey/Osprey.Test/FirstPassModelIoTest.cs
+++ b/pwiz_tools/Osprey/Osprey.Test/FirstPassModelIoTest.cs
@@ -1,0 +1,160 @@
+/*
+ * Original author: Brendan MacLean <brendanx .at. uw.edu>,
+ *                  MacCoss Lab, Department of Genome Sciences, UW
+ * AI assistance: Claude Code (Claude Opus 4.8) <noreply .at. anthropic.com>
+ *
+ * Based on osprey (https://github.com/MacCossLab/osprey)
+ *   by Michael J. MacCoss, MacCoss Lab, Department of Genome Sciences, UW
+ *
+ * Copyright 2026 University of Washington - Seattle, WA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using pwiz.Osprey.FDR;
+using pwiz.Osprey.ML;
+using pwiz.Osprey.Tasks;
+
+namespace pwiz.Osprey.Test
+{
+    /// <summary>
+    /// Round-trip tests for <see cref="FirstPassModelIO"/>: a reloaded 1st-pass model
+    /// (the sidecar a distributed SecondPassFDR merge node reads to run the frozen
+    /// 2nd-pass modes) must score BIT-IDENTICALLY to the in-process original. Without
+    /// bit-parity the pass-2-only path would report different q-values than a
+    /// straight-through run under the same flag.
+    /// </summary>
+    [TestClass]
+    public class FirstPassModelIoTest
+    {
+        private static PercolatorResults MakeSvmModel()
+        {
+            // Deliberately awkward doubles (long mantissas, negatives, tiny/huge) so a
+            // lossy serializer would visibly break the round-trip. Negative zero is
+            // intentionally NOT tested: JSON normalizes -0.0 to +0.0, which is harmless
+            // here (means/weights only feed subtraction and multiplication, where the two
+            // zeros are interchangeable), but would fail a raw bit-parity assertion.
+            var means = new[] { 0.1234567890123456, -12.98765432109876, 1e-9, 42.0, 0.0009765625 };
+            var stds = new[] { 1.4142135623730951, 2.718281828459045, 3.141592653589793, 0.5, 1e6 };
+            return new PercolatorResults
+            {
+                Standardizer = FeatureStandardizer.FromMeansStds(means, stds),
+                FoldWeights = new List<double[]>
+                {
+                    new[] { 0.9, -1.1, 2.2222222222222223, -3.3, 0.0001 },
+                    new[] { -0.5, 1.25, -2.5, 3.75, -1e-8 },
+                    new[] { 1e-12, -1e12, 0.333333333333333, -0.6666666666666666, 7.0 },
+                },
+                FoldBiases = new List<double> { 0.123456789, -9.87654321, 1e-7 },
+            };
+        }
+
+        private static void AssertBitEqual(double expected, double actual, string what)
+        {
+            Assert.AreEqual(
+                BitConverter.DoubleToInt64Bits(expected),
+                BitConverter.DoubleToInt64Bits(actual),
+                what + string.Format(@" (expected {0:R}, got {1:R})", expected, actual));
+        }
+
+        [TestMethod]
+        public void TestFirstPassModelRoundTripScoresBitIdentical()
+        {
+            var model = MakeSvmModel();
+            var scorerBefore = FrozenModelScorer.TryCreate(model);
+            Assert.IsNotNull(scorerBefore, @"original model should produce a scorer");
+
+            string path = Path.Combine(Path.GetTempPath(),
+                @"osprey_model_roundtrip_" + Guid.NewGuid().ToString(@"N") + @".json");
+            try
+            {
+                Assert.IsTrue(FirstPassModelIO.Save(path, model), @"SVM model should persist");
+                Assert.IsTrue(File.Exists(path), @"sidecar should exist after Save");
+
+                var reloaded = FirstPassModelIO.Load(path);
+                Assert.IsNotNull(reloaded, @"reloaded model should not be null");
+
+                // Structural bit-parity.
+                AssertBitEqual(model.Standardizer.NumFeatures, reloaded.Standardizer.NumFeatures, @"NumFeatures");
+                for (int i = 0; i < model.Standardizer.Means.Length; i++)
+                {
+                    AssertBitEqual(model.Standardizer.Means[i], reloaded.Standardizer.Means[i], @"Means[" + i + @"]");
+                    AssertBitEqual(model.Standardizer.Stds[i], reloaded.Standardizer.Stds[i], @"Stds[" + i + @"]");
+                }
+                Assert.AreEqual(model.FoldWeights.Count, reloaded.FoldWeights.Count, @"fold count");
+                for (int f = 0; f < model.FoldWeights.Count; f++)
+                {
+                    AssertBitEqual(model.FoldBiases[f], reloaded.FoldBiases[f], @"FoldBiases[" + f + @"]");
+                    for (int j = 0; j < model.FoldWeights[f].Length; j++)
+                        AssertBitEqual(model.FoldWeights[f][j], reloaded.FoldWeights[f][j], @"FoldWeights[" + f + @"][" + j + @"]");
+                }
+
+                // The contract that actually matters: identical scores through the scorer.
+                var scorerAfter = FrozenModelScorer.TryCreate(reloaded);
+                Assert.IsNotNull(scorerAfter, @"reloaded model should produce a scorer");
+                var rows = new[]
+                {
+                    new[] { 1.0, 2.0, 3.0, 4.0, 5.0 },
+                    new[] { -3.14, 0.0, 100.0, -1e-6, 2.5 },
+                    new[] { 0.0, 0.0, 0.0, 0.0, 0.0 },
+                    new[] { 1e9, -1e9, 1e-9, -1e-9, 12.5 },
+                };
+                foreach (var row in rows)
+                    AssertBitEqual(scorerBefore.Score(row), scorerAfter.Score(row), @"Score");
+            }
+            finally
+            {
+                if (File.Exists(path))
+                    File.Delete(path);
+            }
+        }
+
+        [TestMethod]
+        public void TestFirstPassModelSaveDeclinesGbtAndDegenerate()
+        {
+            // No linear weights (the GBDT shape, or a degenerate/empty model) -> Save writes
+            // nothing so the merge node keeps its existing fail-fast rather than loading a
+            // sidecar it cannot score with.
+            string path = Path.Combine(Path.GetTempPath(),
+                @"osprey_model_decline_" + Guid.NewGuid().ToString(@"N") + @".json");
+            try
+            {
+                var noWeights = new PercolatorResults
+                {
+                    Standardizer = FeatureStandardizer.FromMeansStds(new[] { 0.0, 1.0 }, new[] { 1.0, 1.0 }),
+                };
+                Assert.IsFalse(FirstPassModelIO.Save(path, noWeights), @"model without linear weights should not persist");
+                Assert.IsFalse(File.Exists(path), @"no sidecar should be written when Save declines");
+                Assert.IsFalse(FirstPassModelIO.Save(path, null), @"null model should not persist");
+            }
+            finally
+            {
+                if (File.Exists(path))
+                    File.Delete(path);
+            }
+        }
+
+        [TestMethod]
+        public void TestFirstPassModelLoadMissingReturnsNull()
+        {
+            // Absent sidecar -> null (the caller then fails fast exactly as before persistence).
+            string missing = Path.Combine(Path.GetTempPath(),
+                @"osprey_model_missing_" + Guid.NewGuid().ToString(@"N") + @".json");
+            Assert.IsNull(FirstPassModelIO.Load(missing), @"missing sidecar should load as null");
+        }
+    }
+}

--- a/pwiz_tools/Osprey/Osprey.Test/FirstPassModelIoTest.cs
+++ b/pwiz_tools/Osprey/Osprey.Test/FirstPassModelIoTest.cs
@@ -156,5 +156,46 @@ namespace pwiz.Osprey.Test
                 @"osprey_model_missing_" + Guid.NewGuid().ToString(@"N") + @".json");
             Assert.IsNull(FirstPassModelIO.Load(missing), @"missing sidecar should load as null");
         }
+
+        [TestMethod]
+        public void TestFirstPassModelLoadRejectsCorruptOrInconsistent()
+        {
+            // Load's contract is null (fail-fast) on anything unreadable: it must never
+            // throw and crash the merge node, and never accept a shape-inconsistent model
+            // that the frozen scorer would then crash on or silently mis-score with.
+            AssertLoadsNull(@"{ not valid json", @"malformed JSON");
+            AssertLoadsNull(@"{}", @"empty object (all fields null)");
+            AssertLoadsNull(
+                @"{ ""SchemaVersion"": 2, ""NumFeatures"": 2, ""Means"": [0.0, 1.0], ""Stds"": [1.0, 1.0], " +
+                @"""FoldWeights"": [[0.5, 0.5]], ""FoldBiases"": [0.0] }", @"future schema version");
+            AssertLoadsNull(
+                @"{ ""SchemaVersion"": 1, ""NumFeatures"": 3, ""Means"": [0.0, 1.0], ""Stds"": [1.0, 1.0], " +
+                @"""FoldWeights"": [[0.5, 0.5]], ""FoldBiases"": [0.0] }", @"NumFeatures != Means.Length");
+            AssertLoadsNull(
+                @"{ ""SchemaVersion"": 1, ""NumFeatures"": 2, ""Means"": [0.0, 1.0], ""Stds"": [1.0], " +
+                @"""FoldWeights"": [[0.5, 0.5]], ""FoldBiases"": [0.0] }", @"Means/Stds length mismatch");
+            AssertLoadsNull(
+                @"{ ""SchemaVersion"": 1, ""NumFeatures"": 2, ""Means"": [0.0, 1.0], ""Stds"": [1.0, 1.0], " +
+                @"""FoldWeights"": [[0.5, 0.5, 0.5]], ""FoldBiases"": [0.0] }", @"fold width != feature count");
+            AssertLoadsNull(
+                @"{ ""SchemaVersion"": 1, ""NumFeatures"": 2, ""Means"": [0.0, 1.0], ""Stds"": [1.0, 1.0], " +
+                @"""FoldWeights"": [[0.5, 0.5]], ""FoldBiases"": [0.0, 0.0] }", @"bias/fold count mismatch");
+        }
+
+        private static void AssertLoadsNull(string json, string what)
+        {
+            string path = Path.Combine(Path.GetTempPath(),
+                @"osprey_model_bad_" + Guid.NewGuid().ToString(@"N") + @".json");
+            try
+            {
+                File.WriteAllText(path, json);
+                Assert.IsNull(FirstPassModelIO.Load(path), what + @" should load as null");
+            }
+            finally
+            {
+                if (File.Exists(path))
+                    File.Delete(path);
+            }
+        }
     }
 }

--- a/pwiz_tools/Osprey/regression.ps1
+++ b/pwiz_tools/Osprey/regression.ps1
@@ -640,6 +640,13 @@ function Invoke-HpcChain {
         Copy-Item (Join-Path $ph1 "$s.calibration.json")        (Join-Path $ph3 "$s.calibration.json")
         Copy-Item (Join-Path $ph2 "$s.1st-pass.fdr_scores.bin") (Join-Path $ph3 "$s.1st-pass.fdr_scores.bin")
         Copy-Item (Join-Path $ph2 "$s.reconciliation.json")     (Join-Path $ph3 "$s.reconciliation.json")
+        # The 1st-pass model sidecar (frozen 2nd-pass modes) must ride the same
+        # phase2 -> phase3 -> phase4 relay as the other Stage-5 sidecars: $ph2 is
+        # deleted below (before the merge node), so the merge node can only reach it
+        # via a phase-3 hop. Present only for the SVM/percolator framework; absent for
+        # the GBDT golden, so guard with Test-Path.
+        $ph2model = Join-Path $ph2 "$s.1st-pass.model.json"
+        if (Test-Path $ph2model) { Copy-Item $ph2model (Join-Path $ph3 "$s.1st-pass.model.json") }
         Copy-LibraryInto -Library $Library -Dir $ph3 -Manifest $Manifest
         $a3 = @('--task', 'PerFileRescoring', '--input-scores', "$s.scores.parquet",
                 '-l', $libName, '-o', 'output.blib', '--resolution', $Resolution,
@@ -679,11 +686,11 @@ function Invoke-HpcChain {
         Copy-Item (Join-Path $ph3 "$s.calibration.json")          (Join-Path $ph4 "$s.calibration.json")
         Copy-Item (Join-Path $ph3 "$s.reconciliation.json")       (Join-Path $ph4 "$s.reconciliation.json")
         # Ship the persisted 1st-pass model so the merge node can run the frozen 2nd-pass
-        # modes (transfer / transfer-compete) without re-training. It is written by the
-        # FirstPassFDR join node (phase 2), not the per-file rescore (phase 3). Absent for
-        # the default percolator golden (which retrains), so guard with Test-Path.
-        # (protein-compact additionally needs the protein stratum, not yet persisted.)
-        $modelSide = Join-Path $ph2 "$s.1st-pass.model.json"
+        # modes (transfer / transfer-compete) without re-training. Written by the
+        # FirstPassFDR join node (phase 2) and relayed into $ph3 above ($ph2 is already
+        # deleted by now). Present for the SVM/percolator framework, so guard with
+        # Test-Path. (protein-compact additionally needs the protein stratum, not yet persisted.)
+        $modelSide = Join-Path $ph3 "$s.1st-pass.model.json"
         if (Test-Path $modelSide) { Copy-Item $modelSide (Join-Path $ph4 "$s.1st-pass.model.json") }
         $pass2 = Join-Path $ph3 "$s.2nd-pass.fdr_scores.bin"
         if (Test-Path $pass2) { Copy-Item $pass2 (Join-Path $ph4 "$s.2nd-pass.fdr_scores.bin") }

--- a/pwiz_tools/Osprey/regression.ps1
+++ b/pwiz_tools/Osprey/regression.ps1
@@ -678,6 +678,11 @@ function Invoke-HpcChain {
         Copy-Item (Join-Path $ph3 "$s.1st-pass.fdr_scores.bin")   (Join-Path $ph4 "$s.1st-pass.fdr_scores.bin")
         Copy-Item (Join-Path $ph3 "$s.calibration.json")          (Join-Path $ph4 "$s.calibration.json")
         Copy-Item (Join-Path $ph3 "$s.reconciliation.json")       (Join-Path $ph4 "$s.reconciliation.json")
+        # Ship the persisted 1st-pass model so the merge node can run the frozen 2nd-pass
+        # modes (transfer / transfer-compete / protein-compact) without re-training. Absent
+        # for the default percolator golden (which retrains), so guard with Test-Path.
+        $modelSide = Join-Path $ph3 "$s.1st-pass.model.json"
+        if (Test-Path $modelSide) { Copy-Item $modelSide (Join-Path $ph4 "$s.1st-pass.model.json") }
         $pass2 = Join-Path $ph3 "$s.2nd-pass.fdr_scores.bin"
         if (Test-Path $pass2) { Copy-Item $pass2 (Join-Path $ph4 "$s.2nd-pass.fdr_scores.bin") }
         New-Item -ItemType File -Path (Join-Path $ph4 "$s.mzML") -Force | Out-Null

--- a/pwiz_tools/Osprey/regression.ps1
+++ b/pwiz_tools/Osprey/regression.ps1
@@ -679,9 +679,11 @@ function Invoke-HpcChain {
         Copy-Item (Join-Path $ph3 "$s.calibration.json")          (Join-Path $ph4 "$s.calibration.json")
         Copy-Item (Join-Path $ph3 "$s.reconciliation.json")       (Join-Path $ph4 "$s.reconciliation.json")
         # Ship the persisted 1st-pass model so the merge node can run the frozen 2nd-pass
-        # modes (transfer / transfer-compete / protein-compact) without re-training. Absent
-        # for the default percolator golden (which retrains), so guard with Test-Path.
-        $modelSide = Join-Path $ph3 "$s.1st-pass.model.json"
+        # modes (transfer / transfer-compete) without re-training. It is written by the
+        # FirstPassFDR join node (phase 2), not the per-file rescore (phase 3). Absent for
+        # the default percolator golden (which retrains), so guard with Test-Path.
+        # (protein-compact additionally needs the protein stratum, not yet persisted.)
+        $modelSide = Join-Path $ph2 "$s.1st-pass.model.json"
         if (Test-Path $modelSide) { Copy-Item $modelSide (Join-Path $ph4 "$s.1st-pass.model.json") }
         $pass2 = Join-Path $ph3 "$s.2nd-pass.fdr_scores.bin"
         if (Test-Path $pass2) { Copy-Item $pass2 (Join-Path $ph4 "$s.2nd-pass.fdr_scores.bin") }


### PR DESCRIPTION
## Summary

* Persisted the trained 1st-pass Percolator model to a per-file `<stem>.1st-pass.model.json`
  sidecar (feature standardizer + fold weights/biases, byte-exact via `RoundtripDoubleConverter`)
  so the frozen 2nd-pass modes can run in a distributed `--task SecondPassFDR` merge node — or any
  resume that skips 1st-pass training — without re-training. Previously the merge node had no
  in-process model and fail-fasted.
* Added `FeatureStandardizer.FromMeansStds` to reconstruct the standardizer from persisted stats.
* Reload in `Pass2FdrSidecar.ComputeAndPersist`: when a frozen mode is requested and the model
  isn't in ctx, load the sidecar and publish it; the existing frozen dispatch is unchanged.
  Fail-fast still applies when the sidecar (or, for `protein-compact`, the protein stratum) is absent.
* Wrote the sidecar per-file (identical copies) so the merge node finds it by the same input-file
  stem it uses for every other reconciled sidecar; `regression.ps1`'s HPC-chain phase-4 setup ships
  it from the FirstPassFDR (phase 2) node to the merge node.
* SVM/percolator-framework only; the GBDT path declines to persist (merge-node GBDT keeps its
  prior fail-fast, unchanged).

This unblocks running the frozen 2nd-pass modes at HPC scale (one stable stage 1-6, vary only the
pass-2 FDR), which the pass-2 default decision (#4484) needs.

## Scope / follow-ups (honest status)

* Enables `transfer` / `transfer-compete` in the merge node (model-only). **`protein-compact`
  additionally needs the protein stratum (`ProteinCompactStratum`) persisted** — a small,
  same-shaped follow-up (a set of base_ids); its merge-node path fail-fasts until then.
* End-to-end live merge-node reload verified structurally (persist fires + writes correct sidecars
  in the HPC chain phase 2, confirmed this session); a full `transfer-compete` chain run to watch
  the reload fire is queued (the machine was busy on the 82-file oracle overnight).
* `/code-review max` and an inspection re-verify (one pre-existing dangling-cref warning fixed here)
  are pending — deferred by the overnight budget.

## Test plan

- [x] `FirstPassModelIoTest` (3 tests) — reloaded model scores bit-identically; Save declines
  GBDT/degenerate; Load of a missing path returns null.
- [x] Straight-through `protein-compact` byte-unchanged with the change (30,130 @ 0.90% reproduced).
- [x] `regression.ps1 -Dataset Stellar` — mode 1/2/3 byte-identical golden (blib 30,597,120); the
  change is byte-neutral for the default percolator path.
- [x] Persist verified in the HPC chain — phase-2 writes per-file `<stem>.1st-pass.model.json`.
- [ ] Live `transfer-compete` merge-node reload run (queued).
- [ ] `protein-compact` merge-node (needs stratum persistence — follow-up).

Co-Authored-By: Claude <noreply@anthropic.com>
