### PR TITLE
osprey: Ignored the local bo.bat Osprey build wrapper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -442,6 +442,7 @@ SkylineTester Results
 /b.bat
 /b64.bat
 /b32.bat
+/bo*.bat
 /bs.bat
 /bs64.bat
 /bs32.bat


### PR DESCRIPTION
## Summary

* `.gitignore` covered `/b.bat`, `/bs.bat` and `/bs*.bat` but nothing matched `bo.bat`, so it showed as untracked and a `git add -A` would have committed it.
* That file carries `--i-agree-to-the-vendor-licenses`, which must never be committed.

Verified with `git check-ignore -v bo.bat` -> `.gitignore:445:/bo*.bat`, and `git status` is clean afterwards.

## Test plan

- [x] `git check-ignore -v bo.bat` matches the new rule
- [x] `git status` no longer lists it; no tracked file is newly ignored

Co-Authored-By: Claude <noreply@anthropic.com>