### PR TITLE
skyline: Preserved retention time precision when reading vendor files

### DIFF
--- a/pwiz_tools/Shared/ProteowizardWrapper/MsDataFileImpl.cs
+++ b/pwiz_tools/Shared/ProteowizardWrapper/MsDataFileImpl.cs
@@ -2102,6 +2102,15 @@ namespace pwiz.ProteowizardWrapper
             using CVParam param = scans[0].cvParam(CVID.MS_scan_start_time);
             if (param.empty())
                 return null;
+            // A value already recorded in minutes is returned as recorded.
+            // timeInSeconds()/60 is NOT an identity in floating point - it
+            // multiplies by 60 and divides again - so it silently perturbs most
+            // retention times by an ULP: 0.5903117 becomes 0.5903116999999999.
+            // Every vendor reader that sets scan start time in UO_minute (Thermo
+            // among them) was affected, which made a direct raw read disagree
+            // with the mzML converted from that same raw file.
+            if (param.units == CVID.UO_minute)
+                return param.value;
             return param.timeInSeconds() / 60;
         }
 


### PR DESCRIPTION
## Summary

**Experimental / not ready for review** - posted for TeamCity coverage.

* `MsDataFileImpl.GetStartTime` returned `param.timeInSeconds() / 60` for a scan start time the vendor reader had **already recorded in minutes** (`SpectrumList_Thermo.cpp:260` sets `UO_minute`). Minutes -> seconds -> minutes is not an identity in floating point:

      0.5903117      * 60 / 60 == 0.5903116999999999
      1.811994433333 * 60 / 60 == 1.8119944333330003

* This perturbed **9,269 of 161,099** retention times in one Thermo DIA acquisition, and affects every vendor reader that records scan start time in `UO_minute` - so Skyline has been reading retention times an ULP off for those formats too, independently of the Osprey work that surfaced it.
* Fix: return the recorded value when the unit is already minutes; keep the seconds conversion otherwise.

## Test plan

- [x] `ProteowizardWrapper` builds clean (x64)
- [x] With this fix, a `.spectra.bin` built by reading a Thermo `.raw` directly is **byte-identical** to one built from the mzML msconvert produced from that same raw file: 2,260,174,556 bytes, 161,099 MS2 + 965 MS1
- [x] Same file read through ProteoWizard vs a hand-written mzML parser: byte-identical on three datasets (TDP-43 Astral, SEA-AD Astral, Stellar unit-resolution)
- [ ] Skyline test suite - not run locally; leaving to TeamCity, since this changes retention times by up to an ULP for every vendor format that records minutes

Related: #4496

Co-Authored-By: Claude <noreply@anthropic.com>