### PR TITLE
osprey: Checked DiagnosticAbort before handing the model to the capture hook

### DIFF
--- a/pwiz_tools/Osprey/Osprey.FDR/PercolatorEngine.cs
+++ b/pwiz_tools/Osprey/Osprey.FDR/PercolatorEngine.cs
@@ -132,18 +132,25 @@ namespace pwiz.Osprey.FDR
             // is a pure hand-off, no behavior change on any production path.
             contributions = results.FeatureContributions;
 
+            // A diagnostic-only (*Only) dump fired inside the engine; it left the
+            // run as a pure no-op and signalled here. Stop without scoring the
+            // stubs and let the Tasks-layer caller perform the process exit.
+            //
+            // CHECKED BEFORE captureModel, not after. On an abort DispatchSvm returns
+            // `new PercolatorResults { DiagnosticAbort = true }` with FoldWeights,
+            // FoldBiases and Standardizer all NULL - nothing was trained. Handing that
+            // to the frozen-model hook passes an untrained model off as a trained one,
+            // and the 2nd pass would then re-score against nulls. The sibling path in
+            // this same file (RunStreamingFirstPass) already orders it this way.
+            if (results.DiagnosticAbort)
+                return true;
+
             // Frozen-model capture hook (OSPREY_PASS2_QVALUE=transfer): the caller
             // can grab the trained model (FoldWeights / FoldBiases / Standardizer)
             // here so a later 2nd-pass step re-scores reconciled features with this
             // FROZEN 1st-pass model instead of retraining. No-op (null) on every
             // default percolator run, so scoring stays byte-identical.
             captureModel?.Invoke(results);
-
-            // A diagnostic-only (*Only) dump fired inside the engine; it left the
-            // run as a pure no-op and signalled here. Stop without scoring the
-            // stubs and let the Tasks-layer caller perform the process exit.
-            if (results.DiagnosticAbort)
-                return true;
 
             // Zip the SVM results back onto the FdrEntry stubs by position
             // (replaces the former psm_id-keyed resultMap re-join).

--- a/pwiz_tools/Osprey/Osprey.Test/FdrTest.cs
+++ b/pwiz_tools/Osprey/Osprey.Test/FdrTest.cs
@@ -1075,6 +1075,59 @@ namespace pwiz.Osprey.Test
         }
 
         /// <summary>
+        /// Issue #4493: a diagnostic-only (<c>*Only</c>) dump aborts the run, and the abort
+        /// sentinel <see cref="PercolatorTrainer"/> returns carries NO trained model -
+        /// FoldWeights, FoldBiases and Standardizer are all null. The frozen-model capture
+        /// hook must therefore NOT be handed that object, or a later 2nd-pass step re-scores
+        /// against nulls believing it holds a trained 1st-pass model.
+        ///
+        /// <para>The ordering used to be conventional rather than enforced: this overload
+        /// invoked <c>captureModel</c> BEFORE testing <c>DiagnosticAbort</c>, while the
+        /// streaming sibling in the same file tested it first, so the two disagreed. No
+        /// abort-path test existed, which is why nothing caught it.</para>
+        /// </summary>
+        [TestMethod]
+        public void TestDiagnosticAbortDoesNotCaptureUntrainedModel()
+        {
+            const int nFeat = 3;
+            var featureInfos = new[]
+            {
+                new OspreyFeatureInfo("feat_a", "Feature A", false),
+                new OspreyFeatureInfo("feat_b", "Feature B", false),
+                new OspreyFeatureInfo("feat_c", "Feature C", false)
+            };
+            var config = new OspreyConfig();
+            var fdrStubs = BuildMultiObservationEquivFixture(nFeat, out var features);
+
+            // StandardizerOnly is the earliest abort: it fires before any fold is trained,
+            // so the sentinel is maximally empty and the assertion is unambiguous.
+            var diagnostics = new PercolatorDiagnosticsConfig
+            {
+                DumpStandardizer = true,
+                StandardizerOnly = true
+            };
+
+            PercolatorResults captured = null;
+            bool aborted;
+            try
+            {
+                aborted = PercolatorEngine.RunPercolatorFdr(
+                    fdrStubs, config, featureInfos, s => { }, out _, diagnostics, "First-pass",
+                    f => features[f], r => captured = r);
+            }
+            finally
+            {
+                // The dump writes a fixed relative path; do not leave it in the test cwd.
+                if (File.Exists(@"cs_stage5_standardizer.tsv"))
+                    File.Delete(@"cs_stage5_standardizer.tsv");
+            }
+
+            Assert.IsTrue(aborted, "a *Only diagnostic dump must stop the run");
+            Assert.IsNull(captured,
+                "captureModel must not be handed the abort sentinel - it carries no trained model");
+        }
+
+        /// <summary>
         /// Issue #4355 step (b) increment iii (the transient-SVM-stack collapse, gate
         /// 1): the projection-native STREAMING score+compete path
         /// (<see cref="PercolatorEngine.RunStreamingIntoProjection"/>) must


### PR DESCRIPTION
## Summary

* Checked `results.DiagnosticAbort` BEFORE invoking the `captureModel` hook in
  `PercolatorEngine.RunPercolatorFdr`, so the frozen-model hook can no longer be handed an
  untrained model
* Added `TestDiagnosticAbortDoesNotCaptureUntrainedModel`, the abort-path test the issue names
  as missing

Fixes #4493

## Why

On a diagnostic-only (`*Only`) run `DispatchSvm` returns
`new PercolatorResults { DiagnosticAbort = true }` with `FoldWeights`, `FoldBiases` and
`Standardizer` all NULL - nothing was trained. That object was being passed to the
frozen-model capture hook (`OSPREY_PASS2_QVALUE=transfer`) as though it were a trained
1st-pass model, so a later 2nd-pass step would re-score against nulls.

The streaming sibling in the SAME file already had it right - it tests the abort at
`PercolatorEngine.cs:906` and invokes the hook at `:914`. The two paths simply disagreed.

Root cause is the abort sentinel riding on the data object: nothing ORDERED the check before
the use, so correctness was conventional rather than enforced.

## Test

`TestDiagnosticAbortDoesNotCaptureUntrainedModel` drives the real overload with
`StandardizerOnly` - the earliest abort, firing before any fold is trained, so the sentinel is
maximally empty - and asserts the run aborted AND the hook was never called.

**Verified it actually catches the bug**: stashing only the `PercolatorEngine.cs` change and
re-running gives `Failed: 1 / Passed: 574`; with the fix, 575/575. A regression test that
passes either way would have been worthless here.

The dump writes to a fixed relative path, so the test deletes `cs_stage5_standardizer.tsv` in a
`finally` rather than leaving it in the test working directory.

## Not in this PR

The issue suggests the deeper fix - a dedicated result type, or an explicit abort return,
making the ordering *unrepresentable* rather than conventional. That is a wider refactor
touching all four `DiagnosticAbort` return sites in `PercolatorTrainer` and the parity-locked
dispatch, so it is left on #4493 as the follow-up if this pattern bites again.

## Test plan

- [x] `Build-Osprey.ps1 -Configuration Debug -RunTests -RunInspection` - 575/575, zero inspections
- [x] New test verified failing without the fix
- [ ] `regression.ps1 -Dataset Stellar` - NOT run, see below
- [ ] TeamCity Perf/Regression - not triggered

**On the Stellar gate**: this change is inert on every production path - `captureModel` is null
on default percolator runs, and the abort only fires under a `*Only` diagnostic env var, which
no regression leg sets. So it cannot move a golden. It was also not run because the machine is
mid-way through a 197-file `.spectra.bin` staging sweep and the two would contend for the same
disk. Happy to run it before merge if a reviewer wants the belt-and-braces confirmation.

**`/code-review max` was NOT run on this branch** - the harness refuses model-invoked runs of
that skill, so it needs to be started by the developer.

See ai/todos/active/TODO-20260805_osprey_diagnostic_abort_capture.md

Co-Authored-By: Claude <noreply@anthropic.com>
