### PR TITLE
skyline: Fixed intermittent failure in TestSkylineMcp

### DIFF
--- a/pwiz_tools/Skyline/TestFunctional/SkylineMcpTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/SkylineMcpTest.cs
@@ -316,12 +316,14 @@ RREAEDLQVGQVELGGGPGAGSLQPLALEGSLQKRGIVEQCCTSICSLYQLENYCN";
                 new JObject { ["fastaPath"] = fastaPath });
 
             // Verify from inside Skyline that the import worked
-            var doc = SkylineWindow.Document;
+            var doc = WaitForProteinMetadataBackgroundLoaderCompletedUI();
             var protein = doc.PeptideGroups.First();
 
             RunUI(() =>
             {
-                AssertEx.IsDocumentState(doc, 1, 1, 1, 1, 1);   // Strange but correct
+                // Expected transition count is 1 because one peptide clears the 8-25 length filter,
+                // and one transition is between "m/z > precursor" and instrument MaxMz.
+                AssertEx.IsDocumentState(doc, 2, 1, 1, 1, 1);
                 AssertEx.Contains(protein.Name, "INS_HUMAN");
             });
 


### PR DESCRIPTION
## Summary

* `TestSkylineMcp` failed intermittently with `RevisionIndex mismatch: expected 1, actual 2` (nightly runs 2026-07-27 on BRENDANX-DT1 and 2026-07-30 on BRENDANX-UW6, same stack)
* The MCP `skyline_import_fasta` call is one document revision, but the imported `INS_HUMAN` group leaves `IsProteinMetadataPending` set, so `ProteinMetadataManager` immediately resolves the metadata on a background thread and writes back a second revision
* The test snapshotted `SkylineWindow.Document` right after the MCP call returned, racing that loader - usually the pipe round-trip won (revision 1), occasionally the loader did (revision 2)
* Now waits with `WaitForProteinMetadataBackgroundLoaderCompletedUI()` before snapshotting and expects revision 2, so the revision index is pinned rather than relaxed to `null`
* Also replaced the `// Strange but correct` comment with an explanation of why a whole insulin protein yields a single transition

## Test plan

- [x] TestSkylineMcp - 3 loops, 0 failures (previously non-deterministic)
- [x] CodeInspection - 0 failures

Co-Authored-By: Claude <noreply@anthropic.com>
