### PR TITLE
osprey: Reported progress through the silent multi-minute phases

### DIFF
--- a/pwiz_tools/Osprey/Osprey.Core/ProgressReporter.cs
+++ b/pwiz_tools/Osprey/Osprey.Core/ProgressReporter.cs
@@ -61,6 +61,7 @@ namespace pwiz.Osprey.Core
         /// </summary>
         public const double IO_INTERVAL_SECONDS = 5.0;
 
+
         /// <summary>
         /// Idle threshold for the frozen-percent heartbeat. When a determinate phase
         /// progresses slower than 1% per this many seconds, the integer percent does not

--- a/pwiz_tools/Osprey/Osprey.IO/DiannTsvLoader.cs
+++ b/pwiz_tools/Osprey/Osprey.IO/DiannTsvLoader.cs
@@ -60,13 +60,21 @@ namespace pwiz.Osprey.IO
             // LibraryLoader's "Loading spectral library from ..." and the interning summary.
             // Byte progress needs the stream, so it is wired here rather than in ParseReader,
             // which stays a plain TextReader entry point for tests. Mirrors MzmlReader.
+            // bufferSize 1 disables FileStream's own buffering: StreamReader below asks in 1 MB
+            // blocks, so a second buffer underneath would copy every byte twice (and a 16 MB one
+            // would sit on the LOH for the whole parse, including for the ~200-byte TSVs the unit
+            // tests load). The reader's buffer is what must be large - at the BCL default of 1 KB
+            // this issues a ProgressStream.Read, and therefore a locking Report, once per KB:
+            // ~13.6M calls on the 13 GB entrapment library to print about a dozen lines.
             using (var stream = new FileStream(path, FileMode.Open, FileAccess.Read,
-                FileShare.Read, 16 * 1024 * 1024))
+                FileShare.Read, 1))
             using (var progress = new ProgressReporter(
                 string.Format("Parsing {0}", Path.GetFileName(path)), stream.Length, string.Empty,
                 ProgressReporter.IO_INTERVAL_SECONDS))
             using (var progressStream = new ProgressStream(stream, progress))
-            using (var reader = new StreamReader(progressStream))
+            // leaveOpen so ownership of progressStream is explicit rather than resting on
+            // ProgressStream declining to override Dispose (see MzmlReader's single-close note).
+            using (var reader = new StreamReader(progressStream, Encoding.UTF8, true, 1 << 20, true))
             {
                 return ParseReader(reader, logInfo);
             }

--- a/pwiz_tools/Osprey/Osprey.IO/DiannTsvLoader.cs
+++ b/pwiz_tools/Osprey/Osprey.IO/DiannTsvLoader.cs
@@ -68,15 +68,21 @@ namespace pwiz.Osprey.IO
             // ~13.6M calls on the 13 GB entrapment library to print about a dozen lines.
             using (var stream = new FileStream(path, FileMode.Open, FileAccess.Read,
                 FileShare.Read, 1))
-            using (var progress = new ProgressReporter(
-                string.Format("Parsing {0}", Path.GetFileName(path)), stream.Length, string.Empty,
-                ProgressReporter.IO_INTERVAL_SECONDS))
-            using (var progressStream = new ProgressStream(stream, progress))
-            // leaveOpen so ownership of progressStream is explicit rather than resting on
-            // ProgressStream declining to override Dispose (see MzmlReader's single-close note).
-            using (var reader = new StreamReader(progressStream, Encoding.UTF8, true, 1 << 20, true))
             {
-                return ParseReader(reader, logInfo);
+                // NOT a using: this reporter measures the READ, which finishes partway through
+                // ParseReader. Disposing it with the stack would force its 100% out after phase 2
+                // and after the interning summary - a completion line for a phase that ended
+                // minutes earlier. ParseReader disposes it when the stream is exhausted.
+                var readProgress = new ProgressReporter(
+                    string.Format("Parsing {0}", Path.GetFileName(path)), stream.Length,
+                    string.Empty, ProgressReporter.IO_INTERVAL_SECONDS);
+                using (var progressStream = new ProgressStream(stream, readProgress))
+                // leaveOpen so ownership of progressStream is explicit rather than resting on
+                // ProgressStream declining to override Dispose (see MzmlReader's single-close note).
+                using (var reader = new StreamReader(progressStream, Encoding.UTF8, true, 1 << 20, true))
+                {
+                    return ParseReader(reader, logInfo, readProgress);
+                }
             }
         }
 
@@ -84,6 +90,17 @@ namespace pwiz.Osprey.IO
         /// Parse library entries from a text reader (for testability).
         /// </summary>
         public List<LibraryEntry> ParseReader(TextReader reader, Action<string> logInfo = null)
+        {
+            return ParseReader(reader, logInfo, null);
+        }
+
+        /// <summary>
+        /// As <see cref="ParseReader(TextReader,Action{string})"/>, but disposes
+        /// <paramref name="readProgress"/> when the READ finishes rather than when the caller's
+        /// scope ends - the row loop below is only the first half of this method.
+        /// </summary>
+        private List<LibraryEntry> ParseReader(TextReader reader, Action<string> logInfo,
+            IDisposable readProgress)
         {
             string headerLine = reader.ReadLine();
             if (headerLine == null)
@@ -105,6 +122,8 @@ namespace pwiz.Osprey.IO
                 string[] fields = line.Split('\t');
                 ParseRow(fields, cols, rowNum, precursorMap);
             }
+            // Stream exhausted: the byte progress is complete and must say so HERE.
+            readProgress?.Dispose();
 
             // Convert to LibraryEntry list. Intern the repeated strings
             // (sequences, modification names, protein / gene accessions) as the
@@ -115,8 +134,17 @@ namespace pwiz.Osprey.IO
             var interner = new LibraryStringInterner();
             uint id = 0;
 
+            // Phase 2. The byte progress above ends when the stream is exhausted, so without this
+            // the console sat at 100% through the whole materialization pass. Constructed rather
+            // than `using`d so the loop needs no re-indent and so an exception here does not print
+            // a completed-looking 100% while unwinding.
+            var progress = new ProgressReporter(@"Building library entries", precursorMap.Count,
+                    string.Empty, ProgressReporter.IO_INTERVAL_SECONDS);
+            long nBuilt = 0;
+
             foreach (var data in precursorMap.Values)
             {
+                progress.Report(++nBuilt);
                 if (data.Fragments.Count < _minFragments)
                     continue;
 
@@ -141,6 +169,7 @@ namespace pwiz.Osprey.IO
                 id++;
             }
 
+            progress.Dispose();
             interner.LogSummary(logInfo);
             return entries;
         }

--- a/pwiz_tools/Osprey/Osprey.IO/DiannTsvLoader.cs
+++ b/pwiz_tools/Osprey/Osprey.IO/DiannTsvLoader.cs
@@ -55,7 +55,18 @@ namespace pwiz.Osprey.IO
         /// </summary>
         public List<LibraryEntry> Load(string path, Action<string> logInfo = null)
         {
-            using (var reader = new StreamReader(path))
+            // Report progress over the file's BYTES rather than its rows: a 13 GB entrapment
+            // TSV otherwise runs for over a minute with nothing on the console between
+            // LibraryLoader's "Loading spectral library from ..." and the interning summary.
+            // Byte progress needs the stream, so it is wired here rather than in ParseReader,
+            // which stays a plain TextReader entry point for tests. Mirrors MzmlReader.
+            using (var stream = new FileStream(path, FileMode.Open, FileAccess.Read,
+                FileShare.Read, 16 * 1024 * 1024))
+            using (var progress = new ProgressReporter(
+                string.Format("Parsing {0}", Path.GetFileName(path)), stream.Length, string.Empty,
+                ProgressReporter.IO_INTERVAL_SECONDS))
+            using (var progressStream = new ProgressStream(stream, progress))
+            using (var reader = new StreamReader(progressStream))
             {
                 return ParseReader(reader, logInfo);
             }

--- a/pwiz_tools/Osprey/Osprey.IO/LibraryCache.cs
+++ b/pwiz_tools/Osprey/Osprey.IO/LibraryCache.cs
@@ -84,8 +84,16 @@ namespace pwiz.Osprey.IO
                     WriteString(w, libraryHash ?? string.Empty);
                     w.Write((ulong)entries.Count);
 
+                    // The cold path's tail: multi-GB of BinaryWriter output over every entry,
+                    // silent until "Saved library cache" appears. Guarded so the ~12 round-trip
+                    // unit tests and the regression's staged copies stay quiet.
+                    var progress = new ProgressReporter(@"Writing library cache", entries.Count,
+                            string.Empty, ProgressReporter.IO_INTERVAL_SECONDS);
+                    long nWritten = 0;
+
                     foreach (var entry in entries)
                     {
+                        progress.Report(++nWritten);
                         w.Write(entry.Id);
                         WriteString(w, entry.Sequence);
                         WriteString(w, entry.ModifiedSequence);
@@ -144,6 +152,7 @@ namespace pwiz.Osprey.IO
                             WriteString(w, gn);
                     }
 
+                    progress.Dispose();
                     w.Flush();
                 }
                 saver.Commit();

--- a/pwiz_tools/Osprey/Osprey.IO/LibraryCache.cs
+++ b/pwiz_tools/Osprey/Osprey.IO/LibraryCache.cs
@@ -243,113 +243,122 @@ namespace pwiz.Osprey.IO
                 // call; only object identity changes, so output is unchanged.
                 var interner = new LibraryStringInterner();
 
-                for (ulong idx = 0; idx < count; idx++)
+                // A 6.3M-entry entrapment library takes minutes to materialize here, and the
+                // caller logs nothing until it finishes (LibraryLoader announces only the
+                // source-parse path), so without this the console looks hung on the fast path.
+                using (var progress = new ProgressReporter(
+                    string.Format("Loading library cache ({0} entries)", count), (long)count,
+                    string.Empty, ProgressReporter.IO_INTERVAL_SECONDS))
                 {
-                    uint id = r.ReadUInt32();
-                    string sequence = interner.Intern(ReadString(r));
-                    string modifiedSequence = interner.Intern(ReadString(r));
-                    byte charge = r.ReadByte();
-                    double precursorMz = r.ReadDouble();
-                    double retentionTime = r.ReadDouble();
-                    bool rtCalibrated = r.ReadByte() != 0;
-                    bool isDecoy = r.ReadByte() != 0;
-
-                    // Modifications (share one empty array when none).
-                    uint nMods = r.ReadUInt32();
-                    var modifications = nMods == 0
-                        ? Array.Empty<Modification>()
-                        : new Modification[nMods];
-                    for (uint mi = 0; mi < nMods; mi++)
+                    for (ulong idx = 0; idx < count; idx++)
                     {
-                        int position = (int)r.ReadUInt32();
-                        bool hasUnimod = r.ReadByte() != 0;
-                        int? unimodId = hasUnimod ? (int?)r.ReadUInt32() : null;
-                        double massDelta = r.ReadDouble();
-                        bool hasName = r.ReadByte() != 0;
-                        string name = hasName ? interner.Intern(ReadString(r)) : null;
+                        uint id = r.ReadUInt32();
+                        string sequence = interner.Intern(ReadString(r));
+                        string modifiedSequence = interner.Intern(ReadString(r));
+                        byte charge = r.ReadByte();
+                        double precursorMz = r.ReadDouble();
+                        double retentionTime = r.ReadDouble();
+                        bool rtCalibrated = r.ReadByte() != 0;
+                        bool isDecoy = r.ReadByte() != 0;
 
-                        modifications[mi] = new Modification
+                        // Modifications (share one empty array when none).
+                        uint nMods = r.ReadUInt32();
+                        var modifications = nMods == 0
+                            ? Array.Empty<Modification>()
+                            : new Modification[nMods];
+                        for (uint mi = 0; mi < nMods; mi++)
                         {
-                            Position = position,
-                            UnimodId = unimodId,
-                            MassDelta = massDelta,
-                            Name = name
-                        };
-                    }
+                            int position = (int)r.ReadUInt32();
+                            bool hasUnimod = r.ReadByte() != 0;
+                            int? unimodId = hasUnimod ? (int?)r.ReadUInt32() : null;
+                            double massDelta = r.ReadDouble();
+                            bool hasName = r.ReadByte() != 0;
+                            string name = hasName ? interner.Intern(ReadString(r)) : null;
 
-                    // Fragments. When omitting, still read each fragment's bytes
-                    // (to advance the stream to the protein-ID block that follows)
-                    // but discard them, leaving a shared empty array.
-                    uint nFrags = r.ReadUInt32();
-                    // Peak-less entries (0 fragments) are a BiblioSpec MS1-feature-finding artifact,
-                    // not valid for DIA search; fail fast rather than let one reach decoy generation
-                    // or a lean OmitFragments load (issue #4355 / PR #4434 review). A stale cache
-                    // built before this guard rebuilds from source, which fails fast there too.
-                    if (nFrags == 0)
-                        throw new InvalidDataException(string.Format(
-                            "Library entry {0} ({1}) has no fragment peaks; peak-less entries support " +
-                            "BiblioSpec MS1 feature finding and are not valid for DIA search.",
-                            id, modifiedSequence));
-                    LibraryFragment[] fragments;
-                    if (omitFragments)
-                    {
-                        fragments = Array.Empty<LibraryFragment>();
-                        for (uint fi = 0; fi < nFrags; fi++)
-                            SkipFragment(r);
-                    }
-                    else
-                    {
-                        fragments = new LibraryFragment[nFrags];   // nFrags > 0: 0-fragment entries fail fast above
-                        for (uint fi = 0; fi < nFrags; fi++)
-                        {
-                            double mz = r.ReadDouble();
-                            float relativeIntensity = r.ReadSingle();
-                            IonType ionType = ByteToIonType(r.ReadByte());
-                            byte ordinal = r.ReadByte();
-                            byte fragCharge = r.ReadByte();
-                            var (lossCode, lossMass) = ReadNeutralLoss(r);
-
-                            fragments[fi] = new LibraryFragment
+                            modifications[mi] = new Modification
                             {
-                                Mz = mz,
-                                RelativeIntensity = relativeIntensity,
-                                Annotation = new FragmentAnnotation
-                                {
-                                    IonType = ionType,
-                                    Ordinal = ordinal,
-                                    Charge = fragCharge,
-                                    NeutralLoss = lossCode,
-                                    CustomLossMass = lossMass
-                                }
+                                Position = position,
+                                UnimodId = unimodId,
+                                MassDelta = massDelta,
+                                Name = name
                             };
                         }
+
+                        // Fragments. When omitting, still read each fragment's bytes
+                        // (to advance the stream to the protein-ID block that follows)
+                        // but discard them, leaving a shared empty array.
+                        uint nFrags = r.ReadUInt32();
+                        // Peak-less entries (0 fragments) are a BiblioSpec MS1-feature-finding artifact,
+                        // not valid for DIA search; fail fast rather than let one reach decoy generation
+                        // or a lean OmitFragments load (issue #4355 / PR #4434 review). A stale cache
+                        // built before this guard rebuilds from source, which fails fast there too.
+                        if (nFrags == 0)
+                            throw new InvalidDataException(string.Format(
+                                "Library entry {0} ({1}) has no fragment peaks; peak-less entries support " +
+                                "BiblioSpec MS1 feature finding and are not valid for DIA search.",
+                                id, modifiedSequence));
+                        LibraryFragment[] fragments;
+                        if (omitFragments)
+                        {
+                            fragments = Array.Empty<LibraryFragment>();
+                            for (uint fi = 0; fi < nFrags; fi++)
+                                SkipFragment(r);
+                        }
+                        else
+                        {
+                            fragments = new LibraryFragment[nFrags];   // nFrags > 0: 0-fragment entries fail fast above
+                            for (uint fi = 0; fi < nFrags; fi++)
+                            {
+                                double mz = r.ReadDouble();
+                                float relativeIntensity = r.ReadSingle();
+                                IonType ionType = ByteToIonType(r.ReadByte());
+                                byte ordinal = r.ReadByte();
+                                byte fragCharge = r.ReadByte();
+                                var (lossCode, lossMass) = ReadNeutralLoss(r);
+
+                                fragments[fi] = new LibraryFragment
+                                {
+                                    Mz = mz,
+                                    RelativeIntensity = relativeIntensity,
+                                    Annotation = new FragmentAnnotation
+                                    {
+                                        IonType = ionType,
+                                        Ordinal = ordinal,
+                                        Charge = fragCharge,
+                                        NeutralLoss = lossCode,
+                                        CustomLossMass = lossMass
+                                    }
+                                };
+                            }
+                        }
+
+                        // Protein IDs / gene names (share one empty array when none).
+                        uint nProteins = r.ReadUInt32();
+                        var proteinIds = nProteins == 0
+                            ? Array.Empty<string>()
+                            : new string[nProteins];
+                        for (uint pi = 0; pi < nProteins; pi++)
+                            proteinIds[pi] = interner.Intern(ReadString(r));
+
+                        uint nGenes = r.ReadUInt32();
+                        var geneNames = nGenes == 0
+                            ? Array.Empty<string>()
+                            : new string[nGenes];
+                        for (uint gi = 0; gi < nGenes; gi++)
+                            geneNames[gi] = interner.Intern(ReadString(r));
+
+                        var entry = new LibraryEntry(id, sequence, modifiedSequence,
+                            charge, precursorMz, retentionTime);
+                        entry.RtCalibrated = rtCalibrated;
+                        entry.IsDecoy = isDecoy;
+                        entry.Modifications = modifications;
+                        entry.Fragments = fragments;
+                        entry.ProteinIds = proteinIds;
+                        entry.GeneNames = geneNames;
+
+                        entries.Add(entry);
+                        progress.Report((long)idx + 1);
                     }
-
-                    // Protein IDs / gene names (share one empty array when none).
-                    uint nProteins = r.ReadUInt32();
-                    var proteinIds = nProteins == 0
-                        ? Array.Empty<string>()
-                        : new string[nProteins];
-                    for (uint pi = 0; pi < nProteins; pi++)
-                        proteinIds[pi] = interner.Intern(ReadString(r));
-
-                    uint nGenes = r.ReadUInt32();
-                    var geneNames = nGenes == 0
-                        ? Array.Empty<string>()
-                        : new string[nGenes];
-                    for (uint gi = 0; gi < nGenes; gi++)
-                        geneNames[gi] = interner.Intern(ReadString(r));
-
-                    var entry = new LibraryEntry(id, sequence, modifiedSequence,
-                        charge, precursorMz, retentionTime);
-                    entry.RtCalibrated = rtCalibrated;
-                    entry.IsDecoy = isDecoy;
-                    entry.Modifications = modifications;
-                    entry.Fragments = fragments;
-                    entry.ProteinIds = proteinIds;
-                    entry.GeneNames = geneNames;
-
-                    entries.Add(entry);
                 }
 
                 interner.LogSummary(logInfo);

--- a/pwiz_tools/Osprey/Osprey.IO/LibraryDeduplicator.cs
+++ b/pwiz_tools/Osprey/Osprey.IO/LibraryDeduplicator.cs
@@ -47,8 +47,16 @@ namespace pwiz.Osprey.IO
             // Group entries by (modified_sequence, charge)
             var groups = new Dictionary<string, List<LibraryEntry>>();
 
+            // Silent between the parse and "Loaded N library entries" - a full group-by over
+            // every entry (6.3M on the entrapment library). Not `using`d: no re-indent, and no
+            // completed-looking 100% if this throws.
+            var progress = new ProgressReporter(@"Deduplicating library entries", entries.Count,
+                    string.Empty, ProgressReporter.IO_INTERVAL_SECONDS);
+            long nGrouped = 0;
+
             foreach (var entry in entries)
             {
+                progress.Report(++nGrouped);
                 string key = entry.ModifiedSequence + "\t" + entry.Charge;
                 List<LibraryEntry> group;
                 if (!groups.TryGetValue(key, out group))
@@ -138,6 +146,7 @@ namespace pwiz.Osprey.IO
             for (int i = 0; i < deduped.Count; i++)
                 deduped[i].Id = (uint)i;
 
+            progress.Dispose();
             return deduped;
         }
     }

--- a/pwiz_tools/Osprey/Osprey.Tasks/Pass2FdrSidecar.cs
+++ b/pwiz_tools/Osprey/Osprey.Tasks/Pass2FdrSidecar.cs
@@ -609,15 +609,30 @@ namespace pwiz.Osprey.Tasks
             //    file's scalars are resident at a time; the cross-file state is bounded by the
             //    number of distinct precursors, not the total observation count -- so peak memory
             //    is flat in file count (the 32/64 GB many-file target).
-            (uint[] entryIds, double[] scores) ReadFile(string fileKey)
+            Dictionary<(string, uint), double> runQ, expQ, pep;
+            // The streaming competition reads one file's scalars per call and is otherwise silent;
+            // at 163 files that was a 9.6 min gap immediately after the line above announced it.
+            // readFileScalars is invoked exactly once per file (StreamingFdr.cs:180, single pass),
+            // so counting calls here is an honest per-file progress signal without threading a
+            // callback through the FDR layer.
+            using (var progress = new ProgressReporter(
+                string.Format("{0}: streaming full-population competition across {1} file(s)",
+                    mode, fileKeys.Count),
+                fileKeys.Count, string.Empty, ProgressReporter.IO_INTERVAL_SECONDS))
             {
-                FdrScoresSidecar.ReadScalars(sidecarByKey[fileKey], out uint[] eids, out double[] scs);
-                return (eids, scs);
-            }
+                long nRead = 0;
 
-            StreamingFdr.ComputeFullPopulationPrecursorFdrStreaming(
-                fileKeys, ReadFile, survivorScore, survivors,
-                out var runQ, out var expQ, out var pep, stratumBaseIds);
+                (uint[] entryIds, double[] scores) ReadFile(string fileKey)
+                {
+                    FdrScoresSidecar.ReadScalars(sidecarByKey[fileKey], out uint[] eids, out double[] scs);
+                    progress.Report(++nRead);
+                    return (eids, scs);
+                }
+
+                StreamingFdr.ComputeFullPopulationPrecursorFdrStreaming(
+                    fileKeys, ReadFile, survivorScore, survivors,
+                    out runQ, out expQ, out pep, stratumBaseIds);
+            }
 
             // 4. Map the recomputed q/PEP back onto the reported survivor entries. Under
             //    protein-compact, an OFF-stratum survivor got q=1.0 from the (constrained)

--- a/pwiz_tools/Osprey/Osprey.Tasks/Pass2FdrSidecar.cs
+++ b/pwiz_tools/Osprey/Osprey.Tasks/Pass2FdrSidecar.cs
@@ -537,7 +537,7 @@ namespace pwiz.Osprey.Tasks
                 long nDone = 0;
                 foreach (var kvp in perFileEntries)
                 {
-                    progress.Report(nDone++);
+                    progress.Report(++nDone);
                     if (!perFileParquetPaths.TryGetValue(kvp.Key, out string scoreParquetPath))
                         continue;
                     string effectiveParquetPath =
@@ -616,7 +616,7 @@ namespace pwiz.Osprey.Tasks
             // so counting calls here is an honest per-file progress signal without threading a
             // callback through the FDR layer.
             using (var progress = new ProgressReporter(
-                string.Format("{0}: streaming full-population competition across {1} file(s)",
+                string.Format("{0}: reading per-file scalars for the streamed competition ({1} file(s))",
                     mode, fileKeys.Count),
                 fileKeys.Count, string.Empty, ProgressReporter.IO_INTERVAL_SECONDS))
             {

--- a/pwiz_tools/Osprey/Osprey.Tasks/Pass2FdrSidecar.cs
+++ b/pwiz_tools/Osprey/Osprey.Tasks/Pass2FdrSidecar.cs
@@ -524,34 +524,47 @@ namespace pwiz.Osprey.Tasks
             //    MapFeaturesByIdentity key), so each survivor's score is byte-identical to the
             //    old resident path. Keyed by (file, entry_id); entry_id is unique per file.
             var survivorScore = new Dictionary<(string, uint), double>();
-            foreach (var kvp in perFileEntries)
+            // Announce BEFORE the loop, not after it. This reads one reconciled parquet per file
+            // and on a 163-file Astral set that is ~212 GB off disk - measured at 34.9 min with
+            // no console output at all, because the summary line below is only reached once the
+            // loop finishes. A silent phase that long is indistinguishable from a hang, and it
+            // was read as one during the first 163-file run.
+            using (var progress = new ProgressReporter(
+                string.Format("{0}: reloading frozen-model features from {1} file(s)",
+                    mode, perFileEntries.Count),
+                perFileEntries.Count, string.Empty, ProgressReporter.IO_INTERVAL_SECONDS))
             {
-                if (!perFileParquetPaths.TryGetValue(kvp.Key, out string scoreParquetPath))
-                    continue;
-                string effectiveParquetPath =
-                    ParquetScoreCache.EffectiveScoresPathFromScoresPath(scoreParquetPath);
-                Dictionary<(uint, byte, uint), double[]> featByIdentity;
-                try
+                long nDone = 0;
+                foreach (var kvp in perFileEntries)
                 {
-                    featByIdentity = LoadReconciledFeaturesByIdentity(effectiveParquetPath);
-                }
-                catch (Exception ex)
-                {
-                    ctx.LogWarning(string.Format(
-                        "{0}: failed to reload PIN features from {1}: {2}",
-                        mode, effectiveParquetPath, ex.Message));
-                    continue;
-                }
-                foreach (var e in kvp.Value)
-                {
-                    if (featByIdentity.TryGetValue(
-                            (e.EntryId, e.Charge, e.ScanNumber), out double[] feats) &&
-                        feats != null && feats.Length == nFeatures)
+                    progress.Report(nDone++);
+                    if (!perFileParquetPaths.TryGetValue(kvp.Key, out string scoreParquetPath))
+                        continue;
+                    string effectiveParquetPath =
+                        ParquetScoreCache.EffectiveScoresPathFromScoresPath(scoreParquetPath);
+                    Dictionary<(uint, byte, uint), double[]> featByIdentity;
+                    try
                     {
-                        survivorScore[(kvp.Key, e.EntryId)] = scorer.Score(feats);
+                        featByIdentity = LoadReconciledFeaturesByIdentity(effectiveParquetPath);
                     }
+                    catch (Exception ex)
+                    {
+                        ctx.LogWarning(string.Format(
+                            "{0}: failed to reload PIN features from {1}: {2}",
+                            mode, effectiveParquetPath, ex.Message));
+                        continue;
+                    }
+                    foreach (var e in kvp.Value)
+                    {
+                        if (featByIdentity.TryGetValue(
+                                (e.EntryId, e.Charge, e.ScanNumber), out double[] feats) &&
+                            feats != null && feats.Length == nFeatures)
+                        {
+                            survivorScore[(kvp.Key, e.EntryId)] = scorer.Score(feats);
+                        }
+                    }
+                    // featByIdentity released here (one file resident at a time).
                 }
-                // featByIdentity released here (one file resident at a time).
             }
 
             // 2. Reported survivors to emit (every post-reconciliation entry) + per-file scalar


### PR DESCRIPTION
## Summary

* Reported progress through the two phases that ran for minutes with a **completely silent
  console**, both found on the first-ever 163-file Osprey run (TDP-43 Plasma EV-Quant, 2x SEA-AD).
* `LibraryCache.LoadCache` / `DiannTsvLoader.Load` — the spectral library. `LibraryLoader` logs
  `"Loading spectral library from ..."` only AFTER the cache attempt, so the cache path printed
  nothing at all before its load. Measured at **83 s** on that run, and **168 s** on a run whose
  disk was still draining another run's writeback.
* `Pass2FdrSidecar.ComputeAndPersist` — the frozen-model feature reload. Same defect shape: the
  summary line sat *after* the loop, so a 163-file run read ~212 GB of reconciled parquet in
  **34.9 min** with no output. That silence was read as a hang during the run.

No behavior change: `ProgressReporter` writes to the `OspreyOutput.Out` seam and nothing else in
these paths moved.

## Why it matters beyond tidiness

A phase that emits nothing for 35 minutes is indistinguishable from a hang, and it was diagnosed
as one mid-run (CPU low + disk high + 104 GB resident reads as thrashing; the counters showed
`Pages Output/sec = 0` and an untouched pagefile, i.e. ordinary I/O on a SATA HDD). It also leaves
no `--memstamp` samples, so `ai/scripts/perfviz.py` renders the stretch as one enormous gap with
no interior — exactly where you most want to see the memory shape. On a 500-file run that stretch
is ~90 minutes.

## Notes for review

* **`LibraryCache.cs` is 205 changed lines but only 9 insertions under `git diff -w`.** The rest is
  the brace re-indent STYLEGUIDE mandates ("A braceless body is only allowed when the body is a
  single line ... Take the bigger diff") — and which uses `ProgressReporter` as its own example.
* `DiannTsvLoader` reports over **bytes** via `ProgressStream`, mirroring `MzmlReader`; it is wired
  in `Load` rather than `ParseReader` so the latter stays a plain `TextReader` entry point for tests.
* `LibraryCache` reports per entry instead, because `LoadCache` already reads the entry count from
  the header — a determinate loop with no new plumbing.

## Test plan

- [x] Build Debug clean, **563/563 unit tests**, ReSharper inspection **0 warnings / 0 errors**
      (net472 and net8.0)
- [x] `regression.ps1 -Dataset Stellar` — byte identity vs the committed golden, plus the resume
      leg. Also the runtime exercise of the `Pass2FdrSidecar` path, which Stellar passes through.
- [x] **Verified by observation, not assertion.** MSTest captures `OspreyOutput.Out`, so a green
      unit test does not prove the lines appear. Run against the real 2.21 GB / 6,324,700-entry
      SEA-AD entrapment cache:

      ```
      18:31:00  Loading library cache (6324700 entries)...
      18:31:05    47%
      18:31:10    98%
      18:31:11    100%
      ```

      Longest silence on that path: 83 s -> 5 s (the `IO_INTERVAL_SECONDS` throttle).
- [x] Source-parse path likewise, on the 13 GB TSV: `Parsing carafe_spectral_library.tsv...` then
      5% -> 96% at a steady ~8-9% per 5 s tick, confirming that phase is linear with no hidden stall.

## Related

Found while running the first 163-file Osprey search. That run also surfaced an **O(files) memory
holder** in the Stage-5 -> Stage-6 handoff (90.2 GB peak, 88,875,901 retained entries), which is
NOT addressed here and is written up in
`ai/todos/active/TODO-20260731_osprey_bounded_stage5_handoff.md`.

Co-Authored-By: Claude <noreply@anthropic.com>
