### PR TITLE
skyline: Noted when TestPanoramaDownloadFileWeb is skipped for lack of internet access

### DIFF
--- a/pwiz_tools/Skyline/TestConnected/PanoramaClientDownloadTest.cs
+++ b/pwiz_tools/Skyline/TestConnected/PanoramaClientDownloadTest.cs
@@ -68,6 +68,10 @@ namespace pwiz.SkylineTestConnected
                 DoActualWebAccess = true; // Actually go to the web
                 RunFunctionalTest();
             }
+            else
+            {
+                Console.Error.WriteLine("NOTE: skipping TestPanoramaDownloadFileWeb because AllowInternetAccess is off");
+            }
         }
 
         protected override void DoTest()


### PR DESCRIPTION
## Summary

* `TestPanoramaDownloadFileWeb` reported PASSED on every CI run while executing nothing. Its body is guarded by `if (AllowInternetAccess || IsRecordMode)` with no `else`, and `AllowInternetAccess` is `TestContext.GetBoolValue("AccessInternet", false)` - false unless explicitly enabled. Nothing in the automated path enables it: only SkylineTester Access Internet sets `internet=on` (SkylineTester/Main.cs:274, 284), and neither SkylineNightly nor the TeamCity configurations pass it.
* Adds the house skip note, matching the nine existing sites in `TestConnected` (Ardia tests) and `EncyclopeDiaSearchTest`, so the skip is visible in the build log rather than indistinguishable from a real pass.

Confirmed in bt210 build #5134, where this test completed in 0 sec while its sibling `TestPanoramaDownloadFile` took 7 sec on recorded playback.

`Assert.Inconclusive` was considered and rejected: there is no handling of `Inconclusive` anywhere in `TestRunnerLib` or `TestRunner`, so `AssertInconclusiveException` would be reported as a test failure and turn CI red.

### Known limitation

The note goes to stderr, so it appears on the console and in TeamCity as `[Test Error Output]` at warning level - the same treatment the Ardia notes get - but not in TestRunner's own `log=` file, which records only the structured per-test summary line. The test also still reports PASSED. Making the results summary itself honest would require excluding the test from the TeamCity configuration, which is a separate decision, tracked in the issue.

Fixes #4519

## Test plan

- [x] TestPanoramaDownloadFileWeb - passes, note emitted, 0.8s
- [x] CodeInspection - passed
- [x] ReSharper full-solution inspection - 0 errors, 0 warnings

Co-Authored-By: Claude <noreply@anthropic.com>