### PR TITLE
osprey: Released library fragments nothing can score after Stage 5

### DIFF
--- a/pwiz_tools/Osprey/Osprey.Core/FragmentMath.cs
+++ b/pwiz_tools/Osprey/Osprey.Core/FragmentMath.cs
@@ -48,6 +48,21 @@ namespace pwiz.Osprey.Core
         private static readonly ConcurrentDictionary<uint, double[]> _top6MzCache =
             new ConcurrentDictionary<uint, double[]>();
 
+        /// <summary>
+        /// Drop the memoized top-6 table. Keyed by full entry Id and never evicted, it grows to
+        /// the size of the WHOLE library during Stages 3-4 - library-derived spectral data that
+        /// outlives the spectra themselves, on the order of a gigabyte at SEA-AD scale.
+        ///
+        /// <para>Safe to call at any time: this is a pure memo of
+        /// <see cref="LibraryEntry.Fragments"/>, so an entry that still holds its spectrum
+        /// recomputes the identical value on the next call. Called from the library-fragment
+        /// release, whose retained entries are the only ones that can be asked again.</para>
+        /// </summary>
+        public static void ClearTop6MzCache()
+        {
+            _top6MzCache.Clear();
+        }
+
         private static double[] GetTop6FragmentMzs(LibraryEntry entry)
         {
             return _top6MzCache.GetOrAdd(entry.Id, _ =>

--- a/pwiz_tools/Osprey/Osprey.Core/LibraryEntry.cs
+++ b/pwiz_tools/Osprey/Osprey.Core/LibraryEntry.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Original author: Brendan MacLean <brendanx .at. uw.edu>,
  *                  MacCoss Lab, Department of Genome Sciences, UW
  * AI assistance: Claude Code (Claude Opus 4) <noreply .at. anthropic.com>
@@ -22,6 +22,7 @@
  */
 
 using System;
+using System.Collections;
 using System.Collections.Generic;
 
 namespace pwiz.Osprey.Core
@@ -41,6 +42,27 @@ namespace pwiz.Osprey.Core
         /// Maps to Rust <c>osprey_core::types::DECOY_ID_BIT</c>.
         /// </summary>
         public const uint DECOY_ID_BIT = 0x80000000u;
+
+        /// <summary>
+        /// The shared value <see cref="Fragments"/> is set to when its spectra have been
+        /// released (issue #4532) - the counterpart of the <c>Array.Empty</c> the constructor
+        /// assigns, for entries whose fragments were dropped rather than never present.
+        /// One instance for the whole process, so releasing costs nothing per entry.
+        ///
+        /// <para>It THROWS on every access, and that is the point. Both obvious sentinels are
+        /// silent: every scorer guards with
+        /// <c>if (entry.Fragments == null || entry.Fragments.Count == 0)</c>, so a null and an
+        /// empty list are equally absorbed as "this entry has no spectrum" - and an entry whose
+        /// spectra were released, but which something still wanted, would score a degenerate
+        /// zero instead of failing. Fragments are released only where nothing is believed to
+        /// read them; this makes a wrong belief loud rather than quiet, by turning that same
+        /// guard expression into a tripwire (the null test short-circuits false, then
+        /// <c>Count</c> throws).</para>
+        ///
+        /// <para>Test membership with <c>ReferenceEquals(entry.Fragments,
+        /// LibraryEntry.RELEASED)</c> - reading <c>Count</c> to detect it would throw.</para>
+        /// </summary>
+        public static readonly IReadOnlyList<LibraryFragment> RELEASED = new ReleasedFragmentList();
 
         public uint Id { get; set; }
         public string Sequence { get; set; }
@@ -115,6 +137,38 @@ namespace pwiz.Osprey.Core
                 }
             }
             return false;
+        }
+
+        /// <summary>
+        /// Backing type of <see cref="RELEASED"/>: a zero-state list that throws on every
+        /// access. Private and instantiated exactly once - callers only ever see the singleton
+        /// through <see cref="RELEASED"/>, so there is no way to create a second one or to
+        /// mistake it for an ordinary empty list.
+        /// </summary>
+        private sealed class ReleasedFragmentList : IReadOnlyList<LibraryFragment>
+        {
+            public int Count => throw Released();
+
+            public LibraryFragment this[int index] => throw Released();
+
+            public IEnumerator<LibraryFragment> GetEnumerator()
+            {
+                throw Released();
+            }
+
+            IEnumerator IEnumerable.GetEnumerator()
+            {
+                throw Released();
+            }
+
+            private static InvalidOperationException Released()
+            {
+                return new InvalidOperationException(
+                    @"These library fragments were released after Stage 5 because the entry is " +
+                    @"neither a compaction survivor nor a gap-fill candidate, so nothing should " +
+                    @"score or write it. Reaching them means the retained set is wrong. Set " +
+                    @"OSPREY_RELEASE_LIBRARY_FRAGMENTS=0 to keep the whole library resident.");
+            }
         }
     }
 }

--- a/pwiz_tools/Osprey/Osprey.Core/LibraryEntry.cs
+++ b/pwiz_tools/Osprey/Osprey.Core/LibraryEntry.cs
@@ -43,26 +43,10 @@ namespace pwiz.Osprey.Core
         /// </summary>
         public const uint DECOY_ID_BIT = 0x80000000u;
 
-        /// <summary>
-        /// The shared value <see cref="Fragments"/> is set to when its spectra have been
-        /// released (issue #4532) - the counterpart of the <c>Array.Empty</c> the constructor
-        /// assigns, for entries whose fragments were dropped rather than never present.
-        /// One instance for the whole process, so releasing costs nothing per entry.
-        ///
-        /// <para>It THROWS on every access, and that is the point. Both obvious sentinels are
-        /// silent: every scorer guards with
-        /// <c>if (entry.Fragments == null || entry.Fragments.Count == 0)</c>, so a null and an
-        /// empty list are equally absorbed as "this entry has no spectrum" - and an entry whose
-        /// spectra were released, but which something still wanted, would score a degenerate
-        /// zero instead of failing. Fragments are released only where nothing is believed to
-        /// read them; this makes a wrong belief loud rather than quiet, by turning that same
-        /// guard expression into a tripwire (the null test short-circuits false, then
-        /// <c>Count</c> throws).</para>
-        ///
-        /// <para>Test membership with <c>ReferenceEquals(entry.Fragments,
-        /// LibraryEntry.RELEASED)</c> - reading <c>Count</c> to detect it would throw.</para>
-        /// </summary>
-        public static readonly IReadOnlyList<LibraryFragment> RELEASED = new ReleasedFragmentList();
+        /// <summary>Backing value for <see cref="ReleaseSpectrum"/>; see there for why it
+        /// throws rather than being empty. Private - no caller needs to know it exists.</summary>
+        private static readonly IReadOnlyList<LibraryFragment> RELEASED_SPECTRUM =
+            new ReleasedFragmentList();
 
         public uint Id { get; set; }
         public string Sequence { get; set; }
@@ -140,10 +124,33 @@ namespace pwiz.Osprey.Core
         }
 
         /// <summary>
-        /// Backing type of <see cref="RELEASED"/>: a zero-state list that throws on every
+        /// Drop this entry's spectrum, freeing the fragment array, and report whether it was
+        /// still held (so a caller can count releases, and a second call is a no-op).
+        /// Identity - sequence, protein ids, m/z, RT - is untouched: protein parsimony walks
+        /// the whole library after the spectra are gone and reads exactly those fields.
+        ///
+        /// <para>The released state THROWS on any access to <see cref="Fragments"/>, which is
+        /// the point of releasing through a method rather than assigning null or an empty
+        /// list. Every scorer guards with
+        /// <c>if (entry.Fragments == null || entry.Fragments.Count == 0)</c>, so both of those
+        /// are silently absorbed as "this entry has no spectrum" - an entry released in error
+        /// would score a degenerate zero instead of failing. Spectra are released only where
+        /// nothing is believed to read them; this makes a wrong belief loud, by turning that
+        /// same guard expression into a tripwire.</para>
+        /// </summary>
+        public bool ReleaseSpectrum()
+        {
+            if (ReferenceEquals(Fragments, RELEASED_SPECTRUM))
+                return false;
+            Fragments = RELEASED_SPECTRUM;
+            return true;
+        }
+
+        /// <summary>
+        /// Backing type of <see cref="RELEASED_SPECTRUM"/>: a zero-state list that throws on every
         /// access. Private and instantiated exactly once - callers only ever see the singleton
-        /// through <see cref="RELEASED"/>, so there is no way to create a second one or to
-        /// mistake it for an ordinary empty list.
+        /// through <see cref="ReleaseSpectrum"/>, so there is no way to create a second one or
+        /// to mistake it for an ordinary empty list.
         /// </summary>
         private sealed class ReleasedFragmentList : IReadOnlyList<LibraryFragment>
         {

--- a/pwiz_tools/Osprey/Osprey.Core/LibraryEntry.cs
+++ b/pwiz_tools/Osprey/Osprey.Core/LibraryEntry.cs
@@ -124,6 +124,14 @@ namespace pwiz.Osprey.Core
         }
 
         /// <summary>
+        /// True once <see cref="ReleaseSpectrum"/> has dropped this entry's spectrum. The only
+        /// safe way to ask: inspecting <see cref="Fragments"/> to find out throws by design, so
+        /// without this the released state would be write-only and callers would be left
+        /// catching an exception to detect it.
+        /// </summary>
+        public bool IsSpectrumReleased => ReferenceEquals(Fragments, RELEASED_SPECTRUM);
+
+        /// <summary>
         /// Drop this entry's spectrum, freeing the fragment array, and report whether it was
         /// still held (so a caller can count releases, and a second call is a no-op).
         /// Identity - sequence, protein ids, m/z, RT - is untouched: protein parsimony walks
@@ -138,14 +146,6 @@ namespace pwiz.Osprey.Core
         /// nothing is believed to read them; this makes a wrong belief loud, by turning that
         /// same guard expression into a tripwire.</para>
         /// </summary>
-        /// <summary>
-        /// True once <see cref="ReleaseSpectrum"/> has dropped this entry's spectrum. The only
-        /// safe way to ask: inspecting <see cref="Fragments"/> to find out throws by design, so
-        /// without this the released state would be write-only and callers would be left
-        /// catching an exception to detect it.
-        /// </summary>
-        public bool IsSpectrumReleased => ReferenceEquals(Fragments, RELEASED_SPECTRUM);
-
         public bool ReleaseSpectrum()
         {
             if (IsSpectrumReleased)

--- a/pwiz_tools/Osprey/Osprey.Core/LibraryEntry.cs
+++ b/pwiz_tools/Osprey/Osprey.Core/LibraryEntry.cs
@@ -138,9 +138,17 @@ namespace pwiz.Osprey.Core
         /// nothing is believed to read them; this makes a wrong belief loud, by turning that
         /// same guard expression into a tripwire.</para>
         /// </summary>
+        /// <summary>
+        /// True once <see cref="ReleaseSpectrum"/> has dropped this entry's spectrum. The only
+        /// safe way to ask: inspecting <see cref="Fragments"/> to find out throws by design, so
+        /// without this the released state would be write-only and callers would be left
+        /// catching an exception to detect it.
+        /// </summary>
+        public bool IsSpectrumReleased => ReferenceEquals(Fragments, RELEASED_SPECTRUM);
+
         public bool ReleaseSpectrum()
         {
-            if (ReferenceEquals(Fragments, RELEASED_SPECTRUM))
+            if (IsSpectrumReleased)
                 return false;
             Fragments = RELEASED_SPECTRUM;
             return true;

--- a/pwiz_tools/Osprey/Osprey.Core/LibraryEntry.cs
+++ b/pwiz_tools/Osprey/Osprey.Core/LibraryEntry.cs
@@ -124,10 +124,18 @@ namespace pwiz.Osprey.Core
         }
 
         /// <summary>
-        /// True once <see cref="ReleaseSpectrum"/> has dropped this entry's spectrum. The only
-        /// safe way to ask: inspecting <see cref="Fragments"/> to find out throws by design, so
-        /// without this the released state would be write-only and callers would be left
-        /// catching an exception to detect it.
+        /// True once <see cref="ReleaseSpectrum"/> has dropped this entry's spectrum, and only
+        /// then. It exists because inspecting <see cref="Fragments"/> to find out throws by
+        /// design, which would otherwise leave the released state write-only - detectable only
+        /// by catching an exception.
+        ///
+        /// <para>This answers "was the spectrum RELEASED", NOT "does this entry have a
+        /// spectrum". An entry can legitimately hold no fragments and report false here: the
+        /// constructor default and the <c>OmitFragments</c> load arm both leave
+        /// <c>Array.Empty</c>, which is a readable empty spectrum rather than a released one.
+        /// Asking the has-a-spectrum question is what the ordinary
+        /// <c>Fragments == null || Fragments.Count == 0</c> guard is for - and on a released
+        /// entry that guard throws, which is the point.</para>
         /// </summary>
         public bool IsSpectrumReleased => ReferenceEquals(Fragments, RELEASED_SPECTRUM);
 
@@ -176,6 +184,11 @@ namespace pwiz.Osprey.Core
                 throw Released();
             }
 
+            // The message cannot name WHICH entry was wrongly released, because one shared
+            // singleton stands in for every released spectrum - deliberately, since a
+            // per-entry sentinel would reintroduce the per-entry allocation the release
+            // exists to remove. The stack trace names the READER, which is the half that
+            // matters: rerun with OSPREY_RELEASE_LIBRARY_FRAGMENTS=0 to get the entry.
             private static InvalidOperationException Released()
             {
                 return new InvalidOperationException(

--- a/pwiz_tools/Osprey/Osprey.Core/LibraryEntry.cs
+++ b/pwiz_tools/Osprey/Osprey.Core/LibraryEntry.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Original author: Brendan MacLean <brendanx .at. uw.edu>,
  *                  MacCoss Lab, Department of Genome Sciences, UW
  * AI assistance: Claude Code (Claude Opus 4) <noreply .at. anthropic.com>

--- a/pwiz_tools/Osprey/Osprey.Core/OspreyEnvironment.cs
+++ b/pwiz_tools/Osprey/Osprey.Core/OspreyEnvironment.cs
@@ -196,11 +196,18 @@ namespace pwiz.Osprey.Core
         /// compaction survivors and the gap-fill candidates. The identity fields
         /// (<c>ModifiedSequence</c> / <c>ProteinIds</c> / m/z / RT) are KEPT on every entry.
         ///
-        /// DEFAULT ON. The library is ~7.1 GB of a 20.1 GB Stage 6 floor at 82 SEA-AD files,
-        /// held to the end of Stage 7 in order to write 37,078 spectra out of 6,275,151
-        /// entries - 0.6%. Set OSPREY_RELEASE_LIBRARY_FRAGMENTS=0 to keep the whole library
-        /// resident as the A/B byte-identity oracle, the same role
+        /// DEFAULT ON. The library is held to the end of Stage 7 in order to write 37,078
+        /// spectra out of 6,275,151 entries - 0.6%. Set OSPREY_RELEASE_LIBRARY_FRAGMENTS=0 to
+        /// keep the whole library resident as the A/B byte-identity oracle, the same role
         /// OSPREY_STAGE6_STREAM_SURVIVORS=0 plays for the Stage 6 handoff.
+        ///
+        /// <para>MEASURED, as an A/B on 4 SEA-AD files against the full 12.7 GB library: Stage 7
+        /// peak working set 28.5 -&gt; 17.7 GB, a 10.8 GB (-38%) saving, releasing 87.0% of the
+        /// entries. Few files is the MAXIMUM-saving case rather than a scaled-down one - the
+        /// library is fixed while the retained set grows with file count - so expect a smaller
+        /// (still large) saving at 82. Only the FRAGMENTS are freed, never a whole entry, and
+        /// the in-repo figure for the fragment share alone is ~3.2 GB at SEA-AD scale; do not
+        /// read a saving here as recovering the library's total footprint.</para>
         ///
         /// <para>Why fragments and not whole entries: <c>ProteinFdr.BuildProteinParsimony</c>
         /// and <c>FirstJoinTask.BuildProteinCompactStratum</c> both walk the ENTIRE library
@@ -211,24 +218,19 @@ namespace pwiz.Osprey.Core
         /// <c>bestByPrecursor</c>, which is derived from the post-compaction survivors, so
         /// blib-written is a SUBSET of what is retained here.</para>
         ///
+        /// <para>Turning this OFF costs a full Stage-5 recompute rather than a resume, because
+        /// the changed validity key fails <c>CanRehydrate</c> and <c>Run</c> deletes its own
+        /// validity sidecars. The suffix is still required - the release is a Run-only side
+        /// effect, so without it an in-place A/B would adopt the other arm's reconciled parquets
+        /// and report a memory profile it never computed - but the escape hatch is not cheap.
+        /// The suffix itself lives with the release
+        /// (<c>LibraryFragmentRelease.ValidityKeySuffix</c>), keyed on whether the release
+        /// actually RAN rather than on this flag alone.</para>
+        ///
         /// <para>A settable property (not a readonly field) so unit tests can A/B both arms.</para>
         /// </summary>
         public static bool ReleaseLibraryFragments { get; set; } =
             IsNotZero(@"OSPREY_RELEASE_LIBRARY_FRAGMENTS");
-
-        /// <summary>
-        /// Cache-validity suffix for the library-fragment release arm. EMPTY on the default,
-        /// so shipping this invalidates no existing output directory; only the resident opt-out
-        /// adds a term. It participates at all for the reason
-        /// <see cref="Stage6StreamSurvivorsValidityKeySuffix"/> does: the two arms are supposed
-        /// to write byte-identical outputs, and an in-place A/B that adopted the first arm's
-        /// reconciled parquets would skip Stage 6 entirely and report that identity - and the
-        /// memory saving - without ever computing either.
-        /// </summary>
-        public static string ReleaseLibraryFragmentsValidityKeySuffix()
-        {
-            return ReleaseLibraryFragments ? string.Empty : @";libfrag=0";
-        }
 
         /// <summary>
         /// Cache-validity suffix for the Stage 6 handoff arm. EMPTY on the streamed default,

--- a/pwiz_tools/Osprey/Osprey.Core/OspreyEnvironment.cs
+++ b/pwiz_tools/Osprey/Osprey.Core/OspreyEnvironment.cs
@@ -191,6 +191,46 @@ namespace pwiz.Osprey.Core
             IsNotZero(@"OSPREY_STAGE6_STREAM_SURVIVORS");
 
         /// <summary>
+        /// At the Stage 5 -> 6 boundary, drop <c>LibraryEntry.Fragments</c> for every library
+        /// entry that can no longer be scored or written - i.e. everything outside the
+        /// compaction survivors and the gap-fill candidates. The identity fields
+        /// (<c>ModifiedSequence</c> / <c>ProteinIds</c> / m/z / RT) are KEPT on every entry.
+        ///
+        /// DEFAULT ON. The library is ~7.1 GB of a 20.1 GB Stage 6 floor at 82 SEA-AD files,
+        /// held to the end of Stage 7 in order to write 37,078 spectra out of 6,275,151
+        /// entries - 0.6%. Set OSPREY_RELEASE_LIBRARY_FRAGMENTS=0 to keep the whole library
+        /// resident as the A/B byte-identity oracle, the same role
+        /// OSPREY_STAGE6_STREAM_SURVIVORS=0 plays for the Stage 6 handoff.
+        ///
+        /// <para>Why fragments and not whole entries: <c>ProteinFdr.BuildProteinParsimony</c>
+        /// and <c>FirstJoinTask.BuildProteinCompactStratum</c> both walk the ENTIRE library
+        /// after Stage 5, including entries already judged false. They read only the identity
+        /// fields, never the spectra - so dropping entries would silently move protein FDR,
+        /// while dropping fragments cannot. The blib write is safe for a separate reason:
+        /// <c>BlibOutputWriter.PrecompressSpectra</c> reads fragments only for
+        /// <c>bestByPrecursor</c>, which is derived from the post-compaction survivors, so
+        /// blib-written is a SUBSET of what is retained here.</para>
+        ///
+        /// <para>A settable property (not a readonly field) so unit tests can A/B both arms.</para>
+        /// </summary>
+        public static bool ReleaseLibraryFragments { get; set; } =
+            IsNotZero(@"OSPREY_RELEASE_LIBRARY_FRAGMENTS");
+
+        /// <summary>
+        /// Cache-validity suffix for the library-fragment release arm. EMPTY on the default,
+        /// so shipping this invalidates no existing output directory; only the resident opt-out
+        /// adds a term. It participates at all for the reason
+        /// <see cref="Stage6StreamSurvivorsValidityKeySuffix"/> does: the two arms are supposed
+        /// to write byte-identical outputs, and an in-place A/B that adopted the first arm's
+        /// reconciled parquets would skip Stage 6 entirely and report that identity - and the
+        /// memory saving - without ever computing either.
+        /// </summary>
+        public static string ReleaseLibraryFragmentsValidityKeySuffix()
+        {
+            return ReleaseLibraryFragments ? string.Empty : @";libfrag=0";
+        }
+
+        /// <summary>
         /// Cache-validity suffix for the Stage 6 handoff arm. EMPTY on the streamed default,
         /// so shipping this does not invalidate a single existing output directory; only the
         /// resident opt-out adds a term.

--- a/pwiz_tools/Osprey/Osprey.Tasks/FirstJoinTask.cs
+++ b/pwiz_tools/Osprey/Osprey.Tasks/FirstJoinTask.cs
@@ -125,9 +125,16 @@ namespace pwiz.Osprey.Tasks
         // reconciled + rescored + reported). Null unless OSPREY_PASS2_QVALUE=protein-compact.
         private HashSet<uint> _proteinCompactStratum;
 
-        /// <summary>The post-compaction surviving base_ids, kept from the projection path so the
-        /// Stage 5 -> 6 boundary can release the library fragments nothing can score any more.
-        /// Null on every other path, which simply skips the release.</summary>
+        /// <summary>The post-compaction surviving base_ids, so the Stage 5 -&gt; 6 boundary can
+        /// release the library fragments nothing can score any more. Null on the legacy resident
+        /// path, which simply skips the release.
+        ///
+        /// <para>This is the same set <see cref="_survivorLoader"/> holds privately, and it is a
+        /// separate field on purpose rather than by oversight: the loader is built only on the
+        /// projection path, while <see cref="Rehydrate"/> - the resume, and the one run that most
+        /// needs a lean library - has no loader and takes the set off the reconciliation bundle
+        /// instead. One field that both paths can fill beats an accessor that is null on
+        /// half of them.</para></summary>
         private HashSet<uint> _firstPassBaseIds;
 
         // Rebuilds any one file's survivors from its .scores.parquet + finalized
@@ -219,7 +226,7 @@ namespace pwiz.Osprey.Tasks
                 + @";reconciliation=" + ctx.Config.Identity.ReconciliationParameterHash()
                 + OspreyEnvironment.ExperimentAggValidityKeySuffix()
                 + OspreyEnvironment.Pass2QValueValidityKeySuffix()
-                + OspreyEnvironment.ReleaseLibraryFragmentsValidityKeySuffix();
+                + LibraryFragmentRelease.ValidityKeySuffix(ctx);
         }
 
         public override bool Run(PipelineContext ctx)
@@ -1736,41 +1743,28 @@ namespace pwiz.Osprey.Tasks
         /// <para>Called from BOTH <see cref="Run"/> (projection path) and
         /// <see cref="Rehydrate"/> (resume / bundle-adopt), which set
         /// <c>_firstPassBaseIds</c> from the compaction result and the reconciliation bundle
-        /// respectively. Skipped when it is null, which now means only the legacy RESIDENT
-        /// first-pass path.</para>
+        /// respectively. <see cref="LibraryFragmentRelease.RunsOnThisLeg"/> decides whether this
+        /// leg releases at all, and is the same predicate the validity-key suffix reads, so the
+        /// key can never claim an arm the code did not run.</para>
         ///
         /// <para>Deliberately NOT gated on diagnostics. The only dump that reads fragments is
         /// <c>WriteCalXicEntryDumpAndExit</c>, a Stage 3 dump that exits the process where it
         /// stands, so it cannot observe a Stage 5 -&gt; 6 release. Gating on
         /// <c>ctx.Diagnostics</c> would instead disable this in exactly the regression run
-        /// that is compared against the committed golden (<c>regression.ps1</c> passes
-        /// <c>-DumpProteinFdr</c> on the straight-through leg), making the byte-identity gate
-        /// vacuous for this feature.</para>
+        /// that is compared against the committed golden - <c>regression.ps1 -DumpProteinFdr</c>
+        /// sets OSPREY_DUMP_STAGE7_PROTEIN_FDR, and any variable in the forced-dump bundle makes
+        /// <c>ctx.Diagnostics</c> non-null - making the byte-identity gate vacuous for this
+        /// feature.</para>
         /// </summary>
         private void ReleaseUnscorableLibraryFragments(List<LibraryEntry> fullLibrary, PipelineContext ctx)
         {
-            // StopAfterStage5 (--task FirstPassFDR) is excluded for TWO independent reasons, and
-            // either alone is disqualifying:
-            //
-            // 1. The gap-fill plan is NOT populated there. PlanStage6 returns early before
-            //    assigning _perFileGapFillForRescore, so the field is still its empty default -
-            //    while _firstPassBaseIds IS set. The retained set would be survivors ONLY, and
-            //    the release would strip exactly the gap-fill candidates this method exists to
-            //    protect. Harmless today only because nothing downstream runs in that process.
-            // 2. There is nothing to free. That path already loaded the library with
-            //    OmitFragments (PerFileScoringTask: omitFragments = config.StopAfterStage5), so
-            //    every entry holds the shared Array.Empty. ReleaseSpectrum recognizes an
-            //    already-released entry by reference identity, not by "has a spectrum", so it
-            //    would swap one shared singleton for another and report millions released
-            //    having freed zero bytes - a fabricated saving printed straight above a [MEM]
-            //    probe, which an HPC sizing A/B would read as measured.
-            //
-            // The worker also exits after Stage 5, so there is no Stage 6/7 to save memory for.
-            if (!OspreyEnvironment.ReleaseLibraryFragments || _firstPassBaseIds == null ||
-                fullLibrary == null || ctx.Config.StopAfterStage5)
-            {
+            // _firstPassBaseIds is the one meaningful null here: it separates the paths that
+            // computed a surviving set (projection Run, bundle-adopt Rehydrate) from the legacy
+            // resident path that did not. fullLibrary is not checked - it is a published
+            // byproduct every other reader dereferences unguarded, so a null is a wiring fault
+            // and should say so.
+            if (!LibraryFragmentRelease.RunsOnThisLeg(ctx) || _firstPassBaseIds == null)
                 return;
-            }
 
             var retained = LibraryFragmentRelease.BuildRetainedBaseIds(
                 _firstPassBaseIds, _perFileGapFillForRescore);

--- a/pwiz_tools/Osprey/Osprey.Tasks/FirstJoinTask.cs
+++ b/pwiz_tools/Osprey/Osprey.Tasks/FirstJoinTask.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Original author: Brendan MacLean <brendanx .at. uw.edu>,
  *                  MacCoss Lab, Department of Genome Sciences, UW
  * AI assistance: Claude Code (Claude Opus 4.7) <noreply .at. anthropic.com>
@@ -600,6 +600,15 @@ namespace pwiz.Osprey.Tasks
             ctx.Publish(new ReconciliationActions(bundle.ReconciliationActions));
             ctx.Publish(new RefinedCalibrations(bundle.RefinedCalibrations));
             ctx.Publish(new PerFileGapFillForRescore(bundle.PerFileGapFill));
+            // Release here too, not just on Run. This path is a RESUME - which is exactly what
+            // an operator does after the OOM this release exists to prevent - so skipping it
+            // would leave the whole library resident in the one run that most needs it lean.
+            // The bundle carries both halves of the retained set: GlobalFirstPassBaseIds is a
+            // required field of the v3 reconciliation envelope, and PerFileGapFill was just
+            // published above.
+            _firstPassBaseIds = bundle.GlobalFirstPassBaseIds;
+            _perFileGapFillForRescore = bundle.PerFileGapFill;
+            ReleaseUnscorableLibraryFragments(ctx.Get<FullLibrary>().Value, ctx);
             ctx.Publish(new PerFileConsensusTargets(ConsensusTargetsFromBundle(ctx, bundle)));
             ctx.Publish(new CompactedEntries(perFileEntries));
             // Null off the projection path (legacy resident / rehydrate), where a
@@ -1724,9 +1733,11 @@ namespace pwiz.Osprey.Tasks
         /// states of passing peptides through the library, so by construction it reaches
         /// entries that did NOT survive compaction and still needs their spectra.</para>
         ///
-        /// <para>Skipped when <c>_firstPassBaseIds</c> is null - the resident and rehydrate
-        /// paths do not surface the surviving set here, and at scale the production route is
-        /// the projection path anyway.</para>
+        /// <para>Called from BOTH <see cref="Run"/> (projection path) and
+        /// <see cref="Rehydrate"/> (resume / bundle-adopt), which set
+        /// <c>_firstPassBaseIds</c> from the compaction result and the reconciliation bundle
+        /// respectively. Skipped when it is null, which now means only the legacy RESIDENT
+        /// first-pass path.</para>
         ///
         /// <para>Deliberately NOT gated on diagnostics. The only dump that reads fragments is
         /// <c>WriteCalXicEntryDumpAndExit</c>, a Stage 3 dump that exits the process where it
@@ -1738,8 +1749,25 @@ namespace pwiz.Osprey.Tasks
         /// </summary>
         private void ReleaseUnscorableLibraryFragments(List<LibraryEntry> fullLibrary, PipelineContext ctx)
         {
+            // StopAfterStage5 (--task FirstPassFDR) is excluded for TWO independent reasons, and
+            // either alone is disqualifying:
+            //
+            // 1. The gap-fill plan is NOT populated there. PlanStage6 returns early before
+            //    assigning _perFileGapFillForRescore, so the field is still its empty default -
+            //    while _firstPassBaseIds IS set. The retained set would be survivors ONLY, and
+            //    the release would strip exactly the gap-fill candidates this method exists to
+            //    protect. Harmless today only because nothing downstream runs in that process.
+            // 2. There is nothing to free. That path already loaded the library with
+            //    OmitFragments (PerFileScoringTask: omitFragments = config.StopAfterStage5), so
+            //    every entry holds the shared Array.Empty. ReleaseSpectrum recognizes an
+            //    already-released entry by reference identity, not by "has a spectrum", so it
+            //    would swap one shared singleton for another and report millions released
+            //    having freed zero bytes - a fabricated saving printed straight above a [MEM]
+            //    probe, which an HPC sizing A/B would read as measured.
+            //
+            // The worker also exits after Stage 5, so there is no Stage 6/7 to save memory for.
             if (!OspreyEnvironment.ReleaseLibraryFragments || _firstPassBaseIds == null ||
-                fullLibrary == null)
+                fullLibrary == null || ctx.Config.StopAfterStage5)
             {
                 return;
             }

--- a/pwiz_tools/Osprey/Osprey.Tasks/FirstJoinTask.cs
+++ b/pwiz_tools/Osprey/Osprey.Tasks/FirstJoinTask.cs
@@ -1726,14 +1726,20 @@ namespace pwiz.Osprey.Tasks
         ///
         /// <para>Skipped when <c>_firstPassBaseIds</c> is null - the resident and rehydrate
         /// paths do not surface the surviving set here, and at scale the production route is
-        /// the projection path anyway. Also skipped whenever any diagnostic dump is enabled,
-        /// because the <c>-d</c> dumps read fragments for entries chosen by their own criteria
-        /// rather than by what the pipeline still needs.</para>
+        /// the projection path anyway.</para>
+        ///
+        /// <para>Deliberately NOT gated on diagnostics. The only dump that reads fragments is
+        /// <c>WriteCalXicEntryDumpAndExit</c>, a Stage 3 dump that exits the process where it
+        /// stands, so it cannot observe a Stage 5 -&gt; 6 release. Gating on
+        /// <c>ctx.Diagnostics</c> would instead disable this in exactly the regression run
+        /// that is compared against the committed golden (<c>regression.ps1</c> passes
+        /// <c>-DumpProteinFdr</c> on the straight-through leg), making the byte-identity gate
+        /// vacuous for this feature.</para>
         /// </summary>
         private void ReleaseUnscorableLibraryFragments(List<LibraryEntry> fullLibrary, PipelineContext ctx)
         {
             if (!OspreyEnvironment.ReleaseLibraryFragments || _firstPassBaseIds == null ||
-                fullLibrary == null || ctx.Diagnostics != null)
+                fullLibrary == null)
             {
                 return;
             }

--- a/pwiz_tools/Osprey/Osprey.Tasks/FirstJoinTask.cs
+++ b/pwiz_tools/Osprey/Osprey.Tasks/FirstJoinTask.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Original author: Brendan MacLean <brendanx .at. uw.edu>,
  *                  MacCoss Lab, Department of Genome Sciences, UW
  * AI assistance: Claude Code (Claude Opus 4.7) <noreply .at. anthropic.com>
@@ -125,6 +125,11 @@ namespace pwiz.Osprey.Tasks
         // reconciled + rescored + reported). Null unless OSPREY_PASS2_QVALUE=protein-compact.
         private HashSet<uint> _proteinCompactStratum;
 
+        /// <summary>The post-compaction surviving base_ids, kept from the projection path so the
+        /// Stage 5 -> 6 boundary can release the library fragments nothing can score any more.
+        /// Null on every other path, which simply skips the release.</summary>
+        private HashSet<uint> _firstPassBaseIds;
+
         // Rebuilds any one file's survivors from its .scores.parquet + finalized
         // 1st-pass sidecar, so a per-file consumer never needs the all-files buffer
         // (issue #4526). Set on the projection path, which is the only one that
@@ -213,7 +218,8 @@ namespace pwiz.Osprey.Tasks
             return base.ValidityKey(ctx)
                 + @";reconciliation=" + ctx.Config.Identity.ReconciliationParameterHash()
                 + OspreyEnvironment.ExperimentAggValidityKeySuffix()
-                + OspreyEnvironment.Pass2QValueValidityKeySuffix();
+                + OspreyEnvironment.Pass2QValueValidityKeySuffix()
+                + OspreyEnvironment.ReleaseLibraryFragmentsValidityKeySuffix();
         }
 
         public override bool Run(PipelineContext ctx)
@@ -517,6 +523,7 @@ namespace pwiz.Osprey.Tasks
             ctx.Publish(new ReconciliationActions(_reconciliationActions));
             ctx.Publish(new RefinedCalibrations(_refinedCalibrations));
             ctx.Publish(new PerFileGapFillForRescore(_perFileGapFillForRescore));
+            ReleaseUnscorableLibraryFragments(fullLibrary, ctx);
             ctx.Publish(new CompactedEntries(perFileEntries));
             // Null off the projection path (legacy resident / rehydrate), where a
             // consumer falls back to the buffer above.
@@ -1706,6 +1713,41 @@ namespace pwiz.Osprey.Tasks
         }
 
         /// <summary>
+        /// Stage 5 -> 6 boundary: drop <c>Fragments</c> from every library entry that nothing
+        /// downstream can score or write, keeping the identity fields on all of them. See
+        /// <see cref="OspreyEnvironment.ReleaseLibraryFragments"/> for the rationale and the
+        /// safety argument.
+        ///
+        /// <para>The retained set is the post-compaction survivors (<c>_firstPassBaseIds</c>,
+        /// already pair-symmetric so a target's decoy rides along) PLUS the gap-fill candidates.
+        /// Gap-fill has to be in it: <c>GapFillTargetIdentifier</c> looks up the MISSING charge
+        /// states of passing peptides through the library, so by construction it reaches
+        /// entries that did NOT survive compaction and still needs their spectra.</para>
+        ///
+        /// <para>Skipped when <c>_firstPassBaseIds</c> is null - the resident and rehydrate
+        /// paths do not surface the surviving set here, and at scale the production route is
+        /// the projection path anyway. Also skipped whenever any diagnostic dump is enabled,
+        /// because the <c>-d</c> dumps read fragments for entries chosen by their own criteria
+        /// rather than by what the pipeline still needs.</para>
+        /// </summary>
+        private void ReleaseUnscorableLibraryFragments(List<LibraryEntry> fullLibrary, PipelineContext ctx)
+        {
+            if (!OspreyEnvironment.ReleaseLibraryFragments || _firstPassBaseIds == null ||
+                fullLibrary == null || ctx.Diagnostics != null)
+            {
+                return;
+            }
+
+            var retained = LibraryFragmentRelease.BuildRetainedBaseIds(
+                _firstPassBaseIds, _perFileGapFillForRescore);
+            int released = LibraryFragmentRelease.ReleaseFragments(fullLibrary, retained);
+            ctx.LogInfo(string.Format(
+                @"Released library fragments for {0} of {1} entries ({2} base_ids retained for rescore + gap-fill)",
+                released, fullLibrary.Count, retained.Count));
+            ProfilerHooks.LogMemoryStatsIfEnabled(ctx.LogInfo, @"after library-fragment release");
+        }
+
+        /// <summary>
         /// Build the protein-compact stratum: the base_ids of every library precursor whose
         /// peptide maps to a protein detected in the 1st pass by &gt;=2 DISTINCT peptides (the
         /// honest multi-hit anchor -- single-hit proteins break the independent-filtering
@@ -1999,6 +2041,7 @@ namespace pwiz.Osprey.Tasks
                 projections, perFileParquetPaths, config, ctx, _proteinCompactStratum);
             if (firstPassBaseIds == null)
                 return null;  // streaming sidecar read fault; ExitCode already set
+            _firstPassBaseIds = firstPassBaseIds;
 
             // Reload full FdrEntry survivors from the ORIGINAL parquet + the
             // just-written 1st-pass sidecar. ParquetIndex therefore comes from

--- a/pwiz_tools/Osprey/Osprey.Tasks/LibraryFragmentRelease.cs
+++ b/pwiz_tools/Osprey/Osprey.Tasks/LibraryFragmentRelease.cs
@@ -69,9 +69,9 @@ namespace pwiz.Osprey.Tasks
         }
 
         /// <summary>
-        /// Point <see cref="LibraryEntry.Fragments"/> at <see cref="LibraryEntry.RELEASED"/> on
-        /// every entry whose base_id is outside <paramref name="retainedBaseIds"/>, freeing the
-        /// backing array, and return how many were released. Identity fields
+        /// Call <see cref="LibraryEntry.ReleaseSpectrum"/> on every entry whose base_id is
+        /// outside <paramref name="retainedBaseIds"/> and return how many were released.
+        /// Identity fields
         /// are untouched on ALL entries, because protein parsimony and the protein-compact
         /// stratum walk the whole library after this point and read them.
         /// </summary>
@@ -84,16 +84,10 @@ namespace pwiz.Osprey.Tasks
             int released = 0;
             foreach (var e in fullLibrary)
             {
-                // ReferenceEquals, not .Count: the sentinel THROWS on Count, so an
-                // already-released entry has to be recognized by identity. That also makes the
-                // pass idempotent without ever touching a released entry's contents.
-                if (ReferenceEquals(e.Fragments, LibraryEntry.RELEASED) ||
-                    retainedBaseIds.Contains(e.Id & ScoringTaskShared.BASE_ID_MASK))
-                {
+                if (retainedBaseIds.Contains(e.Id & ScoringTaskShared.BASE_ID_MASK))
                     continue;
-                }
-                e.Fragments = LibraryEntry.RELEASED;
-                released++;
+                if (e.ReleaseSpectrum())
+                    released++;
             }
             return released;
         }

--- a/pwiz_tools/Osprey/Osprey.Tasks/LibraryFragmentRelease.cs
+++ b/pwiz_tools/Osprey/Osprey.Tasks/LibraryFragmentRelease.cs
@@ -28,13 +28,104 @@ using pwiz.Osprey.FDR.Reconciliation;
 namespace pwiz.Osprey.Tasks
 {
     /// <summary>
-    /// The Stage 5 -&gt; 6 library-fragment release (issue #4532), as a pure function of the
-    /// surviving base_ids and the gap-fill plan so it can be tested without a pipeline.
+    /// The library-fragment release (issue #4532): the set arithmetic, plus the ONE predicate
+    /// that decides whether a given leg of the pipeline performs it.
     /// <see cref="OspreyEnvironment.ReleaseLibraryFragments"/> carries the rationale and the
-    /// safety argument; this type carries only the set arithmetic.
+    /// safety argument.
+    ///
+    /// <para>The retained-set builders are pure functions of their inputs so they can be tested
+    /// without a pipeline; <see cref="RunsOnThisLeg"/> needs the config and is the single source
+    /// of truth for BOTH the call sites and the validity-key suffix. That is deliberate: those
+    /// two must never be able to disagree, because the suffix's whole job is to record which
+    /// arm produced an output directory.</para>
     /// </summary>
     internal static class LibraryFragmentRelease
     {
+        /// <summary>
+        /// Whether the release actually executes on THIS leg. Not simply
+        /// <see cref="OspreyEnvironment.ReleaseLibraryFragments"/>: the release rides specific
+        /// code paths, and a leg that cannot reach one of them keeps the whole library resident
+        /// no matter what the flag says.
+        ///
+        /// <para>Two things gate it: whether the LEG admits a release at all
+        /// (<see cref="LegAdmitsRelease"/>, a pure function of the config) and whether the env
+        /// arms asked for one. The merge node is the exception to the second - its release is
+        /// its own, so it does not ride <c>OSPREY_FDR_PROJECTION</c>.</para>
+        /// </summary>
+        public static bool RunsOnThisLeg(PipelineContext ctx)
+        {
+            if (!OspreyEnvironment.ReleaseLibraryFragments || ctx?.Config == null)
+                return false;
+            if (!LegAdmitsRelease(ctx.Config))
+                return false;
+            // MergeNodeTask releases against the reported pool, which Stage 5's projection
+            // path has no part in; everywhere else the release rides that path.
+            return ctx.Config.ExpectReconciledInput || OspreyEnvironment.UseFdrProjection;
+        }
+
+        /// <summary>
+        /// Cache-validity suffix for the release arm. EMPTY when the release RAN, and equally
+        /// EMPTY where <see cref="LegAdmitsRelease"/> is false - on such a leg the two arms are
+        /// literally the same run, so a term would invalidate output directories to record a
+        /// difference that cannot exist. It is emitted only for the case that matters: a leg
+        /// that COULD have released and did not.
+        ///
+        /// <para>Keyed on <see cref="RunsOnThisLeg"/> rather than on
+        /// <see cref="OspreyEnvironment.ReleaseLibraryFragments"/> alone, because the flag is not
+        /// what the outputs record. A leg that never released - the flag was on but
+        /// <c>OSPREY_FDR_PROJECTION=0</c> put Stage 5 on the resident path, say - would otherwise
+        /// stamp the same EMPTY suffix as a leg that did, and a later run WITH the release could
+        /// adopt those outputs, skip the work, and report the release arm's memory profile
+        /// without ever executing it. That is the self-confirming A/B the suffix exists to
+        /// prevent, left open one gate upstream.</para>
+        /// </summary>
+        public static string ValidityKeySuffix(PipelineContext ctx)
+        {
+            if (RunsOnThisLeg(ctx))
+                return string.Empty;
+            return ctx?.Config != null && LegAdmitsRelease(ctx.Config) ? @";libfrag=0" : string.Empty;
+        }
+
+        /// <summary>
+        /// Whether this leg can perform a release AT ALL, whatever the env arms say. Separate
+        /// from <see cref="RunsOnThisLeg"/> because the validity key needs the distinction:
+        /// "did not release" is worth recording only where releasing was possible.
+        ///
+        /// <para><c>StopAfterStage5</c> (<c>--task FirstPassFDR</c>) is excluded for TWO
+        /// independent reasons, either alone disqualifying. (1) The gap-fill plan is NOT
+        /// populated there - <c>PlanStage6</c> returns early before assigning it - so the
+        /// retained set would be survivors ONLY and the release would strip exactly the
+        /// gap-fill candidates it exists to protect. (2) There is nothing to free: that path
+        /// already loads the library with <c>OmitFragments</c>, and
+        /// <see cref="LibraryEntry.ReleaseSpectrum"/> detects an already-released entry by
+        /// reference identity rather than by "has a spectrum", so it would swap one shared
+        /// singleton for another and report millions released having freed zero bytes - a
+        /// fabricated saving printed straight above a [MEM] probe. The worker also exits after
+        /// Stage 5, so there is no Stage 6/7 to save memory for.</para>
+        ///
+        /// <para><c>ExpectReconciledInput</c> (<c>--task SecondPassFDR</c>) releases from
+        /// <c>MergeNodeTask</c> instead of <c>FirstJoinTask</c>, which is excluded from that
+        /// leg's pipeline entirely. See
+        /// <see cref="BuildRetainedBaseIds(IEnumerable{KeyValuePair{string, List{FdrEntry}}})"/>.</para>
+        ///
+        /// <para>Everywhere else the release rides <c>FirstJoinTask</c>'s projection path and
+        /// inherits its config conditions. <c>--fdrbench-pass 1</c> is the one that bites: it
+        /// forces the RESIDENT first-pass pool, which computes no surviving base_id set to
+        /// release against.</para>
+        /// </summary>
+        private static bool LegAdmitsRelease(OspreyConfig config)
+        {
+            if (config.StopAfterStage5)
+                return false;
+            if (config.ExpectReconciledInput)
+                return true;
+
+            bool needsResidentFirstPassPool =
+                !string.IsNullOrEmpty(config.OutputFdrBench) &&
+                config.FdrBenchPass == OspreyConfig.FDRBENCH_PASS_1;
+            return config.FdrMethod.UsesPercolatorFramework() && !needsResidentFirstPassPool;
+        }
+
         /// <summary>
         /// The base_ids whose spectra are still needed after Stage 5: the post-compaction
         /// survivors plus every gap-fill candidate.
@@ -46,15 +137,20 @@ namespace pwiz.Osprey.Tasks
         /// ask for.</para>
         ///
         /// <paramref name="firstPassBaseIds"/> is already pair-symmetric (a target and its
-        /// paired decoy share a base_id), so decoys ride along without being named.
+        /// paired decoy share a base_id), so decoys ride along without being named. It is
+        /// required; the caller's null check is what decides whether this leg releases at all,
+        /// so a null reaching here is a wiring fault and throws.
+        ///
+        /// <para><paramref name="gapFillByFile"/> is optional, and NOT because "planning was
+        /// skipped" - skipping planning leaves the non-null empty initializer. It is optional
+        /// because the bundle-adopt path sources it from the reconciliation envelope, which can
+        /// carry nothing.</para>
         /// </summary>
         public static HashSet<uint> BuildRetainedBaseIds(
             HashSet<uint> firstPassBaseIds,
             IReadOnlyDictionary<string, List<GapFillTarget>> gapFillByFile)
         {
-            var retained = firstPassBaseIds == null
-                ? new HashSet<uint>()
-                : new HashSet<uint>(firstPassBaseIds);
+            var retained = new HashSet<uint>(firstPassBaseIds);
             if (gapFillByFile == null)
                 return retained;
 
@@ -69,18 +165,58 @@ namespace pwiz.Osprey.Tasks
         }
 
         /// <summary>
+        /// The merge node's retained set: every base_id present in the final per-file pool.
+        ///
+        /// <para>The merge node (<c>--task SecondPassFDR</c>) cannot use the survivors +
+        /// gap-fill form above, because <c>FirstJoinTask</c> - which computes both halves - is
+        /// excluded from that leg's pipeline. It has the post-rescore pool instead, and that is
+        /// the tighter statement of the same fact: everything Stage 7 and the blib write can
+        /// reach is IN this pool. <c>BlibOutputWriter.PrecompressSpectra</c> reads fragments for
+        /// <c>bestByPrecursor</c>, which is derived from it by successive filtering, and nothing
+        /// else after Stage 6 reads a spectrum at all - second-pass Percolator reloads FEATURES
+        /// from the reconciled parquet, and protein parsimony reads only identity.</para>
+        ///
+        /// <para>Decoys are included rather than filtered out. Keeping them costs nothing (a
+        /// target and its paired decoy share a base_id, so a decoy row adds an entry only where
+        /// the target is absent) and it keeps this a statement about the POOL rather than about
+        /// what is believed to read it.</para>
+        /// </summary>
+        public static HashSet<uint> BuildRetainedBaseIds(
+            IEnumerable<KeyValuePair<string, List<FdrEntry>>> perFileEntries)
+        {
+            var retained = new HashSet<uint>();
+            foreach (var kvp in perFileEntries)
+            {
+                if (kvp.Value == null)
+                    continue;
+                foreach (var e in kvp.Value)
+                    retained.Add(e.EntryId & ScoringTaskShared.BASE_ID_MASK);
+            }
+            return retained;
+        }
+
+        /// <summary>
         /// Call <see cref="LibraryEntry.ReleaseSpectrum"/> on every entry whose base_id is
         /// outside <paramref name="retainedBaseIds"/> and return how many were released.
         /// Identity fields
         /// are untouched on ALL entries, because protein parsimony and the protein-compact
         /// stratum walk the whole library after this point and read them.
+        ///
+        /// <para>Also drops <see cref="FragmentMath"/>'s memoized top-6 m/z table, which is
+        /// library-derived data of the same order (a <c>double[]</c> per entry Id, keyed over
+        /// the WHOLE library rather than the survivors) sitting inside the same floor this
+        /// release is measured against. Behavior-neutral in both directions: it is a pure memo,
+        /// so a retained entry recomputes the identical value, and dropping it also stops a
+        /// released entry's stale cached top-6 from satisfying the prefilter that would
+        /// otherwise have tripped the released-spectrum tripwire.</para>
         /// </summary>
         public static int ReleaseFragments(
             IList<LibraryEntry> fullLibrary, HashSet<uint> retainedBaseIds)
         {
-            if (fullLibrary == null || retainedBaseIds == null)
-                return 0;
-
+            // Both arguments are required. A null library here would be a wiring fault, and
+            // returning 0 for it would print "released 0 entries" - indistinguishable from a
+            // correct run with nothing to release, in a design whose whole posture is to fail
+            // loudly rather than degrade quietly.
             int released = 0;
             foreach (var e in fullLibrary)
             {
@@ -89,6 +225,7 @@ namespace pwiz.Osprey.Tasks
                 if (e.ReleaseSpectrum())
                     released++;
             }
+            FragmentMath.ClearTop6MzCache();
             return released;
         }
     }

--- a/pwiz_tools/Osprey/Osprey.Tasks/LibraryFragmentRelease.cs
+++ b/pwiz_tools/Osprey/Osprey.Tasks/LibraryFragmentRelease.cs
@@ -1,0 +1,151 @@
+﻿/*
+ * Original author: Brendan MacLean <brendanx .at. uw.edu>,
+ *                  MacCoss Lab, Department of Genome Sciences, UW
+ * AI assistance: Claude Code (Claude Opus 5) <noreply .at. anthropic.com>
+ *
+ * Based on osprey (https://github.com/MacCossLab/osprey)
+ *   by Michael J. MacCoss, MacCoss Lab, Department of Genome Sciences, UW
+ *
+ * Copyright 2026 University of Washington - Seattle, WA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using pwiz.Osprey.Core;
+using pwiz.Osprey.FDR.Reconciliation;
+
+namespace pwiz.Osprey.Tasks
+{
+    /// <summary>
+    /// The value a released <see cref="LibraryEntry.Fragments"/> is set to: a single shared
+    /// instance that THROWS on every access.
+    ///
+    /// <para>Neither <c>null</c> nor <c>Array.Empty</c> works here. Every scorer already guards
+    /// with <c>if (entry.Fragments == null || entry.Fragments.Count == 0)</c> - so both a null
+    /// and an empty list are silently absorbed as "this entry has no spectrum", and a released
+    /// entry that something still wanted would score as a degenerate zero instead of failing.
+    /// That is precisely the silently-invalid output a caller would trust. Throwing turns the
+    /// SAME guard expression into a tripwire: the null check short-circuits false, then
+    /// <see cref="Count"/> throws and names the defect.</para>
+    ///
+    /// <para>We free these arrays because we believe nothing reads them. This makes a wrong
+    /// belief loud instead of quiet, and costs one object for the whole process.</para>
+    /// </summary>
+    internal sealed class ReleasedFragments : IReadOnlyList<LibraryFragment>
+    {
+        public static readonly ReleasedFragments INSTANCE = new ReleasedFragments();
+
+        private ReleasedFragments()
+        {
+        }
+
+        public int Count => throw Fail();
+
+        public LibraryFragment this[int index] => throw Fail();
+
+        public IEnumerator<LibraryFragment> GetEnumerator()
+        {
+            throw Fail();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            throw Fail();
+        }
+
+        private static InvalidOperationException Fail()
+        {
+            return new InvalidOperationException(
+                @"Library fragments for this entry were released at the Stage 5 -> 6 boundary " +
+                @"because it is neither a compaction survivor nor a gap-fill candidate, so " +
+                @"nothing should score or write it. Reaching them means the retained set is " +
+                @"wrong. Set OSPREY_RELEASE_LIBRARY_FRAGMENTS=0 to keep the whole library " +
+                @"resident and confirm.");
+        }
+    }
+
+    /// <summary>
+    /// The Stage 5 -&gt; 6 library-fragment release (issue #4532), as a pure function of the
+    /// surviving base_ids and the gap-fill plan so it can be tested without a pipeline.
+    /// <see cref="OspreyEnvironment.ReleaseLibraryFragments"/> carries the rationale and the
+    /// safety argument; this type carries only the set arithmetic.
+    /// </summary>
+    internal static class LibraryFragmentRelease
+    {
+        /// <summary>
+        /// The base_ids whose spectra are still needed after Stage 5: the post-compaction
+        /// survivors plus every gap-fill candidate.
+        ///
+        /// <para>Gap-fill MUST be unioned in. <c>GapFillTargetIdentifier</c> resolves the
+        /// MISSING charge states of passing peptides through the library, so by construction it
+        /// names entries that did not survive compaction - and Stage 6 then scores them. A
+        /// retained set of survivors alone would strip exactly the spectra gap-fill is about to
+        /// ask for.</para>
+        ///
+        /// <paramref name="firstPassBaseIds"/> is already pair-symmetric (a target and its
+        /// paired decoy share a base_id), so decoys ride along without being named.
+        /// </summary>
+        public static HashSet<uint> BuildRetainedBaseIds(
+            HashSet<uint> firstPassBaseIds,
+            IReadOnlyDictionary<string, List<GapFillTarget>> gapFillByFile)
+        {
+            var retained = firstPassBaseIds == null
+                ? new HashSet<uint>()
+                : new HashSet<uint>(firstPassBaseIds);
+            if (gapFillByFile == null)
+                return retained;
+
+            foreach (var kvp in gapFillByFile)
+            {
+                if (kvp.Value == null)
+                    continue;
+                foreach (var g in kvp.Value)
+                    retained.Add(g.TargetEntryId & ScoringTaskShared.BASE_ID_MASK);
+            }
+            return retained;
+        }
+
+        /// <summary>
+        /// Point <see cref="LibraryEntry.Fragments"/> at <see cref="ReleasedFragments"/> on
+        /// every entry whose base_id is outside <paramref name="retainedBaseIds"/>, freeing the
+        /// backing array, and return how many were released. Identity fields
+        /// are untouched on ALL entries, because protein parsimony and the protein-compact
+        /// stratum walk the whole library after this point and read them.
+        /// </summary>
+        public static int ReleaseFragments(
+            IList<LibraryEntry> fullLibrary, HashSet<uint> retainedBaseIds)
+        {
+            if (fullLibrary == null || retainedBaseIds == null)
+                return 0;
+
+            int released = 0;
+            foreach (var e in fullLibrary)
+            {
+                // ReferenceEquals, not .Count: the sentinel THROWS on Count, so an
+                // already-released entry has to be recognized by identity. That also makes the
+                // pass idempotent without ever touching a released entry's contents.
+                if (ReferenceEquals(e.Fragments, ReleasedFragments.INSTANCE) ||
+                    retainedBaseIds.Contains(e.Id & ScoringTaskShared.BASE_ID_MASK))
+                {
+                    continue;
+                }
+                e.Fragments = ReleasedFragments.INSTANCE;
+                released++;
+            }
+            return released;
+        }
+    }
+}

--- a/pwiz_tools/Osprey/Osprey.Tasks/LibraryFragmentRelease.cs
+++ b/pwiz_tools/Osprey/Osprey.Tasks/LibraryFragmentRelease.cs
@@ -21,62 +21,12 @@
  * limitations under the License.
  */
 
-using System;
-using System.Collections;
 using System.Collections.Generic;
 using pwiz.Osprey.Core;
 using pwiz.Osprey.FDR.Reconciliation;
 
 namespace pwiz.Osprey.Tasks
 {
-    /// <summary>
-    /// The value a released <see cref="LibraryEntry.Fragments"/> is set to: a single shared
-    /// instance that THROWS on every access.
-    ///
-    /// <para>Neither <c>null</c> nor <c>Array.Empty</c> works here. Every scorer already guards
-    /// with <c>if (entry.Fragments == null || entry.Fragments.Count == 0)</c> - so both a null
-    /// and an empty list are silently absorbed as "this entry has no spectrum", and a released
-    /// entry that something still wanted would score as a degenerate zero instead of failing.
-    /// That is precisely the silently-invalid output a caller would trust. Throwing turns the
-    /// SAME guard expression into a tripwire: the null check short-circuits false, then
-    /// <see cref="Count"/> throws and names the defect.</para>
-    ///
-    /// <para>We free these arrays because we believe nothing reads them. This makes a wrong
-    /// belief loud instead of quiet, and costs one object for the whole process.</para>
-    /// </summary>
-    internal sealed class ReleasedFragments : IReadOnlyList<LibraryFragment>
-    {
-        public static readonly ReleasedFragments INSTANCE = new ReleasedFragments();
-
-        private ReleasedFragments()
-        {
-        }
-
-        public int Count => throw Fail();
-
-        public LibraryFragment this[int index] => throw Fail();
-
-        public IEnumerator<LibraryFragment> GetEnumerator()
-        {
-            throw Fail();
-        }
-
-        IEnumerator IEnumerable.GetEnumerator()
-        {
-            throw Fail();
-        }
-
-        private static InvalidOperationException Fail()
-        {
-            return new InvalidOperationException(
-                @"Library fragments for this entry were released at the Stage 5 -> 6 boundary " +
-                @"because it is neither a compaction survivor nor a gap-fill candidate, so " +
-                @"nothing should score or write it. Reaching them means the retained set is " +
-                @"wrong. Set OSPREY_RELEASE_LIBRARY_FRAGMENTS=0 to keep the whole library " +
-                @"resident and confirm.");
-        }
-    }
-
     /// <summary>
     /// The Stage 5 -&gt; 6 library-fragment release (issue #4532), as a pure function of the
     /// surviving base_ids and the gap-fill plan so it can be tested without a pipeline.
@@ -119,7 +69,7 @@ namespace pwiz.Osprey.Tasks
         }
 
         /// <summary>
-        /// Point <see cref="LibraryEntry.Fragments"/> at <see cref="ReleasedFragments"/> on
+        /// Point <see cref="LibraryEntry.Fragments"/> at <see cref="LibraryEntry.RELEASED"/> on
         /// every entry whose base_id is outside <paramref name="retainedBaseIds"/>, freeing the
         /// backing array, and return how many were released. Identity fields
         /// are untouched on ALL entries, because protein parsimony and the protein-compact
@@ -137,12 +87,12 @@ namespace pwiz.Osprey.Tasks
                 // ReferenceEquals, not .Count: the sentinel THROWS on Count, so an
                 // already-released entry has to be recognized by identity. That also makes the
                 // pass idempotent without ever touching a released entry's contents.
-                if (ReferenceEquals(e.Fragments, ReleasedFragments.INSTANCE) ||
+                if (ReferenceEquals(e.Fragments, LibraryEntry.RELEASED) ||
                     retainedBaseIds.Contains(e.Id & ScoringTaskShared.BASE_ID_MASK))
                 {
                     continue;
                 }
-                e.Fragments = ReleasedFragments.INSTANCE;
+                e.Fragments = LibraryEntry.RELEASED;
                 released++;
             }
             return released;

--- a/pwiz_tools/Osprey/Osprey.Tasks/LibraryFragmentRelease.cs
+++ b/pwiz_tools/Osprey/Osprey.Tasks/LibraryFragmentRelease.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Original author: Brendan MacLean <brendanx .at. uw.edu>,
  *                  MacCoss Lab, Department of Genome Sciences, UW
  * AI assistance: Claude Code (Claude Opus 5) <noreply .at. anthropic.com>

--- a/pwiz_tools/Osprey/Osprey.Tasks/MergeNodeTask.cs
+++ b/pwiz_tools/Osprey/Osprey.Tasks/MergeNodeTask.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Original author: Brendan MacLean <brendanx .at. uw.edu>,
  *                  MacCoss Lab, Department of Genome Sciences, UW
  * AI assistance: Claude Code (Claude Opus 4.7) <noreply .at. anthropic.com>
@@ -107,7 +107,8 @@ namespace pwiz.Osprey.Tasks
             return base.ValidityKey(ctx)
                 + @";reconciliation=" + ctx.Config.Identity.ReconciliationParameterHash()
                 + OspreyEnvironment.ExperimentAggValidityKeySuffix()
-                + OspreyEnvironment.Pass2QValueValidityKeySuffix();
+                + OspreyEnvironment.Pass2QValueValidityKeySuffix()
+                + OspreyEnvironment.ReleaseLibraryFragmentsValidityKeySuffix();
         }
 
         /// <summary>

--- a/pwiz_tools/Osprey/Osprey.Tasks/MergeNodeTask.cs
+++ b/pwiz_tools/Osprey/Osprey.Tasks/MergeNodeTask.cs
@@ -108,7 +108,7 @@ namespace pwiz.Osprey.Tasks
                 + @";reconciliation=" + ctx.Config.Identity.ReconciliationParameterHash()
                 + OspreyEnvironment.ExperimentAggValidityKeySuffix()
                 + OspreyEnvironment.Pass2QValueValidityKeySuffix()
-                + OspreyEnvironment.ReleaseLibraryFragmentsValidityKeySuffix();
+                + LibraryFragmentRelease.ValidityKeySuffix(ctx);
         }
 
         /// <summary>
@@ -137,6 +137,8 @@ namespace pwiz.Osprey.Tasks
             var fullLibrary = ctx.Get<FullLibrary>().Value;
             var libraryById = ctx.Get<LibraryById>().Value;
             var perFileParquetPaths = ctx.Get<PerFileParquetPaths>().Value;
+
+            ReleaseUnscorableLibraryFragments(perFileEntries, fullLibrary, ctx);
 
             // The 2nd-pass Percolator model, captured for the model-diagnostics
             // pass-2 model view; null when no reconciliation rescore happened.
@@ -243,6 +245,40 @@ namespace pwiz.Osprey.Tasks
                     perFileEntries, pass2Contributions, libraryById, config, ctx.LogInfo);
 
             return true;
+        }
+
+        /// <summary>
+        /// Drop <c>Fragments</c> from every library entry outside the final per-file pool,
+        /// keeping the identity fields on all of them. See
+        /// <see cref="OspreyEnvironment.ReleaseLibraryFragments"/> for the rationale and
+        /// <see cref="LibraryFragmentRelease"/> for the set arithmetic.
+        ///
+        /// <para>This is the merge node's own release, and on the HPC chain it is the ONLY one.
+        /// <c>FirstJoinTask</c> - where the Stage 5 -&gt; 6 release lives - is excluded from a
+        /// <c>--task SecondPassFDR</c> pipeline altogether, and that leg loads the library
+        /// fragment-laden (<c>OmitFragments</c> is gated on <c>StopAfterStage5</c>, false here),
+        /// so without this the one process that holds the whole 6.3 M-entry fragment set through
+        /// second-pass Percolator, protein FDR AND the blib write realized no saving at all -
+        /// the distributed path being exactly where memory hurts most.</para>
+        ///
+        /// <para>Harmless and near-free on the straight-through pipeline, where FirstJoin
+        /// already released in this same process: <see cref="LibraryEntry.ReleaseSpectrum"/> is
+        /// idempotent, so the count reported here is only what Stage 6 dropped afterwards (a
+        /// gap-fill candidate that did not survive rescoring).</para>
+        /// </summary>
+        private void ReleaseUnscorableLibraryFragments(
+            List<KeyValuePair<string, List<FdrEntry>>> perFileEntries,
+            List<LibraryEntry> fullLibrary, PipelineContext ctx)
+        {
+            if (!LibraryFragmentRelease.RunsOnThisLeg(ctx))
+                return;
+
+            var retained = LibraryFragmentRelease.BuildRetainedBaseIds(perFileEntries);
+            int released = LibraryFragmentRelease.ReleaseFragments(fullLibrary, retained);
+            ctx.LogInfo(string.Format(
+                @"Released library fragments for {0} of {1} entries ({2} base_ids retained for the reported pool)",
+                released, fullLibrary.Count, retained.Count));
+            ProfilerHooks.LogMemoryStatsIfEnabled(ctx.LogInfo, @"after library-fragment release");
         }
 
         /// <summary>

--- a/pwiz_tools/Osprey/Osprey.Tasks/MergeNodeTask.cs
+++ b/pwiz_tools/Osprey/Osprey.Tasks/MergeNodeTask.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Original author: Brendan MacLean <brendanx .at. uw.edu>,
  *                  MacCoss Lab, Department of Genome Sciences, UW
  * AI assistance: Claude Code (Claude Opus 4.7) <noreply .at. anthropic.com>

--- a/pwiz_tools/Osprey/Osprey.Tasks/PerFileRescoreTask.cs
+++ b/pwiz_tools/Osprey/Osprey.Tasks/PerFileRescoreTask.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Original author: Brendan MacLean <brendanx .at. uw.edu>,
  *                  MacCoss Lab, Department of Genome Sciences, UW
  * AI assistance: Claude Code (Claude Opus 4.7) <noreply .at. anthropic.com>
@@ -197,7 +197,8 @@ namespace pwiz.Osprey.Tasks
                 + @";reconciliation=" + ctx.Config.Identity.ReconciliationParameterHash()
                 + OspreyEnvironment.ExperimentAggValidityKeySuffix()
                 + OspreyEnvironment.Pass2QValueValidityKeySuffix()
-                + OspreyEnvironment.Stage6StreamSurvivorsValidityKeySuffix();
+                + OspreyEnvironment.Stage6StreamSurvivorsValidityKeySuffix()
+                + OspreyEnvironment.ReleaseLibraryFragmentsValidityKeySuffix();
         }
 
         public override bool Run(PipelineContext ctx)

--- a/pwiz_tools/Osprey/Osprey.Tasks/PerFileRescoreTask.cs
+++ b/pwiz_tools/Osprey/Osprey.Tasks/PerFileRescoreTask.cs
@@ -198,7 +198,7 @@ namespace pwiz.Osprey.Tasks
                 + OspreyEnvironment.ExperimentAggValidityKeySuffix()
                 + OspreyEnvironment.Pass2QValueValidityKeySuffix()
                 + OspreyEnvironment.Stage6StreamSurvivorsValidityKeySuffix()
-                + OspreyEnvironment.ReleaseLibraryFragmentsValidityKeySuffix();
+                + LibraryFragmentRelease.ValidityKeySuffix(ctx);
         }
 
         public override bool Run(PipelineContext ctx)

--- a/pwiz_tools/Osprey/Osprey.Tasks/PerFileRescoreTask.cs
+++ b/pwiz_tools/Osprey/Osprey.Tasks/PerFileRescoreTask.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Original author: Brendan MacLean <brendanx .at. uw.edu>,
  *                  MacCoss Lab, Department of Genome Sciences, UW
  * AI assistance: Claude Code (Claude Opus 4.7) <noreply .at. anthropic.com>

--- a/pwiz_tools/Osprey/Osprey.Test/LibraryFragmentReleaseTest.cs
+++ b/pwiz_tools/Osprey/Osprey.Test/LibraryFragmentReleaseTest.cs
@@ -44,9 +44,11 @@ namespace pwiz.Osprey.Test
         public void TestLibraryFragmentRelease()
         {
             ValidateGapFillCandidatesAreRetained();
+            ValidateReportedPoolIsRetainedOnTheMergeNode();
             ValidateOnlyUnscorableFragmentsAreReleased();
             ValidateIdentityFieldsSurvive();
-            ValidateValidityKeySuffix();
+            ValidateEveryLegThatHoldsTheLibraryReleasesIt();
+            ValidateValidityKeySuffixTracksWhetherTheReleaseRan();
         }
 
         /// <summary>
@@ -69,9 +71,41 @@ namespace pwiz.Osprey.Test
             Assert.IsTrue(retained.Contains(20u), @"gap-fill base_id must be retained");
             Assert.AreEqual(2, retained.Count);
 
-            // A null gap-fill plan is legal (planning skipped) and must not throw.
+            // A null gap-fill plan must not throw. NOT because "planning was skipped" - that
+            // leaves the non-null empty initializer - but because the bundle-adopt path sources
+            // it from the reconciliation envelope, which can carry nothing.
             var survivorsOnly = LibraryFragmentRelease.BuildRetainedBaseIds(survivors, null);
             Assert.AreEqual(1, survivorsOnly.Count);
+        }
+
+        /// <summary>
+        /// The merge node has no survivors + gap-fill pair to work from - FirstJoin is excluded
+        /// from a --task SecondPassFDR pipeline - so it retains every base_id in the final
+        /// reported pool instead. Decoys included: a decoy row must retain its base_id rather
+        /// than being skipped, or a decoy whose paired target did not survive would have its
+        /// spectrum pulled out from under the pool it is still in.
+        /// </summary>
+        private static void ValidateReportedPoolIsRetainedOnTheMergeNode()
+        {
+            var perFileEntries = new List<KeyValuePair<string, List<FdrEntry>>>
+            {
+                new KeyValuePair<string, List<FdrEntry>>(@"fileA", new List<FdrEntry>
+                {
+                    new FdrEntry { EntryId = 10u },
+                    new FdrEntry { EntryId = 10u | DECOY_BIT }
+                }),
+                new KeyValuePair<string, List<FdrEntry>>(@"fileB", new List<FdrEntry>
+                {
+                    new FdrEntry { EntryId = 10u },
+                    new FdrEntry { EntryId = 40u | DECOY_BIT }
+                })
+            };
+
+            var retained = LibraryFragmentRelease.BuildRetainedBaseIds(perFileEntries);
+
+            Assert.AreEqual(2, retained.Count, @"the decoy bit must be masked off, not counted twice");
+            Assert.IsTrue(retained.Contains(10u));
+            Assert.IsTrue(retained.Contains(40u), @"a decoy-only row still retains its base_id");
         }
 
         /// <summary>
@@ -123,27 +157,124 @@ namespace pwiz.Osprey.Test
         }
 
         /// <summary>
-        /// EMPTY on the default arm so no existing output directory is invalidated; non-empty on
-        /// the resident opt-out so an in-place A/B cannot adopt the other arm's outputs and
-        /// report a memory saving it never computed.
+        /// The leg truth table. Two entries carry the weight.
+        ///
+        /// <para><c>--task SecondPassFDR</c> MUST release. That process holds the whole fragment
+        /// set through second-pass Percolator, protein FDR and the blib write, and it is the one
+        /// place a distributed run can free it - <c>FirstJoinTask</c>, where the Stage 5 -&gt; 6
+        /// release lives, is excluded from that leg's pipeline entirely. It realized zero saving
+        /// until the merge node grew its own release, so this row is the regression guard for
+        /// the distributed path, which is where memory hurts most.</para>
+        ///
+        /// <para><c>--task FirstPassFDR</c> MUST NOT. Its gap-fill plan is unpopulated (the
+        /// retained set would be survivors only, stripping the very entries gap-fill is about to
+        /// score) and it already loads with <c>OmitFragments</c>, so a release there would
+        /// report millions of entries freed having freed nothing - a fabricated saving logged
+        /// directly above a [MEM] probe.</para>
         /// </summary>
-        private static void ValidateValidityKeySuffix()
+        private static void ValidateEveryLegThatHoldsTheLibraryReleasesIt()
         {
-            bool saved = OspreyEnvironment.ReleaseLibraryFragments;
+            AssertRunsOnLeg(true, @"straight-through", new OspreyConfig());
+            AssertRunsOnLeg(true, @"--task SecondPassFDR",
+                WithInputScores(c => c.ExpectReconciledInput = true));
+            AssertRunsOnLeg(true, @"--input-scores full pipeline", WithInputScores(_ => { }));
+            AssertRunsOnLeg(false, @"--task FirstPassFDR",
+                WithInputScores(c => c.StopAfterStage5 = true));
+
+            // --fdrbench-pass 1 forces the RESIDENT first-pass pool, which never computes a
+            // surviving base_id set, so there is nothing to release against.
+            AssertRunsOnLeg(false, @"--fdrbench-pass 1", new OspreyConfig
+            {
+                OutputFdrBench = @"bench.tsv",
+                FdrBenchPass = OspreyConfig.FDRBENCH_PASS_1
+            });
+
+            bool savedProjection = OspreyEnvironment.UseFdrProjection;
+            bool savedRelease = OspreyEnvironment.ReleaseLibraryFragments;
             try
             {
-                OspreyEnvironment.ReleaseLibraryFragments = true;
-                Assert.AreEqual(string.Empty,
-                    OspreyEnvironment.ReleaseLibraryFragmentsValidityKeySuffix());
+                OspreyEnvironment.UseFdrProjection = false;
+                AssertRunsOnLeg(false, @"OSPREY_FDR_PROJECTION=0", new OspreyConfig());
+                OspreyEnvironment.UseFdrProjection = savedProjection;
 
                 OspreyEnvironment.ReleaseLibraryFragments = false;
-                Assert.AreNotEqual(string.Empty,
-                    OspreyEnvironment.ReleaseLibraryFragmentsValidityKeySuffix());
+                AssertRunsOnLeg(false, @"OSPREY_RELEASE_LIBRARY_FRAGMENTS=0", new OspreyConfig());
             }
             finally
             {
-                OspreyEnvironment.ReleaseLibraryFragments = saved;
+                OspreyEnvironment.UseFdrProjection = savedProjection;
+                OspreyEnvironment.ReleaseLibraryFragments = savedRelease;
             }
+        }
+
+        /// <summary>
+        /// The suffix records whether the release RAN, not whether the flag was set. Keying it
+        /// on the flag alone left the guarantee resting one gate upstream: a leg that never
+        /// released (Stage 5 forced onto the resident path, say) stamped the same EMPTY suffix
+        /// as a leg that did, so a later run WITH the release could adopt those outputs, skip
+        /// the work, and report the release arm's memory profile without ever executing it.
+        ///
+        /// <para>It is EMPTY on a leg that could not have released either. There the two arms
+        /// are literally the same run, so a term would invalidate output directories - forcing
+        /// hours of re-scoring on an HPC resume - to record a difference that cannot exist.</para>
+        /// </summary>
+        private static void ValidateValidityKeySuffixTracksWhetherTheReleaseRan()
+        {
+            bool savedProjection = OspreyEnvironment.UseFdrProjection;
+            bool savedRelease = OspreyEnvironment.ReleaseLibraryFragments;
+            try
+            {
+                AssertSuffix(true, @"straight-through, released", new OspreyConfig());
+                AssertSuffix(true, @"--task SecondPassFDR, released",
+                    WithInputScores(c => c.ExpectReconciledInput = true));
+                AssertSuffix(true, @"--task FirstPassFDR cannot release",
+                    WithInputScores(c => c.StopAfterStage5 = true));
+
+                OspreyEnvironment.UseFdrProjection = false;
+                AssertSuffix(false, @"could have released, Stage 5 went resident instead",
+                    new OspreyConfig());
+                // The merge node's release is its own and does not ride the Stage 5 path.
+                AssertSuffix(true, @"--task SecondPassFDR ignores OSPREY_FDR_PROJECTION",
+                    WithInputScores(c => c.ExpectReconciledInput = true));
+                OspreyEnvironment.UseFdrProjection = savedProjection;
+
+                OspreyEnvironment.ReleaseLibraryFragments = false;
+                AssertSuffix(false, @"opted out where a release was possible", new OspreyConfig());
+                AssertSuffix(true, @"opted out where it was not possible anyway",
+                    WithInputScores(c => c.StopAfterStage5 = true));
+            }
+            finally
+            {
+                OspreyEnvironment.UseFdrProjection = savedProjection;
+                OspreyEnvironment.ReleaseLibraryFragments = savedRelease;
+            }
+        }
+
+        private static void AssertRunsOnLeg(bool expected, string leg, OspreyConfig config)
+        {
+            Assert.AreEqual(expected, LibraryFragmentRelease.RunsOnThisLeg(MakeContext(config)),
+                string.Format(@"{0}: the release must {1}run on this leg",
+                    leg, expected ? string.Empty : @"NOT "));
+        }
+
+        private static void AssertSuffix(bool expectEmpty, string leg, OspreyConfig config)
+        {
+            string suffix = LibraryFragmentRelease.ValidityKeySuffix(MakeContext(config));
+            Assert.AreEqual(expectEmpty, suffix.Length == 0, string.Format(
+                @"{0}: expected {1} suffix, got '{2}'",
+                leg, expectEmpty ? @"an empty" : @"a non-empty", suffix));
+        }
+
+        private static PipelineContext MakeContext(OspreyConfig config)
+        {
+            return new PipelineContext(config, AnalysisPipeline.CanonicalPipeline(), null, null, null);
+        }
+
+        private static OspreyConfig WithInputScores(Action<OspreyConfig> set)
+        {
+            var config = new OspreyConfig { InputScores = new List<string> { @"a.scores.parquet" } };
+            set(config);
+            return config;
         }
 
         /// <summary>

--- a/pwiz_tools/Osprey/Osprey.Test/LibraryFragmentReleaseTest.cs
+++ b/pwiz_tools/Osprey/Osprey.Test/LibraryFragmentReleaseTest.cs
@@ -156,6 +156,7 @@ namespace pwiz.Osprey.Test
         private static void AssertReleased(LibraryEntry e)
         {
             Assert.IsNotNull(e.Fragments, @"a null would be silently absorbed by every scorer guard");
+            Assert.AreSame(LibraryEntry.RELEASED, e.Fragments);
             Assert.ThrowsException<InvalidOperationException>(() => _ = e.Fragments.Count);
             Assert.ThrowsException<InvalidOperationException>(() => _ = e.Fragments[0]);
             Assert.ThrowsException<InvalidOperationException>(() =>

--- a/pwiz_tools/Osprey/Osprey.Test/LibraryFragmentReleaseTest.cs
+++ b/pwiz_tools/Osprey/Osprey.Test/LibraryFragmentReleaseTest.cs
@@ -156,7 +156,6 @@ namespace pwiz.Osprey.Test
         private static void AssertReleased(LibraryEntry e)
         {
             Assert.IsNotNull(e.Fragments, @"a null would be silently absorbed by every scorer guard");
-            Assert.AreSame(LibraryEntry.RELEASED, e.Fragments);
             Assert.ThrowsException<InvalidOperationException>(() => _ = e.Fragments.Count);
             Assert.ThrowsException<InvalidOperationException>(() => _ = e.Fragments[0]);
             Assert.ThrowsException<InvalidOperationException>(() =>

--- a/pwiz_tools/Osprey/Osprey.Test/LibraryFragmentReleaseTest.cs
+++ b/pwiz_tools/Osprey/Osprey.Test/LibraryFragmentReleaseTest.cs
@@ -94,9 +94,9 @@ namespace pwiz.Osprey.Test
             int released = LibraryFragmentRelease.ReleaseFragments(library, retained);
 
             Assert.AreEqual(2, released);
-            Assert.IsNotNull(library[0].Fragments, @"survivor keeps its spectra");
-            Assert.IsNotNull(library[1].Fragments, @"paired decoy of a survivor keeps its spectra");
-            Assert.IsNotNull(library[2].Fragments, @"gap-fill candidate keeps its spectra");
+            AssertRetained(library[0], @"survivor");
+            AssertRetained(library[1], @"paired decoy of a survivor");
+            AssertRetained(library[2], @"gap-fill candidate");
             AssertReleased(library[3]);
             AssertReleased(library[4]);
 
@@ -147,6 +147,19 @@ namespace pwiz.Osprey.Test
         }
 
         /// <summary>
+        /// A retained entry's spectrum must still be READABLE. Asserting only non-null would
+        /// pass on a released entry too - the released state is deliberately non-null - so the
+        /// assertion has to read through it. That also makes this the released-check in
+        /// reverse: reading a wrongly-released entry throws here rather than passing quietly.
+        /// </summary>
+        private static void AssertRetained(LibraryEntry e, string what)
+        {
+            Assert.IsFalse(e.IsSpectrumReleased, what + @" must not be released");
+            Assert.AreEqual(1, e.Fragments.Count, what + @" must keep a readable spectrum");
+            Assert.AreEqual(300.1, e.Fragments[0].Mz, 1e-12);
+        }
+
+        /// <summary>
         /// A released entry's Fragments must be NON-NULL and must THROW on access. Both halves
         /// matter: every scorer guards with
         /// <c>entry.Fragments == null || entry.Fragments.Count == 0</c>, so a null (or an empty
@@ -155,6 +168,7 @@ namespace pwiz.Osprey.Test
         /// </summary>
         private static void AssertReleased(LibraryEntry e)
         {
+            Assert.IsTrue(e.IsSpectrumReleased);
             Assert.IsNotNull(e.Fragments, @"a null would be silently absorbed by every scorer guard");
             Assert.ThrowsException<InvalidOperationException>(() => _ = e.Fragments.Count);
             Assert.ThrowsException<InvalidOperationException>(() => _ = e.Fragments[0]);

--- a/pwiz_tools/Osprey/Osprey.Test/LibraryFragmentReleaseTest.cs
+++ b/pwiz_tools/Osprey/Osprey.Test/LibraryFragmentReleaseTest.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Original author: Brendan MacLean <brendanx .at. uw.edu>,
  *                  MacCoss Lab, Department of Genome Sciences, UW
  * AI assistance: Claude Code (Claude Opus 5) <noreply .at. anthropic.com>

--- a/pwiz_tools/Osprey/Osprey.Test/LibraryFragmentReleaseTest.cs
+++ b/pwiz_tools/Osprey/Osprey.Test/LibraryFragmentReleaseTest.cs
@@ -1,0 +1,180 @@
+﻿/*
+ * Original author: Brendan MacLean <brendanx .at. uw.edu>,
+ *                  MacCoss Lab, Department of Genome Sciences, UW
+ * AI assistance: Claude Code (Claude Opus 5) <noreply .at. anthropic.com>
+ *
+ * Based on osprey (https://github.com/MacCossLab/osprey)
+ *   by Michael J. MacCoss, MacCoss Lab, Department of Genome Sciences, UW
+ *
+ * Copyright 2026 University of Washington - Seattle, WA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
+using System.Collections.Generic;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using pwiz.Osprey.Core;
+using pwiz.Osprey.FDR.Reconciliation;
+using pwiz.Osprey.Tasks;
+
+namespace pwiz.Osprey.Test
+{
+    /// <summary>
+    /// Tests the Stage 5 -&gt; 6 library-fragment release (issue #4532): survivors and gap-fill
+    /// candidates keep their spectra, everything else loses them, paired decoys ride along on
+    /// the base_id, and identity fields survive on every entry.
+    /// </summary>
+    [TestClass]
+    public class LibraryFragmentReleaseTest
+    {
+        private const uint DECOY_BIT = 0x80000000;
+
+        [TestMethod]
+        public void TestLibraryFragmentRelease()
+        {
+            ValidateGapFillCandidatesAreRetained();
+            ValidateOnlyUnscorableFragmentsAreReleased();
+            ValidateIdentityFieldsSurvive();
+            ValidateValidityKeySuffix();
+        }
+
+        /// <summary>
+        /// Gap-fill resolves the MISSING charge states of passing peptides, so it names entries
+        /// that did NOT survive compaction - and Stage 6 scores them. If the retained set were
+        /// survivors alone it would strip exactly the spectra gap-fill is about to ask for,
+        /// which is the defect this assertion exists to catch.
+        /// </summary>
+        private static void ValidateGapFillCandidatesAreRetained()
+        {
+            var survivors = new HashSet<uint> { 10u };
+            var gapFill = new Dictionary<string, List<GapFillTarget>>
+            {
+                { @"fileA", new List<GapFillTarget> { new GapFillTarget { TargetEntryId = 20u, DecoyEntryId = 20u | DECOY_BIT } } }
+            };
+
+            var retained = LibraryFragmentRelease.BuildRetainedBaseIds(survivors, gapFill);
+
+            Assert.IsTrue(retained.Contains(10u), @"survivor base_id must be retained");
+            Assert.IsTrue(retained.Contains(20u), @"gap-fill base_id must be retained");
+            Assert.AreEqual(2, retained.Count);
+
+            // A null gap-fill plan is legal (planning skipped) and must not throw.
+            var survivorsOnly = LibraryFragmentRelease.BuildRetainedBaseIds(survivors, null);
+            Assert.AreEqual(1, survivorsOnly.Count);
+        }
+
+        /// <summary>
+        /// Entries outside the retained set lose Fragments; retained targets AND their paired
+        /// decoys keep them, because the base_id is shared and the survivor set is
+        /// pair-symmetric.
+        /// </summary>
+        private static void ValidateOnlyUnscorableFragmentsAreReleased()
+        {
+            var library = new List<LibraryEntry>
+            {
+                MakeEntry(10u),               // survivor target
+                MakeEntry(10u | DECOY_BIT),   // its paired decoy - same base_id
+                MakeEntry(20u),               // gap-fill target
+                MakeEntry(30u),               // neither: released
+                MakeEntry(30u | DECOY_BIT)    // its decoy: released too
+            };
+            var retained = new HashSet<uint> { 10u, 20u };
+
+            int released = LibraryFragmentRelease.ReleaseFragments(library, retained);
+
+            Assert.AreEqual(2, released);
+            Assert.IsNotNull(library[0].Fragments, @"survivor keeps its spectra");
+            Assert.IsNotNull(library[1].Fragments, @"paired decoy of a survivor keeps its spectra");
+            Assert.IsNotNull(library[2].Fragments, @"gap-fill candidate keeps its spectra");
+            AssertReleased(library[3]);
+            AssertReleased(library[4]);
+
+            // Idempotent: a second pass finds nothing left to release rather than double-counting.
+            Assert.AreEqual(0, LibraryFragmentRelease.ReleaseFragments(library, retained));
+        }
+
+        /// <summary>
+        /// The identity fields must survive on RELEASED entries too. ProteinFdr's parsimony and
+        /// the protein-compact stratum walk the entire library after this point and read
+        /// ModifiedSequence / ProteinIds, including for entries already judged false - so
+        /// dropping whole entries would silently move protein FDR.
+        /// </summary>
+        private static void ValidateIdentityFieldsSurvive()
+        {
+            var library = new List<LibraryEntry> { MakeEntry(99u) };
+            LibraryFragmentRelease.ReleaseFragments(library, new HashSet<uint>());
+
+            AssertReleased(library[0]);
+            Assert.AreEqual(@"PEPTIDER", library[0].ModifiedSequence);
+            Assert.IsNotNull(library[0].ProteinIds);
+            Assert.AreEqual(1, library[0].ProteinIds.Count);
+            Assert.AreEqual(500.25, library[0].PrecursorMz, 1e-12);
+        }
+
+        /// <summary>
+        /// EMPTY on the default arm so no existing output directory is invalidated; non-empty on
+        /// the resident opt-out so an in-place A/B cannot adopt the other arm's outputs and
+        /// report a memory saving it never computed.
+        /// </summary>
+        private static void ValidateValidityKeySuffix()
+        {
+            bool saved = OspreyEnvironment.ReleaseLibraryFragments;
+            try
+            {
+                OspreyEnvironment.ReleaseLibraryFragments = true;
+                Assert.AreEqual(string.Empty,
+                    OspreyEnvironment.ReleaseLibraryFragmentsValidityKeySuffix());
+
+                OspreyEnvironment.ReleaseLibraryFragments = false;
+                Assert.AreNotEqual(string.Empty,
+                    OspreyEnvironment.ReleaseLibraryFragmentsValidityKeySuffix());
+            }
+            finally
+            {
+                OspreyEnvironment.ReleaseLibraryFragments = saved;
+            }
+        }
+
+        /// <summary>
+        /// A released entry's Fragments must be NON-NULL and must THROW on access. Both halves
+        /// matter: every scorer guards with
+        /// <c>entry.Fragments == null || entry.Fragments.Count == 0</c>, so a null (or an empty
+        /// list) would be silently absorbed as "no spectrum" and score a degenerate zero. The
+        /// non-null sentinel makes that same guard expression throw instead.
+        /// </summary>
+        private static void AssertReleased(LibraryEntry e)
+        {
+            Assert.IsNotNull(e.Fragments, @"a null would be silently absorbed by every scorer guard");
+            Assert.ThrowsException<InvalidOperationException>(() => _ = e.Fragments.Count);
+            Assert.ThrowsException<InvalidOperationException>(() => _ = e.Fragments[0]);
+            Assert.ThrowsException<InvalidOperationException>(() =>
+            {
+                foreach (var unused in e.Fragments)
+                    break;
+            });
+        }
+
+        private static LibraryEntry MakeEntry(uint id)
+        {
+            return new LibraryEntry(id, @"PEPTIDER", @"PEPTIDER", 2, 500.25, 10.0)
+            {
+                ProteinIds = new List<string> { @"P12345" },
+                Fragments = new List<LibraryFragment>
+                {
+                    new LibraryFragment { Mz = 300.1, RelativeIntensity = 1.0f }
+                }
+            };
+        }
+    }
+}

--- a/pwiz_tools/Osprey/Osprey.Test/TaskValidityKeyTest.cs
+++ b/pwiz_tools/Osprey/Osprey.Test/TaskValidityKeyTest.cs
@@ -48,6 +48,7 @@ namespace pwiz.Osprey.Test
             AssertSuffixesAreUnconditional();
             AssertEachArmKeysDifferently();
             AssertEveryTaskCarriesTheSuffixesItNeeds();
+            AssertLibraryFragmentArmIsPinnedToThePipeline();
         }
 
         /// <summary>
@@ -123,6 +124,61 @@ namespace pwiz.Osprey.Test
                 Assert.AreEqual(expectPass2, key.Contains(pass2), string.Format(
                     @"{0} must {1} key on the 2nd-pass q-value mode",
                     task.Name, expectPass2 ? @"" : @"NOT "));
+            }
+        }
+
+        /// <summary>
+        /// The library-fragment arm, pinned to the pipeline by the same walk. It is hand-wired
+        /// into three tasks, so without this, dropping any one of those lines stays green.
+        ///
+        /// <para>Asserted against a NON-EMPTY arm on purpose. The default arm emits nothing -
+        /// deliberately, so shipping the feature invalidates no existing output directory - and
+        /// a test written against that arm asserts nothing at all. Flipping the flag off is what
+        /// makes the term observable.</para>
+        ///
+        /// <para>The term must also be DISTINCT from every other arm's, which
+        /// <c>AreNotEqual(string.Empty, ...)</c> alone would not catch: a suffix that collided
+        /// with a token another arm already emits would let two different configurations
+        /// compute the same key, which is the failure the whole file exists to prevent.</para>
+        /// </summary>
+        private static void AssertLibraryFragmentArmIsPinnedToThePipeline()
+        {
+            bool saved = OspreyEnvironment.ReleaseLibraryFragments;
+            try
+            {
+                OspreyEnvironment.ReleaseLibraryFragments = false;
+                var tasks = AnalysisPipeline.CanonicalPipeline();
+                var ctx = new PipelineContext(new OspreyConfig(), tasks, null, null, null);
+                string libfrag = LibraryFragmentRelease.ValidityKeySuffix(ctx);
+
+                Assert.AreNotEqual(string.Empty, libfrag,
+                    @"the resident opt-out must emit a term, or an in-place A/B adopts the other arm's outputs");
+                foreach (string other in new[]
+                {
+                    OspreyEnvironment.PickValidityKeySuffix(),
+                    OspreyEnvironment.Pass2QValueValidityKeySuffix(),
+                    OspreyEnvironment.ExperimentAggValidityKeySuffix(),
+                    OspreyEnvironment.Stage6StreamSurvivorsValidityKeySuffix()
+                })
+                {
+                    Assert.AreNotEqual(libfrag, other,
+                        @"the library-fragment term must not collide with another arm's token");
+                }
+
+                // Per-file scoring is exempt for the reason it is exempt from the 2nd-pass mode:
+                // its parquet is written in Stages 1-4, before any release can happen, and
+                // keying it here would re-run hours of scoring to reproduce a byte-identical file.
+                foreach (var task in tasks)
+                {
+                    bool expectLibfrag = task.Name != @"PerFileScoring";
+                    Assert.AreEqual(expectLibfrag, task.ValidityKey(ctx).Contains(libfrag),
+                        string.Format(@"{0} must {1}key on the library-fragment release arm",
+                            task.Name, expectLibfrag ? string.Empty : @"NOT "));
+                }
+            }
+            finally
+            {
+                OspreyEnvironment.ReleaseLibraryFragments = saved;
             }
         }
     }


### PR DESCRIPTION
## Summary

* Released `LibraryEntry.Fragments` at the Stage 5 -> 6 boundary for every entry outside the compaction survivors and the gap-fill candidates, keeping the identity fields on all of them
* Pointed released entries at a private sentinel that THROWS on access, rather than nulling or emptying them, because every scorer guards on null-or-empty and would otherwise absorb a released entry as a degenerate zero score
* Gated on `OSPREY_RELEASE_LIBRARY_FRAGMENTS` with a `=0` A/B opt-out, and an EMPTY cache-validity suffix on the default so no existing output directory is invalidated

The library is held from load to process exit. On 82 SEA-AD Astral files that is ~13.5 GB (library + pairing manifest) of a 20.1 GB Stage 6 floor, retained in order to write **37,078 spectra out of 6,275,151 entries - 0.6%**.

Fixes #4532

### Why fragments and not entries

`ProteinFdr.BuildProteinParsimony` and `FirstJoinTask.BuildProteinCompactStratum` both walk the ENTIRE library after Stage 5, including entries already judged false. They read only `ModifiedSequence` / `ProteinIds`, never the spectra. Dropping entries would silently move protein FDR; dropping fragments cannot.

The blib write is safe for a different reason: `BlibOutputWriter.PrecompressSpectra` reads fragments only for `bestByPrecursor`, which is derived from the post-compaction survivors - so blib-written is a strict SUBSET of what is retained.

Gap-fill candidates must be retained alongside the survivors: `GapFillTargetIdentifier` resolves the MISSING charge states of passing peptides through the library, so by construction it names entries that did not survive compaction, and Stage 6 then scores them.

### Why the released state throws

Both obvious sentinels are silent. Every scorer - `SpectralScorer`, `CoelutionScorer`, `XcorrCalculators`, `TopFragmentExtractor`, `ApexMatchCalculators`, `BatchScorer`, `Calibrator`, `BlibWriter` - guards with `if (entry.Fragments == null || entry.Fragments.Count == 0)`, so a null and an empty list are equally absorbed as "this entry has no spectrum". An entry released in error would score a degenerate zero instead of failing. The sentinel turns that same guard expression into a tripwire: the null test short-circuits false, then `Count` throws and names the retained set as the defect. It costs one object process-wide, and `LibraryEntry` exposes only `ReleaseSpectrum()` / `IsSpectrumReleased` - no caller sees the sentinel.

## Test plan

- [x] `regression.ps1 -Dataset All` - PASS on Stellar, StellarLibDecoy, StellarGenDecoyEntrap and Astral, every mode (vs golden, diagnostics vs golden, FDR sanity bounds, HPC chain==straight, warm re-run, resume cache hits, resume==straight)
- [x] Verified the release actually ENGAGES in the golden-compared leg, so byte-identity is not vacuous: `Released library fragments for 152830 of 485628 entries (166399 base_ids retained for rescore + gap-fill)` with `Stellar mode1 (vs golden): PASS`. An earlier revision gated the release on `ctx.Diagnostics`, which disabled it in exactly that leg (`regression.ps1` passes `-DumpProteinFdr` there); that guard was removed after confirming the only fragment-reading dump is `WriteCalXicEntryDumpAndExit`, a Stage 3 dump that exits where it stands
- [x] `LibraryFragmentReleaseTest` - gap-fill candidates retained, only unscorable entries released, release idempotent, identity fields survive, released entries throw on `Count` / indexer / enumeration, validity-key suffix empty on the default arm
- [x] Mutation-checked that test: disabling retention in the release loop makes it fail (`Expected:<2>. Actual:<5>`)
- [x] Build + 575 unit tests + zero-warning ReSharper inspection

### Measured memory saving

A/B on **4 SEA-AD Astral files against the full 12.7 GB gated-no-il library**, same pinned binary in both arms, sequential, differing only in `OSPREY_RELEASE_LIBRARY_FRAGMENTS`. Released **5,459,501 of 6,275,151 entries (87.0%)**, retaining 409,235 base_ids.

| stage | release ON (default) | release OFF (`=0`) | delta peak |
|---|---|---|---|
| PerFileScoring (pre-release) | 13.9 / 30.5 GB | 15.2 / 30.9 GB | -0.4 (noise) |
| FirstPassFDR | 27.7 / 35.7 GB | 27.3 / 40.3 GB | **-4.6 GB** |
| PerFileRescoring | 14.5 / **34.0** GB | 20.5 / **41.8** GB | **-7.8 GB** |
| SecondPassFDR | 15.9 / **17.7** GB | 22.2 / **28.5** GB | **-10.8 GB** |

(floor p10 / peak.) **Stage 7 peak falls 28.5 -> 17.7 GB, a 38% cut**, and Stage 6 floor drops 6.0 GB. Stage 1-4 is unchanged, as it must be - the release is after Stage 5. Slightly FASTER, not slower (Stage 6 5.3 vs 6.0 min), so there is no speed trade.

**Read the absolute numbers with care.** Few files is the MAXIMUM-saving case, not a scaled-down one: the library is fixed while the retained set (survivors + gap-fill) grows with file count. At 4 files 87% of entries are released; an 82-file production run would retain more - roughly 70-75% released by extrapolation from the 82-file stratum sizes - so the saving there is smaller than shown, though still most of the library. This is a demonstration that the mechanism works and how much it can free, not a production figure.

Also confirmed end to end on the production library: arm ON wrote **56,451 library spectra** with no exception and no sentinel trip, after releasing 87% of the library - which is the `blib-written` subset-of-`retained` argument holding in practice, not just on paper.

Co-Authored-By: Claude <noreply@anthropic.com>
