### PR TITLE
pwiz: Preserved full double precision in cvParam text

### DIFF
--- a/pwiz/utility/misc/Jamfile.jam
+++ b/pwiz/utility/misc/Jamfile.jam
@@ -122,6 +122,7 @@ unit-test-if-exists almost_equal_test : almost_equal_test.cpp pwiz_utility_misc 
 unit-test-if-exists endian_test : endian_test.cpp pwiz_utility_misc Std ;
 unit-test-if-exists BinaryDataTestNative : BinaryDataTest.cpp pwiz_utility_misc Std ;
 unit-test-if-exists Base64Test : Base64Test.cpp pwiz_utility_misc Std ;
+unit-test-if-exists StringTest : StringTest.cpp pwiz_utility_misc Std ;
 unit-test-if-exists IntegerSetTest : IntegerSetTest.cpp pwiz_utility_misc Std ;
 unit-test-if-exists IterationListenerTest : IterationListenerTest.cpp pwiz_utility_misc Std ;
 unit-test-if-exists DateTimeTest : DateTimeTest.cpp pwiz_utility_misc Std ;

--- a/pwiz/utility/misc/String.cpp
+++ b/pwiz/utility/misc/String.cpp
@@ -21,6 +21,9 @@
 #include "String.hpp"
 #include <limits>
 #include <algorithm>
+#include <iomanip>
+#include <locale>
+#include <sstream>
 #include <boost/spirit/include/karma.hpp>
 
 using boost::spirit::karma::real_policies;
@@ -84,6 +87,50 @@ struct float5_policy_scientific : real_policies<T>
 };
 
 
+namespace {
+
+/// Parse a decimal string back to double independently of the global locale.
+/// karma generates locale-independently, so the round-trip check has to read
+/// that way too; strtod would follow a comma-decimal-point locale and reject
+/// text karma had just written with a period.
+double parseClassic(const std::string& text)
+{
+    std::istringstream iss(text);
+    iss.imbue(std::locale::classic());
+    double value = 0;
+    iss >> value;
+    return value;
+}
+
+/// The shortest decimal form of value that reloads bit-exact, found by trying
+/// 15, 16 and 17 significant digits in turn (17 = max_digits10, which always
+/// round-trips a double). Default float formatting is %g semantics, i.e.
+/// SIGNIFICANT digits, which is what round-tripping needs at every magnitude;
+/// karma's precision() counts FRACTIONAL digits and so cannot express this.
+///
+/// Deliberately not std::to_chars: floating-point to_chars is C++17 but its
+/// library support is not universal across the toolsets pwiz builds with
+/// (libstdc++ needs GCC 11, libc++ a recent LLVM), and this file is compiled
+/// everywhere. Deliberately not snprintf either: that follows the global
+/// locale, and would emit a comma decimal point into XML under e.g. de_DE.
+std::string toRoundTripString(double value)
+{
+    std::string widest;
+    for (int significantDigits = 15; significantDigits <= 17; ++significantDigits)
+    {
+        std::ostringstream oss;
+        oss.imbue(std::locale::classic());
+        oss << std::setprecision(significantDigits) << value;
+        widest = oss.str();
+        if (parseClassic(widest) == value)
+            return widest;
+    }
+    return widest; // 17 significant digits always round-trips a double
+}
+
+} // namespace
+
+
 template<typename PolicyT> std::string generateWithPolicy(typename PolicyT::value_type value)
 {
     static const real_generator<typename PolicyT::value_type, PolicyT> policy = PolicyT();
@@ -104,7 +151,24 @@ std::string pwiz::util::toString(double value, RealConvertPolicy policyFlags)
 
     switch (policyFlags)
     {
-        case RealConvertPolicy::AutoNotation: return generateWithPolicy<double12_policy<double>>(value);
+        case RealConvertPolicy::AutoNotation:
+        {
+            // 12 fractional digits is enough for almost every value pwiz writes,
+            // and it is what keeps output free of lexical_cast noise like
+            // 123.00000000007. But it is a SILENT truncation when a value needs
+            // more: a Thermo scan start time of 1.8119944333330003 minutes was
+            // written as 1.811994433333 and reloaded one ULP away, so an mzML
+            // could not reproduce the value read from the raw file.
+            //
+            // Keep the historical text whenever it already reloads bit-exact
+            // (the overwhelmingly common case, so existing output and file sizes
+            // are unchanged), and fall back to the shortest round-tripping form
+            // only where the fast path would lose information.
+            std::string result = generateWithPolicy<double12_policy<double>>(value);
+            if (parseClassic(result) == value)
+                return result;
+            return toRoundTripString(value);
+        }
         case RealConvertPolicy::FixedNotation: return generateWithPolicy<double12_policy_fixed<double>>(value);
         case RealConvertPolicy::ScientificNotation: return generateWithPolicy<double12_policy_scientific<double>>(value);
         default: throw std::runtime_error("[toString] unknown RealConvertPolicy");

--- a/pwiz/utility/misc/String.cpp
+++ b/pwiz/utility/misc/String.cpp
@@ -89,17 +89,24 @@ struct float5_policy_scientific : real_policies<T>
 
 namespace {
 
-/// Parse a decimal string back to double independently of the global locale.
-/// karma generates locale-independently, so the round-trip check has to read
-/// that way too; strtod would follow a comma-decimal-point locale and reject
-/// text karma had just written with a period.
-double parseClassic(const std::string& text)
+/// True when text reloads to exactly value, read independently of the global
+/// locale. karma generates locale-independently, so the round-trip check has to
+/// read that way too; strtod would follow a comma-decimal-point locale and
+/// reject text karma had just written with a period.
+///
+/// The failbit test is NOT redundant with the equality test. C++11 requires an
+/// extraction that goes out of range to set failbit AND store the largest
+/// representable value, so a decimal just above DBL_MAX such as
+/// 1.79769313486232e+308 reads back as exactly DBL_MAX and compares equal
+/// without being the same number. A consumer reading that text with strtod
+/// gets inf instead.
+bool reloadsExactly(const std::string& text, double value)
 {
     std::istringstream iss(text);
     iss.imbue(std::locale::classic());
-    double value = 0;
-    iss >> value;
-    return value;
+    double reloaded = 0;
+    iss >> reloaded;
+    return !iss.fail() && reloaded == value;
 }
 
 /// The shortest decimal form of value that reloads bit-exact, found by trying
@@ -122,7 +129,7 @@ std::string toRoundTripString(double value)
         oss.imbue(std::locale::classic());
         oss << std::setprecision(significantDigits) << value;
         widest = oss.str();
-        if (parseClassic(widest) == value)
+        if (reloadsExactly(widest, value))
             return widest;
     }
     return widest; // 17 significant digits always round-trips a double
@@ -165,7 +172,7 @@ std::string pwiz::util::toString(double value, RealConvertPolicy policyFlags)
             // are unchanged), and fall back to the shortest round-tripping form
             // only where the fast path would lose information.
             std::string result = generateWithPolicy<double12_policy<double>>(value);
-            if (parseClassic(result) == value)
+            if (reloadsExactly(result, value))
                 return result;
             return toRoundTripString(value);
         }

--- a/pwiz/utility/misc/StringTest.cpp
+++ b/pwiz/utility/misc/StringTest.cpp
@@ -53,7 +53,10 @@ void testRoundTrip()
         // Ordinary values that the fast path already represents exactly; these
         // must keep their existing short text (see testFastPathTextUnchanged).
         0.0, 1.0, 0.1, 12.5, 500.25, -3.75,
-        // Range extremes and awkward magnitudes.
+        // Range extremes and awkward magnitudes. DBL_MAX is the one that caught
+        // toString accepting a 15-digit form whose decimal exceeds DBL_MAX: an
+        // out-of-range istringstream extraction stores the largest representable
+        // value, so the round-trip check saw equality where strtod sees inf.
         1e-9, 1e9, 1.7976931348623157e308, 2.2250738585072014e-308,
         std::numeric_limits<double>::epsilon(),
         // A value whose shortest round-trip form needs all 17 digits.
@@ -64,6 +67,9 @@ void testRoundTrip()
     {
         double value = values[i];
         string text = toString(value);
+        // strtod, not the istringstream toString validates with: the oracle has
+        // to be a reader independent of the code under test, and the two differ
+        // on out-of-range text, which is where the defect was.
         double reloaded = strtod(text.c_str(), NULL);
         if (os_) *os_ << "  " << text << " <- " << value << endl;
         unit_assert_operator_equal(value, reloaded);

--- a/pwiz/utility/misc/StringTest.cpp
+++ b/pwiz/utility/misc/StringTest.cpp
@@ -1,0 +1,131 @@
+//
+// $Id$
+//
+//
+// Original author: Brendan MacLean <brendanx .at. uw.edu>
+//
+// Copyright 2026 University of Washington - Seattle, WA
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+
+#include "Std.hpp"
+#include "String.hpp"
+#include "pwiz/utility/misc/unit.hpp"
+#include <cstring>
+#include <cstdlib>
+#include <limits>
+
+
+using namespace pwiz::util;
+
+
+ostream* os_ = 0;
+
+
+// The property that matters: whatever toString writes, reading it back must
+// give the identical double. Without this, a value can be serialized to mzML
+// and reloaded a ULP away, and nothing in the pipeline notices.
+void testRoundTrip()
+{
+    if (os_) *os_ << "testRoundTrip()\n";
+
+    const double values[] =
+    {
+        // Retention times observed in a Thermo DIA acquisition. These are the
+        // motivating case: the 12-fractional-digit fast path truncated them,
+        // so an mzML written from a .raw could not reproduce the raw value.
+        1.8119944333330003,
+        3.0261190166670002,
+        0.5903116999999999,
+        4.774856783332999,
+        // Ordinary values that the fast path already represents exactly; these
+        // must keep their existing short text (see testFastPathTextUnchanged).
+        0.0, 1.0, 0.1, 12.5, 500.25, -3.75,
+        // Range extremes and awkward magnitudes.
+        1e-9, 1e9, 1.7976931348623157e308, 2.2250738585072014e-308,
+        std::numeric_limits<double>::epsilon(),
+        // A value whose shortest round-trip form needs all 17 digits.
+        0.10000000000000002,
+    };
+
+    for (size_t i = 0; i < sizeof(values) / sizeof(values[0]); ++i)
+    {
+        double value = values[i];
+        string text = toString(value);
+        double reloaded = strtod(text.c_str(), NULL);
+        if (os_) *os_ << "  " << text << " <- " << value << endl;
+        unit_assert_operator_equal(value, reloaded);
+    }
+}
+
+
+// Every double that survives a serialize/parse cycle must do so for the RIGHT
+// reason. Walking a wide range of magnitudes catches a policy change that
+// happens to work for the handful of literals above.
+void testRoundTripAcrossMagnitudes()
+{
+    if (os_) *os_ << "testRoundTripAcrossMagnitudes()\n";
+
+    // A cheap deterministic generator; no <random> so the sequence is identical
+    // on every platform and a failure is reproducible from the seed alone.
+    unsigned int seed = 20260729u;
+    for (int i = 0; i < 20000; ++i)
+    {
+        seed = seed * 1103515245u + 12345u;
+        double mantissa = (double)(seed % 1000000007u) / 1000000007.0;
+        seed = seed * 1103515245u + 12345u;
+        int exponent = (int)(seed % 40u) - 20;   // 1e-20 .. 1e19
+        double value = mantissa * pow(10.0, exponent);
+
+        string text = toString(value);
+        unit_assert_operator_equal(value, strtod(text.c_str(), NULL));
+    }
+}
+
+
+// The round-trip guarantee must not come at the cost of noisy output: values
+// the 12-digit path already renders exactly keep exactly that text, so existing
+// mzML output and file sizes are unchanged.
+void testFastPathTextUnchanged()
+{
+    if (os_) *os_ << "testFastPathTextUnchanged()\n";
+
+    unit_assert_operator_equal(string("0.0"), toString(0.0));
+    unit_assert_operator_equal(string("1.0"), toString(1.0));
+    unit_assert_operator_equal(string("0.1"), toString(0.1));
+    unit_assert_operator_equal(string("12.5"), toString(12.5));
+    unit_assert_operator_equal(string("500.25"), toString(500.25));
+    unit_assert_operator_equal(string("-3.75"), toString(-3.75));
+}
+
+
+int main(int argc, char* argv[])
+{
+    TEST_PROLOG(argc, argv)
+
+    try
+    {
+        if (argc>1 && !strcmp(argv[1],"-v")) os_ = &cout;
+        testRoundTrip();
+        testRoundTripAcrossMagnitudes();
+        testFastPathTextUnchanged();
+    }
+    catch (exception& e)
+    {
+        TEST_FAILED(e.what())
+    }
+
+    TEST_EPILOG
+}


### PR DESCRIPTION
## Summary

**Experimental / not ready for review** - posted to get TeamCity coverage and for information. See the note to Matt at the bottom; declining this in favour of #4178 is a reasonable outcome.

* `pwiz::util::toString(double)` truncates every double cvParam to **12 fractional digits** (`double12_policy`, `String.cpp`), so a Thermo scan start time of `1.8119944333330003` minutes is written as `1.811994433333` and reloads one ULP away. An mzML therefore cannot reproduce the value read from the raw file.
* The 12-digit policy exists to avoid `lexical_cast` noise like `123.00000000007`. Shortest round-trip formatting satisfies that aim and is also exact, so this keeps the karma output whenever it already reloads bit-exact and escalates only where it would lose information. **Existing output and file sizes are unchanged except where today's output is silently lossy** (+0.09% on a 2.41 GB Astral file).
* Deliberately not `std::to_chars`: floating-point `to_chars` is C++17 but library support is not universal across the toolsets pwiz builds with (`Jamroot.jam:393-396` targets msvc, gcc, darwin and clang; libstdc++ needs GCC 11). Deliberately not `snprintf` either: that follows the global locale and would emit a comma decimal point into XML under e.g. `de_DE`. Uses a classic-locale `ostringstream`, which is portable and locale-safe, on a path reached only for the rare values the fast path cannot represent.
* New `StringTest` asserts the property directly: everything `toString` writes must parse back equal, over the motivating Thermo retention times, range extremes, and 20,000 generated values across 40 decades - plus that ordinary values keep their exact existing text.

## Test plan

- [x] `StringTest` (new) - passes
- [x] `pwiz/data/msdata` - `Serializer_mzML_Test`, `IOTest`, `DiffTest`, `MSDataTest`, `SpectrumList_mzML_Test`, `ChromatogramList_mzML_Test`, `Serializer_mzXML_Test` all pass
- [x] Vendor readers - Thermo, Waters, Agilent, ABI, UNIFI, Shimadzu, UIMF, Mobilion all pass
- [x] No baseline regeneration needed: `VendorReaderTestHarness.cpp:382` compares parsed `MSData` via `Diff<MSData, DiffConfig>` with a precision tolerance, not mzML text, so extra digits do not disturb baselines
- [ ] `ReaderTest` and 4 of 52 `Reader_Bruker_Test` cases fail locally, but **identically on master**: both are `--without-compassxtract` artifacts (`Bruker API was built with only BAF and TDF support; YEP and FID files not supported`). Left for TeamCity to confirm on a full build.

## Note for @chambm

This is informational, not a request. Two things worth knowing:

1. **Nothing of ours is blocked on it.** Our downstream work reads mzML correctly without this fix, verified byte-for-byte on three datasets whose mzML was written by unpatched msconvert.
2. **#4178 may make it moot.** If ProteoWizard core moves to .NET 8, the conversion becomes .NET's own, which has been correctly-rounded shortest-round-trip since .NET Core 3.0, and the 12-digit policy disappears on its own.

One consequence if it does land: every mzML already archived was written by unpatched msconvert, so reading those raw files directly would no longer byte-match the stored mzML. That is a one-time discontinuity to land deliberately, not an argument against.

Related: #4496

Co-Authored-By: Claude <noreply@anthropic.com>