### PR TITLE
osprey: Restored transfer pass-2 to bounded memory and ratcheted the resident-pool hatch

### DIFF
--- a/pwiz_tools/Osprey/Osprey.Core/OspreyEnvironment.cs
+++ b/pwiz_tools/Osprey/Osprey.Core/OspreyEnvironment.cs
@@ -365,18 +365,25 @@ namespace pwiz.Osprey.Core
             IsSetAndNotZero(@"OSPREY_PROTEIN_COMPACT_RETRAIN");
 
         /// <summary>
-        /// OSPREY_ALLOW_UNBOUNDED_MEMORY: opt in to the RESIDENT first-pass pool paths, which
-        /// hold every entry resident and grow O(files) so they do not scale to large file
-        /// counts. DEFAULT OFF: with this unset, a run that would take such a path fails fast
-        /// with an error naming the trigger, rather than silently exhausting memory -- so no
-        /// user reaches an O(files) memory path by accident. Set to a non-zero value ONLY for
-        /// our own testing (A/B byte-identity oracles, small runs, HPC test harnesses). The
-        /// existing <see cref="UseFdrProjection"/>=false (OSPREY_FDR_PROJECTION=0) switch is
-        /// itself an explicit resident-path opt-in and is honored the same way. Read once at
-        /// process start. See ai/todos/active/TODO-20260720_osprey_pass2_per_run_qvalue.md.
+        /// OSPREY_ALLOW_UNFIXED_RESIDENT: name the ONE known-unfixed resident path this run may
+        /// take, e.g. <c>OSPREY_ALLOW_UNFIXED_RESIDENT=mdiag-full-resume</c>. Legal values are
+        /// exactly <see cref="ResidentPaths.KNOWN_UNFIXED"/>; anything else, and any resident path
+        /// that is not on that list, is refused no matter what this is set to.
+        ///
+        /// This REPLACES the former blanket <c>OSPREY_ALLOW_UNBOUNDED_MEMORY=1</c>, which granted
+        /// amnesty to every trigger at once. That is not a hypothetical failure: it let
+        /// <c>OSPREY_PASS2_QVALUE=transfer</c> silently regress back onto the resident pool for
+        /// ten days (#4438 removed the forcing, a #4446 merge artifact restored it), because
+        /// developers simply set the boolean and a re-broken memory bound looked like normal
+        /// operating procedure. A named token cannot do that: an unlisted path errors even with
+        /// this set, so the ONLY way to re-admit one is to add it to the committed list, which is
+        /// a reviewed diff that fails <c>ResidentPoolGuardTest</c>.
+        ///
+        /// Read once at process start. Intended for local testing; CI names its token explicitly
+        /// (regression.ps1 mode 2), so what CI depends on is visible rather than ambient.
         /// </summary>
-        public static readonly bool AllowUnboundedMemory =
-            IsSetAndNotZero(@"OSPREY_ALLOW_UNBOUNDED_MEMORY");
+        public static readonly string AllowUnfixedResident =
+            (Environment.GetEnvironmentVariable(@"OSPREY_ALLOW_UNFIXED_RESIDENT") ?? string.Empty).Trim();
 
         private static string NormalizePass2QValue(string raw)
         {

--- a/pwiz_tools/Osprey/Osprey.Core/OspreyEnvironment.cs
+++ b/pwiz_tools/Osprey/Osprey.Core/OspreyEnvironment.cs
@@ -19,6 +19,7 @@
  */
 
 using System;
+using System.Linq;
 
 namespace pwiz.Osprey.Core
 {
@@ -316,11 +317,16 @@ namespace pwiz.Osprey.Core
         ///     a target/decoy null on the reconciled + compacted pool. Preserves the
         ///     always-on Rust 2nd pass. Compaction has already stripped most decoys from
         ///     that pool, so the null is decoy-depleted and the retrained q anti-conservative.
-        ///   <see cref="PASS2_QVALUE_TRANSFER"/>: score each reconciled peak with the FROZEN
-        ///     1st-pass model and read its q from the FULL pre-compaction 1st-pass
-        ///     score-&gt;q table (co-monotonic confidence transfer; Rost 2016 TRIC). No
+        ///   <see cref="PASS2_QVALUE_TRANSFER"/>: carry the pass-1 q through and recompute ONLY
+        ///     the per-run q of the peaks reconciliation MOVED, scoring each with the FROZEN
+        ///     1st-pass model and mapping it through THAT FILE'S OWN on-disk
+        ///     <c>.1st-pass.fdr_scores.bin</c> score-&gt;run-q table, one file at a time. No
         ///     retrain, no reduced-pool null. Restores calibration while keeping the
         ///     re-scoring ID gain.
+        ///     NOTE: the per-run-only redesign (#4438) REPLACED the earlier full pre-compaction
+        ///     score-&gt;q table, which is why transfer no longer needs the O(files) resident
+        ///     pool. Re-adding it to any resident-pool gate is the #4446 regression; see
+        ///     <c>ResidentPaths</c>.
         /// Unset or unrecognized normalizes to the parity-preserving default. Read once at
         /// process start. See ai/todos/active/TODO-20260710_osprey_pass2_recalibration_fix.md.
         ///
@@ -384,6 +390,19 @@ namespace pwiz.Osprey.Core
         /// </summary>
         public static readonly string AllowUnfixedResident =
             (Environment.GetEnvironmentVariable(@"OSPREY_ALLOW_UNFIXED_RESIDENT") ?? string.Empty).Trim();
+
+        /// <summary>
+        /// True when <see cref="AllowUnfixedResident"/> was set to something that is not a legal
+        /// token, so the guard can say "that value is not a known path" instead of printing the
+        /// same message it prints when the variable is unset. Without this, a typo
+        /// (<c>mdiag_full_resume</c>) or a shell-quoted value (cmd.exe stores the quotes) is
+        /// byte-for-byte indistinguishable from not setting it, and the operator is told to do
+        /// what they believe they just did. Mirrors <see cref="Pass2QValueUnrecognized"/>.
+        /// </summary>
+        public static readonly bool AllowUnfixedResidentUnrecognized =
+            AllowUnfixedResident.Length > 0 &&
+            !ResidentPaths.KNOWN_UNFIXED.Any(
+                t => string.Equals(t, AllowUnfixedResident, StringComparison.OrdinalIgnoreCase));
 
         private static string NormalizePass2QValue(string raw)
         {

--- a/pwiz_tools/Osprey/Osprey.Core/ResidentPaths.cs
+++ b/pwiz_tools/Osprey/Osprey.Core/ResidentPaths.cs
@@ -74,12 +74,27 @@ namespace pwiz.Osprey.Core
         public const string NON_PERCOLATOR_FDR = @"non-percolator-fdr";
 
         /// <summary>
+        /// <c>OSPREY_FDR_PROJECTION=0</c>: the operator explicitly forced the legacy
+        /// <c>FdrEntry</c>-buffer implementation, so the whole run is resident by request. This
+        /// is the A/B byte-identity oracle that proves the streaming path did not change
+        /// results, and it is deliberately COARSE - naming it exempts the run wholesale, because
+        /// residency is the thing being asked for rather than a symptom to diagnose.
+        ///
+        /// <para>It still has to be named. The previous blanket bypass let this switch silently
+        /// exempt every OTHER resident trigger too, which is the same masking property that hid
+        /// the transfer regression. This entry leaves the list last: it can only go when the
+        /// legacy path itself does, which needs #4507 (FDRBench pass 1) and #4505 (mdiag full
+        /// resume) first.</para>
+        /// </summary>
+        public const string PROJECTION_OFF = @"projection-off";
+
+        /// <summary>
         /// Every legal <c>OSPREY_ALLOW_UNFIXED_RESIDENT</c> value. Pinned by
         /// <c>ResidentPoolGuardTest</c> - see the class remarks for why it may only shrink.
         /// </summary>
         public static readonly IReadOnlyList<string> KNOWN_UNFIXED = new[]
         {
-            HPC_MERGE, FDRBENCH_PASS1, MDIAG_FULL_RESUME, NON_PERCOLATOR_FDR
+            HPC_MERGE, FDRBENCH_PASS1, MDIAG_FULL_RESUME, NON_PERCOLATOR_FDR, PROJECTION_OFF
         };
     }
 }

--- a/pwiz_tools/Osprey/Osprey.Core/ResidentPaths.cs
+++ b/pwiz_tools/Osprey/Osprey.Core/ResidentPaths.cs
@@ -1,0 +1,85 @@
+/*
+ * Original author: Brendan MacLean <brendanx .at. uw.edu>,
+ *                  MacCoss Lab, Department of Genome Sciences, UW
+ * AI assistance: Claude Code (Claude Opus 5) <noreply .at. anthropic.com>
+ *
+ * Based on osprey (https://github.com/MacCossLab/osprey)
+ *   by Michael J. MacCoss, MacCoss Lab, Department of Genome Sciences, UW
+ *
+ * Copyright 2026 University of Washington - Seattle, WA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System.Collections.Generic;
+
+namespace pwiz.Osprey.Core
+{
+    /// <summary>
+    /// The high-water mark for O(files) RESIDENT first-pass pool paths: every path we have NOT
+    /// yet streamed, named, so that a run may be granted exactly one of them via
+    /// <c>OSPREY_ALLOW_UNFIXED_RESIDENT=&lt;token&gt;</c> and nothing else.
+    ///
+    /// <para>This list may SHRINK as paths are streamed. It must not GROW. Growing it means a
+    /// path we believed bounded is resident again, which is a defect to fix rather than to
+    /// admit - so <c>ResidentPoolGuardTest</c> pins the contents exactly, and any addition
+    /// shows up in review as the ratchet running backwards instead of as an ambient
+    /// environment variable somebody set months ago.</para>
+    ///
+    /// <para>Why named tokens instead of the former blanket <c>OSPREY_ALLOW_UNBOUNDED_MEMORY=1</c>:
+    /// a boolean grants amnesty to every trigger at once, so it cannot distinguish "the one path
+    /// we know is unfixed" from "a path that silently regressed". It did not: with the boolean in
+    /// place, <c>OSPREY_PASS2_QVALUE=transfer</c> regressed back onto the resident pool for ten
+    /// days unnoticed, because setting the boolean was routine. An unlisted path now errors even
+    /// when the variable is set.</para>
+    /// </summary>
+    public static class ResidentPaths
+    {
+        /// <summary>
+        /// The HPC reconciled-input merge (<c>--task SecondPassFDR</c>), which loads every
+        /// worker's entries to reconcile them. Tracked by issue #4486.
+        /// </summary>
+        public const string HPC_MERGE = @"hpc-merge";
+
+        /// <summary>
+        /// <c>--fdrbench-pass 1</c>, which reads the full pre-compaction first-pass pool
+        /// (decoys + entrapment, with scores) - exactly what the projection path drops.
+        /// </summary>
+        public const string FDRBENCH_PASS1 = @"fdrbench-pass1";
+
+        /// <summary>
+        /// <c>--model-diagnostics</c> on a FULL resume, where the 1st-pass sidecars are already
+        /// on disk so FirstJoin skips its score pass, the streaming accumulator is never fed,
+        /// and the report falls back to the resident batch write. Tracked by issue #4505; the
+        /// scale case was streamed by #4420, and a verified fix for this remainder is parked on
+        /// the closed #4437 branch.
+        /// </summary>
+        public const string MDIAG_FULL_RESUME = @"mdiag-full-resume";
+
+        /// <summary>
+        /// A non-Percolator <c>FdrMethod</c> (Simple / Mokapot), which does not use the
+        /// projection framework at all. By design rather than unfinished work, but it still
+        /// takes the resident path and so must be named to be allowed.
+        /// </summary>
+        public const string NON_PERCOLATOR_FDR = @"non-percolator-fdr";
+
+        /// <summary>
+        /// Every legal <c>OSPREY_ALLOW_UNFIXED_RESIDENT</c> value. Pinned by
+        /// <c>ResidentPoolGuardTest</c> - see the class remarks for why it may only shrink.
+        /// </summary>
+        public static readonly IReadOnlyList<string> KNOWN_UNFIXED = new[]
+        {
+            HPC_MERGE, FDRBENCH_PASS1, MDIAG_FULL_RESUME, NON_PERCOLATOR_FDR
+        };
+    }
+}

--- a/pwiz_tools/Osprey/Osprey.Core/ResidentPaths.cs
+++ b/pwiz_tools/Osprey/Osprey.Core/ResidentPaths.cs
@@ -49,13 +49,13 @@ namespace pwiz.Osprey.Core
         /// The HPC reconciled-input merge (<c>--task SecondPassFDR</c>), which loads every
         /// worker's entries to reconcile them. Tracked by issue #4486.
         /// </summary>
-        public const string HPC_MERGE = @"hpc-merge";
+        public static readonly string HPC_MERGE = @"hpc-merge";
 
         /// <summary>
         /// <c>--fdrbench-pass 1</c>, which reads the full pre-compaction first-pass pool
         /// (decoys + entrapment, with scores) - exactly what the projection path drops.
         /// </summary>
-        public const string FDRBENCH_PASS1 = @"fdrbench-pass1";
+        public static readonly string FDRBENCH_PASS1 = @"fdrbench-pass1";
 
         /// <summary>
         /// <c>--model-diagnostics</c> on a FULL resume, where the 1st-pass sidecars are already
@@ -64,14 +64,14 @@ namespace pwiz.Osprey.Core
         /// scale case was streamed by #4420, and a verified fix for this remainder is parked on
         /// the closed #4437 branch.
         /// </summary>
-        public const string MDIAG_FULL_RESUME = @"mdiag-full-resume";
+        public static readonly string MDIAG_FULL_RESUME = @"mdiag-full-resume";
 
         /// <summary>
         /// A non-Percolator <c>FdrMethod</c> (Simple / Mokapot), which does not use the
         /// projection framework at all. By design rather than unfinished work, but it still
         /// takes the resident path and so must be named to be allowed.
         /// </summary>
-        public const string NON_PERCOLATOR_FDR = @"non-percolator-fdr";
+        public static readonly string NON_PERCOLATOR_FDR = @"non-percolator-fdr";
 
         /// <summary>
         /// <c>OSPREY_FDR_PROJECTION=0</c>: the operator explicitly forced the legacy
@@ -86,7 +86,7 @@ namespace pwiz.Osprey.Core
         /// legacy path itself does, which needs #4507 (FDRBench pass 1) and #4505 (mdiag full
         /// resume) first.</para>
         /// </summary>
-        public const string PROJECTION_OFF = @"projection-off";
+        public static readonly string PROJECTION_OFF = @"projection-off";
 
         /// <summary>
         /// Every legal <c>OSPREY_ALLOW_UNFIXED_RESIDENT</c> value. Pinned by

--- a/pwiz_tools/Osprey/Osprey.Tasks/FirstJoinTask.cs
+++ b/pwiz_tools/Osprey/Osprey.Tasks/FirstJoinTask.cs
@@ -286,8 +286,7 @@ namespace pwiz.Osprey.Tasks
             // streamed report is byte-identical to the resident build, and it stays off the
             // default output path.
             bool needsResidentFirstPassPool =
-                (!string.IsNullOrEmpty(config.OutputFdrBench) && config.FdrBenchPass == 1) ||
-                OspreyEnvironment.Pass2TransferQ;
+                !string.IsNullOrEmpty(config.OutputFdrBench) && config.FdrBenchPass == 1;
             // NOTE: transfer-compete does NOT force the resident pool -- it only needs the
             // trained 1st-pass MODEL (not the full-population score->q table), which the
             // streaming projection path publishes cheaply via captureModel below. Forcing

--- a/pwiz_tools/Osprey/Osprey.Tasks/PerFileScoringTask.cs
+++ b/pwiz_tools/Osprey/Osprey.Tasks/PerFileScoringTask.cs
@@ -1963,7 +1963,10 @@ namespace pwiz.Osprey.Tasks
                     @"be unfixed. Something that was streamed is resident again - fix that rather " +
                     @"than allowing it. OSPREY_ALLOW_UNFIXED_RESIDENT cannot admit this path.";
             }
-            if (string.Equals(trigger, allowUnfixedResident, StringComparison.Ordinal))
+            // Case-insensitive to match how the rest of the CLI parses tokens (ParseFdrBenchPass):
+            // the error names the exact token to set, so rejecting it for capitalization would
+            // read as the guard ignoring what the operator just did.
+            if (string.Equals(trigger, allowUnfixedResident, StringComparison.OrdinalIgnoreCase))
                 return null;
             return string.Format(
                 @"This run takes the '{0}' RESIDENT first-pass pool path, which holds every entry " +

--- a/pwiz_tools/Osprey/Osprey.Tasks/PerFileScoringTask.cs
+++ b/pwiz_tools/Osprey/Osprey.Tasks/PerFileScoringTask.cs
@@ -644,9 +644,9 @@ namespace pwiz.Osprey.Tasks
             // so the fat pool is never on the row-count scaling path. The full elimination (stream
             // the batch report from the sidecar+parquet too) is a documented follow-up.
             // See TODO-20260720_osprey_pass2_per_run_qvalue.
-            bool needsResidentPool = NeedsResidentPool(config) ||
-                                     (config.ModelDiagnostics && FirstPassSidecarsPresent(config));
-            GuardResidentPool(config, needsResidentPool);
+            bool mdiagFullResume = config.ModelDiagnostics && FirstPassSidecarsPresent(config);
+            bool needsResidentPool = NeedsResidentPool(config) || mdiagFullResume;
+            GuardResidentPool(config, needsResidentPool, mdiagFullResume);
             FdrProjectionSet projections = null;
 
             var swAllFiles = Stopwatch.StartNew();
@@ -1415,7 +1415,9 @@ namespace pwiz.Osprey.Tasks
         /// OSPREY_DUMP_PERCOLATOR bisection dump (emitted by FirstJoin's rehydrate before it
         /// compacts, so it genuinely needs the all-files pre-compaction pool rather than a
         /// silently post-compaction one), OSPREY_FDR_PROJECTION=0, a non-Percolator
-        /// FdrMethod, --fdrbench-pass 1, and OSPREY_PASS2_QVALUE=transfer. The
+        /// FdrMethod, and --fdrbench-pass 1. OSPREY_PASS2_QVALUE=transfer is NOT among them:
+        /// the per-run-only redesign (#4438) resolves each adjusted peak against that file's
+        /// own on-disk sidecar. The
         /// --task SecondPassFDR merge is NOT among them: it sets ExpectReconciledInput, which
         /// <c>--task</c> selection makes mutually exclusive with <c>NoJoin</c>, so term 2's
         /// NoJoin clause already excludes it.
@@ -1926,10 +1928,12 @@ namespace pwiz.Osprey.Tasks
         /// <c>OSPREY_FDR_PROJECTION=0</c>, which requests the legacy resident implementation
         /// outright and so must be named like any other.
         /// </summary>
-        private static void GuardResidentPool(OspreyConfig config, bool needsResidentPool)
+        private static void GuardResidentPool(
+            OspreyConfig config, bool needsResidentPool, bool mdiagFullResume = false)
         {
             string error = ResidentPoolGuardError(config, needsResidentPool,
-                OspreyEnvironment.AllowUnfixedResident, OspreyEnvironment.UseFdrProjection);
+                OspreyEnvironment.AllowUnfixedResident, OspreyEnvironment.UseFdrProjection,
+                mdiagFullResume);
             if (error != null)
                 throw new InvalidOperationException(error);
         }
@@ -1950,11 +1954,18 @@ namespace pwiz.Osprey.Tasks
         /// distinguish, and is how transfer regressed unnoticed.</para>
         /// </summary>
         internal static string ResidentPoolGuardError(
-            OspreyConfig config, bool needsResidentPool, string allowUnfixedResident, bool useFdrProjection)
+            OspreyConfig config, bool needsResidentPool, string allowUnfixedResident,
+            bool useFdrProjection, bool mdiagFullResume = false)
         {
             if (!needsResidentPool)
                 return null;
-            string trigger = ResidentPoolTrigger(config, useFdrProjection);
+            string trigger = ResidentPoolTrigger(config, useFdrProjection, mdiagFullResume);
+            // Membership in the committed list is what makes it the high-water mark rather than
+            // documentation: a token the trigger chain invents but the list does not carry is
+            // refused here, so re-admitting a path really does require editing the list (and
+            // failing its pinning test), not just adding a branch above.
+            if (trigger != null && !ResidentPaths.KNOWN_UNFIXED.Contains(trigger))
+                trigger = null;
             if (trigger == null)
             {
                 return
@@ -1968,28 +1979,41 @@ namespace pwiz.Osprey.Tasks
             // read as the guard ignoring what the operator just did.
             if (string.Equals(trigger, allowUnfixedResident, StringComparison.OrdinalIgnoreCase))
                 return null;
+            // Name the offending value when one was supplied, so a typo or a shell-quoted token
+            // does not produce the identical message the unset case produces.
+            string supplied = string.IsNullOrEmpty(allowUnfixedResident)
+                ? string.Empty
+                : string.Format(@" OSPREY_ALLOW_UNFIXED_RESIDENT is currently '{0}', which does " +
+                                @"not name this path.", allowUnfixedResident);
             return string.Format(
                 @"This run takes the '{0}' RESIDENT first-pass pool path, which holds every entry " +
                 @"in memory and grows O(files) - it does not scale to large file counts and can " +
                 @"exhaust memory. Set OSPREY_ALLOW_UNFIXED_RESIDENT={0} to accept it and proceed " +
-                @"(intended for local testing / small runs); otherwise this path is unavailable.",
-                trigger);
+                @"(intended for local testing / small runs); otherwise this path is unavailable.{1}",
+                trigger, supplied);
         }
 
         /// <summary>
         /// The <see cref="ResidentPaths"/> token for the known-unfixed resident path this config
-        /// takes, or <c>null</c> when it needs the resident pool for a reason NOT on that list.
-        /// Order is most-specific-first and mirrors <see cref="PreCompactionPoolReason"/>.
-        /// <c>--model-diagnostics</c> is last because it only forces the pool in combination with
-        /// a full resume (the caller's <c>FirstPassSidecarsPresent</c> conjunction).
+        /// takes, or <c>null</c> when it needs the resident pool for a reason NOT on that list -
+        /// which the caller refuses outright, since reaching that state means something we
+        /// believed bounded is resident again.
         ///
-        /// <para><c>OSPREY_FDR_PROJECTION=0</c> is checked FIRST and deliberately outranks the
-        /// config-driven reasons: it selects the legacy implementation for the WHOLE run, so it
-        /// is the honest description of why the run is resident even when another trigger also
-        /// applies. Naming it is therefore coarse by design - but it is now named, where it used
-        /// to bypass the guard silently.</para>
+        /// <para>Order here is BEHAVIORAL, unlike <see cref="PreCompactionPoolReason"/> where only
+        /// the reported string depends on it: this decides which token the operator must set, so
+        /// a config matching two triggers is attributable to exactly one.
+        /// <c>OSPREY_FDR_PROJECTION=0</c> is checked FIRST and deliberately outranks the
+        /// config-driven reasons, because it selects the legacy implementation for the WHOLE run
+        /// and is therefore the honest description even when another trigger also applies.</para>
+        ///
+        /// <para><paramref name="mdiagFullResume"/> is passed in rather than read off
+        /// <paramref name="config"/>: <c>--model-diagnostics</c> forces the pool only in
+        /// combination with a full resume, and testing <c>config.ModelDiagnostics</c> alone here
+        /// would make mdiag an unconditional catch-all that silently absorbed any FUTURE arming
+        /// condition - handing it a token CI already exports.</para>
         /// </summary>
-        private static string ResidentPoolTrigger(OspreyConfig config, bool useFdrProjection)
+        private static string ResidentPoolTrigger(
+            OspreyConfig config, bool useFdrProjection, bool mdiagFullResume)
         {
             if (!useFdrProjection)
                 return ResidentPaths.PROJECTION_OFF;
@@ -1999,7 +2023,7 @@ namespace pwiz.Osprey.Tasks
                 return ResidentPaths.NON_PERCOLATOR_FDR;
             if (!string.IsNullOrEmpty(config.OutputFdrBench) && config.FdrBenchPass == 1)
                 return ResidentPaths.FDRBENCH_PASS1;
-            if (config.ModelDiagnostics)
+            if (mdiagFullResume)
                 return ResidentPaths.MDIAG_FULL_RESUME;
             return null;
         }

--- a/pwiz_tools/Osprey/Osprey.Tasks/PerFileScoringTask.cs
+++ b/pwiz_tools/Osprey/Osprey.Tasks/PerFileScoringTask.cs
@@ -1471,8 +1471,10 @@ namespace pwiz.Osprey.Tasks
                 return @"OSPREY_DUMP_PERCOLATOR";
             if (!string.IsNullOrEmpty(config.OutputFdrBench) && config.FdrBenchPass == 1)
                 return @"--fdrbench-pass 1";
-            if (OspreyEnvironment.Pass2TransferQ)
-                return @"OSPREY_PASS2_QVALUE=transfer";
+            // OSPREY_PASS2_QVALUE=transfer is deliberately NOT a reason here, and must not
+            // become one again: the per-run-only redesign maps each adjusted peak through
+            // that file's own 1st-pass (score -> run q) sidecar, one file at a time, so it
+            // needs no pre-compaction pool. See NeedsResidentPool.
             if (!config.FdrMethod.UsesPercolatorFramework())
                 return @"A non-Percolator FDR method";
             if (!OspreyEnvironment.UseFdrProjection)
@@ -1863,11 +1865,29 @@ namespace pwiz.Osprey.Tasks
         /// </summary>
         private static bool NeedsResidentPool(OspreyConfig config)
         {
+            return NeedsResidentPool(config, OspreyEnvironment.UseFdrProjection);
+        }
+
+        /// <summary>
+        /// Pure core of <see cref="NeedsResidentPool(OspreyConfig)"/> (the env static is passed
+        /// in so it is unit testable), and the single definition of the trigger set.
+        /// <c>OSPREY_PASS2_QVALUE=transfer</c> is NOT a trigger and must not become one again:
+        /// #4438 removed it when the per-run-only redesign dropped the full pre-compaction
+        /// score-&gt;q table, and a #4446 merge artifact silently restored it, re-breaking
+        /// 82-file transfer runs on <see cref="GuardResidentPool"/> with the memory bounding
+        /// #4438 had shipped. Deliberately reads no <see cref="OspreyEnvironment"/> state other
+        /// than the passed-in projection switch: the trigger set is then enumerable, and
+        /// <c>ResidentPoolGuardTest</c> pins it. Note the test cannot by itself catch a
+        /// re-added env read (the var is unset in a test process), so a pass-2 mode arriving
+        /// in this list is a review-caught error - it contradicts #4438's invariant that
+        /// transfer resolves run q per file, from data already on disk.
+        /// </summary>
+        internal static bool NeedsResidentPool(OspreyConfig config, bool useFdrProjection)
+        {
             return config.ExpectReconciledInput ||
-                   !OspreyEnvironment.UseFdrProjection ||
+                   !useFdrProjection ||
                    !config.FdrMethod.UsesPercolatorFramework() ||
-                   (!string.IsNullOrEmpty(config.OutputFdrBench) && config.FdrBenchPass == 1) ||
-                   OspreyEnvironment.Pass2TransferQ;
+                   (!string.IsNullOrEmpty(config.OutputFdrBench) && config.FdrBenchPass == 1);
         }
 
         /// <summary>

--- a/pwiz_tools/Osprey/Osprey.Tasks/PerFileScoringTask.cs
+++ b/pwiz_tools/Osprey/Osprey.Tasks/PerFileScoringTask.cs
@@ -1918,12 +1918,13 @@ namespace pwiz.Osprey.Tasks
         /// Fail fast when a run would build the RESIDENT first-pass pool -- an O(files) memory
         /// path (the fat <see cref="FdrEntry"/> stub buffer, and the <c>FirstJoin.Rehydrate</c>
         /// pre-compaction load it feeds) that does not scale to large file counts. Unless the
-        /// operator explicitly accepted unbounded memory (<c>OSPREY_ALLOW_UNBOUNDED_MEMORY</c>, or
-        /// the <c>OSPREY_FDR_PROJECTION=0</c> A/B-oracle switch which is itself an explicit resident
-        /// opt-in), throw with the trigger named so the failure is actionable rather than an opaque
-        /// OOM at scale. Triggers: the HPC reconciled-input merge (#4486), <c>--fdrbench-pass 1</c>,
-        /// a non-Percolator FdrMethod, and <c>--model-diagnostics</c> on a full resume (#4505 - the
-        /// scale case was streamed by #4420; only the full-resume batch report remains).
+        /// operator named THIS path via <c>OSPREY_ALLOW_UNFIXED_RESIDENT</c>, throw with the token
+        /// named so the failure is actionable rather than an opaque OOM at scale. Triggers: the
+        /// HPC reconciled-input merge (#4486), <c>--fdrbench-pass 1</c> (#4507), a non-Percolator
+        /// FdrMethod, <c>--model-diagnostics</c> on a full resume (#4505 - the scale case was
+        /// streamed by #4420; only the full-resume batch report remains), and
+        /// <c>OSPREY_FDR_PROJECTION=0</c>, which requests the legacy resident implementation
+        /// outright and so must be named like any other.
         /// </summary>
         private static void GuardResidentPool(OspreyConfig config, bool needsResidentPool)
         {
@@ -1938,7 +1939,8 @@ namespace pwiz.Osprey.Tasks
         /// testable): returns the actionable error message when the run would take the resident
         /// first-pass pool, or <c>null</c> when the pool is not needed or this exact path was
         /// named. <paramref name="useFdrProjection"/> == false is the <c>OSPREY_FDR_PROJECTION=0</c>
-        /// A/B-oracle switch, itself an explicit resident opt-in.
+        /// A/B-oracle switch, which is no longer an automatic exemption: it is its own token, so
+        /// forcing the legacy implementation is stated rather than inferred.
         ///
         /// <para>The allowance is a TOKEN, not a boolean, and it must match the path this run
         /// actually takes. A resident path with no token in <see cref="ResidentPaths.KNOWN_UNFIXED"/>
@@ -1950,9 +1952,9 @@ namespace pwiz.Osprey.Tasks
         internal static string ResidentPoolGuardError(
             OspreyConfig config, bool needsResidentPool, string allowUnfixedResident, bool useFdrProjection)
         {
-            if (!needsResidentPool || !useFdrProjection)
+            if (!needsResidentPool)
                 return null;
-            string trigger = ResidentPoolTrigger(config);
+            string trigger = ResidentPoolTrigger(config, useFdrProjection);
             if (trigger == null)
             {
                 return
@@ -1977,9 +1979,17 @@ namespace pwiz.Osprey.Tasks
         /// Order is most-specific-first and mirrors <see cref="PreCompactionPoolReason"/>.
         /// <c>--model-diagnostics</c> is last because it only forces the pool in combination with
         /// a full resume (the caller's <c>FirstPassSidecarsPresent</c> conjunction).
+        ///
+        /// <para><c>OSPREY_FDR_PROJECTION=0</c> is checked FIRST and deliberately outranks the
+        /// config-driven reasons: it selects the legacy implementation for the WHOLE run, so it
+        /// is the honest description of why the run is resident even when another trigger also
+        /// applies. Naming it is therefore coarse by design - but it is now named, where it used
+        /// to bypass the guard silently.</para>
         /// </summary>
-        private static string ResidentPoolTrigger(OspreyConfig config)
+        private static string ResidentPoolTrigger(OspreyConfig config, bool useFdrProjection)
         {
+            if (!useFdrProjection)
+                return ResidentPaths.PROJECTION_OFF;
             if (config.ExpectReconciledInput)
                 return ResidentPaths.HPC_MERGE;
             if (!config.FdrMethod.UsesPercolatorFramework())

--- a/pwiz_tools/Osprey/Osprey.Tasks/PerFileScoringTask.cs
+++ b/pwiz_tools/Osprey/Osprey.Tasks/PerFileScoringTask.cs
@@ -1921,15 +1921,14 @@ namespace pwiz.Osprey.Tasks
         /// operator explicitly accepted unbounded memory (<c>OSPREY_ALLOW_UNBOUNDED_MEMORY</c>, or
         /// the <c>OSPREY_FDR_PROJECTION=0</c> A/B-oracle switch which is itself an explicit resident
         /// opt-in), throw with the trigger named so the failure is actionable rather than an opaque
-        /// OOM at scale. Triggers: the HPC reconciled-input merge, <c>--fdrbench-pass 1</c>, a
-        /// non-Percolator FdrMethod, and <c>--model-diagnostics</c> on a full resume. Streaming the
-        /// remaining resident paths is tracked in
-        /// <c>TODO-osprey_stage6_rescored_buffer_streaming.md</c>.
+        /// OOM at scale. Triggers: the HPC reconciled-input merge (#4486), <c>--fdrbench-pass 1</c>,
+        /// a non-Percolator FdrMethod, and <c>--model-diagnostics</c> on a full resume (#4505 - the
+        /// scale case was streamed by #4420; only the full-resume batch report remains).
         /// </summary>
         private static void GuardResidentPool(OspreyConfig config, bool needsResidentPool)
         {
             string error = ResidentPoolGuardError(config, needsResidentPool,
-                OspreyEnvironment.AllowUnboundedMemory, OspreyEnvironment.UseFdrProjection);
+                OspreyEnvironment.AllowUnfixedResident, OspreyEnvironment.UseFdrProjection);
             if (error != null)
                 throw new InvalidOperationException(error);
         }
@@ -1937,26 +1936,59 @@ namespace pwiz.Osprey.Tasks
         /// <summary>
         /// Pure core of <see cref="GuardResidentPool"/> (env statics passed in so it is unit
         /// testable): returns the actionable error message when the run would take the resident
-        /// first-pass pool without an explicit unbounded-memory opt-in, or <c>null</c> when the
-        /// pool is not needed or the operator opted in. <paramref name="useFdrProjection"/> == false
-        /// is the <c>OSPREY_FDR_PROJECTION=0</c> A/B-oracle switch, itself an explicit resident opt-in.
+        /// first-pass pool, or <c>null</c> when the pool is not needed or this exact path was
+        /// named. <paramref name="useFdrProjection"/> == false is the <c>OSPREY_FDR_PROJECTION=0</c>
+        /// A/B-oracle switch, itself an explicit resident opt-in.
+        ///
+        /// <para>The allowance is a TOKEN, not a boolean, and it must match the path this run
+        /// actually takes. A resident path with no token in <see cref="ResidentPaths.KNOWN_UNFIXED"/>
+        /// is refused unconditionally - no environment variable can admit it - because reaching
+        /// here off the known list means something we believed bounded became resident again.
+        /// That is the case the former blanket <c>OSPREY_ALLOW_UNBOUNDED_MEMORY=1</c> could not
+        /// distinguish, and is how transfer regressed unnoticed.</para>
         /// </summary>
         internal static string ResidentPoolGuardError(
-            OspreyConfig config, bool needsResidentPool, bool allowUnbounded, bool useFdrProjection)
+            OspreyConfig config, bool needsResidentPool, string allowUnfixedResident, bool useFdrProjection)
         {
-            if (!needsResidentPool || allowUnbounded || !useFdrProjection)
+            if (!needsResidentPool || !useFdrProjection)
                 return null;
-            string trigger =
-                config.ExpectReconciledInput ? @"the reconciled-input merge (HPC --task SecondPassFDR)"
-                : !config.FdrMethod.UsesPercolatorFramework() ? string.Format(@"{0} FDR (non-Percolator)", config.FdrMethod)
-                : (!string.IsNullOrEmpty(config.OutputFdrBench) && config.FdrBenchPass == 1) ? @"--fdrbench-pass 1"
-                : config.ModelDiagnostics ? @"--model-diagnostics on a full resume"
-                : @"this configuration";
+            string trigger = ResidentPoolTrigger(config);
+            if (trigger == null)
+            {
+                return
+                    @"This configuration requires the RESIDENT first-pass pool, which holds every " +
+                    @"entry in memory and grows O(files), but it is not one of the paths known to " +
+                    @"be unfixed. Something that was streamed is resident again - fix that rather " +
+                    @"than allowing it. OSPREY_ALLOW_UNFIXED_RESIDENT cannot admit this path.";
+            }
+            if (string.Equals(trigger, allowUnfixedResident, StringComparison.Ordinal))
+                return null;
             return string.Format(
-                @"{0} requires the RESIDENT first-pass pool, which holds every entry in memory and " +
-                @"grows O(files) -- it does not scale to large file counts and can exhaust memory. " +
-                @"Set OSPREY_ALLOW_UNBOUNDED_MEMORY=1 to accept unbounded memory and proceed " +
-                @"(intended for testing / small runs); otherwise this path is unavailable.", trigger);
+                @"This run takes the '{0}' RESIDENT first-pass pool path, which holds every entry " +
+                @"in memory and grows O(files) - it does not scale to large file counts and can " +
+                @"exhaust memory. Set OSPREY_ALLOW_UNFIXED_RESIDENT={0} to accept it and proceed " +
+                @"(intended for local testing / small runs); otherwise this path is unavailable.",
+                trigger);
+        }
+
+        /// <summary>
+        /// The <see cref="ResidentPaths"/> token for the known-unfixed resident path this config
+        /// takes, or <c>null</c> when it needs the resident pool for a reason NOT on that list.
+        /// Order is most-specific-first and mirrors <see cref="PreCompactionPoolReason"/>.
+        /// <c>--model-diagnostics</c> is last because it only forces the pool in combination with
+        /// a full resume (the caller's <c>FirstPassSidecarsPresent</c> conjunction).
+        /// </summary>
+        private static string ResidentPoolTrigger(OspreyConfig config)
+        {
+            if (config.ExpectReconciledInput)
+                return ResidentPaths.HPC_MERGE;
+            if (!config.FdrMethod.UsesPercolatorFramework())
+                return ResidentPaths.NON_PERCOLATOR_FDR;
+            if (!string.IsNullOrEmpty(config.OutputFdrBench) && config.FdrBenchPass == 1)
+                return ResidentPaths.FDRBENCH_PASS1;
+            if (config.ModelDiagnostics)
+                return ResidentPaths.MDIAG_FULL_RESUME;
+            return null;
         }
 
         /// <summary>

--- a/pwiz_tools/Osprey/Osprey.Test/ResidentPoolGuardTest.cs
+++ b/pwiz_tools/Osprey/Osprey.Test/ResidentPoolGuardTest.cs
@@ -31,13 +31,19 @@ namespace pwiz.Osprey.Test
     /// <summary>
     /// Unit tests for the resident first-pass pool guard
     /// (<see cref="PerFileScoringTask.ResidentPoolGuardError"/>): a run that would take the
-    /// O(files) resident pool must fail fast with an actionable error naming the trigger,
-    /// UNLESS the operator explicitly accepted unbounded memory
-    /// (OSPREY_ALLOW_UNBOUNDED_MEMORY, or OSPREY_FDR_PROJECTION=0 which forces the resident
-    /// A/B-oracle path). So no user reaches an O(files) memory path by accident.
-    /// Also pins the trigger set that arms it
-    /// (<see cref="PerFileScoringTask.NeedsResidentPool(OspreyConfig, bool)"/>), since a
-    /// wrongly-added trigger is what re-broke 82-file OSPREY_PASS2_QVALUE=transfer runs.
+    /// O(files) resident pool must fail fast with an actionable error, UNLESS the operator
+    /// named THAT path via <c>OSPREY_ALLOW_UNFIXED_RESIDENT=&lt;token&gt;</c>. Naming a
+    /// different path does not help, and a path absent from
+    /// <see cref="ResidentPaths.KNOWN_UNFIXED"/> is refused whatever the variable says - so no
+    /// user reaches an O(files) memory path by accident, and no single value re-opens all of
+    /// them the way the former blanket <c>OSPREY_ALLOW_UNBOUNDED_MEMORY=1</c> did.
+    /// <c>OSPREY_FDR_PROJECTION=0</c> is included: it requests the legacy resident
+    /// implementation outright, so it is the <see cref="ResidentPaths.PROJECTION_OFF"/> token
+    /// rather than an automatic exemption.
+    /// Also pins the trigger set that arms the guard
+    /// (<see cref="PerFileScoringTask.NeedsResidentPool(OspreyConfig, bool)"/>) and the
+    /// contents of the token list itself, since a wrongly-added trigger is what re-broke
+    /// 82-file OSPREY_PASS2_QVALUE=transfer runs.
     /// </summary>
     [TestClass]
     public class ResidentPoolGuardTest

--- a/pwiz_tools/Osprey/Osprey.Test/ResidentPoolGuardTest.cs
+++ b/pwiz_tools/Osprey/Osprey.Test/ResidentPoolGuardTest.cs
@@ -58,7 +58,7 @@ namespace pwiz.Osprey.Test
                 allowUnfixedResident: null, useFdrProjection: true));
 
             // HPC reconciled-input merge trips the fat pool: guarded (armed), and the message is
-            // actionable -- it names the token the operator would set, not just a symptom.
+            // actionable - it names the token the operator would set, not just a symptom.
             var hpc = new OspreyConfig { ExpectReconciledInput = true };
             string hpcErr = PerFileScoringTask.ResidentPoolGuardError(hpc, needsResidentPool: true,
                 allowUnfixedResident: null, useFdrProjection: true);
@@ -69,7 +69,7 @@ namespace pwiz.Osprey.Test
             Assert.IsNull(PerFileScoringTask.ResidentPoolGuardError(hpc, needsResidentPool: true,
                 allowUnfixedResident: ResidentPaths.HPC_MERGE, useFdrProjection: true));
             // OSPREY_FDR_PROJECTION=0 (the A/B byte-identity oracle) is NOT an automatic
-            // exemption any more -- it is its own token. Unnamed it is refused like anything
+            // exemption any more - it is its own token. Unnamed it is refused like anything
             // else, which closes the last route to a resident pool nobody had to ask for.
             Assert.IsNotNull(PerFileScoringTask.ResidentPoolGuardError(hpc, needsResidentPool: true,
                 allowUnfixedResident: null, useFdrProjection: false));
@@ -85,16 +85,25 @@ namespace pwiz.Osprey.Test
             Assert.IsNotNull(PerFileScoringTask.ResidentPoolGuardError(hpc, needsResidentPool: true,
                 allowUnfixedResident: ResidentPaths.FDRBENCH_PASS1, useFdrProjection: true));
 
-            // Capitalization does not defeat it -- the error names the exact token to set, so
+            // Capitalization does not defeat it - the error names the exact token to set, so
             // rejecting the operator's own value for case would read as the guard ignoring them.
             Assert.IsNull(PerFileScoringTask.ResidentPoolGuardError(hpc, needsResidentPool: true,
                 allowUnfixedResident: ResidentPaths.HPC_MERGE.ToUpperInvariant(),
                 useFdrProjection: true));
 
             // Each user-reachable trigger names its own token so the failure is diagnosable:
+            // mdiag arms the pool only in COMBINATION with a full resume, so the caller passes
+            // that conjunction in. Testing config.ModelDiagnostics alone inside the trigger would
+            // make mdiag an unconditional catch-all that absorbed any future arming condition -
+            // and hand it the one token CI already exports (regression.ps1 mode 2).
             var mdiag = new OspreyConfig { ModelDiagnostics = true };
-            StringAssert.Contains(PerFileScoringTask.ResidentPoolGuardError(mdiag, true, null, true),
+            StringAssert.Contains(
+                PerFileScoringTask.ResidentPoolGuardError(mdiag, true, null, true,
+                    mdiagFullResume: true),
                 ResidentPaths.MDIAG_FULL_RESUME);
+            // --model-diagnostics WITHOUT the full resume is not a known path: refused outright.
+            Assert.IsNotNull(PerFileScoringTask.ResidentPoolGuardError(mdiag, true,
+                ResidentPaths.MDIAG_FULL_RESUME, true, mdiagFullResume: false));
 
             var fdrbench1 = new OspreyConfig { OutputFdrBench = "bench.tsv", FdrBenchPass = 1 };
             StringAssert.Contains(PerFileScoringTask.ResidentPoolGuardError(fdrbench1, true, null, true),
@@ -104,7 +113,7 @@ namespace pwiz.Osprey.Test
             StringAssert.Contains(PerFileScoringTask.ResidentPoolGuardError(simple, true, null, true),
                 ResidentPaths.NON_PERCOLATOR_FDR);
 
-            // A resident path with NO token is refused unconditionally -- no value admits it.
+            // A resident path with NO token is refused unconditionally - no value admits it.
             // This is the ratchet: when something we streamed goes resident again, as transfer
             // did, it cannot be waved through. It has to be fixed, or deliberately listed.
             // (lean is the default config: Percolator, no fdrbench, no mdiag, not a merge.)
@@ -118,12 +127,15 @@ namespace pwiz.Osprey.Test
             // never GROW. Asserting the WHOLE set rather than membership is the point: an
             // addition then shows up in review as the ratchet running backwards, instead of
             // as an environment variable somebody set months ago and nobody re-examined.
+            // LITERALS, not the constants: comparing the constants to themselves would pin
+            // membership and order but not the text, and the text is what regression.ps1 mode 2
+            // hard-codes. Renaming a value would otherwise compile, pass here, and only surface
+            // hours later when the expensive gate reaches mode 2 and Osprey throws.
             CollectionAssert.AreEqual(
                 new[]
                 {
-                    ResidentPaths.HPC_MERGE, ResidentPaths.FDRBENCH_PASS1,
-                    ResidentPaths.MDIAG_FULL_RESUME, ResidentPaths.NON_PERCOLATOR_FDR,
-                    ResidentPaths.PROJECTION_OFF
+                    "hpc-merge", "fdrbench-pass1", "mdiag-full-resume", "non-percolator-fdr",
+                    "projection-off"
                 },
                 ResidentPaths.KNOWN_UNFIXED.ToArray());
 

--- a/pwiz_tools/Osprey/Osprey.Test/ResidentPoolGuardTest.cs
+++ b/pwiz_tools/Osprey/Osprey.Test/ResidentPoolGuardTest.cs
@@ -34,6 +34,9 @@ namespace pwiz.Osprey.Test
     /// UNLESS the operator explicitly accepted unbounded memory
     /// (OSPREY_ALLOW_UNBOUNDED_MEMORY, or OSPREY_FDR_PROJECTION=0 which forces the resident
     /// A/B-oracle path). So no user reaches an O(files) memory path by accident.
+    /// Also pins the trigger set that arms it
+    /// (<see cref="PerFileScoringTask.NeedsResidentPool(OspreyConfig, bool)"/>), since a
+    /// wrongly-added trigger is what re-broke 82-file OSPREY_PASS2_QVALUE=transfer runs.
     /// </summary>
     [TestClass]
     public class ResidentPoolGuardTest
@@ -76,6 +79,33 @@ namespace pwiz.Osprey.Test
             var simple = new OspreyConfig { FdrMethod = FdrMethod.Simple };
             StringAssert.Contains(
                 PerFileScoringTask.ResidentPoolGuardError(simple, true, false, true), "non-Percolator");
+
+            // The trigger SET itself, not just the message it produces. Each of these takes the
+            // O(files) resident pool and so arms the guard above.
+            AssertNeedsResidentPool(true, hpc);
+            AssertNeedsResidentPool(true, fdrbench1);
+            AssertNeedsResidentPool(true, simple);
+            // OSPREY_FDR_PROJECTION=0 is itself an explicit resident opt-in.
+            Assert.IsTrue(PerFileScoringTask.NeedsResidentPool(lean, useFdrProjection: false));
+
+            // Nothing else does. Context for OSPREY_PASS2_QVALUE=transfer, which #4438 took off
+            // the list (the per-run-only redesign maps each adjusted peak through that file's
+            // own 1st-pass score to run-q sidecar, one file at a time) and a #4446 merge
+            // artifact silently put back, killing an 82-file transfer run on the guard in ~25 s:
+            // the predicate is now env-free apart from the projection switch, so the triggers
+            // are exactly the four above. That is what these two assertions pin.
+            AssertNeedsResidentPool(false, lean);
+            AssertNeedsResidentPool(false, mdiag);
+        }
+
+        /// <summary>
+        /// Assert the resident-pool predicate on the projection path (the shipping default),
+        /// where <paramref name="config"/> alone decides.
+        /// </summary>
+        private static void AssertNeedsResidentPool(bool expected, OspreyConfig config)
+        {
+            Assert.AreEqual(expected,
+                PerFileScoringTask.NeedsResidentPool(config, useFdrProjection: true));
         }
     }
 }

--- a/pwiz_tools/Osprey/Osprey.Test/ResidentPoolGuardTest.cs
+++ b/pwiz_tools/Osprey/Osprey.Test/ResidentPoolGuardTest.cs
@@ -79,6 +79,12 @@ namespace pwiz.Osprey.Test
             Assert.IsNotNull(PerFileScoringTask.ResidentPoolGuardError(hpc, needsResidentPool: true,
                 allowUnfixedResident: ResidentPaths.FDRBENCH_PASS1, useFdrProjection: true));
 
+            // Capitalization does not defeat it -- the error names the exact token to set, so
+            // rejecting the operator's own value for case would read as the guard ignoring them.
+            Assert.IsNull(PerFileScoringTask.ResidentPoolGuardError(hpc, needsResidentPool: true,
+                allowUnfixedResident: ResidentPaths.HPC_MERGE.ToUpperInvariant(),
+                useFdrProjection: true));
+
             // Each user-reachable trigger names its own token so the failure is diagnosable:
             var mdiag = new OspreyConfig { ModelDiagnostics = true };
             StringAssert.Contains(PerFileScoringTask.ResidentPoolGuardError(mdiag, true, null, true),

--- a/pwiz_tools/Osprey/Osprey.Test/ResidentPoolGuardTest.cs
+++ b/pwiz_tools/Osprey/Osprey.Test/ResidentPoolGuardTest.cs
@@ -62,9 +62,17 @@ namespace pwiz.Osprey.Test
             // Naming THIS path exempts it (no error):
             Assert.IsNull(PerFileScoringTask.ResidentPoolGuardError(hpc, needsResidentPool: true,
                 allowUnfixedResident: ResidentPaths.HPC_MERGE, useFdrProjection: true));
-            //   OSPREY_FDR_PROJECTION=0 (useFdrProjection == false, the A/B-oracle switch)
-            Assert.IsNull(PerFileScoringTask.ResidentPoolGuardError(hpc, needsResidentPool: true,
+            // OSPREY_FDR_PROJECTION=0 (the A/B byte-identity oracle) is NOT an automatic
+            // exemption any more -- it is its own token. Unnamed it is refused like anything
+            // else, which closes the last route to a resident pool nobody had to ask for.
+            Assert.IsNotNull(PerFileScoringTask.ResidentPoolGuardError(hpc, needsResidentPool: true,
                 allowUnfixedResident: null, useFdrProjection: false));
+            Assert.IsNull(PerFileScoringTask.ResidentPoolGuardError(hpc, needsResidentPool: true,
+                allowUnfixedResident: ResidentPaths.PROJECTION_OFF, useFdrProjection: false));
+            // It outranks a config-driven trigger, because it selects the legacy implementation
+            // for the whole run: naming the other reason is not enough.
+            Assert.IsNotNull(PerFileScoringTask.ResidentPoolGuardError(hpc, needsResidentPool: true,
+                allowUnfixedResident: ResidentPaths.HPC_MERGE, useFdrProjection: false));
 
             // Naming a DIFFERENT path does not: the token grants one exemption, not amnesty.
             // This is the property the former blanket boolean lacked.
@@ -102,7 +110,8 @@ namespace pwiz.Osprey.Test
                 new[]
                 {
                     ResidentPaths.HPC_MERGE, ResidentPaths.FDRBENCH_PASS1,
-                    ResidentPaths.MDIAG_FULL_RESUME, ResidentPaths.NON_PERCOLATOR_FDR
+                    ResidentPaths.MDIAG_FULL_RESUME, ResidentPaths.NON_PERCOLATOR_FDR,
+                    ResidentPaths.PROJECTION_OFF
                 },
                 ResidentPaths.KNOWN_UNFIXED.ToArray());
 

--- a/pwiz_tools/Osprey/Osprey.Test/ResidentPoolGuardTest.cs
+++ b/pwiz_tools/Osprey/Osprey.Test/ResidentPoolGuardTest.cs
@@ -21,6 +21,7 @@
  * limitations under the License.
  */
 
+using System.Linq;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using pwiz.Osprey.Core;
 using pwiz.Osprey.Tasks;
@@ -48,37 +49,62 @@ namespace pwiz.Osprey.Test
             // of the opt-in flags -- the default straight-through + resume paths land here.
             var lean = new OspreyConfig();
             Assert.IsNull(PerFileScoringTask.ResidentPoolGuardError(lean, needsResidentPool: false,
-                allowUnbounded: false, useFdrProjection: true));
+                allowUnfixedResident: null, useFdrProjection: true));
 
             // HPC reconciled-input merge trips the fat pool: guarded (armed), and the message is
-            // actionable -- it names the trigger AND the env var the operator would set.
+            // actionable -- it names the token the operator would set, not just a symptom.
             var hpc = new OspreyConfig { ExpectReconciledInput = true };
             string hpcErr = PerFileScoringTask.ResidentPoolGuardError(hpc, needsResidentPool: true,
-                allowUnbounded: false, useFdrProjection: true);
+                allowUnfixedResident: null, useFdrProjection: true);
             Assert.IsNotNull(hpcErr);
-            StringAssert.Contains(hpcErr, "OSPREY_ALLOW_UNBOUNDED_MEMORY");
-            StringAssert.Contains(hpcErr, "reconciled-input merge");
+            StringAssert.Contains(hpcErr, "OSPREY_ALLOW_UNFIXED_RESIDENT=" + ResidentPaths.HPC_MERGE);
 
-            // Both explicit opt-ins exempt the same fat path (no error):
-            //   OSPREY_ALLOW_UNBOUNDED_MEMORY (allowUnbounded == true)
+            // Naming THIS path exempts it (no error):
             Assert.IsNull(PerFileScoringTask.ResidentPoolGuardError(hpc, needsResidentPool: true,
-                allowUnbounded: true, useFdrProjection: true));
+                allowUnfixedResident: ResidentPaths.HPC_MERGE, useFdrProjection: true));
             //   OSPREY_FDR_PROJECTION=0 (useFdrProjection == false, the A/B-oracle switch)
             Assert.IsNull(PerFileScoringTask.ResidentPoolGuardError(hpc, needsResidentPool: true,
-                allowUnbounded: false, useFdrProjection: false));
+                allowUnfixedResident: null, useFdrProjection: false));
 
-            // Each user-reachable trigger names itself so the failure is diagnosable:
+            // Naming a DIFFERENT path does not: the token grants one exemption, not amnesty.
+            // This is the property the former blanket boolean lacked.
+            Assert.IsNotNull(PerFileScoringTask.ResidentPoolGuardError(hpc, needsResidentPool: true,
+                allowUnfixedResident: ResidentPaths.FDRBENCH_PASS1, useFdrProjection: true));
+
+            // Each user-reachable trigger names its own token so the failure is diagnosable:
             var mdiag = new OspreyConfig { ModelDiagnostics = true };
-            StringAssert.Contains(
-                PerFileScoringTask.ResidentPoolGuardError(mdiag, true, false, true), "--model-diagnostics");
+            StringAssert.Contains(PerFileScoringTask.ResidentPoolGuardError(mdiag, true, null, true),
+                ResidentPaths.MDIAG_FULL_RESUME);
 
             var fdrbench1 = new OspreyConfig { OutputFdrBench = "bench.tsv", FdrBenchPass = 1 };
-            StringAssert.Contains(
-                PerFileScoringTask.ResidentPoolGuardError(fdrbench1, true, false, true), "--fdrbench-pass 1");
+            StringAssert.Contains(PerFileScoringTask.ResidentPoolGuardError(fdrbench1, true, null, true),
+                ResidentPaths.FDRBENCH_PASS1);
 
             var simple = new OspreyConfig { FdrMethod = FdrMethod.Simple };
-            StringAssert.Contains(
-                PerFileScoringTask.ResidentPoolGuardError(simple, true, false, true), "non-Percolator");
+            StringAssert.Contains(PerFileScoringTask.ResidentPoolGuardError(simple, true, null, true),
+                ResidentPaths.NON_PERCOLATOR_FDR);
+
+            // A resident path with NO token is refused unconditionally -- no value admits it.
+            // This is the ratchet: when something we streamed goes resident again, as transfer
+            // did, it cannot be waved through. It has to be fixed, or deliberately listed.
+            // (lean is the default config: Percolator, no fdrbench, no mdiag, not a merge.)
+            foreach (string token in new[] { null, "", ResidentPaths.HPC_MERGE, "anything" })
+            {
+                Assert.IsNotNull(
+                    PerFileScoringTask.ResidentPoolGuardError(lean, true, token, true), token);
+            }
+
+            // The high-water mark itself. This list may SHRINK as paths are streamed; it must
+            // never GROW. Asserting the WHOLE set rather than membership is the point: an
+            // addition then shows up in review as the ratchet running backwards, instead of
+            // as an environment variable somebody set months ago and nobody re-examined.
+            CollectionAssert.AreEqual(
+                new[]
+                {
+                    ResidentPaths.HPC_MERGE, ResidentPaths.FDRBENCH_PASS1,
+                    ResidentPaths.MDIAG_FULL_RESUME, ResidentPaths.NON_PERCOLATOR_FDR
+                },
+                ResidentPaths.KNOWN_UNFIXED.ToArray());
 
             // The trigger SET itself, not just the message it produces. Each of these takes the
             // O(files) resident pool and so arms the guard above.

--- a/pwiz_tools/Osprey/regression.ps1
+++ b/pwiz_tools/Osprey/regression.ps1
@@ -911,18 +911,22 @@ foreach ($name in $selected) {
         #
         # This is NOT the scale case. --model-diagnostics over --input-scores streams the
         # report off ModelDiagnosticsData.Accumulator one file at a time and needs no opt-in
-        # at any file count -- that is the 82-file path this PR bounds. What remains is the
-        # full-resume batch report, tracked separately; the fix is to feed the same
-        # accumulator during the resume's per-file load and report from it.
+        # at any file count. What remains is the full-resume batch report, tracked in #4505;
+        # the fix is to feed the same accumulator during the resume's per-file load and
+        # report from it, and it is already written and verified on the closed #4437 branch.
         #
         # mode 3 above deliberately has NO opt-in: its old one wrapped the entire HPC chain
         # and would mask a guard regression on any --input-scores worker.
-        $env:OSPREY_ALLOW_UNBOUNDED_MEMORY = '1'
+        # Names the ONE path it needs, so what CI depends on is visible rather than ambient.
+        # The former blanket OSPREY_ALLOW_UNBOUNDED_MEMORY=1 would also have waved through any
+        # OTHER resident path this leg happened to take - which is how a transfer regression
+        # rode along unnoticed. An unlisted path now fails here even with this set.
+        $env:OSPREY_ALLOW_UNFIXED_RESIDENT = 'mdiag-full-resume'
         try {
             $rResume = Invoke-OspreyRun -Mzmls $inputs.Mzmls -Library $inputs.Library -Resolution $cfg.Resolution `
                 -WorkDir $straightDir -LogName 'resume.log' -Spec $cfg -Manifest $inputs.Manifest
         } finally {
-            Remove-Item Env:OSPREY_ALLOW_UNBOUNDED_MEMORY -ErrorAction SilentlyContinue
+            Remove-Item Env:OSPREY_ALLOW_UNFIXED_RESIDENT -ErrorAction SilentlyContinue
         }
         $resumeBlib = Join-Path $straightDir 'output.blib'
         Write-Host ("  resume wall {0:mm\:ss}; blib {1:N0} bytes" -f $rResume.Wall, (Get-Item $resumeBlib).Length)


### PR DESCRIPTION
## Summary

* Stopped `OSPREY_PASS2_QVALUE=transfer` forcing the O(files) RESIDENT first-pass pool. This is a
  regression in shipped code: #4438 removed the forcing when it redesigned transfer to per-run-only,
  and a #4446 merge artifact restored it, so an 82-file transfer run died in ~25 s on
  `GuardResidentPool` (or needed ~104 GB). It had to be reverted at THREE sites, not one -- #4488
  transcribed the already-regressed clause into `PreCompactionPoolReason` two days ago, which governs
  exactly the `--input-scores` resume path a large run uses.
* Ratcheted the escape hatch so this cannot recur silently. `OSPREY_ALLOW_UNFIXED_RESIDENT=<token>`
  replaces the blanket `OSPREY_ALLOW_UNBOUNDED_MEMORY=1`: the value names the ONE resident path a run
  may take, and a path absent from `ResidentPaths.KNOWN_UNFIXED` is refused unconditionally -- no
  environment variable can admit it. The blanket boolean is what let this regression hide for ten
  days, because setting it was routine.
* Made `OSPREY_FDR_PROJECTION=0` a named token (`projection-off`) instead of an automatic exemption,
  closing the last route to a resident pool nobody had to ask for.
* Filed and referenced the two resident paths that had no tracking: #4505 (`--model-diagnostics` on a
  full resume; a verified fix is parked on the closed #4437 branch) and #4507 (`--fdrbench-pass 1`).
  Pointed the guard comments at those issues instead of a completed TODO filename.

Two properties worth calling out for review:

**The unit test does not fail on master, deliberately.** `Pass2TransferQ` is a `static readonly` read
from the environment, which is unset in a test process, so no unit test can turn this regression red
without the testability refactor that is part of the fix. The real verifier is the 82-file arm below.
`NeedsResidentPool` was split into an env-reading wrapper and a pure core so the trigger set is
enumerable, and `ResidentPoolGuardTest` pins it.

**The token list is a high-water mark.** It may shrink as paths are streamed; it must not grow.
`ResidentPoolGuardTest` asserts the whole set rather than membership, so an addition shows up in
review as the ratchet running backwards. When the list empties, `OSPREY_FDR_PROJECTION` and the
legacy resident path can be deleted.

## Test plan

- [x] Build Debug clean, 556/556 unit tests, ReSharper inspection 0 warnings / 0 errors
- [x] `regression.ps1 -Dataset Stellar` byte-identity, run twice (before and after the ratchet):
      mode1 (vs golden), mode2 (resume), mode3 (HPC chain) all PASS, blib 30,597,120 throughout --
      the golden did not move, as required with transfer off by default. The second run is what
      exercises mode 2 naming `OSPREY_ALLOW_UNFIXED_RESIDENT=mdiag-full-resume` instead of setting
      the old blanket.
- [x] **82-file SEA-AD transfer arm completes** (`exit=0`, 3 h 55 min) where master dies in ~25 s on
      `GuardResidentPool`. It took the streaming path on the exact failing route:
      `PerFileScoring:skipping (outputs valid)` -> `Streaming first-pass ingest from 82 file(s)`.
- [x] **Memory is bounded**: total floor 24.4 -> 24.4 GB, **-0 MB/file (LEVEL)** across the run,
      which is the bounded signature from ai/docs/memory-band-guide.md (a sawtooth returning to the
      same floor, not O(files) accumulation). Peak 49.0 GB total / 30.3 GB managed, versus the
      ~104 GB a resident pool implies at this file count.
- [x] **Pass-2 calibration ladder reproduces the 2026-07-20 transfer run exactly**: true FDP
      0.11 / 0.18 / 0.42 / **0.92** / 1.80 / 4.83 % at 0.1 / 0.25 / 0.5 / 1 / 2 / 5 % nominal,
      segment slopes 0.48 / 0.96 / 1.00 / 0.88 / 1.01. Still tracks the diagonal past 2 % where
      pass 1's pool is exhausted, and stays conservative at the operating point (0.92x at 1 %).

Two observations from the 82-file run that I am reporting rather than explaining away:

* **Peak 49.0 GB vs the ~42 GB recorded for the 2026-07-20 run.** The ladder above is identical, so
  FDR behavior is unchanged; this is a memory-accounting difference. Master has moved since that run
  (#4488, #4490, #4502) and `--memstamp` includes uncollected garbage, which the memory-band guide
  says shows shape rather than magnitude. I did not run a same-build A/B, so I am not claiming a
  cause.
* **One reporting gap over threshold**: 40 s at 19:20:08, after `5027 protein groups pass 1.0%
  protein FDR`. Single occurrence, median gap 2 s, p95 7 s.

Neither is a resident-pool question. The whole-run peak at this file count is Stage 7 /
SecondPassFDR, tracked separately by #4486, and nothing here moves it.

Co-Authored-By: Claude <noreply@anthropic.com>

Co-Authored-By: Claude <noreply@anthropic.com>
