### PR TITLE
osprey: Added vendor raw reading to the net472 configuration

### DIFF
--- a/pwiz_tools/Osprey/Documentation/Help/en/CommandLine.html
+++ b/pwiz_tools/Osprey/Documentation/Help/en/CommandLine.html
@@ -1,7 +1,7 @@
 <html><head>
 <meta charset="utf-8">
 <title>Osprey command-line usage</title>
-<meta name="description" content="Command-line usage for Osprey, the C# (.NET 8) implementation of Mike MacCoss's peptide-centric DIA search tool: search and FDR arguments, protein inference, and the four distributed HPC --task workers (PerFileScoring, FirstPassFDR, PerFileRescoring, SecondPassFDR).">
+<meta name="description" content="Command-line usage for Osprey, the C# (.NET 8) implementation of Mike MacCoss's peptide-centric DIA search tool: search and FDR arguments, protein inference, the SpectraCache staging task, and the four distributed HPC --task workers (PerFileScoring, FirstPassFDR, PerFileRescoring, SecondPassFDR).">
 <style>
 body { font: .875em/1.35 'Segoe UI','Lucida Grande',Verdana,Arial,Helvetica,sans-serif; max-width: 70em; }
 h1 { font-size: 1.6em; font-weight: 600; color: #000; margin: 0 0 .3em; }
@@ -66,7 +66,7 @@ a { color: #1565c0; }
 <div class="RowType">Distributed / HPC</div>
 <table>
 <tr><th>Argument</th><th>Description</th></tr>
-<tr><td><nobr>--task</nobr> &lt;PerFileScoring | FirstPassFDR | PerFileRescoring | SecondPassFDR&gt;</td><td>HPC: run exactly one pipeline task (one node = one task). Omit for the full pipeline.</td></tr>
+<tr><td><nobr>--task</nobr> &lt;SpectraCache | PerFileScoring | FirstPassFDR | PerFileRescoring | SecondPassFDR&gt;</td><td>HPC: run exactly one pipeline task (one node = one task). Omit for the full pipeline.</td></tr>
 <tr><td><nobr>--input-scores</nobr> &lt;paths|dir&gt;</td><td>HPC: one or more .scores.parquet files, or a single directory (<nobr>non-recursive</nobr>). Mutex with <nobr>--input</nobr>.</td></tr>
 </table>
 <div class="RowType">Logging</div>

--- a/pwiz_tools/Osprey/Jamfile.jam
+++ b/pwiz_tools/Osprey/Jamfile.jam
@@ -47,7 +47,7 @@ if [ modules.peek : NT ]
     # Osprey uses SDK-style csproj that auto-generates AssemblyInfo from
     # the MSBuild properties in pwiz_tools/Osprey/Directory.Build.props
     # (Company, Copyright, Version, etc.).  Unlike SkylineBatch/AutoQC/SeeMS,
-    # we do NOT generate Properties/AssemblyInfo.cs here -- doing so would
+    # we do NOT generate Properties/AssemblyInfo.cs here - doing so would
     # conflict with the SDK auto-gen and break the standalone build.ps1 flow
     # with CS0579 duplicate-attribute errors.  Instead we override the
     # Directory.Build.props placeholder version via /p:Version at build time.
@@ -90,11 +90,18 @@ if [ modules.peek : NT ]
         REM Osprey.sln, so it has to be built here first.  Its own up-to-date
         REM check makes this a couple of seconds when current.  Building
         REM CommonUtil comes along as its ProjectReference.
-        IF "$(OSPREY_VENDOR_READER)"=="true" (
-            echo Building ProteowizardWrapper for Osprey vendor raw reading...
-            msbuild $(PWIZ_WRAPPER_PATH)/ProteowizardWrapper.csproj /p:Configuration=$(CONFIGURATION);Platform=x64 /nologo /verbosity:minimal
-            IF ERRORLEVEL 1 exit %ERRORLEVEL%
-        )
+        REM Branch with GOTO rather than a parenthesized IF block. cmd.exe parses a
+        REM whole ( ) block before running any of it, so %ERRORLEVEL% inside one is
+        REM substituted with its value at PARSE time - 0 - and a failed wrapper build
+        REM would `exit 0`, killing the action before Osprey.sln builds while bjam
+        REM recorded success. Verified: the block form returns 0 on a command that
+        REM exits 7; this form returns 7. Same top-level idiom as Skyline
+        REM (Skyline/Jamfile.jam:185), which is correct for exactly this reason.
+        IF NOT "$(OSPREY_VENDOR_READER)"=="true" GOTO skip_wrapper_build
+        echo Building ProteowizardWrapper for Osprey vendor raw reading...
+        msbuild $(PWIZ_WRAPPER_PATH)/ProteowizardWrapper.csproj /p:Configuration=$(CONFIGURATION);Platform=x64 /nologo /verbosity:minimal
+        IF ERRORLEVEL 1 exit %ERRORLEVEL%
+        :skip_wrapper_build
         echo Building Osprey $(OSPREY_VERSION) in $(CONFIGURATION:L) configuration...
         msbuild $(OSPREY_PATH)/Osprey.sln /p:Configuration=$(CONFIGURATION);Platform=x64;Version=$(OSPREY_VERSION);OspreyVendorReader=$(OSPREY_VENDOR_READER) /nologo /verbosity:minimal
         IF ERRORLEVEL 1 exit %ERRORLEVEL%
@@ -122,7 +129,7 @@ if [ modules.peek : NT ]
     #
     # Note the TFM subdirectory. Osprey multi-targets net472;net8.0
     # (Directory.Build.props), and pwiz_data_cli is a net472-only mixed-mode
-    # assembly, so only the net472 output can load it -- putting the native
+    # assembly, so only the net472 output can load it - putting the native
     # vendor DLLs anywhere else would leave the wrapper unable to resolve them
     # at run time with nothing but "could not load file or assembly" to go on.
     # Both configurations are covered the way Skyline covers them: the vendor

--- a/pwiz_tools/Osprey/Jamfile.jam
+++ b/pwiz_tools/Osprey/Jamfile.jam
@@ -26,6 +26,23 @@ import modules ;
 if [ modules.peek : NT ]
 {
     path-constant OSPREY_PATH : $(PWIZ_ROOT_PATH)/pwiz_tools/Osprey ;
+    path-constant PWIZ_WRAPPER_PATH : $(PWIZ_ROOT_PATH)/pwiz_tools/Shared/ProteowizardWrapper ;
+
+    # Vendor raw reading (issue #4496) is net472-only and OPT-IN, because it
+    # needs pwiz_data_cli behind ProteowizardWrapper and those are bjam build
+    # products, not checked in.  Gate it on the same
+    # --i-agree-to-the-vendor-licenses flag every other vendor-API consumer in
+    # this tree keys off (Skyline/Jamfile.jam:22), so `bjam Osprey` in a plain
+    # checkout still builds the default, ProteoWizard-free Osprey that
+    # Osprey.sln builds anywhere.  The MSBuild side is off unless it is asked
+    # for by name; see Osprey.IO/Osprey.IO.csproj for why opting in by property
+    # beats probing for the DLL on disk.
+    local vendor-reader = false ;
+    if --i-agree-to-the-vendor-licenses in [ modules.peek : ARGV ]
+    {
+        vendor-reader = true ;
+    }
+    constant OSPREY_VENDOR_READER : $(vendor-reader) ;
 
     # Osprey uses SDK-style csproj that auto-generates AssemblyInfo from
     # the MSBuild properties in pwiz_tools/Osprey/Directory.Build.props
@@ -67,8 +84,19 @@ if [ modules.peek : NT ]
     actions do_osprey
     {
         $(MSVC_CURRENT_SETUP_SCRIPT)
+        REM Osprey.IO references the BUILT x64 wrapper by HintPath rather than by
+        REM ProjectReference (an SDK-style project cannot pass Platform across a
+        REM ProjectReference to an old-style one), and the wrapper is not in
+        REM Osprey.sln, so it has to be built here first.  Its own up-to-date
+        REM check makes this a couple of seconds when current.  Building
+        REM CommonUtil comes along as its ProjectReference.
+        IF "$(OSPREY_VENDOR_READER)"=="true" (
+            echo Building ProteowizardWrapper for Osprey vendor raw reading...
+            msbuild $(PWIZ_WRAPPER_PATH)/ProteowizardWrapper.csproj /p:Configuration=$(CONFIGURATION);Platform=x64 /nologo /verbosity:minimal
+            IF ERRORLEVEL 1 exit %ERRORLEVEL%
+        )
         echo Building Osprey $(OSPREY_VERSION) in $(CONFIGURATION:L) configuration...
-        msbuild $(OSPREY_PATH)/Osprey.sln /p:Configuration=$(CONFIGURATION);Platform=x64;Version=$(OSPREY_VERSION) /nologo /verbosity:minimal
+        msbuild $(OSPREY_PATH)/Osprey.sln /p:Configuration=$(CONFIGURATION);Platform=x64;Version=$(OSPREY_VERSION);OspreyVendorReader=$(OSPREY_VENDOR_READER) /nologo /verbosity:minimal
         IF ERRORLEVEL 1 exit %ERRORLEVEL%
     }
 
@@ -87,6 +115,114 @@ if [ modules.peek : NT ]
         exit %status%
     }
 
+    # Osprey's variant of Skyline's install-vendor-api-dependencies-to-debug-and-release
+    # (Skyline/Jamfile.jam:442). The underlying rule is Jamroot.jam:801 and takes
+    # arbitrary locations, so this is a pointer at Osprey's own output rather
+    # than a copy of the vendor list.
+    #
+    # Note the TFM subdirectory. Osprey multi-targets net472;net8.0
+    # (Directory.Build.props), and pwiz_data_cli is a net472-only mixed-mode
+    # assembly, so only the net472 output can load it -- putting the native
+    # vendor DLLs anywhere else would leave the wrapper unable to resolve them
+    # at run time with nothing but "could not load file or assembly" to go on.
+    # Both configurations are covered the way Skyline covers them: the vendor
+    # runtime is variant-independent, so installing to both costs nothing and
+    # means a Debug run is not silently missing raw support.
+    rule install-vendor-api-dependencies-to-osprey-net472 ( properties * )
+    {
+        local locations =
+            $(OSPREY_PATH)/Osprey/bin/x64/Debug/net472
+            $(OSPREY_PATH)/Osprey/bin/x64/Release/net472 ;
+
+        local result = [ install-vendor-api-dependencies-to-locations $(locations) : $(properties) ] ;
+
+        # The vendor rule installs the vendor APIs but NOT the C/C++ runtimes they
+        # link against. The Sciex, Agilent and Waters DLLs need the VC110/VC120
+        # runtimes and the VC140 UCRT apiset shims, none of which are present on a
+        # machine without those redistributables. Leaving them out does not
+        # produce a missing-file error naming them: pwiz_data_cli is mixed-mode,
+        # so the loader reports only "Could not load file or assembly
+        # 'pwiz_data_cli.dll' or one of its dependencies", which is what an Osprey
+        # built without this looked like.
+        if <toolset>msvc in $(properties)
+        {
+            result += <dependency>install-osprey-native-runtime-debug
+                      <dependency>install-osprey-native-runtime-release ;
+        }
+
+        return $(result) ;
+    }
+
+    # pwiz_data_cli imports msparser.dll directly (confirmed with
+    # dumpbin /dependents, alongside timsdata, MassLynxRaw, baf2sql_c and
+    # MBI_SDK). The Mascot parser is not a pwiz_aux vendor API, so
+    # install-vendor-api-dependencies-to-locations does not carry it: Skyline gets
+    # it from the msparser searched-lib's <assembly-dependency>
+    # (Jamroot.jam:1391) by way of install-native-dependencies' install-dependencies.
+    # Osprey's output is populated by MSBuild instead, so it has to be installed
+    # explicitly. Which of the pair is real depends on the runtime, exactly as
+    # Jamroot's msparser-usage-requirements decides it.
+    rule osprey-msparser-requirement ( properties * )
+    {
+        local msparser_path = [ msparser-path $(properties) ] ;
+        if $(msparser_path)
+        {
+            if <runtime-debugging>on in $(properties)
+            {
+                return <source>$(msparser_path)/lib/msparserD.dll ;
+            }
+            else
+            {
+                return <source>$(msparser_path)/lib/msparser.dll ;
+            }
+        }
+    }
+
+    # The native runtime Osprey needs next to Osprey.exe: the C/C++ runtimes from
+    # Jamroot's install-msvc-runtime-dlls source list (Jamroot.jam:1585) plus
+    # msparser. That target cannot be retargeted with a location-qualified
+    # <dependency> the way the vendor API installs can (Skyline/Jamfile.jam:526):
+    # its requirements include <conditional>@install-location, which returns
+    # <location> unconditionally, so an override hands stage.jam two locations and
+    # bjam dies inside path.relative. Declaring the installs here keeps one
+    # location per target; only the source lists are shared, through the same
+    # Jamroot conditionals.
+    install install-osprey-native-runtime-debug
+        : # sources come from the conditionals below
+        : # requirements
+            <location>$(OSPREY_PATH)/Osprey/bin/x64/Debug/net472
+            <conditional>@install-msvc-runtime-dlls-requirements
+            <conditional>@osprey-msparser-requirement
+        ;
+    install install-osprey-native-runtime-release
+        : # sources come from the conditionals below
+        : # requirements
+            <location>$(OSPREY_PATH)/Osprey/bin/x64/Release/net472
+            <conditional>@install-msvc-runtime-dlls-requirements
+            <conditional>@osprey-msparser-requirement
+        ;
+    explicit install-osprey-native-runtime-debug install-osprey-native-runtime-release ;
+
+    # Wiring for vendor raw reading, added only when the capability is on.
+    #
+    # The staging of ProteowizardWrapper/obj/x64 (pwiz_data_cli plus the managed
+    # vendor assemblies the wrapper csproj references by HintPath) is REUSED
+    # from Skyline's install-native-dependencies rather than redeclared here.
+    # Two installs writing the same files to the same location would collide as
+    # duplicate targets in any build that requested both, and this is the exact
+    # staging every parity result for #4496 was produced against. The cost is
+    # that an Osprey vendor build also builds msconvert and TestDiagnostics,
+    # which that target carries. Lifting the shared rules into a common Jamfile
+    # is the follow-up cleanup, deliberately not gating this change.
+    local vendor-requirements ;
+    if $(OSPREY_VENDOR_READER) = true
+    {
+        vendor-requirements =
+            <assembly>../../pwiz/utility/bindings/CLI//pwiz_data_cli
+            <dependency>../Skyline//install-native-dependencies
+            <conditional>@install-vendor-api-dependencies-to-osprey-net472 ;
+    }
+
     # Full solution build. Explicit so it is opt-in (requested by name from
     # TeamCity or via `bjam Osprey`), not pulled into the default
     # Skyline build.
@@ -97,6 +233,7 @@ if [ modules.peek : NT ]
         : # requirements
             <conditional>@no-express-requirement
             <conditional>@msvc-dotnet-requirement
+            $(vendor-requirements)
         ;
     explicit Osprey ;
 

--- a/pwiz_tools/Osprey/Osprey.Core/FileParallelism.cs
+++ b/pwiz_tools/Osprey/Osprey.Core/FileParallelism.cs
@@ -225,12 +225,26 @@ namespace pwiz.Osprey.Core
         {
             try
             {
-                if (!string.IsNullOrEmpty(path) && File.Exists(path))
+                if (string.IsNullOrEmpty(path))
+                    return 0;
+                if (File.Exists(path))
                     return new FileInfo(path).Length;
+                // A vendor bundle is a DIRECTORY (Agilent .d, Bruker .d, Waters .raw).
+                // Sizing it at 0 does not merely lose precision: EstimatePerFileBytes
+                // returns 0 for the whole set, ResolveAuto takes its no-signal branch
+                // and runs at the full core count with NO memory budget at all. That is
+                // the opposite of conservative on exactly the largest inputs.
+                var dir = new DirectoryInfo(path);
+                if (!dir.Exists)
+                    return 0;
+                long total = 0;
+                foreach (var f in dir.EnumerateFiles(@"*", SearchOption.AllDirectories))
+                    total += f.Length;
+                return total;
             }
             catch (Exception)
             {
-                // Unreadable path -- treat as unknown size (0), never throw from a
+                // Unreadable path - treat as unknown size (0), never throw from a
                 // sizing hint.
             }
             return 0;

--- a/pwiz_tools/Osprey/Osprey.Core/OspreyConfig.cs
+++ b/pwiz_tools/Osprey/Osprey.Core/OspreyConfig.cs
@@ -414,7 +414,13 @@ namespace pwiz.Osprey.Core
         PerFileScoring,
         FirstJoin,
         PerFileRescore,
-        MergeNode
+        MergeNode,
+        // Stage 1 alone: build each input's .spectra.bin cache and stop. Not an
+        // HPC fan-out node like the four above but the data-staging step ahead of
+        // them, which is why it needs no library and publishes no byproducts.
+        // Appended rather than ordered first so the existing members keep their
+        // ordinal values.
+        SpectraCache
     }
 
     /// <summary>

--- a/pwiz_tools/Osprey/Osprey.Core/OspreyEnvironment.cs
+++ b/pwiz_tools/Osprey/Osprey.Core/OspreyEnvironment.cs
@@ -79,6 +79,22 @@ namespace pwiz.Osprey.Core
         public static readonly bool ExitAfterCalibration = IsSet(@"OSPREY_EXIT_AFTER_CALIBRATION");
 
         /// <summary>
+        /// OSPREY_MZML_VIA_PWIZ=1: read mzML through ProteoWizard
+        /// (<c>pwiz_data_cli</c>) instead of the hand-written
+        /// <c>MzmlReader</c>. Diagnostic only, and net472 only.
+        ///
+        /// This isolates the two READERS against a fixed input: run the same
+        /// mzML both ways and the resulting <c>.spectra.bin</c> files should be
+        /// byte-identical, because nothing about the source file differs. A
+        /// raw-vs-mzML comparison cannot make that claim - it varies the reader
+        /// and the file at the same time, so a difference could come from
+        /// either. Any difference this switch exposes is a defect in
+        /// <c>MzmlReader</c>, which is the only parser in the picture that is
+        /// not ProteoWizard.
+        /// </summary>
+        public static readonly bool MzmlViaPwiz = IsSetAndNotZero(@"OSPREY_MZML_VIA_PWIZ");
+
+        /// <summary>
         /// OSPREY_CAL_MEDIANPOLISH=1: add median-polish cosine (the dominant full-search
         /// Percolator feature) as a 5th calibration-LDA feature, computed over the
         /// peak-cropped calibration XICs. Experimental lever for raising the calibration

--- a/pwiz_tools/Osprey/Osprey.Core/OspreyEnvironment.cs
+++ b/pwiz_tools/Osprey/Osprey.Core/OspreyEnvironment.cs
@@ -79,20 +79,27 @@ namespace pwiz.Osprey.Core
         public static readonly bool ExitAfterCalibration = IsSet(@"OSPREY_EXIT_AFTER_CALIBRATION");
 
         /// <summary>
-        /// OSPREY_MZML_VIA_PWIZ=1: read mzML through ProteoWizard
-        /// (<c>pwiz_data_cli</c>) instead of the hand-written
-        /// <c>MzmlReader</c>. Diagnostic only, and net472 only.
+        /// OSPREY_MZML_VIA_MZMLREADER=1: read mzML with the hand-written
+        /// <c>MzmlReader</c> instead of ProteoWizard. Diagnostic only, and
+        /// meaningful only in a build that HAS ProteoWizard (net472 with
+        /// <c>/p:OspreyVendorReader=true</c>), where ProteoWizard is otherwise used
+        /// for every input format including mzML. A no-op anywhere else, since
+        /// <c>MzmlReader</c> is already the only reader there.
         ///
         /// This isolates the two READERS against a fixed input: run the same
-        /// mzML both ways and the resulting <c>.spectra.bin</c> files should be
+        /// mzML both ways and the resulting <c>.spectra.bin</c> files must be
         /// byte-identical, because nothing about the source file differs. A
         /// raw-vs-mzML comparison cannot make that claim - it varies the reader
         /// and the file at the same time, so a difference could come from
         /// either. Any difference this switch exposes is a defect in
         /// <c>MzmlReader</c>, which is the only parser in the picture that is
         /// not ProteoWizard.
+        ///
+        /// The switch is deliberately the ESCAPE HATCH rather than the opt-in: it
+        /// exists to keep that comparison possible, and it disappears along with
+        /// <c>MzmlReader</c> once ProteoWizard has a .NET 8 build (#4178).
         /// </summary>
-        public static readonly bool MzmlViaPwiz = IsSetAndNotZero(@"OSPREY_MZML_VIA_PWIZ");
+        public static readonly bool MzmlViaMzmlReader = IsSetAndNotZero(@"OSPREY_MZML_VIA_MZMLREADER");
 
         /// <summary>
         /// OSPREY_CAL_MEDIANPOLISH=1: add median-polish cosine (the dominant full-search

--- a/pwiz_tools/Osprey/Osprey.IO/MzmlReader.cs
+++ b/pwiz_tools/Osprey/Osprey.IO/MzmlReader.cs
@@ -690,16 +690,23 @@ namespace pwiz.Osprey.IO
         #endregion
 
         /// <summary>
-        /// IEEE-754 correct double parser for mzML cvParam values.
-        /// .NET Framework 4.7.2's double.TryParse can be off by 1-2 ULPs
-        /// on 16-digit scientific values; XmlConvert.ToDouble is required
-        /// by XML schema spec to be IEEE-correct, matching Rust mzdata's
-        /// parser. Without this, cvParams like scan_start_time
-        /// "17.0286203070330" parse to slightly different f64 cross-impl,
-        /// producing 2-ULP apex_rt drift downstream.
+        /// IEEE-754 correct double parser for mzML cvParam values. Without a
+        /// correctly-rounded parse, cvParams like scan_start_time land 1-2 ULPs
+        /// away and produce apex_rt drift downstream and cross-impl.
+        ///
+        /// On .NET Framework this goes through the C runtime's strtod (see
+        /// <see cref="NativeStrtod"/>). The previous version of this method used
+        /// XmlConvert.ToDouble on the stated grounds that XML Schema requires it
+        /// to be IEEE-correct; **that is not true of .NET Framework's
+        /// implementation**, which parses "0.86653405" one ULP high. .NET Core 3.0
+        /// fixed both parsing and "R" formatting, so the .NET 8 build needs
+        /// nothing beyond XmlConvert.
         /// </summary>
         private static bool TryParseXmlDouble(string s, out double result)
         {
+#if NET472
+            return NativeStrtod.TryParse(s, out result);
+#else
             try
             {
                 result = XmlConvert.ToDouble(s);
@@ -710,6 +717,7 @@ namespace pwiz.Osprey.IO
                 result = 0.0;
                 return false;
             }
+#endif
         }
     }
 

--- a/pwiz_tools/Osprey/Osprey.IO/MzmlReader.cs
+++ b/pwiz_tools/Osprey/Osprey.IO/MzmlReader.cs
@@ -362,43 +362,12 @@ namespace pwiz.Osprey.IO
             }
             else if (msLevel == 2 && hasPrecursor)
             {
-                // Use selected ion m/z as center if no isolation window target
-                double center = hasIsolationWindow && isoTarget > 0 ? isoTarget : precursorMz;
-                if (center <= 0)
+                var ms2 = SpectrumBuilder.CreateMs2Spectrum(spectrumIndex, retentionTime,
+                    precursorMz, hasIsolationWindow, isoTarget, isoLower, isoUpper,
+                    mzArray, intensityArray);
+                if (ms2 == null)
                     return; // Skip spectra without precursor info
-
-                // Fail fast on missing offsets rather than substituting a
-                // 12.5 hardcoded default. DIA processing cannot proceed
-                // without true isolation windows, and a silent default
-                // produces bogus results that are very hard to diagnose
-                // downstream. The error names the spectrum index and which
-                // cvParam is missing. Mirrors the equivalent fail-fast
-                // change in osprey/crates/osprey-io/src/mzml/parser.rs
-                // (PR #39 on maccoss/osprey).
-                if (isoLower <= 0)
-                    throw new InvalidDataException(string.Format(
-                        "spectrum index {0}: no valid isolation-window lower offset " +
-                        "(cvParam MS:1000828 missing or non-positive); cannot process DIA data " +
-                        "without true isolation windows.",
-                        spectrumIndex));
-                if (isoUpper <= 0)
-                    throw new InvalidDataException(string.Format(
-                        "spectrum index {0}: no valid isolation-window upper offset " +
-                        "(cvParam MS:1000829 missing or non-positive); cannot process DIA data " +
-                        "without true isolation windows.",
-                        spectrumIndex));
-
-                var isoWindow = new IsolationWindow(center, isoLower, isoUpper);
-
-                ms2List.Add(new Spectrum
-                {
-                    ScanNumber = spectrumIndex,
-                    RetentionTime = retentionTime,
-                    PrecursorMz = precursorMz > 0 ? precursorMz : center,
-                    IsolationWindow = isoWindow,
-                    Mzs = mzArray,
-                    Intensities = intensityArray,
-                });
+                ms2List.Add(ms2);
             }
         }
 
@@ -657,91 +626,14 @@ namespace pwiz.Osprey.IO
         }
 
         /// <summary>
-        /// Some mzML producers emit peaks that are not strictly ascending in
-        /// m/z (observed in a HeLa Astral 3 mz DIA file: ~0.07% of spectra
-        /// have a single inverted pair of consecutive centroids). Downstream
-        /// fragment matching binary-searches the spectrum; the Rust
-        /// partition_point and BinarySearchLowerBound here use procedurally
-        /// different step patterns, so an unsorted region produces UB-style
-        /// divergence between the two impls. Sort once at load time so every
-        /// downstream consumer sees a well-defined ordering. The leading O(n)
-        /// sortedness check is the common-case fast path; the OrderBy
-        /// permutation only runs on inversions. LINQ OrderBy is stable
-        /// (matches Rust slice::sort_by); Array.Sort on parallel arrays is
-        /// unstable introsort and would reorder ties differently.
+        /// Thin forwarder to <see cref="SpectrumBuilder.EnsureSorted"/>, which owns
+        /// the peak sort for every input format. Kept as a named method here
+        /// because both mzML parse paths call it from inside their decode loops.
         /// </summary>
-        // Cap on [unsorted-spectrum] log lines per process — otherwise an
-        // Astral 3-file run with millions of spectra and a 0.07% inversion
-        // rate produces thousands of interleaved lines from concurrent
-        // ProcessFile calls. After the cap, we suppress further lines
-        // (the first ones already prove the case is happening).
-        private static int s_unsortedLogCount;
-        private const int MaxUnsortedLogLines = 10;
-
         private static bool EnsureSortedSpectrum(uint spectrumIndex,
             ref double[] mzArray, ref float[] intensityArray)
         {
-            if (mzArray == null || mzArray.Length < 2)
-                return false;
-            // Defensive guard: a malformed mzML where the m/z and intensity
-            // arrays are not the same length would IndexOutOfRange on the
-            // permutation step. Skip sorting in that case (downstream code
-            // already has its own length checks).
-            if (intensityArray == null || intensityArray.Length != mzArray.Length)
-                return false;
-            // Walk the array once: detect NaN m/z (malformed mzML — fail
-            // loudly so a user report surfaces) and check sortedness in
-            // the same pass. NaN comparison semantics differ between
-            // Comparer<double>.Default and Rust's total_cmp, so we cannot
-            // sort consistently across impls; better to refuse the
-            // spectrum than silently diverge.
-            bool sorted = true;
-            for (int i = 0; i < mzArray.Length; i++)
-            {
-                if (double.IsNaN(mzArray[i]))
-                {
-                    throw new InvalidDataException(string.Format(
-                        "NaN m/z at index {0} of spectrum_index={1} (n_peaks={2}); " +
-                        "cannot sort or fragment-match a malformed centroid array.",
-                        i, spectrumIndex, mzArray.Length));
-                }
-                if (i > 0 && mzArray[i] < mzArray[i - 1])
-                    sorted = false;
-            }
-            if (sorted)
-                return false;
-            // Re-sorting below is unconditional (correctness); the per-spectrum
-            // notice is implementer detail -- some instrument mzML carries a tiny
-            // fraction of unsorted peak arrays (e.g. Astral ~0.07%) that Osprey
-            // silently corrects -- so it stays behind --verbose.
-            if (OspreyOutput.Verbose)
-            {
-                int logCount = Interlocked.Increment(ref s_unsortedLogCount);
-                if (logCount <= MaxUnsortedLogLines)
-                {
-                    OspreyOutput.Out.WriteLine(
-                        $"[unsorted-spectrum] spectrum_index={spectrumIndex} n_peaks={mzArray.Length}");
-                    if (logCount == MaxUnsortedLogLines)
-                    {
-                        OspreyOutput.Out.WriteLine(
-                            $"[unsorted-spectrum] suppressing further lines (>{MaxUnsortedLogLines} per process)");
-                    }
-                }
-            }
-            int n = mzArray.Length;
-            double[] keyMz = mzArray;
-            int[] order = Enumerable.Range(0, n)
-                .OrderBy(i => keyMz[i]).ToArray();
-            double[] sortedMzs = new double[n];
-            float[] sortedInts = new float[n];
-            for (int i = 0; i < n; i++)
-            {
-                sortedMzs[i] = mzArray[order[i]];
-                sortedInts[i] = intensityArray[order[i]];
-            }
-            mzArray = sortedMzs;
-            intensityArray = sortedInts;
-            return true;
+            return SpectrumBuilder.EnsureSorted(spectrumIndex, ref mzArray, ref intensityArray);
         }
 
         #endregion
@@ -784,47 +676,16 @@ namespace pwiz.Osprey.IO
 
             public MS1Spectrum ToMs1Spectrum()
             {
-                return new MS1Spectrum
-                {
-                    ScanNumber = Index,
-                    RetentionTime = RetentionTime,
-                    Mzs = MzArray,
-                    Intensities = IntensityArray,
-                };
+                return SpectrumBuilder.CreateMs1Spectrum(Index, RetentionTime,
+                    MzArray, IntensityArray);
             }
 
             public Spectrum ToMs2Spectrum()
             {
                 if (!HasPrecursor)
                     return null;
-                double center = HasIsolationWindow && IsoTarget > 0 ? IsoTarget : PrecursorMz;
-                if (center <= 0)
-                    return null;
-
-                // Fail fast on missing offsets (see the equivalent block
-                // in the linear convert path above for the rationale).
-                if (IsoLower <= 0)
-                    throw new InvalidDataException(string.Format(
-                        "spectrum index {0}: no valid isolation-window lower offset " +
-                        "(cvParam MS:1000828 missing or non-positive); cannot process DIA data " +
-                        "without true isolation windows.",
-                        Index));
-                if (IsoUpper <= 0)
-                    throw new InvalidDataException(string.Format(
-                        "spectrum index {0}: no valid isolation-window upper offset " +
-                        "(cvParam MS:1000829 missing or non-positive); cannot process DIA data " +
-                        "without true isolation windows.",
-                        Index));
-
-                return new Spectrum
-                {
-                    ScanNumber = Index,
-                    RetentionTime = RetentionTime,
-                    PrecursorMz = PrecursorMz > 0 ? PrecursorMz : center,
-                    IsolationWindow = new IsolationWindow(center, IsoLower, IsoUpper),
-                    Mzs = MzArray,
-                    Intensities = IntensityArray,
-                };
+                return SpectrumBuilder.CreateMs2Spectrum(Index, RetentionTime, PrecursorMz,
+                    HasIsolationWindow, IsoTarget, IsoLower, IsoUpper, MzArray, IntensityArray);
             }
         }
 

--- a/pwiz_tools/Osprey/Osprey.IO/MzmlReader.cs
+++ b/pwiz_tools/Osprey/Osprey.IO/MzmlReader.cs
@@ -26,8 +26,6 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using System.IO.Compression;
-using System.Linq;
-using System.Threading;
 using System.Threading.Tasks;
 using System.Xml;
 using pwiz.Osprey.Core;

--- a/pwiz_tools/Osprey/Osprey.IO/MzmlReader.cs
+++ b/pwiz_tools/Osprey/Osprey.IO/MzmlReader.cs
@@ -695,7 +695,8 @@ namespace pwiz.Osprey.IO
         /// away and produce apex_rt drift downstream and cross-impl.
         ///
         /// On .NET Framework this goes through the C runtime's strtod (see
-        /// <see cref="NativeStrtod"/>). The previous version of this method used
+        /// <c>NativeStrtod</c>, which is compiled only for net472, so a cref to it
+        /// would not resolve in the net8.0 pass). The previous version of this method used
         /// XmlConvert.ToDouble on the stated grounds that XML Schema requires it
         /// to be IEEE-correct; **that is not true of .NET Framework's
         /// implementation**, which parses "0.86653405" one ULP high. .NET Core 3.0

--- a/pwiz_tools/Osprey/Osprey.IO/NativeStrtod.cs
+++ b/pwiz_tools/Osprey/Osprey.IO/NativeStrtod.cs
@@ -55,9 +55,23 @@ namespace pwiz.Osprey.IO
         // implementation behind pwiz_data_cli's own conversions. Present on every
         // supported Windows and under Wine. The single PInvoke declaration for
         // Osprey lives here, per the "isolate PInvoke in one place" rule.
-        [DllImport(@"ucrtbase.dll", EntryPoint = "strtod", CallingConvention = CallingConvention.Cdecl,
+        // _strtod_l rather than strtod: plain strtod follows the process-global UCRT
+        // locale, so a third-party DLL calling setlocale to a comma-decimal locale
+        // would make "17.0286203070330" parse as 17 with 2 characters consumed. That
+        // fails the whole-string check and returns 0.0 for every retention time in the
+        // file. XmlConvert.ToDouble was culture-invariant by contract and this has to
+        // be too. Verified under de-DE: plain strtod stops at the '.', _strtod_l with
+        // the C locale returns the full value.
+        [DllImport(@"ucrtbase.dll", EntryPoint = "_strtod_l", CallingConvention = CallingConvention.Cdecl,
             ExactSpelling = true, SetLastError = false)]
-        private static extern double Strtod(IntPtr text, out IntPtr endPtr);
+        private static extern double StrtodL(IntPtr text, out IntPtr endPtr, IntPtr locale);
+
+        // _create_locale(LC_ALL = 0, "C") - an invariant locale handle, created once.
+        [DllImport(@"ucrtbase.dll", EntryPoint = "_create_locale", CallingConvention = CallingConvention.Cdecl,
+            ExactSpelling = true, SetLastError = false)]
+        private static extern IntPtr CreateLocale(int category, string locale);
+
+        private static readonly IntPtr C_LOCALE = CreateLocale(0, @"C");
 
         /// <summary>
         /// Parse an XML decimal value. Returns false unless the WHOLE string was
@@ -77,6 +91,12 @@ namespace pwiz.Osprey.IO
             if (trimmed.Length == 0)
                 return false;
 
+            // Hex float forms ("0x1.8p3" -> 12) are accepted by the CRT and rejected by
+            // XML Schema. No value-level check can catch them: they parse to ordinary
+            // finite numbers, unlike the nan/inf spellings caught below.
+            if (trimmed.IndexOf('x') >= 0 || trimmed.IndexOf('X') >= 0)
+                return false;
+
             // Marshal explicitly rather than letting the string marshaller do it:
             // validating "was everything consumed" needs the start pointer to
             // compare endPtr against, which the automatic marshaller does not
@@ -85,13 +105,21 @@ namespace pwiz.Osprey.IO
             IntPtr buffer = Marshal.StringToHGlobalAnsi(trimmed);
             try
             {
-                double parsed = Strtod(buffer, out IntPtr endPtr);
+                double parsed = StrtodL(buffer, out IntPtr endPtr, C_LOCALE);
                 long consumed = endPtr.ToInt64() - buffer.ToInt64();
                 if (consumed <= 0 || consumed != trimmed.Length)
                     return false;
                 // Overflow returns +/-HUGE_VAL; the old XmlConvert path threw and
                 // reported failure, and no mzML value is legitimately infinite.
-                if (double.IsInfinity(parsed))
+                //
+                // NaN matters more than it looks. The CRT accepts spellings XML Schema
+                // does not - "nan", "NaN", "-nan(ind)", and hex floats like "0x1.8p3" -
+                // and XmlConvert.ToDouble threw on all of them. A NaN that got through
+                // would defeat every downstream guard rather than trip one, because
+                // both "NaN > 0" and "NaN <= 0" are false: SpectrumBuilder's
+                // isolation-window fail-fast would pass it straight through and cache
+                // an IsolationWindow(NaN) that silently matches no precursor at all.
+                if (double.IsInfinity(parsed) || double.IsNaN(parsed))
                     return false;
                 value = parsed;
                 return true;

--- a/pwiz_tools/Osprey/Osprey.IO/NativeStrtod.cs
+++ b/pwiz_tools/Osprey/Osprey.IO/NativeStrtod.cs
@@ -1,0 +1,106 @@
+/*
+ * Original author: Brendan MacLean <brendanx .at. uw.edu>,
+ *                  MacCoss Lab, Department of Genome Sciences, UW
+ * AI assistance: Claude Code (Claude Opus 5) <noreply .at. anthropic.com>
+ *
+ * Copyright 2026 University of Washington - Seattle, WA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#if NET472
+using System;
+using System.Runtime.InteropServices;
+
+namespace pwiz.Osprey.IO
+{
+    /// <summary>
+    /// Correctly-rounded decimal-to-double conversion for the .NET Framework
+    /// build, via the C runtime's <c>strtod</c>.
+    ///
+    /// WHY: .NET Framework's string-to-double conversion is not correctly rounded
+    /// for some decimals. "0.86653405" parses to 0x3FEBBAA59DB3DA8E, one ULP above
+    /// the correctly rounded 0x3FEBBAA59DB3DA8D that .NET Core 3.0+ and C++
+    /// <c>strtod</c> both produce. <c>XmlConvert.ToDouble</c> inherits the defect
+    /// despite XML Schema requiring IEEE-correct behavior, so it is not a way out.
+    /// Two of 161,099 retention times in one Thermo DIA run were affected, which is
+    /// enough to break bit-exact comparison of a <c>.spectra.bin</c> written by the
+    /// hand-written mzML reader against one written through ProteoWizard
+    /// (issue #4496).
+    ///
+    /// Going through the CRT is not merely "a" fix, it is the one that matches by
+    /// construction: ProteoWizard's own parser
+    /// (<c>pwiz/utility/misc/optimized_lexical_cast.hpp</c>) is <c>STRTOD</c>, so
+    /// net472 Osprey, net8.0 Osprey and pwiz all land on the same bits.
+    ///
+    /// net472 only, and deliberately so. .NET 8 needs nothing here, and the
+    /// hand-written mzML reader is expected to retire with the .NET 8 port, so this
+    /// interop retires with it. Being Windows-specific costs nothing: the net472
+    /// configuration is Windows (or Wine) only already, as is the msconvert that
+    /// produces the files it reads.
+    /// </summary>
+    internal static class NativeStrtod
+    {
+        // ucrtbase.dll is the Universal CRT that MSVC 14.x links, i.e. the same
+        // implementation behind pwiz_data_cli's own conversions. Present on every
+        // supported Windows and under Wine. The single PInvoke declaration for
+        // Osprey lives here, per the "isolate PInvoke in one place" rule.
+        [DllImport(@"ucrtbase.dll", EntryPoint = "strtod", CallingConvention = CallingConvention.Cdecl,
+            ExactSpelling = true, SetLastError = false)]
+        private static extern double Strtod(IntPtr text, out IntPtr endPtr);
+
+        /// <summary>
+        /// Parse an XML decimal value. Returns false unless the WHOLE string was
+        /// consumed, so trailing garbage is a failure rather than a silently
+        /// truncated number - matching the contract the previous
+        /// XmlConvert-plus-catch had.
+        /// </summary>
+        internal static bool TryParse(string text, out double value)
+        {
+            value = 0.0;
+            if (string.IsNullOrEmpty(text))
+                return false;
+
+            // Trim so a trailing newline or padding in the attribute does not read
+            // as unconsumed input. strtod already skips leading whitespace.
+            string trimmed = text.Trim();
+            if (trimmed.Length == 0)
+                return false;
+
+            // Marshal explicitly rather than letting the string marshaller do it:
+            // validating "was everything consumed" needs the start pointer to
+            // compare endPtr against, which the automatic marshaller does not
+            // expose. The values are ASCII (XML numeric text), so byte length and
+            // char length agree.
+            IntPtr buffer = Marshal.StringToHGlobalAnsi(trimmed);
+            try
+            {
+                double parsed = Strtod(buffer, out IntPtr endPtr);
+                long consumed = endPtr.ToInt64() - buffer.ToInt64();
+                if (consumed <= 0 || consumed != trimmed.Length)
+                    return false;
+                // Overflow returns +/-HUGE_VAL; the old XmlConvert path threw and
+                // reported failure, and no mzML value is legitimately infinite.
+                if (double.IsInfinity(parsed))
+                    return false;
+                value = parsed;
+                return true;
+            }
+            finally
+            {
+                Marshal.FreeHGlobal(buffer);
+            }
+        }
+    }
+}
+#endif

--- a/pwiz_tools/Osprey/Osprey.IO/Osprey.IO.csproj
+++ b/pwiz_tools/Osprey/Osprey.IO/Osprey.IO.csproj
@@ -46,6 +46,13 @@
     <ProjectReference Include="..\..\Shared\ProteowizardWrapper\ProteowizardWrapper.csproj" />
   </ItemGroup>
 
+  <!-- The vendor reader compiles only where ProteoWizard is available.
+       SpectrumFileReader (the by-extension dispatcher) builds on both and
+       raises a clear error on net8.0 for a vendor path. -->
+  <ItemGroup Condition="'$(TargetFramework)' != 'net472'">
+    <Compile Remove="VendorRawReader.cs" />
+  </ItemGroup>
+
   <!-- DotNetZip (Ionic.Zlib) for stock-zlib-compatible deflate output.
        Matches Skyline's BlibData writer (Util/Extensions/UtilDB.Compress)
        so Osprey .blib peak blobs are byte-identical to Skyline's

--- a/pwiz_tools/Osprey/Osprey.IO/Osprey.IO.csproj
+++ b/pwiz_tools/Osprey/Osprey.IO/Osprey.IO.csproj
@@ -25,31 +25,59 @@
     <ProjectReference Include="..\Osprey.Core\Osprey.Core.csproj" />
   </ItemGroup>
 
-  <!-- Vendor raw reading (issue #4496) goes through ProteowizardWrapper rather
-       than binding pwiz_data_cli directly: the wrapper already exposes every
-       field SpectraCache stores, including the isolation-window LOWER/UPPER
-       OFFSET semantics that a hand-rolled binding is most likely to get wrong.
-       net472 only, because pwiz_data_cli is net472-only: the net8.0
-       configuration keeps reading mzML through MzmlReader.
-       Requires a full build to have staged
-       pwiz_tools/Shared/ProteowizardWrapper/obj/x64 (bs.bat, or any bjam build
-       of Skyline); those vendor assemblies are build products, not checked in. -->
-  <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
-    <!-- Platform matters here: ProteowizardWrapper resolves pwiz_data_cli and
-         the vendor assemblies from obj\$(Platform)\, and only obj\x64\ is ever
-         staged. An SDK-style project does not pass its Platform across a
-         ProjectReference to an old-style one (neither AdditionalProperties nor
-         SetPlatform metadata takes effect here), so the x64 mapping is made in
-         Osprey.sln instead, exactly as Skyline.sln does it. Build Osprey
-         through the solution; a bare csproj build of this project would
-         resolve the wrapper as AnyCPU and fail on every pwiz.CLI type. -->
-    <ProjectReference Include="..\..\Shared\ProteowizardWrapper\ProteowizardWrapper.csproj" />
+  <!-- Vendor raw reading (issue #4496) is an OPT-IN build capability, off by
+       default. Build with /p:OspreyVendorReader=true to include it.
+       Off  : Osprey.sln builds anywhere, with no ProteoWizard dependency. This
+              is what the unit-test CI config and a plain developer clone use.
+       On   : requires pwiz_tools/Shared/ProteowizardWrapper/obj/x64 to have been
+              staged by a bjam build (bs.bat, or the pwiz_data_cli + vendor
+              install targets). Used by the Perf/Regression config, which can
+              afford that build and runs the raw-vs-mzML parity test.
+       Opt-in by property rather than by probing for the DLL on disk: a missing
+       staged assembly is then a hard build error in the configuration that asked
+       for the capability, instead of silently producing an Osprey that cannot
+       read raw files - which would vary by machine and quietly skip the very
+       test that validates the feature. -->
+  <PropertyGroup>
+    <OspreyVendorReader Condition="'$(OspreyVendorReader)' == ''">false</OspreyVendorReader>
+    <!-- pwiz_data_cli is net472-only, so the capability can never be on for
+         net8.0 no matter what the property says. -->
+    <OspreyVendorReaderEnabled>false</OspreyVendorReaderEnabled>
+    <OspreyVendorReaderEnabled
+        Condition="'$(TargetFramework)' == 'net472' And '$(OspreyVendorReader)' == 'true'">true</OspreyVendorReaderEnabled>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(OspreyVendorReaderEnabled)' == 'true'">
+    <DefineConstants>$(DefineConstants);OSPREY_VENDOR_READER</DefineConstants>
+  </PropertyGroup>
+
+  <!-- Assembly references to the ALREADY-BUILT x64 wrapper, not ProjectReferences.
+       ProteowizardWrapper resolves pwiz_data_cli and the vendor assemblies out of
+       obj\$(Platform)\, and only obj\x64\ is ever staged, so it must be built as
+       x64. An SDK-style project will not pass Platform across a ProjectReference
+       to an old-style one - AdditionalProperties, SetPlatform and
+       EnableDynamicPlatformResolution were all tried and none take effect - and
+       putting it in Osprey.sln to get the mapping would build it even when this
+       capability is off, which is what the default build must avoid. Referencing
+       the built output sidesteps the negotiation entirely and follows the
+       existing precedent in pwiz_tools/Skyline/BullseyeSharp/BullseyeSharp.csproj,
+       which references pwiz_data_cli by HintPath for the same reason.
+       The bjam build that stages obj\x64 also produces these. -->
+  <ItemGroup Condition="'$(OspreyVendorReaderEnabled)' == 'true'">
+    <Reference Include="ProteowizardWrapper">
+      <HintPath>..\..\Shared\ProteowizardWrapper\bin\x64\$(Configuration)\ProteowizardWrapper.dll</HintPath>
+      <Private>true</Private>
+    </Reference>
+    <Reference Include="pwiz.CommonUtil">
+      <HintPath>..\..\Shared\CommonUtil\bin\x64\$(Configuration)\pwiz.CommonUtil.dll</HintPath>
+      <Private>true</Private>
+    </Reference>
   </ItemGroup>
 
   <!-- The vendor reader compiles only where ProteoWizard is available.
-       SpectrumFileReader (the by-extension dispatcher) builds on both and
-       raises a clear error on net8.0 for a vendor path. -->
-  <ItemGroup Condition="'$(TargetFramework)' != 'net472'">
+       SpectrumFileReader (the by-extension dispatcher) always builds, and
+       raises a clear error for a vendor path when the capability is absent. -->
+  <ItemGroup Condition="'$(OspreyVendorReaderEnabled)' != 'true'">
     <Compile Remove="VendorRawReader.cs" />
   </ItemGroup>
 

--- a/pwiz_tools/Osprey/Osprey.IO/Osprey.IO.csproj
+++ b/pwiz_tools/Osprey/Osprey.IO/Osprey.IO.csproj
@@ -25,6 +25,27 @@
     <ProjectReference Include="..\Osprey.Core\Osprey.Core.csproj" />
   </ItemGroup>
 
+  <!-- Vendor raw reading (issue #4496) goes through ProteowizardWrapper rather
+       than binding pwiz_data_cli directly: the wrapper already exposes every
+       field SpectraCache stores, including the isolation-window LOWER/UPPER
+       OFFSET semantics that a hand-rolled binding is most likely to get wrong.
+       net472 only, because pwiz_data_cli is net472-only: the net8.0
+       configuration keeps reading mzML through MzmlReader.
+       Requires a full build to have staged
+       pwiz_tools/Shared/ProteowizardWrapper/obj/x64 (bs.bat, or any bjam build
+       of Skyline); those vendor assemblies are build products, not checked in. -->
+  <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
+    <!-- Platform matters here: ProteowizardWrapper resolves pwiz_data_cli and
+         the vendor assemblies from obj\$(Platform)\, and only obj\x64\ is ever
+         staged. An SDK-style project does not pass its Platform across a
+         ProjectReference to an old-style one (neither AdditionalProperties nor
+         SetPlatform metadata takes effect here), so the x64 mapping is made in
+         Osprey.sln instead, exactly as Skyline.sln does it. Build Osprey
+         through the solution; a bare csproj build of this project would
+         resolve the wrapper as AnyCPU and fail on every pwiz.CLI type. -->
+    <ProjectReference Include="..\..\Shared\ProteowizardWrapper\ProteowizardWrapper.csproj" />
+  </ItemGroup>
+
   <!-- DotNetZip (Ionic.Zlib) for stock-zlib-compatible deflate output.
        Matches Skyline's BlibData writer (Util/Extensions/UtilDB.Compress)
        so Osprey .blib peak blobs are byte-identical to Skyline's

--- a/pwiz_tools/Osprey/Osprey.IO/SpectraCache.cs
+++ b/pwiz_tools/Osprey/Osprey.IO/SpectraCache.cs
@@ -86,6 +86,13 @@ namespace pwiz.Osprey.IO
         // first use.
         private const uint VERSION = 4;
 
+        // Stored in the source-size field when the source exists but could not be
+        // measured. No real source is this large, so it is unambiguous in-band and
+        // needs no format version bump: a reader that does not know the sentinel
+        // simply compares it against the real size, mismatches, and re-parses -
+        // which is the intended outcome anyway.
+        private const ulong FINGERPRINT_UNMEASURABLE = ulong.MaxValue;
+
         // Fixed EOF footer: [ms1_section_offset: int64][index_offset: int64].
         private const int FOOTER_BYTES = 16;
 
@@ -115,7 +122,14 @@ namespace pwiz.Osprey.IO
             if (ms1Spectra == null)
                 ms1Spectra = new List<MS1Spectrum>();
 
-            ComputeSourceFingerprint(sourcePath, out long sourceSize, out long sourceMtimeMs);
+            // Record a distinct sentinel when the source is there but unmeasurable, so
+            // the reader can tell that apart from "no source was given" (0) and refuse
+            // the cache instead of trusting it forever after one I/O error.
+            if (!TryComputeSourceFingerprint(sourcePath, out long sourceSize, out long sourceMtimeMs))
+            {
+                sourceSize = unchecked((long)FINGERPRINT_UNMEASURABLE);
+                sourceMtimeMs = 0;
+            }
 
             int nMs2 = ms2Spectra.Count;
 
@@ -302,9 +316,17 @@ namespace pwiz.Osprey.IO
             // (e.g. a resume run whose mzML is not beside the cache).
             ulong storedSize = r.ReadUInt64();
             long storedMtimeMs = r.ReadInt64();
+            // Written when the source existed but could not be measured. Distinct from
+            // 0, which means "no source was given" and is legitimately trusted; folding
+            // the two together would make one I/O error trust the cache forever.
+            if (storedSize == FINGERPRINT_UNMEASURABLE)
+                return false;
             if (storedSize != 0 && !string.IsNullOrEmpty(sourcePath))
             {
-                ComputeSourceFingerprint(sourcePath, out long actualSize, out long actualMtimeMs);
+                // Likewise on the read side: a source that exists but cannot be measured
+                // is stale, not "skip the check".
+                if (!TryComputeSourceFingerprint(sourcePath, out long actualSize, out long actualMtimeMs))
+                    return false;
                 if (actualSize != 0 && ((ulong)actualSize != storedSize || actualMtimeMs != storedMtimeMs))
                     return false;
             }
@@ -426,12 +448,21 @@ namespace pwiz.Osprey.IO
         // same value for the same file. Returns (0, 0) when the source is null,
         // missing, or cannot be stat'd, which the load path treats as "no
         // fingerprint -- trust the cache".
-        private static void ComputeSourceFingerprint(string sourcePath, out long size, out long mtimeMs)
+        /// <summary>
+        /// Measure the source for the staleness check. Returns FALSE when the source
+        /// exists but could not be measured - an unreadable subdirectory part-way
+        /// through a bundle walk, say. That case must not be reported as (0, 0),
+        /// because a zero size is the "no fingerprint" signal and would make a stale
+        /// cache un-invalidatable forever. A source that simply is not present still
+        /// returns true with (0, 0): there is nothing to compare, which is the
+        /// documented resume case.
+        /// </summary>
+        private static bool TryComputeSourceFingerprint(string sourcePath, out long size, out long mtimeMs)
         {
             size = 0;
             mtimeMs = 0;
             if (string.IsNullOrEmpty(sourcePath))
-                return;
+                return true;
             try
             {
                 var fi = new FileInfo(sourcePath);
@@ -439,7 +470,7 @@ namespace pwiz.Osprey.IO
                 {
                     size = fi.Length;
                     mtimeMs = new DateTimeOffset(fi.LastWriteTimeUtc).ToUnixTimeMilliseconds();
-                    return;
+                    return true;
                 }
 
                 // Several vendor formats are DIRECTORIES (Agilent .d, Bruker .d,
@@ -460,23 +491,34 @@ namespace pwiz.Osprey.IO
                 // modified.
                 var di = new DirectoryInfo(sourcePath);
                 if (!di.Exists)
-                    return;
+                    return true;
                 long totalSize = 0;
                 long newestMtimeMs = 0;
+                int fileCount = 0;
                 foreach (var f in di.EnumerateFiles(@"*", SearchOption.AllDirectories))
                 {
                     totalSize += f.Length;
+                    fileCount++;
                     long fileMtimeMs = new DateTimeOffset(f.LastWriteTimeUtc).ToUnixTimeMilliseconds();
                     if (fileMtimeMs > newestMtimeMs)
                         newestMtimeMs = fileMtimeMs;
                 }
+                // An existing bundle with nothing in it, or one whose files are all
+                // empty, would land on the (0, 0) "no fingerprint" signal. No real
+                // vendor bundle looks like that, so treat it as unmeasurable rather
+                // than as permission to trust the cache.
+                if (fileCount == 0 || totalSize == 0)
+                    return false;
                 size = totalSize;
                 mtimeMs = newestMtimeMs;
+                return true;
             }
             catch (Exception)
             {
+                // Exists (we got past the Exists checks) but could not be measured.
                 size = 0;
                 mtimeMs = 0;
+                return false;
             }
         }
 

--- a/pwiz_tools/Osprey/Osprey.IO/SpectraCache.cs
+++ b/pwiz_tools/Osprey/Osprey.IO/SpectraCache.cs
@@ -435,10 +435,43 @@ namespace pwiz.Osprey.IO
             try
             {
                 var fi = new FileInfo(sourcePath);
-                if (!fi.Exists)
+                if (fi.Exists)
+                {
+                    size = fi.Length;
+                    mtimeMs = new DateTimeOffset(fi.LastWriteTimeUtc).ToUnixTimeMilliseconds();
                     return;
-                size = fi.Length;
-                mtimeMs = new DateTimeOffset(fi.LastWriteTimeUtc).ToUnixTimeMilliseconds();
+                }
+
+                // Several vendor formats are DIRECTORIES (Agilent .d, Bruker .d,
+                // Waters .raw), and FileInfo.Exists is false for a directory. Leaving
+                // the fingerprint at 0 would not be a conservative default: the reader
+                // SKIPS the staleness comparison when the stored size is 0, so such a
+                // cache would be accepted no matter how the source had changed. Sum the
+                // contents instead and take the newest write time, which moves whenever
+                // any file in the bundle is rewritten. The walk costs far less than the
+                // parse it protects.
+                //
+                // Trade-off: a vendor SDK that writes a sidecar into the bundle when it
+                // reads it would move this fingerprint and cost a re-parse on the next
+                // run. That is a performance cost, not a correctness one, and it says so
+                // in the log ("Spectra cache stale or invalid"), whereas trusting a stale
+                // cache would be silent and wrong. Verified not to happen for Agilent .d:
+                // msconvert read one of the tracked test bundles and left no file in it
+                // modified.
+                var di = new DirectoryInfo(sourcePath);
+                if (!di.Exists)
+                    return;
+                long totalSize = 0;
+                long newestMtimeMs = 0;
+                foreach (var f in di.EnumerateFiles(@"*", SearchOption.AllDirectories))
+                {
+                    totalSize += f.Length;
+                    long fileMtimeMs = new DateTimeOffset(f.LastWriteTimeUtc).ToUnixTimeMilliseconds();
+                    if (fileMtimeMs > newestMtimeMs)
+                        newestMtimeMs = fileMtimeMs;
+                }
+                size = totalSize;
+                mtimeMs = newestMtimeMs;
             }
             catch (Exception)
             {

--- a/pwiz_tools/Osprey/Osprey.IO/SpectrumBuilder.cs
+++ b/pwiz_tools/Osprey/Osprey.IO/SpectrumBuilder.cs
@@ -1,0 +1,203 @@
+/*
+ * Original author: Brendan MacLean <brendanx .at. uw.edu>,
+ *                  MacCoss Lab, Department of Genome Sciences, UW
+ * AI assistance: Claude Code (Claude Opus 5) <noreply .at. anthropic.com>
+ *
+ * Based on osprey (https://github.com/MacCossLab/osprey)
+ *   by Michael J. MacCoss, MacCoss Lab, Department of Genome Sciences, UW
+ *
+ * Copyright 2026 University of Washington - Seattle, WA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using pwiz.Osprey.Core;
+
+namespace pwiz.Osprey.IO
+{
+    /// <summary>
+    /// Turns decoded peak arrays plus per-spectrum metadata into the
+    /// <see cref="Spectrum"/> / <see cref="MS1Spectrum"/> objects the rest of
+    /// Osprey consumes, independent of where the peaks came from.
+    ///
+    /// This is the single definition of what a spectrum IS: peak sort order,
+    /// the isolation-window fail-fast, the precursor-m/z fallback. Both
+    /// <see cref="MzmlReader"/> and (on net472) the vendor-raw reader build
+    /// through it, so a cache written from a <c>.raw</c> and one written from the
+    /// mzML msconvert produced from that same <c>.raw</c> can differ only where
+    /// the two PARSERS genuinely disagree - never because two code paths
+    /// assembled equivalent data differently. That distinction is what makes a
+    /// raw-vs-mzML byte comparison a meaningful test (issue #4496).
+    /// </summary>
+    internal static class SpectrumBuilder
+    {
+        // Unsorted-centroid notices are per-process, not per-file: the cap keeps
+        // a pathological file from flooding the log across parallel ProcessFile
+        // calls. After the cap, we suppress further lines (the first ones
+        // already prove the case is happening).
+        private static int s_unsortedLogCount;
+        private const int MaxUnsortedLogLines = 10;
+
+        /// <summary>
+        /// Sort a spectrum's peaks by m/z if they are not already sorted,
+        /// permuting the intensity array with them. Returns true when a sort was
+        /// performed, which the callers accumulate into
+        /// <see cref="MzmlResult.UnsortedSpectrumCount"/>.
+        ///
+        /// Some producers emit peaks that are not strictly ascending in m/z
+        /// (observed in a HeLa Astral 3 mz DIA file: ~0.07% of spectra have a
+        /// single inverted pair of consecutive centroids). Downstream fragment
+        /// matching binary-searches the spectrum; the Rust partition_point and
+        /// BinarySearchLowerBound use procedurally different step patterns, so an
+        /// unsorted region produces UB-style divergence between the two impls.
+        /// Sort once at load time so every downstream consumer sees a
+        /// well-defined ordering. The leading O(n) sortedness check is the
+        /// common-case fast path; the OrderBy permutation only runs on
+        /// inversions. LINQ OrderBy is stable (matches Rust slice::sort_by);
+        /// Array.Sort on parallel arrays is unstable introsort and would reorder
+        /// ties differently.
+        ///
+        /// Throws on NaN m/z: NaN comparison semantics differ between
+        /// Comparer&lt;double&gt;.Default and Rust's total_cmp, so we cannot sort
+        /// consistently across impls; better to refuse the spectrum than
+        /// silently diverge.
+        /// </summary>
+        internal static bool EnsureSorted(uint spectrumIndex,
+            ref double[] mzArray, ref float[] intensityArray)
+        {
+            if (mzArray == null || mzArray.Length < 2)
+                return false;
+            // Defensive guard: a malformed source where the m/z and intensity
+            // arrays are not the same length would IndexOutOfRange on the
+            // permutation step. Skip sorting in that case (downstream code
+            // already has its own length checks).
+            if (intensityArray == null || intensityArray.Length != mzArray.Length)
+                return false;
+            // Walk the array once: detect NaN m/z (fail loudly so a user report
+            // surfaces) and check sortedness in the same pass.
+            bool sorted = true;
+            for (int i = 0; i < mzArray.Length; i++)
+            {
+                if (double.IsNaN(mzArray[i]))
+                {
+                    throw new InvalidDataException(string.Format(
+                        "NaN m/z at index {0} of spectrum_index={1} (n_peaks={2}); " +
+                        "cannot sort or fragment-match a malformed centroid array.",
+                        i, spectrumIndex, mzArray.Length));
+                }
+                if (i > 0 && mzArray[i] < mzArray[i - 1])
+                    sorted = false;
+            }
+            if (sorted)
+                return false;
+            // Re-sorting below is unconditional (correctness); the per-spectrum
+            // notice is implementer detail - some instrument data carries a tiny
+            // fraction of unsorted peak arrays (e.g. Astral ~0.07%) that Osprey
+            // silently corrects - so it stays behind --verbose.
+            if (OspreyOutput.Verbose)
+            {
+                int logCount = Interlocked.Increment(ref s_unsortedLogCount);
+                if (logCount <= MaxUnsortedLogLines)
+                {
+                    OspreyOutput.Out.WriteLine(
+                        $@"[unsorted-spectrum] spectrum_index={spectrumIndex} n_peaks={mzArray.Length}");
+                    if (logCount == MaxUnsortedLogLines)
+                    {
+                        OspreyOutput.Out.WriteLine(
+                            $@"[unsorted-spectrum] suppressing further lines (>{MaxUnsortedLogLines} per process)");
+                    }
+                }
+            }
+            int n = mzArray.Length;
+            double[] keyMz = mzArray;
+            int[] order = Enumerable.Range(0, n)
+                .OrderBy(i => keyMz[i]).ToArray();
+            double[] sortedMzs = new double[n];
+            float[] sortedInts = new float[n];
+            for (int i = 0; i < n; i++)
+            {
+                sortedMzs[i] = mzArray[order[i]];
+                sortedInts[i] = intensityArray[order[i]];
+            }
+            mzArray = sortedMzs;
+            intensityArray = sortedInts;
+            return true;
+        }
+
+        /// <summary>
+        /// Build an MS1 spectrum record. <paramref name="spectrumIndex"/> is the
+        /// 0-based position in the source file, which is what
+        /// <see cref="MS1Spectrum.ScanNumber"/> carries (NOT a vendor scan number).
+        /// </summary>
+        internal static MS1Spectrum CreateMs1Spectrum(uint spectrumIndex, double retentionTime,
+            double[] mzArray, float[] intensityArray)
+        {
+            return new MS1Spectrum
+            {
+                ScanNumber = spectrumIndex,
+                RetentionTime = retentionTime,
+                Mzs = mzArray,
+                Intensities = intensityArray,
+            };
+        }
+
+        /// <summary>
+        /// Build an MS2 spectrum record, or null when the spectrum carries no
+        /// usable precursor center (the caller skips it).
+        ///
+        /// <paramref name="isoLower"/> / <paramref name="isoUpper"/> are OFFSETS
+        /// from the center, not absolute bounds and not a width. Missing offsets
+        /// fail fast rather than substituting a hardcoded 12.5 default: DIA
+        /// processing cannot proceed without true isolation windows, and a silent
+        /// default produces bogus results that are very hard to diagnose
+        /// downstream. Mirrors the equivalent fail-fast in
+        /// osprey/crates/osprey-io/src/mzml/parser.rs (PR #39 on maccoss/osprey).
+        /// </summary>
+        internal static Spectrum CreateMs2Spectrum(uint spectrumIndex, double retentionTime,
+            double precursorMz, bool hasIsolationWindow, double isoTarget, double isoLower,
+            double isoUpper, double[] mzArray, float[] intensityArray)
+        {
+            // Use selected ion m/z as center if no isolation window target.
+            double center = hasIsolationWindow && isoTarget > 0 ? isoTarget : precursorMz;
+            if (center <= 0)
+                return null;
+
+            if (isoLower <= 0)
+                throw new InvalidDataException(string.Format(
+                    "spectrum index {0}: no valid isolation-window lower offset " +
+                    "(cvParam MS:1000828 missing or non-positive); cannot process DIA data " +
+                    "without true isolation windows.",
+                    spectrumIndex));
+            if (isoUpper <= 0)
+                throw new InvalidDataException(string.Format(
+                    "spectrum index {0}: no valid isolation-window upper offset " +
+                    "(cvParam MS:1000829 missing or non-positive); cannot process DIA data " +
+                    "without true isolation windows.",
+                    spectrumIndex));
+
+            return new Spectrum
+            {
+                ScanNumber = spectrumIndex,
+                RetentionTime = retentionTime,
+                PrecursorMz = precursorMz > 0 ? precursorMz : center,
+                IsolationWindow = new IsolationWindow(center, isoLower, isoUpper),
+                Mzs = mzArray,
+                Intensities = intensityArray,
+            };
+        }
+    }
+}

--- a/pwiz_tools/Osprey/Osprey.IO/SpectrumBuilder.cs
+++ b/pwiz_tools/Osprey/Osprey.IO/SpectrumBuilder.cs
@@ -21,7 +21,6 @@
  * limitations under the License.
  */
 
-using System;
 using System.IO;
 using System.Linq;
 using System.Threading;

--- a/pwiz_tools/Osprey/Osprey.IO/SpectrumFileReader.cs
+++ b/pwiz_tools/Osprey/Osprey.IO/SpectrumFileReader.cs
@@ -1,0 +1,73 @@
+/*
+ * Original author: Brendan MacLean <brendanx .at. uw.edu>,
+ *                  MacCoss Lab, Department of Genome Sciences, UW
+ * AI assistance: Claude Code (Claude Opus 5) <noreply .at. anthropic.com>
+ *
+ * Based on osprey (https://github.com/MacCossLab/osprey)
+ *   by Michael J. MacCoss, MacCoss Lab, Department of Genome Sciences, UW
+ *
+ * Copyright 2026 University of Washington - Seattle, WA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
+using System.IO;
+
+namespace pwiz.Osprey.IO
+{
+    /// <summary>
+    /// Selects a spectrum reader by file extension. The single place that knows
+    /// Osprey can read more than one input format, so callers
+    /// (<c>ScoringTaskShared.EnsureSpectraCache</c>) stay unaware of the source
+    /// format and everything downstream keeps seeing one
+    /// <see cref="MzmlResult"/>.
+    ///
+    /// mzML is handled by the hand-written <see cref="MzmlReader"/> on every
+    /// target framework. Vendor formats go through ProteoWizard, which is
+    /// net472-only (pwiz_data_cli has no .NET 8 build), so on net8.0 a vendor
+    /// path is a clear error rather than a silent fallback that would produce
+    /// nothing.
+    /// </summary>
+    public static class SpectrumFileReader
+    {
+        /// <summary>
+        /// Load all MS1 and MS2 spectra from an mzML or vendor raw file.
+        /// </summary>
+        public static MzmlResult LoadAllSpectra(string path)
+        {
+            if (IsMzml(path))
+                return MzmlReader.LoadAllSpectra(path);
+#if NET472
+            return VendorRawReader.LoadAllSpectra(path);
+#else
+            throw new NotSupportedException(string.Format(
+                "Cannot read '{0}': reading vendor instrument files requires the .NET Framework " +
+                "build of Osprey (ProteoWizard's pwiz_data_cli is net472-only). Convert the file " +
+                "to mzML with msconvert, or run the net472 build.", path));
+#endif
+        }
+
+        /// <summary>
+        /// Whether this path is handled by the hand-written mzML parser. Covers
+        /// the gzipped form because <see cref="MzmlReader"/> reads it.
+        /// </summary>
+        public static bool IsMzml(string path)
+        {
+            string ext = Path.GetExtension(path);
+            if (string.Equals(ext, @".gz", StringComparison.OrdinalIgnoreCase))
+                ext = Path.GetExtension(Path.GetFileNameWithoutExtension(path));
+            return string.Equals(ext, @".mzml", StringComparison.OrdinalIgnoreCase);
+        }
+    }
+}

--- a/pwiz_tools/Osprey/Osprey.IO/SpectrumFileReader.cs
+++ b/pwiz_tools/Osprey/Osprey.IO/SpectrumFileReader.cs
@@ -23,6 +23,7 @@
 
 using System;
 using System.IO;
+using pwiz.Osprey.Core;
 
 namespace pwiz.Osprey.IO
 {
@@ -46,11 +47,28 @@ namespace pwiz.Osprey.IO
         /// </summary>
         public static MzmlResult LoadAllSpectra(string path)
         {
-            if (IsMzml(path))
-                return MzmlReader.LoadAllSpectra(path);
+            bool isMzml = IsMzml(path);
 #if NET472
-            return VendorRawReader.LoadAllSpectra(path);
+            // OSPREY_MZML_VIA_PWIZ routes mzML through ProteoWizard too, so the
+            // two readers can be compared against one fixed input file. Vendor
+            // centroiding is NOT requested for an mzML: those peaks are already
+            // centroided, and MsDataFileImpl would centroid through a
+            // VendorOnlyPeakDetector that throws with no vendor API behind it.
+            if (isMzml && !OspreyEnvironment.MzmlViaPwiz)
+                return MzmlReader.LoadAllSpectra(path);
+            return VendorRawReader.LoadAllSpectra(path, requireVendorCentroiding: !isMzml);
 #else
+            if (isMzml)
+            {
+                if (OspreyEnvironment.MzmlViaPwiz)
+                {
+                    throw new NotSupportedException(
+                        "OSPREY_MZML_VIA_PWIZ requires the .NET Framework build of Osprey: it reads " +
+                        "mzML through ProteoWizard, whose pwiz_data_cli is net472-only. Unset the " +
+                        "variable to use the built-in mzML reader, or run the net472 build.");
+                }
+                return MzmlReader.LoadAllSpectra(path);
+            }
             throw new NotSupportedException(string.Format(
                 "Cannot read '{0}': reading vendor instrument files requires the .NET Framework " +
                 "build of Osprey (ProteoWizard's pwiz_data_cli is net472-only). Convert the file " +

--- a/pwiz_tools/Osprey/Osprey.IO/SpectrumFileReader.cs
+++ b/pwiz_tools/Osprey/Osprey.IO/SpectrumFileReader.cs
@@ -23,7 +23,11 @@
 
 using System;
 using System.IO;
+#if OSPREY_VENDOR_READER
+// Only the ProteoWizard build reads OspreyEnvironment here; without the
+// conditional this is a redundant-using warning in the default build.
 using pwiz.Osprey.Core;
+#endif
 
 namespace pwiz.Osprey.IO
 {
@@ -34,11 +38,19 @@ namespace pwiz.Osprey.IO
     /// format and everything downstream keeps seeing one
     /// <see cref="MzmlResult"/>.
     ///
-    /// mzML is handled by the hand-written <see cref="MzmlReader"/> on every
-    /// target framework. Vendor formats go through ProteoWizard, which is
-    /// net472-only (pwiz_data_cli has no .NET 8 build), so on net8.0 a vendor
-    /// path is a clear error rather than a silent fallback that would produce
-    /// nothing.
+    /// Which reader handles mzML depends on whether the build HAS ProteoWizard:
+    ///
+    /// * With it (net472, <c>/p:OspreyVendorReader=true</c>): ProteoWizard reads
+    ///   everything, mzML included. One parser for all mass spec data is the
+    ///   intended end state, and byte-level parity with <see cref="MzmlReader"/>
+    ///   is proven, so there is nothing left for a second parser to add.
+    /// * Without it (net8.0, or net472 by default): <see cref="MzmlReader"/> reads
+    ///   mzML because it is the only reader present, and a vendor path is a clear
+    ///   error rather than a silent fallback that would produce nothing.
+    ///
+    /// ProteoWizard is net472-only today (<c>pwiz_data_cli</c> has no .NET 8
+    /// build). Once #4178 supplies one, <see cref="MzmlReader"/> should be removed
+    /// and this class stops having a decision to make.
     /// </summary>
     public static class SpectrumFileReader
     {
@@ -58,25 +70,30 @@ namespace pwiz.Osprey.IO
         {
             bool isMzml = IsMzml(path);
 #if OSPREY_VENDOR_READER
-            // OSPREY_MZML_VIA_PWIZ routes mzML through ProteoWizard too, so the
-            // two readers can be compared against one fixed input file. Vendor
-            // centroiding is NOT requested for an mzML: those peaks are already
+            // EVERY format goes through ProteoWizard in a build that has it, mzML
+            // included. Reader-vs-reader parity is proven byte-for-byte on three
+            // datasets, so a second mzML parser earns nothing but a second place for
+            // a defect to live - and it is the one parser here that ProteoWizard,
+            // Skyline and msconvert do not already agree on. MzmlReader survives only
+            // because pwiz_data_cli has no .NET 8 build; when #4178 lands it should be
+            // deleted outright and this method collapses to a single call.
+            //
+            // OSPREY_MZML_VIA_MZMLREADER forces the hand-written reader back for one
+            // run. That is what keeps the parity check expressible: the same mzML read
+            // both ways must produce byte-identical .spectra.bin.
+            //
+            // Vendor centroiding is NOT requested for an mzML: those peaks are already
             // centroided, and MsDataFileImpl would centroid through a
             // VendorOnlyPeakDetector that throws with no vendor API behind it.
-            if (isMzml && !OspreyEnvironment.MzmlViaPwiz)
+            if (isMzml && OspreyEnvironment.MzmlViaMzmlReader)
                 return MzmlReader.LoadAllSpectra(path);
             return VendorRawReader.LoadAllSpectra(path, requireVendorCentroiding: !isMzml);
 #else
+            // No ProteoWizard in this build, so mzML is MzmlReader's by necessity and
+            // OSPREY_MZML_VIA_MZMLREADER is a no-op rather than an error: it asks for
+            // what already happens.
             if (isMzml)
-            {
-                if (OspreyEnvironment.MzmlViaPwiz)
-                {
-                    throw new NotSupportedException(
-                        "OSPREY_MZML_VIA_PWIZ needs a build that includes the ProteoWizard reader. " +
-                        VENDOR_READER_ABSENT + " Unset the variable to use the built-in mzML reader.");
-                }
                 return MzmlReader.LoadAllSpectra(path);
-            }
             throw new NotSupportedException(string.Format(
                 "Cannot read '{0}': it is not an mzML, and this build of Osprey cannot read vendor " +
                 "instrument files. {1} Otherwise convert the file to mzML with msconvert.",

--- a/pwiz_tools/Osprey/Osprey.IO/SpectrumFileReader.cs
+++ b/pwiz_tools/Osprey/Osprey.IO/SpectrumFileReader.cs
@@ -42,13 +42,22 @@ namespace pwiz.Osprey.IO
     /// </summary>
     public static class SpectrumFileReader
     {
+#if !OSPREY_VENDOR_READER
+        // Named once so both "cannot read this file" messages say the same thing
+        // about how to get a build that can.
+        private const string VENDOR_READER_ABSENT =
+            "Vendor reading is an opt-in build capability: build the net472 configuration with " +
+            "/p:OspreyVendorReader=true, which requires a bjam build to have staged " +
+            "pwiz_tools/Shared/ProteowizardWrapper/obj/x64.";
+#endif
+
         /// <summary>
         /// Load all MS1 and MS2 spectra from an mzML or vendor raw file.
         /// </summary>
         public static MzmlResult LoadAllSpectra(string path)
         {
             bool isMzml = IsMzml(path);
-#if NET472
+#if OSPREY_VENDOR_READER
             // OSPREY_MZML_VIA_PWIZ routes mzML through ProteoWizard too, so the
             // two readers can be compared against one fixed input file. Vendor
             // centroiding is NOT requested for an mzML: those peaks are already
@@ -63,16 +72,15 @@ namespace pwiz.Osprey.IO
                 if (OspreyEnvironment.MzmlViaPwiz)
                 {
                     throw new NotSupportedException(
-                        "OSPREY_MZML_VIA_PWIZ requires the .NET Framework build of Osprey: it reads " +
-                        "mzML through ProteoWizard, whose pwiz_data_cli is net472-only. Unset the " +
-                        "variable to use the built-in mzML reader, or run the net472 build.");
+                        "OSPREY_MZML_VIA_PWIZ needs a build that includes the ProteoWizard reader. " +
+                        VENDOR_READER_ABSENT + " Unset the variable to use the built-in mzML reader.");
                 }
                 return MzmlReader.LoadAllSpectra(path);
             }
             throw new NotSupportedException(string.Format(
-                "Cannot read '{0}': reading vendor instrument files requires the .NET Framework " +
-                "build of Osprey (ProteoWizard's pwiz_data_cli is net472-only). Convert the file " +
-                "to mzML with msconvert, or run the net472 build.", path));
+                "Cannot read '{0}': it is not an mzML, and this build of Osprey cannot read vendor " +
+                "instrument files. {1} Otherwise convert the file to mzML with msconvert.",
+                path, VENDOR_READER_ABSENT));
 #endif
         }
 

--- a/pwiz_tools/Osprey/Osprey.IO/SpectrumFileReader.cs
+++ b/pwiz_tools/Osprey/Osprey.IO/SpectrumFileReader.cs
@@ -87,7 +87,13 @@ namespace pwiz.Osprey.IO
             // VendorOnlyPeakDetector that throws with no vendor API behind it.
             if (isMzml && OspreyEnvironment.MzmlViaMzmlReader)
                 return MzmlReader.LoadAllSpectra(path);
-            return VendorRawReader.LoadAllSpectra(path, requireVendorCentroiding: !isMzml);
+            // Ask for vendor centroiding only where a vendor API can actually do it.
+            // "Not mzML" is not the same question: an .mzXML or .mgf reaches here too,
+            // and requesting it for one of those lands in MsDataFileImpl's
+            // VendorOnlyPeakDetector, whose constructor leaves a null algorithm and
+            // whose first spectrum throws NoVendorPeakPickingException - an error about
+            // peak picking that says nothing about the real problem, the format choice.
+            return VendorRawReader.LoadAllSpectra(path, requireVendorCentroiding: IsVendorFormat(path));
 #else
             // No ProteoWizard in this build, so mzML is MzmlReader's by necessity and
             // OSPREY_MZML_VIA_MZMLREADER is a no-op rather than an error: it asks for
@@ -99,6 +105,28 @@ namespace pwiz.Osprey.IO
                 "instrument files. {1} Otherwise convert the file to mzML with msconvert.",
                 path, VENDOR_READER_ABSENT));
 #endif
+        }
+
+        /// <summary>
+        /// Whether this path is a vendor instrument format, i.e. one with a vendor API
+        /// behind it that can centroid. Deliberately a positive list rather than
+        /// "anything that is not mzML": ProteoWizard also reads mzXML, MGF and MS2,
+        /// and none of those has a vendor peak picker to ask.
+        ///
+        /// Several of these are DIRECTORIES rather than files (Agilent and Bruker .d,
+        /// Waters .raw), which is why the extension is taken from the path rather than
+        /// from any file inside it.
+        /// </summary>
+        public static bool IsVendorFormat(string path)
+        {
+            string ext = Path.GetExtension(path);
+            if (string.IsNullOrEmpty(ext))
+                return false;
+            return string.Equals(ext, @".raw", StringComparison.OrdinalIgnoreCase)      // Thermo, Waters
+                   || string.Equals(ext, @".d", StringComparison.OrdinalIgnoreCase)     // Agilent, Bruker
+                   || string.Equals(ext, @".wiff", StringComparison.OrdinalIgnoreCase)  // Sciex
+                   || string.Equals(ext, @".wiff2", StringComparison.OrdinalIgnoreCase) // Sciex
+                   || string.Equals(ext, @".lcd", StringComparison.OrdinalIgnoreCase);  // Shimadzu
         }
 
         /// <summary>

--- a/pwiz_tools/Osprey/Osprey.IO/VendorRawReader.cs
+++ b/pwiz_tools/Osprey/Osprey.IO/VendorRawReader.cs
@@ -1,0 +1,157 @@
+/*
+ * Original author: Brendan MacLean <brendanx .at. uw.edu>,
+ *                  MacCoss Lab, Department of Genome Sciences, UW
+ * AI assistance: Claude Code (Claude Opus 5) <noreply .at. anthropic.com>
+ *
+ * Based on osprey (https://github.com/MacCossLab/osprey)
+ *   by Michael J. MacCoss, MacCoss Lab, Department of Genome Sciences, UW
+ *
+ * Copyright 2026 University of Washington - Seattle, WA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System.Collections.Generic;
+using System.IO;
+using pwiz.Osprey.Core;
+using pwiz.ProteowizardWrapper;
+
+namespace pwiz.Osprey.IO
+{
+    /// <summary>
+    /// Reads vendor raw files directly through ProteoWizard, producing the same
+    /// <see cref="MzmlResult"/> <see cref="MzmlReader"/> produces from the mzML
+    /// msconvert would have written from that same file (issue #4496). net472
+    /// only: pwiz_data_cli is net472-only, so the net8.0 configuration still
+    /// reads mzML.
+    ///
+    /// This is an adapter, not an integration. Osprey needs roughly seven scalars
+    /// and two arrays per spectrum, all of which <see cref="MsDataFileImpl"/>
+    /// already exposes, so there is no direct pwiz_data_cli binding here. The
+    /// spectra themselves are assembled by <see cref="SpectrumBuilder"/>, shared
+    /// with <see cref="MzmlReader"/>, so the two paths cannot drift in how they
+    /// sort peaks or validate isolation windows.
+    ///
+    /// The isolation window is the detail most likely to be silently wrong in a
+    /// hand-rolled binding: <see cref="MsPrecursor.IsolationWindowLower"/> and
+    /// <see cref="MsPrecursor.IsolationWindowUpper"/> are OFFSETS from the target
+    /// m/z (MsDataFileImpl reads MS_isolation_window_lower_offset /
+    /// _upper_offset), which is exactly what
+    /// <see cref="IsolationWindow"/>(center, lowerOffset, upperOffset) wants.
+    /// Not a width, not absolute bounds.
+    /// </summary>
+    public static class VendorRawReader
+    {
+        /// <summary>
+        /// Load all MS1 and MS2 spectra from a vendor raw file.
+        ///
+        /// The reader options reproduce the msconvert command line Osprey's mzML
+        /// was produced with (ai/scripts/Osprey/SEA-AD/convert-one.cmd):
+        /// <c>--filter "peakPicking vendor msLevel=1-"</c> becomes
+        /// requireVendorCentroided for both MS levels, and <c>--simAsSpectra</c>
+        /// becomes simAsSpectra. Getting these wrong does not perturb the numbers
+        /// slightly, it changes WHICH spectra exist, which shifts every record
+        /// after the first difference.
+        /// </summary>
+        public static MzmlResult LoadAllSpectra(string path)
+        {
+            var ms2Spectra = new List<Spectrum>();
+            var ms1Spectra = new List<MS1Spectrum>();
+            int unsortedCount = 0;
+
+            using (var msData = new MsDataFileImpl(path,
+                       simAsSpectra: true,
+                       requireVendorCentroidedMS1: true,
+                       requireVendorCentroidedMS2: true))
+            {
+                int count = msData.SpectrumCount;
+                // Per-spectrum rather than per-byte progress (the vendor reader
+                // exposes no byte position), on the same throttled interval the
+                // mzML read uses -- a large raw file is minutes of otherwise
+                // silent work.
+                using (var progress = new ProgressReporter(
+                           string.Format("Reading {0}", Path.GetFileName(path)), count,
+                           string.Empty, ProgressReporter.IO_INTERVAL_SECONDS))
+                {
+                    for (int i = 0; i < count; i++)
+                    {
+                        AddSpectrum(msData, i, ms2Spectra, ms1Spectra, ref unsortedCount);
+                        progress.Report(i + 1);
+                    }
+                }
+            }
+
+            return new MzmlResult(ms2Spectra, ms1Spectra, unsortedCount);
+        }
+
+        private static void AddSpectrum(MsDataFileImpl msData, int scanIndex,
+            List<Spectrum> ms2Spectra, List<MS1Spectrum> ms1Spectra, ref int unsortedCount)
+        {
+            var spectrum = msData.GetSpectrum(scanIndex);
+            if (spectrum == null || (spectrum.Level != 1 && spectrum.Level != 2))
+                return;
+
+            // Zero-peak spectra are KEPT, not skipped. MzmlReader has no
+            // empty-array guard, so msconvert's mzML yields a record for every
+            // acquired spectrum; dropping them here cost exactly 945 MS2 records
+            // (88 bytes each: a 48-byte record with no peaks plus its 40-byte
+            // index entry) against the TDP-43 reference and shifted nothing else.
+            double[] mzs = spectrum.Mzs ?? new double[0];
+            double[] rawIntensities = spectrum.Intensities ?? new double[0];
+            if (rawIntensities.Length != mzs.Length)
+                return;
+
+            // SpectraCache stores intensities as f32 while ProteoWizard hands back
+            // f64. Vendor intensities originate as f32, so widening then narrowing
+            // round-trips exactly; this is the same width the mzML path decodes
+            // from a 32-bit binary array.
+            float[] intensities = new float[rawIntensities.Length];
+            for (int i = 0; i < rawIntensities.Length; i++)
+                intensities[i] = (float)rawIntensities[i];
+
+            // Index, not a vendor scan number: Spectrum.ScanNumber carries the
+            // 0-based position in the source file, matching the mzML "index"
+            // attribute MzmlReader reads.
+            uint index = (uint)spectrum.Index;
+            if (SpectrumBuilder.EnsureSorted(index, ref mzs, ref intensities))
+                unsortedCount++;
+
+            // RetentionTime is minutes on both sides (MsDataSpectrum reports
+            // minutes; MzmlReader divides seconds-valued cvParams by 60).
+            double retentionTime = spectrum.RetentionTime ?? 0.0;
+
+            if (spectrum.Level == 1)
+            {
+                ms1Spectra.Add(SpectrumBuilder.CreateMs1Spectrum(index, retentionTime,
+                    mzs, intensities));
+                return;
+            }
+
+            var precursors = spectrum.Precursors;
+            if (precursors == null || precursors.Count == 0)
+                return; // No precursor: not a usable MS2, same as the mzML path.
+
+            var precursor = precursors[0];
+            double precursorMz = precursor.PrecursorMz?.Value ?? 0.0;
+            bool hasIsolationWindow = precursor.IsolationWindowTargetMz.HasValue;
+            double isoTarget = precursor.IsolationWindowTargetMz?.Value ?? 0.0;
+            double isoLower = precursor.IsolationWindowLower ?? 0.0;
+            double isoUpper = precursor.IsolationWindowUpper ?? 0.0;
+
+            var ms2 = SpectrumBuilder.CreateMs2Spectrum(index, retentionTime, precursorMz,
+                hasIsolationWindow, isoTarget, isoLower, isoUpper, mzs, intensities);
+            if (ms2 != null)
+                ms2Spectra.Add(ms2);
+        }
+    }
+}

--- a/pwiz_tools/Osprey/Osprey.IO/VendorRawReader.cs
+++ b/pwiz_tools/Osprey/Osprey.IO/VendorRawReader.cs
@@ -78,15 +78,31 @@ namespace pwiz.Osprey.IO
             var ms1Spectra = new List<MS1Spectrum>();
             int unsortedCount = 0;
 
+            // combineIonMobilitySpectra defaults to TRUE in the wrapper (Skyline wants
+            // IMS in 3-array frames) and FALSE in pwiz, which is what msconvert uses.
+            // Left at the wrapper default, an IMS acquisition would come back as one
+            // combined frame per drift-bin group instead of the per-scan spectra the
+            // mzML has - a different spectrum SET, which shifts every .spectra.bin
+            // record, not just their values. Osprey reads no mobility dimension at all,
+            // so the combined form has nothing to offer it either.
+            //
+            // Two ReaderConfig values still differ from msconvert and CANNOT be set
+            // from here: ignoreCalibrationScans (wrapper hardcodes true, dropping
+            // Waters lockmass scans) and allowMsMsWithoutPrecursor (wrapper hardcodes
+            // false, dropping precursor-less MS2). Both are deliberate Skyline choices
+            // in shared code. They bound the parity claim rather than break it: it
+            // holds for Thermo, where it was measured, and Waters or Bruker PASEF data
+            // needs its own comparison before being trusted.
             using (var msData = new MsDataFileImpl(path,
                        simAsSpectra: true,
+                       combineIonMobilitySpectra: false,
                        requireVendorCentroidedMS1: requireVendorCentroiding,
                        requireVendorCentroidedMS2: requireVendorCentroiding))
             {
                 int count = msData.SpectrumCount;
                 // Per-spectrum rather than per-byte progress (the vendor reader
                 // exposes no byte position), on the same throttled interval the
-                // mzML read uses -- a large raw file is minutes of otherwise
+                // mzML read uses - a large raw file is minutes of otherwise
                 // silent work.
                 using (var progress = new ProgressReporter(
                            string.Format("Reading {0}", Path.GetFileName(path)), count,

--- a/pwiz_tools/Osprey/Osprey.IO/VendorRawReader.cs
+++ b/pwiz_tools/Osprey/Osprey.IO/VendorRawReader.cs
@@ -63,8 +63,9 @@ namespace pwiz.Osprey.IO
         /// slightly, it changes WHICH spectra exist, which shifts every record
         /// after the first difference.
         /// </summary>
-        /// <param name="path">The instrument file, or an mzML under the
-        /// <c>OSPREY_MZML_VIA_PWIZ</c> diagnostic switch.</param>
+        /// <param name="path">The instrument file, or an mzML - in a build with
+        /// ProteoWizard every format arrives here, and only
+        /// <c>OSPREY_MZML_VIA_MZMLREADER</c> diverts mzML away.</param>
         /// <param name="requireVendorCentroiding">Whether to ask ProteoWizard for
         /// vendor centroiding, reproducing msconvert's
         /// <c>peakPicking vendor msLevel=1-</c>. Must be FALSE for an mzML

--- a/pwiz_tools/Osprey/Osprey.IO/VendorRawReader.cs
+++ b/pwiz_tools/Osprey/Osprey.IO/VendorRawReader.cs
@@ -63,7 +63,15 @@ namespace pwiz.Osprey.IO
         /// slightly, it changes WHICH spectra exist, which shifts every record
         /// after the first difference.
         /// </summary>
-        public static MzmlResult LoadAllSpectra(string path)
+        /// <param name="path">The instrument file, or an mzML under the
+        /// <c>OSPREY_MZML_VIA_PWIZ</c> diagnostic switch.</param>
+        /// <param name="requireVendorCentroiding">Whether to ask ProteoWizard for
+        /// vendor centroiding, reproducing msconvert's
+        /// <c>peakPicking vendor msLevel=1-</c>. Must be FALSE for an mzML
+        /// source: the peaks are already centroided by whatever wrote the file,
+        /// and MsDataFileImpl centroids through a <c>VendorOnlyPeakDetector</c>
+        /// that throws when no vendor API is behind the data.</param>
+        public static MzmlResult LoadAllSpectra(string path, bool requireVendorCentroiding = true)
         {
             var ms2Spectra = new List<Spectrum>();
             var ms1Spectra = new List<MS1Spectrum>();
@@ -71,8 +79,8 @@ namespace pwiz.Osprey.IO
 
             using (var msData = new MsDataFileImpl(path,
                        simAsSpectra: true,
-                       requireVendorCentroidedMS1: true,
-                       requireVendorCentroidedMS2: true))
+                       requireVendorCentroidedMS1: requireVendorCentroiding,
+                       requireVendorCentroidedMS2: requireVendorCentroiding))
             {
                 int count = msData.SpectrumCount;
                 // Per-spectrum rather than per-byte progress (the vendor reader

--- a/pwiz_tools/Osprey/Osprey.Tasks/PerFileScoringTask.cs
+++ b/pwiz_tools/Osprey/Osprey.Tasks/PerFileScoringTask.cs
@@ -1745,7 +1745,7 @@ namespace pwiz.Osprey.Tasks
             // progress slice under --parallel-files.
             MultiProgressReporter.Current?.BeginSegment();
             var swParse = Stopwatch.StartNew();
-            SpectraWindowIndex windowIndex = EnsureSpectraCache(
+            SpectraWindowIndex windowIndex = ScoringTaskShared.EnsureSpectraCache(
                 inputFile, ctx.RunPlan.EffectiveFileParallelism > 1, out int unsortedCount, ctx);
             swParse.Stop();
 
@@ -2397,100 +2397,6 @@ namespace pwiz.Osprey.Tasks
 
             ctx.LogInfo(string.Format("[COUNT] Wrote feature dump: {0} ({1} entries)",
                 dumpPath, sorted.Count));
-        }
-
-        /// <summary>
-        /// Ensure a valid <c>.spectra.bin</c> cache exists for the input and return a
-        /// streaming <see cref="SpectraWindowIndex"/> over it (per-window MS2 offsets, plus
-        /// MS1 and the first-cycle isolation windows) WITHOUT materializing the full MS2
-        /// <c>List&lt;Spectrum&gt;</c>. On a cache hit (the common re-run path) the file is only
-        /// header-indexed; on a miss the mzML is parsed once (gated across parallel files),
-        /// written to the cache, then indexed and the parsed list dropped. Stages 1-4
-        /// (calibration + scoring) stream each isolation window from the returned index. The
-        /// full resident load survives only in Stage-6 rescore
-        /// (<see cref="PerFileRescoreTask"/>.LoadSpectraForRescore), a separate follow-up.
-        /// </summary>
-        private SpectraWindowIndex EnsureSpectraCache(string inputFile, bool serializeMzmlRead,
-            out int unsortedCount, PipelineContext ctx)
-        {
-            unsortedCount = 0;
-            // Shared GetCachePath so the write and the rescore read (PerFileRescoreTask)
-            // derive an identical filename + directory (ArtifactPaths redirects the dir).
-            string cachePath = SpectraCache.GetCachePath(inputFile);
-            if (File.Exists(cachePath))
-            {
-                try
-                {
-                    // Cache hit: index the file directly (header pass only) -- never build the
-                    // full MS2 list. Returns null when stale/invalid (bad magic/version or the
-                    // source fingerprint changed), which falls through to a re-parse below.
-                    var hit = SpectraWindowIndex.BuildFromCache(cachePath, inputFile);
-                    if (hit != null)
-                    {
-                        ctx.LogInfo(string.Format("Streaming spectra from cache: {0}", cachePath));
-                        return hit;
-                    }
-                    ctx.LogInfo("Spectra cache stale or invalid; re-parsing mzML.");
-                }
-                catch (Exception ex)
-                {
-                    // A present-but-corrupt/truncated cache body (intact header, e.g. an
-                    // interrupted write) throws during the index pass; re-parse the mzML and
-                    // rewrite the cache rather than faulting the file. Matches the old
-                    // LoadSpectra fallback. Only the miss-path re-index below stays a hard
-                    // error, since that indexes a cache we just wrote.
-                    ctx.LogWarning(string.Format(
-                        "Failed to index spectra cache: {0}. Re-parsing mzML.", ex.Message));
-                }
-            }
-
-            // Miss/stale/absent: parse the mzML once (materialized only transiently here),
-            // optionally serialized across files, write the cache, then index it and drop the
-            // parsed list. The "Processing file N/M: <path>" banner already named the file.
-            MzmlResult mzmlResult;
-            if (serializeMzmlRead)
-                ScoringTaskShared.s_mzmlReadGate.Wait();
-            try
-            {
-                mzmlResult = MzmlReader.LoadAllSpectra(inputFile);
-            }
-            finally
-            {
-                if (serializeMzmlRead)
-                    ScoringTaskShared.s_mzmlReadGate.Release();
-            }
-            unsortedCount = mzmlResult.UnsortedSpectrumCount;
-
-            try
-            {
-                SpectraCache.SaveSpectraCache(cachePath, mzmlResult.Ms2Spectra, mzmlResult.Ms1Spectra, inputFile);
-            }
-            catch (Exception ex)
-            {
-                ctx.LogWarning(string.Format("Failed to save spectra cache: {0}", ex.Message));
-            }
-
-            // Index the just-written cache and stream from it (the parsed MS2 list drops when
-            // this method returns). Per-file scoring REQUIRES the cache; if it could not be
-            // written/indexed (e.g. a read-only or full output directory, or a failed write),
-            // fail clearly -- preserving the underlying error -- rather than silently fall back
-            // to a resident load that would OOM a large run.
-            SpectraWindowIndex index = null;
-            Exception indexError = null;
-            try
-            {
-                index = SpectraWindowIndex.BuildFromCache(cachePath, inputFile);
-            }
-            catch (Exception ex)
-            {
-                indexError = ex;
-            }
-            if (index == null)
-                throw new IOException(string.Format(
-                    "Could not index the spectra cache for '{0}'. Per-file scoring streams MS2 from " +
-                    "'{1}'; ensure that directory is writable (the .scores.parquet and .calibration.json " +
-                    "outputs are written to the same place).", inputFile, cachePath), indexError);
-            return index;
         }
 
         /// <summary>

--- a/pwiz_tools/Osprey/Osprey.Tasks/ScoringTaskShared.cs
+++ b/pwiz_tools/Osprey/Osprey.Tasks/ScoringTaskShared.cs
@@ -54,7 +54,8 @@ namespace pwiz.Osprey.Tasks
         // bits, shared by a target and its paired decoy.
         internal const uint BASE_ID_MASK = 0x7FFFFFFFu;
 
-        // Serializes mzML reads across concurrent ProcessFile() calls. The
+        // Serializes input parsing across concurrent ProcessFile() calls (mzML or
+        // vendor raw; the name predates vendor reading). The
         // producer inside MzmlReader.LoadAllSpectra is a sequential XmlReader over
         // a FileStream, so 3 files parsing in parallel means 3 sequential disk
         // scans fighting for the same head/cache. Gating the parse step funnels
@@ -118,7 +119,8 @@ namespace pwiz.Osprey.Tasks
         /// streaming <see cref="SpectraWindowIndex"/> over it (per-window MS2 offsets, plus
         /// MS1 and the first-cycle isolation windows) WITHOUT materializing the full MS2
         /// <c>List&lt;Spectrum&gt;</c>. On a cache hit (the common re-run path) the file is only
-        /// header-indexed; on a miss the mzML is parsed once (gated across parallel files),
+        /// header-indexed; on a miss the input is parsed once - mzML or vendor raw, whichever
+        /// <see cref="SpectrumFileReader"/> selects - (gated across parallel files),
         /// written to the cache, then indexed and the parsed list dropped. Stages 1-4
         /// (calibration + scoring) stream each isolation window from the returned index. The
         /// full resident load survives only in Stage-6 rescore
@@ -149,17 +151,17 @@ namespace pwiz.Osprey.Tasks
                         ctx.LogInfo(string.Format("Streaming spectra from cache: {0}", cachePath));
                         return hit;
                     }
-                    ctx.LogInfo("Spectra cache stale or invalid; re-parsing mzML.");
+                    ctx.LogInfo("Spectra cache stale or invalid; re-parsing the input.");
                 }
                 catch (Exception ex)
                 {
                     // A present-but-corrupt/truncated cache body (intact header, e.g. an
-                    // interrupted write) throws during the index pass; re-parse the mzML and
+                    // interrupted write) throws during the index pass; re-parse the input and
                     // rewrite the cache rather than faulting the file. Matches the old
                     // LoadSpectra fallback. Only the miss-path re-index below stays a hard
                     // error, since that indexes a cache we just wrote.
                     ctx.LogWarning(string.Format(
-                        "Failed to index spectra cache: {0}. Re-parsing mzML.", ex.Message));
+                        "Failed to index spectra cache: {0}. Re-parsing the input.", ex.Message));
                 }
             }
 

--- a/pwiz_tools/Osprey/Osprey.Tasks/ScoringTaskShared.cs
+++ b/pwiz_tools/Osprey/Osprey.Tasks/ScoringTaskShared.cs
@@ -23,8 +23,10 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Threading;
 using pwiz.Osprey.Core;
+using pwiz.Osprey.IO;
 using pwiz.Osprey.Scoring;
 
 namespace pwiz.Osprey.Tasks
@@ -109,6 +111,105 @@ namespace pwiz.Osprey.Tasks
         internal static MS1Spectrum FindNearestMs1(List<MS1Spectrum> ms1Spectra, double rt)
         {
             return MS1Spectrum.FindNearest(ms1Spectra, rt);
+        }
+
+        /// <summary>
+        /// Ensure a valid <c>.spectra.bin</c> cache exists for the input and return a
+        /// streaming <see cref="SpectraWindowIndex"/> over it (per-window MS2 offsets, plus
+        /// MS1 and the first-cycle isolation windows) WITHOUT materializing the full MS2
+        /// <c>List&lt;Spectrum&gt;</c>. On a cache hit (the common re-run path) the file is only
+        /// header-indexed; on a miss the mzML is parsed once (gated across parallel files),
+        /// written to the cache, then indexed and the parsed list dropped. Stages 1-4
+        /// (calibration + scoring) stream each isolation window from the returned index. The
+        /// full resident load survives only in Stage-6 rescore
+        /// (<c>PerFileRescoreTask.LoadSpectraForRescore</c>, a separate follow-up).
+        ///
+        /// Shared here rather than owned by <see cref="PerFileScoringTask"/> because
+        /// <see cref="SpectraCacheTask"/> (<c>--task SpectraCache</c>) builds exactly the
+        /// same caches. Two copies would let the staging path and the scoring path drift,
+        /// which is precisely what a raw-vs-mzML parity check must be able to rule out.
+        /// </summary>
+        internal static SpectraWindowIndex EnsureSpectraCache(string inputFile, bool serializeMzmlRead,
+            out int unsortedCount, PipelineContext ctx)
+        {
+            unsortedCount = 0;
+            // Shared GetCachePath so the write and the rescore read (PerFileRescoreTask)
+            // derive an identical filename + directory (ArtifactPaths redirects the dir).
+            string cachePath = SpectraCache.GetCachePath(inputFile);
+            if (File.Exists(cachePath))
+            {
+                try
+                {
+                    // Cache hit: index the file directly (header pass only) -- never build the
+                    // full MS2 list. Returns null when stale/invalid (bad magic/version or the
+                    // source fingerprint changed), which falls through to a re-parse below.
+                    var hit = SpectraWindowIndex.BuildFromCache(cachePath, inputFile);
+                    if (hit != null)
+                    {
+                        ctx.LogInfo(string.Format("Streaming spectra from cache: {0}", cachePath));
+                        return hit;
+                    }
+                    ctx.LogInfo("Spectra cache stale or invalid; re-parsing mzML.");
+                }
+                catch (Exception ex)
+                {
+                    // A present-but-corrupt/truncated cache body (intact header, e.g. an
+                    // interrupted write) throws during the index pass; re-parse the mzML and
+                    // rewrite the cache rather than faulting the file. Matches the old
+                    // LoadSpectra fallback. Only the miss-path re-index below stays a hard
+                    // error, since that indexes a cache we just wrote.
+                    ctx.LogWarning(string.Format(
+                        "Failed to index spectra cache: {0}. Re-parsing mzML.", ex.Message));
+                }
+            }
+
+            // Miss/stale/absent: parse the mzML once (materialized only transiently here),
+            // optionally serialized across files, write the cache, then index it and drop the
+            // parsed list. The "Processing file N/M: <path>" banner already named the file.
+            MzmlResult mzmlResult;
+            if (serializeMzmlRead)
+                s_mzmlReadGate.Wait();
+            try
+            {
+                mzmlResult = MzmlReader.LoadAllSpectra(inputFile);
+            }
+            finally
+            {
+                if (serializeMzmlRead)
+                    s_mzmlReadGate.Release();
+            }
+            unsortedCount = mzmlResult.UnsortedSpectrumCount;
+
+            try
+            {
+                SpectraCache.SaveSpectraCache(cachePath, mzmlResult.Ms2Spectra, mzmlResult.Ms1Spectra, inputFile);
+            }
+            catch (Exception ex)
+            {
+                ctx.LogWarning(string.Format("Failed to save spectra cache: {0}", ex.Message));
+            }
+
+            // Index the just-written cache and stream from it (the parsed MS2 list drops when
+            // this method returns). Per-file scoring REQUIRES the cache; if it could not be
+            // written/indexed (e.g. a read-only or full output directory, or a failed write),
+            // fail clearly -- preserving the underlying error -- rather than silently fall back
+            // to a resident load that would OOM a large run.
+            SpectraWindowIndex index = null;
+            Exception indexError = null;
+            try
+            {
+                index = SpectraWindowIndex.BuildFromCache(cachePath, inputFile);
+            }
+            catch (Exception ex)
+            {
+                indexError = ex;
+            }
+            if (index == null)
+                throw new IOException(string.Format(
+                    "Could not index the spectra cache for '{0}'. Per-file scoring streams MS2 from " +
+                    "'{1}'; ensure that directory is writable (the .scores.parquet and .calibration.json " +
+                    "outputs are written to the same place).", inputFile, cachePath), indexError);
+            return index;
         }
     }
 }

--- a/pwiz_tools/Osprey/Osprey.Tasks/ScoringTaskShared.cs
+++ b/pwiz_tools/Osprey/Osprey.Tasks/ScoringTaskShared.cs
@@ -163,15 +163,17 @@ namespace pwiz.Osprey.Tasks
                 }
             }
 
-            // Miss/stale/absent: parse the mzML once (materialized only transiently here),
+            // Miss/stale/absent: parse the input once (materialized only transiently here),
             // optionally serialized across files, write the cache, then index it and drop the
             // parsed list. The "Processing file N/M: <path>" banner already named the file.
+            // SpectrumFileReader picks the mzML or vendor-raw reader by extension; both
+            // return the same MzmlResult, so nothing below here knows the source format.
             MzmlResult mzmlResult;
             if (serializeMzmlRead)
                 s_mzmlReadGate.Wait();
             try
             {
-                mzmlResult = MzmlReader.LoadAllSpectra(inputFile);
+                mzmlResult = SpectrumFileReader.LoadAllSpectra(inputFile);
             }
             finally
             {

--- a/pwiz_tools/Osprey/Osprey.Tasks/SpectraCacheTask.cs
+++ b/pwiz_tools/Osprey/Osprey.Tasks/SpectraCacheTask.cs
@@ -103,9 +103,11 @@ namespace pwiz.Osprey.Tasks
                     index = ScoringTaskShared.EnsureSpectraCache(
                         inputFile, false, out int unsortedCount, ctx);
                     if (unsortedCount > 0)
+                    {
                         ctx.LogWarning(string.Format(
                             "{0}: {1} spectra had unsorted centroids (sorted before caching).",
                             Path.GetFileName(inputFile), unsortedCount));
+                    }
                 }
                 catch (Exception ex)
                 {
@@ -118,6 +120,21 @@ namespace pwiz.Osprey.Tasks
                     continue;
                 }
                 swFile.Stop();
+
+                // A cache with no MS2 is a staging failure, not a staged file. It is
+                // header-valid, so every later scoring run ACCEPTS it, reports "No
+                // spectra found" and drops the file - and never re-parses, because the
+                // cache is valid rather than stale. The scoring path already refuses a
+                // zero-MS2 index; staging has to refuse it too or it launders the
+                // problem into a cache. The usual cause is a reader configuration that
+                // filtered every spectrum out, which is worth failing loudly on.
+                if (index.Ms2Count == 0)
+                {
+                    ctx.LogError(string.Format(
+                        "No MS2 spectra were read from {0}; refusing to stage an empty cache.", inputFile));
+                    ctx.ExitCode = 1;
+                    continue;
+                }
                 built++;
 
                 string cachePath = SpectraCache.GetCachePath(inputFile);

--- a/pwiz_tools/Osprey/Osprey.Tasks/SpectraCacheTask.cs
+++ b/pwiz_tools/Osprey/Osprey.Tasks/SpectraCacheTask.cs
@@ -1,0 +1,144 @@
+/*
+ * Original author: Brendan MacLean <brendanx .at. uw.edu>,
+ *                  MacCoss Lab, Department of Genome Sciences, UW
+ * AI assistance: Claude Code (Claude Opus 5) <noreply .at. anthropic.com>
+ *
+ * Based on osprey (https://github.com/MacCossLab/osprey)
+ *   by Michael J. MacCoss, MacCoss Lab, Department of Genome Sciences, UW
+ *
+ * Copyright 2026 University of Washington - Seattle, WA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using pwiz.Osprey.Core;
+using pwiz.Osprey.IO;
+
+namespace pwiz.Osprey.Tasks
+{
+    /// <summary>
+    /// Stage 1 alone: build each input's <c>.spectra.bin</c> cache and stop
+    /// (<c>--task SpectraCache</c>).
+    ///
+    /// This is the data-staging step ahead of the pipeline rather than one of its
+    /// HPC fan-out nodes, which is why it needs no <c>--library</c> and publishes no
+    /// byproducts: caching depends only on the input file. Staging a dataset is
+    /// otherwise only reachable by running all of Stage 1-4 through
+    /// <see cref="PerFileScoringTask"/>, which additionally demands a library and
+    /// spends calibration + scoring + parquet time that a staging pass does not need.
+    ///
+    /// It builds caches through the same
+    /// <see cref="ScoringTaskShared.EnsureSpectraCache"/> the scoring path uses, so a
+    /// cache written here is byte-for-byte what a full run would have written.
+    /// </summary>
+    internal sealed class SpectraCacheTask : OspreyTask
+    {
+        public override string Name => @"SpectraCache";
+
+        /// <summary>
+        /// Selected explicitly and never part of the canonical pipeline: a full run
+        /// reaches the identical caching code through
+        /// <see cref="PerFileScoringTask"/>, so including this task there would
+        /// double-index every input for nothing.
+        /// </summary>
+        public override bool IsIncluded(PipelineContext ctx)
+        {
+            return ctx.Config.SelectedTask == HpcTask.SpectraCache;
+        }
+
+        public override IEnumerable<string> Inputs(PipelineContext ctx)
+        {
+            if (ctx.Config.InputFiles == null)
+                yield break;
+            foreach (var input in ctx.Config.InputFiles)
+                yield return input;
+        }
+
+        /// <summary>
+        /// Deliberately empty, so the driver always calls <see cref="Run"/>. The
+        /// caches ARE this task's durable output, but reporting them here would have
+        /// the driver skip the task wholesale on a validity sidecar; the per-file
+        /// cache-hit check inside <see cref="ScoringTaskShared.EnsureSpectraCache"/>
+        /// already makes a re-run cheap, and it is per input rather than all-or-
+        /// nothing, which is what a 164-file staging sweep interrupted partway
+        /// through actually needs.
+        /// </summary>
+        public override IEnumerable<string> Outputs(PipelineContext ctx) => Array.Empty<string>();
+
+        public override bool Run(PipelineContext ctx)
+        {
+            var config = ctx.Config;
+            int nFiles = config.InputFiles.Count;
+            var swAll = Stopwatch.StartNew();
+            int built = 0;
+
+            // Sequential by design. The work is one disk-bound parse per file, which
+            // is exactly what s_mzmlReadGate serializes on the scoring path anyway;
+            // running files in parallel here would contend for the same spindle while
+            // multiplying the transient parse buffer by the file count.
+            for (int fileIdx = 0; fileIdx < nFiles; fileIdx++)
+            {
+                string inputFile = config.InputFiles[fileIdx];
+                ctx.LogInfo(string.Format("Caching spectra {0}/{1}: {2}",
+                    fileIdx + 1, nFiles, inputFile));
+
+                var swFile = Stopwatch.StartNew();
+                SpectraWindowIndex index;
+                try
+                {
+                    index = ScoringTaskShared.EnsureSpectraCache(
+                        inputFile, false, out int unsortedCount, ctx);
+                    if (unsortedCount > 0)
+                        ctx.LogWarning(string.Format(
+                            "{0}: {1} spectra had unsorted centroids (sorted before caching).",
+                            Path.GetFileName(inputFile), unsortedCount));
+                }
+                catch (Exception ex)
+                {
+                    // One unreadable input must not abandon the rest of a long
+                    // staging sweep, but it must still fail the run: a partially
+                    // staged dataset that reports success would be discovered much
+                    // later, in a scoring run that silently re-parses.
+                    ctx.LogError(string.Format("Failed to cache {0}: {1}", inputFile, ex.Message));
+                    ctx.ExitCode = 1;
+                    continue;
+                }
+                swFile.Stop();
+                built++;
+
+                string cachePath = SpectraCache.GetCachePath(inputFile);
+                var cacheInfo = new FileInfo(cachePath);
+                ctx.LogInfo(string.Format(
+                    "  {0}: ms2={1:N0} ms1={2:N0} {3:N2} GB in {4:N1}s",
+                    Path.GetFileName(cachePath), index.Ms2Count, index.Ms1Spectra.Count,
+                    cacheInfo.Length / (1024.0 * 1024.0 * 1024.0), swFile.Elapsed.TotalSeconds));
+            }
+
+            swAll.Stop();
+            ctx.LogInfo(string.Format("Cached {0} of {1} file(s) in {2:N1}s",
+                built, nFiles, swAll.Elapsed.TotalSeconds));
+            return ctx.ExitCode == 0;
+        }
+
+        /// <summary>
+        /// Nothing to rehydrate: this task publishes no byproducts, so no consumer
+        /// can demand it. Its outputs are read back off disk by
+        /// <see cref="ScoringTaskShared.EnsureSpectraCache"/> on a later scoring run.
+        /// </summary>
+        public override bool Rehydrate(PipelineContext ctx) => true;
+    }
+}

--- a/pwiz_tools/Osprey/Osprey.Test/IOTest.cs
+++ b/pwiz_tools/Osprey/Osprey.Test/IOTest.cs
@@ -28,7 +28,6 @@ using System.Globalization;
 using System.IO;
 using System.IO.Compression;
 using System.Linq;
-using System.Xml;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Newtonsoft.Json;
 using Parquet;

--- a/pwiz_tools/Osprey/Osprey.Test/IOTest.cs
+++ b/pwiz_tools/Osprey/Osprey.Test/IOTest.cs
@@ -28,6 +28,7 @@ using System.Globalization;
 using System.IO;
 using System.IO.Compression;
 using System.Linq;
+using System.Xml;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Newtonsoft.Json;
 using Parquet;
@@ -1567,6 +1568,67 @@ namespace pwiz.Osprey.Test
             }
 
             Assert.AreEqual(0, entries.Count); // should be skipped (only 2 fragments)
+        }
+
+        #endregion
+
+        #region Retention time precision
+
+        /// <summary>
+        /// A scan start time must survive the mzML round trip bit-exactly.
+        /// 0.86653405 is a real Thermo value (spectrum index 5679 of a TDP-43
+        /// PlasmaEV acquisition) that came out of <see cref="MzmlReader"/> as
+        /// 0.8665340500000001 on the net472 build while the net8.0 build of the
+        /// same code returned it exactly - a 1-ULP difference that made a
+        /// raw-sourced .spectra.bin disagree with an mzML-sourced one
+        /// (issue #4496).
+        ///
+        /// Root cause: .NET Framework's string-to-double conversion is not
+        /// correctly rounded for some decimals, and XmlConvert.ToDouble inherits
+        /// it. "0.86653405" parses to 0x3FEBBAA59DB3DA8E on .NET Framework and
+        /// 0x3FEBBAA59DB3DA8D (the correctly rounded value, and what C++ strtod
+        /// gives) on .NET Core 3.0+. So this test asserts what the READER
+        /// controls - that the value reaching a <see cref="Spectrum"/> is exactly
+        /// what the runtime's parser produced, with nothing perturbing it in
+        /// between. It deliberately does NOT compare against a compiled literal:
+        /// that comparison fails on net472 for reasons no Osprey code can fix,
+        /// and pinning it here would just encode the runtime defect as expected.
+        /// The cross-runtime deviation itself is tracked separately.
+        /// </summary>
+        [TestMethod]
+        public void TestMzmlReaderRetentionTimePrecision()
+        {
+            foreach (string text in new[] { @"0.86653405", @"0.97263695", @"0.5903117" })
+            {
+                double expected = XmlConvert.ToDouble(text);
+                // Exact: any delta would hide the very defect under test.
+                Assert.AreEqual(double.Parse(text, CultureInfo.InvariantCulture), expected, 0.0,
+                    @"XmlConvert vs double.Parse disagree on " + text);
+
+                string mzml = BuildMinimalMzml(
+                    msLevel: 2,
+                    retentionTimeMinutes: expected,
+                    precursorMz: 711.07312,
+                    isoTarget: 711.07312,
+                    isoLower: 1.5006999969482422,
+                    isoUpper: 1.5006999969482422,
+                    mzValues: new[] { 200.0, 300.0, 400.0 },
+                    intensityValues: new[] { 100.0f, 200.0f, 300.0f });
+
+                string path = Path.GetTempFileName() + ".mzML";
+                try
+                {
+                    File.WriteAllText(path, mzml);
+                    var result = MzmlReader.LoadAllSpectra(path);
+                    Assert.AreEqual(1, result.Ms2Spectra.Count);
+                    Assert.AreEqual(expected, result.Ms2Spectra[0].RetentionTime, 0.0,
+                        @"retention time not preserved bit-exactly for " + text);
+                }
+                finally
+                {
+                    File.Delete(path);
+                }
+            }
         }
 
         #endregion

--- a/pwiz_tools/Osprey/Osprey.Test/IOTest.cs
+++ b/pwiz_tools/Osprey/Osprey.Test/IOTest.cs
@@ -762,6 +762,80 @@ namespace pwiz.Osprey.Test
             }
         }
 
+        /// <summary>
+        /// A build WITHOUT the vendor reader must still run against a <c>.spectra.bin</c>
+        /// that an opt-in build produced from a vendor raw file. That is the whole point of
+        /// staging caches once on a vendor-capable machine: every other machine consumes
+        /// them with no ProteoWizard and no mzML conversion.
+        ///
+        /// The guarantee is an ORDERING one - <c>EnsureSpectraCache</c> has to consult the
+        /// cache before it dispatches on file extension - and nothing else pins it. An
+        /// up-front extension check, added for a friendlier error message, would silently
+        /// break this workflow while every other test stayed green.
+        ///
+        /// The assertion is sound in either build. Where the vendor reader is absent
+        /// <see cref="SpectrumFileReader"/> throws for a non-mzML path, so a cache MISS
+        /// fails loudly rather than passing for the wrong reason; where it is present the
+        /// stand-in file is not a real raw, so a miss fails there too.
+        /// </summary>
+        [TestMethod]
+        public void TestVendorCacheUsableWithoutVendorReader()
+        {
+            string dir = Path.Combine(Path.GetTempPath(), @"OspreyVendorCache" + Guid.NewGuid().ToString(@"N"));
+            Directory.CreateDirectory(dir);
+            try
+            {
+                // Stands in for a Thermo .raw. The extension is what dispatch keys off,
+                // and the bytes are never read because the cache hit precedes the reader.
+                string rawPath = Path.Combine(dir, @"vendor_file.raw");
+                File.WriteAllBytes(rawPath, new byte[] { 1, 2, 3, 4 });
+
+                var ms2 = new List<Spectrum>
+                {
+                    new Spectrum
+                    {
+                        ScanNumber = 1,
+                        RetentionTime = 10.5,
+                        PrecursorMz = 500.0,
+                        IsolationWindow = new IsolationWindow(500.0, 1.5, 1.5),
+                        Mzs = new[] { 100.0, 200.0 },
+                        Intensities = new[] { 1000.0f, 2000.0f }
+                    }
+                };
+                var ms1 = new List<MS1Spectrum>
+                {
+                    new MS1Spectrum
+                    {
+                        ScanNumber = 0,
+                        RetentionTime = 10.0,
+                        Mzs = new[] { 400.0 },
+                        Intensities = new[] { 5000.0f }
+                    }
+                };
+
+                // Saved WITH the source path, so the header carries the same fingerprint an
+                // opt-in build would have written, and the read back exercises the real
+                // staleness check rather than the no-fingerprint shortcut.
+                string cachePath = SpectraCache.GetCachePath(rawPath);
+                SpectraCache.SaveSpectraCache(cachePath, ms2, ms1, rawPath);
+
+                var ctx = new PipelineContext(new OspreyConfig(), new OspreyTask[0], null, null, null);
+                SpectraWindowIndex index = ScoringTaskShared.EnsureSpectraCache(
+                    rawPath, false, out int unsortedCount, ctx);
+
+                Assert.IsNotNull(index);
+                Assert.AreEqual(ms2.Count, index.Ms2Count);
+                Assert.AreEqual(0, unsortedCount);
+                List<Spectrum> streamed = index.LoadWindow(SpectraCache.WindowKey(500.0));
+                Assert.AreEqual(1, streamed.Count);
+                Assert.AreEqual(10.5, streamed[0].RetentionTime, 0.0);
+            }
+            finally
+            {
+                TryDeleteDirectory(dir);
+            }
+        }
+
         // Distinct, non-round peak values per record so any field/peak mis-decode
         // surfaces; isolation offsets vary per scan so those decode paths are checked.
         private static Spectrum MakeIndexMs2(uint scan, double rt, double center, int nPeaks)
@@ -2485,6 +2559,19 @@ namespace pwiz.Osprey.Test
                 cmd.Parameters.AddWithValue("@name", tableName);
                 long count = (long)(cmd.ExecuteScalar() ?? 0);
                 Assert.AreEqual(1L, count, "Table " + tableName + " should exist");
+            }
+        }
+
+        private static void TryDeleteDirectory(string path)
+        {
+            try
+            {
+                if (Directory.Exists(path))
+                    Directory.Delete(path, true);
+            }
+            catch (Exception)
+            {
+                // Best effort: a temp directory left behind must never fail a test.
             }
         }
 

--- a/pwiz_tools/Osprey/Osprey.Test/IOTest.cs
+++ b/pwiz_tools/Osprey/Osprey.Test/IOTest.cs
@@ -825,7 +825,10 @@ namespace pwiz.Osprey.Test
 
                 Assert.IsNotNull(index);
                 Assert.AreEqual(ms2.Count, index.Ms2Count);
-                Assert.AreEqual(0, unsortedCount);
+                // Deliberately NOT asserting unsortedCount here. EnsureSpectraCache
+                // zeroes it up front and only assigns on the cache-MISS branch, which
+                // this test asserts is not taken - so the assertion could never fail and
+                // would read as coverage it does not provide.
                 List<Spectrum> streamed = index.LoadWindow(SpectraCache.WindowKey(500.0));
                 Assert.AreEqual(1, streamed.Count);
                 Assert.AreEqual(10.5, streamed[0].RetentionTime, 0.0);

--- a/pwiz_tools/Osprey/Osprey.Test/IOTest.cs
+++ b/pwiz_tools/Osprey/Osprey.Test/IOTest.cs
@@ -1571,6 +1571,45 @@ namespace pwiz.Osprey.Test
 
         #endregion
 
+        #region SpectrumFileReader Tests
+
+        /// <summary>
+        /// The by-extension routing that decides whether an input is parsed by the
+        /// hand-written mzML reader or handed to ProteoWizard. Consolidated: one
+        /// wrong answer here sends a whole run to the wrong parser, and the
+        /// gzip and case variants are exactly where that would happen quietly.
+        /// The vendor branch itself needs a real instrument file and the pwiz
+        /// native dependencies, so it is covered by the raw-vs-mzML
+        /// .spectra.bin comparison rather than here (issue #4496).
+        /// </summary>
+        [TestMethod]
+        public void TestSpectrumFileReaderFormatRouting()
+        {
+            foreach (var mzml in new[]
+                     {
+                         @"a.mzML", @"a.mzml", @"a.MZML",
+                         @"C:\data\some.file.name.mzML",
+                         @"a.mzML.gz", @"a.mzml.gz",
+                     })
+            {
+                Assert.IsTrue(SpectrumFileReader.IsMzml(mzml), mzml);
+            }
+
+            foreach (var vendor in new[]
+                     {
+                         @"a.raw", @"a.RAW", @"a.d", @"a.wiff", @"a.wiff2",
+                         @"C:\data\some.file.name.raw",
+                         // Not mzML despite the substring: routing must key on the
+                         // extension, not a name that happens to contain "mzml".
+                         @"mzml_backup.raw", @"a.mzXML",
+                     })
+            {
+                Assert.IsFalse(SpectrumFileReader.IsMzml(vendor), vendor);
+            }
+        }
+
+        #endregion
+
         #region MzmlReader Tests
 
         /// <summary>

--- a/pwiz_tools/Osprey/Osprey.Test/IOTest.cs
+++ b/pwiz_tools/Osprey/Osprey.Test/IOTest.cs
@@ -1586,24 +1586,33 @@ namespace pwiz.Osprey.Test
         /// Root cause: .NET Framework's string-to-double conversion is not
         /// correctly rounded for some decimals, and XmlConvert.ToDouble inherits
         /// it. "0.86653405" parses to 0x3FEBBAA59DB3DA8E on .NET Framework and
-        /// 0x3FEBBAA59DB3DA8D (the correctly rounded value, and what C++ strtod
-        /// gives) on .NET Core 3.0+. So this test asserts what the READER
-        /// controls - that the value reaching a <see cref="Spectrum"/> is exactly
-        /// what the runtime's parser produced, with nothing perturbing it in
-        /// between. It deliberately does NOT compare against a compiled literal:
-        /// that comparison fails on net472 for reasons no Osprey code can fix,
-        /// and pinning it here would just encode the runtime defect as expected.
-        /// The cross-runtime deviation itself is tracked separately.
+        /// 0x3FEBBAA59DB3DA8D (correctly rounded, and what C++ strtod gives) on
+        /// .NET Core 3.0+. The net472 reader now parses through the CRT's strtod
+        /// so both builds agree with each other and with ProteoWizard.
+        ///
+        /// The reference values below are COMPILED LITERALS on purpose: Roslyn
+        /// rounds them correctly at compile time, so they are a parser-independent
+        /// oracle. An earlier version of this test compared the reader against
+        /// XmlConvert.ToDouble of the same text and passed while the defect was
+        /// live, because both sides were wrong in the same way - a self-referential
+        /// assertion proves nothing.
         /// </summary>
         [TestMethod]
         public void TestMzmlReaderRetentionTimePrecision()
         {
-            foreach (string text in new[] { @"0.86653405", @"0.97263695", @"0.5903117" })
+            // Text as it appears in the mzML, paired with the correctly rounded
+            // double. The text must be exactly what a literal formats to, so the
+            // file really does contain the decimal under test.
+            var cases = new[]
             {
-                double expected = XmlConvert.ToDouble(text);
-                // Exact: any delta would hide the very defect under test.
-                Assert.AreEqual(double.Parse(text, CultureInfo.InvariantCulture), expected, 0.0,
-                    @"XmlConvert vs double.Parse disagree on " + text);
+                new { Text = @"0.86653405", Expected = 0.86653405 },
+                new { Text = @"0.97263695", Expected = 0.97263695 },
+                new { Text = @"0.5903117", Expected = 0.5903117 },
+            };
+            foreach (var testCase in cases)
+            {
+                string text = testCase.Text;
+                double expected = testCase.Expected;
 
                 string mzml = BuildMinimalMzml(
                     msLevel: 2,
@@ -1614,6 +1623,11 @@ namespace pwiz.Osprey.Test
                     isoUpper: 1.5006999969482422,
                     mzValues: new[] { 200.0, 300.0, 400.0 },
                     intensityValues: new[] { 100.0f, 200.0f, 300.0f });
+
+                // The file must actually carry the decimal under test; otherwise a
+                // formatting change could quietly swap in a different value and the
+                // assertion below would still pass.
+                StringAssert.Contains(mzml, @"value=""" + text + @"""");
 
                 string path = Path.GetTempFileName() + ".mzML";
                 try

--- a/pwiz_tools/Osprey/Osprey.Test/ProgramTests.cs
+++ b/pwiz_tools/Osprey/Osprey.Test/ProgramTests.cs
@@ -57,14 +57,14 @@ namespace pwiz.Osprey.Test
             };
         }
 
-        // -- SpectraCache (Stage 1 alone: inputs in, .spectra.bin out) --
+        // - SpectraCache (Stage 1 alone: inputs in, .spectra.bin out) --
 
         [TestMethod]
         public void TestValidateSpectraCache()
         {
             // Consolidated: the whole SpectraCache contract in one place.
             // The defining difference from every other task is that it needs
-            // NO library -- caching depends only on the input file -- so the
+            // NO library - caching depends only on the input file - so the
             // happy path below deliberately leaves LibrarySource null.
             var config = TaskConfig(HpcTask.SpectraCache);
             config.InputFiles = new List<string> { "a.raw" };
@@ -90,7 +90,7 @@ namespace pwiz.Osprey.Test
             StringAssert.Contains(err, expected);
         }
 
-        // -- PerFileScoring (mzML in) --
+        // - PerFileScoring (mzML in) --
 
         [TestMethod]
         public void TestValidatePerFileScoringHappyPath()
@@ -138,7 +138,7 @@ namespace pwiz.Osprey.Test
             StringAssert.Contains(err, "not --input-scores");
         }
 
-        // -- PerFileRescore (--input-scores in) --
+        // - PerFileRescore (--input-scores in) --
 
         [TestMethod]
         public void TestValidatePerFileRescoreHappyPath()
@@ -188,7 +188,7 @@ namespace pwiz.Osprey.Test
             StringAssert.Contains(err, "not -i <mzML>");
         }
 
-        // -- FirstJoin (--input-scores in, 2+ files, reconciliation on) --
+        // - FirstJoin (--input-scores in, 2+ files, reconciliation on) --
 
         [TestMethod]
         public void TestValidateFirstJoinHappyPath()
@@ -265,7 +265,7 @@ namespace pwiz.Osprey.Test
             StringAssert.Contains(err, "Reconciliation.Enabled");
         }
 
-        // -- MergeNode (reconciled --input-scores in) --
+        // - MergeNode (reconciled --input-scores in) --
 
         [TestMethod]
         public void TestValidateMergeNodeHappyPath()
@@ -330,7 +330,7 @@ namespace pwiz.Osprey.Test
             StringAssert.Contains(err, "cannot be combined with --input");
         }
 
-        // -- Default (no --task): full pipeline from -i mzML or --input-scores --
+        // - Default (no --task): full pipeline from -i mzML or --input-scores --
 
         [TestMethod]
         public void TestValidateDefaultFullHappyPath()
@@ -664,7 +664,7 @@ namespace pwiz.Osprey.Test
                 File.WriteAllText(Path.Combine(dir, "b.scores.parquet"), string.Empty); // no reconciled sibling
                 File.WriteAllText(Path.Combine(dir, "c.scores-reconciled.parquet"), string.Empty); // no original
                 // An input stem ending in ".reconciled" stays an original (Copilot
-                // ambiguity regression guard) -- its Stage 4 file must be returned
+                // ambiguity regression guard) - its Stage 4 file must be returned
                 // as an original, not misread as a reconciled output.
                 File.WriteAllText(Path.Combine(dir, "d.reconciled.scores.parquet"), string.Empty);
                 var resolved = Program.ResolveInputScores(new List<string> { dir });

--- a/pwiz_tools/Osprey/Osprey.Test/ProgramTests.cs
+++ b/pwiz_tools/Osprey/Osprey.Test/ProgramTests.cs
@@ -57,6 +57,39 @@ namespace pwiz.Osprey.Test
             };
         }
 
+        // -- SpectraCache (Stage 1 alone: inputs in, .spectra.bin out) --
+
+        [TestMethod]
+        public void TestValidateSpectraCache()
+        {
+            // Consolidated: the whole SpectraCache contract in one place.
+            // The defining difference from every other task is that it needs
+            // NO library -- caching depends only on the input file -- so the
+            // happy path below deliberately leaves LibrarySource null.
+            var config = TaskConfig(HpcTask.SpectraCache);
+            config.InputFiles = new List<string> { "a.raw" };
+            Assert.IsNull(Program.ValidateArgs(config), "no library should be required");
+
+            // A library is merely unnecessary, not rejected: staging a dataset
+            // with the eventual run's full command line must still work.
+            config.LibrarySource = LibrarySource.FromPath("ref.blib");
+            Assert.IsNull(Program.ValidateArgs(config), "a library should be tolerated");
+
+            AssertSpectraCacheError(c => { }, "--input <file");
+            AssertSpectraCacheError(c => c.InputScores = new List<string> { "a.scores.parquet" },
+                "not --input-scores");
+        }
+
+        private static void AssertSpectraCacheError(Action<OspreyConfig> mutate, string expected)
+        {
+            var config = TaskConfig(HpcTask.SpectraCache);
+            mutate(config);
+            string err = Program.ValidateArgs(config);
+            Assert.IsNotNull(err);
+            StringAssert.Contains(err, "--task SpectraCache");
+            StringAssert.Contains(err, expected);
+        }
+
         // -- PerFileScoring (mzML in) --
 
         [TestMethod]
@@ -403,6 +436,13 @@ namespace pwiz.Osprey.Test
         }
 
         [TestMethod]
+        public void TestResolveTaskSpectraCache()
+        {
+            Assert.IsNull(Program.ResolveTask("SpectraCache", out HpcTask task));
+            Assert.AreEqual(HpcTask.SpectraCache, task);
+        }
+
+        [TestMethod]
         public void TestResolveTaskIsCaseInsensitive()
         {
             Assert.IsNull(Program.ResolveTask("perfilerescoring", out HpcTask task));
@@ -429,12 +469,17 @@ namespace pwiz.Osprey.Test
             //   FirstJoin        | false  | true            | false
             //   PerFileRescore   | true   | false           | false
             //   MergeNode        | false  | false           | true
+            //   SpectraCache     | false  | false           | false
+            // SpectraCache is all-false because it drives no membership at all:
+            // it runs its own one-task pipeline (AnalysisPipeline.SpectraCachePipeline)
+            // rather than gating tasks inside the canonical one.
             var cases = new (HpcTask Task, bool NoJoin, bool StopAfterStage5, bool ExpectReconciled)[]
             {
                 (HpcTask.PerFileScoring, true,  false, false),
                 (HpcTask.FirstJoin,      false, true,  false),
                 (HpcTask.PerFileRescore, true,  false, false),
                 (HpcTask.MergeNode,      false, false, true),
+                (HpcTask.SpectraCache,   false, false, false),
             };
             foreach (var c in cases)
             {

--- a/pwiz_tools/Osprey/Osprey.sln
+++ b/pwiz_tools/Osprey/Osprey.sln
@@ -25,8 +25,6 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Osprey.Tasks", "Osprey.Task
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Osprey.Diagnostics", "Osprey.Diagnostics\Osprey.Diagnostics.csproj", "{5CB164A4-2B04-4FAE-B744-765AD5872D56}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ProteowizardWrapper", "..\Shared\ProteowizardWrapper\ProteowizardWrapper.csproj", "{DACEE7D5-5A6A-4001-9602-FAB1A9A2DE59}"
-EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|x64 = Debug|x64
@@ -133,18 +131,6 @@ Global
 		{97ECF0B4-0AAA-4593-ADE0-9E8740973AC2}.Release|Any CPU.Build.0 = Release|Any CPU
 		{97ECF0B4-0AAA-4593-ADE0-9E8740973AC2}.Release|x86.ActiveCfg = Release|Any CPU
 		{97ECF0B4-0AAA-4593-ADE0-9E8740973AC2}.Release|x86.Build.0 = Release|Any CPU
-		{DACEE7D5-5A6A-4001-9602-FAB1A9A2DE59}.Debug|x64.ActiveCfg = Debug|x64
-		{DACEE7D5-5A6A-4001-9602-FAB1A9A2DE59}.Debug|x64.Build.0 = Debug|x64
-		{DACEE7D5-5A6A-4001-9602-FAB1A9A2DE59}.Debug|Any CPU.ActiveCfg = Debug|x64
-		{DACEE7D5-5A6A-4001-9602-FAB1A9A2DE59}.Debug|Any CPU.Build.0 = Debug|x64
-		{DACEE7D5-5A6A-4001-9602-FAB1A9A2DE59}.Debug|x86.ActiveCfg = Debug|x64
-		{DACEE7D5-5A6A-4001-9602-FAB1A9A2DE59}.Debug|x86.Build.0 = Debug|x64
-		{DACEE7D5-5A6A-4001-9602-FAB1A9A2DE59}.Release|x64.ActiveCfg = Release|x64
-		{DACEE7D5-5A6A-4001-9602-FAB1A9A2DE59}.Release|x64.Build.0 = Release|x64
-		{DACEE7D5-5A6A-4001-9602-FAB1A9A2DE59}.Release|Any CPU.ActiveCfg = Release|x64
-		{DACEE7D5-5A6A-4001-9602-FAB1A9A2DE59}.Release|Any CPU.Build.0 = Release|x64
-		{DACEE7D5-5A6A-4001-9602-FAB1A9A2DE59}.Release|x86.ActiveCfg = Release|x64
-		{DACEE7D5-5A6A-4001-9602-FAB1A9A2DE59}.Release|x86.Build.0 = Release|x64
 		{EF7990A9-10A0-4E5A-BB4D-F0E6952F0684}.Debug|x64.ActiveCfg = Debug|x64
 		{EF7990A9-10A0-4E5A-BB4D-F0E6952F0684}.Debug|x64.Build.0 = Debug|x64
 		{EF7990A9-10A0-4E5A-BB4D-F0E6952F0684}.Debug|Any CPU.ActiveCfg = Debug|Any CPU

--- a/pwiz_tools/Osprey/Osprey.sln
+++ b/pwiz_tools/Osprey/Osprey.sln
@@ -25,6 +25,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Osprey.Tasks", "Osprey.Task
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Osprey.Diagnostics", "Osprey.Diagnostics\Osprey.Diagnostics.csproj", "{5CB164A4-2B04-4FAE-B744-765AD5872D56}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ProteowizardWrapper", "..\Shared\ProteowizardWrapper\ProteowizardWrapper.csproj", "{DACEE7D5-5A6A-4001-9602-FAB1A9A2DE59}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|x64 = Debug|x64
@@ -131,6 +133,18 @@ Global
 		{97ECF0B4-0AAA-4593-ADE0-9E8740973AC2}.Release|Any CPU.Build.0 = Release|Any CPU
 		{97ECF0B4-0AAA-4593-ADE0-9E8740973AC2}.Release|x86.ActiveCfg = Release|Any CPU
 		{97ECF0B4-0AAA-4593-ADE0-9E8740973AC2}.Release|x86.Build.0 = Release|Any CPU
+		{DACEE7D5-5A6A-4001-9602-FAB1A9A2DE59}.Debug|x64.ActiveCfg = Debug|x64
+		{DACEE7D5-5A6A-4001-9602-FAB1A9A2DE59}.Debug|x64.Build.0 = Debug|x64
+		{DACEE7D5-5A6A-4001-9602-FAB1A9A2DE59}.Debug|Any CPU.ActiveCfg = Debug|x64
+		{DACEE7D5-5A6A-4001-9602-FAB1A9A2DE59}.Debug|Any CPU.Build.0 = Debug|x64
+		{DACEE7D5-5A6A-4001-9602-FAB1A9A2DE59}.Debug|x86.ActiveCfg = Debug|x64
+		{DACEE7D5-5A6A-4001-9602-FAB1A9A2DE59}.Debug|x86.Build.0 = Debug|x64
+		{DACEE7D5-5A6A-4001-9602-FAB1A9A2DE59}.Release|x64.ActiveCfg = Release|x64
+		{DACEE7D5-5A6A-4001-9602-FAB1A9A2DE59}.Release|x64.Build.0 = Release|x64
+		{DACEE7D5-5A6A-4001-9602-FAB1A9A2DE59}.Release|Any CPU.ActiveCfg = Release|x64
+		{DACEE7D5-5A6A-4001-9602-FAB1A9A2DE59}.Release|Any CPU.Build.0 = Release|x64
+		{DACEE7D5-5A6A-4001-9602-FAB1A9A2DE59}.Release|x86.ActiveCfg = Release|x64
+		{DACEE7D5-5A6A-4001-9602-FAB1A9A2DE59}.Release|x86.Build.0 = Release|x64
 		{EF7990A9-10A0-4E5A-BB4D-F0E6952F0684}.Debug|x64.ActiveCfg = Debug|x64
 		{EF7990A9-10A0-4E5A-BB4D-F0E6952F0684}.Debug|x64.Build.0 = Debug|x64
 		{EF7990A9-10A0-4E5A-BB4D-F0E6952F0684}.Debug|Any CPU.ActiveCfg = Debug|Any CPU

--- a/pwiz_tools/Osprey/Osprey/AnalysisPipeline.cs
+++ b/pwiz_tools/Osprey/Osprey/AnalysisPipeline.cs
@@ -82,7 +82,13 @@ namespace pwiz.Osprey
                     config.InputFiles = synthetic;
                 }
 
-                var pipelineTasks = CanonicalPipeline();
+                // --task SpectraCache stages data rather than analyzing it: it runs
+                // its own one-task pipeline instead of the canonical four. Selecting
+                // it by list, not by an IsIncluded gate on every other task, keeps the
+                // canonical pipeline's membership rules about the analysis itself.
+                var pipelineTasks = config.SelectedTask == HpcTask.SpectraCache
+                    ? SpectraCachePipeline()
+                    : CanonicalPipeline();
                 var ctx = new PipelineContext(config, pipelineTasks,
                     LogInfo, LogWarning, LogError, OspreyDiagnostics.Active);
 
@@ -144,6 +150,19 @@ namespace pwiz.Osprey
                 new FirstJoinTask(),
                 new PerFileRescoreTask(),
                 new MergeNodeTask(),
+            };
+        }
+
+        /// <summary>
+        /// The one-task pipeline behind <c>--task SpectraCache</c>: build every
+        /// input's <c>.spectra.bin</c> and stop, without a library or any of the
+        /// analysis stages.
+        /// </summary>
+        internal static OspreyTask[] SpectraCachePipeline()
+        {
+            return new OspreyTask[]
+            {
+                new SpectraCacheTask(),
             };
         }
 

--- a/pwiz_tools/Osprey/Osprey/OspreyCommandArgs.cs
+++ b/pwiz_tools/Osprey/Osprey/OspreyCommandArgs.cs
@@ -208,7 +208,8 @@ namespace pwiz.Osprey
         // --task is resolved + validated in Program.Main's pre-scan; the tokenizer here only
         // consumes its value (and rejects a missing one). Declared so it appears in help.
         public static readonly OspreyArgument ARG_TASK = new OspreyArgument(@"task",
-            new[] { @"PerFileScoring", @"FirstPassFDR", @"PerFileRescoring", @"SecondPassFDR" }, (c, p) => true);
+            new[] { @"SpectraCache", @"PerFileScoring", @"FirstPassFDR", @"PerFileRescoring", @"SecondPassFDR" },
+            (c, p) => true);
         public static readonly OspreyArgument ARG_INPUT_SCORES = new OspreyArgument(@"input-scores",
             () => @"<paths|dir>", (c, p) => true) { Variadic = true, ProcessVariadic = (c, toks) =>
             {
@@ -360,7 +361,11 @@ namespace pwiz.Osprey
                 {
                     // A non-flag token that exists on disk is a positional input file. Anything
                     // else starting with '-' is unknown and fails fast (caught by Main).
-                    if (!arg.StartsWith(@"-") && File.Exists(arg))
+                    // Directory.Exists matters as much as File.Exists here: the vendor formats
+                    // that are DIRECTORIES (Agilent .d, Bruker .d, Waters .raw) would otherwise
+                    // fall through to "Unknown argument" and be silently dropped from the run,
+                    // while the same path passed with -i was accepted.
+                    if (!arg.StartsWith(@"-") && (File.Exists(arg) || Directory.Exists(arg)))
                     {
                         _inputFiles.Add(arg);
                         i++;
@@ -394,7 +399,7 @@ namespace pwiz.Osprey
                     i++;
                     if (i >= args.Length || args[i].StartsWith(@"-"))
                         throw new ArgumentException(
-                            @"--task requires a task name (PerFileScoring, FirstPassFDR, PerFileRescoring, or SecondPassFDR).");
+                            @"--task requires a task name (SpectraCache, PerFileScoring, FirstPassFDR, PerFileRescoring, or SecondPassFDR).");
                     i++;
                     continue;
                 }
@@ -445,6 +450,8 @@ namespace pwiz.Osprey
 
         private OspreyConfig ToConfig()
         {
+            for (int i = 0; i < _inputFiles.Count; i++)
+                _inputFiles[i] = NormalizeInputPath(_inputFiles[i]);
             _config.InputFiles = _inputFiles;
 
             // --work-dir sets both the derived-artifact output directory and the spectra-cache
@@ -531,6 +538,26 @@ namespace pwiz.Osprey
             }
 
             return _config;
+        }
+
+        /// <summary>
+        /// Strip a trailing directory separator from an input path. Shell tab completion
+        /// adds one for a directory, and the vendor formats this build can read ARE
+        /// directories (Agilent .d, Bruker .d, Waters .raw). Left on, the path has no
+        /// filename component, so every derived artifact - the .spectra.bin, the
+        /// .scores.parquet, the FDR sidecars - loses its stem and is written INSIDE the
+        /// bundle. For the cache that is self-defeating as well as untidy: the artifact
+        /// then counts toward the bundle's own fingerprint, so the cache never matches
+        /// the source it was built from and every run re-parses.
+        /// </summary>
+        private static string NormalizeInputPath(string path)
+        {
+            if (string.IsNullOrEmpty(path))
+                return path;
+            string trimmed = path.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+            // A bare root ("C:\", "/") trims to something that means a different place, and
+            // is never a real input, so leave it exactly as given.
+            return string.IsNullOrEmpty(Path.GetFileName(trimmed)) ? path : trimmed;
         }
 
         private static OspreyArgument FindByToken(string token)
@@ -657,7 +684,7 @@ namespace pwiz.Osprey
             sb.AppendLine(@"<html><head>");
             sb.AppendLine(@"<meta charset=""utf-8"">");
             sb.AppendLine(@"<title>Osprey command-line usage</title>");
-            sb.AppendLine(@"<meta name=""description"" content=""Command-line usage for Osprey, the C# (.NET 8) implementation of Mike MacCoss's peptide-centric DIA search tool: search and FDR arguments, protein inference, and the four distributed HPC --task workers (PerFileScoring, FirstPassFDR, PerFileRescoring, SecondPassFDR)."">");
+            sb.AppendLine(@"<meta name=""description"" content=""Command-line usage for Osprey, the C# (.NET 8) implementation of Mike MacCoss's peptide-centric DIA search tool: search and FDR arguments, protein inference, the SpectraCache staging task, and the four distributed HPC --task workers (PerFileScoring, FirstPassFDR, PerFileRescoring, SecondPassFDR)."">");
             // Self-contained stylesheet (Osprey does not reference Skyline, so it cannot call
             // DocumentationGenerator.GetStyleSheetHtml). The table rules are copied from that Skyline
             // stylesheet so Osprey's generated help matches Skyline's look (cell padding,

--- a/pwiz_tools/Osprey/Osprey/Program.cs
+++ b/pwiz_tools/Osprey/Osprey/Program.cs
@@ -199,7 +199,13 @@ namespace pwiz.Osprey
                 {
                     foreach (string inputFile in config.InputFiles)
                     {
-                        if (!File.Exists(inputFile))
+                        // A directory counts as present. Several vendor formats ARE
+                        // directories (Agilent .d, Bruker .d, Waters .raw), so testing
+                        // File.Exists alone rejected every one of them here, before any
+                        // reader was consulted, on builds with and without the vendor
+                        // reader. It also blocked reusing a raw-derived .spectra.bin,
+                        // which must work on a build that cannot read the raw itself.
+                        if (!File.Exists(inputFile) && !Directory.Exists(inputFile))
                         {
                             LogError(string.Format("Input file not found: {0}", inputFile));
                             return 1;

--- a/pwiz_tools/Osprey/Osprey/Program.cs
+++ b/pwiz_tools/Osprey/Osprey/Program.cs
@@ -232,12 +232,13 @@ namespace pwiz.Osprey
                     LogInfo(string.Format("Task: {0} (single-task run)",
                         TaskCliName(config.SelectedTask.Value)));
                 // --task PerFileScoring writes per-file .scores.parquet next to each
-                // input mzML, not a blib -- report the real output rather than the
-                // ignored --output blib path. (PerFileRescoring still writes --output.)
+                // input file, mzML or vendor raw, not a blib - report the real output
+                // rather than the ignored --output blib path. (PerFileRescoring still
+                // writes --output.)
                 if (config.SelectedTask == HpcTask.SpectraCache)
                     LogInfo("Output: per-file .spectra.bin (no scoring; --output and --library are not used)");
                 else if (config.NoJoin && !fromInputScores)
-                    LogInfo("Output: per-file .scores.parquet (next to each input mzML)");
+                    LogInfo("Output: per-file .scores.parquet (next to each input file)");
                 else
                     LogInfo(string.Format("Output: {0}", config.OutputBlib));
                 LogInfo(string.Format("Resolution: {0}", config.ResolutionMode));

--- a/pwiz_tools/Osprey/Osprey/Program.cs
+++ b/pwiz_tools/Osprey/Osprey/Program.cs
@@ -375,8 +375,10 @@ namespace pwiz.Osprey
                         // input file, and demanding one would make staging a dataset
                         // wait on a library that is often chosen later.
                         if (hasInputScores)
+                        {
                             return "--task SpectraCache takes -i <file>, not --input-scores " +
                                    "(it builds spectra caches from raw inputs, not from scores).";
+                        }
                         if (!hasInputFiles)
                             return "--task SpectraCache requires --input <file...>.";
                         return null;

--- a/pwiz_tools/Osprey/Osprey/Program.cs
+++ b/pwiz_tools/Osprey/Osprey/Program.cs
@@ -91,7 +91,7 @@ namespace pwiz.Osprey
                     {
                         if (i + 1 >= args.Length || args[i + 1].StartsWith("-", StringComparison.Ordinal))
                         {
-                            LogError("--task requires a task name (PerFileScoring, FirstPassFDR, PerFileRescoring, or SecondPassFDR).");
+                            LogError("--task requires a task name (SpectraCache, PerFileScoring, FirstPassFDR, PerFileRescoring, or SecondPassFDR).");
                             return 1;
                         }
                         taskName = args[i + 1];
@@ -228,7 +228,9 @@ namespace pwiz.Osprey
                 // --task PerFileScoring writes per-file .scores.parquet next to each
                 // input mzML, not a blib -- report the real output rather than the
                 // ignored --output blib path. (PerFileRescoring still writes --output.)
-                if (config.NoJoin && !fromInputScores)
+                if (config.SelectedTask == HpcTask.SpectraCache)
+                    LogInfo("Output: per-file .spectra.bin (no scoring; --output and --library are not used)");
+                else if (config.NoJoin && !fromInputScores)
                     LogInfo("Output: per-file .scores.parquet (next to each input mzML)");
                 else
                     LogInfo(string.Format("Output: {0}", config.OutputBlib));
@@ -310,9 +312,14 @@ namespace pwiz.Osprey
                 task = HpcTask.MergeNode;
                 return null;
             }
+            if (string.Equals(taskName, "SpectraCache", StringComparison.OrdinalIgnoreCase))
+            {
+                task = HpcTask.SpectraCache;
+                return null;
+            }
             task = default;
             return string.Format(
-                "--task: unknown task '{0}'. Valid tasks: PerFileScoring, FirstPassFDR, PerFileRescoring, SecondPassFDR.",
+                "--task: unknown task '{0}'. Valid tasks: SpectraCache, PerFileScoring, FirstPassFDR, PerFileRescoring, SecondPassFDR.",
                 taskName);
         }
 
@@ -331,6 +338,7 @@ namespace pwiz.Osprey
                 case HpcTask.FirstJoin: return "FirstPassFDR";
                 case HpcTask.PerFileRescore: return "PerFileRescoring";
                 case HpcTask.MergeNode: return "SecondPassFDR";
+                case HpcTask.SpectraCache: return "SpectraCache";
                 default: return task.ToString();
             }
         }
@@ -354,6 +362,18 @@ namespace pwiz.Osprey
             {
                 switch (config.SelectedTask.Value)
                 {
+                    case HpcTask.SpectraCache:
+                        // Stage 1 alone: inputs in, .spectra.bin out. Deliberately
+                        // does NOT require --library: caching depends only on the
+                        // input file, and demanding one would make staging a dataset
+                        // wait on a library that is often chosen later.
+                        if (hasInputScores)
+                            return "--task SpectraCache takes -i <file>, not --input-scores " +
+                                   "(it builds spectra caches from raw inputs, not from scores).";
+                        if (!hasInputFiles)
+                            return "--task SpectraCache requires --input <file...>.";
+                        return null;
+
                     case HpcTask.PerFileScoring:
                         // Stage 1-4 worker: mzML in, per-file .scores.parquet out.
                         if (hasInputScores)

--- a/pwiz_tools/Osprey/regression.ps1
+++ b/pwiz_tools/Osprey/regression.ps1
@@ -464,9 +464,18 @@ function Resolve-DatasetInputs {
         $srcInfo = Get-Item $library
         if ((-not (Test-Path $stripped)) -or ((Get-Item $stripped).LastWriteTimeUtc -lt $srcInfo.LastWriteTimeUtc)) {
             Write-Host "  deriving decoy-free library (one time, ~1 min)..."
+            # Write to a temp file and rename into place, so the final path only ever
+            # holds a complete derivation. An interrupted run (Ctrl-C, a cancelled
+            # TeamCity build, an agent reboot) otherwise leaves a TRUNCATED file whose
+            # mtime is newer than the source library, so the staleness check above
+            # accepts it and EVERY later run fails deep inside the library parse with
+            # "Missing PrecursorCharge at row N" - an error naming the library rather
+            # than the interruption that caused it. Observed 2026-07-29.
+            $tmp = "$stripped.tmp"
+            Remove-Item $tmp -Force -ErrorAction SilentlyContinue
             $kept = 0; $dropped = 0
             $reader = [IO.StreamReader]::new($library)
-            $writer = [IO.StreamWriter]::new($stripped, $false, [Text.UTF8Encoding]::new($false))
+            $writer = [IO.StreamWriter]::new($tmp, $false, [Text.UTF8Encoding]::new($false))
             try {
                 $header = $reader.ReadLine()
                 if ($null -eq $header) { throw "Empty library: $library" }
@@ -483,6 +492,8 @@ function Resolve-DatasetInputs {
                 }
             } finally { $writer.Dispose(); $reader.Dispose() }
             if ($dropped -eq 0) { throw "StripDecoys removed nothing from $library -- the decoy_ convention changed" }
+            # Only now is the derivation known good, so publish it atomically.
+            Move-Item $tmp $stripped -Force
             Write-Host ("  derived {0}: kept {1:N0} rows, dropped {2:N0} decoy rows" -f (Split-Path -Leaf $stripped), $kept, $dropped)
         }
         $library = $stripped


### PR DESCRIPTION
## Summary

Osprey can read vendor instrument files directly in the **net472** configuration, so
staging a dataset no longer needs an msconvert pass. The capability is **opt-in at build
time and OFF by default**: nothing about a default build, a fresh clone, or the unit CI
config changes.

* `VendorRawReader` reads through `ProteowizardWrapper` rather than binding
  `pwiz_data_cli` directly. The wrapper already exposes every field `SpectraCache`
  stores, including the isolation-window LOWER/UPPER **offset** semantics that a
  hand-rolled binding is most likely to get wrong. Reader options mirror
  `convert-one.cmd`: vendor centroiding plus `simAsSpectra`.
* `SpectrumBuilder` is now the single definition of what a spectrum is - peak sort order,
  isolation-window fail-fast, precursor-m/z fallback - shared by both readers, so a
  raw-vs-mzML difference can only come from the parsers themselves. The extraction was
  verified byte-identical on a 2.26 GB cache.
* **`--task SpectraCache`** builds `.spectra.bin` alone, with no `--library`: the staging
  primitive that replaces the msconvert step. Point it at a directory of raw files, get a
  directory of caches.
* `pwiz_tools/Osprey/Jamfile.jam` installs the vendor runtime next to `Osprey.exe` - the
  vendor APIs, the C/C++ runtimes those link against, and `msparser`. Gated on
  `--i-agree-to-the-vendor-licenses`, the same flag every other vendor-API consumer in
  this tree keys off, so a plain `bjam Osprey` still builds the ProteoWizard-free Osprey.
* **A build WITHOUT the reader still consumes raw-derived caches.** Stage `.spectra.bin`
  once on a vendor-capable machine and every other machine - net8.0 included - can run
  against the same `.raw` inputs with no ProteoWizard and no mzML. A test pins this,
  because the guarantee is an ordering one (cache lookup before extension dispatch) that
  nothing else protected.
* `NativeStrtod`: .NET Framework's string-to-double is not correctly rounded for some
  decimals and `XmlConvert` inherits it (`0.86653405` parses to `0x3FEBBAA59DB3DA8E`
  instead of `...8D`). net472 now parses through the CRT's `strtod`, the same function
  ProteoWizard uses, so **net472, net8.0 and pwiz agree bit for bit** - which also removes
  a cross-target-framework divergence that would otherwise make golden baselines
  framework-specific.

## Byte parity, in its strong form

A raw-sourced `.spectra.bin` is **byte-identical** to one built from the mzML that
msconvert produces from the same file. No tolerance, no characterization:

| comparison | result |
|---|---|
| `2025-0724-TDP43-PlasmaEV-PLT1-A01-365-001.raw` (3.07 GB) raw vs mzML | `PARITY: 2,260,174,556 bytes identical` |
| same mzML through `MzmlReader` vs ProteoWizard | `PARITY: 2,260,174,556 bytes identical` |
| committed `source_cid_test_3scans.raw` vs its tracked `-centroid.mzML` | `PARITY: 12,784 bytes identical` |

The last row uses only data already in the repo and a pure bjam build, so the permanent
guard has a proven assertion available rather than a hoped-for one.

## Why this is safe to merge with the capability off

The bar for this checkpoint is that nothing which does not opt in changes behavior.

* `Osprey.sln` builds with **no ProteoWizard dependency at all** by default -
  `VendorRawReader.cs` is excluded from compilation and the wrapper is not referenced.
  `ProteowizardWrapper` is deliberately NOT in the solution.
* A no-flag `bjam pwiz_tools/Osprey//Osprey` updates 1 target and pulls in no native pwiz
  build - verified, not assumed.
* The shared-path changes (`SpectrumBuilder` extraction, `EnsureSpectraCache` moved to
  `ScoringTaskShared`) are covered by the standing regression gate below.
* The one behavior change that is NOT behind the flag is the net472 `strtod` parse, and it
  moves net472 **toward** the net8.0 goldens rather than away.

## Test plan

- [x] `regression.ps1 -Dataset All` - **18 checks, 0 failures**, all four datasets, modes
      1 / 1b / 2 / 3 at 1e-9 (run twice: once assembled per dataset, once as a single
      clean run)
- [x] `Build-Osprey.ps1 -RunTests -RunInspection` - 556/556, zero inspection warnings,
      both target frameworks, after merging master
- [x] `TestVendorCacheUsableWithoutVendorReader` - and verified it FAILS when the
      cache-before-dispatch ordering is deliberately broken, so it cannot pass vacuously
- [x] Vendor raw read end to end from a pure bjam build (`--task SpectraCache` on a
      committed Thermo fixture)
- [x] `pwiz/utility/misc` + `pwiz/data/msdata` native suites - 1303 targets, only the
      documented pre-existing `ReaderTest` `--without-compassxtract` failure
- [ ] TeamCity Perf/Regression on `pull/4502` (triggered, build 4114865)
- [ ] `Test-PerfGate.ps1` - NOT run: needs the pinned `pwiz-perfbase` worktree, absent on
      the machine used. Worth running before merge because `SpectrumBuilder` was extracted
      into the hot per-spectrum assembly loop.

## Deliberately not in this PR

* **The CI config change that would exercise the vendor build.** It needs
  `--i-agree-to-the-vendor-licenses` in the TeamCity step's Command parameters, and that
  flag must never be committed - agreeing to the vendor licenses has to be an explicit act
  by whoever runs the build. So the Perf/Regression config gains a `quickbuild.bat` step
  and `tctest.bat` needs to forward `%*` so `-NoBuild` can be passed; that is follow-up
  work, not something this PR can carry.
* **`-ReaderParity` in `regression.ps1`.** Blocked on a real detail: `regression.ps1` runs
  the **net8.0** exe (`regression.ps1:137-138`) and the vendor reader is net472-only, so
  the mode has to resolve its own net472 exe rather than reuse `$ospreyExe`.
* Lifting the Jamfile rules Osprey copies from Skyline into a shared Jamfile.

## Related

* **#4501 (`skyline`) is the companion for RT correctness on this path** - it fixes
  `MsDataFileImpl.GetStartTime` doing `timeInSeconds()/60` on a value already in minutes.
  Green, and independent of this PR.
* **#4500 (`pwiz`) is NOT required and is currently parked.** Preserving full precision in
  every double cvParam breaks a saved Skyline document: `ConstantNeutralLossTest` stores
  `operand="161.100006103516"` - the old 12-fractional-digit truncation - and compares it
  with `equals`, so the now-exact `161.10000610351562` no longer matches. It also turns 7
  msconvert comparisons red in the Wine container. Vendor-raw parity depends on the two
  sides being CONSISTENT, not on that change.

Fixes #4496

Co-Authored-By: Claude <noreply@anthropic.com>
