### PR TITLE
osprey: Added the mean(best-N) experiment aggregation behind OSPREY_EXPERIMENT_AGG

### DIFF
--- a/pwiz_tools/Osprey/Osprey.Core/OspreyEnvironment.cs
+++ b/pwiz_tools/Osprey/Osprey.Core/OspreyEnvironment.cs
@@ -438,6 +438,17 @@ namespace pwiz.Osprey.Core
         /// (OSPREY_EXPERIMENT_AGG=mean-best-N, N&gt;=2).</summary>
         public static readonly bool ExperimentAggMeanBest = MeanBestN >= 2;
 
+        /// <summary>True when OSPREY_EXPERIMENT_AGG was set to something that is neither
+        /// <see cref="EXPERIMENT_AGG_MAX"/> nor a well-formed
+        /// <see cref="EXPERIMENT_AGG_MEAN_BEST_PREFIX"/>&lt;N&gt; with N&gt;=2, and was therefore
+        /// normalized to the max default. The consuming site logs a one-line warning, mirroring
+        /// <see cref="Pass2QValueUnrecognized"/>. This matters more here than for most flags: the
+        /// whole point of this one is A/B measurement, so a typo (mean-best-1, meanbest2) that
+        /// silently ran the DEFAULT would be recorded by the operator as a mean(best-N) result and
+        /// would corrupt the comparison rather than fail it.</summary>
+        public static readonly bool ExperimentAggUnrecognized = IsUnrecognizedExperimentAgg(
+            Environment.GetEnvironmentVariable(@"OSPREY_EXPERIMENT_AGG"));
+
         /// <summary>OSPREY_MEANBEST2_FLOOR_MEAN: A/B toggle to use the decoy MEAN instead of the
         /// default decoy MEDIAN as the missing-run floor for mean(best-2). Off by default.</summary>
         public static readonly bool MeanBest2FloorMean =
@@ -464,6 +475,17 @@ namespace pwiz.Osprey.Core
                        System.Globalization.CultureInfo.InvariantCulture, out int n) && n >= 2
                 ? n
                 : 0;
+        }
+
+        // A set-but-unusable OSPREY_EXPERIMENT_AGG: anything that is neither the max default nor a
+        // well-formed mean-best-<N> with N >= 2. Unset / whitespace is NOT unrecognized - that is
+        // simply the default. Mirrors IsUnrecognizedPass2QValue.
+        private static bool IsUnrecognizedExperimentAgg(string raw)
+        {
+            if (string.IsNullOrWhiteSpace(raw))
+                return false;
+            return !string.Equals(raw.Trim(), EXPERIMENT_AGG_MAX, StringComparison.OrdinalIgnoreCase) &&
+                   ParseMeanBestN(raw) == 0;
         }
 
         private static string NormalizeExperimentAgg(string raw)

--- a/pwiz_tools/Osprey/Osprey.Core/OspreyEnvironment.cs
+++ b/pwiz_tools/Osprey/Osprey.Core/OspreyEnvironment.cs
@@ -308,6 +308,22 @@ namespace pwiz.Osprey.Core
         /// decoys. The frozen model avoids the two-pass retrain's over-separation.</summary>
         public const string PASS2_QVALUE_PROTEIN_COMPACT = @"protein-compact";
 
+        /// <summary>The <see cref="ExperimentAgg"/> default: each precursor/peptide keeps its
+        /// single BEST (max) observation across runs before the experiment-wide target/decoy
+        /// competition. The shipped behavior; the committed golden is byte-identical here.</summary>
+        public const string EXPERIMENT_AGG_MAX = @"max";
+
+        /// <summary>Prefix of the <see cref="ExperimentAgg"/> reproducibility mode value
+        /// OSPREY_EXPERIMENT_AGG=mean-best-&lt;N&gt; (e.g. mean-best-2, mean-best-3, mean-best-4): the
+        /// experiment-wide PRECURSOR score becomes the mean of its best-N per-run scores (runs beyond
+        /// the detected count are filled with the decoy-median floor; see the OSPREY_MEANBEST2_FLOOR_*
+        /// A/B toggles), rolled up by MAX to peptide and protein. Larger N rewards detection in more
+        /// runs (drives toward the &gt;=N-run reproducibility frontier). Symmetric for decoys, so the
+        /// null stays honest -- the honest sensitivity lever for #4484 vs. the target-conditioned
+        /// transfer-compete/protein-compact. N is read from the flag value; a future command argument
+        /// may pick N intelligently from the run count.</summary>
+        public const string EXPERIMENT_AGG_MEAN_BEST_PREFIX = @"mean-best-";
+
         /// <summary>
         /// OSPREY_PASS2_QVALUE: selects how the merge-node 2nd pass assigns the reported
         /// precursor/peptide q-values AFTER Stage 6 reconciliation. The 2nd-pass peak
@@ -403,6 +419,60 @@ namespace pwiz.Osprey.Core
             AllowUnfixedResident.Length > 0 &&
             !ResidentPaths.KNOWN_UNFIXED.Any(
                 t => string.Equals(t, AllowUnfixedResident, StringComparison.OrdinalIgnoreCase));
+
+        /// <summary>OSPREY_EXPERIMENT_AGG: how the 1st-pass EXPERIMENT-wide precursor/peptide
+        /// score aggregates a unit's per-run observations before the target/decoy competition.
+        /// <see cref="EXPERIMENT_AGG_MAX"/> (default, byte-identical golden) or
+        /// <see cref="EXPERIMENT_AGG_MEAN_BEST_PREFIX"/>&lt;N&gt;. Normalized for logging. Read once
+        /// at process start.</summary>
+        public static readonly string ExperimentAgg = NormalizeExperimentAgg(
+            Environment.GetEnvironmentVariable(@"OSPREY_EXPERIMENT_AGG"));
+
+        /// <summary>The N in OSPREY_EXPERIMENT_AGG=mean-best-&lt;N&gt;: how many top per-run scores are
+        /// averaged (runs beyond the detected count filled with the decoy floor). 0 in the default
+        /// max mode; otherwise &gt;=2. A value &lt;2 or unrecognized falls back to max.</summary>
+        public static readonly int MeanBestN = ParseMeanBestN(
+            Environment.GetEnvironmentVariable(@"OSPREY_EXPERIMENT_AGG"));
+
+        /// <summary>True when <see cref="MeanBestN"/> selects a mean(best-N) reproducibility score
+        /// (OSPREY_EXPERIMENT_AGG=mean-best-N, N&gt;=2).</summary>
+        public static readonly bool ExperimentAggMeanBest = MeanBestN >= 2;
+
+        /// <summary>OSPREY_MEANBEST2_FLOOR_MEAN: A/B toggle to use the decoy MEAN instead of the
+        /// default decoy MEDIAN as the missing-run floor for mean(best-2). Off by default.</summary>
+        public static readonly bool MeanBest2FloorMean =
+            IsSetAndNotZero(@"OSPREY_MEANBEST2_FLOOR_MEAN");
+
+        /// <summary>OSPREY_MEANBEST2_FLOOR_PCT: A/B override to use a low PERCENTILE (0-100) of the
+        /// decoy score distribution as the missing-run floor instead of the median center -- a
+        /// harder reproducibility cut. Null (unset) selects the median default (or the mean when
+        /// <see cref="MeanBest2FloorMean"/>). Read once at process start.</summary>
+        public static readonly double? MeanBest2FloorPercentile =
+            ParseDoubleOrNull(@"OSPREY_MEANBEST2_FLOOR_PCT");
+
+        // Parse N from OSPREY_EXPERIMENT_AGG=mean-best-<N>. Returns 0 (the max default) when unset,
+        // not a mean-best-<N> value, or N < 2.
+        private static int ParseMeanBestN(string raw)
+        {
+            if (string.IsNullOrWhiteSpace(raw))
+                return 0;
+            string v = raw.Trim().ToLowerInvariant();
+            if (!v.StartsWith(EXPERIMENT_AGG_MEAN_BEST_PREFIX, StringComparison.Ordinal))
+                return 0;
+            string tail = v.Substring(EXPERIMENT_AGG_MEAN_BEST_PREFIX.Length);
+            return int.TryParse(tail, System.Globalization.NumberStyles.Integer,
+                       System.Globalization.CultureInfo.InvariantCulture, out int n) && n >= 2
+                ? n
+                : 0;
+        }
+
+        private static string NormalizeExperimentAgg(string raw)
+        {
+            int n = ParseMeanBestN(raw);
+            return n >= 2
+                ? EXPERIMENT_AGG_MEAN_BEST_PREFIX + n.ToString(System.Globalization.CultureInfo.InvariantCulture)
+                : EXPERIMENT_AGG_MAX;
+        }
 
         private static string NormalizePass2QValue(string raw)
         {

--- a/pwiz_tools/Osprey/Osprey.FDR/PercolatorQValues.cs
+++ b/pwiz_tools/Osprey/Osprey.FDR/PercolatorQValues.cs
@@ -724,7 +724,18 @@ namespace pwiz.Osprey.FDR
             double[] ws;
             bool[] wd;
             using (var progress = QProgress(@"Experiment precursor q-values", n, n))
-                TargetDecoyCompetition.CompeteAll(scores, labels, entryIds, out wi, out ws, out wd, progress);
+            {
+                if (OspreyEnvironment.ExperimentAggMeanBest)
+                {
+                    var aggScore = TargetDecoyCompetition.ComputeBaseIdMeanBestN(
+                        scores, labels, entryIds, OspreyEnvironment.MeanBestN);
+                    TargetDecoyCompetition.CompeteAll(aggScore, labels, entryIds, out wi, out ws, out wd, progress);
+                }
+                else
+                {
+                    TargetDecoyCompetition.CompeteAll(scores, labels, entryIds, out wi, out ws, out wd, progress);
+                }
+            }
 
             var q = new double[wi.Length];
             ComputeConservativeQvalues(ws, wd, q);
@@ -772,11 +783,21 @@ namespace pwiz.Osprey.FDR
             double[] scores, bool[] labels, uint[] entryIds, string[] peptides)
         {
             int n = scores.Length;
+
+            // Reproducibility roll-up (OSPREY_EXPERIMENT_AGG=mean-best-2): the peptide score is
+            // the MAX over its precursors of each precursor's mean-best-2 score. Substituting the
+            // per-row mean-best-2 array for the raw scores turns BestPrecursorPerPeptide's
+            // max-over-observations into exactly that (every observation of a base_id carries the
+            // same precursor score). Default (max) is byte-identical: effScores == scores.
+            double[] effScores = OspreyEnvironment.ExperimentAggMeanBest
+                ? TargetDecoyCompetition.ComputeBaseIdMeanBestN(scores, labels, entryIds, OspreyEnvironment.MeanBestN)
+                : scores;
+
             var allIndices = new int[n];
             for (int i = 0; i < n; i++)
                 allIndices[i] = i;
 
-            var bestPerPeptide = PercolatorSampling.BestPrecursorPerPeptide(allIndices, scores, labels, peptides);
+            var bestPerPeptide = PercolatorSampling.BestPrecursorPerPeptide(allIndices, effScores, labels, peptides);
 
             var peptScores = new double[bestPerPeptide.Length];
             var peptLabels = new bool[bestPerPeptide.Length];
@@ -784,7 +805,7 @@ namespace pwiz.Osprey.FDR
             var allPeptIndices = new int[bestPerPeptide.Length];
             for (int i = 0; i < bestPerPeptide.Length; i++)
             {
-                peptScores[i] = scores[bestPerPeptide[i]];
+                peptScores[i] = effScores[bestPerPeptide[i]];
                 peptLabels[i] = labels[bestPerPeptide[i]];
                 peptEntryIds[i] = entryIds[bestPerPeptide[i]];
                 allPeptIndices[i] = i;

--- a/pwiz_tools/Osprey/Osprey.FDR/PercolatorScorer.cs
+++ b/pwiz_tools/Osprey/Osprey.FDR/PercolatorScorer.cs
@@ -791,7 +791,7 @@ namespace pwiz.Osprey.FDR
             // buffer, reduced into the best-of-runs clamp floors (issue #4390). The score is
             // recomputed per row (bias first, then the averaged-weight dot product in feature order)
             // -- byte-for-byte the resident score loop, only without the O(n) finalScores array.
-            var streamingQ = new StreamingFdr.StreamingFirstPassQ();
+            var streamingQ = new StreamingFdr.StreamingFirstPassQ(OspreyEnvironment.MeanBestN);
             var minRunBothByEntryId = new Dictionary<uint, double>();
             var minRunBothByPeptide = new Dictionary<(string, bool), double>();
             var contribAcc = new FeatureContributions.Accumulator(nFeatures, percConfig.CollectFeatureHistograms);

--- a/pwiz_tools/Osprey/Osprey.FDR/StreamingFdr.cs
+++ b/pwiz_tools/Osprey/Osprey.FDR/StreamingFdr.cs
@@ -23,6 +23,7 @@
 
 using System;
 using System.Collections.Generic;
+using pwiz.Osprey.Core;
 using pwiz.Osprey.ML;
 
 namespace pwiz.Osprey.FDR
@@ -346,6 +347,31 @@ namespace pwiz.Osprey.FDR
             private readonly Dictionary<string, PeptideBest> _peptBest =
                 new Dictionary<string, PeptideBest>();
 
+            // Reproducibility mean(best-N) mode (OSPREY_EXPERIMENT_AGG=mean-best-<N>): per-base_id
+            // top-N accumulators, targets and decoys kept apart exactly like the resident
+            // TargetDecoyCompetition.ComputeBaseIdMeanBestN pair of dicts, plus a bounded decoy-score
+            // floor. Allocated only in mean-best-N mode (_meanBestN >= 2); the default max path leaves
+            // them null, feeds only the raw bests above, and stays byte-identical to the committed
+            // golden.
+            private readonly int _meanBestN;
+            private readonly Dictionary<uint, Mb2Entry> _mb2Targets;
+            private readonly Dictionary<uint, Mb2Entry> _mb2Decoys;
+            private readonly StreamingDecoyFloor _floor;
+
+            public StreamingFirstPassQ() : this(0)
+            {
+            }
+
+            public StreamingFirstPassQ(int meanBestN)
+            {
+                _meanBestN = meanBestN;
+                if (meanBestN < 2)
+                    return;
+                _mb2Targets = new Dictionary<uint, Mb2Entry>();
+                _mb2Decoys = new Dictionary<uint, Mb2Entry>();
+                _floor = new StreamingDecoyFloor();
+            }
+
             /// <summary>Fold one scored row (in flat (file,row) order) into the bounded bests.</summary>
             public void Add(int g, double score, uint entryId, bool isDecoy, string peptide)
             {
@@ -360,6 +386,30 @@ namespace pwiz.Osprey.FDR
                 else
                 {
                     dict[baseId] = new KeyValuePair<int, double>(g, score);
+                }
+
+                if (_meanBestN >= 2)
+                {
+                    // Experiment precursor/peptide q use the mean(best-N) score: accumulate the
+                    // top-N per (base_id, side) and, from decoys, the missing-run floor. The raw
+                    // _precTargets/_precDecoys bests above still feed PEP - matching the resident
+                    // ComputeStreamingCompetitionQvalues, where PEP reads finalScores while the
+                    // experiment q reads ComputeBaseIdMeanBestN. The per-peptide raw max (_peptBest)
+                    // is not needed here (the roll-up is derived from the top-N accumulators).
+                    var mb2 = isDecoy ? _mb2Decoys : _mb2Targets;
+                    if (mb2.TryGetValue(baseId, out Mb2Entry e))
+                    {
+                        e.Acc.Add(score, _meanBestN);
+                        mb2[baseId] = e;
+                    }
+                    else
+                    {
+                        mb2[baseId] = new Mb2Entry(
+                            TargetDecoyCompetition.MeanBestNAcc.First(score, _meanBestN), g, peptide);
+                    }
+                    if (isDecoy)
+                        _floor.Add(score);
+                    return;
                 }
 
                 PeptideBest pb;
@@ -381,7 +431,24 @@ namespace pwiz.Osprey.FDR
             /// </summary>
             public Dictionary<uint, double> BuildExperimentPrecursorQMap()
             {
-                TargetDecoyCompetition.CompeteFromDicts(_precTargets, _precDecoys,
+                Dictionary<uint, KeyValuePair<int, double>> targets, decoys;
+                if (_meanBestN >= 2)
+                {
+                    // Reduce each (base_id, side) top-N accumulator to its mean(best-N) score
+                    // (missing runs use the decoy floor) so the same per-base_id best maps the
+                    // resident ComputeBaseIdMeanBestN -> CompeteAll path builds are competed here.
+                    // Every row of a base_id shares that score, so the resident max-per-base_id
+                    // reduction is a no-op and the two paths agree (modulo the streaming floor).
+                    double floor = _floor.ComputeFloor();
+                    targets = ReduceMeanBestN(_mb2Targets, floor, _meanBestN);
+                    decoys = ReduceMeanBestN(_mb2Decoys, floor, _meanBestN);
+                }
+                else
+                {
+                    targets = _precTargets;
+                    decoys = _precDecoys;
+                }
+                TargetDecoyCompetition.CompeteFromDicts(targets, decoys,
                     out _, out double[] ws, out bool[] wd, out uint[] wb);
                 var q = new double[ws.Length];
                 PercolatorQValues.ComputeConservativeQvalues(ws, wd, q);
@@ -399,6 +466,8 @@ namespace pwiz.Osprey.FDR
             /// </summary>
             public Dictionary<string, double> BuildExperimentPeptideQMap()
             {
+                if (_meanBestN >= 2)
+                    return BuildMeanBestNPeptideQMap();
                 var best = new List<PeptideBest>(_peptBest.Values);
                 best.Sort((a, b) => a.G.CompareTo(b.G)); // Array.Sort OK: G is the unique streaming ordinal of each peptide's best row, so the comparator never ties -- reproduces BestPrecursorPerPeptide's result.Sort() on ascending global index
                 var targets = new Dictionary<uint, KeyValuePair<int, double>>();
@@ -455,6 +524,185 @@ namespace pwiz.Osprey.FDR
                 for (int k = 0; k < nWinners; k++)
                     map[wi[k]] = pepEstimator.PosteriorError(ws[k]);
                 return map;
+            }
+
+            /// <summary>Reduce a per-base_id top-N accumulator dict to the <c>base_id -&gt;
+            /// (min-ordinal, mean(best-N) score)</c> best map the target/decoy competition consumes.
+            /// The stored ordinal is each base_id's earliest row (MinG), matching the resident
+            /// <see cref="TargetDecoyCompetition.CompeteFromIndices"/> first-seen-max index over the
+            /// per-row aggregate array (all rows of a base_id share the aggregate).</summary>
+            private static Dictionary<uint, KeyValuePair<int, double>> ReduceMeanBestN(
+                Dictionary<uint, Mb2Entry> src, double floor, int n)
+            {
+                var dict = new Dictionary<uint, KeyValuePair<int, double>>(src.Count);
+                foreach (var kv in src)
+                    dict[kv.Key] = new KeyValuePair<int, double>(
+                        kv.Value.MinG, kv.Value.Acc.AggregateScore(floor, n));
+                return dict;
+            }
+
+            /// <summary>
+            /// Experiment-peptide <c>peptide -&gt; q</c> for mean(best-N): the peptide score is the
+            /// MAX over its base_ids of each base_id's mean(best-N) precursor score, then the
+            /// per-peptide winners compete by base_id - byte-identical (modulo the streaming floor)
+            /// to the resident <see cref="PercolatorQValues.ComputeExperimentPeptideQMap"/> with
+            /// OSPREY_EXPERIMENT_AGG=mean-best-N, whose
+            /// <see cref="PercolatorSampling.BestPrecursorPerPeptide"/> over the per-row aggregate
+            /// array reduces to exactly this per-peptide max.
+            /// </summary>
+            private Dictionary<string, double> BuildMeanBestNPeptideQMap()
+            {
+                double floor = _floor.ComputeFloor();
+                var repByPeptide = new Dictionary<string, PeptideBest>();
+                AccumulatePeptideReps(repByPeptide, _mb2Targets, floor, false, _meanBestN);
+                AccumulatePeptideReps(repByPeptide, _mb2Decoys, floor, true, _meanBestN);
+
+                var best = new List<PeptideBest>(repByPeptide.Values);
+                best.Sort((a, b) => a.G.CompareTo(b.G)); // Array.Sort OK: G is each winning base_id's unique min ordinal, so the comparator never ties -- reproduces BestPrecursorPerPeptide's ascending-global-index sort
+                var targets = new Dictionary<uint, KeyValuePair<int, double>>();
+                var decoys = new Dictionary<uint, KeyValuePair<int, double>>();
+                for (int i = 0; i < best.Count; i++)
+                {
+                    uint baseId = best[i].EntryId & PercolatorEntry.BASE_ID_MASK;
+                    var dict = best[i].IsDecoy ? decoys : targets;
+                    KeyValuePair<int, double> existing;
+                    if (dict.TryGetValue(baseId, out existing))
+                    {
+                        if (best[i].Score > existing.Value)
+                            dict[baseId] = new KeyValuePair<int, double>(i, best[i].Score);
+                    }
+                    else
+                    {
+                        dict[baseId] = new KeyValuePair<int, double>(i, best[i].Score);
+                    }
+                }
+                TargetDecoyCompetition.CompeteFromDicts(targets, decoys,
+                    out int[] wi, out double[] ws, out bool[] wd, out _);
+                var q = new double[ws.Length];
+                PercolatorQValues.ComputeConservativeQvalues(ws, wd, q);
+                var map = new Dictionary<string, double>(wi.Length);
+                for (int rank = 0; rank < wi.Length; rank++)
+                    map[best[wi[rank]].Peptide] = q[rank];
+                return map;
+            }
+
+            /// <summary>Fold one side's per-base_id mean(best-2) scores into per-peptide winners:
+            /// each peptide keeps the base_id with the strictly greatest aggregate, ties broken by
+            /// the earliest row (min ordinal) - reproducing the first-seen strict '&gt;' that
+            /// <see cref="PercolatorSampling.BestPrecursorPerPeptide"/> applies over the
+            /// ascending-ordinal per-row aggregate array. The stored ordinal (<c>G = MinG</c>) is the
+            /// winning base_id's earliest row, which is the global index
+            /// <see cref="PercolatorSampling.BestPrecursorPerPeptide"/> returns.</summary>
+            private static void AccumulatePeptideReps(
+                Dictionary<string, PeptideBest> repByPeptide,
+                Dictionary<uint, Mb2Entry> src, double floor, bool isDecoy, int n)
+            {
+                foreach (var kv in src)
+                {
+                    uint baseId = kv.Key;
+                    Mb2Entry e = kv.Value;
+                    double agg = e.Acc.AggregateScore(floor, n);
+                    PeptideBest cur;
+                    if (repByPeptide.TryGetValue(e.Peptide, out cur) &&
+                        !(agg > cur.Score || (agg == cur.Score && e.MinG < cur.G)))
+                    {
+                        continue;
+                    }
+                    repByPeptide[e.Peptide] = new PeptideBest(e.MinG, agg, isDecoy, baseId, e.Peptide);
+                }
+            }
+
+            /// <summary>Per-base_id top-2 accumulator plus the metadata the peptide roll-up needs:
+            /// the earliest row ordinal (<see cref="MinG"/>) and the peptide string (constant for a
+            /// (base_id, side)). Value type; callers copy back after mutating <see cref="Acc"/>.</summary>
+            private struct Mb2Entry
+            {
+                internal TargetDecoyCompetition.MeanBestNAcc Acc;
+                internal readonly int MinG;
+                internal readonly string Peptide;
+
+                internal Mb2Entry(TargetDecoyCompetition.MeanBestNAcc acc, int minG, string peptide)
+                {
+                    Acc = acc;
+                    MinG = minG;
+                    Peptide = peptide;
+                }
+            }
+
+            /// <summary>Bounded (O(bins)) streaming estimator of the missing-run decoy floor,
+            /// mirroring <c>TargetDecoyCompetition.ComputeFloorFromDecoyScores</c> without holding
+            /// every decoy score. The mean (OSPREY_MEANBEST2_FLOOR_MEAN) is an exact running sum; the
+            /// median (default) and low-percentile (OSPREY_MEANBEST2_FLOOR_PCT) use a fixed-width
+            /// histogram over a wide fixed range with out-of-range counts tracked, so a central
+            /// quantile stays accurate to the bin width (0.001). The floor is one global scalar
+            /// applied to single-run precursors only, so this quantile approximation is negligible;
+            /// the resident==streaming N=20 cross-check bounds it.</summary>
+            private sealed class StreamingDecoyFloor
+            {
+                private const double RANGE_MIN = -100.0;
+                private const double RANGE_MAX = 100.0;
+                private const int BIN_COUNT = 200000; // Bin width 0.001 over [-100, 100].
+                private const double BIN_WIDTH = (RANGE_MAX - RANGE_MIN) / BIN_COUNT;
+
+                private readonly long[] _bins = new long[BIN_COUNT];
+                private long _underflow;
+                private long _count;
+                private double _sum;
+
+                public void Add(double score)
+                {
+                    _count++;
+                    _sum += score;
+                    if (score < RANGE_MIN)
+                    {
+                        _underflow++;
+                        return;
+                    }
+                    if (score >= RANGE_MAX)
+                        return; // Overflow: above any central quantile, so it only shifts the tail.
+                    int bin = (int)((score - RANGE_MIN) / BIN_WIDTH);
+                    if (bin >= BIN_COUNT)
+                        bin = BIN_COUNT - 1;
+                    _bins[bin]++;
+                }
+
+                public double ComputeFloor()
+                {
+                    if (_count == 0)
+                        return 0.0;
+                    if (OspreyEnvironment.MeanBest2FloorMean)
+                        return _sum / _count;
+                    double pct = OspreyEnvironment.MeanBest2FloorPercentile ?? 50.0;
+                    return PercentileFromHistogram(pct);
+                }
+
+                // Linear-interpolated quantile at rank = pct/100 * (count - 1), matching
+                // PercentileOfSorted's rank convention but computed from bin cumulative counts
+                // (uniform interpolation within the straddling bin).
+                private double PercentileFromHistogram(double pct)
+                {
+                    if (pct <= 0.0)
+                        return RANGE_MIN;
+                    if (pct >= 100.0)
+                        return RANGE_MAX;
+                    double rank = pct / 100.0 * (_count - 1);
+                    double cum = _underflow;
+                    if (rank < cum)
+                        return RANGE_MIN;
+                    for (int b = 0; b < BIN_COUNT; b++)
+                    {
+                        long c = _bins[b];
+                        if (c == 0)
+                            continue;
+                        if (rank < cum + c)
+                        {
+                            double within = (rank - cum) / c;
+                            return RANGE_MIN + (b + within) * BIN_WIDTH;
+                        }
+                        cum += c;
+                    }
+                    return RANGE_MAX;
+                }
             }
 
             private readonly struct PeptideBest

--- a/pwiz_tools/Osprey/Osprey.FDR/TargetDecoyCompetition.cs
+++ b/pwiz_tools/Osprey/Osprey.FDR/TargetDecoyCompetition.cs
@@ -336,5 +336,158 @@ namespace pwiz.Osprey.FDR
             Array.Copy(tmpDecoy, winDecoy, n);
             return n;
         }
+
+        /// <summary>
+        /// Per-row reproducibility score for the experiment-wide competitions when
+        /// OSPREY_EXPERIMENT_AGG=mean-best-2: every row receives its (base_id, target/decoy)
+        /// group's MEAN of best-2 per-run scores -- the mean of the group's two highest member
+        /// scores, or mean(single score, decoy floor) for a single-run group. Stage-4 dedup
+        /// guarantees at most one entry per base_id per file, so a group's members ARE its per-run
+        /// scores and the top-2 are the top-2 distinct runs (the invariant behind nRunsDetected ==
+        /// observation count). Because every row of a group gets the SAME value, feeding this array
+        /// to the existing max-based experiment competition (<see cref="CompeteAll"/> -- the
+        /// max-per-base_id reduction becomes a no-op) and the
+        /// <see cref="PercolatorSampling.BestPrecursorPerPeptide"/> roll-up yields precursor =
+        /// mean-best-2 and peptide = max over its precursors, with decoys treated identically so the
+        /// null stays honest. A single-file run -- every group at one member -- is a uniform
+        /// monotonic transform x -&gt; (x + floor)/2, so ranking and every q are unchanged from the
+        /// max path.
+        /// </summary>
+        internal static double[] ComputeBaseIdMeanBestN(double[] scores, bool[] labels, uint[] entryIds, int bestN)
+        {
+            int len = scores.Length;
+            var targets = new Dictionary<uint, MeanBestNAcc>();
+            var decoys = new Dictionary<uint, MeanBestNAcc>();
+            var decoyScores = new List<double>();
+            for (int idx = 0; idx < len; idx++)
+            {
+                uint baseId = entryIds[idx] & PercolatorEntry.BASE_ID_MASK;
+                var dict = labels[idx] ? decoys : targets;
+                if (labels[idx])
+                    decoyScores.Add(scores[idx]);
+                if (dict.TryGetValue(baseId, out MeanBestNAcc acc))
+                {
+                    acc.Add(scores[idx], bestN);
+                    dict[baseId] = acc;
+                }
+                else
+                {
+                    dict[baseId] = MeanBestNAcc.First(scores[idx], bestN);
+                }
+            }
+
+            double floor = ComputeFloorFromDecoyScores(decoyScores);
+
+            var aggScore = new double[len];
+            for (int idx = 0; idx < len; idx++)
+            {
+                uint baseId = entryIds[idx] & PercolatorEntry.BASE_ID_MASK;
+                var dict = labels[idx] ? decoys : targets;
+                aggScore[idx] = dict[baseId].AggregateScore(floor, bestN);
+            }
+            return aggScore;
+        }
+
+        /// <summary>Per-base_id accumulator for <see cref="ComputeBaseIdMeanBestN"/>: keeps the top-N
+        /// member scores (the N best runs) in a fixed-capacity buffer, ascending. Value type with a
+        /// small backing array -- the array is mutated in place, the length/count fields are copied
+        /// back, so callers MUST write the struct back after <see cref="Add"/> (both existing call
+        /// sites do). Internal (not private) so the streaming
+        /// <see cref="StreamingFdr.StreamingFirstPassQ"/> can hold it as a field without tripping
+        /// inconsistent-accessibility (CS0052). Allocates one length-N array per accumulator --
+        /// acceptable for the opt-in mean(best-N) experiment path (never the flag-off golden). For
+        /// N=2 the aggregate is bit-identical to the former best-2 form (IEEE addition is
+        /// commutative).</summary>
+        internal struct MeanBestNAcc
+        {
+            private double[] _top; // capacity N; _top[0.._len-1] holds the kept scores ascending
+            private int _len;      // slots used == min(Count, N)
+            public int Count;      // total observations seen
+
+            public static MeanBestNAcc First(double score, int n)
+            {
+                var top = new double[n];
+                top[0] = score;
+                return new MeanBestNAcc { _top = top, _len = 1, Count = 1 };
+            }
+
+            public void Add(double score, int n)
+            {
+                Count++;
+                if (_len < n)
+                {
+                    // Still filling toward N: insert keeping the buffer ascending.
+                    int i = _len - 1;
+                    while (i >= 0 && _top[i] > score)
+                    {
+                        _top[i + 1] = _top[i];
+                        i--;
+                    }
+                    _top[i + 1] = score;
+                    _len++;
+                }
+                else if (score > _top[0])
+                {
+                    // Full: drop the smallest kept score, slot this one in ascending.
+                    int i = 0;
+                    while (i + 1 < _len && _top[i + 1] < score)
+                    {
+                        _top[i] = _top[i + 1];
+                        i++;
+                    }
+                    _top[i] = score;
+                }
+            }
+
+            public double AggregateScore(double floor, int n)
+            {
+                double sum = 0.0;
+                for (int i = 0; i < _len; i++)
+                    sum += _top[i];
+                // The (n - _len) runs not detected each contribute the missing-run floor.
+                sum += (n - _len) * floor;
+                return sum / n;
+            }
+        }
+
+        /// <summary>The missing-run floor for <see cref="ComputeBaseIdMeanBestN"/>: the expected
+        /// score of a NON-detection, estimated from the decoy (null) score distribution. Default =
+        /// the decoy MEDIAN (the typical null score, negative on average -- NOT 0, which is the SVM
+        /// decision boundary and would drag a missing unit UP toward detection).
+        /// OSPREY_MEANBEST2_FLOOR_MEAN switches to the decoy mean; OSPREY_MEANBEST2_FLOOR_PCT to a
+        /// low decoy percentile (a harder reproducibility cut). Returns 0 only when there are no
+        /// decoys. Sorts <paramref name="decoyScores"/> in place.</summary>
+        private static double ComputeFloorFromDecoyScores(List<double> decoyScores)
+        {
+            if (decoyScores.Count == 0)
+                return 0.0;
+            if (OspreyEnvironment.MeanBest2FloorMean)
+            {
+                double sum = 0.0;
+                foreach (double s in decoyScores)
+                    sum += s;
+                return sum / decoyScores.Count;
+            }
+            decoyScores.Sort(); // Array.Sort OK: median/percentile of decoy scores -- tie order cannot change the floor value
+            double pct = OspreyEnvironment.MeanBest2FloorPercentile ?? 50.0;
+            return PercentileOfSorted(decoyScores, pct);
+        }
+
+        /// <summary>Linear-interpolated percentile of an ascending-sorted list (pct in [0,100];
+        /// 50 = median). Deterministic.</summary>
+        private static double PercentileOfSorted(List<double> sorted, double pct)
+        {
+            if (sorted.Count == 1 || pct <= 0.0)
+                return sorted[0];
+            if (pct >= 100.0)
+                return sorted[sorted.Count - 1];
+            double rank = pct / 100.0 * (sorted.Count - 1);
+            int lo = (int)Math.Floor(rank);
+            int hi = (int)Math.Ceiling(rank);
+            if (lo == hi)
+                return sorted[lo];
+            double frac = rank - lo;
+            return sorted[lo] * (1.0 - frac) + sorted[hi] * frac;
+        }
     }
 }

--- a/pwiz_tools/Osprey/Osprey.Tasks/FirstJoinTask.cs
+++ b/pwiz_tools/Osprey/Osprey.Tasks/FirstJoinTask.cs
@@ -214,6 +214,20 @@ namespace pwiz.Osprey.Tasks
             var perFileParquetPaths = ctx.Get<PerFileParquetPaths>().Value;
             var fullLibrary = ctx.Get<FullLibrary>().Value;
 
+            // OSPREY_EXPERIMENT_AGG selects how the experiment-wide precursor/peptide score
+            // aggregates a unit's per-run observations. Warn on a set-but-unrecognized token
+            // (normalized to the byte-identical max default) so a typo cannot be mistaken for a
+            // mean(best-N) run - this flag exists to be A/B'd, so a silent fallback would corrupt
+            // the comparison rather than fail it. Mirrors the OSPREY_PASS2_QVALUE warning.
+            if (OspreyEnvironment.ExperimentAggUnrecognized)
+            {
+                ctx.LogWarning(string.Format(
+                    "OSPREY_EXPERIMENT_AGG was set to an unrecognized value; using the default " +
+                    "'{0}'. Recognized values: '{0}', or '{1}<N>' with N >= 2 (e.g. '{1}2').",
+                    OspreyEnvironment.EXPERIMENT_AGG_MAX,
+                    OspreyEnvironment.EXPERIMENT_AGG_MEAN_BEST_PREFIX));
+            }
+
             // Stage 5: First-pass FDR. The Percolator framework (SVM or Gbdt) prints
             // its own "Running First-pass Percolator on N entries..." line from the FDR
             // engine, so the generic header would just be a redundant second

--- a/pwiz_tools/Osprey/Osprey.Test/FdrTest.cs
+++ b/pwiz_tools/Osprey/Osprey.Test/FdrTest.cs
@@ -2110,6 +2110,147 @@ namespace pwiz.Osprey.Test
                 streaming.BuildPepWinnerMap(), "pep-winner");
         }
 
+        /// <summary>
+        /// The mean(best-N) streaming builder (<c>StreamingFirstPassQ(meanBestN)</c>) must produce
+        /// experiment-precursor / experiment-peptide q maps identical to the resident mean(best-N)
+        /// path (<see cref="TargetDecoyCompetition.ComputeBaseIdMeanBestN"/> -&gt;
+        /// <see cref="TargetDecoyCompetition.CompeteFromIndices"/> /
+        /// <see cref="PercolatorSampling.BestPrecursorPerPeptide"/> -&gt; conservative-q) when fed the
+        /// same population in the same flat order. Each fixture gives every (base_id, side) &gt;= N
+        /// observations, so the missing-run floor is never used and the streaming histogram-median
+        /// floor cannot introduce any difference: the maps are then byte-identical. Peptides shared
+        /// across base_ids exercise the max roll-up. Run at N = 2, 3, 4 to validate the top-N
+        /// generalization.
+        /// </summary>
+        [TestMethod]
+        public void TestStreamingMeanBest2MatchesResident()
+        {
+            AssertStreamingMeanBestNMatchesResident(2);
+        }
+
+        [TestMethod]
+        public void TestStreamingMeanBest3MatchesResident()
+        {
+            AssertStreamingMeanBestNMatchesResident(3);
+        }
+
+        [TestMethod]
+        public void TestStreamingMeanBest4MatchesResident()
+        {
+            AssertStreamingMeanBestNMatchesResident(4);
+        }
+
+        private static void AssertStreamingMeanBestNMatchesResident(int n)
+        {
+            var rng = new Random(20260728 + n);
+            const int nFiles = 4;
+            const int nBaseIds = 50;
+            var perFile = new List<(uint EntryId, bool IsDecoy, double Score, string Peptide)>[nFiles];
+            for (int f = 0; f < nFiles; f++)
+                perFile[f] = new List<(uint, bool, double, string)>();
+
+            for (uint baseId = 1; baseId <= nBaseIds; baseId++)
+            {
+                string peptide = "PEP" + (baseId % 30); // Shared peptides span base_ids (charges).
+                foreach (bool isDecoy in new[] { false, true })
+                {
+                    uint entryId = isDecoy ? (baseId | 0x80000000u) : baseId;
+                    int nObs = n + rng.Next(nFiles - n + 1); // N..nFiles observations -> floor never used.
+                    var files = Enumerable.Range(0, nFiles).OrderBy(_ => rng.Next()).Take(nObs);
+                    foreach (int f in files)
+                    {
+                        double score = Math.Round(rng.NextDouble() * 8.0 - 2.0, 1); // 1 dp -> ties.
+                        perFile[f].Add((entryId, isDecoy, score, peptide));
+                    }
+                }
+            }
+
+            var scores = new List<double>();
+            var labels = new List<bool>();
+            var entryIds = new List<uint>();
+            var peptides = new List<string>();
+            var streaming = new StreamingFdr.StreamingFirstPassQ(n);
+            int g = 0;
+            for (int f = 0; f < nFiles; f++)
+            foreach (var row in perFile[f])
+            {
+                scores.Add(row.Score);
+                labels.Add(row.IsDecoy);
+                entryIds.Add(row.EntryId);
+                peptides.Add(row.Peptide);
+                streaming.Add(g, row.Score, row.EntryId, row.IsDecoy, row.Peptide);
+                g++;
+            }
+
+            var scoreArr = scores.ToArray();
+            var labelArr = labels.ToArray();
+            var entryIdArr = entryIds.ToArray();
+            var peptideArr = peptides.ToArray();
+
+            AssertMapsEqual(
+                ResidentMeanBestNPrecursorQMap(scoreArr, labelArr, entryIdArr, n),
+                streaming.BuildExperimentPrecursorQMap(), "mbN exp-precursor");
+            AssertMapsEqual(
+                ResidentMeanBestNPeptideQMap(scoreArr, labelArr, entryIdArr, peptideArr, n),
+                streaming.BuildExperimentPeptideQMap(), "mbN exp-peptide");
+        }
+
+        /// <summary>
+        /// The reproducibility demotion through the streaming path, including the single-run decoy
+        /// floor: two targets with the SAME peak (5.0) - one seen in two runs (keeps mean 5.0), one
+        /// in a single run (scores mean(5.0, decoy floor) ~ 1.5). With decoy mass placed between the
+        /// two aggregate scores, the one-run precursor's experiment q is strictly worse than the
+        /// two-run precursor's, proving the demotion happens on the bounded streaming path (the raw
+        /// max would have scored both identically). Deterministic (no RNG); a large robust-target
+        /// block keeps the q distribution non-degenerate.
+        /// </summary>
+        [TestMethod]
+        public void TestStreamingMeanBest2DemotesSingleRun()
+        {
+            var rows = new List<(int G, uint EntryId, bool IsDecoy, double Score, string Peptide)>();
+            int g = 0;
+
+            // A block of robust two-run targets well above the field so q is meaningful.
+            for (uint baseId = 1; baseId <= 30; baseId++)
+            {
+                rows.Add((g++, baseId, false, 6.0, "PEP" + baseId));
+                rows.Add((g++, baseId, false, 6.0, "PEP" + baseId));
+            }
+            // Control two-run target and single-run target, IDENTICAL peak 5.0.
+            const uint twoRunBase = 50u;
+            const uint oneRunBase = 51u;
+            rows.Add((g++, twoRunBase, false, 5.0, "PEPTWO"));
+            rows.Add((g++, twoRunBase, false, 5.0, "PEPTWO"));
+            rows.Add((g++, oneRunBase, false, 5.0, "PEPONE"));
+            // Mid decoys at mean 3.0: above the one-run aggregate (~1.5), below the 5.0 targets.
+            for (uint baseId = 300; baseId < 310; baseId++)
+            {
+                uint d = baseId | 0x80000000u;
+                rows.Add((g++, d, true, 3.0, "DECMID" + baseId));
+                rows.Add((g++, d, true, 3.0, "DECMID" + baseId));
+            }
+            // Bulk low decoys at -2.0: set the decoy-median floor to -2.0.
+            for (uint baseId = 400; baseId < 460; baseId++)
+            {
+                uint d = baseId | 0x80000000u;
+                rows.Add((g++, d, true, -2.0, "DECLOW" + baseId));
+                rows.Add((g++, d, true, -2.0, "DECLOW" + baseId));
+            }
+
+            var mb2 = new StreamingFdr.StreamingFirstPassQ(2);
+            foreach (var r in rows)
+                mb2.Add(r.G, r.Score, r.EntryId, r.IsDecoy, r.Peptide);
+            var map = mb2.BuildExperimentPrecursorQMap();
+
+            Assert.IsTrue(map.ContainsKey(twoRunBase) && map.ContainsKey(oneRunBase),
+                "both same-peak targets present");
+            foreach (double q in map.Values)
+                Assert.IsTrue(q >= 0.0 && q <= 1.0, "q in [0,1]");
+            Assert.IsTrue(map[oneRunBase] > map[twoRunBase],
+                string.Format("single-run demotion: one-run q ({0}) should exceed two-run q ({1}) at the same peak",
+                    map[oneRunBase], map[twoRunBase]));
+        }
+
         private static void AssertMapsEqual<TKey>(
             Dictionary<TKey, double> flat, Dictionary<TKey, double> streaming, string which)
         {
@@ -2126,6 +2267,54 @@ namespace pwiz.Osprey.Test
                 Assert.AreEqual(kvp.Value, sv, 0.0,
                     string.Format("{0}: value differs at key {1}", which, kvp.Key));
             }
+        }
+
+        // Resident mean(best-N) experiment-precursor q map, reproduced from the primitives exactly
+        // as PercolatorQValues.ComputeExperimentPrecursorQMap does in its mean-best-N branch:
+        // per-row aggregate score -> global competition -> conservative q keyed by base_id.
+        private static Dictionary<uint, double> ResidentMeanBestNPrecursorQMap(
+            double[] scores, bool[] labels, uint[] entryIds, int n)
+        {
+            var agg = TargetDecoyCompetition.ComputeBaseIdMeanBestN(scores, labels, entryIds, n);
+            var allIndices = Enumerable.Range(0, scores.Length).ToArray();
+            TargetDecoyCompetition.CompeteFromIndices(agg, labels, entryIds, allIndices,
+                out int[] wi, out double[] ws, out bool[] wd);
+            var q = new double[wi.Length];
+            PercolatorQValues.ComputeConservativeQvalues(ws, wd, q);
+            var map = new Dictionary<uint, double>(wi.Length);
+            for (int rank = 0; rank < wi.Length; rank++)
+                map[entryIds[wi[rank]] & 0x7FFFFFFFu] = q[rank];
+            return map;
+        }
+
+        // Resident mean(best-N) experiment-peptide q map, reproduced from the primitives exactly as
+        // PercolatorQValues.ComputeExperimentPeptideQMap does in its mean-best-N branch: best
+        // precursor per peptide over the aggregate scores -> competition -> q keyed by peptide.
+        private static Dictionary<string, double> ResidentMeanBestNPeptideQMap(
+            double[] scores, bool[] labels, uint[] entryIds, string[] peptides, int n)
+        {
+            var agg = TargetDecoyCompetition.ComputeBaseIdMeanBestN(scores, labels, entryIds, n);
+            var allIndices = Enumerable.Range(0, scores.Length).ToArray();
+            var bestPerPeptide = PercolatorSampling.BestPrecursorPerPeptide(allIndices, agg, labels, peptides);
+            var peptScores = new double[bestPerPeptide.Length];
+            var peptLabels = new bool[bestPerPeptide.Length];
+            var peptEntryIds = new uint[bestPerPeptide.Length];
+            var allPeptIndices = new int[bestPerPeptide.Length];
+            for (int i = 0; i < bestPerPeptide.Length; i++)
+            {
+                peptScores[i] = agg[bestPerPeptide[i]];
+                peptLabels[i] = labels[bestPerPeptide[i]];
+                peptEntryIds[i] = entryIds[bestPerPeptide[i]];
+                allPeptIndices[i] = i;
+            }
+            TargetDecoyCompetition.CompeteFromIndices(peptScores, peptLabels, peptEntryIds, allPeptIndices,
+                out int[] wi, out double[] ws, out bool[] wd);
+            var q = new double[wi.Length];
+            PercolatorQValues.ComputeConservativeQvalues(ws, wd, q);
+            var map = new Dictionary<string, double>(wi.Length);
+            for (int rank = 0; rank < wi.Length; rank++)
+                map[peptides[bestPerPeptide[wi[rank]]]] = q[rank];
+            return map;
         }
 
         #endregion

--- a/pwiz_tools/Osprey/Osprey.Test/MeanBestNAggregationTest.cs
+++ b/pwiz_tools/Osprey/Osprey.Test/MeanBestNAggregationTest.cs
@@ -1,0 +1,123 @@
+/*
+ * Original author: Brendan MacLean <brendanx .at. uw.edu>,
+ *                  MacCoss Lab, Department of Genome Sciences, UW
+ * AI assistance: Claude Code (Claude Opus 5) <noreply .at. anthropic.com>
+ *
+ * Based on osprey (https://github.com/MacCossLab/osprey)
+ *   by Michael J. MacCoss, MacCoss Lab, Department of Genome Sciences, UW
+ *
+ * Copyright 2026 University of Washington - Seattle, WA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using pwiz.Osprey.FDR;
+
+namespace pwiz.Osprey.Test
+{
+    /// <summary>
+    /// Tests for the reproducibility mean(best-N) experiment aggregation
+    /// (<see cref="TargetDecoyCompetition.ComputeBaseIdMeanBestN"/>,
+    /// OSPREY_EXPERIMENT_AGG=mean-best-N): each row gets its base_id's mean of best-N per-run
+    /// scores, an under-detected precursor is filled with the decoy-median floor, and both target
+    /// and decoy sides are treated symmetrically.
+    /// </summary>
+    [TestClass]
+    public class MeanBestNAggregationTest
+    {
+        private const uint DECOY_BIT = 0x80000000;
+        private const uint BASE_ID_MASK = 0x7FFFFFFF;
+
+        /// <summary>
+        /// A >=2-run precursor scores mean(top-2); a 1-run precursor scores mean(score, floor)
+        /// where floor = the decoy MEDIAN; decoys are aggregated the same way. Every row of a
+        /// base_id gets the same aggregated value. Decoy scores {-3, -1, 0} -> median -1. base10
+        /// target has runs {4, 2} -> mean 3; base20 target one run {5} -> (5 + (-1))/2 = 2;
+        /// base10 decoy one run {-3} -> -2; base20 decoy {-1} -> -1; base30 decoy {0} -> -0.5.
+        /// </summary>
+        [TestMethod]
+        public void TestMeanBest2AggregationAndFloor()
+        {
+            // idx:        0(t10)  1(t10)  2(t20)  3(d10)  4(d20)  5(d30)
+            var scores = new[] { 4.0, 2.0, 5.0, -3.0, -1.0, 0.0 };
+            var labels = new[] { false, false, false, true, true, true };
+            var entryIds = new uint[] { 10, 10, 20, 10 | DECOY_BIT, 20 | DECOY_BIT, 30 | DECOY_BIT };
+
+            var agg = TargetDecoyCompetition.ComputeBaseIdMeanBestN(scores, labels, entryIds, 2);
+
+            Assert.AreEqual(3.0, agg[0], 1e-12, @"base10 target run1 = mean(4,2)");
+            Assert.AreEqual(3.0, agg[1], 1e-12, @"base10 target run2 = mean(4,2)");
+            Assert.AreEqual(2.0, agg[2], 1e-12, @"base20 target 1-run = mean(5, floor -1)");
+            Assert.AreEqual(-2.0, agg[3], 1e-12, @"base10 decoy 1-run = mean(-3, floor -1)");
+            Assert.AreEqual(-1.0, agg[4], 1e-12, @"base20 decoy 1-run = mean(-1, floor -1)");
+            Assert.AreEqual(-0.5, agg[5], 1e-12, @"base30 decoy 1-run = mean(0, floor -1)");
+        }
+
+        /// <summary>
+        /// N=3 (OSPREY_EXPERIMENT_AGG=mean-best-3): a &gt;=3-run precursor scores mean(top-3); a k-run
+        /// precursor with k&lt;3 fills its (3-k) missing runs with the decoy-median floor. base10 target
+        /// {6,4,2} -&gt; 4; base20 target {5,3} -&gt; (5+3-1)/3 = 7/3; base30 target {8} -&gt; (8-2)/3 = 2.
+        /// Decoys {-3,-1,0} -&gt; median floor -1, aggregated the same way. Exercises the top-N buffer
+        /// (fill, full-replace) and the multi-floor fill beyond the best-2 case.
+        /// </summary>
+        [TestMethod]
+        public void TestMeanBest3Aggregation()
+        {
+            var scores = new[] { 6.0, 4.0, 2.0, 5.0, 3.0, 8.0, -3.0, -1.0, 0.0 };
+            var labels = new[] { false, false, false, false, false, false, true, true, true };
+            var entryIds = new uint[]
+                { 10, 10, 10, 20, 20, 30, 10 | DECOY_BIT, 20 | DECOY_BIT, 30 | DECOY_BIT };
+
+            var agg = TargetDecoyCompetition.ComputeBaseIdMeanBestN(scores, labels, entryIds, 3);
+
+            Assert.AreEqual(4.0, agg[0], 1e-12, @"base10 target 3-run = mean(6,4,2)");
+            Assert.AreEqual(7.0 / 3.0, agg[3], 1e-12, @"base20 target 2-run = mean(5,3, floor -1)");
+            Assert.AreEqual(2.0, agg[5], 1e-12, @"base30 target 1-run = mean(8, floor -1, floor -1)");
+            Assert.AreEqual(-5.0 / 3.0, agg[6], 1e-12, @"base10 decoy 1-run = mean(-3, -1, -1)");
+            Assert.AreEqual(-1.0, agg[7], 1e-12, @"base20 decoy 1-run = mean(-1, -1, -1)");
+            Assert.AreEqual(-2.0 / 3.0, agg[8], 1e-12, @"base30 decoy 1-run = mean(0, -1, -1)");
+        }
+
+        /// <summary>
+        /// A single-run experiment (every base_id at one member) makes the aggregation a uniform
+        /// monotonic transform x -> (x + floor)/2, so competing on the aggregated scores produces
+        /// the SAME ranked winner sequence (base_id + target/decoy) as competing on the raw scores.
+        /// The winner scores differ (by the affine transform); the q-values, which depend only on
+        /// the ranking, are unchanged.
+        /// </summary>
+        [TestMethod]
+        public void TestMeanBest2SingleRunMatchesMaxRanking()
+        {
+            var scores = new[] { 4.0, 5.0, -3.0, -1.0 };
+            var labels = new[] { false, false, true, true };
+            var entryIds = new uint[] { 10, 20, 10 | DECOY_BIT, 30 | DECOY_BIT };
+            var indices = new[] { 0, 1, 2, 3 };
+
+            var agg = TargetDecoyCompetition.ComputeBaseIdMeanBestN(scores, labels, entryIds, 2);
+
+            TargetDecoyCompetition.CompeteFromIndices(scores, labels, entryIds, indices,
+                out int[] wiMax, out _, out bool[] wdMax);
+            TargetDecoyCompetition.CompeteFromIndices(agg, labels, entryIds, indices,
+                out int[] wiMb2, out _, out bool[] wdMb2);
+
+            Assert.AreEqual(wiMax.Length, wiMb2.Length, @"same number of winners");
+            for (int i = 0; i < wiMax.Length; i++)
+            {
+                Assert.AreEqual(wdMax[i], wdMb2[i], @"winner target/decoy at rank " + i);
+                Assert.AreEqual(entryIds[wiMax[i]] & BASE_ID_MASK, entryIds[wiMb2[i]] & BASE_ID_MASK,
+                    @"winner base_id at rank " + i);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

* Adds `OSPREY_EXPERIMENT_AGG=mean-best-<N>`, an **opt-in** reproducibility score for the 1st-pass
  EXPERIMENT-wide q. A precursor's experiment score becomes the **mean of its best-N per-run
  scores** instead of its single best run (max), with a decoy-derived floor standing in for each
  run it was not detected in; peptides roll up by max over their precursors.
* **Decoys are aggregated identically**, so the transform reads only each unit's own per-run data
  and the target/decoy competition stays valid. That is what separates this from the
  target-conditioned `transfer-compete` / `protein-compact` levers in #4484.
* Mirrored on the **bounded streaming** first-pass path (`StreamingFirstPassQ`) as well as the
  resident one, so it works at large file counts. Unit tests pin streaming == resident exactly at
  N = 2, 3, 4 on fixtures where the floor is never used.
* **Default is unchanged and byte-identical.** `OSPREY_EXPERIMENT_AGG` unset (or `max`) takes the
  same code path as before; `regression.ps1 -Dataset All` is green.
* Protein roll-up is deliberately **not** in this PR - it needs a new field on `FdrEntry`, which is
  a documented cross-impl parity type, and that decision is its own increment.

### Why (measurement, not a default change)

Aggregating runs by `max` accepts a precursor on the strength of ONE good run. As file counts grow
the real proteome saturates while the null keeps accruing, so the accepted pool's purity falls and
the 1% cut has to tighten - costing IDs in every file. At 82 files, 41% of everything detected at
run level fails the experiment cut, versus 7% at 4 files. Reported q stays conservative throughout
(true FDP 0.77-0.97% at nominal 1%), so this is a **sensitivity** loss, not an FDR violation.

Substituting mean-of-top-N for max lowers every score but lowers the null's more (its highs are
single lucky runs), which improves separation. Measured against the FDRBench entrapment oracle at
matched TRUE FDP over 35 cohort comparisons (81 arms): gains span **+1.8% to +14.6%, median
~+5.6%**, with only the 3-file cohort negative (-4.9%). Within-size spread is large - five ~40-file
cohorts spanned 9.9 points - so **a single cohort's number is unreliable to about +/-4 points** and
cohort composition matters more than cohort size. The honest summary is "roughly +7 to +15% on
large cohorts, ~+3-6% typical". mean-best-N also lowers true FDP at every file count measured,
including the one where the ID count goes the wrong way.

Full study, including the rejected hypotheses (no monotone trend in file count; the `frontier`
block is not a usable upper bound; "best-2 is a stabiliser" is false), is in the TODO.

This closes no issue on its own. It is the flag that makes the #4484 default decision measurable.

## Test plan

- [x] `TestMeanBest2AggregationAndFloor` - mean(top-2) and the decoy-median floor, both sides
- [x] `TestMeanBest3Aggregation` - top-N buffer fill/replace and multi-slot floor fill at N=3
- [x] `TestMeanBest2SingleRunMatchesMaxRanking` - single-run degenerates to a monotone transform,
      so the competition winner sequence is unchanged
- [x] `TestStreamingMeanBest2/3/4MatchesResident` - streaming == resident maps, exactly
- [x] `TestStreamingMeanBest2DemotesSingleRun` - a one-run precursor scores strictly worse than a
      two-run precursor with the identical peak
- [x] Full Osprey suite 563/563 (net8.0), ReSharper inspection 0 warnings
- [x] `regression.ps1 -Dataset All` - flag-off byte-identity across Stellar, StellarLibDecoy,
      StellarGenDecoyEntrap and Astral, every mode (golden / resume / HPC / diagnostics)

See ai/todos/active/TODO-20260728_osprey_mean_best2.md

Co-Authored-By: Claude <noreply@anthropic.com>
