### PR TITLE
osprey: Streamed the model-diagnostics report on a full resume

### DIFF
--- a/pwiz_tools/Osprey/Osprey.Core/OspreyEnvironment.cs
+++ b/pwiz_tools/Osprey/Osprey.Core/OspreyEnvironment.cs
@@ -449,7 +449,7 @@ namespace pwiz.Osprey.Core
 
         /// <summary>
         /// OSPREY_ALLOW_UNFIXED_RESIDENT: name the known-unfixed resident path(s) this run may
-        /// take, e.g. <c>OSPREY_ALLOW_UNFIXED_RESIDENT=mdiag-full-resume</c>. Legal values are
+        /// take, e.g. <c>OSPREY_ALLOW_UNFIXED_RESIDENT=hpc-merge</c>. Legal values are
         /// exactly <see cref="ResidentPaths.KNOWN_UNFIXED"/>; anything else, and any resident path
         /// that is not on that list, is refused no matter what this is set to.
         ///

--- a/pwiz_tools/Osprey/Osprey.Core/OspreyEnvironment.cs
+++ b/pwiz_tools/Osprey/Osprey.Core/OspreyEnvironment.cs
@@ -464,10 +464,9 @@ namespace pwiz.Osprey.Core
         ///
         /// <para>SEVERAL paths may be named, comma- or semicolon-separated, because a run can
         /// legitimately trip more than one at once and a single-value variable made that run
-        /// impossible to perform at all. The A/B that proves the Stage 6 handoff bounded is
-        /// exactly such a run: <c>regression.ps1</c> mode 2 needs
-        /// <see cref="ResidentPaths.MDIAG_FULL_RESUME"/> while the arm under test needs
-        /// <see cref="ResidentPaths.COMPACTED_ENTRIES_BUFFER"/>. A LIST keeps the property that
+        /// impossible to perform at all - an A/B whose own arm needs
+        /// <see cref="ResidentPaths.COMPACTED_ENTRIES_BUFFER"/> could not also name whatever
+        /// path the harness leg it runs under happens to take. A LIST keeps the property that
         /// matters - every admitted path is still named individually, so nothing rides along
         /// unnamed the way the blanket boolean allowed - while a single value only ever
         /// prevented honest work.</para>

--- a/pwiz_tools/Osprey/Osprey.Core/ResidentPaths.cs
+++ b/pwiz_tools/Osprey/Osprey.Core/ResidentPaths.cs
@@ -58,15 +58,6 @@ namespace pwiz.Osprey.Core
         public static readonly string FDRBENCH_PASS1 = @"fdrbench-pass1";
 
         /// <summary>
-        /// <c>--model-diagnostics</c> on a FULL resume, where the 1st-pass sidecars are already
-        /// on disk so FirstJoin skips its score pass, the streaming accumulator is never fed,
-        /// and the report falls back to the resident batch write. Tracked by issue #4505; the
-        /// scale case was streamed by #4420, and a verified fix for this remainder is parked on
-        /// the closed #4437 branch.
-        /// </summary>
-        public static readonly string MDIAG_FULL_RESUME = @"mdiag-full-resume";
-
-        /// <summary>
         /// A non-Percolator <c>FdrMethod</c> (Simple / Mokapot), which does not use the
         /// projection framework at all. By design rather than unfinished work, but it still
         /// takes the resident path and so must be named to be allowed.
@@ -112,7 +103,7 @@ namespace pwiz.Osprey.Core
         /// </summary>
         public static readonly IReadOnlyList<string> KNOWN_UNFIXED = new[]
         {
-            HPC_MERGE, FDRBENCH_PASS1, MDIAG_FULL_RESUME, NON_PERCOLATOR_FDR, PROJECTION_OFF,
+            HPC_MERGE, FDRBENCH_PASS1, NON_PERCOLATOR_FDR, PROJECTION_OFF,
             COMPACTED_ENTRIES_BUFFER
         };
     }

--- a/pwiz_tools/Osprey/Osprey.Tasks/FirstJoinTask.cs
+++ b/pwiz_tools/Osprey/Osprey.Tasks/FirstJoinTask.cs
@@ -570,7 +570,8 @@ namespace pwiz.Osprey.Tasks
             // off the same load for the same reason, and its accumulator is null when the
             // resident twin ran, which leaves the batch report reading perFileEntries.
             LogFirstPassResultsAndDump(perFileEntries, config, ctx, null,
-                bundle.PreCompactionTallies, bundle.ModelDiagnosticsAccumulator);
+                bundle.PreCompactionTallies, bundle.ModelDiagnosticsAccumulator,
+                resumeFromSidecars: true);
             // The accumulator holds the whole run's --model-diagnostics reduction (~1-2 GB
             // at 82 files) and has exactly one reader, the WriteFromAccumulator call the
             // line above just made. It reached here on the published RescoreBundle, whose
@@ -695,7 +696,8 @@ namespace pwiz.Osprey.Tasks
             PipelineContext ctx,
             FeatureContributions contributions = null,
             IReadOnlyList<PreCompactionTally> preCompactionTallies = null,
-            ModelDiagnosticsData.Accumulator mdiagAccumulator = null)
+            ModelDiagnosticsData.Accumulator mdiagAccumulator = null,
+            bool resumeFromSidecars = false)
         {
             LogFirstPassResults(perFileEntries, config, ctx, preCompactionTallies);
 
@@ -719,11 +721,145 @@ namespace pwiz.Osprey.Tasks
                     ModelDiagnosticsReport.WriteFromAccumulator(
                         mdiagAccumulator, contributions, cal, config, ctx.LogInfo);
                 }
+                else if (resumeFromSidecars)
+                {
+                    // Resume with no accumulator: the upstream hydrate did not stream, so
+                    // perFileEntries is NOT the pre-compaction pool the batch writer needs.
+                    // Rebuild the same reduction by streaming each file's sidecar + parquet
+                    // instead of forcing the O(files) resident pool to exist (issue #4505).
+                    WriteModelDiagnosticsFromSidecars(perFileEntries, cal, config, ctx);
+                }
                 else
                 {
                     var libraryById = ctx.Get<LibraryById>().Value;
                     ModelDiagnosticsReport.Write(perFileEntries, contributions, libraryById, cal, config, ctx.LogInfo);
                 }
+            }
+        }
+
+        /// <summary>
+        /// Resume-path <c>--model-diagnostics</c> emission: stream every file's
+        /// <c>.1st-pass.fdr_scores.bin</c> sidecar (SVM score + q-values, in stored row order)
+        /// joined with its parquet scalars (entry_id / charge / is_decoy / modseq, same row
+        /// order) into the reduced <see cref="ModelDiagnosticsData.Accumulator"/>, then render
+        /// via <see cref="ModelDiagnosticsReport.WriteFromAccumulator"/>.
+        ///
+        /// <para>This reproduces the exact rows the resident batch
+        /// <see cref="ModelDiagnosticsReport.Write"/> reads off the fat pool - the sidecar
+        /// carries the SAME per-row score + q the overlay would have assigned each stub - so the
+        /// streamed report is byte-identical to the resident build without ever materializing
+        /// that pool. Contributions are null on a resume (no retrain), matching the resident
+        /// resume path. A failure is logged and swallowed: a diagnostics-only artifact must
+        /// never take down a real run, which is what
+        /// <see cref="ModelDiagnosticsReport.Write"/> and
+        /// <see cref="ModelDiagnosticsReport.WriteFromAccumulator"/> also do.</para>
+        /// </summary>
+        private void WriteModelDiagnosticsFromSidecars(
+            List<KeyValuePair<string, List<FdrEntry>>> perFileEntries,
+            ModelDiagnosticsData.CalibrationData cal,
+            OspreyConfig config,
+            PipelineContext ctx)
+        {
+            try
+            {
+                var runNames = perFileEntries.ConvertAll(kv => kv.Key);
+                var libraryById = ctx.Get<LibraryById>().Value;
+                var accumulator = BuildModelDiagnosticsAccumulator(
+                    runNames, libraryById, config, ctx.LogInfo);
+                var perFileParquetPaths = ctx.Get<PerFileParquetPaths>().Value;
+
+                for (int fileIdx = 0; fileIdx < perFileEntries.Count; fileIdx++)
+                {
+                    string fileName = perFileEntries[fileIdx].Key;
+                    if (perFileParquetPaths == null ||
+                        !perFileParquetPaths.TryGetValue(fileName, out string parquetPath))
+                    {
+                        ctx.LogWarning(string.Format(
+                            @"[MODEL-DIAGNOSTICS] resume: no scores parquet path for {0}; skipping its rows.",
+                            fileName));
+                        continue;
+                    }
+                    string sidecarBase = ScoringTaskShared.ResolveSidecarBasePath(
+                        fileName, perFileParquetPaths, config);
+                    if (string.IsNullOrEmpty(sidecarBase))
+                    {
+                        ctx.LogWarning(string.Format(
+                            @"[MODEL-DIAGNOSTICS] resume: no sidecar base path for {0}; skipping its rows.",
+                            fileName));
+                        continue;
+                    }
+                    string sidecarPath = FdrScoresSidecar.Pass1Path(sidecarBase);
+
+                    // Row order == parquet row order == the order the score-pass sink wrote
+                    // them, so the two sides zip by row ordinal - the same (scalars indexed by
+                    // row) binding the resident overlay uses. entry_id is carried on both
+                    // sides, so a misalignment fails loud rather than folding wrong rows.
+                    var records = new List<FdrScoreRecord>();
+                    if (!FdrScoresSidecar.ReadRecords(
+                            sidecarPath, FdrScoresSidecar.Pass.FirstPass, records.Add))
+                    {
+                        ctx.LogWarning(string.Format(
+                            @"[MODEL-DIAGNOSTICS] resume: failed to read {0}; skipping its rows.",
+                            sidecarPath));
+                        continue;
+                    }
+
+                    // Per-file best-effort: an incomplete / mismatched file (sidecar and parquet
+                    // disagree on row count - the realistic "one bad file" case) is skipped with
+                    // a warning BEFORE any of its rows reach the shared accumulator, so one bad
+                    // file corrupts neither the report nor the remaining files. A same-count
+                    // entry_id scramble cannot arise while both sides read the parquet in row
+                    // order, and still trips the defensive throws below. Footer-only read.
+                    long parquetRowCount = ParquetScoreCache.ProbeCwtRowMetadata(parquetPath).RowCount;
+                    if (parquetRowCount != records.Count)
+                    {
+                        ctx.LogWarning(string.Format(
+                            @"[MODEL-DIAGNOSTICS] resume: {0} row-count mismatch (parquet {1} vs sidecar {2}); skipping its rows.",
+                            fileName, parquetRowCount, records.Count));
+                        continue;
+                    }
+
+                    int localFileIdx = fileIdx;
+                    int row = 0;
+                    ParquetScoreCache.ReadFdrStubScalars(parquetPath,
+                        (entryId, charge, isDecoy, coelutionSum, modseq) =>
+                        {
+                            if (row >= records.Count)
+                            {
+                                throw new InvalidDataException(string.Format(
+                                    @"model-diagnostics resume: {0} has more parquet rows than {1} has records.",
+                                    parquetPath, sidecarPath));
+                            }
+                            var rec = records[row];
+                            if (rec.EntryId != entryId)
+                            {
+                                throw new InvalidDataException(string.Format(
+                                    @"model-diagnostics resume: row {0} entry_id mismatch (parquet {1} vs sidecar {2}) in {3}.",
+                                    row, entryId, rec.EntryId, fileName));
+                            }
+                            var q = new FdrQValues(
+                                rec.RunPrecursorQvalue, rec.RunPeptideQvalue,
+                                rec.ExperimentPrecursorQvalue, rec.ExperimentPeptideQvalue, rec.Pep);
+                            accumulator.Add(localFileIdx, modseq ?? string.Empty, charge, entryId,
+                                isDecoy, rec.Score, in q);
+                            row++;
+                        });
+                    if (row != records.Count)
+                    {
+                        throw new InvalidDataException(string.Format(
+                            @"model-diagnostics resume: {0} has {1} parquet rows but {2} sidecar records.",
+                            fileName, row, records.Count));
+                    }
+                }
+
+                ModelDiagnosticsReport.WriteFromAccumulator(accumulator, null, cal, config, ctx.LogInfo);
+            }
+            catch (Exception ex)
+            {
+                // Log the full exception, not just Message: a sidecar/parquet mismatch is only
+                // diagnosable with the stack.
+                ctx.LogInfo(string.Format(
+                    @"[MODEL-DIAGNOSTICS] resume report generation failed: {0}", ex));
             }
         }
 

--- a/pwiz_tools/Osprey/Osprey.Tasks/PerFileScoringTask.cs
+++ b/pwiz_tools/Osprey/Osprey.Tasks/PerFileScoringTask.cs
@@ -647,9 +647,17 @@ namespace pwiz.Osprey.Tasks
             // so the fat pool is never on the row-count scaling path. The full elimination (stream
             // the batch report from the sidecar+parquet too) is a documented follow-up.
             // See TODO-20260720_osprey_pass2_per_run_qvalue.
-            bool mdiagFullResume = config.ModelDiagnostics && FirstPassSidecarsPresent(config);
-            bool needsResidentPool = NeedsResidentPool(config) || mdiagFullResume;
-            GuardResidentPool(config, needsResidentPool, mdiagFullResume);
+            // --model-diagnostics no longer forces the fat pool (issue #4505). A resume with the
+            // 1st-pass sidecars ABSENT re-runs FirstPassFDR and streams the report off its score
+            // pass, exactly like a compute run. A resume with them PRESENT now emits the report
+            // by streaming each file's sidecar + parquet into the same
+            // ModelDiagnosticsData.Accumulator (FirstJoinTask.WriteModelDiagnosticsFromSidecars)
+            // rather than reading the resident pre-compaction pool. Either way the report is the
+            // same reduction, and the O(files) pool that OOM'd an 82-file mdiag resume is never
+            // materialized - so mdiag now takes the same lean resume path every OTHER resume
+            // already took, rather than being the one exception to it.
+            bool needsResidentPool = NeedsResidentPool(config);
+            GuardResidentPool(config, needsResidentPool);
             FdrProjectionSet projections = null;
 
             var swAllFiles = Stopwatch.StartNew();
@@ -1895,31 +1903,7 @@ namespace pwiz.Osprey.Tasks
                    (!string.IsNullOrEmpty(config.OutputFdrBench) && config.FdrBenchPass == 1);
         }
 
-        /// <summary>
-        /// True when every input file already has its <c>.1st-pass.fdr_scores.bin</c> sidecar on
-        /// disk, so FirstJoin will REHYDRATE first-pass FDR (skip its score pass) rather than
-        /// recompute. Under <c>--model-diagnostics</c> that skip routes the report to the batch
-        /// <c>ModelDiagnosticsReport.Write</c>, which reads the RESIDENT per-file entries -- the
-        /// one case a resume still needs the fat pool. A Stage-1-4 (<c>-LinkFrom</c>) resume links
-        /// only the Stage-4 <c>.scores.parquet</c>, so the 1st-pass sidecars are ABSENT, FirstPassFDR
-        /// re-runs, and its score pass streams the report -- no resident pool needed. Absent sidecars
-        /// therefore mean "stay lean" (correct); present sidecars mean "keep fat" (conservative,
-        /// matching the batch-write path). Mirrors <see cref="FdrScoresSidecar.Pass1Path"/> as used by
-        /// <c>FirstJoinTask</c>'s rehydrate-output enumeration.
-        /// </summary>
-        private static bool FirstPassSidecarsPresent(OspreyConfig config)
-        {
-            if (config.InputFiles == null || config.InputFiles.Count == 0)
-                return false;
-            foreach (var inputFile in config.InputFiles)
-            {
-                if (!File.Exists(FdrScoresSidecar.Pass1Path(inputFile)))
-                    return false;
-            }
-            return true;
-        }
-
-        /// <summary>
+                /// <summary>
         /// Fail fast when a run would build the RESIDENT first-pass pool -- an O(files) memory
         /// path (the fat <see cref="FdrEntry"/> stub buffer, and the <c>FirstJoin.Rehydrate</c>
         /// pre-compaction load it feeds) that does not scale to large file counts. Unless the
@@ -1932,11 +1916,10 @@ namespace pwiz.Osprey.Tasks
         /// outright and so must be named like any other.
         /// </summary>
         private static void GuardResidentPool(
-            OspreyConfig config, bool needsResidentPool, bool mdiagFullResume = false)
+            OspreyConfig config, bool needsResidentPool)
         {
             string error = ResidentPoolGuardError(config, needsResidentPool,
-                OspreyEnvironment.AllowUnfixedResident, OspreyEnvironment.UseFdrProjection,
-                mdiagFullResume);
+                OspreyEnvironment.AllowUnfixedResident, OspreyEnvironment.UseFdrProjection);
             if (error != null)
                 throw new InvalidOperationException(error);
         }
@@ -1958,11 +1941,11 @@ namespace pwiz.Osprey.Tasks
         /// </summary>
         internal static string ResidentPoolGuardError(
             OspreyConfig config, bool needsResidentPool, string allowUnfixedResident,
-            bool useFdrProjection, bool mdiagFullResume = false)
+            bool useFdrProjection)
         {
             if (!needsResidentPool)
                 return null;
-            string trigger = ResidentPoolTrigger(config, useFdrProjection, mdiagFullResume);
+            string trigger = ResidentPoolTrigger(config, useFdrProjection);
             // Membership in the committed list is what makes it the high-water mark rather than
             // documentation: a token the trigger chain invents but the list does not carry is
             // refused here, so re-admitting a path really does require editing the list (and
@@ -2051,14 +2034,14 @@ namespace pwiz.Osprey.Tasks
         /// config-driven reasons, because it selects the legacy implementation for the WHOLE run
         /// and is therefore the honest description even when another trigger also applies.</para>
         ///
-        /// <para><paramref name="mdiagFullResume"/> is passed in rather than read off
-        /// <paramref name="config"/>: <c>--model-diagnostics</c> forces the pool only in
-        /// combination with a full resume, and testing <c>config.ModelDiagnostics</c> alone here
-        /// would make mdiag an unconditional catch-all that silently absorbed any FUTURE arming
-        /// condition - handing it a token CI already exports.</para>
+        /// <para><c>--model-diagnostics</c> used to appear here as a fifth trigger, armed only in
+        /// combination with a full resume. Issue #4505 removed it: the resume report now streams
+        /// from the 1st-pass sidecar + parquet, so mdiag no longer needs the pool at all and the
+        /// token went with it. That is the ratchet SHRINKING, which is the direction it is
+        /// allowed to move.</para>
         /// </summary>
         private static string ResidentPoolTrigger(
-            OspreyConfig config, bool useFdrProjection, bool mdiagFullResume)
+            OspreyConfig config, bool useFdrProjection)
         {
             if (!useFdrProjection)
                 return ResidentPaths.PROJECTION_OFF;
@@ -2068,8 +2051,6 @@ namespace pwiz.Osprey.Tasks
                 return ResidentPaths.NON_PERCOLATOR_FDR;
             if (!string.IsNullOrEmpty(config.OutputFdrBench) && config.FdrBenchPass == 1)
                 return ResidentPaths.FDRBENCH_PASS1;
-            if (mdiagFullResume)
-                return ResidentPaths.MDIAG_FULL_RESUME;
             return null;
         }
 

--- a/pwiz_tools/Osprey/Osprey.Tasks/PerFileScoringTask.cs
+++ b/pwiz_tools/Osprey/Osprey.Tasks/PerFileScoringTask.cs
@@ -635,18 +635,6 @@ namespace pwiz.Osprey.Tasks
             // needs the resident pool. FirstJoin consumes the projection set identically
             // whether Run or this path produced it.
             //
-            // --model-diagnostics forces the fat pool ONLY for a FULL resume, where FirstJoin
-            // ALSO skips the first-pass score pass (every 1st-pass sidecar already on disk) and
-            // emits the report via the batch ModelDiagnosticsReport.Write, which reads the
-            // RESIDENT per-file entries. On a Stage-1-4 (-LinkFrom) resume the 1st-pass sidecars
-            // are absent, so FirstPassFDR RE-RUNS and streams the report off its score pass
-            // (ModelDiagnosticsData.Accumulator) exactly like a compute run -- no resident pool
-            // needed. Probing the sidecars keeps the lean counts-only path for the common
-            // -LinkFrom A/B resume (whose forced fat pool OOM'd an 82-file mdiag run) while
-            // preserving the batch-write path's resident entries for the full-resume re-report,
-            // so the fat pool is never on the row-count scaling path. The full elimination (stream
-            // the batch report from the sidecar+parquet too) is a documented follow-up.
-            // See TODO-20260720_osprey_pass2_per_run_qvalue.
             // --model-diagnostics no longer forces the fat pool (issue #4505). A resume with the
             // 1st-pass sidecars ABSENT re-runs FirstPassFDR and streams the report off its score
             // pass, exactly like a compute run. A resume with them PRESENT now emits the report
@@ -1903,17 +1891,17 @@ namespace pwiz.Osprey.Tasks
                    (!string.IsNullOrEmpty(config.OutputFdrBench) && config.FdrBenchPass == 1);
         }
 
-                /// <summary>
+        /// <summary>
         /// Fail fast when a run would build the RESIDENT first-pass pool -- an O(files) memory
         /// path (the fat <see cref="FdrEntry"/> stub buffer, and the <c>FirstJoin.Rehydrate</c>
         /// pre-compaction load it feeds) that does not scale to large file counts. Unless the
         /// operator named THIS path via <c>OSPREY_ALLOW_UNFIXED_RESIDENT</c>, throw with the token
         /// named so the failure is actionable rather than an opaque OOM at scale. Triggers: the
         /// HPC reconciled-input merge (#4486), <c>--fdrbench-pass 1</c> (#4507), a non-Percolator
-        /// FdrMethod, <c>--model-diagnostics</c> on a full resume (#4505 - the scale case was
-        /// streamed by #4420; only the full-resume batch report remains), and
-        /// <c>OSPREY_FDR_PROJECTION=0</c>, which requests the legacy resident implementation
-        /// outright and so must be named like any other.
+        /// FdrMethod, and <c>OSPREY_FDR_PROJECTION=0</c>, which requests the legacy resident
+        /// implementation outright and so must be named like any other.
+        /// <c>--model-diagnostics</c> on a full resume was a fifth trigger until #4505 streamed
+        /// that report from the sidecar + parquet; it needs no pool and has no token now.
         /// </summary>
         private static void GuardResidentPool(
             OspreyConfig config, bool needsResidentPool)

--- a/pwiz_tools/Osprey/Osprey.Test/ResidentPoolGuardTest.cs
+++ b/pwiz_tools/Osprey/Osprey.Test/ResidentPoolGuardTest.cs
@@ -91,19 +91,17 @@ namespace pwiz.Osprey.Test
                 allowUnfixedResident: ResidentPaths.HPC_MERGE.ToUpperInvariant(),
                 useFdrProjection: true));
 
-            // Each user-reachable trigger names its own token so the failure is diagnosable:
-            // mdiag arms the pool only in COMBINATION with a full resume, so the caller passes
-            // that conjunction in. Testing config.ModelDiagnostics alone inside the trigger would
-            // make mdiag an unconditional catch-all that absorbed any future arming condition -
-            // and hand it the one token CI already exports (regression.ps1 mode 2).
+            // --model-diagnostics is NO LONGER a trigger (issue #4505): the full-resume report
+            // streams from the 1st-pass sidecar + parquet, so it needs no resident pool and has
+            // no token. mdiag alone was never a trigger either, so the config is refused outright
+            // like any other unnamed path - which is what this asserts, and what stops the
+            // removed trigger from creeping back as an unconditional catch-all.
             var mdiag = new OspreyConfig { ModelDiagnostics = true };
-            StringAssert.Contains(
-                PerFileScoringTask.ResidentPoolGuardError(mdiag, true, null, true,
-                    mdiagFullResume: true),
-                ResidentPaths.MDIAG_FULL_RESUME);
-            // --model-diagnostics WITHOUT the full resume is not a known path: refused outright.
-            Assert.IsNotNull(PerFileScoringTask.ResidentPoolGuardError(mdiag, true,
-                ResidentPaths.MDIAG_FULL_RESUME, true, mdiagFullResume: false));
+            foreach (string token in new[] { null, ResidentPaths.HPC_MERGE, "mdiag-full-resume" })
+            {
+                Assert.IsNotNull(
+                    PerFileScoringTask.ResidentPoolGuardError(mdiag, true, token, true), token);
+            }
 
             var fdrbench1 = new OspreyConfig { OutputFdrBench = "bench.tsv", FdrBenchPass = 1 };
             StringAssert.Contains(PerFileScoringTask.ResidentPoolGuardError(fdrbench1, true, null, true),
@@ -134,7 +132,7 @@ namespace pwiz.Osprey.Test
             CollectionAssert.AreEqual(
                 new[]
                 {
-                    "hpc-merge", "fdrbench-pass1", "mdiag-full-resume", "non-percolator-fdr",
+                    "hpc-merge", "fdrbench-pass1", "non-percolator-fdr",
                     "projection-off", "compacted-entries-buffer"
                 },
                 ResidentPaths.KNOWN_UNFIXED.ToArray());
@@ -219,19 +217,18 @@ namespace pwiz.Osprey.Test
             // mdiag-full-resume while the arm under test needs compacted-entries-buffer, so the
             // A/B that proves this very change bounded aborted on its own guard. Both guards
             // read the list, and every admitted path is still named individually.
-            string both = ResidentPaths.MDIAG_FULL_RESUME + "," +
+            string both = ResidentPaths.HPC_MERGE + "," +
                           ResidentPaths.COMPACTED_ENTRIES_BUFFER;
             Assert.IsNull(PerFileScoringTask.Stage6ResidentHandoffGuardError(true, false, both));
-            var mdiagCfg = new OspreyConfig { ModelDiagnostics = true };
-            Assert.IsNull(PerFileScoringTask.ResidentPoolGuardError(mdiagCfg, true, both, true,
-                mdiagFullResume: true));
+            var hpcCfg = new OspreyConfig { ExpectReconciledInput = true };
+            Assert.IsNull(PerFileScoringTask.ResidentPoolGuardError(hpcCfg, true, both, true));
             // Separators are interchangeable and surrounding whitespace is tolerated - an
             // operator composing the value in a shell should not have to match a spelling.
             Assert.IsNull(PerFileScoringTask.Stage6ResidentHandoffGuardError(
                 true, false, " projection-off ; compacted-entries-buffer "));
             // A list still admits ONLY what it names: an unnamed path is refused as before.
             Assert.IsNotNull(PerFileScoringTask.Stage6ResidentHandoffGuardError(
-                true, false, ResidentPaths.MDIAG_FULL_RESUME + "," + ResidentPaths.HPC_MERGE));
+                true, false, ResidentPaths.PROJECTION_OFF + "," + ResidentPaths.HPC_MERGE));
         }
     }
 }

--- a/pwiz_tools/Osprey/Osprey.Test/ResidentPoolGuardTest.cs
+++ b/pwiz_tools/Osprey/Osprey.Test/ResidentPoolGuardTest.cs
@@ -212,11 +212,13 @@ namespace pwiz.Osprey.Test
             // second one would make a single decision need two environment variables.
             Assert.IsNull(PerFileScoringTask.Stage6ResidentHandoffGuardError(false, false, null));
 
-            // SEVERAL paths may be named at once. A run can legitimately trip more than one,
-            // and a single-value variable made that run impossible: regression.ps1 mode 2 needs
-            // mdiag-full-resume while the arm under test needs compacted-entries-buffer, so the
-            // A/B that proves this very change bounded aborted on its own guard. Both guards
-            // read the list, and every admitted path is still named individually.
+            // SEVERAL paths may be named at once. A run can legitimately trip more than one -
+            // an HPC merge measured with the Stage 6 resident handoff forced, say - and a
+            // single-value variable made such a run impossible to perform at all: naming one
+            // path meant the other aborted on its own guard. Both guards read the list, and
+            // every admitted path is still named individually, which is the property that
+            // matters. (The motivating case when this landed was regression.ps1 mode 2, whose
+            // mdiag-full-resume opt-in #4505 has since removed entirely.)
             string both = ResidentPaths.HPC_MERGE + "," +
                           ResidentPaths.COMPACTED_ENTRIES_BUFFER;
             Assert.IsNull(PerFileScoringTask.Stage6ResidentHandoffGuardError(true, false, both));

--- a/pwiz_tools/Osprey/regression.ps1
+++ b/pwiz_tools/Osprey/regression.ps1
@@ -1100,50 +1100,19 @@ foreach ($name in $selected) {
         $coldBlib = Join-Path $straightDir 'output_cold.blib'
         Copy-Item $straightBlib $coldBlib -Force
         Invoke-ResumeInvalidation -WorkDir $straightDir
-        # Scoped opt-in, and ONLY for this leg. A FULL resume with --model-diagnostics is a
-        # genuinely O(files) path that is not fixed yet: the invalidation leaves every
-        # <stem>.1st-pass.fdr_scores.bin on disk, so FirstJoin skips the first-pass score
-        # pass and emits the report through the batch ModelDiagnosticsReport.Write, which
-        # reads the RESIDENT per-file entries (PerFileScoringTask.cs, needsResidentPool at
-        # the --input-files rehydrate). The guard is therefore RIGHT to throw here, and
-        # suppressing it is the honest thing to do only because these are 3-file datasets.
+        # NO opt-in, on any leg. A full resume with --model-diagnostics used to be a genuinely
+        # O(files) path: the invalidation leaves every <stem>.1st-pass.fdr_scores.bin on disk, so
+        # FirstJoin skipped the first-pass score pass and emitted the report through the batch
+        # ModelDiagnosticsReport.Write, which reads the RESIDENT per-file entries. Issue #4505
+        # streamed that report from the sidecar + parquet instead, so the last leg of this gate
+        # that needed OSPREY_ALLOW_UNFIXED_RESIDENT no longer does - and the standing gate now
+        # runs end to end with no memory hatch set anywhere.
         #
-        # This is NOT the scale case. --model-diagnostics over --input-scores streams the
-        # report off ModelDiagnosticsData.Accumulator one file at a time and needs no opt-in
-        # at any file count. What remains is the full-resume batch report, tracked in #4505;
-        # the fix is to feed the same accumulator during the resume's per-file load and
-        # report from it, and it is already written and verified on the closed #4437 branch.
-        #
-        # mode 3 above deliberately has NO opt-in: its old one wrapped the entire HPC chain
-        # and would mask a guard regression on any --input-scores worker.
-        # Names the ONE path it needs, so what CI depends on is visible rather than ambient.
-        # The former blanket OSPREY_ALLOW_UNBOUNDED_MEMORY=1 would also have waved through any
-        # OTHER resident path this leg happened to take - which is how a transfer regression
-        # rode along unnoticed. An unlisted path now fails here even with this set.
-        #
-        # ADDS its token to whatever the caller named rather than replacing it, and restores the
-        # original afterwards. Replacing it made the A/B that this gate exists to support
-        # impossible to run: an operator proving the streamed Stage 6 handoff bounded sets
-        # OSPREY_STAGE6_STREAM_SURVIVORS=0 with OSPREY_ALLOW_UNFIXED_RESIDENT=
-        # compacted-entries-buffer, and this line then dropped that token and aborted the leg on
-        # the guard. Appending keeps every admitted path individually named, which is the
-        # property that matters.
-        $priorAllowResident = $env:OSPREY_ALLOW_UNFIXED_RESIDENT
-        $env:OSPREY_ALLOW_UNFIXED_RESIDENT = if ([string]::IsNullOrWhiteSpace($priorAllowResident)) {
-            'mdiag-full-resume'
-        } else {
-            "$priorAllowResident,mdiag-full-resume"
-        }
-        try {
-            $rResume = Invoke-OspreyRun -Mzmls $inputs.Mzmls -Library $inputs.Library -Resolution $cfg.Resolution `
-                -WorkDir $straightDir -LogName 'resume.log' -Spec $cfg -Manifest $inputs.Manifest
-        } finally {
-            if ([string]::IsNullOrWhiteSpace($priorAllowResident)) {
-                Remove-Item Env:OSPREY_ALLOW_UNFIXED_RESIDENT -ErrorAction SilentlyContinue
-            } else {
-                $env:OSPREY_ALLOW_UNFIXED_RESIDENT = $priorAllowResident
-            }
-        }
+        # Leaving it unset is the POINT, not an omission: a scoped opt-in here would mask exactly
+        # the regression this leg is best placed to catch, which is how a transfer regression rode
+        # along unnoticed under the former blanket OSPREY_ALLOW_UNBOUNDED_MEMORY=1.
+        $rResume = Invoke-OspreyRun -Mzmls $inputs.Mzmls -Library $inputs.Library -Resolution $cfg.Resolution `
+            -WorkDir $straightDir -LogName 'resume.log' -Spec $cfg -Manifest $inputs.Manifest
         $resumeBlib = Join-Path $straightDir 'output.blib'
         Write-Host ("  resume wall {0:mm\:ss}; blib {1:N0} bytes" -f $rResume.Wall, (Get-Item $resumeBlib).Length)
 


### PR DESCRIPTION
## Summary

* Streamed the `--model-diagnostics` report on a FULL resume from each file's 1st-pass sidecar
  joined with its parquet scalars, instead of reading the O(files) resident pre-compaction pool
* Dropped `--model-diagnostics` from the Stage-5 resident-pool gate, and removed the
  `mdiag-full-resume` token with it - **the ratchet shrinks**
* Removed `regression.ps1` mode 2's scoped opt-in: the standing gate now runs end to end with
  **no memory hatch set anywhere**

Fixes #4505

## Why

When every `<stem>.1st-pass.fdr_scores.bin` is on disk, FirstJoin skips its first-pass score
pass, so `ModelDiagnosticsData.Accumulator` was never fed and the report fell back to the batch
`ModelDiagnosticsReport.Write`, which reads the RESIDENT per-file entries. The gate armed that
explicitly (`config.ModelDiagnostics && FirstPassSidecarsPresent(config)`).

This was never the scale case - #4420 already streamed mdiag off the projection path, so
straight-through and `-LinkFrom` runs needed no opt-in at any file count. What remained was the
full-resume batch report, and it was the LAST blanket-hatch dependency in the standing gate.

## The prerequisite #4505 flagged, resolved

The issue said to "verify the `FirstJoin.Rehydrate` lean-stub question first". The answer is
that the lean resume path is ALREADY the default for every resume that is not mdiag - mdiag was
the single exception to it. So making mdiag lean puts it on a well-trodden path rather than a
new one; the fat pool existed solely to feed the batch write this PR replaces.

## Recovered, not reinvented - but ported, not cherry-picked

The approach is the one parked on the closed #4437 branch (`bb7ee88e99`), closed UNMERGED
because its main subject - the transfer score->q table - was superseded by #4438. **The patch no
longer applies**: 2.5 weeks of drift plus #4484, #4528 and #4530 rewrote `FirstJoinTask`, so
this is a port. Two API drifts fixed - `BuildModelDiagnosticsAccumulator` now takes
`libraryById` + `logInfo`, and `ResolveSidecarBasePath` moved to `ScoringTaskShared` in #4530.

The Copilot-review improvement from that branch is kept: a per-file sidecar/parquet row-count
mismatch is skipped with a warning BEFORE any of its rows reach the shared accumulator, so one
incomplete file corrupts neither the report nor the remaining files. entry_id is carried on both
sides, so a genuine misalignment still fails loud rather than folding wrong rows.

## Test plan

- [x] `Build-Osprey.ps1 -Configuration Debug -RunTests -RunInspection` - 574/574, zero inspections
- [x] `regression.ps1 -Dataset Stellar` - all five legs PASS **with no opt-in set**. Mode 2 IS
      the `--model-diagnostics` full-resume leg; it previously could not run without naming
      `mdiag-full-resume`, and it now produces the byte-identical golden blib without it
- [x] `regression.ps1 -Dataset All` - Stellar, StellarLibDecoy, StellarGenDecoyEntrap, Astral all
      PASS, including **mode1b (diagnostics vs golden)** on the two datasets that carry it - the
      direct byte-identity check on the mdiag report this PR reproduces by streaming
- [ ] TeamCity Perf/Regression - not triggered

**`/code-review max` was NOT run on this branch** - the harness refuses model-invoked runs of
that skill, so it needs to be started by the developer.

## Ratchet note for review

`ResidentPaths.KNOWN_UNFIXED` loses `mdiag-full-resume`. That is the list moving in its ALLOWED
direction (it may shrink, never grow), and it is the first time it has shrunk. Remaining:
`hpc-merge` (#4486), `fdrbench-pass1` (#4507), `non-percolator-fdr` (by design),
`projection-off` and `compacted-entries-buffer` (the two A/B oracles).

See ai/todos/active/TODO-20260805_osprey_mdiag_resume_streaming.md

Co-Authored-By: Claude <noreply@anthropic.com>
