### PR TITLE
osprey: Bounded the Stage 6 survivor handoff by streaming it per file

### DIFF
--- a/pwiz_tools/Osprey/Osprey.Core/FdrEntry.cs
+++ b/pwiz_tools/Osprey/Osprey.Core/FdrEntry.cs
@@ -32,6 +32,32 @@ namespace pwiz.Osprey.Core
     /// </summary>
     public class FdrEntry
     {
+        /// <summary>
+        /// The canonical survivor order - (EntryId, Charge, ScanNumber, ParquetIndex) - that
+        /// the post-Percolator-sort + compaction buffer establishes and every path which
+        /// rebuilds that buffer from disk has to reproduce. Held in ONE place because four
+        /// separate copies of this comparison had accumulated across the Stage 5 reload, the
+        /// Stage 6 rebuild and the resume overlays, and a buffer built by one copy is compared
+        /// against a buffer built by another.
+        ///
+        /// <para>Safe with the unstable <c>Array.Sort</c> that <c>List.Sort</c> uses: the
+        /// terminal key ParquetIndex is unique per file, so the comparison never ties and the
+        /// result does not depend on the sort's tie handling.</para>
+        /// </summary>
+        public static readonly Comparison<FdrEntry> CANONICAL_ORDER = (a, b) =>
+        {
+            int c = a.EntryId.CompareTo(b.EntryId);
+            if (c != 0)
+                return c;
+            c = a.Charge.CompareTo(b.Charge);
+            if (c != 0)
+                return c;
+            c = a.ScanNumber.CompareTo(b.ScanNumber);
+            if (c != 0)
+                return c;
+            return a.ParquetIndex.CompareTo(b.ParquetIndex);
+        };
+
         public uint EntryId { get; set; }
         public uint ParquetIndex { get; set; }
         public bool IsDecoy { get; set; }
@@ -121,6 +147,28 @@ namespace pwiz.Osprey.Core
 
         public FdrEntry()
         {
+            RunPrecursorQvalue = 1.0;
+            RunPeptideQvalue = 1.0;
+            RunProteinQvalue = 1.0;
+            ExperimentPrecursorQvalue = 1.0;
+            ExperimentPeptideQvalue = 1.0;
+            ExperimentProteinQvalue = 1.0;
+            Pep = 1.0;
+        }
+
+        /// <summary>
+        /// Reset the discriminant fields to the Rust <c>to_fdr_entry</c> defaults: Score 0,
+        /// every q-value and Pep 1.0. This is the state a Stage 6 rescore target is left in
+        /// for the 2nd pass to fill, and the state a fresh gap-fill stub is appended in.
+        ///
+        /// <para>One method because the same eight assignments had been written out five
+        /// times - the rescore overlay, both gap-fill passes, and the rebuild-from-disk - and
+        /// the paths are compared against each other for byte identity. A field added to the
+        /// set in four places out of five is a divergence nothing would catch.</para>
+        /// </summary>
+        public void ResetScores()
+        {
+            Score = 0.0;
             RunPrecursorQvalue = 1.0;
             RunPeptideQvalue = 1.0;
             RunProteinQvalue = 1.0;

--- a/pwiz_tools/Osprey/Osprey.Core/OspreyEnvironment.cs
+++ b/pwiz_tools/Osprey/Osprey.Core/OspreyEnvironment.cs
@@ -190,6 +190,21 @@ namespace pwiz.Osprey.Core
             IsNotZero(@"OSPREY_STAGE6_STREAM_SURVIVORS");
 
         /// <summary>
+        /// Cache-validity suffix for the Stage 6 handoff arm. EMPTY on the streamed default,
+        /// so shipping this does not invalidate a single existing output directory; only the
+        /// resident opt-out adds a term.
+        ///
+        /// <para>Without it an in-place A/B of the two arms is not an A/B at all: the second
+        /// run finds the first run's reconciled parquets valid, skips Stage 6 entirely, and
+        /// reports a clean match it never computed. That is the exact failure mode the two arms
+        /// exist to detect, so leaving it out makes the oracle self-confirming.</para>
+        /// </summary>
+        public static string Stage6StreamSurvivorsValidityKeySuffix()
+        {
+            return Stage6StreamSurvivors ? string.Empty : @";stage6stream=0";
+        }
+
+        /// <summary>
         /// OSPREY_PICK_DUMP_CANDIDATES: when set to a non-empty / non-zero value, dump one
         /// row per CWT candidate peak of every precursor (targets AND decoys) scored in the
         /// first-pass main search to a per-input-file TSV

--- a/pwiz_tools/Osprey/Osprey.Core/OspreyEnvironment.cs
+++ b/pwiz_tools/Osprey/Osprey.Core/OspreyEnvironment.cs
@@ -19,6 +19,7 @@
  */
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 
 namespace pwiz.Osprey.Core
@@ -447,7 +448,7 @@ namespace pwiz.Osprey.Core
             IsSetAndNotZero(@"OSPREY_PROTEIN_COMPACT_RETRAIN");
 
         /// <summary>
-        /// OSPREY_ALLOW_UNFIXED_RESIDENT: name the ONE known-unfixed resident path this run may
+        /// OSPREY_ALLOW_UNFIXED_RESIDENT: name the known-unfixed resident path(s) this run may
         /// take, e.g. <c>OSPREY_ALLOW_UNFIXED_RESIDENT=mdiag-full-resume</c>. Legal values are
         /// exactly <see cref="ResidentPaths.KNOWN_UNFIXED"/>; anything else, and any resident path
         /// that is not on that list, is refused no matter what this is set to.
@@ -461,24 +462,61 @@ namespace pwiz.Osprey.Core
         /// this set, so the ONLY way to re-admit one is to add it to the committed list, which is
         /// a reviewed diff that fails <c>ResidentPoolGuardTest</c>.
         ///
-        /// Read once at process start. Intended for local testing; CI names its token explicitly
+        /// <para>SEVERAL paths may be named, comma- or semicolon-separated, because a run can
+        /// legitimately trip more than one at once and a single-value variable made that run
+        /// impossible to perform at all. The A/B that proves the Stage 6 handoff bounded is
+        /// exactly such a run: <c>regression.ps1</c> mode 2 needs
+        /// <see cref="ResidentPaths.MDIAG_FULL_RESUME"/> while the arm under test needs
+        /// <see cref="ResidentPaths.COMPACTED_ENTRIES_BUFFER"/>. A LIST keeps the property that
+        /// matters - every admitted path is still named individually, so nothing rides along
+        /// unnamed the way the blanket boolean allowed - while a single value only ever
+        /// prevented honest work.</para>
+        ///
+        /// Read once at process start. Intended for local testing; CI names its tokens explicitly
         /// (regression.ps1 mode 2), so what CI depends on is visible rather than ambient.
         /// </summary>
         public static readonly string AllowUnfixedResident =
             (Environment.GetEnvironmentVariable(@"OSPREY_ALLOW_UNFIXED_RESIDENT") ?? string.Empty).Trim();
 
         /// <summary>
-        /// True when <see cref="AllowUnfixedResident"/> was set to something that is not a legal
-        /// token, so the guard can say "that value is not a known path" instead of printing the
+        /// True when <see cref="AllowUnfixedResident"/> names anything that is not a legal token,
+        /// so the guard can say "that value is not a known path" instead of printing the
         /// same message it prints when the variable is unset. Without this, a typo
         /// (<c>mdiag_full_resume</c>) or a shell-quoted value (cmd.exe stores the quotes) is
         /// byte-for-byte indistinguishable from not setting it, and the operator is told to do
         /// what they believe they just did. Mirrors <see cref="Pass2QValueUnrecognized"/>.
         /// </summary>
         public static readonly bool AllowUnfixedResidentUnrecognized =
-            AllowUnfixedResident.Length > 0 &&
-            !ResidentPaths.KNOWN_UNFIXED.Any(
-                t => string.Equals(t, AllowUnfixedResident, StringComparison.OrdinalIgnoreCase));
+            SplitResidentTokens(AllowUnfixedResident).Any(
+                v => !ResidentPaths.KNOWN_UNFIXED.Any(
+                    t => string.Equals(t, v, StringComparison.OrdinalIgnoreCase)));
+
+        /// <summary>
+        /// Whether <paramref name="allowValue"/> (an OSPREY_ALLOW_UNFIXED_RESIDENT setting) names
+        /// <paramref name="token"/>. Case-insensitive, matching how the rest of the CLI parses
+        /// tokens: the guard's message names the exact token to set, so rejecting the operator's
+        /// own value for capitalization would read as the guard ignoring what they just did.
+        /// </summary>
+        public static bool NamesResidentPath(string allowValue, string token)
+        {
+            return SplitResidentTokens(allowValue).Any(
+                v => string.Equals(v, token, StringComparison.OrdinalIgnoreCase));
+        }
+
+        /// <summary>
+        /// The individual tokens in an OSPREY_ALLOW_UNFIXED_RESIDENT setting. Comma and semicolon
+        /// both separate, and empty entries are dropped, so a trailing separator is not a typo
+        /// the operator has to hunt for.
+        /// </summary>
+        private static IEnumerable<string> SplitResidentTokens(string allowValue)
+        {
+            if (string.IsNullOrEmpty(allowValue))
+                return new string[0];
+            return allowValue
+                .Split(new[] { ',', ';' }, StringSplitOptions.RemoveEmptyEntries)
+                .Select(v => v.Trim())
+                .Where(v => v.Length > 0);
+        }
 
         /// <summary>The N in OSPREY_EXPERIMENT_AGG=mean-best-&lt;N&gt;: how many top per-run scores are
         /// averaged (runs beyond the detected count filled with the decoy floor). 0 in the default

--- a/pwiz_tools/Osprey/Osprey.Core/OspreyEnvironment.cs
+++ b/pwiz_tools/Osprey/Osprey.Core/OspreyEnvironment.cs
@@ -174,6 +174,22 @@ namespace pwiz.Osprey.Core
         public static bool UseFdrProjection { get; set; } = IsNotZero(@"OSPREY_FDR_PROJECTION");
 
         /// <summary>
+        /// Stage 6 rebuilds each file's post-compaction survivors from that file's
+        /// <c>.scores.parquet</c> + 1st-pass sidecar just before rescoring it, and drops
+        /// them again once its reconciled parquet is on disk - so the all-files survivor
+        /// buffer is not resident across the rescore loop.
+        ///
+        /// DEFAULT ON. That buffer is 88.9 M entries / 28 GB live at 163 files, held for
+        /// the 5.5 hours of Stage 6, and it grows super-linearly in file count because the
+        /// passing base_id set grows too (issue #4526). Set
+        /// OSPREY_STAGE6_STREAM_SURVIVORS=0 to keep the resident buffer as the A/B
+        /// byte-identity oracle, the same role OSPREY_FDR_PROJECTION=0 plays for Stage 5.
+        /// A settable property (not a readonly field) so unit tests can A/B both paths.
+        /// </summary>
+        public static bool Stage6StreamSurvivors { get; set; } =
+            IsNotZero(@"OSPREY_STAGE6_STREAM_SURVIVORS");
+
+        /// <summary>
         /// OSPREY_PICK_DUMP_CANDIDATES: when set to a non-empty / non-zero value, dump one
         /// row per CWT candidate peak of every precursor (targets AND decoys) scored in the
         /// first-pass main search to a per-input-file TSV

--- a/pwiz_tools/Osprey/Osprey.Core/OspreyEnvironment.cs
+++ b/pwiz_tools/Osprey/Osprey.Core/OspreyEnvironment.cs
@@ -511,7 +511,7 @@ namespace pwiz.Osprey.Core
         private static IEnumerable<string> SplitResidentTokens(string allowValue)
         {
             if (string.IsNullOrEmpty(allowValue))
-                return new string[0];
+                return Array.Empty<string>();
             return allowValue
                 .Split(new[] { ',', ';' }, StringSplitOptions.RemoveEmptyEntries)
                 .Select(v => v.Trim())

--- a/pwiz_tools/Osprey/Osprey.Core/ResidentPaths.cs
+++ b/pwiz_tools/Osprey/Osprey.Core/ResidentPaths.cs
@@ -89,12 +89,31 @@ namespace pwiz.Osprey.Core
         public static readonly string PROJECTION_OFF = @"projection-off";
 
         /// <summary>
+        /// <c>OSPREY_STAGE6_STREAM_SURVIVORS=0</c>: the operator forced the resident
+        /// POST-compaction handoff, where the all-files survivor buffer built by Stage 5 stays
+        /// live across the whole Stage 6 rescore - 88.9 M entries / 28 GB at 163 files, held
+        /// for 5.5 hours, growing super-linearly in file count because the passing base_id set
+        /// grows too (issue #4526). Like <see cref="PROJECTION_OFF"/> this is the A/B
+        /// byte-identity oracle for the streamed default, and it is named for the same reason.
+        ///
+        /// <para>This entry ADDS to the list, which the class remarks say must only shrink.
+        /// The justification is that it names a path which was previously unnamed rather than
+        /// re-admitting one that had been fixed: the older guard's invariant stops at the
+        /// compaction line - it enforces "no unnamed PRE-compaction pool", and this buffer is
+        /// built after it, so no token could refuse it and none was required. Naming it is the
+        /// ratchet reaching further, not running backwards. It goes when the resident handoff
+        /// itself goes.</para>
+        /// </summary>
+        public static readonly string COMPACTED_ENTRIES_BUFFER = @"compacted-entries-buffer";
+
+        /// <summary>
         /// Every legal <c>OSPREY_ALLOW_UNFIXED_RESIDENT</c> value. Pinned by
         /// <c>ResidentPoolGuardTest</c> - see the class remarks for why it may only shrink.
         /// </summary>
         public static readonly IReadOnlyList<string> KNOWN_UNFIXED = new[]
         {
-            HPC_MERGE, FDRBENCH_PASS1, MDIAG_FULL_RESUME, NON_PERCOLATOR_FDR, PROJECTION_OFF
+            HPC_MERGE, FDRBENCH_PASS1, MDIAG_FULL_RESUME, NON_PERCOLATOR_FDR, PROJECTION_OFF,
+            COMPACTED_ENTRIES_BUFFER
         };
     }
 }

--- a/pwiz_tools/Osprey/Osprey.IO/ParquetScoreCache.cs
+++ b/pwiz_tools/Osprey/Osprey.IO/ParquetScoreCache.cs
@@ -991,7 +991,18 @@ namespace pwiz.Osprey.IO
         /// fields so the Stage 6 reconciled parquet write-back round-
         /// trips them for every row, not just freshly rescored rows.
         /// </summary>
-        public static List<FdrEntry> LoadFullFdrEntries(string path)
+        /// <param name="path">The <c>.scores.parquet</c> / <c>.scores-reconciled.parquet</c> to read.</param>
+        /// <param name="scalarsOnly">Skip the 21 PIN feature columns and the four binary blob
+        /// columns (<c>cwt_candidates</c>, <c>fragment_mzs</c>, <c>fragment_intensities</c>,
+        /// <c>reference_xic_*</c>), leaving <see cref="FdrEntry.Features"/>,
+        /// <see cref="FdrEntry.CwtCandidates"/> and the four array fields null. Every SCALAR
+        /// field is set exactly as the full read sets it.
+        ///
+        /// <para>For callers that overlay reconciled values onto an existing buffer and then
+        /// immediately drop the heavy payload again: decoding ~25 columns per row to null them
+        /// a few lines later is the dominant cost of the Stage 6 rebuild, and it buys
+        /// nothing.</para></param>
+        public static List<FdrEntry> LoadFullFdrEntries(string path, bool scalarsOnly = false)
         {
             var entries = new List<FdrEntry>();
 
@@ -1000,7 +1011,7 @@ namespace pwiz.Osprey.IO
             {
                 var fieldsByName = BuildFieldLookup(reader);
                 for (int g = 0; g < reader.RowGroupCount; g++)
-                    entries.AddRange(ReadFdrEntryGroup(reader, g, fieldsByName, entries.Count));
+                    entries.AddRange(ReadFdrEntryGroup(reader, g, fieldsByName, entries.Count, scalarsOnly));
             }
 
             return entries;
@@ -1201,7 +1212,8 @@ namespace pwiz.Osprey.IO
         /// (the same "skip this group" rule the whole-file loader applies).
         /// </summary>
         private static List<FdrEntry> ReadFdrEntryGroup(ParquetReader reader, int g,
-            IReadOnlyDictionary<string, DataField> fieldsByName, int startParquetIndex)
+            IReadOnlyDictionary<string, DataField> fieldsByName, int startParquetIndex,
+            bool scalarsOnly = false)
         {
             var entries = new List<FdrEntry>();
             using (var groupReader = reader.OpenRowGroupReader(g))
@@ -1215,29 +1227,47 @@ namespace pwiz.Osprey.IO
                 var startCol = ReadColumnByName<double[]>(groupReader, fieldsByName, FIELD_START_RT.Name);
                 var endCol = ReadColumnByName<double[]>(groupReader, fieldsByName, FIELD_END_RT.Name);
                 var coelutionCol = ReadColumnByName<double[]>(groupReader, fieldsByName, FIELD_COELUTION_SUM.Name);
-                var cwtCol = ReadColumnByName<byte[][]>(groupReader, fieldsByName, FIELD_CWT_CANDIDATES.Name);
                 var boundsAreaCol = ReadColumnByName<double[]>(groupReader, fieldsByName, FIELD_BOUNDS_AREA.Name);
                 var boundsSnrCol = ReadColumnByName<double[]>(groupReader, fieldsByName, FIELD_BOUNDS_SNR.Name);
-                var fragMzCol = ReadColumnByName<byte[][]>(groupReader, fieldsByName, FIELD_FRAGMENT_MZS.Name);
-                var fragIntCol = ReadColumnByName<byte[][]>(groupReader, fieldsByName, FIELD_FRAGMENT_INTENSITIES.Name);
-                var refXicRtsCol = ReadColumnByName<byte[][]>(groupReader, fieldsByName, FIELD_REFERENCE_XIC_RTS.Name);
-                var refXicIntsCol = ReadColumnByName<byte[][]>(groupReader, fieldsByName, FIELD_REFERENCE_XIC_INTENSITIES.Name);
+                // The heavy columns: read only when the caller wants the payload.
+                var cwtCol = scalarsOnly
+                    ? null
+                    : ReadColumnByName<byte[][]>(groupReader, fieldsByName, FIELD_CWT_CANDIDATES.Name);
+                var fragMzCol = scalarsOnly
+                    ? null
+                    : ReadColumnByName<byte[][]>(groupReader, fieldsByName, FIELD_FRAGMENT_MZS.Name);
+                var fragIntCol = scalarsOnly
+                    ? null
+                    : ReadColumnByName<byte[][]>(groupReader, fieldsByName, FIELD_FRAGMENT_INTENSITIES.Name);
+                var refXicRtsCol = scalarsOnly
+                    ? null
+                    : ReadColumnByName<byte[][]>(groupReader, fieldsByName, FIELD_REFERENCE_XIC_RTS.Name);
+                var refXicIntsCol = scalarsOnly
+                    ? null
+                    : ReadColumnByName<byte[][]>(groupReader, fieldsByName, FIELD_REFERENCE_XIC_INTENSITIES.Name);
 
                 if (entryIdCol == null || isDecoyCol == null)
                     return entries;
 
                 var featureCols = new double[NUM_PIN_FEATURES][];
-                for (int f = 0; f < NUM_PIN_FEATURES; f++)
-                    featureCols[f] = ReadColumnByName<double[]>(groupReader, fieldsByName, PIN_FEATURE_NAMES[f]);
+                if (!scalarsOnly)
+                {
+                    for (int f = 0; f < NUM_PIN_FEATURES; f++)
+                        featureCols[f] = ReadColumnByName<double[]>(groupReader, fieldsByName, PIN_FEATURE_NAMES[f]);
+                }
 
                 int rowCount = entryIdCol.Length;
                 for (int row = 0; row < rowCount; row++)
                 {
-                    var features = new double[NUM_PIN_FEATURES];
-                    for (int f = 0; f < NUM_PIN_FEATURES; f++)
+                    double[] features = null;
+                    if (!scalarsOnly)
                     {
-                        double v = featureCols[f] != null ? featureCols[f][row] : 0.0;
-                        features[f] = double.IsNaN(v) || double.IsInfinity(v) ? 0.0 : v;
+                        features = new double[NUM_PIN_FEATURES];
+                        for (int f = 0; f < NUM_PIN_FEATURES; f++)
+                        {
+                            double v = featureCols[f] != null ? featureCols[f][row] : 0.0;
+                            features[f] = double.IsNaN(v) || double.IsInfinity(v) ? 0.0 : v;
+                        }
                     }
 
                     List<CwtCandidate> cwt = null;

--- a/pwiz_tools/Osprey/Osprey.Tasks/FirstJoinTask.cs
+++ b/pwiz_tools/Osprey/Osprey.Tasks/FirstJoinTask.cs
@@ -484,6 +484,18 @@ namespace pwiz.Osprey.Tasks
             // survivor source and empties it again after that file's reconciled parquet
             // is written. Without this the 88.9 M entries stay live for the whole rescore
             // - 28 GB across 5.5 hours at 163 files, issue #4526.
+            // The post-compaction counterpart of the pre-compaction resident-pool guard: taking
+            // the resident handoff has to be NAMED, exactly as forcing the legacy first-pass
+            // pool does. Checked here because this is where the decision is made, and BEFORE
+            // the release so a refused run fails with an actionable message rather than an OOM
+            // five hours into Stage 6.
+            string handoffError = PerFileScoringTask.Stage6ResidentHandoffGuardError(
+                _survivorLoader != null && !config.StopAfterStage5,
+                OspreyEnvironment.Stage6StreamSurvivors,
+                OspreyEnvironment.AllowUnfixedResident);
+            if (handoffError != null)
+                throw new InvalidOperationException(handoffError);
+
             if (OspreyEnvironment.Stage6StreamSurvivors && _survivorLoader != null && !config.StopAfterStage5)
             {
                 foreach (var kvp in perFileEntries)

--- a/pwiz_tools/Osprey/Osprey.Tasks/FirstJoinTask.cs
+++ b/pwiz_tools/Osprey/Osprey.Tasks/FirstJoinTask.cs
@@ -106,7 +106,7 @@ namespace pwiz.Osprey.Tasks
             typeof(PerFileConsensusTargets), typeof(ReconciliationActions),
             typeof(RefinedCalibrations), typeof(PerFileGapFillForRescore),
             typeof(CompactedEntries), typeof(PlanningPerformed),
-            typeof(ProteinCompactStratum)
+            typeof(ProteinCompactStratum), typeof(FirstPassSurvivorSource)
         };
 
         // Stage 6 planning state. Set by PlanStage6 (Run) and published into the
@@ -124,6 +124,13 @@ namespace pwiz.Osprey.Tasks
         // protein peptides that did not individually pass 1st-pass FDR (so they get
         // reconciled + rescored + reported). Null unless OSPREY_PASS2_QVALUE=protein-compact.
         private HashSet<uint> _proteinCompactStratum;
+
+        // Rebuilds any one file's survivors from its .scores.parquet + finalized
+        // 1st-pass sidecar, so a per-file consumer never needs the all-files buffer
+        // (issue #4526). Set on the projection path, which is the only one that
+        // computes the passing base_id set here; null on the legacy resident and
+        // rehydrate paths, whose consumers fall back to CompactedEntries.
+        private FirstPassSurvivorLoader _survivorLoader;
         private IReadOnlyDictionary<string, IReadOnlyList<(int Index, double Apex, double Start, double End)>> _perFileConsensusTargets
             = new Dictionary<string, IReadOnlyList<(int, double, double, double)>>();
         private IReadOnlyDictionary<(string FileName, int Index), ReconcileAction> _reconciliationActions
@@ -470,6 +477,26 @@ namespace pwiz.Osprey.Tasks
                     return false;
             }
 
+            // Reconciliation planning was the last consumer that needs every file's
+            // survivors at once. Drop the CONTENTS now, keeping the outer per-file list
+            // (the shared buffer identity every milestone wraps) so nothing downstream
+            // has to learn a new shape: Stage 6 refills one file at a time from the
+            // survivor source and empties it again after that file's reconciled parquet
+            // is written. Without this the 88.9 M entries stay live for the whole rescore
+            // - 28 GB across 5.5 hours at 163 files, issue #4526.
+            if (OspreyEnvironment.Stage6StreamSurvivors && _survivorLoader != null && !config.StopAfterStage5)
+            {
+                foreach (var kvp in perFileEntries)
+                {
+                    ctx.LogInfo(string.Format(@"[4526-DBG] release {0}: {1} entries", kvp.Key, kvp.Value.Count));
+                    kvp.Value.Clear();
+                    kvp.Value.TrimExcess();
+                }
+                ProfilerHooks.LogManagedHeapAfterGcIfEnabled(ctx.LogInfo, @"stage5-handoff-released",
+                    string.Format(@"(post-GC, survivors released after planning, files={0})",
+                        perFileEntries.Count));
+            }
+
             // Publish the Stage 6 planning byproducts (computed values, or the
             // empty defaults when PlanStage6 was skipped / stopped after Stage
             // 5), plus the CompactedEntries milestone of the shared buffer that
@@ -480,6 +507,9 @@ namespace pwiz.Osprey.Tasks
             ctx.Publish(new RefinedCalibrations(_refinedCalibrations));
             ctx.Publish(new PerFileGapFillForRescore(_perFileGapFillForRescore));
             ctx.Publish(new CompactedEntries(perFileEntries));
+            // Null off the projection path (legacy resident / rehydrate), where a
+            // consumer falls back to the buffer above.
+            ctx.Publish(new FirstPassSurvivorSource(_survivorLoader));
             // PlanStage6 (above) sets _didPlan only when the planning block ran;
             // publish it so PerFileRescore reads the gate from the registry
             // instead of reaching for this concrete task.
@@ -554,6 +584,9 @@ namespace pwiz.Osprey.Tasks
             ctx.Publish(new PerFileGapFillForRescore(bundle.PerFileGapFill));
             ctx.Publish(new PerFileConsensusTargets(ConsensusTargetsFromBundle(ctx, bundle)));
             ctx.Publish(new CompactedEntries(perFileEntries));
+            // Null off the projection path (legacy resident / rehydrate), where a
+            // consumer falls back to the buffer above.
+            ctx.Publish(new FirstPassSurvivorSource(_survivorLoader));
             // The bundle-adopt / resume path never plans, so the rescore gate is
             // false (PerFileRescore falls back to the no-op unless a worker
             // RescoreBundle is present). Mirrors the old "FirstJoin rehydrates ->
@@ -2271,7 +2304,11 @@ namespace pwiz.Osprey.Tasks
             OspreyConfig config,
             PipelineContext ctx)
         {
-            var loader = new FirstPassSurvivorLoader(perFileParquetPaths, config, firstPassBaseIds);
+            // Keep the loader for the byproduct: Stage 6 and Stage 7 use it to rebuild a
+            // file's survivors on demand rather than reading them off a buffer somebody
+            // had to hold for the whole run.
+            var loader = _survivorLoader =
+                new FirstPassSurvivorLoader(perFileParquetPaths, config, firstPassBaseIds);
             var survivors = new List<KeyValuePair<string, List<FdrEntry>>>(projections.PerFile.Count);
             // Per-file progress: reloading each file's survivor stubs from parquet + the 1st-pass
             // sidecar was the ~70 s silent "First-pass compaction" gap at 82 files. Console-only.

--- a/pwiz_tools/Osprey/Osprey.Tasks/FirstJoinTask.cs
+++ b/pwiz_tools/Osprey/Osprey.Tasks/FirstJoinTask.cs
@@ -1131,7 +1131,7 @@ namespace pwiz.Osprey.Tasks
             foreach (var kvp in perFileEntries)
             {
                 string fileName = kvp.Key;
-                string sidecarBase = ResolveSidecarBasePath(fileName, perFileParquetPaths, config);
+                string sidecarBase = ScoringTaskShared.ResolveSidecarBasePath(fileName, perFileParquetPaths, config);
                 if (string.IsNullOrEmpty(sidecarBase))
                 {
                     ctx.LogWarning(string.Format(
@@ -1298,7 +1298,7 @@ namespace pwiz.Osprey.Tasks
                 string fileName = kvp.Key;
                 var fileEntries = kvp.Value;
 
-                string sidecarBase = ResolveSidecarBasePath(fileName, perFileParquetPaths, config);
+                string sidecarBase = ScoringTaskShared.ResolveSidecarBasePath(fileName, perFileParquetPaths, config);
                 if (string.IsNullOrEmpty(sidecarBase))
                 {
                     ctx.LogWarning(string.Format(
@@ -1335,46 +1335,6 @@ namespace pwiz.Osprey.Tasks
             return failures;
         }
 
-        /// <summary>
-        /// Resolve a path whose stem matches <paramref name="fileName"/>, used
-        /// only as the base for sidecar file naming (the path itself need
-        /// not exist). In normal mode this is the input mzML; in
-        /// --task FirstPassFDR mode where InputFiles is empty we synthesize the
-        /// path from the matching .scores.parquet by replacing the
-        /// `.scores.parquet` suffix with `.mzML`. Mirrors the Rust
-        /// `synthetic_input_from_parquet` helper.
-        /// </summary>
-        private static string ResolveSidecarBasePath(
-            string fileName,
-            IReadOnlyDictionary<string, string> perFileParquetPaths,
-            OspreyConfig config)
-        {
-            // Normal mode: prefer the actual input mzML path so sidecars
-            // land next to the source mzML.
-            if (config.InputFiles != null)
-            {
-                foreach (string inputPath in config.InputFiles)
-                {
-                    if (string.Equals(
-                        Path.GetFileNameWithoutExtension(inputPath),
-                        fileName,
-                        StringComparison.Ordinal))
-                    {
-                        return inputPath;
-                    }
-                }
-            }
-            // --task FirstPassFDR fallback: derive a synthetic mzML path from the
-            // matching parquet stem so all the existing sidecar path
-            // helpers keep working without conditional branches.
-            if (perFileParquetPaths != null
-                && perFileParquetPaths.TryGetValue(fileName, out string parquetPath))
-            {
-                string parent = Path.GetDirectoryName(parquetPath) ?? ".";
-                return Path.Combine(parent, fileName + ".mzML");
-            }
-            return null;
-        }
 
         /// <summary>
         /// Convert pre-grouped reconciliation actions for one file into
@@ -1817,7 +1777,7 @@ namespace pwiz.Osprey.Tasks
             // StopAfterStage5 gate. Phase 2 patches [52..60] after protein FDR (below).
             int FlushPartialSidecar(string fileName, IReadOnlyList<FdrScoreRecord> records)
             {
-                string sidecarBase = ResolveSidecarBasePath(fileName, perFileParquetPaths, config);
+                string sidecarBase = ScoringTaskShared.ResolveSidecarBasePath(fileName, perFileParquetPaths, config);
                 if (string.IsNullOrEmpty(sidecarBase))
                 {
                     ctx.LogWarning(string.Format(
@@ -2107,7 +2067,7 @@ namespace pwiz.Osprey.Tasks
             {
                 patchProgress.Report(++proteinPatchFiles);
                 string fileName = kvp.Key;
-                string sidecarBase = ResolveSidecarBasePath(fileName, perFileParquetPaths, config);
+                string sidecarBase = ScoringTaskShared.ResolveSidecarBasePath(fileName, perFileParquetPaths, config);
                 if (string.IsNullOrEmpty(sidecarBase))
                     continue;  // no on-disk sidecar to patch (phase 1 already counted it)
                 string parquetPath = perFileParquetPaths[fileName];  // present: pass 1 read it
@@ -2172,7 +2132,7 @@ namespace pwiz.Osprey.Tasks
                 ctx.ExitCode = 1;
                 return false;
             }
-            string sidecarBase = ResolveSidecarBasePath(fileName, perFileParquetPaths, config);
+            string sidecarBase = ScoringTaskShared.ResolveSidecarBasePath(fileName, perFileParquetPaths, config);
             if (string.IsNullOrEmpty(sidecarBase))
             {
                 ctx.LogError(string.Format(
@@ -2252,7 +2212,7 @@ namespace pwiz.Osprey.Tasks
             {
                 compactProgress.Report(++compactFiles);
                 string fileName = kvp.Key;
-                string sidecarBase = ResolveSidecarBasePath(fileName, perFileParquetPaths, config);
+                string sidecarBase = ScoringTaskShared.ResolveSidecarBasePath(fileName, perFileParquetPaths, config);
                 if (string.IsNullOrEmpty(sidecarBase))
                 {
                     ctx.LogError(string.Format(
@@ -2291,19 +2251,18 @@ namespace pwiz.Osprey.Tasks
         }
 
         /// <summary>
-        /// Reload full <see cref="FdrEntry"/> survivors for the projection path. For
-        /// each file: load the full stub set from the ORIGINAL parquet
-        /// (<see cref="ParquetScoreCache.LoadFdrStubsFromParquet"/>, which re-assigns
-        /// <see cref="FdrEntry.ParquetIndex"/> = row -- risk #9), overlay the
-        /// just-written 1st-pass sidecar onto that superset (the loader's TryRead
-        /// requires the stub list to be a superset of the sidecar records), drop
-        /// non-survivors with the same base_id predicate <c>RemoveAll</c> the legacy
-        /// path uses, and canonicalize the order with the full
-        /// (EntryId, Charge, ScanNumber, ParquetIndex) comparer so the survivor
-        /// buffer is byte-order-identical to the legacy post-Percolator-sort +
-        /// compaction buffer. Returns <c>null</c> (ExitCode set) on any missing
-        /// parquet path or failed sidecar overlay -- both genuine faults here, since
-        /// this task just wrote the sidecar.
+        /// Reload full <see cref="FdrEntry"/> survivors for the projection path, one
+        /// file at a time through <see cref="FirstPassSurvivorLoader"/>, and collect
+        /// them into the all-files buffer Stage 6 and Stage 7 read today.
+        ///
+        /// <para>The per-file load is the reusable half and lives on the loader; the
+        /// collection into one list is the O(files) half this method still performs.
+        /// Keeping them separate is what lets a consumer take the loader alone and
+        /// never build the buffer - the direction issue #4526 is headed.</para>
+        ///
+        /// <para>Returns <c>null</c> (ExitCode set) on any missing parquet path or
+        /// failed sidecar overlay - both genuine faults here, since this task just
+        /// wrote the sidecar.</para>
         /// </summary>
         private List<KeyValuePair<string, List<FdrEntry>>> ReloadFirstPassSurvivors(
             FdrProjectionSet projections,
@@ -2312,6 +2271,7 @@ namespace pwiz.Osprey.Tasks
             OspreyConfig config,
             PipelineContext ctx)
         {
+            var loader = new FirstPassSurvivorLoader(perFileParquetPaths, config, firstPassBaseIds);
             var survivors = new List<KeyValuePair<string, List<FdrEntry>>>(projections.PerFile.Count);
             // Per-file progress: reloading each file's survivor stubs from parquet + the 1st-pass
             // sidecar was the ~70 s silent "First-pass compaction" gap at 82 files. Console-only.
@@ -2323,53 +2283,13 @@ namespace pwiz.Osprey.Tasks
             {
                 reloadProgress.Report(++reloadDone);
                 string fileName = kvp.Key;
-                if (!perFileParquetPaths.TryGetValue(fileName, out string parquetPath))
+                var stubs = loader.Load(fileName, out string error);
+                if (stubs == null)
                 {
-                    ctx.LogError(string.Format(
-                        @"Projection survivor reload: no scores parquet path for {0}", fileName));
+                    ctx.LogError(error);
                     ctx.ExitCode = 1;
                     return null;
                 }
-
-                List<FdrEntry> stubs;
-                try
-                {
-                    stubs = ParquetScoreCache.LoadFdrStubsFromParquet(parquetPath);
-                }
-                catch (Exception ex)
-                {
-                    ctx.LogError(string.Format(
-                        @"Projection survivor reload: failed to load stubs from {0}: {1}",
-                        parquetPath, ex.Message));
-                    ctx.ExitCode = 1;
-                    return null;
-                }
-
-                // Overlay the 1st-pass sidecar onto the FULL stub set (superset
-                // contract) BEFORE filtering to survivors.
-                string sidecarBase = ResolveSidecarBasePath(fileName, perFileParquetPaths, config);
-                string pass1Path = FdrScoresSidecar.Pass1Path(sidecarBase);
-                if (!FdrScoresSidecar.TryRead(pass1Path, stubs, FdrScoresSidecar.Pass.FirstPass))
-                {
-                    ctx.LogError(string.Format(
-                        @"Projection survivor reload: failed to overlay .1st-pass.fdr_scores.bin for {0} " +
-                        @"(expected at {1})", fileName, pass1Path));
-                    ctx.ExitCode = 1;
-                    return null;
-                }
-
-                stubs.RemoveAll(e => !firstPassBaseIds.Contains(e.EntryId & ScoringTaskShared.BASE_ID_MASK));
-                stubs.TrimExcess();
-                stubs.Sort((a, b) => // Array.Sort OK: terminal key ParquetIndex is unique per reloaded stub, so the comparator never ties.
-                {
-                    int c = a.EntryId.CompareTo(b.EntryId);
-                    if (c != 0) return c;
-                    c = a.Charge.CompareTo(b.Charge);
-                    if (c != 0) return c;
-                    c = a.ScanNumber.CompareTo(b.ScanNumber);
-                    if (c != 0) return c;
-                    return a.ParquetIndex.CompareTo(b.ParquetIndex);
-                });
                 survivors.Add(new KeyValuePair<string, List<FdrEntry>>(fileName, stubs));
             }
             reloadProgress.Dispose();

--- a/pwiz_tools/Osprey/Osprey.Tasks/FirstJoinTask.cs
+++ b/pwiz_tools/Osprey/Osprey.Tasks/FirstJoinTask.cs
@@ -488,7 +488,6 @@ namespace pwiz.Osprey.Tasks
             {
                 foreach (var kvp in perFileEntries)
                 {
-                    ctx.LogInfo(string.Format(@"[4526-DBG] release {0}: {1} entries", kvp.Key, kvp.Value.Count));
                     kvp.Value.Clear();
                     kvp.Value.TrimExcess();
                 }

--- a/pwiz_tools/Osprey/Osprey.Tasks/FirstPassSurvivorLoader.cs
+++ b/pwiz_tools/Osprey/Osprey.Tasks/FirstPassSurvivorLoader.cs
@@ -50,20 +50,6 @@ namespace pwiz.Osprey.Tasks
     /// </summary>
     internal sealed class FirstPassSurvivorLoader
     {
-        // Canonical survivor order, matching the legacy post-Percolator-sort +
-        // compaction buffer. Array.Sort is safe with this comparison because the
-        // terminal key ParquetIndex is unique per reloaded stub, so it never ties.
-        private static readonly Comparison<FdrEntry> s_survivorOrder = (a, b) =>
-        {
-            int c = a.EntryId.CompareTo(b.EntryId);
-            if (c != 0) return c;
-            c = a.Charge.CompareTo(b.Charge);
-            if (c != 0) return c;
-            c = a.ScanNumber.CompareTo(b.ScanNumber);
-            if (c != 0) return c;
-            return a.ParquetIndex.CompareTo(b.ParquetIndex);
-        };
-
         private readonly IReadOnlyDictionary<string, string> _perFileParquetPaths;
         private readonly OspreyConfig _config;
         private readonly HashSet<uint> _firstPassBaseIds;
@@ -130,7 +116,7 @@ namespace pwiz.Osprey.Tasks
 
             stubs.RemoveAll(e => !_firstPassBaseIds.Contains(e.EntryId & ScoringTaskShared.BASE_ID_MASK));
             stubs.TrimExcess();
-            stubs.Sort(s_survivorOrder); // Array.Sort OK: terminal key ParquetIndex is unique per reloaded stub, so the comparator never ties.
+            stubs.Sort(FdrEntry.CANONICAL_ORDER); // Array.Sort OK: CANONICAL_ORDER's terminal key ParquetIndex is unique per reloaded stub, so the comparison never ties
             return stubs;
         }
     }

--- a/pwiz_tools/Osprey/Osprey.Tasks/FirstPassSurvivorLoader.cs
+++ b/pwiz_tools/Osprey/Osprey.Tasks/FirstPassSurvivorLoader.cs
@@ -1,0 +1,137 @@
+/*
+ * Original author: Brendan MacLean <brendanx .at. uw.edu>,
+ *                  MacCoss Lab, Department of Genome Sciences, UW
+ * AI assistance: Claude Code (Claude Opus 5) <noreply .at. anthropic.com>
+ *
+ * Based on osprey (https://github.com/MacCossLab/osprey)
+ *   by Michael J. MacCoss, MacCoss Lab, Department of Genome Sciences, UW
+ *
+ * Copyright 2026 University of Washington - Seattle, WA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
+using System.Collections.Generic;
+using pwiz.Osprey.Core;
+using pwiz.Osprey.IO;
+
+namespace pwiz.Osprey.Tasks
+{
+    /// <summary>
+    /// Loads ONE file's post-compaction first-pass survivors from that file's
+    /// original <c>.scores.parquet</c> plus its finalized
+    /// <c>.1st-pass.fdr_scores.bin</c> sidecar, filtered to a passing base_id set.
+    ///
+    /// <para>Both artifacts are on disk for every file by the time Stage 5 compacts,
+    /// so a survivor list can be rebuilt at any later point without holding it. That
+    /// is the whole point of this type: the all-files survivor buffer is the O(files)
+    /// resident structure that costs 28 GB at 163 files (issue #4526), and every
+    /// consumer of it reads one file at a time. Extracting the per-file load gives
+    /// those consumers a source they can call per file instead of indexing into a
+    /// buffer somebody else had to materialize.</para>
+    ///
+    /// <para>The load is byte-order-identical to the legacy in-place compaction:
+    /// <see cref="FdrEntry.ParquetIndex"/> comes from the ORIGINAL parquet (row
+    /// ordinal), the sidecar is overlaid onto the FULL stub set before filtering
+    /// (the superset contract <see cref="FdrScoresSidecar.TryRead"/> requires), and
+    /// the result is sorted by the canonical (EntryId, Charge, ScanNumber,
+    /// ParquetIndex) key. Callers must not re-order it.</para>
+    /// </summary>
+    internal sealed class FirstPassSurvivorLoader
+    {
+        // Canonical survivor order, matching the legacy post-Percolator-sort +
+        // compaction buffer. Array.Sort is safe with this comparison because the
+        // terminal key ParquetIndex is unique per reloaded stub, so it never ties.
+        private static readonly Comparison<FdrEntry> s_survivorOrder = (a, b) =>
+        {
+            int c = a.EntryId.CompareTo(b.EntryId);
+            if (c != 0) return c;
+            c = a.Charge.CompareTo(b.Charge);
+            if (c != 0) return c;
+            c = a.ScanNumber.CompareTo(b.ScanNumber);
+            if (c != 0) return c;
+            return a.ParquetIndex.CompareTo(b.ParquetIndex);
+        };
+
+        private readonly IReadOnlyDictionary<string, string> _perFileParquetPaths;
+        private readonly OspreyConfig _config;
+        private readonly HashSet<uint> _firstPassBaseIds;
+
+        /// <param name="perFileParquetPaths">file name -> its original
+        /// <c>.scores.parquet</c>, the same map Stage 5 resolves sidecar paths from.</param>
+        /// <param name="config">Run config, for the sidecar base-path resolution.</param>
+        /// <param name="firstPassBaseIds">The passing base_id set the compaction gate
+        /// produced. Small (446 K uints at 163 files) and shared across every file, so
+        /// holding it costs nothing next to the survivor lists it selects.</param>
+        internal FirstPassSurvivorLoader(
+            IReadOnlyDictionary<string, string> perFileParquetPaths,
+            OspreyConfig config,
+            HashSet<uint> firstPassBaseIds)
+        {
+            _perFileParquetPaths = perFileParquetPaths;
+            _config = config;
+            _firstPassBaseIds = firstPassBaseIds;
+        }
+
+        /// <summary>
+        /// Load one file's survivors. Returns null with <paramref name="error"/> set
+        /// on any missing path or failed sidecar overlay; those are genuine faults
+        /// rather than absences, because Stage 5 just wrote both artifacts. The
+        /// caller owns logging and the exit code, so this type stays free of
+        /// <see cref="PipelineContext"/>.
+        /// </summary>
+        internal List<FdrEntry> Load(string fileName, out string error)
+        {
+            error = null;
+            if (_perFileParquetPaths == null ||
+                !_perFileParquetPaths.TryGetValue(fileName, out string parquetPath))
+            {
+                error = string.Format(
+                    @"First-pass survivor load: no scores parquet path for {0}", fileName);
+                return null;
+            }
+
+            List<FdrEntry> stubs;
+            try
+            {
+                stubs = ParquetScoreCache.LoadFdrStubsFromParquet(parquetPath);
+            }
+            catch (Exception ex)
+            {
+                error = string.Format(
+                    @"First-pass survivor load: failed to load stubs from {0}: {1}",
+                    parquetPath, ex.Message);
+                return null;
+            }
+
+            // Overlay the 1st-pass sidecar onto the FULL stub set (superset contract)
+            // BEFORE filtering to survivors.
+            string sidecarBase = ScoringTaskShared.ResolveSidecarBasePath(
+                fileName, _perFileParquetPaths, _config);
+            string pass1Path = FdrScoresSidecar.Pass1Path(sidecarBase);
+            if (!FdrScoresSidecar.TryRead(pass1Path, stubs, FdrScoresSidecar.Pass.FirstPass))
+            {
+                error = string.Format(
+                    @"First-pass survivor load: failed to overlay .1st-pass.fdr_scores.bin for {0} " +
+                    @"(expected at {1})", fileName, pass1Path);
+                return null;
+            }
+
+            stubs.RemoveAll(e => !_firstPassBaseIds.Contains(e.EntryId & ScoringTaskShared.BASE_ID_MASK));
+            stubs.TrimExcess();
+            stubs.Sort(s_survivorOrder); // Array.Sort OK: terminal key ParquetIndex is unique per reloaded stub, so the comparator never ties.
+            return stubs;
+        }
+    }
+}

--- a/pwiz_tools/Osprey/Osprey.Tasks/PerFileRescoreTask.cs
+++ b/pwiz_tools/Osprey/Osprey.Tasks/PerFileRescoreTask.cs
@@ -252,8 +252,25 @@ namespace pwiz.Osprey.Tasks
                     }
                 }
             }
+            // Non-null only when FirstJoin released the survivor contents after planning
+            // (issue #4526). Every exit from here on has to leave the RescoredEntries
+            // milestone holding a full buffer, because that is what MergeNode reads -
+            // so each return below refills it first.
+            var survivorLoader = StreamedSurvivorLoader(ctx);
+
             if (!didPlan && (rescoreBundle == null || anyPass2Present))
+            {
+                // No rescore to run, so the post-rescore state is just the survivors plus
+                // whatever reconciled parquets are already on disk - the same thing the
+                // resume Rehydrate reconstructs.
+                if (survivorLoader != null)
+                {
+                    if (!MaterializeAllSurvivors(survivorLoader, ctx))
+                        return false;
+                    OverlayReconciledIntoAllFiles(_perFileEntries, ctx);
+                }
                 return true;
+            }
 
             // Per-file sidecar lifecycle (delete-before / write-after) is
             // handled inside ExecuteRescore's loop so a per-file skip can
@@ -295,10 +312,23 @@ namespace pwiz.Osprey.Tasks
                 ctx.Get<FullLibrary>().Value,
                 ctx.Config,
                 ctx,
-                joinFileStems);
+                joinFileStems,
+                survivorLoader);
             ctx.LogInfo(string.Format(
                 @"Reconciliation rescore: {0} entries re-scored ({1} reconciliation actions executed)",
                 rescoreStats.TotalRescored, rescoreStats.TotalReconciliation));
+
+            // The streamed loop emptied every file's list again as it went, so rebuild the
+            // buffer MergeNode reads. Reading it back from the reconciled parquets - rather
+            // than keeping it live through the loop - is the whole point: it is resident
+            // from here to the end of Stage 7 instead of for the entire rescore. Identical
+            // to what the resume path reconstructs, which regression.ps1 mode 2 gates.
+            if (survivorLoader != null)
+            {
+                if (!MaterializeAllSurvivors(survivorLoader, ctx))
+                    return false;
+                OverlayReconciledIntoAllFiles(_perFileEntries, ctx);
+            }
 
             // Cross-impl bisection seam: dump per-precursor state
             // immediately after the rescore loop. Mirrors Rust's
@@ -383,38 +413,14 @@ namespace pwiz.Osprey.Tasks
                 // RTs into the final blib instead of the Stage 6 reconciled values.
                 // Files with no reconciled sibling on disk are no-work files; a fresh
                 // run leaves their entries at 1st-pass too, so they are left unchanged.
-                var gapFill = ctx.Get<PerFileGapFillForRescore>().Value;
-                var parquetPaths = ctx.Get<PerFileParquetPaths>().Value;
-                foreach (var kv in _perFileEntries)
-                {
-                    // Overlay each file's reconciled boundaries when its
-                    // .scores-reconciled.parquet is present; no-work files (none on
-                    // disk) keep their 1st-pass boundaries, matching a fresh run.
-                    if (parquetPaths != null &&
-                        parquetPaths.TryGetValue(kv.Key, out string scoresPath))
-                    {
-                        string reconciledPath = ParquetScoreCache.ReconciledPathFromScoresPath(scoresPath);
-                        if (File.Exists(reconciledPath))
-                        {
-                            IReadOnlyList<GapFillTarget> gapFillForFile = null;
-                            if (gapFill != null && gapFill.TryGetValue(kv.Key, out var gfList))
-                                gapFillForFile = gfList;
-                            OverlayReconciledIntoBuffer(kv.Value, reconciledPath, gapFillForFile);
-                        }
-                    }
-                    // Canonical sort for EVERY file (incl. no-work files) so the WARM
-                    // buffer order matches the order COLD establishes in
-                    // RunPercolatorFdr, independent of whether the file was rescored.
-                    SortFileEntriesCanonical(kv.Value);
-                    // Same release the rescore path does once a file's reconciled parquet is
-                    // on disk: the overlay above re-fattened this file's entries straight
-                    // from that parquet, and holding those arrays for every file is the
-                    // O(files) Stage-6 growth term. A no-work file was never fattened, so
-                    // this is a no-op there. Nothing downstream reads them off the buffer -
-                    // MergeNode's 2nd pass reloads PIN features from the reconciled parquet
-                    // by identity - and this leaves the same buffer shape COLD leaves.
-                    ReleaseRescoredPayload(kv.Value);
-                }
+                //
+                // Refill first when Stage 5 released the survivors (issue #4526). A resume
+                // that re-runs Stage 5 lands here with an EMPTY buffer, and overlaying onto
+                // empty lists produces an almost-empty blib instead of failing.
+                var resumeLoader = StreamedSurvivorLoader(ctx);
+                if (resumeLoader != null && !MaterializeAllSurvivors(resumeLoader, ctx))
+                    return false;
+                OverlayReconciledIntoAllFiles(_perFileEntries, ctx);
 
                 ctx.Publish(new RescoredEntries(_perFileEntries));
                 return true;
@@ -516,7 +522,8 @@ namespace pwiz.Osprey.Tasks
             List<LibraryEntry> fullLibrary,
             OspreyConfig config,
             PipelineContext ctx,
-            IReadOnlyList<string> joinFileStems = null)
+            IReadOnlyList<string> joinFileStems = null,
+            FirstPassSurvivorLoader survivorLoader = null)
         {
             // Pre-group reconciliation actions by file so the per-file loop
             // below just looks up its slice.
@@ -567,10 +574,9 @@ namespace pwiz.Osprey.Tasks
             if (nTotalFiles == 1 || parallelism == 1)
             {
                 for (int fileNum = 0; fileNum < nTotalFiles; fileNum++)
-                    counts[fileNum] = RescoreOneFile(
-                        fileNum, nTotalFiles,
-                        perFileEntries[fileNum].Key, perFileEntries[fileNum].Value,
-                        inputs, ctx);
+                    counts[fileNum] = RescoreOneFileStreamed(
+                        fileNum, nTotalFiles, perFileEntries[fileNum],
+                        inputs, survivorLoader, ctx);
             }
             else
             {
@@ -593,10 +599,9 @@ namespace pwiz.Osprey.Tasks
                 Parallel.For(0, nTotalFiles, parallelOpts, fileNum =>
                 {
                     using (multi.BeginFile(fileNum, RESCORE_FILE_SEGMENTS))
-                        counts[fileNum] = RescoreOneFile(
-                            fileNum, nTotalFiles,
-                            perFileEntries[fileNum].Key, perFileEntries[fileNum].Value,
-                            inputs, ctx);
+                        counts[fileNum] = RescoreOneFileStreamed(
+                            fileNum, nTotalFiles, perFileEntries[fileNum],
+                            inputs, survivorLoader, ctx);
                 });
             }
 
@@ -647,6 +652,51 @@ namespace pwiz.Osprey.Tasks
             public Dictionary<string, int> FileNameToIdx;
             public string TaskValidityKey;
             public IReadOnlyList<string> JoinFileStems;
+        }
+
+        /// <summary>
+        /// Bracket one file's <see cref="RescoreOneFile"/> with the survivor refill and
+        /// release when Stage 6 is streaming (issue #4526), or call straight through when
+        /// the resident buffer is in use.
+        ///
+        /// <para>The refill targets the file's EXISTING list object rather than replacing
+        /// it, because that list is the shared backing store every
+        /// <see cref="PerFileEntries"/> milestone wraps - swapping the reference would
+        /// leave the published milestones pointing at the old one. Contents are transient;
+        /// identity is not.</para>
+        ///
+        /// <para>Safe under the parallel file loop: each call touches only its own file's
+        /// list, and the loader holds no per-file state.</para>
+        /// </summary>
+        private (int Rescored, int GapCwt, int GapForced) RescoreOneFileStreamed(
+            int fileNum, int nTotalFiles, KeyValuePair<string, List<FdrEntry>> file,
+            RescorePassInputs inputs, FirstPassSurvivorLoader survivorLoader, PipelineContext ctx)
+        {
+            if (survivorLoader == null)
+                return RescoreOneFile(fileNum, nTotalFiles, file.Key, file.Value, inputs, ctx);
+
+            var stubs = survivorLoader.Load(file.Key, out string error);
+            if (stubs == null)
+            {
+                // Stage 5 wrote both artifacts, so this is a fault. Throwing (rather than
+                // returning zero counts) keeps a file that could not be rescored from
+                // silently contributing nothing to the totals.
+                throw new InvalidDataException(error);
+            }
+            ctx.LogInfo(string.Format(@"[4526-DBG] refill {0}: {1} entries", file.Key, stubs.Count));
+            file.Value.Clear();
+            file.Value.AddRange(stubs);
+            try
+            {
+                return RescoreOneFile(fileNum, nTotalFiles, file.Key, file.Value, inputs, ctx);
+            }
+            finally
+            {
+                // Drop this file's entries before the next one loads its own. The rebuild
+                // after the loop reads them back from the reconciled parquet.
+                file.Value.Clear();
+                file.Value.TrimExcess();
+            }
         }
 
         /// <summary>
@@ -1428,6 +1478,96 @@ namespace pwiz.Osprey.Tasks
             // The canonical (EntryId, Charge, ScanNumber, ParquetIndex) re-sort is
             // applied by the CALLER via SortFileEntriesCanonical -- it runs for every
             // file in the resume path, not only files with a reconciled parquet.
+        }
+
+        /// <summary>
+        /// The loader Stage 6 refills from, or null when this run keeps the resident
+        /// buffer. Non-null requires BOTH that FirstJoin published a source (only the
+        /// projection path computes the passing base_id set it needs) and that streaming
+        /// is enabled, which is what <c>OSPREY_STAGE6_STREAM_SURVIVORS=0</c> turns off to
+        /// get the resident A/B oracle back.
+        /// </summary>
+        private static FirstPassSurvivorLoader StreamedSurvivorLoader(PipelineContext ctx)
+        {
+            if (!OspreyEnvironment.Stage6StreamSurvivors)
+                return null;
+            return ctx.TryGet<FirstPassSurvivorSource>(out var source) ? source?.Value : null;
+        }
+
+        /// <summary>
+        /// Refill every file whose survivor list was released, leaving files that already
+        /// hold entries untouched so a second call is a no-op. Returns false (ExitCode
+        /// set) if any file's parquet or 1st-pass sidecar cannot be read - Stage 5 wrote
+        /// both, so a failure here is a fault rather than an absence.
+        /// </summary>
+        private bool MaterializeAllSurvivors(FirstPassSurvivorLoader loader, PipelineContext ctx)
+        {
+            foreach (var kv in _perFileEntries)
+            {
+                if (kv.Value.Count > 0)
+                    continue;
+                var stubs = loader.Load(kv.Key, out string error);
+                if (stubs == null)
+                {
+                    ctx.LogError(error);
+                    ctx.ExitCode = 1;
+                    return false;
+                }
+                kv.Value.AddRange(stubs);
+                ctx.LogInfo(string.Format(@"[4526-DBG] rebuild {0}: {1} entries", kv.Key, stubs.Count));
+            }
+            return true;
+        }
+
+        /// <summary>
+        /// Bring EVERY file's list to its post-rescore state by overlaying that file's
+        /// <c>.scores-reconciled.parquet</c>, canonicalizing the order, and releasing the
+        /// re-fattened payload. This is the state a fresh <see cref="ExecuteRescore"/>
+        /// leaves behind, rebuilt from disk.
+        ///
+        /// <para>Two callers, one body. The resume <see cref="Rehydrate"/> uses it because
+        /// the driver skipped <see cref="Run"/> when the reconciled parquets were already
+        /// valid. The streamed rescore uses it because it deliberately dropped each file's
+        /// entries after writing that file's parquet, so the
+        /// <see cref="RescoredEntries"/> milestone MergeNode reads has to be rebuilt at
+        /// the end (issue #4526). Sharing the body is what makes the streamed buffer
+        /// identical to the resumed one, which mode 2 of regression.ps1 already gates.</para>
+        /// </summary>
+        private void OverlayReconciledIntoAllFiles(
+            List<KeyValuePair<string, List<FdrEntry>>> perFileEntries, PipelineContext ctx)
+        {
+            var gapFill = ctx.Get<PerFileGapFillForRescore>().Value;
+            var parquetPaths = ctx.Get<PerFileParquetPaths>().Value;
+            foreach (var kv in perFileEntries)
+            {
+                // Overlay each file's reconciled boundaries when its
+                // .scores-reconciled.parquet is present; no-work files (none on
+                // disk) keep their 1st-pass boundaries, matching a fresh run.
+                if (parquetPaths != null &&
+                    parquetPaths.TryGetValue(kv.Key, out string scoresPath))
+                {
+                    string reconciledPath = ParquetScoreCache.ReconciledPathFromScoresPath(scoresPath);
+                    if (File.Exists(reconciledPath))
+                    {
+                        IReadOnlyList<GapFillTarget> gapFillForFile = null;
+                        if (gapFill != null && gapFill.TryGetValue(kv.Key, out var gfList))
+                            gapFillForFile = gfList;
+                        OverlayReconciledIntoBuffer(kv.Value, reconciledPath, gapFillForFile);
+                    }
+                }
+                // Canonical sort for EVERY file (incl. no-work files) so the WARM
+                // buffer order matches the order COLD establishes in
+                // RunPercolatorFdr, independent of whether the file was rescored.
+                SortFileEntriesCanonical(kv.Value);
+                // Same release the rescore path does once a file's reconciled parquet is
+                // on disk: the overlay above re-fattened this file's entries straight
+                // from that parquet, and holding those arrays for every file is the
+                // O(files) Stage-6 growth term. A no-work file was never fattened, so
+                // this is a no-op there. Nothing downstream reads them off the buffer -
+                // MergeNode's 2nd pass reloads PIN features from the reconciled parquet
+                // by identity - and this leaves the same buffer shape COLD leaves.
+                ReleaseRescoredPayload(kv.Value);
+            }
         }
 
         /// <summary>

--- a/pwiz_tools/Osprey/Osprey.Tasks/PerFileRescoreTask.cs
+++ b/pwiz_tools/Osprey/Osprey.Tasks/PerFileRescoreTask.cs
@@ -22,7 +22,6 @@
  */
 
 using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
@@ -113,15 +112,6 @@ namespace pwiz.Osprey.Tasks
         // PerFileScoringTask.
         private List<KeyValuePair<string, List<FdrEntry>>> _perFileEntries;
 
-        // The gap-fill rows each streamed file's rescore appended, kept so the rebuild can
-        // put back exactly what the rescore produced. They are NOT recoverable from the
-        // reconciled parquet: the fresh buffer holds one row per (file, EntryId), so a
-        // gap-fill row is indistinguishable there from the survivor row for the same
-        // precursor. Cheap to keep - 390 rows across the 3-file Stellar set, and O(gap-fill
-        // targets) rather than O(survivors), which is the term this whole change is
-        // shedding. Written from the parallel per-file loop, so it must be concurrent.
-        private readonly ConcurrentDictionary<string, List<FdrEntry>> _streamedGapFill =
-            new ConcurrentDictionary<string, List<FdrEntry>>();
 
         public override string Name => @"PerFileRescoring";
 
@@ -345,7 +335,6 @@ namespace pwiz.Osprey.Tasks
                 // survives it.
                 ResetRescoredTargets(_perFileEntries, ctx);
                 OverlayReconciledIntoAllFiles(_perFileEntries, ctx, canonicalize: false);
-                AppendStreamedGapFill();
             }
 
             // Cross-impl bisection seam: dump per-precursor state
@@ -709,17 +698,6 @@ namespace pwiz.Osprey.Tasks
             }
             finally
             {
-                // Keep the gap-fill rows the rescore appended (ParquetIndex == uint.MaxValue
-                // is the marker it stamps on them) before dropping the rest. Everything else
-                // is rebuilt from the parquet after the loop; these are not.
-                var appended = new List<FdrEntry>();
-                foreach (var e in file.Value)
-                {
-                    if (e.ParquetIndex == uint.MaxValue)
-                        appended.Add(e);
-                }
-                _streamedGapFill[file.Key] = appended;
-
                 // Drop this file's entries before the next one loads its own.
                 file.Value.Clear();
                 file.Value.TrimExcess();
@@ -1425,11 +1403,13 @@ namespace pwiz.Osprey.Tasks
         /// <param name="gapFillForFile">The file's gap-fill targets, or null when it had none.</param>
         /// <param name="reproducingFreshRescore">TRUE on the streamed rebuild, which reconstructs
         /// the buffer a cold rescore left: carry the rescored ScanNumber, and append no gap-fill
-        /// (the caller replays the captured rows). FALSE on resume, which keeps the established
-        /// behaviour.</param>
+        /// and replay the appended gap-fill tail from disk. FALSE on resume, which keeps the
+        /// established behaviour.</param>
+        /// <param name="appendedTailStart">Row index in the reconciled parquet where the appended
+        /// gap-fill tail begins (the original parquet's row count).</param>
         private void OverlayReconciledIntoBuffer(List<FdrEntry> fileEntries,
             string reconciledPath, IReadOnlyList<GapFillTarget> gapFillForFile,
-            bool reproducingFreshRescore = false)
+            bool reproducingFreshRescore = false, int appendedTailStart = -1)
         {
             List<FdrEntry> loaded;
             try
@@ -1507,11 +1487,24 @@ namespace pwiz.Osprey.Tasks
             // are skipped -- a fresh run would not have appended a stub either.
             if (reproducingFreshRescore)
             {
-                // The caller re-appends the ACTUAL gap-fill rows the rescore produced (see
-                // _streamedGapFill). They cannot be rebuilt from the reconciled parquet by
-                // identity: the fresh buffer holds exactly one row per (file, EntryId), so a
-                // gap-fill row is indistinguishable there from the survivor row for the same
-                // precursor.
+                // Replay the appended gap-fill tail in its persisted row order. The reconciled
+                // parquet writes those rows after the original ones, so the order a fresh
+                // rescore produced - two scoring passes (CWT-hit, then forced), each appended
+                // as the scorer returned it - survives on disk.
+                //
+                // From DISK, not from rows carried out of the rescore: under
+                // --task PerFileRescoring each file is rescored in its own process, so a
+                // carried list is empty by the time the merge node needs it. Carrying them
+                // would also be an O(files) resident term (~270 MB at 163 files), which is the
+                // shape this change exists to remove.
+                for (int row = appendedTailStart; row >= 0 && row < loaded.Count; row++)
+                {
+                    var g = loaded[row];
+                    if (!existingIds.Add(g.EntryId))
+                        continue;
+                    g.ParquetIndex = uint.MaxValue;
+                    fileEntries.Add(g);
+                }
             }
             else if (gapFillForFile != null && gapFillForFile.Count > 0)
             {
@@ -1535,20 +1528,6 @@ namespace pwiz.Osprey.Tasks
             // file in the resume path, not only files with a reconciled parquet.
         }
 
-        /// <summary>
-        /// Put each streamed file's captured gap-fill rows back at the END of its list,
-        /// which is where the rescore appended them and where Stage 7 expects them.
-        /// </summary>
-        private void AppendStreamedGapFill()
-        {
-            if (_perFileEntries == null)
-                return;
-            foreach (var kv in _perFileEntries)
-            {
-                if (_streamedGapFill.TryGetValue(kv.Key, out var appended))
-                    kv.Value.AddRange(appended);
-            }
-        }
 
         /// <summary>
         /// The loader Stage 6 refills from, or null when this run keeps the resident
@@ -1695,7 +1674,9 @@ namespace pwiz.Osprey.Tasks
                         // Replay the appended gap-fill tail in row order when reproducing a
                         // fresh rescore; the original parquet's row count is where it starts.
                         OverlayReconciledIntoBuffer(kv.Value, reconciledPath, gapFillForFile,
-                            reproducingFreshRescore: !canonicalize);
+                            reproducingFreshRescore: !canonicalize,
+                            appendedTailStart: canonicalize ? -1
+                                : checked((int)ParquetScoreCache.ProbeCwtRowMetadata(scoresPath).RowCount));
                     }
                 }
                 // Canonical sort for EVERY file (incl. no-work files) so the WARM

--- a/pwiz_tools/Osprey/Osprey.Tasks/PerFileRescoreTask.cs
+++ b/pwiz_tools/Osprey/Osprey.Tasks/PerFileRescoreTask.cs
@@ -112,6 +112,10 @@ namespace pwiz.Osprey.Tasks
         // PerFileScoringTask.
         private List<KeyValuePair<string, List<FdrEntry>>> _perFileEntries;
 
+        // Admits one survivor refill at a time under the parallel file loop, so the
+        // pre-compaction transient each load holds is not multiplied by the file parallelism.
+        // See RescoreOneFileStreamed for why that trade is free.
+        private readonly object _survivorLoadLock = new object();
 
         public override string Name => @"PerFileRescoring";
 
@@ -186,10 +190,14 @@ namespace pwiz.Osprey.Tasks
             // outputs. Same shared suffix, so the two cannot disagree.
             // Same shared suffix for the 2nd-pass mode, for the same reason: this task writes the
             // per-file 2nd-pass sidecar, whose q-values ARE the mode's output.
+            // The Stage 6 handoff arm joins them: the streamed and resident arms are supposed
+            // to write byte-identical reconciled parquets, and an in-place A/B that silently
+            // adopted the other arm's outputs would report that identity without testing it.
             return base.ValidityKey(ctx)
                 + @";reconciliation=" + ctx.Config.Identity.ReconciliationParameterHash()
                 + OspreyEnvironment.ExperimentAggValidityKeySuffix()
-                + OspreyEnvironment.Pass2QValueValidityKeySuffix();
+                + OspreyEnvironment.Pass2QValueValidityKeySuffix()
+                + OspreyEnvironment.Stage6StreamSurvivorsValidityKeySuffix();
         }
 
         public override bool Run(PipelineContext ctx)
@@ -261,15 +269,16 @@ namespace pwiz.Osprey.Tasks
 
             if (!didPlan && (rescoreBundle == null || anyPass2Present))
             {
-                // No rescore to run, so the post-rescore state is just the survivors plus
-                // whatever reconciled parquets are already on disk - the same thing the
-                // resume Rehydrate reconstructs.
-                if (survivorLoader != null)
-                {
-                    if (!MaterializeAllSurvivors(survivorLoader, ctx))
-                        return false;
-                    OverlayReconciledIntoAllFiles(_perFileEntries, ctx);
-                }
+                // No rescore to run. The RESIDENT arm does nothing at all here - it leaves the
+                // buffer exactly as Stage 5 compacted it, and MergeNode reloads the rescored
+                // features from the valid reconciled parquets on disk. So the streamed arm has
+                // to do exactly one thing: put back the contents FirstJoin released. Overlaying
+                // the reconciled parquets as well (as this did) applied Stage-6 boundaries the
+                // resident arm never applies, which made OSPREY_STAGE6_STREAM_SURVIVORS=0
+                // something other than a byte-identity oracle on this path - the one property
+                // the whole design rests on.
+                if (survivorLoader != null && !MaterializeAllSurvivors(survivorLoader, ctx))
+                    return false;
                 return true;
             }
 
@@ -313,6 +322,7 @@ namespace pwiz.Osprey.Tasks
                 ctx.Get<FullLibrary>().Value,
                 ctx.Config,
                 ctx,
+                out var rescoredFiles,
                 joinFileStems,
                 survivorLoader);
             ctx.LogInfo(string.Format(
@@ -333,7 +343,7 @@ namespace pwiz.Osprey.Tasks
                 // moves the appended rows into EntryId order, shifting every position
                 // after them. The overlay preserves Score / q-values, so the reset
                 // survives it.
-                ResetRescoredTargets(_perFileEntries, ctx);
+                ResetRescoredTargets(_perFileEntries, rescoredFiles, ctx);
                 OverlayReconciledIntoAllFiles(_perFileEntries, ctx, canonicalize: false);
             }
 
@@ -529,6 +539,7 @@ namespace pwiz.Osprey.Tasks
             List<LibraryEntry> fullLibrary,
             OspreyConfig config,
             PipelineContext ctx,
+            out HashSet<string> rescoredFiles,
             IReadOnlyList<string> joinFileStems = null,
             FirstPassSurvivorLoader survivorLoader = null)
         {
@@ -576,14 +587,17 @@ namespace pwiz.Osprey.Tasks
             // gated by regression.ps1 -- because the per-file work shares no mutable
             // state. Per-file results land by index so the accumulation is order-free.
             int parallelism = Math.Max(1, ctx.RunPlan.EffectiveFileParallelism);
-            var counts = new (int Rescored, int GapCwt, int GapForced)[nTotalFiles];
+            var counts = new (int Rescored, int GapCwt, int GapForced, bool Scored)[nTotalFiles];
+            // Per-file survivor-refill failures, collected rather than thrown from inside the
+            // parallel body so the actionable message survives (see RescoreOneFileStreamed).
+            var loadErrors = new string[nTotalFiles];
 
             if (nTotalFiles == 1 || parallelism == 1)
             {
                 for (int fileNum = 0; fileNum < nTotalFiles; fileNum++)
                     counts[fileNum] = RescoreOneFileStreamed(
                         fileNum, nTotalFiles, perFileEntries[fileNum],
-                        inputs, survivorLoader, ctx);
+                        inputs, survivorLoader, ctx, out loadErrors[fileNum]);
             }
             else
             {
@@ -606,10 +620,21 @@ namespace pwiz.Osprey.Tasks
                 Parallel.For(0, nTotalFiles, parallelOpts, fileNum =>
                 {
                     using (multi.BeginFile(fileNum, RESCORE_FILE_SEGMENTS))
+                    {
                         counts[fileNum] = RescoreOneFileStreamed(
                             fileNum, nTotalFiles, perFileEntries[fileNum],
-                            inputs, survivorLoader, ctx);
+                            inputs, survivorLoader, ctx, out loadErrors[fileNum]);
+                    }
                 });
+            }
+
+            // Fail the rescore on any per-file refill failure, HERE rather than inside the
+            // loop above: the message names the file and the missing artifact, which is the
+            // whole value of the diagnostic, and net472 loses it through AggregateException.
+            foreach (string loadError in loadErrors)
+            {
+                if (loadError != null)
+                    throw new InvalidDataException(loadError);
             }
 
             // Reconciliation memory probe (#4376). The pre-GC snapshot's peak
@@ -624,11 +649,17 @@ namespace pwiz.Osprey.Tasks
             int totalRescored = 0;
             int totalGapCwt = 0;
             int totalGapForced = 0;
-            foreach (var c in counts)
+            // The files that actually reached the scoring engine, so the streamed rebuild can
+            // reapply the score / q-value reset to exactly those - see ResetRescoredTargets.
+            rescoredFiles = new HashSet<string>();
+            for (int fileNum = 0; fileNum < nTotalFiles; fileNum++)
             {
+                var c = counts[fileNum];
                 totalRescored += c.Rescored;
                 totalGapCwt += c.GapCwt;
                 totalGapForced += c.GapForced;
+                if (c.Scored)
+                    rescoredFiles.Add(perFileEntries[fileNum].Key);
             }
 
             return new RescoreStats
@@ -674,24 +705,44 @@ namespace pwiz.Osprey.Tasks
         ///
         /// <para>Safe under the parallel file loop: each call touches only its own file's
         /// list, and the loader holds no per-file state.</para>
+        ///
+        /// <para><c>loadError</c> is set when this file's survivors could not be refilled, so
+        /// the caller can fail the whole rescore with an actionable message AFTER the parallel
+        /// loop. Throwing from inside <c>Parallel.For</c> wraps the exception in an
+        /// AggregateException whose net472 message does not include the inner text, and nothing
+        /// in Osprey unwraps it, so the reason was lost.</para>
         /// </summary>
-        private (int Rescored, int GapCwt, int GapForced) RescoreOneFileStreamed(
+        private (int Rescored, int GapCwt, int GapForced, bool Scored) RescoreOneFileStreamed(
             int fileNum, int nTotalFiles, KeyValuePair<string, List<FdrEntry>> file,
-            RescorePassInputs inputs, FirstPassSurvivorLoader survivorLoader, PipelineContext ctx)
+            RescorePassInputs inputs, FirstPassSurvivorLoader survivorLoader, PipelineContext ctx,
+            out string loadError)
         {
+            loadError = null;
             if (survivorLoader == null)
                 return RescoreOneFile(fileNum, nTotalFiles, file.Key, file.Value, inputs, ctx);
 
-            var stubs = survivorLoader.Load(file.Key, out string error);
-            if (stubs == null)
+            List<FdrEntry> stubs;
+            // Serialized: the refill transiently holds the file's FULL pre-compaction stub set
+            // plus the sidecar byte array before filtering down to survivors, which at 163
+            // files is ~700 MB for one file. Under the parallel rescore that transient would
+            // otherwise be multiplied by the file parallelism - several GB of new peak in a
+            // change whose entire purpose is lowering peak. The rescore itself takes 2-2.5
+            // minutes per file against a few seconds for this load, so admitting one loader at
+            // a time costs a rounding error of wall clock and keeps the transient at 1x.
+            lock (_survivorLoadLock)
             {
-                // Stage 5 wrote both artifacts, so this is a fault. Throwing (rather than
-                // returning zero counts) keeps a file that could not be rescored from
-                // silently contributing nothing to the totals.
-                throw new InvalidDataException(error);
+                stubs = survivorLoader.Load(file.Key, out string error);
+                if (stubs == null)
+                {
+                    // Stage 5 wrote both artifacts, so this is a fault. Reporting it (rather
+                    // than returning zero counts) keeps a file that could not be rescored from
+                    // silently contributing nothing to the totals.
+                    loadError = error;
+                    return (0, 0, 0, false);
+                }
+                file.Value.Clear();
+                file.Value.AddRange(stubs);
             }
-            file.Value.Clear();
-            file.Value.AddRange(stubs);
             try
             {
                 return RescoreOneFile(fileNum, nTotalFiles, file.Key, file.Value, inputs, ctx);
@@ -723,7 +774,7 @@ namespace pwiz.Osprey.Tasks
         /// is kept whole here (parity-locked); only the cross-file plumbing was
         /// lifted up into <see cref="ExecuteRescore"/>.
         /// </summary>
-        private (int Rescored, int GapCwt, int GapForced) RescoreOneFile(
+        private (int Rescored, int GapCwt, int GapForced, bool Scored) RescoreOneFile(
             int fileNum, int nTotalFiles, string fileName, List<FdrEntry> fdrEntries,
             RescorePassInputs inputs, PipelineContext ctx)
         {
@@ -734,14 +785,14 @@ namespace pwiz.Osprey.Tasks
             // Per-file resume: a file whose reconciled parquet is already on
             // disk with a matching sidecar is overlaid in place and skipped.
             if (TryResumeRescoredFile(fileNum, nTotalFiles, fileName, fdrEntries, inputs, ctx))
-                return (totalRescored, totalGapCwt, totalGapForced);
+                return (totalRescored, totalGapCwt, totalGapForced, false);
 
             // Assemble this file's rescore targets (multi-charge consensus +
             // reconciliation dedup + gap-fill) and resolve its input mzML.
             // Bails when there is no work or the file has no input_files entry.
             if (!TryAssembleRescoreTargets(fileNum, nTotalFiles, fileName, inputs, ctx,
                     out var combinedTargets, out var gapFillTargets, out string inputFile))
-                return (totalRescored, totalGapCwt, totalGapForced);
+                return (totalRescored, totalGapCwt, totalGapForced, false);
 
             var config = inputs.Config;
             var fullLibrary = inputs.FullLibrary;
@@ -964,7 +1015,7 @@ namespace pwiz.Osprey.Tasks
             ProfilerHooks.LogManagedHeapAfterGcIfEnabled(ctx.LogInfo, @"perfile-rescore-live",
                 @"(post-GC, after release)");
 
-            return (totalRescored, totalGapCwt, totalGapForced);
+            return (totalRescored, totalGapCwt, totalGapForced, true);
         }
 
         /// <summary>
@@ -1350,14 +1401,7 @@ namespace pwiz.Osprey.Tasks
                 uint entryId = fdrEntries[idx].EntryId;
                 if (rescoredByEntryId.TryGetValue(entryId, out FdrEntry rescoredEntry))
                 {
-                    rescoredEntry.Score = 0.0;
-                    rescoredEntry.RunPrecursorQvalue = 1.0;
-                    rescoredEntry.RunPeptideQvalue = 1.0;
-                    rescoredEntry.RunProteinQvalue = 1.0;
-                    rescoredEntry.ExperimentPrecursorQvalue = 1.0;
-                    rescoredEntry.ExperimentPeptideQvalue = 1.0;
-                    rescoredEntry.ExperimentProteinQvalue = 1.0;
-                    rescoredEntry.Pep = 1.0;
+                    rescoredEntry.ResetScores();
                     rescoredEntry.ParquetIndex = fdrEntries[idx].ParquetIndex;
                     fdrEntries[idx] = rescoredEntry;
                     nOverlay++;
@@ -1366,15 +1410,7 @@ namespace pwiz.Osprey.Tasks
                 {
                     // No peak at the override boundary -- reset to
                     // defaults in place to match Rust's behavior.
-                    var existing = fdrEntries[idx];
-                    existing.Score = 0.0;
-                    existing.RunPrecursorQvalue = 1.0;
-                    existing.RunPeptideQvalue = 1.0;
-                    existing.RunProteinQvalue = 1.0;
-                    existing.ExperimentPrecursorQvalue = 1.0;
-                    existing.ExperimentPeptideQvalue = 1.0;
-                    existing.ExperimentProteinQvalue = 1.0;
-                    existing.Pep = 1.0;
+                    fdrEntries[idx].ResetScores();
                     nNoPeak++;
                 }
             }
@@ -1411,18 +1447,16 @@ namespace pwiz.Osprey.Tasks
         /// <param name="fileEntries">One file's entry list, updated in place.</param>
         /// <param name="reconciledPath">That file's <c>.scores-reconciled.parquet</c>.</param>
         /// <param name="gapFillForFile">The file's gap-fill targets, or null when it had none.</param>
-        /// <param name="reproducingFreshRescore">TRUE on the streamed rebuild, which reconstructs
-        /// the buffer a cold rescore left, so it carries the rescored ScanNumber. FALSE on
-        /// resume, which keeps the established behaviour. Gap fill is appended the same way
-        /// either way.</param>
         private void OverlayReconciledIntoBuffer(List<FdrEntry> fileEntries,
-            string reconciledPath, IReadOnlyList<GapFillTarget> gapFillForFile,
-            bool reproducingFreshRescore = false)
+            string reconciledPath, IReadOnlyList<GapFillTarget> gapFillForFile)
         {
             List<FdrEntry> loaded;
             try
             {
-                loaded = ParquetScoreCache.LoadFullFdrEntries(reconciledPath);
+                // Scalars only: every caller releases the heavy payload immediately after this
+                // returns (see ReleaseRescoredPayload), so decoding the 21 PIN feature columns
+                // and the four blob columns per row would be work done purely to discard it.
+                loaded = ParquetScoreCache.LoadFullFdrEntries(reconciledPath, scalarsOnly: true);
             }
             catch (Exception ex)
             {
@@ -1438,52 +1472,67 @@ namespace pwiz.Osprey.Tasks
                     reconciledPath, ex.Message), ex);
             }
 
-            // Index reconciled rows by EntryId. The reconciled parquet carries the
-            // full original entry set (incl. non-passing rows) re-sorted by
-            // (entry_id, charge, scan) plus appended gap-fill; a given EntryId can
-            // appear more than once (multiple charges / scans). Keep the FIRST row
-            // for a given EntryId -- the existing OverlayRescoredEntries path also
-            // matches a single rescored entry per EntryId, and the buffer carries
-            // at most one row per EntryId after compaction.
-            var byId = new Dictionary<uint, FdrEntry>(loaded.Count);
+            // Index reconciled rows by EntryId, keeping ALL rows for an id in the order the
+            // parquet holds them (canonical entry_id, charge, scan). A given EntryId can
+            // legitimately appear more than once - one row per isolation window a precursor
+            // was scored in - and the buffer can hold the same duplication, because
+            // compaction filters by base_id rather than collapsing to one row per EntryId
+            // (nothing enforces the "at most one" the previous comment here asserted). Taking
+            // the FIRST row for every buffer entry aliased both buffer rows onto one
+            // reconciled row, which gave them the same ScanNumber and so the same pass-2
+            // (EntryId, Charge, ScanNumber) identity - two survivors competing as one.
+            var byId = new Dictionary<uint, List<FdrEntry>>(loaded.Count);
             foreach (var r in loaded)
             {
-                if (!byId.ContainsKey(r.EntryId))
-                    byId[r.EntryId] = r;
+                if (!byId.TryGetValue(r.EntryId, out var rows))
+                {
+                    rows = new List<FdrEntry>(1);
+                    byId[r.EntryId] = rows;
+                }
+                rows.Add(r);
             }
 
             // Overlay reconciled boundary / area / feature / blob columns onto the
             // existing buffer rows IN PLACE, preserving each row's ParquetIndex and
             // 1st-pass Score / q-values (FdrEntry is a reference type, so mutating
             // fields updates the shared list element directly).
+            //
+            // Rows are paired POSITIONALLY within an EntryId: both sides are in canonical
+            // order, so the n-th buffer row for an id takes the n-th reconciled row for it.
+            // There is no stable key finer than EntryId available - Charge does not separate
+            // two isolation windows, and ScanNumber is the very field a rescore moves - so
+            // positional pairing is the most specific correspondence the data supports. It
+            // reduces to the obvious answer in the single-row case, which is every row today.
+            var nextRowById = new Dictionary<uint, int>();
             var existingIds = new HashSet<uint>();
             foreach (var entry in fileEntries)
             {
                 existingIds.Add(entry.EntryId);
-                if (!byId.TryGetValue(entry.EntryId, out FdrEntry r))
+                if (!byId.TryGetValue(entry.EntryId, out var rows))
                     continue;
-                if (reproducingFreshRescore)
-                {
-                    // Reproducing a fresh rescore: a MOVED peak's ScanNumber changes, because
-                    // the rescore replaces the buffer entry with the newly scored one. The
-                    // pass-2 frozen-model override is looked up by (EntryId, Charge,
-                    // ScanNumber) (Pass2FdrSidecar), so leaving the 1st-pass ScanNumber here
-                    // makes every moved peak miss that lookup: it gets no override, reads as
-                    // UNCHANGED, never earns a fresh run q, and is reported on its stale
-                    // pass-1 q. On Stellar that was 110,541 of 994,509 survivors missing an
-                    // override and 31,583 spectra reported against the golden 29,364.
-                    entry.ScanNumber = r.ScanNumber;
-                    // Same class of omission as ScanNumber, and the same consequence. A cold
-                    // rescore swaps the whole entry, so CoelutionSum becomes the new peak's
-                    // feature 0; it IS persisted (fragment_coelution_sum) and IS loaded into
-                    // r, but not copying it leaves every reconciled peak on its 1st-pass
-                    // value - and ReleaseRescoredPayload then nulls Features, destroying the
-                    // only fresh copy. Stage 7 reads it straight off the buffer
-                    // (PercolatorEntryBuilder's basic-feature fallback, and best-per-precursor
-                    // selection), so the streamed default would train on a different subset
-                    // than the resident oracle.
-                    entry.CoelutionSum = r.CoelutionSum;
-                }
+                nextRowById.TryGetValue(entry.EntryId, out int next);
+                if (next >= rows.Count)
+                    continue;
+                nextRowById[entry.EntryId] = next + 1;
+                var r = rows[next];
+                // A MOVED peak's ScanNumber changes, because the rescore replaces the buffer
+                // entry with the newly scored one. The pass-2 frozen-model override is looked
+                // up by (EntryId, Charge, ScanNumber) (Pass2FdrSidecar), so leaving the
+                // 1st-pass ScanNumber here makes every moved peak miss that lookup: it gets no
+                // override, reads as UNCHANGED, never earns a fresh run q, and is reported on
+                // its stale pass-1 q. On Stellar that was 110,541 of 994,509 survivors missing
+                // an override and 31,583 spectra reported against the golden 29,364.
+                entry.ScanNumber = r.ScanNumber;
+                // Same class of omission as ScanNumber, and the same consequence. A cold
+                // rescore swaps the whole entry, so CoelutionSum becomes the new peak's
+                // feature 0; it IS persisted (fragment_coelution_sum) and IS loaded into
+                // r, but not copying it leaves every reconciled peak on its 1st-pass
+                // value - and ReleaseRescoredPayload then nulls Features, destroying the
+                // only fresh copy. Stage 7 reads it straight off the buffer
+                // (PercolatorEntryBuilder's basic-feature fallback, and best-per-precursor
+                // selection), so a path that skipped this would train on a different subset
+                // than the resident oracle.
+                entry.CoelutionSum = r.CoelutionSum;
                 entry.ApexRt = r.ApexRt;
                 entry.StartRt = r.StartRt;
                 entry.EndRt = r.EndRt;
@@ -1504,17 +1553,21 @@ namespace pwiz.Osprey.Tasks
             // for determinism. Targets whose reconciled row is missing (no peak)
             // are skipped -- a fresh run would not have appended a stub either.
             // Gap fill is appended from the target list in reconciliation.json, for BOTH the
-            // resume overlay and the streamed rebuild. Two earlier mechanisms were tried and
-            // are recorded here so they are not retried:
+            // resume overlay and the streamed rebuild, in ascending TargetEntryId - the same
+            // order the fresh rescore now appends its own gap-fill block in
+            // (RunGapFillTwoPass sorts before appending, for exactly this reason). Two earlier
+            // mechanisms were tried and are recorded here so they are not retried:
             //
             //  * Rows carried out of the rescore in memory. Cannot work: --task
             //    PerFileRescoring rescores each file in its own process, so nothing held
             //    there reaches the merge node - and it is an O(files) resident term
             //    (~270 MB at 163 files), the shape this change exists to remove.
-            //  * Replaying the reconciled parquet's appended tail by row index.
-            //    LoadFullFdrEntries does NOT preserve parquet row order, so the "tail" is
-            //    not the gap-fill rows: on Stellar file 20 it appended 36 rows that were
-            //    not gap fill and dropped all 133 that were.
+            //  * Replaying the reconciled parquet's appended "tail" by row index. There is no
+            //    tail to replay: StreamReconciledScoresParquet MERGES the gap-fill rows into
+            //    their canonical (entry_id, charge, scan) position rather than appending them,
+            //    because Pass 2 recovers scan order from the reconciled row index. (An earlier
+            //    comment here blamed LoadFullFdrEntries for not preserving parquet row order.
+            //    That was wrong - it reads the row groups in order and preserves it exactly.)
             if (gapFillForFile != null && gapFillForFile.Count > 0)
             {
                 var gapFillIds = new SortedSet<uint>();
@@ -1524,8 +1577,9 @@ namespace pwiz.Osprey.Tasks
                 {
                     if (existingIds.Contains(gid))
                         continue;
-                    if (!byId.TryGetValue(gid, out FdrEntry g))
+                    if (!byId.TryGetValue(gid, out var gapRows) || gapRows.Count == 0)
                         continue;
+                    var g = gapRows[0];
                     g.ParquetIndex = uint.MaxValue;
                     fileEntries.Add(g);
                     existingIds.Add(gid);
@@ -1539,17 +1593,22 @@ namespace pwiz.Osprey.Tasks
 
 
         /// <summary>
-        /// True when this file's <c>.scores-reconciled.parquet</c> is on disk, i.e. the
-        /// end-of-loop rebuild can restore its rescored state from it.
+        /// True when this file's <c>.scores-reconciled.parquet</c> is on disk AND current for
+        /// this run's validity key, i.e. the end-of-loop rebuild really can restore its
+        /// rescored state from it. Asks the same question <see cref="TryResumeRescoredFile"/>
+        /// asks, so the answer cannot disagree with it: a parquet the rebuild would refuse to
+        /// overlay must not be treated as a safe place to drop this file's entries.
         /// </summary>
-        private static bool ReconciledParquetOnDisk(string fileName, RescorePassInputs inputs)
+        private bool ReconciledParquetOnDisk(string fileName, RescorePassInputs inputs)
         {
             if (inputs.ParquetPaths == null ||
                 !inputs.ParquetPaths.TryGetValue(fileName, out string scoresPath))
             {
                 return false;
             }
-            return File.Exists(ParquetScoreCache.ReconciledPathFromScoresPath(scoresPath));
+            return PerFileResumeDriver.IsCurrent(
+                ParquetScoreCache.ReconciledPathFromScoresPath(scoresPath), Name,
+                inputs.TaskValidityKey);
         }
 
         /// <summary>
@@ -1574,18 +1633,29 @@ namespace pwiz.Osprey.Tasks
         /// </summary>
         private bool MaterializeAllSurvivors(FirstPassSurvivorLoader loader, PipelineContext ctx)
         {
-            foreach (var kv in _perFileEntries)
+            // Reported, not silent: this is a per-file parquet + sidecar read across every file
+            // in the run, landing immediately after the parallel rescore where nothing else is
+            // printing. An unreported sequential loop of exactly this shape has twice read as a
+            // hung run in this codebase (#4513, Pass2FdrSidecar). Console-only.
+            using (var progress = new ProgressReporter(string.Format(
+                       @"Rebuilding first-pass survivors from {0} file(s)", _perFileEntries.Count),
+                       _perFileEntries.Count))
             {
-                if (kv.Value.Count > 0)
-                    continue;
-                var stubs = loader.Load(kv.Key, out string error);
-                if (stubs == null)
+                int done = 0;
+                foreach (var kv in _perFileEntries)
                 {
-                    ctx.LogError(error);
-                    ctx.ExitCode = 1;
-                    return false;
+                    progress.Report(++done);
+                    if (kv.Value.Count > 0)
+                        continue;
+                    var stubs = loader.Load(kv.Key, out string error);
+                    if (stubs == null)
+                    {
+                        ctx.LogError(error);
+                        ctx.ExitCode = 1;
+                        return false;
+                    }
+                    kv.Value.AddRange(stubs);
                 }
-                kv.Value.AddRange(stubs);
             }
             return true;
         }
@@ -1612,15 +1682,29 @@ namespace pwiz.Osprey.Tasks
         /// <see cref="TryAssembleRescoreTargets"/> reads, and the rebuilt list is in the
         /// same canonical order the planner indexed, so the positional indices select the
         /// same entries they did during the rescore.</para>
+        ///
+        /// <para>Applied ONLY to the files in <paramref name="rescoredFiles"/> - the ones that
+        /// actually reached <see cref="OverlayRescoredEntries"/> in this process. Having
+        /// planner targets is not the same as having been rescored: a file that took the
+        /// per-file resume skip (<see cref="TryResumeRescoredFile"/>), or whose
+        /// <see cref="TryAssembleRescoreTargets"/> returned false because it has no
+        /// <c>input_files</c> entry, returns before the reset and keeps its real 1st-pass
+        /// q-values. Resetting those too would zero q-values the resident path leaves alone,
+        /// and under protein-compact an off-stratum survivor KEEPS its 1st-pass q - so they
+        /// would drop out of the report. That is the mirror image of the over-reporting this
+        /// reset exists to fix.</para>
         /// </summary>
         private static void ResetRescoredTargets(
-            List<KeyValuePair<string, List<FdrEntry>>> perFileEntries, PipelineContext ctx)
+            List<KeyValuePair<string, List<FdrEntry>>> perFileEntries,
+            HashSet<string> rescoredFiles, PipelineContext ctx)
         {
             var consensus = ctx.Get<PerFileConsensusTargets>().Value;
             var reconTargets = GroupReconciliationActionsByFile(
                 ctx.Get<ReconciliationActions>().Value, out _);
             foreach (var kv in perFileEntries)
             {
+                if (!rescoredFiles.Contains(kv.Key))
+                    continue;
                 var indices = new HashSet<int>();
                 if (consensus != null && consensus.TryGetValue(kv.Key, out var consensusTargets))
                 {
@@ -1635,17 +1719,19 @@ namespace pwiz.Osprey.Tasks
                 var entries = kv.Value;
                 foreach (int idx in indices)
                 {
+                    // A planner index outside the rebuilt list means the rebuild did not
+                    // reproduce the list the planner indexed - which would silently reset the
+                    // WRONG rows for every index that IS in range. Skipping it (as this did)
+                    // swallowed the one cheap symptom of a misaligned rebuild; the fresh
+                    // rescore would have thrown IndexOutOfRange on the same index.
                     if (idx < 0 || idx >= entries.Count)
-                        continue;
-                    var e = entries[idx];
-                    e.Score = 0.0;
-                    e.RunPrecursorQvalue = 1.0;
-                    e.RunPeptideQvalue = 1.0;
-                    e.RunProteinQvalue = 1.0;
-                    e.ExperimentPrecursorQvalue = 1.0;
-                    e.ExperimentPeptideQvalue = 1.0;
-                    e.ExperimentProteinQvalue = 1.0;
-                    e.Pep = 1.0;
+                    {
+                        throw new InvalidDataException(string.Format(
+                            @"Stage 6 rebuild: planner index {0} for {1} is outside the rebuilt " +
+                            @"survivor list ({2} entries). The rebuilt buffer does not match the " +
+                            @"one the planner indexed.", idx, kv.Key, entries.Count));
+                    }
+                    entries[idx].ResetScores();
                 }
             }
         }
@@ -1662,7 +1748,7 @@ namespace pwiz.Osprey.Tasks
         /// entries after writing that file's parquet, so the
         /// <see cref="RescoredEntries"/> milestone MergeNode reads has to be rebuilt at
         /// the end (issue #4526). Sharing the body is what makes the streamed buffer
-        /// identical to the resumed one, which mode 2 of regression.ps1 already gates.</para>
+        /// identical to the resumed one.</para>
         /// </summary>
         /// <param name="perFileEntries">The shared per-file buffer to bring to its
         /// post-rescore state, updated in place.</param>
@@ -1680,39 +1766,53 @@ namespace pwiz.Osprey.Tasks
         {
             var gapFill = ctx.Get<PerFileGapFillForRescore>().Value;
             var parquetPaths = ctx.Get<PerFileParquetPaths>().Value;
-            foreach (var kv in perFileEntries)
+            string validityKey = ValidityKey(ctx);
+            // Reported for the same reason as the survivor rebuild above: a per-file parquet
+            // read across the whole run, in the silent window after the parallel rescore.
+            using (var progress = new ProgressReporter(string.Format(
+                       @"Overlaying reconciled results from {0} file(s)", perFileEntries.Count),
+                       perFileEntries.Count))
             {
-                // Overlay each file's reconciled boundaries when its
-                // .scores-reconciled.parquet is present; no-work files (none on
-                // disk) keep their 1st-pass boundaries, matching a fresh run.
-                if (parquetPaths != null &&
-                    parquetPaths.TryGetValue(kv.Key, out string scoresPath))
+                int done = 0;
+                foreach (var kv in perFileEntries)
                 {
-                    string reconciledPath = ParquetScoreCache.ReconciledPathFromScoresPath(scoresPath);
-                    if (File.Exists(reconciledPath))
+                    progress.Report(++done);
+                    // Overlay each file's reconciled boundaries when its
+                    // .scores-reconciled.parquet is present AND CURRENT; no-work files (none on
+                    // disk) keep their 1st-pass boundaries, matching a fresh run.
+                    //
+                    // Validity, not mere existence. The rescore's own per-file gate
+                    // (TryResumeRescoredFile) asks PerFileResumeDriver.IsCurrent, so testing
+                    // File.Exists here accepted a reconciled parquet this run would have
+                    // REJECTED and re-scored - one left by a run with different reconciliation
+                    // parameters, say. That overlays stale boundaries onto a cold run's buffer,
+                    // which is worse than the no-work fallback of leaving 1st-pass values.
+                    if (parquetPaths != null &&
+                        parquetPaths.TryGetValue(kv.Key, out string scoresPath))
                     {
-                        IReadOnlyList<GapFillTarget> gapFillForFile = null;
-                        if (gapFill != null && gapFill.TryGetValue(kv.Key, out var gfList))
-                            gapFillForFile = gfList;
-                        // Replay the appended gap-fill tail in row order when reproducing a
-                        // fresh rescore; the original parquet's row count is where it starts.
-                        OverlayReconciledIntoBuffer(kv.Value, reconciledPath, gapFillForFile,
-                            reproducingFreshRescore: !canonicalize);
+                        string reconciledPath = ParquetScoreCache.ReconciledPathFromScoresPath(scoresPath);
+                        if (PerFileResumeDriver.IsCurrent(reconciledPath, Name, validityKey))
+                        {
+                            IReadOnlyList<GapFillTarget> gapFillForFile = null;
+                            if (gapFill != null && gapFill.TryGetValue(kv.Key, out var gfList))
+                                gapFillForFile = gfList;
+                            OverlayReconciledIntoBuffer(kv.Value, reconciledPath, gapFillForFile);
+                        }
                     }
+                    // Canonical sort for EVERY file (incl. no-work files) so the WARM
+                    // buffer order matches the order COLD establishes in
+                    // RunPercolatorFdr, independent of whether the file was rescored.
+                    if (canonicalize)
+                        SortFileEntriesCanonical(kv.Value);
+                    // Same release the rescore path does once a file's reconciled parquet is
+                    // on disk: the overlay above re-fattened this file's entries straight
+                    // from that parquet, and holding those arrays for every file is the
+                    // O(files) Stage-6 growth term. A no-work file was never fattened, so
+                    // this is a no-op there. Nothing downstream reads them off the buffer -
+                    // MergeNode's 2nd pass reloads PIN features from the reconciled parquet
+                    // by identity - and this leaves the same buffer shape COLD leaves.
+                    ReleaseRescoredPayload(kv.Value);
                 }
-                // Canonical sort for EVERY file (incl. no-work files) so the WARM
-                // buffer order matches the order COLD establishes in
-                // RunPercolatorFdr, independent of whether the file was rescored.
-                if (canonicalize)
-                    SortFileEntriesCanonical(kv.Value);
-                // Same release the rescore path does once a file's reconciled parquet is
-                // on disk: the overlay above re-fattened this file's entries straight
-                // from that parquet, and holding those arrays for every file is the
-                // O(files) Stage-6 growth term. A no-work file was never fattened, so
-                // this is a no-op there. Nothing downstream reads them off the buffer -
-                // MergeNode's 2nd pass reloads PIN features from the reconciled parquet
-                // by identity - and this leaves the same buffer shape COLD leaves.
-                ReleaseRescoredPayload(kv.Value);
             }
         }
 
@@ -1733,19 +1833,7 @@ namespace pwiz.Osprey.Tasks
         /// </summary>
         private static void SortFileEntriesCanonical(List<FdrEntry> fileEntries)
         {
-            // Array.Sort OK: the terminal key is ParquetIndex, which is unique per row
-            // (the row's position in the parquet), so the comparator never returns 0 and
-            // the unstable-sort tie path is unreachable.
-            fileEntries.Sort((a, b) => // Array.Sort OK: (see above) terminal key ParquetIndex is unique per row, comparator never ties
-            {
-                int c = a.EntryId.CompareTo(b.EntryId);
-                if (c != 0) return c;
-                c = a.Charge.CompareTo(b.Charge);
-                if (c != 0) return c;
-                c = a.ScanNumber.CompareTo(b.ScanNumber);
-                if (c != 0) return c;
-                return a.ParquetIndex.CompareTo(b.ParquetIndex);
-            });
+            fileEntries.Sort(FdrEntry.CANONICAL_ORDER); // Array.Sort OK: CANONICAL_ORDER's terminal key ParquetIndex is unique per row, so the comparison never ties
         }
 
         /// <summary>
@@ -1783,6 +1871,18 @@ namespace pwiz.Osprey.Tasks
         {
             int nGapCwt = 0;
             int nGapForced = 0;
+
+            // Both passes collect here instead of appending straight onto fdrEntries, so the
+            // whole gap-fill block can be appended ONCE in ascending EntryId order (below).
+            // The two passes emit in scoring order - all CWT hits, then all forced - which is
+            // an order no other path can reconstruct: it depends on which targets CWT happened
+            // to hit, and that is recorded nowhere on disk. The rebuild-from-disk therefore had
+            // to append by ascending TargetEntryId and could not match a file that produced
+            // both kinds. Every 163-file file does (e.g. 10,965 CWT + 2,361 forced), so the two
+            // buffers would differ at scale while 3-file Stellar stayed green. Sorting here
+            // makes the order a property of the data rather than of the scoring emit sequence,
+            // which both paths can then reproduce.
+            var gapFillAppended = new List<FdrEntry>();
 
             // Build gap-fill library subset (targets only).
             var gapFillIds = new HashSet<uint>();
@@ -1823,21 +1923,14 @@ namespace pwiz.Osprey.Tasks
                     cwtHitIds.Add(entry.EntryId);
                 nGapCwt = cwtResults.Count;
 
-                // Append CWT results as new FdrEntry stubs with the
+                // Collect the CWT results as new FdrEntry stubs with the
                 // gap-fill sentinel + score-reset (mirroring Rust
                 // to_fdr_entry semantics for new stubs).
                 foreach (var entry in cwtResults)
                 {
                     entry.ParquetIndex = uint.MaxValue;
-                    entry.Score = 0.0;
-                    entry.RunPrecursorQvalue = 1.0;
-                    entry.RunPeptideQvalue = 1.0;
-                    entry.RunProteinQvalue = 1.0;
-                    entry.ExperimentPrecursorQvalue = 1.0;
-                    entry.ExperimentPeptideQvalue = 1.0;
-                    entry.ExperimentProteinQvalue = 1.0;
-                    entry.Pep = 1.0;
-                    fdrEntries.Add(entry);
+                    entry.ResetScores();
+                    gapFillAppended.Add(entry);
                 }
 
                 ctx.LogInfo(string.Format(
@@ -1890,21 +1983,29 @@ namespace pwiz.Osprey.Tasks
                 foreach (var entry in forcedResults)
                 {
                     entry.ParquetIndex = uint.MaxValue;
-                    entry.Score = 0.0;
-                    entry.RunPrecursorQvalue = 1.0;
-                    entry.RunPeptideQvalue = 1.0;
-                    entry.RunProteinQvalue = 1.0;
-                    entry.ExperimentPrecursorQvalue = 1.0;
-                    entry.ExperimentPeptideQvalue = 1.0;
-                    entry.ExperimentProteinQvalue = 1.0;
-                    entry.Pep = 1.0;
-                    fdrEntries.Add(entry);
+                    entry.ResetScores();
+                    gapFillAppended.Add(entry);
                 }
 
                 ctx.LogInfo(string.Format(
                     "  Gap-fill forced: {0} integrated ({1:F1}s)",
                     nGapForced, swForced.Elapsed.TotalSeconds));
             }
+
+            // Append the whole block at the END of the buffer, in ascending EntryId - the one
+            // order the rebuild-from-disk can also produce (it appends by ascending
+            // TargetEntryId from the persisted target list). Appending at the end rather than
+            // merging into canonical position is itself required: the Stage 6 planner's
+            // positional indices address the survivors as loaded, so anything inserted before
+            // them shifts every index after it.
+            //
+            // EntryId alone decides the order here, so the shared comparison's terminal
+            // ParquetIndex key being the uint.MaxValue sentinel on every one of these rows
+            // does not matter: the CWT pass emits at most one row per library entry and the
+            // forced pass runs only for the targets CWT missed, so the two blocks are disjoint
+            // and no two rows in this list share an EntryId. The comparison never ties.
+            gapFillAppended.Sort(FdrEntry.CANONICAL_ORDER); // Array.Sort OK: the CWT and forced blocks are disjoint, so EntryId is unique here and the comparison never ties
+            fdrEntries.AddRange(gapFillAppended);
 
             return (nGapCwt, nGapForced);
         }

--- a/pwiz_tools/Osprey/Osprey.Tasks/PerFileRescoreTask.cs
+++ b/pwiz_tools/Osprey/Osprey.Tasks/PerFileRescoreTask.cs
@@ -22,6 +22,7 @@
  */
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
@@ -111,6 +112,16 @@ namespace pwiz.Osprey.Tasks
         // the list reference falls through unchanged from
         // PerFileScoringTask.
         private List<KeyValuePair<string, List<FdrEntry>>> _perFileEntries;
+
+        // The gap-fill rows each streamed file's rescore appended, kept so the rebuild can
+        // put back exactly what the rescore produced. They are NOT recoverable from the
+        // reconciled parquet: the fresh buffer holds one row per (file, EntryId), so a
+        // gap-fill row is indistinguishable there from the survivor row for the same
+        // precursor. Cheap to keep - 390 rows across the 3-file Stellar set, and O(gap-fill
+        // targets) rather than O(survivors), which is the term this whole change is
+        // shedding. Written from the parallel per-file loop, so it must be concurrent.
+        private readonly ConcurrentDictionary<string, List<FdrEntry>> _streamedGapFill =
+            new ConcurrentDictionary<string, List<FdrEntry>>();
 
         public override string Name => @"PerFileRescoring";
 
@@ -334,6 +345,7 @@ namespace pwiz.Osprey.Tasks
                 // survives it.
                 ResetRescoredTargets(_perFileEntries, ctx);
                 OverlayReconciledIntoAllFiles(_perFileEntries, ctx, canonicalize: false);
+                AppendStreamedGapFill();
             }
 
             // Cross-impl bisection seam: dump per-precursor state
@@ -697,8 +709,18 @@ namespace pwiz.Osprey.Tasks
             }
             finally
             {
-                // Drop this file's entries before the next one loads its own. The rebuild
-                // after the loop reads them back from the reconciled parquet.
+                // Keep the gap-fill rows the rescore appended (ParquetIndex == uint.MaxValue
+                // is the marker it stamps on them) before dropping the rest. Everything else
+                // is rebuilt from the parquet after the loop; these are not.
+                var appended = new List<FdrEntry>();
+                foreach (var e in file.Value)
+                {
+                    if (e.ParquetIndex == uint.MaxValue)
+                        appended.Add(e);
+                }
+                _streamedGapFill[file.Key] = appended;
+
+                // Drop this file's entries before the next one loads its own.
                 file.Value.Clear();
                 file.Value.TrimExcess();
             }
@@ -1401,13 +1423,13 @@ namespace pwiz.Osprey.Tasks
         /// <param name="fileEntries">One file's entry list, updated in place.</param>
         /// <param name="reconciledPath">That file's <c>.scores-reconciled.parquet</c>.</param>
         /// <param name="gapFillForFile">The file's gap-fill targets, or null when it had none.</param>
-        /// <param name="appendedTailStart">Row index in the reconciled parquet at which the
-        /// appended gap-fill tail begins (the original parquet's row count), or -1 to fall
-        /// back to appending by ascending TargetEntryId. See the append block for why the
-        /// tail order is the faithful one.</param>
+        /// <param name="reproducingFreshRescore">TRUE on the streamed rebuild, which reconstructs
+        /// the buffer a cold rescore left: carry the rescored ScanNumber, and append no gap-fill
+        /// (the caller replays the captured rows). FALSE on resume, which keeps the established
+        /// behaviour.</param>
         private void OverlayReconciledIntoBuffer(List<FdrEntry> fileEntries,
             string reconciledPath, IReadOnlyList<GapFillTarget> gapFillForFile,
-            int appendedTailStart = -1)
+            bool reproducingFreshRescore = false)
         {
             List<FdrEntry> loaded;
             try
@@ -1452,7 +1474,7 @@ namespace pwiz.Osprey.Tasks
                 existingIds.Add(entry.EntryId);
                 if (!byId.TryGetValue(entry.EntryId, out FdrEntry r))
                     continue;
-                if (appendedTailStart >= 0)
+                if (reproducingFreshRescore)
                 {
                     // Reproducing a fresh rescore: a MOVED peak's ScanNumber changes, because
                     // the rescore replaces the buffer entry with the newly scored one. The
@@ -1483,49 +1505,49 @@ namespace pwiz.Osprey.Tasks
             // is not already in the buffer; append in ascending TargetEntryId order
             // for determinism. Targets whose reconciled row is missing (no peak)
             // are skipped -- a fresh run would not have appended a stub either.
-            if (gapFillForFile != null && gapFillForFile.Count > 0)
+            if (reproducingFreshRescore)
             {
-                if (appendedTailStart >= 0)
+                // The caller re-appends the ACTUAL gap-fill rows the rescore produced (see
+                // _streamedGapFill). They cannot be rebuilt from the reconciled parquet by
+                // identity: the fresh buffer holds exactly one row per (file, EntryId), so a
+                // gap-fill row is indistinguishable there from the survivor row for the same
+                // precursor.
+            }
+            else if (gapFillForFile != null && gapFillForFile.Count > 0)
+            {
+                var gapFillIds = new SortedSet<uint>();
+                foreach (var t in gapFillForFile)
+                    gapFillIds.Add(t.TargetEntryId);
+                foreach (var gid in gapFillIds)
                 {
-                    // Reproduce the order a FRESH rescore appends in. It runs two gap-fill
-                    // passes (CWT-hit, then forced integration) and appends each pass's
-                    // results as the scorer returns them, which is neither TargetEntryId
-                    // order nor the two passes interleaved. That exact order is preserved
-                    // on disk - the reconciled parquet writes the appended rows as a tail
-                    // after the original rows - so replay the tail in row order rather
-                    // than re-deriving an order the fresh path never had. Order matters
-                    // because the 2nd-pass sidecar is written in buffer order and the
-                    // experiment-wide competition it feeds is order-sensitive.
-                    for (int row = appendedTailStart; row < loaded.Count; row++)
-                    {
-                        var g = loaded[row];
-                        if (!existingIds.Add(g.EntryId))
-                            continue;
-                        g.ParquetIndex = uint.MaxValue;
-                        fileEntries.Add(g);
-                    }
-                }
-                else
-                {
-                    var gapFillIds = new SortedSet<uint>();
-                    foreach (var t in gapFillForFile)
-                        gapFillIds.Add(t.TargetEntryId);
-                    foreach (var gid in gapFillIds)
-                    {
-                        if (existingIds.Contains(gid))
-                            continue;
-                        if (!byId.TryGetValue(gid, out FdrEntry g))
-                            continue;
-                        g.ParquetIndex = uint.MaxValue;
-                        fileEntries.Add(g);
-                        existingIds.Add(gid);
-                    }
+                    if (existingIds.Contains(gid))
+                        continue;
+                    if (!byId.TryGetValue(gid, out FdrEntry g))
+                        continue;
+                    g.ParquetIndex = uint.MaxValue;
+                    fileEntries.Add(g);
+                    existingIds.Add(gid);
                 }
             }
 
             // The canonical (EntryId, Charge, ScanNumber, ParquetIndex) re-sort is
             // applied by the CALLER via SortFileEntriesCanonical -- it runs for every
             // file in the resume path, not only files with a reconciled parquet.
+        }
+
+        /// <summary>
+        /// Put each streamed file's captured gap-fill rows back at the END of its list,
+        /// which is where the rescore appended them and where Stage 7 expects them.
+        /// </summary>
+        private void AppendStreamedGapFill()
+        {
+            if (_perFileEntries == null)
+                return;
+            foreach (var kv in _perFileEntries)
+            {
+                if (_streamedGapFill.TryGetValue(kv.Key, out var appended))
+                    kv.Value.AddRange(appended);
+            }
         }
 
         /// <summary>
@@ -1672,10 +1694,8 @@ namespace pwiz.Osprey.Tasks
                             gapFillForFile = gfList;
                         // Replay the appended gap-fill tail in row order when reproducing a
                         // fresh rescore; the original parquet's row count is where it starts.
-                        int tailStart = -1;
-                        if (!canonicalize)
-                            tailStart = checked((int)ParquetScoreCache.ProbeCwtRowMetadata(scoresPath).RowCount);
-                        OverlayReconciledIntoBuffer(kv.Value, reconciledPath, gapFillForFile, tailStart);
+                        OverlayReconciledIntoBuffer(kv.Value, reconciledPath, gapFillForFile,
+                            reproducingFreshRescore: !canonicalize);
                     }
                 }
                 // Canonical sort for EVERY file (incl. no-work files) so the WARM

--- a/pwiz_tools/Osprey/Osprey.Tasks/PerFileRescoreTask.cs
+++ b/pwiz_tools/Osprey/Osprey.Tasks/PerFileRescoreTask.cs
@@ -1452,6 +1452,18 @@ namespace pwiz.Osprey.Tasks
                 existingIds.Add(entry.EntryId);
                 if (!byId.TryGetValue(entry.EntryId, out FdrEntry r))
                     continue;
+                if (appendedTailStart >= 0)
+                {
+                    // Reproducing a fresh rescore: a MOVED peak's ScanNumber changes, because
+                    // the rescore replaces the buffer entry with the newly scored one. The
+                    // pass-2 frozen-model override is looked up by (EntryId, Charge,
+                    // ScanNumber) (Pass2FdrSidecar), so leaving the 1st-pass ScanNumber here
+                    // makes every moved peak miss that lookup: it gets no override, reads as
+                    // UNCHANGED, never earns a fresh run q, and is reported on its stale
+                    // pass-1 q. On Stellar that was 110,541 of 994,509 survivors missing an
+                    // override and 31,583 spectra reported against the golden 29,364.
+                    entry.ScanNumber = r.ScanNumber;
+                }
                 entry.ApexRt = r.ApexRt;
                 entry.StartRt = r.StartRt;
                 entry.EndRt = r.EndRt;

--- a/pwiz_tools/Osprey/Osprey.Tasks/PerFileRescoreTask.cs
+++ b/pwiz_tools/Osprey/Osprey.Tasks/PerFileRescoreTask.cs
@@ -327,7 +327,13 @@ namespace pwiz.Osprey.Tasks
             {
                 if (!MaterializeAllSurvivors(survivorLoader, ctx))
                     return false;
-                OverlayReconciledIntoAllFiles(_perFileEntries, ctx);
+                // BEFORE the overlay, which appends gap-fill rows and re-sorts: the
+                // planner's indices address the survivor list as loaded, and the sort
+                // moves the appended rows into EntryId order, shifting every position
+                // after them. The overlay preserves Score / q-values, so the reset
+                // survives it.
+                ResetRescoredTargets(_perFileEntries, ctx);
+                OverlayReconciledIntoAllFiles(_perFileEntries, ctx, canonicalize: false);
             }
 
             // Cross-impl bisection seam: dump per-precursor state
@@ -683,7 +689,6 @@ namespace pwiz.Osprey.Tasks
                 // silently contributing nothing to the totals.
                 throw new InvalidDataException(error);
             }
-            ctx.LogInfo(string.Format(@"[4526-DBG] refill {0}: {1} entries", file.Key, stubs.Count));
             file.Value.Clear();
             file.Value.AddRange(stubs);
             try
@@ -1514,9 +1519,68 @@ namespace pwiz.Osprey.Tasks
                     return false;
                 }
                 kv.Value.AddRange(stubs);
-                ctx.LogInfo(string.Format(@"[4526-DBG] rebuild {0}: {1} entries", kv.Key, stubs.Count));
             }
             return true;
+        }
+
+        /// <summary>
+        /// Reapply the score / q-value reset that <see cref="OverlayRescoredEntries"/>
+        /// performs on every rescore target, which the rebuild-from-disk cannot recover.
+        ///
+        /// <para>A fresh rescore sets each target's Score to 0 and all q-values and Pep to
+        /// 1.0, because the 2nd pass is what assigns their real values. That reset lives
+        /// ONLY in memory: <c>ReconciledParquetWriter</c> persists boundaries, area and
+        /// features, not scores, and <see cref="OverlayReconciledIntoBuffer"/> documents
+        /// that it deliberately preserves each row's 1st-pass Score / q-values. So a
+        /// buffer rebuilt from the reconciled parquet carries 1st-pass q-values where a
+        /// fresh run carries 1.0.</para>
+        ///
+        /// <para>That used to be invisible, because the retired pass-2 Percolator recomputed
+        /// q for every entry. Under the frozen-model modes that replaced it (#4528,
+        /// protein-compact now the default) an OFF-stratum survivor KEEPS its 1st-pass q,
+        /// so the difference reaches the report: without this reset the Stellar straight-
+        /// through run reported 31,583 precursors against the golden 29,364.</para>
+        ///
+        /// <para>The target set is rebuilt from the same bounded planner byproducts
+        /// <see cref="TryAssembleRescoreTargets"/> reads, and the rebuilt list is in the
+        /// same canonical order the planner indexed, so the positional indices select the
+        /// same entries they did during the rescore.</para>
+        /// </summary>
+        private static void ResetRescoredTargets(
+            List<KeyValuePair<string, List<FdrEntry>>> perFileEntries, PipelineContext ctx)
+        {
+            var consensus = ctx.Get<PerFileConsensusTargets>().Value;
+            var reconTargets = GroupReconciliationActionsByFile(
+                ctx.Get<ReconciliationActions>().Value, out _);
+            foreach (var kv in perFileEntries)
+            {
+                var indices = new HashSet<int>();
+                if (consensus != null && consensus.TryGetValue(kv.Key, out var consensusTargets))
+                {
+                    foreach (var t in consensusTargets)
+                        indices.Add(t.Index);
+                }
+                if (reconTargets.TryGetValue(kv.Key, out var recon))
+                {
+                    foreach (var t in recon)
+                        indices.Add(t.Index);
+                }
+                var entries = kv.Value;
+                foreach (int idx in indices)
+                {
+                    if (idx < 0 || idx >= entries.Count)
+                        continue;
+                    var e = entries[idx];
+                    e.Score = 0.0;
+                    e.RunPrecursorQvalue = 1.0;
+                    e.RunPeptideQvalue = 1.0;
+                    e.RunProteinQvalue = 1.0;
+                    e.ExperimentPrecursorQvalue = 1.0;
+                    e.ExperimentPeptideQvalue = 1.0;
+                    e.ExperimentProteinQvalue = 1.0;
+                    e.Pep = 1.0;
+                }
+            }
         }
 
         /// <summary>
@@ -1533,8 +1597,19 @@ namespace pwiz.Osprey.Tasks
         /// the end (issue #4526). Sharing the body is what makes the streamed buffer
         /// identical to the resumed one, which mode 2 of regression.ps1 already gates.</para>
         /// </summary>
+        /// <param name="perFileEntries">The shared per-file buffer to bring to its
+        /// post-rescore state, updated in place.</param>
+        /// <param name="ctx">Pipeline context, for the planner byproducts and parquet paths.</param>
+        /// <param name="canonicalize">Re-sort each file by the canonical
+        /// (EntryId, Charge, ScanNumber, ParquetIndex) key. TRUE on resume, where the
+        /// buffer has to be brought to the order a cold run ends in. FALSE on the streamed
+        /// rebuild, which is REPRODUCING a cold run: a cold rescore appends gap-fill at the
+        /// END of the list and never re-sorts, so sorting here would move those rows into
+        /// EntryId order and change the buffer order Stage 7 writes its 2nd-pass sidecars
+        /// in - which changes the protein-compact competition and the reported set.</param>
         private void OverlayReconciledIntoAllFiles(
-            List<KeyValuePair<string, List<FdrEntry>>> perFileEntries, PipelineContext ctx)
+            List<KeyValuePair<string, List<FdrEntry>>> perFileEntries, PipelineContext ctx,
+            bool canonicalize = true)
         {
             var gapFill = ctx.Get<PerFileGapFillForRescore>().Value;
             var parquetPaths = ctx.Get<PerFileParquetPaths>().Value;
@@ -1558,7 +1633,8 @@ namespace pwiz.Osprey.Tasks
                 // Canonical sort for EVERY file (incl. no-work files) so the WARM
                 // buffer order matches the order COLD establishes in
                 // RunPercolatorFdr, independent of whether the file was rescored.
-                SortFileEntriesCanonical(kv.Value);
+                if (canonicalize)
+                    SortFileEntriesCanonical(kv.Value);
                 // Same release the rescore path does once a file's reconciled parquet is
                 // on disk: the overlay above re-fattened this file's entries straight
                 // from that parquet, and holding those arrays for every file is the

--- a/pwiz_tools/Osprey/Osprey.Tasks/PerFileRescoreTask.cs
+++ b/pwiz_tools/Osprey/Osprey.Tasks/PerFileRescoreTask.cs
@@ -1398,8 +1398,16 @@ namespace pwiz.Osprey.Tasks
         /// Non-passing reconciled rows (compacted out of the buffer) are skipped,
         /// matching the buffer a fresh run produces.
         /// </summary>
+        /// <param name="fileEntries">One file's entry list, updated in place.</param>
+        /// <param name="reconciledPath">That file's <c>.scores-reconciled.parquet</c>.</param>
+        /// <param name="gapFillForFile">The file's gap-fill targets, or null when it had none.</param>
+        /// <param name="appendedTailStart">Row index in the reconciled parquet at which the
+        /// appended gap-fill tail begins (the original parquet's row count), or -1 to fall
+        /// back to appending by ascending TargetEntryId. See the append block for why the
+        /// tail order is the faithful one.</param>
         private void OverlayReconciledIntoBuffer(List<FdrEntry> fileEntries,
-            string reconciledPath, IReadOnlyList<GapFillTarget> gapFillForFile)
+            string reconciledPath, IReadOnlyList<GapFillTarget> gapFillForFile,
+            int appendedTailStart = -1)
         {
             List<FdrEntry> loaded;
             try
@@ -1465,18 +1473,41 @@ namespace pwiz.Osprey.Tasks
             // are skipped -- a fresh run would not have appended a stub either.
             if (gapFillForFile != null && gapFillForFile.Count > 0)
             {
-                var gapFillIds = new SortedSet<uint>();
-                foreach (var t in gapFillForFile)
-                    gapFillIds.Add(t.TargetEntryId);
-                foreach (var gid in gapFillIds)
+                if (appendedTailStart >= 0)
                 {
-                    if (existingIds.Contains(gid))
-                        continue;
-                    if (!byId.TryGetValue(gid, out FdrEntry g))
-                        continue;
-                    g.ParquetIndex = uint.MaxValue;
-                    fileEntries.Add(g);
-                    existingIds.Add(gid);
+                    // Reproduce the order a FRESH rescore appends in. It runs two gap-fill
+                    // passes (CWT-hit, then forced integration) and appends each pass's
+                    // results as the scorer returns them, which is neither TargetEntryId
+                    // order nor the two passes interleaved. That exact order is preserved
+                    // on disk - the reconciled parquet writes the appended rows as a tail
+                    // after the original rows - so replay the tail in row order rather
+                    // than re-deriving an order the fresh path never had. Order matters
+                    // because the 2nd-pass sidecar is written in buffer order and the
+                    // experiment-wide competition it feeds is order-sensitive.
+                    for (int row = appendedTailStart; row < loaded.Count; row++)
+                    {
+                        var g = loaded[row];
+                        if (!existingIds.Add(g.EntryId))
+                            continue;
+                        g.ParquetIndex = uint.MaxValue;
+                        fileEntries.Add(g);
+                    }
+                }
+                else
+                {
+                    var gapFillIds = new SortedSet<uint>();
+                    foreach (var t in gapFillForFile)
+                        gapFillIds.Add(t.TargetEntryId);
+                    foreach (var gid in gapFillIds)
+                    {
+                        if (existingIds.Contains(gid))
+                            continue;
+                        if (!byId.TryGetValue(gid, out FdrEntry g))
+                            continue;
+                        g.ParquetIndex = uint.MaxValue;
+                        fileEntries.Add(g);
+                        existingIds.Add(gid);
+                    }
                 }
             }
 
@@ -1627,7 +1658,12 @@ namespace pwiz.Osprey.Tasks
                         IReadOnlyList<GapFillTarget> gapFillForFile = null;
                         if (gapFill != null && gapFill.TryGetValue(kv.Key, out var gfList))
                             gapFillForFile = gfList;
-                        OverlayReconciledIntoBuffer(kv.Value, reconciledPath, gapFillForFile);
+                        // Replay the appended gap-fill tail in row order when reproducing a
+                        // fresh rescore; the original parquet's row count is where it starts.
+                        int tailStart = -1;
+                        if (!canonicalize)
+                            tailStart = checked((int)ParquetScoreCache.ProbeCwtRowMetadata(scoresPath).RowCount);
+                        OverlayReconciledIntoBuffer(kv.Value, reconciledPath, gapFillForFile, tailStart);
                     }
                 }
                 // Canonical sort for EVERY file (incl. no-work files) so the WARM

--- a/pwiz_tools/Osprey/Osprey.Tasks/PerFileRescoreTask.cs
+++ b/pwiz_tools/Osprey/Osprey.Tasks/PerFileRescoreTask.cs
@@ -1402,14 +1402,12 @@ namespace pwiz.Osprey.Tasks
         /// <param name="reconciledPath">That file's <c>.scores-reconciled.parquet</c>.</param>
         /// <param name="gapFillForFile">The file's gap-fill targets, or null when it had none.</param>
         /// <param name="reproducingFreshRescore">TRUE on the streamed rebuild, which reconstructs
-        /// the buffer a cold rescore left: carry the rescored ScanNumber, and append no gap-fill
-        /// and replay the appended gap-fill tail from disk. FALSE on resume, which keeps the
-        /// established behaviour.</param>
-        /// <param name="appendedTailStart">Row index in the reconciled parquet where the appended
-        /// gap-fill tail begins (the original parquet's row count).</param>
+        /// the buffer a cold rescore left, so it carries the rescored ScanNumber. FALSE on
+        /// resume, which keeps the established behaviour. Gap fill is appended the same way
+        /// either way.</param>
         private void OverlayReconciledIntoBuffer(List<FdrEntry> fileEntries,
             string reconciledPath, IReadOnlyList<GapFillTarget> gapFillForFile,
-            bool reproducingFreshRescore = false, int appendedTailStart = -1)
+            bool reproducingFreshRescore = false)
         {
             List<FdrEntry> loaded;
             try
@@ -1485,28 +1483,19 @@ namespace pwiz.Osprey.Tasks
             // is not already in the buffer; append in ascending TargetEntryId order
             // for determinism. Targets whose reconciled row is missing (no peak)
             // are skipped -- a fresh run would not have appended a stub either.
-            if (reproducingFreshRescore)
-            {
-                // Replay the appended gap-fill tail in its persisted row order. The reconciled
-                // parquet writes those rows after the original ones, so the order a fresh
-                // rescore produced - two scoring passes (CWT-hit, then forced), each appended
-                // as the scorer returned it - survives on disk.
-                //
-                // From DISK, not from rows carried out of the rescore: under
-                // --task PerFileRescoring each file is rescored in its own process, so a
-                // carried list is empty by the time the merge node needs it. Carrying them
-                // would also be an O(files) resident term (~270 MB at 163 files), which is the
-                // shape this change exists to remove.
-                for (int row = appendedTailStart; row >= 0 && row < loaded.Count; row++)
-                {
-                    var g = loaded[row];
-                    if (!existingIds.Add(g.EntryId))
-                        continue;
-                    g.ParquetIndex = uint.MaxValue;
-                    fileEntries.Add(g);
-                }
-            }
-            else if (gapFillForFile != null && gapFillForFile.Count > 0)
+            // Gap fill is appended from the target list in reconciliation.json, for BOTH the
+            // resume overlay and the streamed rebuild. Two earlier mechanisms were tried and
+            // are recorded here so they are not retried:
+            //
+            //  * Rows carried out of the rescore in memory. Cannot work: --task
+            //    PerFileRescoring rescores each file in its own process, so nothing held
+            //    there reaches the merge node - and it is an O(files) resident term
+            //    (~270 MB at 163 files), the shape this change exists to remove.
+            //  * Replaying the reconciled parquet's appended tail by row index.
+            //    LoadFullFdrEntries does NOT preserve parquet row order, so the "tail" is
+            //    not the gap-fill rows: on Stellar file 20 it appended 36 rows that were
+            //    not gap fill and dropped all 133 that were.
+            if (gapFillForFile != null && gapFillForFile.Count > 0)
             {
                 var gapFillIds = new SortedSet<uint>();
                 foreach (var t in gapFillForFile)
@@ -1674,9 +1663,7 @@ namespace pwiz.Osprey.Tasks
                         // Replay the appended gap-fill tail in row order when reproducing a
                         // fresh rescore; the original parquet's row count is where it starts.
                         OverlayReconciledIntoBuffer(kv.Value, reconciledPath, gapFillForFile,
-                            reproducingFreshRescore: !canonicalize,
-                            appendedTailStart: canonicalize ? -1
-                                : checked((int)ParquetScoreCache.ProbeCwtRowMetadata(scoresPath).RowCount));
+                            reproducingFreshRescore: !canonicalize);
                     }
                 }
                 // Canonical sort for EVERY file (incl. no-work files) so the WARM

--- a/pwiz_tools/Osprey/Osprey.Tasks/PerFileRescoreTask.cs
+++ b/pwiz_tools/Osprey/Osprey.Tasks/PerFileRescoreTask.cs
@@ -698,9 +698,19 @@ namespace pwiz.Osprey.Tasks
             }
             finally
             {
-                // Drop this file's entries before the next one loads its own.
-                file.Value.Clear();
-                file.Value.TrimExcess();
+                // Drop this file's entries before the next one loads its own - but ONLY when
+                // its reconciled parquet is actually on disk, because that file is what the
+                // end-of-loop rebuild restores them from. RescoreOneFile makes the same call
+                // about the heavy payload for the same reason (see the wroteReconciled gate
+                // it applies to ReleaseRescoredPayload): when the write no-opped or failed,
+                // these entries are the ONLY copy of the rescore, and dropping them would
+                // discard it on a warning. Keeping one file's entries resident is the right
+                // trade against silently losing its precursors.
+                if (ReconciledParquetOnDisk(file.Key, inputs))
+                {
+                    file.Value.Clear();
+                    file.Value.TrimExcess();
+                }
             }
         }
 
@@ -1463,6 +1473,16 @@ namespace pwiz.Osprey.Tasks
                     // pass-1 q. On Stellar that was 110,541 of 994,509 survivors missing an
                     // override and 31,583 spectra reported against the golden 29,364.
                     entry.ScanNumber = r.ScanNumber;
+                    // Same class of omission as ScanNumber, and the same consequence. A cold
+                    // rescore swaps the whole entry, so CoelutionSum becomes the new peak's
+                    // feature 0; it IS persisted (fragment_coelution_sum) and IS loaded into
+                    // r, but not copying it leaves every reconciled peak on its 1st-pass
+                    // value - and ReleaseRescoredPayload then nulls Features, destroying the
+                    // only fresh copy. Stage 7 reads it straight off the buffer
+                    // (PercolatorEntryBuilder's basic-feature fallback, and best-per-precursor
+                    // selection), so the streamed default would train on a different subset
+                    // than the resident oracle.
+                    entry.CoelutionSum = r.CoelutionSum;
                 }
                 entry.ApexRt = r.ApexRt;
                 entry.StartRt = r.StartRt;
@@ -1517,6 +1537,20 @@ namespace pwiz.Osprey.Tasks
             // file in the resume path, not only files with a reconciled parquet.
         }
 
+
+        /// <summary>
+        /// True when this file's <c>.scores-reconciled.parquet</c> is on disk, i.e. the
+        /// end-of-loop rebuild can restore its rescored state from it.
+        /// </summary>
+        private static bool ReconciledParquetOnDisk(string fileName, RescorePassInputs inputs)
+        {
+            if (inputs.ParquetPaths == null ||
+                !inputs.ParquetPaths.TryGetValue(fileName, out string scoresPath))
+            {
+                return false;
+            }
+            return File.Exists(ParquetScoreCache.ReconciledPathFromScoresPath(scoresPath));
+        }
 
         /// <summary>
         /// The loader Stage 6 refills from, or null when this run keeps the resident

--- a/pwiz_tools/Osprey/Osprey.Tasks/PerFileRescoreTask.cs
+++ b/pwiz_tools/Osprey/Osprey.Tasks/PerFileRescoreTask.cs
@@ -1538,12 +1538,10 @@ namespace pwiz.Osprey.Tasks
                 entry.EndRt = r.EndRt;
                 entry.BoundsArea = r.BoundsArea;
                 entry.BoundsSnr = r.BoundsSnr;
-                entry.Features = r.Features;
-                entry.CwtCandidates = r.CwtCandidates;
-                entry.FragmentMzs = r.FragmentMzs;
-                entry.FragmentIntensities = r.FragmentIntensities;
-                entry.ReferenceXicRts = r.ReferenceXicRts;
-                entry.ReferenceXicIntensities = r.ReferenceXicIntensities;
+                // The heavy payload is deliberately NOT copied. The load above is scalar-only,
+                // so those fields are null on r, and assigning them would only overwrite the
+                // entry's own payload with nulls - inert while every caller releases the
+                // payload immediately afterwards, but a trap the moment one does not.
             }
 
             // Append gap-fill rows. A fresh run appends one stub per gap-fill
@@ -1579,9 +1577,23 @@ namespace pwiz.Osprey.Tasks
                         continue;
                     if (!byId.TryGetValue(gid, out var gapRows) || gapRows.Count == 0)
                         continue;
-                    var g = gapRows[0];
-                    g.ParquetIndex = uint.MaxValue;
-                    fileEntries.Add(g);
+                    // EVERY row for this target, not just the first. Gap fill is the one place
+                    // a duplicate EntryId can actually arise: the survivor rows come from
+                    // .scores.parquet, which Stage 4 wrote AFTER DeduplicatePairs, but
+                    // RunGapFillTwoPass calls RunCoelutionScoring with neither
+                    // DeduplicatePairs nor DeduplicateDoubleCounting, and ScoreWindow admits a
+                    // candidate per isolation window. With overlapping windows one target
+                    // yields two stubs, and a cold rescore appends both. Taking only the first
+                    // silently dropped a survivor from the buffer Stage 7 competes over.
+                    //
+                    // Parquet order within an EntryId is canonical (entry_id, charge, scan),
+                    // which is the order the cold path's sorted block puts them in too, so the
+                    // two agree row for row.
+                    foreach (var g in gapRows)
+                    {
+                        g.ParquetIndex = uint.MaxValue;
+                        fileEntries.Add(g);
+                    }
                     existingIds.Add(gid);
                 }
             }
@@ -1999,12 +2011,16 @@ namespace pwiz.Osprey.Tasks
             // positional indices address the survivors as loaded, so anything inserted before
             // them shifts every index after it.
             //
-            // EntryId alone decides the order here, so the shared comparison's terminal
-            // ParquetIndex key being the uint.MaxValue sentinel on every one of these rows
-            // does not matter: the CWT pass emits at most one row per library entry and the
-            // forced pass runs only for the targets CWT missed, so the two blocks are disjoint
-            // and no two rows in this list share an EntryId. The comparison never ties.
-            gapFillAppended.Sort(FdrEntry.CANONICAL_ORDER); // Array.Sort OK: the CWT and forced blocks are disjoint, so EntryId is unique here and the comparison never ties
+            // The CWT and forced blocks are disjoint (forced runs only for the targets CWT
+            // missed), but EntryId is NOT unique within this list: neither pass runs
+            // DeduplicatePairs or DeduplicateDoubleCounting, and ScoreWindow admits a candidate
+            // per isolation window, so one target scored in two overlapping windows emits two
+            // rows. Charge and ScanNumber separate them, and every row carries the same
+            // uint.MaxValue ParquetIndex sentinel - so the comparison can only tie on rows that
+            // agree on all four keys, which are indistinguishable anyway. The rebuild-from-disk
+            // reproduces this by appending EVERY reconciled row for a target, in the parquet's
+            // canonical (entry_id, charge, scan) order, which is the order this sort produces.
+            gapFillAppended.Sort(FdrEntry.CANONICAL_ORDER); // Array.Sort OK: a tie needs equal (EntryId, Charge, ScanNumber), and such rows are indistinguishable
             fdrEntries.AddRange(gapFillAppended);
 
             return (nGapCwt, nGapForced);

--- a/pwiz_tools/Osprey/Osprey.Tasks/PerFileScoringTask.cs
+++ b/pwiz_tools/Osprey/Osprey.Tasks/PerFileScoringTask.cs
@@ -1997,6 +1997,46 @@ namespace pwiz.Osprey.Tasks
         }
 
         /// <summary>
+        /// The same refusal, one stage later: the guard above stops at the compaction line, and
+        /// the POST-compaction survivor handoff is O(files) too - 88.9 M entries / 28 GB at 163
+        /// files, live for the whole Stage 6 rescore (issue #4526). Stage 6 streams that buffer
+        /// by default; <c>OSPREY_STAGE6_STREAM_SURVIVORS=0</c> restores the resident handoff as
+        /// the A/B byte-identity oracle, and like every other resident path it has to be NAMED
+        /// to be available. Returns the actionable error, or <c>null</c> when the run streams.
+        ///
+        /// <para><paramref name="streamingAvailable"/> is false when this run could not stream
+        /// whatever the flag says - the resident and rehydrate paths never compute the passing
+        /// base_id set the per-file loader needs. Those runs are already resident for a reason
+        /// with its own token (<see cref="ResidentPaths.PROJECTION_OFF"/> above all), so
+        /// demanding a second token on top would tell the operator to set two variables for one
+        /// decision, and would fire on the plain <c>--task SecondPassFDR</c> merge that
+        /// <see cref="ResidentPaths.HPC_MERGE"/> already covers.</para>
+        /// </summary>
+        internal static string Stage6ResidentHandoffGuardError(
+            bool streamingAvailable, bool streamingEnabled, string allowUnfixedResident)
+        {
+            if (!streamingAvailable || streamingEnabled)
+                return null;
+            if (string.Equals(ResidentPaths.COMPACTED_ENTRIES_BUFFER, allowUnfixedResident,
+                    StringComparison.OrdinalIgnoreCase))
+            {
+                return null;
+            }
+            string supplied = string.IsNullOrEmpty(allowUnfixedResident)
+                ? string.Empty
+                : string.Format(@" OSPREY_ALLOW_UNFIXED_RESIDENT is currently '{0}', which does " +
+                                @"not name this path.", allowUnfixedResident);
+            return string.Format(
+                @"OSPREY_STAGE6_STREAM_SURVIVORS=0 takes the '{0}' RESIDENT path, which holds " +
+                @"every file's post-compaction survivors in memory across the whole Stage 6 " +
+                @"rescore and grows O(files) - 28 GB at 163 files. Set " +
+                @"OSPREY_ALLOW_UNFIXED_RESIDENT={0} to accept it and proceed (it is the A/B " +
+                @"byte-identity oracle for the streamed default); otherwise this path is " +
+                @"unavailable.{1}",
+                ResidentPaths.COMPACTED_ENTRIES_BUFFER, supplied);
+        }
+
+        /// <summary>
         /// The <see cref="ResidentPaths"/> token for the known-unfixed resident path this config
         /// takes, or <c>null</c> when it needs the resident pool for a reason NOT on that list -
         /// which the caller refuses outright, since reaching that state means something we

--- a/pwiz_tools/Osprey/Osprey.Tasks/PerFileScoringTask.cs
+++ b/pwiz_tools/Osprey/Osprey.Tasks/PerFileScoringTask.cs
@@ -1977,10 +1977,12 @@ namespace pwiz.Osprey.Tasks
                     @"be unfixed. Something that was streamed is resident again - fix that rather " +
                     @"than allowing it. OSPREY_ALLOW_UNFIXED_RESIDENT cannot admit this path.";
             }
-            // Case-insensitive to match how the rest of the CLI parses tokens (ParseFdrBenchPass):
-            // the error names the exact token to set, so rejecting it for capitalization would
-            // read as the guard ignoring what the operator just did.
-            if (string.Equals(trigger, allowUnfixedResident, StringComparison.OrdinalIgnoreCase))
+            // Membership, not equality: the setting may name SEVERAL paths, because a run can
+            // legitimately trip more than one at once. Case-insensitive, matching how the rest of
+            // the CLI parses tokens (ParseFdrBenchPass): the error names the exact token to set,
+            // so rejecting it for capitalization would read as the guard ignoring what the
+            // operator just did.
+            if (OspreyEnvironment.NamesResidentPath(allowUnfixedResident, trigger))
                 return null;
             // Name the offending value when one was supplied, so a typo or a shell-quoted token
             // does not produce the identical message the unset case produces.
@@ -2017,8 +2019,8 @@ namespace pwiz.Osprey.Tasks
         {
             if (!streamingAvailable || streamingEnabled)
                 return null;
-            if (string.Equals(ResidentPaths.COMPACTED_ENTRIES_BUFFER, allowUnfixedResident,
-                    StringComparison.OrdinalIgnoreCase))
+            if (OspreyEnvironment.NamesResidentPath(
+                    allowUnfixedResident, ResidentPaths.COMPACTED_ENTRIES_BUFFER))
             {
                 return null;
             }

--- a/pwiz_tools/Osprey/Osprey.Tasks/PipelineByproducts.cs
+++ b/pwiz_tools/Osprey/Osprey.Tasks/PipelineByproducts.cs
@@ -261,6 +261,28 @@ namespace pwiz.Osprey.Tasks
     }
 
     /// <summary>
+    /// The means to REBUILD any one file's post-compaction survivors from disk,
+    /// published by FirstJoin alongside <see cref="CompactedEntries"/>.
+    ///
+    /// <para>Every artifact the rebuild needs - the original <c>.scores.parquet</c>
+    /// and the finalized <c>.1st-pass.fdr_scores.bin</c> - is on disk by the time
+    /// Stage 5 compacts, so holding the survivors is a choice rather than a
+    /// requirement. It is an expensive one: the all-files survivor buffer is
+    /// 88.9 M entries / 28 GB at 163 files, live for the whole Stage 6 rescore
+    /// (issue #4526). A consumer that works one file at a time takes this instead
+    /// and the buffer never has to exist.</para>
+    ///
+    /// <para><c>Value</c> is null when the run kept the resident buffer (the
+    /// token-gated parity oracle), so a consumer must fall back to
+    /// <see cref="CompactedEntries"/> when it is absent.</para>
+    /// </summary>
+    internal sealed class FirstPassSurvivorSource
+    {
+        public FirstPassSurvivorLoader Value { get; }
+        public FirstPassSurvivorSource(FirstPassSurvivorLoader value) { Value = value; }
+    }
+
+    /// <summary>
     /// The FROZEN 1st-pass Percolator model (fold weights + biases + feature
     /// standardizer, carried on <see cref="PercolatorResults"/>), captured at
     /// first-pass FDR time. Published only under the OSPREY_PASS2_QVALUE=transfer

--- a/pwiz_tools/Osprey/Osprey.Tasks/ScoringTaskShared.cs
+++ b/pwiz_tools/Osprey/Osprey.Tasks/ScoringTaskShared.cs
@@ -215,5 +215,51 @@ namespace pwiz.Osprey.Tasks
                     "outputs are written to the same place).", inputFile, cachePath), indexError);
             return index;
         }
+
+        /// <summary>
+        /// Resolve a path whose stem matches <paramref name="fileName"/>, used
+        /// only as the base for sidecar file naming (the path itself need
+        /// not exist). In normal mode this is the input mzML; in
+        /// --task FirstPassFDR mode where InputFiles is empty we synthesize the
+        /// path from the matching .scores.parquet by replacing the
+        /// `.scores.parquet` suffix with `.mzML`. Mirrors the Rust
+        /// `synthetic_input_from_parquet` helper.
+        ///
+        /// <para>Lives here rather than on <see cref="FirstJoinTask"/> because
+        /// <see cref="FirstPassSurvivorLoader"/> needs the same resolution to find a
+        /// file's 1st-pass sidecar, and a loader reaching into a task class for it
+        /// would be the wrong direction of dependency.</para>
+        /// </summary>
+        internal static string ResolveSidecarBasePath(
+            string fileName,
+            IReadOnlyDictionary<string, string> perFileParquetPaths,
+            OspreyConfig config)
+        {
+            // Normal mode: prefer the actual input mzML path so sidecars
+            // land next to the source mzML.
+            if (config.InputFiles != null)
+            {
+                foreach (string inputPath in config.InputFiles)
+                {
+                    if (string.Equals(
+                        Path.GetFileNameWithoutExtension(inputPath),
+                        fileName,
+                        StringComparison.Ordinal))
+                    {
+                        return inputPath;
+                    }
+                }
+            }
+            // --task FirstPassFDR fallback: derive a synthetic mzML path from the
+            // matching parquet stem so all the existing sidecar path
+            // helpers keep working without conditional branches.
+            if (perFileParquetPaths != null
+                && perFileParquetPaths.TryGetValue(fileName, out string parquetPath))
+            {
+                string parent = Path.GetDirectoryName(parquetPath) ?? ".";
+                return Path.Combine(parent, fileName + ".mzML");
+            }
+            return null;
+        }
     }
 }

--- a/pwiz_tools/Osprey/Osprey.Test/ResidentPoolGuardTest.cs
+++ b/pwiz_tools/Osprey/Osprey.Test/ResidentPoolGuardTest.cs
@@ -135,9 +135,15 @@ namespace pwiz.Osprey.Test
                 new[]
                 {
                     "hpc-merge", "fdrbench-pass1", "mdiag-full-resume", "non-percolator-fdr",
-                    "projection-off"
+                    "projection-off", "compacted-entries-buffer"
                 },
                 ResidentPaths.KNOWN_UNFIXED.ToArray());
+
+            // The POST-compaction handoff guard (issue #4526). The guard above stops at the
+            // compaction line, so the all-files survivor buffer Stage 5 hands to Stage 6 - 28 GB
+            // at 163 files, live for the whole rescore - was never named and no token could
+            // refuse it. Streaming it is the default; the resident opt-out is a named path.
+            AssertStage6HandoffGuard();
 
             // The trigger SET itself, not just the message it produces. Each of these takes the
             // O(files) resident pool and so arms the guard above.
@@ -165,6 +171,48 @@ namespace pwiz.Osprey.Test
         {
             Assert.AreEqual(expected,
                 PerFileScoringTask.NeedsResidentPool(config, useFdrProjection: true));
+        }
+
+        /// <summary>
+        /// The Stage 6 post-compaction handoff guard: streaming (the default) is never guarded,
+        /// the resident opt-out is refused unless it is named, and a run that could not stream
+        /// in the first place is not asked for a second token on top of the one its own
+        /// resident path already requires.
+        /// </summary>
+        private static void AssertStage6HandoffGuard()
+        {
+            // Streaming: no error, whatever the token says.
+            Assert.IsNull(PerFileScoringTask.Stage6ResidentHandoffGuardError(
+                streamingAvailable: true, streamingEnabled: true, allowUnfixedResident: null));
+            Assert.IsNull(PerFileScoringTask.Stage6ResidentHandoffGuardError(
+                true, true, ResidentPaths.HPC_MERGE));
+
+            // OSPREY_STAGE6_STREAM_SURVIVORS=0 on a run that COULD stream: refused, and the
+            // message names the token to set rather than describing a symptom.
+            string err = PerFileScoringTask.Stage6ResidentHandoffGuardError(true, false, null);
+            Assert.IsNotNull(err);
+            StringAssert.Contains(err,
+                "OSPREY_ALLOW_UNFIXED_RESIDENT=" + ResidentPaths.COMPACTED_ENTRIES_BUFFER);
+
+            // Naming THIS path admits it - that is the A/B byte-identity oracle. Case-
+            // insensitive, matching the pre-compaction guard.
+            Assert.IsNull(PerFileScoringTask.Stage6ResidentHandoffGuardError(
+                true, false, ResidentPaths.COMPACTED_ENTRIES_BUFFER));
+            Assert.IsNull(PerFileScoringTask.Stage6ResidentHandoffGuardError(
+                true, false, ResidentPaths.COMPACTED_ENTRIES_BUFFER.ToUpperInvariant()));
+
+            // Naming a DIFFERENT path does not, and the message says which value was supplied
+            // so a stale token does not read like an unset one.
+            string wrongToken = PerFileScoringTask.Stage6ResidentHandoffGuardError(
+                true, false, ResidentPaths.PROJECTION_OFF);
+            Assert.IsNotNull(wrongToken);
+            StringAssert.Contains(wrongToken, ResidentPaths.PROJECTION_OFF);
+
+            // A run that cannot stream at all (no per-file survivor source: the legacy resident
+            // and rehydrate paths never compute the passing base_id set) is NOT guarded here.
+            // It is already resident for a reason carrying its own token, and demanding a
+            // second one would make a single decision need two environment variables.
+            Assert.IsNull(PerFileScoringTask.Stage6ResidentHandoffGuardError(false, false, null));
         }
     }
 }

--- a/pwiz_tools/Osprey/Osprey.Test/ResidentPoolGuardTest.cs
+++ b/pwiz_tools/Osprey/Osprey.Test/ResidentPoolGuardTest.cs
@@ -213,6 +213,25 @@ namespace pwiz.Osprey.Test
             // It is already resident for a reason carrying its own token, and demanding a
             // second one would make a single decision need two environment variables.
             Assert.IsNull(PerFileScoringTask.Stage6ResidentHandoffGuardError(false, false, null));
+
+            // SEVERAL paths may be named at once. A run can legitimately trip more than one,
+            // and a single-value variable made that run impossible: regression.ps1 mode 2 needs
+            // mdiag-full-resume while the arm under test needs compacted-entries-buffer, so the
+            // A/B that proves this very change bounded aborted on its own guard. Both guards
+            // read the list, and every admitted path is still named individually.
+            string both = ResidentPaths.MDIAG_FULL_RESUME + "," +
+                          ResidentPaths.COMPACTED_ENTRIES_BUFFER;
+            Assert.IsNull(PerFileScoringTask.Stage6ResidentHandoffGuardError(true, false, both));
+            var mdiagCfg = new OspreyConfig { ModelDiagnostics = true };
+            Assert.IsNull(PerFileScoringTask.ResidentPoolGuardError(mdiagCfg, true, both, true,
+                mdiagFullResume: true));
+            // Separators are interchangeable and surrounding whitespace is tolerated - an
+            // operator composing the value in a shell should not have to match a spelling.
+            Assert.IsNull(PerFileScoringTask.Stage6ResidentHandoffGuardError(
+                true, false, " projection-off ; compacted-entries-buffer "));
+            // A list still admits ONLY what it names: an unnamed path is refused as before.
+            Assert.IsNotNull(PerFileScoringTask.Stage6ResidentHandoffGuardError(
+                true, false, ResidentPaths.MDIAG_FULL_RESUME + "," + ResidentPaths.HPC_MERGE));
         }
     }
 }

--- a/pwiz_tools/Osprey/regression.ps1
+++ b/pwiz_tools/Osprey/regression.ps1
@@ -1120,12 +1120,29 @@ foreach ($name in $selected) {
         # The former blanket OSPREY_ALLOW_UNBOUNDED_MEMORY=1 would also have waved through any
         # OTHER resident path this leg happened to take - which is how a transfer regression
         # rode along unnoticed. An unlisted path now fails here even with this set.
-        $env:OSPREY_ALLOW_UNFIXED_RESIDENT = 'mdiag-full-resume'
+        #
+        # ADDS its token to whatever the caller named rather than replacing it, and restores the
+        # original afterwards. Replacing it made the A/B that this gate exists to support
+        # impossible to run: an operator proving the streamed Stage 6 handoff bounded sets
+        # OSPREY_STAGE6_STREAM_SURVIVORS=0 with OSPREY_ALLOW_UNFIXED_RESIDENT=
+        # compacted-entries-buffer, and this line then dropped that token and aborted the leg on
+        # the guard. Appending keeps every admitted path individually named, which is the
+        # property that matters.
+        $priorAllowResident = $env:OSPREY_ALLOW_UNFIXED_RESIDENT
+        $env:OSPREY_ALLOW_UNFIXED_RESIDENT = if ([string]::IsNullOrWhiteSpace($priorAllowResident)) {
+            'mdiag-full-resume'
+        } else {
+            "$priorAllowResident,mdiag-full-resume"
+        }
         try {
             $rResume = Invoke-OspreyRun -Mzmls $inputs.Mzmls -Library $inputs.Library -Resolution $cfg.Resolution `
                 -WorkDir $straightDir -LogName 'resume.log' -Spec $cfg -Manifest $inputs.Manifest
         } finally {
-            Remove-Item Env:OSPREY_ALLOW_UNFIXED_RESIDENT -ErrorAction SilentlyContinue
+            if ([string]::IsNullOrWhiteSpace($priorAllowResident)) {
+                Remove-Item Env:OSPREY_ALLOW_UNFIXED_RESIDENT -ErrorAction SilentlyContinue
+            } else {
+                $env:OSPREY_ALLOW_UNFIXED_RESIDENT = $priorAllowResident
+            }
         }
         $resumeBlib = Join-Path $straightDir 'output.blib'
         Write-Host ("  resume wall {0:mm\:ss}; blib {1:N0} bytes" -f $rResume.Wall, (Get-Item $resumeBlib).Length)


### PR DESCRIPTION
## Summary

* Stage 6 no longer holds every file's post-compaction survivors: it refills one file at a
  time from that file's `.scores.parquet` + 1st-pass sidecar, drops them once its reconciled
  parquet is written, and rebuilds the buffer once at the end for Stage 7
* The resident handoff survives behind `OSPREY_STAGE6_STREAM_SURVIVORS=0` as the A/B
  byte-identity oracle, the role `OSPREY_FDR_PROJECTION=0` plays for Stage 5, and it is now
  a NAMED `ResidentPaths` path (`compacted-entries-buffer`) rather than a silent one
* Extracted the per-file survivor load into `FirstPassSurvivorLoader`, so a consumer can
  rebuild one file's survivors without anyone materializing the all-files buffer

Fixes #4526

## Why

The 163-file TDP-43 run held **88,875,901 survivor entries / 28.17 GB live** for the 5.5
hours of `PerFileRescoring`, and that buffer is the blind spot in the `ResidentPaths`
ratchet: all five `KNOWN_UNFIXED` tokens gate the PRE-compaction pool, and the guard stops
at the compaction line. The run took the streaming projection correctly and the guard never
fired.

It also grows super-linearly, because the passing base_id set grows with file count too -
20 -> 163 files is 8.2x the files but **17.2x the entries** (5,178,890 -> 88,875,901;
measured floor 6.65 GB -> 28.17 GB). That is why #4488's "~19 MB/file, no longer the scaling
blocker" projection did not hold: this run measures **173 MB/file**.

## What the buffer is made of

Survivors arrive from `LoadFdrStubsFromParquet` with all six reference fields null, so there
is no payload to shed - the object count itself is the cost (~208 B x 88.9 M ~ 18.5 GB, plus
one un-interned `ModifiedSequence` per row). A payload fix could not have helped.

## Correctness

The streamed rebuild has to reproduce the buffer a fresh rescore leaves. Each difference was
found by measurement, not inspection:

1. **The rescore's score/q reset.** A fresh `OverlayRescoredEntries` sets every rescore
   target to `Score=0, q=1.0`; that reset lives only in memory, because the reconciled
   parquet stores boundaries and features, not scores. It must be reapplied - and BEFORE the
   overlay, whose gap-fill append and re-sort shift the planner's positional indices. It is
   reapplied ONLY to files that actually reached the scoring engine: a file that took the
   per-file resume skip, or that has no `input_files` entry, keeps its real 1st-pass q in the
   resident arm, and under protein-compact an off-stratum survivor keeps that q, so resetting
   it would drop the precursor from the report.
2. **No canonical re-sort.** A fresh rescore appends gap fill at the end and never re-sorts.
3. **The rescored `ScanNumber` and `CoelutionSum`.** A moved peak's scan changes, and the
   pass-2 frozen-model override is looked up by `(EntryId, Charge, ScanNumber)`. Dropping it
   left **110,541 of 994,509 survivors without an override**, so `StreamingFdr`'s
   `ov != scores[i]` discriminator saw `changed=0` instead of `changed=110,646`, those peaks
   never earned a fresh run q, and they were reported on a stale pass-1 q - 31,583 spectra
   against the golden 29,364. Both fields are now carried on EVERY caller of the shared
   overlay, not just the streamed rebuild.
4. **Gap-fill ORDER is now a property of the data.** A cold rescore emitted all CWT-pass rows
   then all forced rows, each in scoring-emit order - an order that depends on which targets
   CWT happened to hit, which is persisted nowhere, so no rebuild-from-disk could ever
   reproduce it. Every file of a real cohort produces both kinds (at 163 files, file 1 is
   10,965 CWT + 2,361 forced), so the two buffers would have diverged at scale while 3-file
   Stellar stayed green. The cold path now appends the whole block sorted by EntryId, which
   both paths can produce; it is still appended at the END, which is the property the
   planner's positional indices actually need. **No golden moved on any dataset.**
5. **Duplicate EntryIds are paired positionally.** A precursor scored in two isolation windows
   gives one buffer row per window, and compaction filters by base_id rather than collapsing
   them. Taking the first reconciled row for both aliased them onto one scan and so onto one
   pass-2 identity - two survivors competing as one.
6. **The overlay is gated on resume VALIDITY, not file existence.** It now asks
   `PerFileResumeDriver.IsCurrent`, the same question the rescore's own per-file gate asks, so
   a stale reconciled parquet from different reconciliation parameters cannot be overlaid onto
   a cold run's buffer.
7. **The no-rescore arm no longer diverges between the arms.** With no planning state the
   resident path leaves the buffer exactly as Stage 5 compacted it, so the streamed path now
   only refills and no longer overlays - otherwise `OSPREY_STAGE6_STREAM_SURVIVORS=0` was not
   the byte-identity oracle the design rests on.

Two mechanisms for gap fill were tried and rejected, recorded so they are not retried:
carrying the rows in memory (cannot work - `--task PerFileRescoring` runs each file in its own
process, and it reintroduces ~270 MB of O(files)), and replaying the reconciled parquet's
appended "tail" (there is none - `StreamReconciledScoresParquet` MERGES gap-fill rows into
canonical position, because Pass 2 recovers scan order from the reconciled row index).

## Guard, token, and the A/B that validates it

`ResidentPaths.COMPACTED_ENTRIES_BUFFER` names the resident handoff, and
`Stage6ResidentHandoffGuardError` refuses it unless named - checked in FirstJoin at the release
decision and BEFORE the release, so a refused run fails in seconds rather than OOMing hours
into Stage 6. `;stage6stream=0` joins the Stage 6 validity key (EMPTY on the streamed default,
so no existing output directory is invalidated) - without it an in-place A/B adopts the first
arm's reconciled parquets and reports a match it never computed.

This ADDS to `KNOWN_UNFIXED`, which the ratchet says may only shrink. It names a path that was
previously UNNAMED rather than re-admitting a fixed one: the older guard's invariant stops at
the compaction line, so no token could refuse this buffer and none was required. It goes when
the resident handoff does.

`OSPREY_ALLOW_UNFIXED_RESIDENT` now takes a **list**, and `regression.ps1` mode 2 ADDS its
token instead of replacing the caller's. This was found by running the oracle, not by reading
it: mode 2 needs `mdiag-full-resume` while the arm under test needs `compacted-entries-buffer`,
and with a single-value variable the A/B that proves this change bounded aborted on its own
guard. The limit was a pre-existing hole - any run tripping two known-unfixed paths hit it -
that the new token exposed. Every admitted path is still named individually.

## Measured

Stellar, `OSPREY_LOG_MEMORY=1`, identical output both arms (29,364 spectra / 88,092 passing):

| | reconciliation floor |
|---|---|
| resident | 0.84 GB |
| streamed | **0.64 GB** |

The 0.20 GB drop is the survivor pool exactly (994,509 x ~208 B = 0.207 GB).

**40 files (TDP-43, `-LinkFrom` Stages 1-4, protein-compact, `-PickLda`)** - same cohort as the
existing baseline, compaction `134,395,432 -> 13,398,508 entries (272,526 passing base_ids)`:

| probe | managed heap |
|---|---|
| `library-resident` (6.32 M entries) | 4.38 GB |
| `stage5-start-live` | 4.41 GB |
| `stage5-handoff-released` | 4.53 GB |
| `reconciliation-floor` (Stage 6 entry) | **4.57 GB** |

Stage 6 enters the rescore **0.19 GB above the bare library floor**, where the resident arm
carries the whole pool (13,398,508 x ~208 B ~ 2.8 GB). `perfviz.py` over the Stage-6-ONLY slice
(log split at `PerFileRescoring:starting`; 8 files, 14 min), which is where floor drift has to
be judged:

```
managed MB : peak 14.5 GB   floor 4.8 -> 4.8 GB   drift -0.00 GB   -0 MB/file   LEVEL
```

Per-file sawteeth all return to the same floor: no step-up, no plateau. The comparison run at
82 files rises to a 40-50 GB band and stays there (peak 50.7 GB).

This is a single arm, not a paired A/B: the ~7.2 GB resident figure at 40 files is a
prediction, not a measurement taken here. What is measured is that the O(files) term is absent
and the Stage 6 floor does not drift. Byte-identity is gated separately, below.

## Test plan

- [x] `Build-Osprey.ps1 -RunTests -RunInspection` - 574/574, zero inspections
- [x] `regression.ps1 -Dataset Stellar` - all five legs PASS with streaming ON by default
- [x] `regression.ps1 -Dataset Stellar` with `OSPREY_STAGE6_STREAM_SURVIVORS=0` +
      `OSPREY_ALLOW_UNFIXED_RESIDENT=compacted-entries-buffer` - all five PASS with the exact
      golden blib, so the oracle is intact and the resident arm is inert
- [x] `regression.ps1 -Dataset All` - Stellar, StellarLibDecoy, StellarGenDecoyEntrap and
      Astral all PASS, including the mode1b diagnostics comparison and FDR sanity bounds
- [x] 40-file Stage 6 memory measurement (above)
- [x] `ResidentPoolGuardTest` extended: pins the new token, covers the new guard, and pins the
      multi-token parsing
- [ ] TeamCity Osprey Windows .NET Perf/Regression on `pull/<N>` - NOT triggered

## Not in this PR

The `protein-compact` stratum accounts for **84% of the survivor entries** (74.4 M of 88.9 M;
386,486 of 446,343 base_ids come from the stratum clause alone, against 59,857 from both FDR
clauses combined), and its consumer already streams one file at a time. Whether stratum-only
survivors need to be Stage-6 entries at all is a ~6x term on the same buffer, recorded on
#4526.

The 163-file Stage-5-only re-measure was dropped deliberately: the 40-file run answers whether
the plateau is gone, and 163 costs ~75 min to confirm it.

See ai/todos/active/TODO-20260731_osprey_bounded_stage5_handoff.md

Co-Authored-By: Claude <noreply@anthropic.com>
