### PR TITLE
osprey: Streamed FirstJoin's rehydrate instead of loading the resident pool

### DIFF
--- a/pwiz_tools/Osprey/Osprey.Core/OspreyEnvironment.cs
+++ b/pwiz_tools/Osprey/Osprey.Core/OspreyEnvironment.cs
@@ -449,7 +449,7 @@ namespace pwiz.Osprey.Core
 
         /// <summary>
         /// OSPREY_ALLOW_UNFIXED_RESIDENT: name the known-unfixed resident path(s) this run may
-        /// take, e.g. <c>OSPREY_ALLOW_UNFIXED_RESIDENT=mdiag-full-resume</c>. Legal values are
+        /// take, e.g. <c>OSPREY_ALLOW_UNFIXED_RESIDENT=hpc-merge</c>. Legal values are
         /// exactly <see cref="ResidentPaths.KNOWN_UNFIXED"/>; anything else, and any resident path
         /// that is not on that list, is refused no matter what this is set to.
         ///
@@ -464,16 +464,20 @@ namespace pwiz.Osprey.Core
         ///
         /// <para>SEVERAL paths may be named, comma- or semicolon-separated, because a run can
         /// legitimately trip more than one at once and a single-value variable made that run
-        /// impossible to perform at all. The A/B that proves the Stage 6 handoff bounded is
-        /// exactly such a run: <c>regression.ps1</c> mode 2 needs
-        /// <see cref="ResidentPaths.MDIAG_FULL_RESUME"/> while the arm under test needs
-        /// <see cref="ResidentPaths.COMPACTED_ENTRIES_BUFFER"/>. A LIST keeps the property that
-        /// matters - every admitted path is still named individually, so nothing rides along
-        /// unnamed the way the blanket boolean allowed - while a single value only ever
-        /// prevented honest work.</para>
+        /// impossible to perform at all. An operator running the Stage 6 handoff A/B on a
+        /// configuration that is already resident for its own reason needs
+        /// <see cref="ResidentPaths.COMPACTED_ENTRIES_BUFFER"/> alongside that run's own token.
+        /// A LIST keeps the property that matters - every admitted path is still named
+        /// individually, so nothing rides along unnamed the way the blanket boolean allowed -
+        /// while a single value only ever prevented honest work.</para>
         ///
-        /// Read once at process start. Intended for local testing; CI names its tokens explicitly
-        /// (regression.ps1 mode 2), so what CI depends on is visible rather than ambient.
+        /// Read once at process start. Intended for local testing. The standing
+        /// <c>regression.ps1</c> gate names exactly ONE token, on one leg
+        /// (<see cref="ResidentPaths.RESUME_SURVIVOR_HANDOFF"/>, issue #4536); every other leg
+        /// runs with nothing suppressed, and an INHERITED value is cleared at startup unless a
+        /// deliberate A/B switch needs it. A resident path appearing anywhere else fails CI
+        /// rather than riding along on an ambient allowance, and each token the gate does
+        /// require carries an open issue to remove it.
         /// </summary>
         public static readonly string AllowUnfixedResident =
             (Environment.GetEnvironmentVariable(@"OSPREY_ALLOW_UNFIXED_RESIDENT") ?? string.Empty).Trim();

--- a/pwiz_tools/Osprey/Osprey.Core/ResidentPaths.cs
+++ b/pwiz_tools/Osprey/Osprey.Core/ResidentPaths.cs
@@ -57,14 +57,13 @@ namespace pwiz.Osprey.Core
         /// </summary>
         public static readonly string FDRBENCH_PASS1 = @"fdrbench-pass1";
 
-        /// <summary>
-        /// <c>--model-diagnostics</c> on a FULL resume, where the 1st-pass sidecars are already
-        /// on disk so FirstJoin skips its score pass, the streaming accumulator is never fed,
-        /// and the report falls back to the resident batch write. Tracked by issue #4505; the
-        /// scale case was streamed by #4420, and a verified fix for this remainder is parked on
-        /// the closed #4437 branch.
-        /// </summary>
-        public static readonly string MDIAG_FULL_RESUME = @"mdiag-full-resume";
+        // mdiag-full-resume is GONE (#4505), and this note is the record of the ratchet
+        // shrinking rather than a gap. --model-diagnostics on a full resume took the resident
+        // pool because FirstJoin skipped its score pass (every 1st-pass sidecar already on
+        // disk), so the streaming accumulator was never fed and the report fell back to the
+        // batch write over the resident entries. FirstJoin's rehydrate now feeds that
+        // accumulator from the per-file load it already performs, off the same PRE-compaction
+        // rows, so the flag arms no resident path at any file count and no token can name one.
 
         /// <summary>
         /// A non-Percolator <c>FdrMethod</c> (Simple / Mokapot), which does not use the
@@ -83,8 +82,7 @@ namespace pwiz.Osprey.Core
         /// <para>It still has to be named. The previous blanket bypass let this switch silently
         /// exempt every OTHER resident trigger too, which is the same masking property that hid
         /// the transfer regression. This entry leaves the list last: it can only go when the
-        /// legacy path itself does, which needs #4507 (FDRBench pass 1) and #4505 (mdiag full
-        /// resume) first.</para>
+        /// legacy path itself does, which needs #4507 (FDRBench pass 1) first.</para>
         /// </summary>
         public static readonly string PROJECTION_OFF = @"projection-off";
 
@@ -107,13 +105,36 @@ namespace pwiz.Osprey.Core
         public static readonly string COMPACTED_ENTRIES_BUFFER = @"compacted-entries-buffer";
 
         /// <summary>
+        /// A straight-through RESUME that rebuilds its first-pass state from its own sidecars:
+        /// only a computed Stage 5 produces the per-file survivor loader, so the rehydrate arm
+        /// hands Stage 6 the all-files post-compaction buffer instead. Tracked by issue #4536.
+        ///
+        /// <para>Deliberately its OWN token rather than reusing
+        /// <see cref="COMPACTED_ENTRIES_BUFFER"/>, which would have been the convenient choice
+        /// - both name the same buffer. Sharing would have let one unfixed path hold the door
+        /// open for a DIFFERENT one that is already fixed: any leg naming the shared token to
+        /// admit this resume would simultaneously admit an
+        /// <c>OSPREY_STAGE6_STREAM_SURVIVORS=0</c> regression on the computed path that #4530
+        /// closed. A token has to admit exactly one path or the high-water mark leaks, which
+        /// is the entire reason the boolean was replaced by names.</para>
+        ///
+        /// <para>This ADDS to the list, which the class remarks say must only shrink. Same
+        /// justification as <see cref="COMPACTED_ENTRIES_BUFFER"/>: it names a path that was
+        /// previously unnamed and UNGUARDED - it ran on any multi-file resume with nothing
+        /// required and nothing reported - rather than re-admitting one that had been fixed.
+        /// Naming it is the ratchet reaching further, not running backwards. It goes when
+        /// #4536 gives the rehydrate its own survivor loader.</para>
+        /// </summary>
+        public static readonly string RESUME_SURVIVOR_HANDOFF = @"resume-survivor-handoff";
+
+        /// <summary>
         /// Every legal <c>OSPREY_ALLOW_UNFIXED_RESIDENT</c> value. Pinned by
         /// <c>ResidentPoolGuardTest</c> - see the class remarks for why it may only shrink.
         /// </summary>
         public static readonly IReadOnlyList<string> KNOWN_UNFIXED = new[]
         {
-            HPC_MERGE, FDRBENCH_PASS1, MDIAG_FULL_RESUME, NON_PERCOLATOR_FDR, PROJECTION_OFF,
-            COMPACTED_ENTRIES_BUFFER
+            HPC_MERGE, FDRBENCH_PASS1, NON_PERCOLATOR_FDR, PROJECTION_OFF,
+            COMPACTED_ENTRIES_BUFFER, RESUME_SURVIVOR_HANDOFF
         };
     }
 }

--- a/pwiz_tools/Osprey/Osprey.Tasks/FirstJoinTask.cs
+++ b/pwiz_tools/Osprey/Osprey.Tasks/FirstJoinTask.cs
@@ -552,8 +552,33 @@ namespace pwiz.Osprey.Tasks
             // deferring to Run -- so a lazy Demand loads, never computes, and
             // Run stays outer-loop-only.
             var bundle = ctx.Get<RescoreBundle>().Value;
-            if (bundle == null)
+            bool builtOwnBundle = bundle == null;
+            if (builtOwnBundle)
             {
+                // Refuse the O(files) Stage 6 handoff BEFORE the load, not after: this
+                // rebuild reads every sidecar and parquet, so checking afterwards would
+                // spend minutes (hours at scale) only to abort. See
+                // PerFileScoringTask.ResumeResidentHandoffGuardError and issue #4536.
+                //
+                // Restricted to a STRAIGHT-THROUGH resume. A null bundle also occurs in worker
+                // mode when the .reconciliation.json sidecars are simply absent (a --task
+                // PerFileRescoring node pointed at parquets whose FirstPassFDR has not run) -
+                // that is a missing-input fault, and answering it with a memory-token refusal
+                // would name the wrong problem, quote that worker's slice as if it were the
+                // all-files buffer, and offer a remediation ("re-run without resuming") that
+                // means nothing to a --task worker. Those runs fall through to the load, which
+                // reports the envelope that is actually missing.
+                bool straightThroughResume =
+                    config.InputScores == null || config.InputScores.Count == 0;
+                if (straightThroughResume)
+                {
+                    string resumeHandoffError = PerFileScoringTask.ResumeResidentHandoffGuardError(
+                        perFileEntries.Count, OspreyEnvironment.AllowUnfixedResident,
+                        PerFileScoringTask.NeedsResidentPoolForRun(config));
+                    if (resumeHandoffError != null)
+                        throw new InvalidOperationException(resumeHandoffError);
+                }
+
                 bundle = LoadOwnReconciliationBundle(ctx, perFileEntries);
                 if (bundle == null)
                     return false;  // load failure; ExitCode already set
@@ -561,14 +586,16 @@ namespace pwiz.Osprey.Tasks
 
             ctx.LogInfo(@"Bundle hydration: skipping first-pass Percolator (sidecar provides q-values).");
 
-            // The bundle's PreCompactionTallies are non-null only when the upstream
-            // hydrate streamed (compacting each file as it loaded, so it never held the
-            // all-files pre-compaction pool). The per-file passing-target counts below are
-            // then read from those tallies rather than recomputed off perFileEntries, which
-            // by that point holds only survivors - the same reason the lean projection path
-            // reads them off its score-pass sink. The --model-diagnostics report is streamed
-            // off the same load for the same reason, and its accumulator is null when the
-            // resident twin ran, which leaves the batch report reading perFileEntries.
+            // The bundle's PreCompactionTallies are non-null only when the hydrate that
+            // produced it STREAMED (compacting each file as it loaded, so it never held the
+            // all-files pre-compaction pool) - either the upstream worker-mode load or this
+            // task's own LoadOwnReconciliationBundle on a lean resume. The per-file
+            // passing-target counts below are then read from those tallies rather than
+            // recomputed off perFileEntries, which by that point holds only survivors - the
+            // same reason the lean projection path reads them off its score-pass sink. The
+            // --model-diagnostics report is streamed off the same load for the same reason,
+            // and its accumulator is null only where the RESIDENT twin ran, which is exactly
+            // where perFileEntries still IS the pre-compaction pool the batch report reads.
             LogFirstPassResultsAndDump(perFileEntries, config, ctx, null,
                 bundle.PreCompactionTallies, bundle.ModelDiagnosticsAccumulator);
             // The accumulator holds the whole run's --model-diagnostics reduction (~1-2 GB
@@ -598,6 +625,40 @@ namespace pwiz.Osprey.Tasks
             // Null off the projection path (legacy resident / rehydrate), where a
             // consumer falls back to the buffer above.
             ctx.Publish(new FirstPassSurvivorSource(_survivorLoader));
+            // ... and a null loader is exactly what leaves Stage 6 on the RESIDENT
+            // post-compaction handoff: PerFileRescore's streamed branches are all gated on
+            // this slot, so with nothing to stream from, the all-files survivor buffer
+            // published above stays live across the whole rescore and into the merge. Run
+            // guards that with Stage6ResidentHandoffGuardError; the guard cannot fire here,
+            // because it deliberately no-ops when streaming is unavailable on the grounds
+            // that such runs are "already resident for a reason with its own token" - which
+            // was true of every rehydrate that used to reach this point (an mdiag full
+            // resume needed the resident first-pass pool) and is NOT true now that a lean
+            // resume gets here. Warn rather than throw, matching WarnPreCompactionPool: the
+            // mdiag full resume reached Stage 6 this way before #4505 too, so refusing it
+            // would turn a working configuration into a failing one.
+            //
+            // NOT covered by #4526, which is CLOSED: #4530 bounded this handoff by giving
+            // Run a per-file survivor loader, and the rehydrate arm never got one, so the
+            // resident fallback survives here. Tracked by #4536.
+            //
+            // This is the SECOND half of token + warning. Reaching this line means the
+            // operator named resume-survivor-handoff (the guard above refused the run
+            // otherwise), so the warning explains what that token bought rather than
+            // annotating something nobody asked for. A warning WITHOUT the refusal would be
+            // the insufficient case: on a default path there is no request to explain, and
+            // the line reads as normal within a week. Both halves go when #4536 gives the
+            // rehydrate its own survivor loader.
+            if (builtOwnBundle && !config.StopAfterStage5 && perFileEntries.Count > 1)
+            {
+                ctx.LogWarning(string.Format(
+                    @"OSPREY_ALLOW_UNFIXED_RESIDENT={1}: Stage 6 takes the RESIDENT " +
+                    @"post-compaction handoff on this resume. The survivor buffer for all " +
+                    @"{0} files stays in memory for the whole rescore, so memory here grows " +
+                    @"O(files) - 28 GB at 163 files when last measured. Only a computed " +
+                    @"Stage 5 produces the per-file survivor loader (issue #4536).",
+                    perFileEntries.Count, ResidentPaths.RESUME_SURVIVOR_HANDOFF));
+            }
             // The bundle-adopt / resume path never plans, so the rescore gate is
             // false (PerFileRescore falls back to the no-op unless a worker
             // RescoreBundle is present). Mirrors the old "FirstJoin rehydrates ->
@@ -613,7 +674,7 @@ namespace pwiz.Osprey.Tasks
         /// <see cref="Run"/> because those outputs were already valid on disk
         /// (<see cref="PipelineContext.CanRehydrate"/>) and a downstream task is
         /// the first to touch this task's state. Overlays the first-pass q-values
-        /// onto the shared stubs and parses the reconciliation envelopes -- the
+        /// onto the per-file stubs and parses the reconciliation envelopes -- the
         /// same bundle PerFileScoring's worker-mode hydration produces, but owned
         /// here against this task's own outputs. Returns <c>null</c> (with
         /// <see cref="PipelineContext.ExitCode"/> set) on a load failure; because
@@ -622,17 +683,38 @@ namespace pwiz.Osprey.Tasks
         /// exactly as the worker hydration does, so PerFileRescore's "Features !=
         /// null means rescored" parquet criterion and MergeNode's feature reload
         /// stay correct.
+        ///
+        /// <para>Which hydrate runs is decided by what upstream actually loaded,
+        /// not by a flag. Stage 5 takes the LEAN load unless an opt-in output reads
+        /// every entry's resident features (<c>NeedsResidentPool</c>), and the lean
+        /// load publishes one EMPTY stub list per scored file. Those empty lists
+        /// cannot carry the sidecar overlay: <c>FdrScoresSidecar.TryRead</c> binds
+        /// each record to a stub by <c>entry_id</c> and fails the file when one is
+        /// missing, so any sidecar that carries at least one record is refused
+        /// against zero stubs. (A zero-record sidecar would "succeed" vacuously -
+        /// the refusal comes from the records, not from the emptiness.) So the batch
+        /// <see cref="RescoreHydration.HydrateReconciliationOverlay"/> is only
+        /// correct when the resident pool is present. The lean case loads each
+        /// file's stubs from its own <c>.scores.parquet</c> through
+        /// <see cref="RescoreHydration.HydrateCompactedStreaming"/> instead, which
+        /// compacts each file before touching the next and so never holds more than
+        /// ONE file's pre-compaction pool (~1.19 GB per file, vs O(files) for the
+        /// batch twin). That is what lets <c>--model-diagnostics</c> report off this
+        /// path without the resident pool (issue #4505): the accumulator is fed from
+        /// the pass that already reads every sidecar, so the report comes off the
+        /// same PRE-compaction rows the batch write would have read.</para>
         /// </summary>
         private RescoreInputs LoadOwnReconciliationBundle(
             PipelineContext ctx,
             List<KeyValuePair<string, List<FdrEntry>>> perFileEntries)
         {
-            // Resolve each loaded file's own .scores.parquet path in
-            // perFileEntries order so HydrateReconciliationOverlay's
-            // index-correspondence contract (entries[i] <-> parquetPaths[i])
-            // holds; PerFileScoring published these paths as PerFileParquetPaths.
+            // Resolve each loaded file's own .scores.parquet path in perFileEntries
+            // order so both hydrates' index-correspondence contract (entries[i] <->
+            // parquetPaths[i]) holds; PerFileScoring published these paths as
+            // PerFileParquetPaths.
             var perFileParquetPaths = ctx.Get<PerFileParquetPaths>().Value;
             var parquetPaths = new List<string>(perFileEntries.Count);
+            long residentStubs = 0;
             foreach (var kvp in perFileEntries)
             {
                 if (!perFileParquetPaths.TryGetValue(kvp.Key, out var path))
@@ -643,12 +725,31 @@ namespace pwiz.Osprey.Tasks
                     return null;
                 }
                 parquetPaths.Add(path);
+                residentStubs += kvp.Value.Count;
             }
+
+            // Zero stubs across every file IS the lean load's signature: it appends a keyed
+            // entry per scored file with an empty list, while every resident arm appends real
+            // ones. Tested on the DATA rather than read off a published flag because it is the
+            // overlay's actual precondition - "are there stubs to overlay onto" - and the
+            // batch hydrate fails on exactly this shape.
+            //
+            // The alternative signal is FdrProjections, non-null exactly on the lean arm.
+            // Equivalent today. If the two ever disagree, that is a bug in Stage 5's own
+            // lean/fat bookkeeping, and this test still picks the hydrate the data can serve.
+            // (An earlier version of this comment claimed an all-zero-row run could not reach
+            // here because it stops at PerFileScoring's "no scored entries" boundary. That is
+            // NOT true on the lazy-Demand path, which swallows the stop when ExitCode == 0.
+            // The conclusion survives for a different reason: such a run writes no 1st-pass
+            // sidecar, so FirstJoin Runs rather than Rehydrates and never reaches this line.)
+            bool leanStubs = residentStubs == 0;
 
             RescoreInputs bundle;
             try
             {
-                bundle = RescoreHydration.HydrateReconciliationOverlay(perFileEntries, parquetPaths);
+                bundle = leanStubs
+                    ? StreamOwnReconciliationBundle(ctx, perFileEntries, parquetPaths)
+                    : RescoreHydration.HydrateReconciliationOverlay(perFileEntries, parquetPaths);
             }
             catch (InvalidDataException ex)
             {
@@ -663,11 +764,168 @@ namespace pwiz.Osprey.Tasks
             // "Features != null means this entry was rescored" parquet criterion
             // stays correct and MergeNode reloads features from the reconciled
             // parquet -- mirrors PerFileScoringTask.HydrateRescoreBundleIfPresent.
-            foreach (var kvp in perFileEntries)
-                foreach (var entry in kvp.Value)
-                    entry.Features = null;
+            //
+            // Skipped on the streaming arm, where it is provably a no-op: those stubs come
+            // from LoadFdrStubsFromParquet, which never assigns Features. Running it anyway
+            // would store null over null across every file's survivors - ~88.9 M reference
+            // writes at 163 files, each tripping the GC write barrier and dirtying the card
+            // table over the whole survivor buffer, immediately before Stage 6 adopts it.
+            if (!leanStubs)
+            {
+                foreach (var kvp in perFileEntries)
+                    foreach (var entry in kvp.Value)
+                        entry.Features = null;
+            }
 
             return bundle;
+        }
+
+        /// <summary>
+        /// The file-count-bounded arm of <see cref="LoadOwnReconciliationBundle"/>: load
+        /// each file's stubs from its own <c>.scores.parquet</c> inside
+        /// <see cref="RescoreHydration.HydrateCompactedStreaming"/>, so one file's
+        /// pre-compaction pool is resident at a time rather than all of them.
+        ///
+        /// <para><paramref name="perFileEntries"/> arrives holding the lean load's empty
+        /// per-file lists and is CLEARED here, because the streaming hydrate appends the
+        /// survivors itself and requires an empty buffer on entry. The list OBJECT is
+        /// kept - it is the published <c>ScoredEntries</c> buffer that
+        /// <see cref="Rehydrate"/> goes on to compact and republish as
+        /// <c>CompactedEntries</c> - so clearing rather than replacing it is what keeps
+        /// those consumers pointed at the same buffer.</para>
+        ///
+        /// <para>The per-file hook is the run's one look at each file's PRE-compaction
+        /// pool, and both reductions taken there are the ones a resident pool used to
+        /// serve afterwards: the run-level passing-target count Stage 5 reports per file,
+        /// and the <c>--model-diagnostics</c> report reduction. The report needs those
+        /// rows specifically - compaction discards ~52x of them, mostly the decoys and
+        /// entrapment its FDP and calibration views are built from - so feeding it here
+        /// is what makes the streamed report identical to the batch one rather than a
+        /// plausible-looking survivors-only page.</para>
+        ///
+        /// <para>COST, stated rather than hidden: this is the SECOND full pass over every
+        /// <c>.scores.parquet</c> on a lean resume. Stage 5 already streamed all five scalar
+        /// columns of every file to build the counts-only projection - whose only consumer
+        /// is <see cref="Run"/>, so on this path its surviving product is a log line and the
+        /// empty-set gate - and this method then re-opens each file for the full stub read.
+        /// The pre-#4505 mdiag full resume read each parquet ONCE, fat. The trade is
+        /// deliberate: one extra sequential scan per file buys an O(files) -> O(1-file)
+        /// pre-compaction pool, which is the whole point at 82 files. Removing the
+        /// redundancy means making the Stage 5 lean load lazy about work only Run consumes,
+        /// which is a separate change.</para>
+        /// </summary>
+        private RescoreInputs StreamOwnReconciliationBundle(
+            PipelineContext ctx,
+            List<KeyValuePair<string, List<FdrEntry>>> perFileEntries,
+            IList<string> parquetPaths)
+        {
+            var config = ctx.Config;
+            // File names in load order. The accumulator is seeded with them so its per-run
+            // report rows are keyed by the same index the hook reports, and the streaming
+            // hydrate rederives its own names from the parquet stems (checked below).
+            var fileNames = perFileEntries.ConvertAll(kv => kv.Key);
+            // This log line is what regression.ps1 mode 5 asserts on. It has to come from
+            // THIS arm: Rehydrate's own "Bundle hydration" line is emitted before the bundle
+            // source is even known, so a worker-supplied bundle logs it too and it cannot
+            // witness the own-sidecar streaming path.
+            ctx.LogInfo(string.Format(
+                @"Resume rehydrate: streaming the first-pass bundle from {0} file(s) " +
+                @"(one file's pre-compaction pool resident at a time).", fileNames.Count));
+
+            // Diagnostics must never take down a real run - the invariant
+            // ModelDiagnosticsReport states three times and enforces with catch-all guards
+            // around its own builders. This path calls one of those builders directly
+            // (BuildClassificationFromLibrary reads the --decoy-pairing-manifest through a
+            // StreamReader and allocates multi-million-entry dictionaries), and the only
+            // enclosing handler catches InvalidDataException, so an IOException or an OOM
+            // would kill a search for the sake of an opt-in HTML page - where the batch write
+            // it replaces logged and swallowed it. A failure here drops the report, not the
+            // run: the accumulator stays null and LogFirstPassResultsAndDump skips it.
+            ModelDiagnosticsData.Accumulator mdiagAccumulator = null;
+            if (config.ModelDiagnostics)
+            {
+                try
+                {
+                    mdiagAccumulator = BuildModelDiagnosticsAccumulator(
+                        fileNames, ctx.Get<LibraryById>().Value, config, ctx.LogInfo);
+                }
+                catch (Exception ex)
+                {
+                    ctx.LogWarning(string.Format(
+                        @"--model-diagnostics: could not build the report accumulator on this " +
+                        @"resume, so no report will be written. The search is unaffected. {0}",
+                        ex.Message));
+                }
+            }
+            // Hydrate into a LOCAL buffer, then swap the contents in only on success.
+            // perFileEntries is the PUBLISHED ScoredEntries list, and the streaming hydrate
+            // appends per file, so clearing it up front would leave it holding a partial
+            // survivor set with the original keys gone if any file threw midway. The list
+            // OBJECT still has to be the one that was published (Rehydrate compacts and
+            // republishes it as CompactedEntries), which is why the contents are copied
+            // rather than the reference replaced.
+            var hydrated = new List<KeyValuePair<string, List<FdrEntry>>>(fileNames.Count);
+            var bundle = RescoreHydration.HydrateCompactedStreaming(
+                hydrated, parquetPaths,
+                (fileIdx, fileName, parquetPath) => LoadResumeStubs(fileName, parquetPath),
+                (fileIdx, fileName, stubs, tally) =>
+                {
+                    ScoringTaskShared.TallyPreCompaction(config, stubs, tally);
+                    if (mdiagAccumulator != null)
+                        ScoringTaskShared.FeedModelDiagnostics(mdiagAccumulator, fileIdx, stubs);
+                });
+
+            // The hydrate re-derived every key from its parquet stem, while the accumulator
+            // above and the published PerFileParquetPaths map are keyed by the ORIGINAL
+            // ScoredEntries stems. They agree today because GetScoresPath appends exactly
+            // ".scores.parquet" and SyntheticInputFromParquet strips it - a round trip, not a
+            // guarantee. Left unchecked, a divergence is SILENT: PerFileRescore looks its
+            // parquet up by the new key, misses, and that file keeps its 1st-pass boundaries
+            // all the way into the blib. Assert the coupling instead of relying on it.
+            for (int i = 0; i < hydrated.Count; i++)
+            {
+                if (!string.Equals(hydrated[i].Key, fileNames[i], StringComparison.Ordinal))
+                {
+                    throw new InvalidDataException(string.Format(
+                        @"Resume rehydrate: file {0} is keyed '{1}' by the loaded scores but " +
+                        @"'{2}' by its parquet stem. The rescore looks parquet paths up by " +
+                        @"the loaded key, so proceeding would silently leave this file " +
+                        @"un-rescored.", i, fileNames[i], hydrated[i].Key));
+                }
+            }
+
+            perFileEntries.Clear();
+            perFileEntries.AddRange(hydrated);
+            bundle.PerFileEntries = perFileEntries;
+            bundle.ModelDiagnosticsAccumulator = mdiagAccumulator;
+            return bundle;
+        }
+
+        /// <summary>
+        /// One file's stub load for <see cref="StreamOwnReconciliationBundle"/>, with any
+        /// parquet fault wrapped as <see cref="InvalidDataException"/>.
+        ///
+        /// <para><see cref="LoadOwnReconciliationBundle"/> catches exactly that type and
+        /// promises an operator-facing "failed to hydrate reconciliation bundle from own
+        /// sidecars" line plus <c>ExitCode = 1</c>. That was free for the batch arm, which
+        /// never opened a parquet; this arm does, so a truncated or locked
+        /// <c>.scores.parquet</c> would otherwise throw <c>IOException</c> straight out of
+        /// <c>Rehydrate</c> with no exit code and none of that text. Mirrors
+        /// <c>RescoreHydration.HydrateForRescore</c> and both upstream resume loaders, which
+        /// all wrap for the same reason.</para>
+        /// </summary>
+        private static List<FdrEntry> LoadResumeStubs(string fileName, string parquetPath)
+        {
+            try
+            {
+                return ParquetScoreCache.LoadFdrStubsFromParquet(parquetPath);
+            }
+            catch (Exception ex)
+            {
+                throw new InvalidDataException(string.Format(
+                    @"failed to load scored entries for {0} from {1}: {2}",
+                    fileName, parquetPath, ex.Message), ex);
+            }
         }
 
         /// <summary>
@@ -677,6 +935,12 @@ namespace pwiz.Osprey.Tasks
         /// OSPREY_DUMP_PERCOLATOR; written before compaction drops rows so the
         /// cross-impl diff sees both targets and decoys) and the
         /// OSPREY_PERCOLATOR_ONLY measurement exit.
+        ///
+        /// <paramref name="preCompactionTallies"/> non-null says the hydrate that produced
+        /// <paramref name="perFileEntries"/> compacted each file as it loaded, so this list
+        /// holds SURVIVORS, not the pre-compaction pool. Both consumers below key off that:
+        /// the per-file counts come from the tallies, and the Percolator dump is skipped
+        /// rather than written from rows it would misreport.
         ///
         /// <paramref name="mdiagAccumulator"/> is the streamed
         /// <c>--model-diagnostics</c> reduction the bounded reconciled-bundle rehydrate
@@ -699,10 +963,57 @@ namespace pwiz.Osprey.Tasks
         {
             LogFirstPassResults(perFileEntries, config, ctx, preCompactionTallies);
 
+            bool dumpWritten = false;
             if (ctx.Diagnostics?.DumpPercolator ?? false)
-                ctx.Diagnostics?.WriteStage5PercolatorDump(perFileEntries);
+            {
+                // The dump's whole value is that it is written BEFORE compaction drops rows,
+                // so the cross-impl diff sees decoys as well as targets. A non-null tally list
+                // means the hydrate that produced perFileEntries already compacted each file as
+                // it loaded, so what is left here is the survivors - roughly 1/52 of the rows,
+                // with the decoys gone. Writing that would produce a file that LOOKS like a
+                // Stage 5 dump and silently disagrees with every reference it is diffed
+                // against, which is worse than not writing one. The lean projection path emits
+                // no dump either (LogFirstPassResultsProjection has no dump point at all), so
+                // skipping matches it; the warning is what keeps the operator from reading an
+                // absent file as "the run had nothing to say".
+                if (preCompactionTallies == null)
+                {
+                    ctx.Diagnostics?.WriteStage5PercolatorDump(perFileEntries);
+                    dumpWritten = true;
+                }
+                else
+                {
+                    // Names the exact token, like every ResidentPoolGuardError message: an
+                    // operator told to "set the matching token" without being told which one
+                    // has to go read the source to act on the warning.
+                    ctx.LogWarning(string.Format(
+                        @"OSPREY_DUMP_PERCOLATOR: no Stage 5 dump written. This run hydrated " +
+                        @"its first-pass state through the bounded per-file path, which " +
+                        @"compacts each file as it loads, so the PRE-compaction pool the dump " +
+                        @"reports never exists all at once. Re-run with " +
+                        @"OSPREY_FDR_PROJECTION=0 OSPREY_ALLOW_UNFIXED_RESIDENT={0} for the " +
+                        @"resident dump.", ResidentPaths.PROJECTION_OFF));
+                }
+            }
             if (ctx.Diagnostics?.PercolatorOnly ?? false)
+            {
+                // Master exited here unconditionally, and that stays true for every
+                // combination it could reach - including OSPREY_PERCOLATOR_ONLY without
+                // OSPREY_DUMP_PERCOLATOR, which the two env vars being read independently
+                // makes legal. The one NEW combination is a dump that was asked for and
+                // could not be written: exiting 0 there would hand a bisection harness a
+                // success code with a stale dump or none, so it fails instead of lying.
+                if ((ctx.Diagnostics?.DumpPercolator ?? false) && !dumpWritten)
+                {
+                    throw new InvalidOperationException(string.Format(
+                        @"OSPREY_DUMP_PERCOLATOR + OSPREY_PERCOLATOR_ONLY: no Stage 5 dump " +
+                        @"could be written on this run (see the warning above), so there is " +
+                        @"nothing to stop after and exiting would report success without the " +
+                        @"file. Re-run with OSPREY_FDR_PROJECTION=0 " +
+                        @"OSPREY_ALLOW_UNFIXED_RESIDENT={0}.", ResidentPaths.PROJECTION_OFF));
+                }
                 OspreyDiagnosticsLog.ExitAfterDump(@"OSPREY_PERCOLATOR_ONLY");
+            }
 
             // --model-diagnostics: emit the self-contained interactive HTML
             // report from the just-scored, pre-compaction first-pass entries

--- a/pwiz_tools/Osprey/Osprey.Tasks/PerFileScoringTask.cs
+++ b/pwiz_tools/Osprey/Osprey.Tasks/PerFileScoringTask.cs
@@ -378,8 +378,9 @@ namespace pwiz.Osprey.Tasks
             // projection. It must mirror that task's dispatch exactly (FirstJoinTask.cs:
             // UseFdrProjection && Percolator && !needsResidentFirstPassPool): any other
             // combination -- a non-Percolator FdrMethod, OSPREY_FDR_PROJECTION=0, or the
-            // resident-pool consumers (--model-diagnostics / FDRBench pass 1, which walk
-            // the full pre-compaction FdrEntry pool) -- still needs the fat stubs here.
+            // resident-pool consumer FDRBench pass 1, which walks the full pre-compaction
+            // FdrEntry pool -- still needs the fat stubs here. --model-diagnostics is NOT
+            // one of them any more (#4505): it streams its report on every path.
             bool needsResidentPool = NeedsResidentPool(ctx.Config);
             GuardResidentPool(ctx.Config, needsResidentPool);
 
@@ -635,21 +636,15 @@ namespace pwiz.Osprey.Tasks
             // needs the resident pool. FirstJoin consumes the projection set identically
             // whether Run or this path produced it.
             //
-            // --model-diagnostics forces the fat pool ONLY for a FULL resume, where FirstJoin
-            // ALSO skips the first-pass score pass (every 1st-pass sidecar already on disk) and
-            // emits the report via the batch ModelDiagnosticsReport.Write, which reads the
-            // RESIDENT per-file entries. On a Stage-1-4 (-LinkFrom) resume the 1st-pass sidecars
-            // are absent, so FirstPassFDR RE-RUNS and streams the report off its score pass
-            // (ModelDiagnosticsData.Accumulator) exactly like a compute run -- no resident pool
-            // needed. Probing the sidecars keeps the lean counts-only path for the common
-            // -LinkFrom A/B resume (whose forced fat pool OOM'd an 82-file mdiag run) while
-            // preserving the batch-write path's resident entries for the full-resume re-report,
-            // so the fat pool is never on the row-count scaling path. The full elimination (stream
-            // the batch report from the sidecar+parquet too) is a documented follow-up.
-            // See TODO-20260720_osprey_pass2_per_run_qvalue.
-            bool mdiagFullResume = config.ModelDiagnostics && FirstPassSidecarsPresent(config);
-            bool needsResidentPool = NeedsResidentPool(config) || mdiagFullResume;
-            GuardResidentPool(config, needsResidentPool, mdiagFullResume);
+            // --model-diagnostics is NOT a trigger, on a full resume or any other (#4505).
+            // It used to be: with every 1st-pass sidecar already on disk FirstJoin skips its
+            // score pass, so the streaming accumulator was never fed and the report fell back
+            // to the batch ModelDiagnosticsReport.Write over the RESIDENT entries. FirstJoin's
+            // rehydrate now feeds that accumulator from the per-file load it already performs
+            // (FirstJoinTask.StreamOwnReconciliationBundle), off the same PRE-compaction rows,
+            // so the report emits from this lean load at any file count.
+            bool needsResidentPool = NeedsResidentPool(config);
+            GuardResidentPool(config, needsResidentPool);
             FdrProjectionSet projections = null;
 
             var swAllFiles = Stopwatch.StartNew();
@@ -804,10 +799,11 @@ namespace pwiz.Osprey.Tasks
             ctx.Publish(new PerFileIsolationMz(_perFileIsolationMz));
             ctx.Publish(new PerFileParquetPaths(_perFileParquetPaths));
             ctx.Publish(new ScoredEntries(_perFileEntries));
-            // Lean first-pass rows (issue #4397). Null on the rehydrate/merge paths (including
-            // a --model-diagnostics resume, which needs resident entries for the batch report)
-            // and on FDRBench pass 1 / OSPREY_PASS2_QVALUE=transfer, which publish fat stubs
-            // above; FirstJoinTask falls back to ScoredEntries whenever this is null.
+            // Lean first-pass rows (issue #4397). Null on the merge paths and on FDRBench
+            // pass 1, which publish fat stubs above; FirstJoinTask falls back to ScoredEntries
+            // whenever this is null. A --model-diagnostics resume publishes a NON-null
+            // projection since #4505 - it no longer needs resident entries, because
+            // FirstJoin's rehydrate streams the report off its own per-file load.
             ctx.Publish(new FdrProjections(projections));
             ctx.Publish(new RescoreBundle(_rescoreInputs));
 
@@ -1285,9 +1281,9 @@ namespace pwiz.Osprey.Tasks
                             perFileCalibrations, perFileIsolationMz, ctx),
                         (fileIdx, fileName, stubs, tally) =>
                         {
-                            TallyPreCompaction(config, stubs, tally);
+                            ScoringTaskShared.TallyPreCompaction(config, stubs, tally);
                             if (mdiagAccumulator != null)
-                                FeedModelDiagnostics(mdiagAccumulator, fileIdx, stubs);
+                                ScoringTaskShared.FeedModelDiagnostics(mdiagAccumulator, fileIdx, stubs);
                         }), ctx);
                 if (_rescoreInputs == null)
                 {
@@ -1427,7 +1423,7 @@ namespace pwiz.Osprey.Tasks
         ///
         /// --model-diagnostics needs no exclusion at all any more. It needs the same
         /// pre-compaction rows, but it consumes them one at a time:
-        /// <see cref="FeedModelDiagnostics"/> folds every row into a
+        /// <see cref="ScoringTaskShared.FeedModelDiagnostics"/> folds every row into a
         /// ModelDiagnosticsData.Accumulator during this load, after the 1st-pass sidecar
         /// overlay and before compaction drops the non-survivors, and FirstJoin reports from
         /// that reduction instead of from the pool. Same rows in, same report out, bounded
@@ -1538,47 +1534,6 @@ namespace pwiz.Osprey.Tasks
             LoadJoinOnlyCalibration(fileName, parquetPath, perFileCalibrations,
                 perFileIsolationMz, ctx);
             return stubs;
-        }
-
-        /// <summary>
-        /// Reduce off one file's PRE-compaction stub pool everything the rehydrate used to
-        /// read off the resident all-files pool. Only the run-level FDR passing-target count
-        /// is needed: FirstJoin's Stage 5 result line reports it per file, and the streaming
-        /// hydrate has already dropped the non-survivors by the time that line is written.
-        /// Identical predicate to <c>FirstJoinTask.LogFirstPassResults</c>.
-        /// </summary>
-        private static void TallyPreCompaction(
-            OspreyConfig config, List<FdrEntry> stubs, PreCompactionTally tally)
-        {
-            int passing = 0;
-            foreach (var entry in stubs)
-            {
-                if (!entry.IsDecoy && entry.EffectiveRunQvalue(config.FdrLevel) <= config.RunFdr)
-                    passing++;
-            }
-            tally.PassingTargets = passing;
-        }
-
-        /// <summary>
-        /// Fold one file's PRE-compaction stubs into the <c>--model-diagnostics</c> report
-        /// accumulator, handing it exactly the scalars the batch
-        /// <c>ModelDiagnosticsData.Build</c> reads off each <see cref="FdrEntry"/> - identity,
-        /// is_decoy, SVM score, and the four first-pass q-values the
-        /// <c>.1st-pass.fdr_scores.bin</c> overlay has just written onto these stubs. Rows
-        /// arrive here in the same nested (file, row) order the batch build walks
-        /// (<c>--input-scores</c> order, parquet row order within a file), which is what makes
-        /// the streamed reductions reproduce the resident ones element for element.
-        /// </summary>
-        private static void FeedModelDiagnostics(
-            ModelDiagnosticsData.Accumulator accumulator, int fileIdx, List<FdrEntry> stubs)
-        {
-            foreach (var entry in stubs)
-            {
-                accumulator.Add(fileIdx, entry.ModifiedSequence, entry.Charge, entry.EntryId,
-                    entry.IsDecoy, entry.Score,
-                    new FdrQValues(entry.RunPrecursorQvalue, entry.RunPeptideQvalue,
-                        entry.ExperimentPrecursorQvalue, entry.ExperimentPeptideQvalue, entry.Pep));
-            }
         }
 
         /// <summary>
@@ -1874,6 +1829,17 @@ namespace pwiz.Osprey.Tasks
         }
 
         /// <summary>
+        /// <see cref="NeedsResidentPool(OspreyConfig)"/> for callers outside this class:
+        /// "this run already requires a resident-pool token of its own". Only
+        /// <see cref="ResumeResidentHandoffGuardError"/>'s caller needs it, to avoid charging
+        /// a second token for one decision.
+        /// </summary>
+        internal static bool NeedsResidentPoolForRun(OspreyConfig config)
+        {
+            return NeedsResidentPool(config);
+        }
+
+        /// <summary>
         /// Pure core of <see cref="NeedsResidentPool(OspreyConfig)"/> (the env static is passed
         /// in so it is unit testable), and the single definition of the trigger set.
         /// <c>OSPREY_PASS2_QVALUE=transfer</c> is NOT a trigger and must not become one again:
@@ -1896,47 +1862,19 @@ namespace pwiz.Osprey.Tasks
         }
 
         /// <summary>
-        /// True when every input file already has its <c>.1st-pass.fdr_scores.bin</c> sidecar on
-        /// disk, so FirstJoin will REHYDRATE first-pass FDR (skip its score pass) rather than
-        /// recompute. Under <c>--model-diagnostics</c> that skip routes the report to the batch
-        /// <c>ModelDiagnosticsReport.Write</c>, which reads the RESIDENT per-file entries -- the
-        /// one case a resume still needs the fat pool. A Stage-1-4 (<c>-LinkFrom</c>) resume links
-        /// only the Stage-4 <c>.scores.parquet</c>, so the 1st-pass sidecars are ABSENT, FirstPassFDR
-        /// re-runs, and its score pass streams the report -- no resident pool needed. Absent sidecars
-        /// therefore mean "stay lean" (correct); present sidecars mean "keep fat" (conservative,
-        /// matching the batch-write path). Mirrors <see cref="FdrScoresSidecar.Pass1Path"/> as used by
-        /// <c>FirstJoinTask</c>'s rehydrate-output enumeration.
-        /// </summary>
-        private static bool FirstPassSidecarsPresent(OspreyConfig config)
-        {
-            if (config.InputFiles == null || config.InputFiles.Count == 0)
-                return false;
-            foreach (var inputFile in config.InputFiles)
-            {
-                if (!File.Exists(FdrScoresSidecar.Pass1Path(inputFile)))
-                    return false;
-            }
-            return true;
-        }
-
-        /// <summary>
         /// Fail fast when a run would build the RESIDENT first-pass pool -- an O(files) memory
         /// path (the fat <see cref="FdrEntry"/> stub buffer, and the <c>FirstJoin.Rehydrate</c>
         /// pre-compaction load it feeds) that does not scale to large file counts. Unless the
         /// operator named THIS path via <c>OSPREY_ALLOW_UNFIXED_RESIDENT</c>, throw with the token
         /// named so the failure is actionable rather than an opaque OOM at scale. Triggers: the
         /// HPC reconciled-input merge (#4486), <c>--fdrbench-pass 1</c> (#4507), a non-Percolator
-        /// FdrMethod, <c>--model-diagnostics</c> on a full resume (#4505 - the scale case was
-        /// streamed by #4420; only the full-resume batch report remains), and
-        /// <c>OSPREY_FDR_PROJECTION=0</c>, which requests the legacy resident implementation
-        /// outright and so must be named like any other.
+        /// FdrMethod, and <c>OSPREY_FDR_PROJECTION=0</c>, which requests the legacy resident
+        /// implementation outright and so must be named like any other.
         /// </summary>
-        private static void GuardResidentPool(
-            OspreyConfig config, bool needsResidentPool, bool mdiagFullResume = false)
+        private static void GuardResidentPool(OspreyConfig config, bool needsResidentPool)
         {
             string error = ResidentPoolGuardError(config, needsResidentPool,
-                OspreyEnvironment.AllowUnfixedResident, OspreyEnvironment.UseFdrProjection,
-                mdiagFullResume);
+                OspreyEnvironment.AllowUnfixedResident, OspreyEnvironment.UseFdrProjection);
             if (error != null)
                 throw new InvalidOperationException(error);
         }
@@ -1958,11 +1896,11 @@ namespace pwiz.Osprey.Tasks
         /// </summary>
         internal static string ResidentPoolGuardError(
             OspreyConfig config, bool needsResidentPool, string allowUnfixedResident,
-            bool useFdrProjection, bool mdiagFullResume = false)
+            bool useFdrProjection)
         {
             if (!needsResidentPool)
                 return null;
-            string trigger = ResidentPoolTrigger(config, useFdrProjection, mdiagFullResume);
+            string trigger = ResidentPoolTrigger(config, useFdrProjection);
             // Membership in the committed list is what makes it the high-water mark rather than
             // documentation: a token the trigger chain invents but the list does not carry is
             // refused here, so re-admitting a path really does require editing the list (and
@@ -1999,6 +1937,62 @@ namespace pwiz.Osprey.Tasks
         }
 
         /// <summary>
+        /// The RESUME counterpart of <see cref="Stage6ResidentHandoffGuardError"/>, and the
+        /// reason that one cannot serve here: it exempts runs that cannot stream, on the
+        /// grounds that they are resident under a token of their own. A straight-through
+        /// resume rebuilding its bundle from its own sidecars has NO such token - since #4505
+        /// it needs none at all - yet it still hands Stage 6 the all-files survivor buffer,
+        /// because only a computed Stage 5 produces the per-file loader. Left unguarded that
+        /// is an O(files) path on a DEFAULT user path with nothing asked for and nothing said,
+        /// which is the one shape the ratchet exists to forbid.
+        ///
+        /// <para>So it is refused unless named, exactly like every other resident path: omit
+        /// the token and the run fails loudly with an actionable message; name it and the run
+        /// proceeds with a warning saying what was granted. A warning ALONE would be the
+        /// insufficient case - on a default path there is no request to explain.</para>
+        ///
+        /// <para>Silent for a single-file join, where "all files" is one file and there is no
+        /// O(files) growth to refuse, and silent when <paramref name="alreadyResidentByToken"/>
+        /// says this run is resident under a token it already had to name. Tracked by issue
+        /// #4536: when the rehydrate gets its own survivor loader this guard goes away with
+        /// the buffer.</para>
+        /// </summary>
+        internal static string ResumeResidentHandoffGuardError(
+            int joinedFileCount, string allowUnfixedResident, bool alreadyResidentByToken)
+        {
+            if (joinedFileCount <= 1)
+                return null;
+            // Already resident for a reason that carries its OWN token (projection-off,
+            // fdrbench-pass1, non-percolator-fdr, hpc-merge): demanding a second one would
+            // tell the operator to set two variables for one decision, and neither message
+            // mentions the other, so the natural fix - set the token it names - fails again
+            // naming a different token. Same exemption Stage6ResidentHandoffGuardError makes,
+            // for the same reason. The rule this guard enforces is about the UNTOKENED
+            // default path; a run that already asked for residency has asked.
+            if (alreadyResidentByToken)
+                return null;
+            if (OspreyEnvironment.NamesResidentPath(
+                    allowUnfixedResident, ResidentPaths.RESUME_SURVIVOR_HANDOFF))
+            {
+                return null;
+            }
+            string suppliedOnResume = string.IsNullOrEmpty(allowUnfixedResident)
+                ? string.Empty
+                : string.Format(@" OSPREY_ALLOW_UNFIXED_RESIDENT is currently '{0}', which does " +
+                                @"not name this path.", allowUnfixedResident);
+            return string.Format(
+                @"This resume rebuilds its first-pass state from its own sidecars, which leaves " +
+                @"Stage 6 on the '{0}' RESIDENT path: the survivor buffer for all {1} files " +
+                @"stays in memory for the whole rescore and grows O(files) - 28 GB at 163 " +
+                @"files when last measured. Only a computed Stage 5 produces the per-file " +
+                @"survivor loader, so a resume cannot stream it (issue #4536). Set " +
+                @"OSPREY_ALLOW_UNFIXED_RESIDENT={0} to accept that and proceed, or re-run " +
+                @"without resuming so Stage 5 is computed; otherwise this path is " +
+                @"unavailable.{2}",
+                ResidentPaths.RESUME_SURVIVOR_HANDOFF, joinedFileCount, suppliedOnResume);
+        }
+
+        /// <summary>
         /// The same refusal, one stage later: the guard above stops at the compaction line, and
         /// the POST-compaction survivor handoff is O(files) too - 88.9 M entries / 28 GB at 163
         /// files, live for the whole Stage 6 rescore (issue #4526). Stage 6 streams that buffer
@@ -2008,11 +2002,19 @@ namespace pwiz.Osprey.Tasks
         ///
         /// <para><paramref name="streamingAvailable"/> is false when this run could not stream
         /// whatever the flag says - the resident and rehydrate paths never compute the passing
-        /// base_id set the per-file loader needs. Those runs are already resident for a reason
-        /// with its own token (<see cref="ResidentPaths.PROJECTION_OFF"/> above all), so
-        /// demanding a second token on top would tell the operator to set two variables for one
-        /// decision, and would fire on the plain <c>--task SecondPassFDR</c> merge that
-        /// <see cref="ResidentPaths.HPC_MERGE"/> already covers.</para>
+        /// base_id set the per-file loader needs. Those runs are exempt HERE because they are
+        /// already resident for a reason with its own token
+        /// (<see cref="ResidentPaths.PROJECTION_OFF"/> above all), so demanding a second token
+        /// would mean two variables for one decision, and would fire on the plain
+        /// <c>--task SecondPassFDR</c> merge that <see cref="ResidentPaths.HPC_MERGE"/> already
+        /// covers.</para>
+        ///
+        /// <para>That reasoning covers every caller of THIS guard, and deliberately leaves one
+        /// gap it cannot see: a lean straight-through resume needs no first-pass token at all
+        /// since #4505, so "already resident under another token" is false for it. That case
+        /// is refused by <see cref="ResumeResidentHandoffGuardError"/> instead, at the point
+        /// where the rehydrate decides to rebuild its own bundle. Both guards disappear when
+        /// #4536 gives the rehydrate a survivor loader.</para>
         /// </summary>
         internal static string Stage6ResidentHandoffGuardError(
             bool streamingAvailable, bool streamingEnabled, string allowUnfixedResident)
@@ -2051,14 +2053,14 @@ namespace pwiz.Osprey.Tasks
         /// config-driven reasons, because it selects the legacy implementation for the WHOLE run
         /// and is therefore the honest description even when another trigger also applies.</para>
         ///
-        /// <para><paramref name="mdiagFullResume"/> is passed in rather than read off
-        /// <paramref name="config"/>: <c>--model-diagnostics</c> forces the pool only in
-        /// combination with a full resume, and testing <c>config.ModelDiagnostics</c> alone here
-        /// would make mdiag an unconditional catch-all that silently absorbed any FUTURE arming
-        /// condition - handing it a token CI already exports.</para>
+        /// <para><c>--model-diagnostics</c> is deliberately NOT a branch here, and must not
+        /// become one again. It was, for the full-resume case only (#4505), and the arming
+        /// condition had to be passed in rather than read off <paramref name="config"/> so that
+        /// testing <c>config.ModelDiagnostics</c> alone could not make mdiag an unconditional
+        /// catch-all absorbing any FUTURE arming condition - handing it a token CI exports.
+        /// FirstJoin's rehydrate now streams that report, so the flag arms nothing.</para>
         /// </summary>
-        private static string ResidentPoolTrigger(
-            OspreyConfig config, bool useFdrProjection, bool mdiagFullResume)
+        private static string ResidentPoolTrigger(OspreyConfig config, bool useFdrProjection)
         {
             if (!useFdrProjection)
                 return ResidentPaths.PROJECTION_OFF;
@@ -2068,8 +2070,6 @@ namespace pwiz.Osprey.Tasks
                 return ResidentPaths.NON_PERCOLATOR_FDR;
             if (!string.IsNullOrEmpty(config.OutputFdrBench) && config.FdrBenchPass == 1)
                 return ResidentPaths.FDRBENCH_PASS1;
-            if (mdiagFullResume)
-                return ResidentPaths.MDIAG_FULL_RESUME;
             return null;
         }
 

--- a/pwiz_tools/Osprey/Osprey.Tasks/ScoringTaskShared.cs
+++ b/pwiz_tools/Osprey/Osprey.Tasks/ScoringTaskShared.cs
@@ -26,6 +26,8 @@ using System.Collections.Generic;
 using System.IO;
 using System.Threading;
 using pwiz.Osprey.Core;
+using pwiz.Osprey.FDR;
+using pwiz.Osprey.FDR.ModelDiagnostics;
 using pwiz.Osprey.IO;
 using pwiz.Osprey.Scoring;
 
@@ -260,6 +262,60 @@ namespace pwiz.Osprey.Tasks
                 return Path.Combine(parent, fileName + ".mzML");
             }
             return null;
+        }
+
+        /// <summary>
+        /// Reduce off one file's PRE-compaction stub pool everything a rehydrate used to
+        /// read off the resident all-files pool. Only the run-level FDR passing-target count
+        /// is needed: FirstJoin's Stage 5 result line reports it per file, and the streaming
+        /// hydrate has already dropped the non-survivors by the time that line is written.
+        /// Identical predicate to <c>FirstJoinTask.LogFirstPassResults</c>.
+        ///
+        /// <para>Shared by both callers of
+        /// <see cref="RescoreHydration.HydrateCompactedStreaming"/> -- the
+        /// <c>--task PerFileRescoring</c> worker load in <see cref="PerFileScoringTask"/>
+        /// and the straight-through resume in <see cref="FirstJoinTask"/> - so the two
+        /// cannot drift into reporting per-file counts under different predicates. NOT the
+        /// <c>--task SecondPassFDR</c> merge: that sets <c>ExpectReconciledInput</c>, the
+        /// first branch of <c>PreCompactionPoolReason</c>, so it always takes the resident
+        /// batch twin and is still O(files) (issue #4486).</para>
+        /// </summary>
+        internal static void TallyPreCompaction(
+            OspreyConfig config, List<FdrEntry> stubs, PreCompactionTally tally)
+        {
+            int passing = 0;
+            foreach (var entry in stubs)
+            {
+                if (!entry.IsDecoy && entry.EffectiveRunQvalue(config.FdrLevel) <= config.RunFdr)
+                    passing++;
+            }
+            tally.PassingTargets = passing;
+        }
+
+        /// <summary>
+        /// Fold one file's PRE-compaction stubs into the <c>--model-diagnostics</c> report
+        /// accumulator, handing it exactly the scalars the batch
+        /// <c>ModelDiagnosticsData.Build</c> reads off each <see cref="FdrEntry"/> - identity,
+        /// is_decoy, SVM score, and the four first-pass q-values the
+        /// <c>.1st-pass.fdr_scores.bin</c> overlay has just written onto these stubs. Rows
+        /// arrive here in the same nested (file, row) order the batch build walks (input-file
+        /// order, parquet row order within a file), which is what makes the streamed
+        /// reductions reproduce the resident ones element for element.
+        ///
+        /// <para>Shared by the same two hydrate callers as
+        /// <see cref="TallyPreCompaction"/>: the report must be identical whether the
+        /// pre-compaction rows passed through the worker load or a resume's.</para>
+        /// </summary>
+        internal static void FeedModelDiagnostics(
+            ModelDiagnosticsData.Accumulator accumulator, int fileIdx, List<FdrEntry> stubs)
+        {
+            foreach (var entry in stubs)
+            {
+                accumulator.Add(fileIdx, entry.ModifiedSequence, entry.Charge, entry.EntryId,
+                    entry.IsDecoy, entry.Score,
+                    new FdrQValues(entry.RunPrecursorQvalue, entry.RunPeptideQvalue,
+                        entry.ExperimentPrecursorQvalue, entry.ExperimentPeptideQvalue, entry.Pep));
+            }
         }
     }
 }

--- a/pwiz_tools/Osprey/Osprey.Test/IOTest.cs
+++ b/pwiz_tools/Osprey/Osprey.Test/IOTest.cs
@@ -4013,10 +4013,45 @@ namespace pwiz.Osprey.Test
                     typeof(ReconcileAction.ForcedIntegration));
                 Assert.IsInstanceOfType(streamed.ReconciliationActions[("s2", 1)],
                     typeof(ReconcileAction.UseCwtPeak));
+
+                AssertBatchOverlayRejectsLeanStubs(parquetPaths, stems);
             }
             finally
             {
                 try { Directory.Delete(dir, true); } catch (IOException) { }
+            }
+        }
+
+        /// <summary>
+        /// The batch <see cref="RescoreHydration.HydrateReconciliationOverlay"/> must REFUSE
+        /// the per-file lists a LEAN Stage 5 load publishes - one keyed entry per scored file,
+        /// every list EMPTY - rather than quietly hydrate a bundle with no entries in it.
+        ///
+        /// This is not a hypothetical: it is the shape <c>FirstJoin.Rehydrate</c> is handed on
+        /// every resume that did not need the resident pool, and the reason that path has to
+        /// take <see cref="RescoreHydration.HydrateCompactedStreaming"/> (which loads each
+        /// file's stubs itself) instead. The refusal comes from the sidecar reader's superset
+        /// contract - <c>FdrScoresSidecar.TryRead</c> cannot bind a record to a list of zero
+        /// entries - so it is the CALLER's job to pick the hydrate that matches what upstream
+        /// loaded. Pinned here because the failure is a mid-pipeline
+        /// <see cref="InvalidDataException"/> that reads like sidecar corruption rather than
+        /// like the wrong hydrate being called.
+        /// </summary>
+        private static void AssertBatchOverlayRejectsLeanStubs(
+            List<string> parquetPaths, string[] stems)
+        {
+            var leanEntries = new List<KeyValuePair<string, List<FdrEntry>>>();
+            foreach (string stem in stems)
+                leanEntries.Add(new KeyValuePair<string, List<FdrEntry>>(stem, new List<FdrEntry>()));
+            try
+            {
+                RescoreHydration.HydrateReconciliationOverlay(leanEntries, parquetPaths);
+                Assert.Fail("expected InvalidDataException overlaying a sidecar onto empty stubs");
+            }
+            catch (InvalidDataException ex)
+            {
+                StringAssert.Contains(ex.Message, "1st-pass.fdr_scores.bin");
+                StringAssert.Contains(ex.Message, stems[0]);
             }
         }
 

--- a/pwiz_tools/Osprey/Osprey.Test/ResidentPoolGuardTest.cs
+++ b/pwiz_tools/Osprey/Osprey.Test/ResidentPoolGuardTest.cs
@@ -91,19 +91,32 @@ namespace pwiz.Osprey.Test
                 allowUnfixedResident: ResidentPaths.HPC_MERGE.ToUpperInvariant(),
                 useFdrProjection: true));
 
-            // Each user-reachable trigger names its own token so the failure is diagnosable:
-            // mdiag arms the pool only in COMBINATION with a full resume, so the caller passes
-            // that conjunction in. Testing config.ModelDiagnostics alone inside the trigger would
-            // make mdiag an unconditional catch-all that absorbed any future arming condition -
-            // and hand it the one token CI already exports (regression.ps1 mode 2).
+            // Each user-reachable trigger names its own token so the failure is diagnosable.
+            // --model-diagnostics is NOT among them any more (#4505): it armed the pool on a
+            // full resume, where FirstJoin skipped its score pass and reported off the resident
+            // entries, and FirstJoin's rehydrate now streams that report instead.
+            //
+            // Pinned on the MESSAGE, not just on non-null. Asserting "some error" across a
+            // list of tokens looks thorough and proves nothing here: mdiag has no trigger at
+            // all, so ResidentPoolTrigger returns null and ResidentPoolGuardError returns the
+            // generic "not one of the paths known to be unfixed" refusal BEFORE it ever
+            // consults the token. Every token therefore yields the identical string, and the
+            // loop would stay green with ModelDiagnostics = false.
+            //
+            // The claim worth pinning is that mdiag reaches the resident pool by NO named
+            // route, and the generic refusal IS that claim: it is the branch taken when the
+            // trigger chain produced no token to offer. If someone re-arms mdiag onto an
+            // already-legal token, this message changes to the one naming that token and the
+            // assertion fails.
             var mdiag = new OspreyConfig { ModelDiagnostics = true };
-            StringAssert.Contains(
-                PerFileScoringTask.ResidentPoolGuardError(mdiag, true, null, true,
-                    mdiagFullResume: true),
-                ResidentPaths.MDIAG_FULL_RESUME);
-            // --model-diagnostics WITHOUT the full resume is not a known path: refused outright.
-            Assert.IsNotNull(PerFileScoringTask.ResidentPoolGuardError(mdiag, true,
-                ResidentPaths.MDIAG_FULL_RESUME, true, mdiagFullResume: false));
+            string mdiagErr = PerFileScoringTask.ResidentPoolGuardError(mdiag, true, null, true);
+            StringAssert.Contains(mdiagErr, "not one of the paths known to be unfixed");
+            foreach (string token in ResidentPaths.KNOWN_UNFIXED)
+            {
+                Assert.AreEqual(mdiagErr,
+                    PerFileScoringTask.ResidentPoolGuardError(mdiag, true, token, true),
+                    string.Format("--model-diagnostics changed disposition under token '{0}'", token));
+            }
 
             var fdrbench1 = new OspreyConfig { OutputFdrBench = "bench.tsv", FdrBenchPass = 1 };
             StringAssert.Contains(PerFileScoringTask.ResidentPoolGuardError(fdrbench1, true, null, true),
@@ -128,14 +141,18 @@ namespace pwiz.Osprey.Test
             // addition then shows up in review as the ratchet running backwards, instead of
             // as an environment variable somebody set months ago and nobody re-examined.
             // LITERALS, not the constants: comparing the constants to themselves would pin
-            // membership and order but not the text, and the text is what regression.ps1 mode 2
-            // hard-codes. Renaming a value would otherwise compile, pass here, and only surface
-            // hours later when the expensive gate reaches mode 2 and Osprey throws.
+            // membership and order but not the text, and the text is what an operator types
+            // into OSPREY_ALLOW_UNFIXED_RESIDENT. Renaming a value would otherwise compile and
+            // pass here while silently invalidating every written-down invocation.
+            // 'mdiag-full-resume' is GONE (#4505) - the ratchet shrinking.
+            // 'resume-survivor-handoff' is ADDED (#4536), which the class remarks allow only
+            // because it names a path that was previously unnamed AND unguarded, not one that
+            // had been fixed.
             CollectionAssert.AreEqual(
                 new[]
                 {
-                    "hpc-merge", "fdrbench-pass1", "mdiag-full-resume", "non-percolator-fdr",
-                    "projection-off", "compacted-entries-buffer"
+                    "hpc-merge", "fdrbench-pass1", "non-percolator-fdr",
+                    "projection-off", "compacted-entries-buffer", "resume-survivor-handoff"
                 },
                 ResidentPaths.KNOWN_UNFIXED.ToArray());
 
@@ -208,6 +225,8 @@ namespace pwiz.Osprey.Test
             Assert.IsNotNull(wrongToken);
             StringAssert.Contains(wrongToken, ResidentPaths.PROJECTION_OFF);
 
+            AssertResumeHandoffGuard();
+
             // A run that cannot stream at all (no per-file survivor source: the legacy resident
             // and rehydrate paths never compute the passing base_id set) is NOT guarded here.
             // It is already resident for a reason carrying its own token, and demanding a
@@ -215,23 +234,91 @@ namespace pwiz.Osprey.Test
             Assert.IsNull(PerFileScoringTask.Stage6ResidentHandoffGuardError(false, false, null));
 
             // SEVERAL paths may be named at once. A run can legitimately trip more than one,
-            // and a single-value variable made that run impossible: regression.ps1 mode 2 needs
-            // mdiag-full-resume while the arm under test needs compacted-entries-buffer, so the
-            // A/B that proves this very change bounded aborted on its own guard. Both guards
-            // read the list, and every admitted path is still named individually.
-            string both = ResidentPaths.MDIAG_FULL_RESUME + "," +
-                          ResidentPaths.COMPACTED_ENTRIES_BUFFER;
+            // and a single-value variable made that run impossible: an operator proving the
+            // streamed Stage 6 handoff bounded on a configuration that is already resident for
+            // its own reason needs that run's token AND compacted-entries-buffer, so the very
+            // A/B that establishes the bound aborted on its own guard. Both guards read the
+            // list, and every admitted path is still named individually.
+            string both = ResidentPaths.HPC_MERGE + "," + ResidentPaths.COMPACTED_ENTRIES_BUFFER;
             Assert.IsNull(PerFileScoringTask.Stage6ResidentHandoffGuardError(true, false, both));
-            var mdiagCfg = new OspreyConfig { ModelDiagnostics = true };
-            Assert.IsNull(PerFileScoringTask.ResidentPoolGuardError(mdiagCfg, true, both, true,
-                mdiagFullResume: true));
+            var hpcCfg = new OspreyConfig { ExpectReconciledInput = true };
+            Assert.IsNull(PerFileScoringTask.ResidentPoolGuardError(hpcCfg, true, both, true));
             // Separators are interchangeable and surrounding whitespace is tolerated - an
             // operator composing the value in a shell should not have to match a spelling.
             Assert.IsNull(PerFileScoringTask.Stage6ResidentHandoffGuardError(
                 true, false, " projection-off ; compacted-entries-buffer "));
             // A list still admits ONLY what it names: an unnamed path is refused as before.
             Assert.IsNotNull(PerFileScoringTask.Stage6ResidentHandoffGuardError(
-                true, false, ResidentPaths.MDIAG_FULL_RESUME + "," + ResidentPaths.HPC_MERGE));
+                true, false, ResidentPaths.PROJECTION_OFF + "," + ResidentPaths.HPC_MERGE));
+        }
+
+        /// <summary>
+        /// The RESUME Stage 6 handoff guard: a straight-through resume rebuilding its bundle
+        /// from its own sidecars cannot stream the survivor handoff, so it must NAME
+        /// <see cref="ResidentPaths.RESUME_SURVIVOR_HANDOFF"/> or be refused.
+        ///
+        /// <para>Pins both halves of the rule, because only having both is the policy: omit
+        /// the token and the run FAILS with an actionable message; name it and the run
+        /// proceeds (the caller then warns). A warning alone on an untokened default path is
+        /// what this guard exists to stop being possible - that state shipped briefly while
+        /// #4505 was in review, and is exactly how an O(files) path reaches a user who never
+        /// asked for one.</para>
+        /// </summary>
+        private static void AssertResumeHandoffGuard()
+        {
+            // Unnamed: refused, and the message names the token to set plus the file count
+            // that makes it O(files), so the operator can judge the cost rather than guess.
+            string err = PerFileScoringTask.ResumeResidentHandoffGuardError(82, null, false);
+            Assert.IsNotNull(err);
+            StringAssert.Contains(err,
+                "OSPREY_ALLOW_UNFIXED_RESIDENT=" + ResidentPaths.RESUME_SURVIVOR_HANDOFF);
+            StringAssert.Contains(err, "82");
+
+            // Named: admitted. Case-insensitive and list-tolerant, like every other token.
+            Assert.IsNull(PerFileScoringTask.ResumeResidentHandoffGuardError(
+                82, ResidentPaths.RESUME_SURVIVOR_HANDOFF, false));
+            Assert.IsNull(PerFileScoringTask.ResumeResidentHandoffGuardError(
+                82, ResidentPaths.RESUME_SURVIVOR_HANDOFF.ToUpperInvariant(), false));
+            Assert.IsNull(PerFileScoringTask.ResumeResidentHandoffGuardError(
+                82, ResidentPaths.PROJECTION_OFF + "," + ResidentPaths.RESUME_SURVIVOR_HANDOFF, false));
+
+            // COMPACTED_ENTRIES_BUFFER must NOT admit it, and this pair of assertions is what
+            // the separate-token decision rests on. Both name the same physical buffer, so
+            // reusing it here would have been the convenient choice - and would have meant any
+            // leg admitting this unfixed resume ALSO admitted an
+            // OSPREY_STAGE6_STREAM_SURVIVORS=0 regression on the computed path that #4530
+            // already closed. One token, one path, or the high-water mark leaks.
+            string sharedToken = PerFileScoringTask.ResumeResidentHandoffGuardError(
+                82, ResidentPaths.COMPACTED_ENTRIES_BUFFER, false);
+            Assert.IsNotNull(sharedToken);
+            StringAssert.Contains(sharedToken, ResidentPaths.COMPACTED_ENTRIES_BUFFER);
+            // ... and symmetrically, this run's token does not re-open the computed-path
+            // handoff that #4530 fixed.
+            Assert.IsNotNull(PerFileScoringTask.Stage6ResidentHandoffGuardError(
+                true, false, ResidentPaths.RESUME_SURVIVOR_HANDOFF));
+
+            // A DIFFERENT token does not admit it, and the message says what was supplied so
+            // a stale value does not read like an unset one.
+            string wrong = PerFileScoringTask.ResumeResidentHandoffGuardError(
+                82, ResidentPaths.HPC_MERGE, false);
+            Assert.IsNotNull(wrong);
+            StringAssert.Contains(wrong, ResidentPaths.HPC_MERGE);
+
+            // Single-file join: "all files" is one file, so there is no O(files) growth to
+            // refuse and an ordinary one-file resume must not demand a token to run.
+            Assert.IsNull(PerFileScoringTask.ResumeResidentHandoffGuardError(1, null, false));
+            Assert.IsNull(PerFileScoringTask.ResumeResidentHandoffGuardError(0, null, false));
+            // Two IS O(files) - the threshold is "more than one", not "many". A guard that
+            // waited for a big number would let the growth establish itself unnoticed.
+            Assert.IsNotNull(PerFileScoringTask.ResumeResidentHandoffGuardError(2, null, false));
+
+            // A run already resident under a token it HAD to name (projection-off,
+            // fdrbench-pass1, ...) is exempt with no token of its own. Without this, an
+            // OSPREY_FDR_PROJECTION=0 resume needed TWO tokens and neither message mentioned
+            // the other, so setting the one it named failed again naming a different one.
+            Assert.IsNull(PerFileScoringTask.ResumeResidentHandoffGuardError(82, null, true));
+            Assert.IsNull(PerFileScoringTask.ResumeResidentHandoffGuardError(
+                82, ResidentPaths.PROJECTION_OFF, true));
         }
     }
 }

--- a/pwiz_tools/Osprey/Osprey.Test/ResidentPoolGuardTest.cs
+++ b/pwiz_tools/Osprey/Osprey.Test/ResidentPoolGuardTest.cs
@@ -96,23 +96,27 @@ namespace pwiz.Osprey.Test
             // full resume, where FirstJoin skipped its score pass and reported off the resident
             // entries, and FirstJoin's rehydrate now streams that report instead.
             //
-            // Pinned on the MESSAGE, not just on non-null. Asserting "some error" across a
-            // list of tokens looks thorough and proves nothing here: mdiag has no trigger at
-            // all, so ResidentPoolTrigger returns null and ResidentPoolGuardError returns the
-            // generic "not one of the paths known to be unfixed" refusal BEFORE it ever
-            // consults the token. Every token therefore yields the identical string, and the
-            // loop would stay green with ModelDiagnostics = false.
+            // Pinned on what the message MEANS, not on its prose. Two things have to hold,
+            // and neither is "some error came back": mdiag has no trigger at all, so
+            // ResidentPoolTrigger returns null and the refusal is the generic one issued
+            // BEFORE any token is consulted - a bare non-null assertion would stay green even
+            // with ModelDiagnostics = false.
             //
-            // The claim worth pinning is that mdiag reaches the resident pool by NO named
-            // route, and the generic refusal IS that claim: it is the branch taken when the
-            // trigger chain produced no token to offer. If someone re-arms mdiag onto an
-            // already-legal token, this message changes to the one naming that token and the
-            // assertion fails.
+            // 1. The refusal NAMES NO TOKEN. That is exactly "no named route admits mdiag":
+            //    the tokened refusal always carries OSPREY_ALLOW_UNFIXED_RESIDENT=<token>, so
+            //    if someone re-arms mdiag onto an already-legal token the message gains that
+            //    token and this fails. Asserting the absence of every legal token says it
+            //    without pinning a sentence, which would break on any rewording.
+            // 2. The disposition does not CHANGE under any token, which the absence check
+            //    alone does not cover.
             var mdiag = new OspreyConfig { ModelDiagnostics = true };
             string mdiagErr = PerFileScoringTask.ResidentPoolGuardError(mdiag, true, null, true);
-            StringAssert.Contains(mdiagErr, "not one of the paths known to be unfixed");
+            StringAssert.Contains(mdiagErr, "OSPREY_ALLOW_UNFIXED_RESIDENT");
             foreach (string token in ResidentPaths.KNOWN_UNFIXED)
             {
+                Assert.IsFalse(mdiagErr.Contains(token),
+                    string.Format("--model-diagnostics refusal names token '{0}', so that " +
+                                  "token now admits it", token));
                 Assert.AreEqual(mdiagErr,
                     PerFileScoringTask.ResidentPoolGuardError(mdiag, true, token, true),
                     string.Format("--model-diagnostics changed disposition under token '{0}'", token));

--- a/pwiz_tools/Osprey/Regression/DiagnosticsGolden.ps1
+++ b/pwiz_tools/Osprey/Regression/DiagnosticsGolden.ps1
@@ -192,12 +192,27 @@ function Compare-DiagnosticsGolden {
     Tier 1: compare a fresh report's metrics against the committed golden.
     Numeric metrics at absolute Tolerance; everything else exact. Returns
     Pass + Issues.
+
+    -NoTrainedModel is for a report emitted by a run that ADOPTED first-pass
+    q-values from the .1st-pass.fdr_scores.bin sidecars instead of training
+    Percolator (FirstJoinTask.Rehydrate -- regression.ps1 mode 5). Exactly one
+    metric is model-derived: featureCount comes from the FeatureContributions
+    the trainer produces, and a run that never trained has none to report. The
+    switch does NOT skip that metric -- it PINS it at 0, so the comparison stays
+    total: every metric is still asserted, one of them against the value a
+    modelless run must have rather than against the golden. Skipping instead
+    would leave the report free to lose its feature view on the straight-through
+    path too, unnoticed.
     #>
     param([Parameter(Mandatory = $true)][string]$HtmlPath,
           [Parameter(Mandatory = $true)][string]$GoldenDir,
-          [double]$Tolerance = 1e-9)
+          [double]$Tolerance = 1e-9,
+          [switch]$NoTrainedModel)
 
     $issues = [System.Collections.Generic.List[string]]::new()
+    # The one model-derived metric, named once so the two places below that treat
+    # it specially cannot drift apart.
+    $modelMetric = 'featureCount'
     $goldenPath = Join-Path $GoldenDir 'diagnostics.tsv'
     if (-not (Test-Path $goldenPath)) {
         $issues.Add("diagnostics: missing golden $goldenPath")
@@ -217,6 +232,23 @@ function Compare-DiagnosticsGolden {
     foreach ($name in $goldenOrder) {
         if (-not $fresh.ContainsKey($name)) { $issues.Add("diagnostics: metric missing from run: $name"); continue }
         $g = $golden[$name]; $f = $fresh[$name]
+        if ($NoTrainedModel -and $name -eq $modelMetric) {
+            # Pinned, not skipped. A run that adopted its q-values from the 1st-pass
+            # sidecars trained no model, so it has no feature contributions to report
+            # and this must read 0. Anything else means the report claims a feature
+            # view it cannot have computed, which is the direction that would matter.
+            if ($f -ne '0') {
+                # Double parens: -f binds TIGHTER than the ',' separating method arguments,
+                # so Add(("...") -f $name, $f) parses as a TWO-argument call and the format
+                # operator throws on the missing {1}. Every other Add in this file does the
+                # same. Getting it wrong is invisible until the branch first fires - which
+                # here is the failure path this pin exists to report.
+                $issues.Add((("diagnostics: {0} run='{1}', expected '0' - this run adopted " +
+                    "first-pass q-values from the sidecars and trained no model, so it has " +
+                    "no feature contributions to report") -f $name, $f))
+            }
+            continue
+        }
         $gd = 0.0; $fd = 0.0
         # Invariant, matching how Format-CellValue WROTE these. The current-culture
         # overload reads its own invariant output wrong on a comma-decimal agent, and

--- a/pwiz_tools/Osprey/Regression/README.md
+++ b/pwiz_tools/Osprey/Regression/README.md
@@ -62,6 +62,41 @@ artifact**, so the multi-GB spectra caches there are harmless):
    in resume mode (invalidate the Stage 5 join + blib, re-run the same command
    so the rehydrate paths fire) and asserts the resume blib equals the
    straight-through blib at 1e-9. The build is its own oracle — no baseline.
+4. **mode 5 - Stage-5 rehydrate self-consistency**. Invalidates ONLY the
+   `SecondPassFDR` task (the blib + its `SecondPassFDR` stamp), leaving the
+   `FirstPassFDR` stamp and every 1st-pass sidecar valid, so the re-run rebuilds
+   its post-Stage-5 bundle from those **own** sidecars
+   (`LoadOwnReconciliationBundle`). (Task **names** throughout - the classes
+   behind them are `FirstJoinTask` and `MergeNodeTask`, and only the names appear
+   in the `[TASK]` log lines and `.osprey.task` stamps.) **No other leg reaches
+   that loader**: mode 2 deletes the `FirstPassFDR` stamp, so that task *runs*;
+   mode 4 invalidates nothing, so nothing demands its state; and mode 3's
+   `PerFileRescoring` phase *does* enter the rehydrate arm, but adopts a
+   **worker-supplied** bundle rather than loading its own. Asserts a marker logged
+   from inside that loader (a cache hit does not prove it ran, and neither does the
+   generic rehydrate line, which a worker bundle emits too), the blib against the
+   pristine straight-through one at 1e-9, and, for datasets with
+   `ModelDiagnostics`, the report re-emitted from those sidecars against the same
+   golden mode 1b uses.
+
+   Runs **last**, after mode 2: its merge rewrites the 2nd-pass sidecars and the
+   diagnostics report as well as the blib, none of which `Invoke-ResumeInvalidation`
+   deletes, so running it earlier would leave mode 2 resuming on top of mode-5
+   state.
+
+**modes 3 and 4** (the HPC 4-task worker chain, and the warm re-run cache-hit
+assertion) are described in `regression.ps1`'s own comment header, alongside why
+comparing output alone cannot detect a cache-invalidation regression.
+
+Exactly **one** leg names a resident-pool token: mode 5 sets
+`OSPREY_ALLOW_UNFIXED_RESIDENT=resume-survivor-handoff`, because a resume cannot stream the
+Stage 6 survivor handoff (issue #4536). Every other leg runs with nothing suppressed, and an
+*inherited* value is cleared at startup unless a deliberate A/B switch needs it. Each
+required token must have an open issue to remove it, and the run summary prints the count.
+
+An ambient allowance on a standing gate can only mask the regression the gate exists to
+catch - which is how the former blanket `OSPREY_ALLOW_UNBOUNDED_MEMORY=1` let an
+`OSPREY_PASS2_QVALUE=transfer` regression ride along for ten days.
 
 Every leg of a dataset — straight-through, resume, and each HPC phase — is given
 the **same** dataset CLI flags (`Get-DatasetCliArgs`). A self-consistency oracle

--- a/pwiz_tools/Osprey/Regression/RegressionData.ps1
+++ b/pwiz_tools/Osprey/Regression/RegressionData.ps1
@@ -211,3 +211,58 @@ function Invoke-ResumeInvalidation {
     }
     $targets | Remove-Item -Force
 }
+
+<#
+.SYNOPSIS
+    Invalidate ONLY the SecondPassFDR task, leaving FirstPassFDR valid, so a
+    re-run enters FirstPassFDR's rehydrate arm.
+
+.DESCRIPTION
+    Named for the task NAMES the driver stamps and logs -- FirstPassFDR and
+    SecondPassFDR -- not for the C# class names (FirstJoinTask, MergeNodeTask) and
+    not for "the join" / "the merge node", which are the same metaphor applied to
+    two tasks that both join and so distinguish nothing. The stamp filenames below
+    carry the Name, so the Name is what this reads.
+
+    The narrower sibling of Invoke-ResumeInvalidation, and the only invalidation
+    that reaches FirstPassFDR's REHYDRATE arm. Invoke-ResumeInvalidation deletes
+    '*.FirstPassFDR.osprey.task' -- that task's validity stamp -- so FirstPassFDR
+    RUNS and recomputes from the entries it is handed. Rehydrate is entered on the
+    opposite state: FirstPassFDR's own outputs are still valid on disk, so the
+    driver skips its Run, and a downstream task is the first to touch its state
+    (FirstJoinTask.LoadOwnReconciliationBundle then rebuilds the post-Stage-5
+    bundle from the .1st-pass.fdr_scores.bin + .reconciliation.json sidecars).
+
+    Deleting the blib plus its SecondPassFDR stamp is exactly that state: every
+    per-file parquet, every 1st-pass sidecar, and the FirstPassFDR stamp survive,
+    so PerFileScoring / FirstPassFDR / PerFileRescoring must all report cache hits
+    while SecondPassFDR recomputes and demands FirstJoin's state on the way.
+
+    Deleting nothing is a hard failure, for Invoke-ResumeInvalidation's reason: a
+    silently no-op invalidation yields a green leg that only compared a run
+    against itself.
+
+.PARAMETER WorkDir
+    The straight-through run directory to invalidate in place.
+#>
+function Invoke-SecondPassOnlyInvalidation {
+    param([Parameter(Mandatory=$true)][string]$WorkDir)
+
+    $targets = @(Get-ChildItem -Path $WorkDir -File | Where-Object {
+        $_.Name -eq 'output.blib' -or $_.Name -eq 'output.blib.SecondPassFDR.osprey.task'
+    })
+    # BOTH are required, so check the count rather than truthiness. Realistic drift
+    # renames ONE of the two, and a single match is a truthy scalar that sails past a
+    # `-not $targets` test: deleting only the stamp leaves the blib un-invalidated (the
+    # leg then compares a stale blib to itself), and deleting only the blib leaves the
+    # merge cached (it never re-runs). Both surface downstream as a whole-run ABORTED
+    # from regression.ps1's outer catch, skipping every remaining dataset, instead of
+    # the named mode 5 failure the assertions here were written to produce.
+    if ($targets.Count -lt 2) {
+        throw (("Invoke-SecondPassOnlyInvalidation matched {1} of the 2 required files in '{0}'. " +
+                "The rehydrate leg would not have re-run the merge. Expected 'output.blib' + " +
+                "'output.blib.SecondPassFDR.osprey.task' (MergeNodeTask.Name); check that " +
+                "Name value has not changed.") -f $WorkDir, $targets.Count)
+    }
+    $targets | Remove-Item -Force
+}

--- a/pwiz_tools/Osprey/regression.ps1
+++ b/pwiz_tools/Osprey/regression.ps1
@@ -46,6 +46,23 @@
               Stage 5 first, so it never exercises the all-cached case; it now
               carries the same skip assertion for the tasks its invalidation leaves
               valid. See Test-TaskCacheHits for the driver log lines both key on.
+      mode 5  Stage-5 rehydrate self-consistency - invalidates ONLY the SecondPassFDR
+              task (the blib + its SecondPassFDR stamp), leaving the FirstPassFDR
+              stamp and every 1st-pass sidecar valid, so the re-run rebuilds its
+              post-Stage-5 bundle from those OWN sidecars
+              (FirstJoinTask.LoadOwnReconciliationBundle - the class name differs
+              from the task Name). That loader is what no other leg reaches: mode 2
+              deletes the FirstPassFDR stamp so the task RUNS instead, mode 4
+              invalidates nothing so nothing demands its state, and mode 3's
+              PerFileRescoring phase does enter the rehydrate arm but adopts a
+              WORKER-supplied bundle, never the own-sidecar loader. The leg asserts
+              a marker logged from INSIDE that loader (a cache hit does not prove it
+              ran, and neither does the generic rehydrate line, which a worker bundle
+              emits too), that the merge's blib still equals the straight-through one
+              at 1e-9, and that the --model-diagnostics report re-emitted from those
+              sidecars matches the golden. It is the ONE leg that names a token
+              (resume-survivor-handoff, issue #4536); every other leg runs with
+              nothing suppressed.
 
     NO dependency on the sibling ai/ checkout: data acquisition, blib golden
     capture/compare, and the tolerance comparators all live under
@@ -82,6 +99,11 @@
     is the only leg that can see a cache-invalidation regression, and a fully
     cached re-run costs seconds because it runs no task at all. This switch exists
     for the same fast-local-iteration reason as -SkipHpcChain.
+
+.PARAMETER SkipRehydrate
+    Skip the mode-5 Stage-5 rehydrate leg. The overnight gate leaves it on: it is
+    the only leg that enters FirstJoinTask.Rehydrate at all, and it costs one merge
+    re-run. This switch is for fast local iteration, like -SkipHpcChain.
 
 .PARAMETER SkipHpcChain
     Skip the mode-3 HPC 4-task worker-chain leg. The overnight gate leaves it on
@@ -136,6 +158,7 @@ param(
     [switch]$CreateGolden,
     [switch]$SkipResume,
     [switch]$SkipWarmRerun,
+    [switch]$SkipRehydrate,
     [switch]$SkipHpcChain,
     [string]$DownloadsPath,
     [int]$Threads = 16,
@@ -164,6 +187,77 @@ $ospreyExe    = Join-Path $ospreyBinDir 'Osprey.exe'
 # golden stays green without the comparator skipping the field. Must match the
 # osprey_version value committed in osprey-regression.data/*/tables/OspreyMetadata.tsv.
 $env:OSPREY_VERSION_OVERRIDE = '26.1.1.0'
+
+# No leg of this gate may run under a resident-pool allowance, so clear any INHERITED
+# one rather than merely declining to set it. A TeamCity agent, or a developer shell
+# that just ran a Stage 6 A/B, can have OSPREY_ALLOW_UNFIXED_RESIDENT exported; every
+# leg of every dataset would then run under that blanket and a regression back onto an
+# O(files) resident pool would pass fully green. That is the ten-day
+# OSPREY_PASS2_QVALUE=transfer failure the named-token ratchet was built to stop, so
+# "the gate sets it nowhere" has to mean the variable is UNSET when Osprey reads it,
+# not just that this script never assigns it. Announced rather than silent: an operator
+# who deliberately exported it should see why their run behaves differently here.
+# --- Known O(files) resident gaps, stated where the gate can be read -----------
+# "No leg sets OSPREY_ALLOW_UNFIXED_RESIDENT" is necessary but NOT sufficient as a
+# statement of health, and reading it as sufficient is the trap: a token is only
+# required where a guard demands one, so a resident path that no guard covers is
+# invisible in a token audit. #4536 is exactly that - every resume hands Stage 6 the
+# all-files survivor buffer, and because FirstJoin.Rehydrate publishes no survivor
+# loader, Stage6ResidentHandoffGuardError no-ops and nothing asks for a token. Zero
+# tokens therefore does NOT mean zero gaps, and this table is what keeps the
+# difference legible.
+#
+# Printed in the run summary (not just parked in a comment) so every CI log states the
+# outstanding gaps, and so a fixed entry left here shows up as a stale line in output
+# rather than as a comment nobody re-reads.
+#
+# Rules, from ai/docs/osprey-development-guide.md:
+#   * token + warning = an operator asked for residency and was told what they got
+#   * warning alone on a default path = INSUFFICIENT, allowed only as an interim
+#     tripwire with an open issue against it
+#   * any token this gate REQUIRES must have an open issue to remove it, and the token
+#     comes OUT of the gate when the issue lands. One is required today
+#     (resume-survivor-handoff, mode 5, issue #4536); driving that to zero is the goal.
+#     It is a DEDICATED token, not a borrowed one: compacted-entries-buffer names the same
+#     physical buffer, and reusing it would have let this leg simultaneously admit an
+#     OSPREY_STAGE6_STREAM_SURVIVORS=0 regression on the computed path that #4530 already
+#     fixed. One token admits one path, or the high-water mark leaks.
+$knownResidentGaps = @(
+    @{ Issue = '#4536'
+       Token = 'resume-survivor-handoff'
+       Path  = 'Stage 6 post-compaction survivor buffer on a resume (28 GB at 163 files)'
+       Legs  = 'mode 5 only - it is the only leg that rehydrates Stage 5; mode 2 recomputes it, so it streams' }
+)
+# Reachable only outside this gate, tokened, each with an open issue:
+#   #4486  hpc-merge      -- --task SecondPassFDR reconciled-input merge (Stage 7 peak)
+#   #4507  fdrbench-pass1 -- --fdrbench-pass 1 walks the pre-compaction pool
+# By design rather than unfinished, so no issue: projection-off and
+# compacted-entries-buffer (the A/B byte-identity oracles) and non-percolator-fdr.
+
+# Preserved and RESTORED at the end of the run (see the finally block): this mutates the
+# process environment, so a developer running the gate in their interactive shell would
+# otherwise silently lose an exported token for the rest of the session.
+$script:priorAllowResident = $env:OSPREY_ALLOW_UNFIXED_RESIDENT
+# An operator running a deliberate A/B needs their token: OSPREY_STAGE6_STREAM_SURVIVORS=0
+# and OSPREY_FDR_PROJECTION=0 force resident paths ON PURPOSE, and clearing the token that
+# admits them would abort the gate on its first leg with a guard error - making the very
+# comparison this harness exists to support impossible to run. Ambient tokens are stripped
+# ONLY when no such switch is set, which is the case the clearing is aimed at.
+$abSwitchSet = ($env:OSPREY_STAGE6_STREAM_SURVIVORS -eq '0') -or ($env:OSPREY_FDR_PROJECTION -eq '0')
+if (-not [string]::IsNullOrWhiteSpace($env:OSPREY_ALLOW_UNFIXED_RESIDENT)) {
+    if ($abSwitchSet) {
+        # Extra parens: -f binds TIGHTER than +, so without them only the LAST fragment is
+        # formatted and '{0}' survives verbatim into the output.
+        Write-Host (("Keeping inherited OSPREY_ALLOW_UNFIXED_RESIDENT='{0}' - an A/B switch " +
+            "(OSPREY_STAGE6_STREAM_SURVIVORS/OSPREY_FDR_PROJECTION=0) is set and needs it.") `
+            -f $env:OSPREY_ALLOW_UNFIXED_RESIDENT) -ForegroundColor Yellow
+    } else {
+        Write-Host (("Clearing inherited OSPREY_ALLOW_UNFIXED_RESIDENT='{0}' - no leg of this " +
+            "gate may run under an ambient resident-pool allowance.") `
+            -f $env:OSPREY_ALLOW_UNFIXED_RESIDENT) -ForegroundColor Yellow
+        Remove-Item Env:OSPREY_ALLOW_UNFIXED_RESIDENT -ErrorAction SilentlyContinue
+    }
+}
 
 # Every Osprey invocation in this run is timestamped and mem-stamped, so each leg's log
 # doubles as a memory-band trace: `[yyyy/MM/dd HH:mm:ss]<TAB>managedMB<TAB>privateMB<TAB>`.
@@ -702,6 +796,50 @@ function Test-TaskCacheHits {
     return @{ Pass = ($issues.Count -eq 0); Issues = $issues }
 }
 
+# The line FirstPassFDR logs from the OWN-SIDECAR STREAMING arm specifically
+# (FirstJoinTask.StreamOwnReconciliationBundle).
+#
+# Deliberately not the 'Bundle hydration: skipping first-pass Percolator' line at the
+# top of Rehydrate. That one is emitted before the bundle source is even known, so a
+# worker-supplied bundle logs it too - it witnesses "Rehydrate ran", which is NOT what
+# mode 5 is here to prove. Mode 3's PerFileRescoring phase also enters Rehydrate (with
+# a worker bundle), so "Rehydrate ran" is not even unique to this leg. What IS unique
+# is LoadOwnReconciliationBundle rebuilding the bundle from this run's own sidecars,
+# and this marker is emitted from inside it.
+#
+# Matched as a substring for the reason Get-TaskCacheMap matches its own: if the C#
+# wording drifts, mode 5 goes red naming the token it could not find rather than
+# passing vacuously.
+$firstJoinRehydrateMarker = 'Resume rehydrate: streaming the first-pass bundle from'
+
+function Test-LogMarker {
+    <#
+    Assert a run log contains a marker line proving a specific code path executed.
+    Returns the { Pass; Issues } shape every other comparator returns, so a caller
+    reports it exactly like any other leg. -Description names what the marker
+    proves, so a failure says which path did not run rather than quoting a string.
+    #>
+    param(
+        [Parameter(Mandatory = $true)][string]$LogPath,
+        [Parameter(Mandatory = $true)][string]$Marker,
+        [Parameter(Mandatory = $true)][string]$Description
+    )
+    $issues = [System.Collections.Generic.List[string]]::new()
+    if (-not (Test-Path -LiteralPath $LogPath)) {
+        $issues.Add("run log not found: $LogPath")
+        return @{ Pass = $false; Issues = $issues }
+    }
+    $logName = Split-Path -Leaf $LogPath
+    $lines = @(Get-Content -LiteralPath $LogPath)
+    $found = @($lines | Where-Object { $_.Contains($Marker) })
+    if ($found.Count -eq 0) {
+        $issues.Add((("{0}: no line containing '{1}' - {2} did not happen, or the C# log " +
+            "wording has drifted and this assertion is no longer reading anything") -f
+            $logName, $Marker, $Description))
+    }
+    return @{ Pass = ($issues.Count -eq 0); Issues = $issues }
+}
+
 # --- mode 3: HPC 4-task worker chain ------------------------------------------
 # Low-level runner for a single --task phase: CWD = its own scratch dir so the
 # task's CWD-relative outputs (parquets, sidecars, blib) land there, mirroring a
@@ -1094,56 +1232,33 @@ foreach ($name in $selected) {
         }
     }
 
+    # The pristine straight-through blib, kept aside for BOTH legs below that re-run
+    # into $straightDir in place. Taken ONCE, here, so each leg is compared against
+    # the straight-through output rather than against whatever the previous leg left:
+    # mode 2 and mode 5 both rewrite output.blib, so a per-leg copy would make the
+    # second leg's oracle the first leg's product. Placed after mode 4, whose
+    # byte-identity assertion needs the dir untouched.
+    $coldBlib = Join-Path $straightDir 'output_cold.blib'
+    Copy-Item $straightBlib $coldBlib -Force
+
     # ---- mode 2: resume vs straight-through self-consistency ----
     if (-not $SkipResume) {
         Write-Progress-Tc "${name}: resume self-consistency (mode 2)"
-        $coldBlib = Join-Path $straightDir 'output_cold.blib'
-        Copy-Item $straightBlib $coldBlib -Force
         Invoke-ResumeInvalidation -WorkDir $straightDir
-        # Scoped opt-in, and ONLY for this leg. A FULL resume with --model-diagnostics is a
-        # genuinely O(files) path that is not fixed yet: the invalidation leaves every
-        # <stem>.1st-pass.fdr_scores.bin on disk, so FirstJoin skips the first-pass score
-        # pass and emits the report through the batch ModelDiagnosticsReport.Write, which
-        # reads the RESIDENT per-file entries (PerFileScoringTask.cs, needsResidentPool at
-        # the --input-files rehydrate). The guard is therefore RIGHT to throw here, and
-        # suppressing it is the honest thing to do only because these are 3-file datasets.
+        # No OSPREY_ALLOW_UNFIXED_RESIDENT opt-in, and this leg is the reason the variable is
+        # now unset on EVERY leg of the gate. It used to name mdiag-full-resume: the
+        # invalidation leaves every <stem>.1st-pass.fdr_scores.bin on disk, so under
+        # --model-diagnostics Stage 5 held the RESIDENT per-file entries for the batch
+        # ModelDiagnosticsReport.Write to read, which is O(files) and genuinely needed
+        # suppressing at 3 files. #4505 streamed that report off FirstJoin's own per-file load,
+        # so the trigger is gone and so is the token.
         #
-        # This is NOT the scale case. --model-diagnostics over --input-scores streams the
-        # report off ModelDiagnosticsData.Accumulator one file at a time and needs no opt-in
-        # at any file count. What remains is the full-resume batch report, tracked in #4505;
-        # the fix is to feed the same accumulator during the resume's per-file load and
-        # report from it, and it is already written and verified on the closed #4437 branch.
-        #
-        # mode 3 above deliberately has NO opt-in: its old one wrapped the entire HPC chain
-        # and would mask a guard regression on any --input-scores worker.
-        # Names the ONE path it needs, so what CI depends on is visible rather than ambient.
-        # The former blanket OSPREY_ALLOW_UNBOUNDED_MEMORY=1 would also have waved through any
-        # OTHER resident path this leg happened to take - which is how a transfer regression
-        # rode along unnoticed. An unlisted path now fails here even with this set.
-        #
-        # ADDS its token to whatever the caller named rather than replacing it, and restores the
-        # original afterwards. Replacing it made the A/B that this gate exists to support
-        # impossible to run: an operator proving the streamed Stage 6 handoff bounded sets
-        # OSPREY_STAGE6_STREAM_SURVIVORS=0 with OSPREY_ALLOW_UNFIXED_RESIDENT=
-        # compacted-entries-buffer, and this line then dropped that token and aborted the leg on
-        # the guard. Appending keeps every admitted path individually named, which is the
-        # property that matters.
-        $priorAllowResident = $env:OSPREY_ALLOW_UNFIXED_RESIDENT
-        $env:OSPREY_ALLOW_UNFIXED_RESIDENT = if ([string]::IsNullOrWhiteSpace($priorAllowResident)) {
-            'mdiag-full-resume'
-        } else {
-            "$priorAllowResident,mdiag-full-resume"
-        }
-        try {
-            $rResume = Invoke-OspreyRun -Mzmls $inputs.Mzmls -Library $inputs.Library -Resolution $cfg.Resolution `
-                -WorkDir $straightDir -LogName 'resume.log' -Spec $cfg -Manifest $inputs.Manifest
-        } finally {
-            if ([string]::IsNullOrWhiteSpace($priorAllowResident)) {
-                Remove-Item Env:OSPREY_ALLOW_UNFIXED_RESIDENT -ErrorAction SilentlyContinue
-            } else {
-                $env:OSPREY_ALLOW_UNFIXED_RESIDENT = $priorAllowResident
-            }
-        }
+        # Nothing here replaces it. An opt-in on this leg would mask exactly the regression the
+        # leg exists to catch, which is why mode 3 and mode 4 never had one either: the former
+        # blanket OSPREY_ALLOW_UNBOUNDED_MEMORY=1 wrapped a whole leg and let a transfer
+        # regression ride along unnoticed for ten days.
+        $rResume = Invoke-OspreyRun -Mzmls $inputs.Mzmls -Library $inputs.Library -Resolution $cfg.Resolution `
+            -WorkDir $straightDir -LogName 'resume.log' -Spec $cfg -Manifest $inputs.Manifest
         $resumeBlib = Join-Path $straightDir 'output.blib'
         Write-Host ("  resume wall {0:mm\:ss}; blib {1:N0} bytes" -f $rResume.Wall, (Get-Item $resumeBlib).Length)
 
@@ -1183,6 +1298,190 @@ foreach ($name in $selected) {
         }
     }
 
+    # ---- mode 5: Stage-5 rehydrate (FirstPassFDR's rehydrate arm) ----
+    # Runs AFTER mode 2, and the order is not arbitrary. Mode 5's SecondPassFDR run
+    # rewrites more than output.blib: every <stem>.2nd-pass.fdr_scores.bin, the
+    # model-diagnostics report, and its .data.json are merge outputs too, and
+    # Invoke-ResumeInvalidation deletes none of them. Running mode 5 first therefore
+    # left mode 2 resuming on top of mode-5-produced pass-2 state, which feeds
+    # PerFileRescore's pass-2 self-gate and MergeNode's 2nd-pass rehydrate - so mode
+    # 2's oracle silently depended on whether -SkipRehydrate was passed, and a defect
+    # that only appears when Stage 5 is rehydrated twice would hide behind mode 5's
+    # own passing blib assertion. Ordering it last costs nothing: mode 2's resume
+    # re-runs FirstPassFDR and SecondPassFDR, so it leaves exactly the all-valid state
+    # mode 5 needs, and mode 5 still compares against the pristine $coldBlib.
+    #
+    # Stated plainly, because the coupling MOVED rather than vanished: mode 2 rewrites
+    # every .1st-pass.fdr_scores.bin and .reconciliation.json (its invalidation deletes
+    # the FirstPassFDR stamp, so that task RUNS), and mode 5 then streams its bundle from
+    # those recomputed sidecars. Under -SkipResume it streams the ORIGINAL straight-through
+    # sidecars instead. Both are valid Stage 5 states and mode 2 asserts they agree at 1e-9,
+    # so neither is a wrong input - but they are not the SAME input, and a bisection that
+    # reproduces a mode 5 failure must match the switch combination that produced it.
+    # Removing the coupling entirely needs a second work dir, which costs a full
+    # straight-through run per dataset.
+    #
+    # Task NAMES throughout, not class names: the driver stamps and logs
+    # 'FirstPassFDR' and 'SecondPassFDR', while the classes behind them are
+    # FirstJoinTask and MergeNodeTask. Keying prose off the class names is how a
+    # copy of the invalidation helper once matched zero files and produced a
+    # 'resume' that never resumed (see Invoke-ResumeInvalidation).
+    #
+    # The one leg that reaches FirstPassFDR's OWN-SIDECAR bundle loader. Mode 2
+    # deletes that task's validity stamp, so it RUNS there; mode 4 invalidates
+    # nothing, so nothing demands its state; mode 3's PerFileRescoring phase does
+    # enter the rehydrate arm, but with a worker-supplied bundle, so it never calls
+    # LoadOwnReconciliationBundle. Invalidating ONLY SecondPassFDR leaves the
+    # FirstPassFDR stamp and every .1st-pass.fdr_scores.bin + .reconciliation.json
+    # sidecar valid, which is exactly the state that loader exists to serve.
+    #
+    # Names exactly ONE token (below) and suppresses nothing else. Note what that does
+    # and does not buy: a regression that puts STAGE 5 back on the resident pool fails on
+    # PerFileScoringTask's guard (mdiag no longer has a token), but nothing guards
+    # FirstJoin's own loader, so a regression confined to it would NOT fail here.
+    # What catches that one is the marker below plus the memory trace in the log.
+    if (-not $SkipRehydrate) {
+        Write-Progress-Tc "${name}: Stage-5 rehydrate self-consistency (mode 5)"
+        Invoke-SecondPassOnlyInvalidation -WorkDir $straightDir
+        # Delete the straight-through run's report so the comparison below cannot pass
+        # against it. Nothing about the invalidation forces FirstJoin to re-emit the
+        # report - if the rehydrate arm stopped writing one, a surviving file from the
+        # straight-through leg would compare EQUAL to the golden and the leg would go
+        # green having tested nothing. Removing it makes "the report the rehydrate
+        # produced" the only thing that can be compared.
+        # BOTH files. MergeNodeTask re-renders the HTML from output.model-diagnostics.data.json
+        # during its pass-2 enrichment, inside a catch-all that swallows failures - so if any
+        # earlier leg threw partway through that block, the .data.json survives, and deleting
+        # only the .html would let the merge rebuild a complete page from the PREVIOUS leg's
+        # pass-1 data. The comparison would then pass against a report the rehydrate never
+        # wrote, which is the exact regression this deletion exists to catch.
+        if ($cfg.ModelDiagnostics) {
+            Remove-Item -LiteralPath $diagHtml -Force -ErrorAction SilentlyContinue
+            Remove-Item -LiteralPath ($diagHtml -replace '\.html$', '.data.json') `
+                -Force -ErrorAction SilentlyContinue
+        }
+        # The ONE token this gate requires, scoped to this leg alone and listed in
+        # $knownResidentGaps above. DEDICATED to this path (#4536), deliberately not the
+        # compacted-entries-buffer token that names the same buffer on the computed path:
+        # sharing it would have made this leg admit a regression #4530 already fixed. A resume cannot stream the Stage 6 survivor handoff
+        # (only a computed Stage 5 builds the per-file loader), so FirstPassFDR's rehydrate
+        # arm REFUSES to run without it - that refusal is the point, and issue #4536 is what
+        # takes both the refusal and this assignment back out. Set here rather than at
+        # script scope so every OTHER leg still runs with nothing suppressed: an ambient
+        # value would let a resident regression anywhere else ride along, which is precisely
+        # the failure the named-token ratchet replaced.
+        $env:OSPREY_ALLOW_UNFIXED_RESIDENT = 'resume-survivor-handoff'
+        try {
+            $rRehydrate = Invoke-OspreyRun -Mzmls $inputs.Mzmls -Library $inputs.Library -Resolution $cfg.Resolution `
+                -WorkDir $straightDir -LogName 'rehydrate.log' -Spec $cfg -Manifest $inputs.Manifest
+        } finally {
+            Remove-Item Env:OSPREY_ALLOW_UNFIXED_RESIDENT -ErrorAction SilentlyContinue
+        }
+        $rehydrateBlib = Join-Path $straightDir 'output.blib'
+        Write-Host ("  rehydrate wall {0:mm\:ss}; blib {1:N0} bytes" -f $rRehydrate.Wall, (Get-Item $rehydrateBlib).Length)
+
+        # Three tasks kept their outputs; only the merge lost its stamp. Asserting
+        # the ran side keeps the leg from going vacuous exactly as in mode 2.
+        $m5cache = Test-TaskCacheHits -LogPath $rRehydrate.Log `
+            -ExpectSkipped @('PerFileScoring', 'FirstPassFDR', 'PerFileRescoring') `
+            -ExpectRan @('SecondPassFDR') `
+            -NoColdScoring -NoColdRescoring
+        # ... and the FirstPassFDR cache hit above is NOT evidence the rehydrate arm
+        # ran: a skipped task whose state nobody demands never enters Rehydrate at
+        # all. This marker is the only thing that says it did.
+        $m5marker = Test-LogMarker -LogPath $rRehydrate.Log -Marker $firstJoinRehydrateMarker `
+            -Description 'FirstPassFDR streaming the post-Stage-5 bundle from its own sidecars'
+        foreach ($issue in $m5marker.Issues) { $m5cache.Issues.Add($issue) }
+        # Repair Pass after mutating Issues. Test-TaskCacheHits computed it at return
+        # time, so appending above leaves Pass $true with a non-empty Issues list. Every
+        # other leg in this file reports off .Pass; leaving it stale here means the first
+        # edit toward that house style silently turns a MISSING rehydrate marker into a
+        # mode 5 PASS - green on exactly the regression this leg exists to catch.
+        $m5cache.Pass = ($m5cache.Issues.Count -eq 0)
+        if ($m5cache.Pass) {
+            $summaryLines.Add("$name mode5 (rehydrate entered + cache hits): PASS")
+        } else {
+            $overallFail = $true
+            Write-Problem-Tc "$name mode5 (rehydrate entered + cache hits): FAIL - $($m5cache.Issues.Count) issue(s)"
+            $m5cache.Issues | Select-Object -First 15 | ForEach-Object { Write-Host "    $_" -ForegroundColor Red }
+            $summaryLines.Add("$name mode5 (rehydrate entered + cache hits): FAIL ($($m5cache.Issues.Count) issues)")
+        }
+
+        $m5 = Compare-BlibFull -BlibExpected $coldBlib -BlibActual $rehydrateBlib -Tolerance $Tolerance
+        if ($m5.Pass) {
+            $summaryLines.Add("$name mode5 (rehydrate==straight): PASS")
+        } else {
+            $overallFail = $true
+            Write-Problem-Tc "$name mode5 (rehydrate==straight): FAIL - $($m5.Issues.Count) issue(s)"
+            $m5.Issues | Select-Object -First 15 | ForEach-Object { Write-Host "    $_" -ForegroundColor Red }
+            $summaryLines.Add("$name mode5 (rehydrate==straight): FAIL ($($m5.Issues.Count) issues)")
+        }
+
+        # The rehydrate re-emits the --model-diagnostics report from the 1st-pass
+        # sidecars rather than from a just-scored pool, which is the substitution
+        # #4505 is about. Comparing it to the SAME golden mode 1b compares the
+        # straight-through report against is what makes the two reports equivalent
+        # rather than merely both present.
+        #
+        # -NoTrainedModel because this run adopted its q-values instead of training
+        # Percolator, so featureCount is pinned at 0 rather than compared (see
+        # Compare-DiagnosticsGolden). That is pre-existing resume behavior, not a
+        # property of the streamed report: FirstJoin's rehydrate has always passed a
+        # null FeatureContributions, on the resident batch write too. Every metric
+        # the resume CAN reproduce - pool composition, the null-alignment density
+        # ratio, the paired decoy-win fraction, and pass-1/pass-2 FDP at the reported
+        # q - is still compared at $Tolerance, and those are exactly the reductions
+        # the streaming accumulator had to reproduce row for row.
+        if ($cfg.ModelDiagnostics) {
+            # try/catch, not just Test-Path. Absence is only ONE way this fails: a report that
+            # exists but carries no JSON payload, or a truncated one, throws out of
+            # Get-DiagnosticsPayload / ConvertFrom-Json, and with $ErrorActionPreference='Stop'
+            # that unwinds past the dataset loop into the outer catch - which is deliberately
+            # NOT per-dataset, so the WHOLE run reports ABORTED and every remaining dataset is
+            # skipped. Mode 1b compares the straight-through report first with no guard, so
+            # this bites in exactly one case: straight-through fine, REHYDRATE report
+            # malformed - precisely the regression this leg exists to catch.
+            $m5d = $null
+            try {
+                if (Test-Path -LiteralPath $diagHtml) {
+                    $m5d = Compare-DiagnosticsGolden -HtmlPath $diagHtml -GoldenDir $goldenDir `
+                        -Tolerance $Tolerance -NoTrainedModel
+                } else {
+                    $m5d = [pscustomobject]@{ Pass = $false; Issues = [System.Collections.Generic.List[string]]@(
+                        "diagnostics: the rehydrate wrote no model-diagnostics report at $diagHtml") }
+                }
+            } catch {
+                $m5d = [pscustomobject]@{ Pass = $false; Issues = [System.Collections.Generic.List[string]]@(
+                    ("diagnostics: the rehydrate's report at {0} could not be read: {1}" -f $diagHtml, $_.Exception.Message)) }
+            }
+            if ($m5d.Pass) {
+                $summaryLines.Add("$name mode5 (rehydrate diagnostics vs golden): PASS")
+            } else {
+                $overallFail = $true
+                Write-Problem-Tc "$name mode5 (rehydrate diagnostics vs golden): FAIL - $($m5d.Issues.Count) issue(s)"
+                $m5d.Issues | Select-Object -First 15 | ForEach-Object { Write-Host "    $_" -ForegroundColor Red }
+                $summaryLines.Add("$name mode5 (rehydrate diagnostics vs golden): FAIL ($($m5d.Issues.Count) issues)")
+            }
+
+            # Tier 2, the same absolute bounds mode 1b applies to the straight-through
+            # report. Without it this leg has only the golden compare, and the golden is
+            # regenerable: once a bad calibration is blessed by -CreateGolden, comparing the
+            # rehydrate report against the poisoned baseline passes forever. That would leave
+            # the one leg specifically exercising the streamed accumulator with no independent
+            # correctness floor. $bounds is already computed per dataset, so this is free.
+            $m5bounds = Get-SanityBounds $cfg
+            $m5s = Test-DiagnosticsSanity -HtmlPath $diagHtml @m5bounds
+            if ($m5s.Pass) {
+                $summaryLines.Add("$name mode5 (rehydrate FDR sanity bounds): PASS")
+            } else {
+                $overallFail = $true
+                Write-Problem-Tc "$name mode5 (rehydrate FDR sanity bounds): FAIL - calibration is out of bounds"
+                $m5s.Issues | ForEach-Object { Write-Host "    $_" -ForegroundColor Red }
+                $summaryLines.Add("$name mode5 (rehydrate FDR sanity bounds): FAIL ($($m5s.Issues.Count) issues)")
+            }
+        }
+    }
+
     # All legs for this dataset are done -- free its scratch now so peak disk stays
     # at ~one dataset (the next dataset / the perf-gate step gets the space back).
     Remove-Scratch (Join-Path $runRoot $name)
@@ -1205,6 +1504,12 @@ catch {
     Write-Host ($_.ScriptStackTrace) -ForegroundColor DarkGray
 }
 finally {
+    # Restore the operator's environment, whatever happened above.
+    if ([string]::IsNullOrWhiteSpace($script:priorAllowResident)) {
+        Remove-Item Env:OSPREY_ALLOW_UNFIXED_RESIDENT -ErrorAction SilentlyContinue
+    } else {
+        $env:OSPREY_ALLOW_UNFIXED_RESIDENT = $script:priorAllowResident
+    }
     # Safety net for a dataset that threw before its own cleanup -- drop the whole
     # run root. Raw input data lives outside $runRoot and is untouched.
     Remove-Scratch $runRoot
@@ -1231,6 +1536,27 @@ foreach ($d in $watchedDirs) {
 Write-Host ""
 Write-Host "=== Osprey regression summary ===" -ForegroundColor Cyan
 $summaryLines | ForEach-Object { Write-Host "  $_" }
+
+# The gaps this gate KNOWS it still traverses. Printed green-or-red runs alike: these
+# are not failures (the legs above passed), they are the O(files) paths a passing gate
+# is nonetheless walking, and a passing gate is exactly when nobody goes looking.
+Write-Host ""
+Write-Host "=== Known O(files) resident paths this gate still traverses ===" -ForegroundColor Cyan
+if ($knownResidentGaps.Count -eq 0) {
+    Write-Host "  none" -ForegroundColor Green
+} else {
+    foreach ($g in $knownResidentGaps) {
+        Write-Host ("  {0}  token: {1}" -f $g.Issue, $g.Token) -ForegroundColor Yellow
+        Write-Host ("      {0}" -f $g.Path)
+        Write-Host ("      {0}" -f $g.Legs)
+    }
+    # DERIVED, not typed. A literal count reads identically before and after a gap is
+    # closed, so it can never report the invariant it claims to state - and a hardcoded 0
+    # sitting three lines under a table naming a required token is worse than no line.
+    $requiredTokens = @($knownResidentGaps | Where-Object { $_.Token -and $_.Token -ne 'NONE' })
+    Write-Host (("  Tokens REQUIRED by this gate: {0} (target: 0). Each must have an open " +
+        "issue to remove it.") -f $requiredTokens.Count)
+}
 # No artifacts are published, and the run's scratch under TestResults is deleted on
 # completion (the downloaded raw input data is kept). A red gate's diagnosis lives in
 # the build log (every per-file log is Tee'd to the console TeamCity captures) and


### PR DESCRIPTION
## Summary

* Fixed `FirstPassFDR`'s rehydrate arm, which threw on every lean resume - not just under `--model-diagnostics`
* Streamed the `--model-diagnostics` report off the per-file load that already reads every sidecar, instead of the resident batch write
* Dropped `mdiag-full-resume` from the Stage-5 resident-pool gate and from `ResidentPaths.KNOWN_UNFIXED`
* Added `regression.ps1` mode 5, the only leg that reaches the own-sidecar bundle loader
* Named and refused the O(files) Stage 6 handoff a resume still takes, rather than letting it happen silently

Fixes #4505

## The bug was larger than the issue described

#4505 is written as a memory problem. It is also a correctness one, and it was not confined to `--model-diagnostics`.

Since #4400, Stage 5 takes a lean load unless an opt-in output needs resident features, publishing one **empty** stub list per scored file. `FirstJoin.Rehydrate` handed those to the batch `HydrateReconciliationOverlay`, whose sidecar reader binds each record to a stub by `entry_id` and fails the file when one is missing - so any sidecar carrying records is refused against zero stubs:

```
[ERROR] Resume rehydrate: failed to hydrate reconciliation bundle from own sidecars:
        HydrateReconciliationOverlay: failed to overlay .1st-pass.fdr_scores.bin for <stem>
[ERROR] Pipeline failed: Task 'FirstJoinTask' failed to rehydrate its state (exit code 1).
```

Reproduced on **Stellar**, which has `ModelDiagnostics = $false`. `--model-diagnostics` was the only thing holding the path up: `mdiagFullResume` forced the resident pool, which incidentally gave the overlay real stubs. That is why removing the term alone - the literal reading of #4505 - hard-failed in the earlier attempt (PR #4533).

## Why no test caught it

No leg of the standing gate entered that arm. Mode 2 deletes the `FirstPassFDR` stamp so the task **runs**; mode 4 invalidates nothing so nothing demands its state; mode 3's `PerFileRescoring` phase does enter the rehydrate arm but adopts a **worker-supplied** bundle, never the own-sidecar loader.

Mode 5 invalidates only `SecondPassFDR`, which is exactly the state `LoadOwnReconciliationBundle` exists to serve. It asserts a marker logged from inside that loader (a cache hit does not prove it ran, and neither does the generic rehydrate line, which a worker bundle emits too), the blib against the pristine straight-through one at 1e-9, and both diagnostics tiers on the re-emitted report.

## Fix

`LoadOwnReconciliationBundle` picks its hydrate from what upstream actually loaded and routes the lean case through `HydrateCompactedStreaming`, feeding the model-diagnostics accumulator and the passing-target tally from the per-file hook that already reads every sidecar. No second join, no second I/O pass, no `resumeFromSidecars` flag.

`featureCount` is pinned at 0 rather than compared on that leg: a resume adopts q-values from sidecars and never trains Percolator, so it has no feature contributions - pre-existing behavior, verified in source, unchanged here.

## Memory-policy enforcement

A resume cannot stream the Stage 6 survivor handoff (only a computed Stage 5 builds the per-file loader), so it takes the O(files) post-compaction buffer - 28 GB at 163 files. Before this PR that happened on a default path with no token, no guard, and no warning, and #4526 was closed on the computed-path half of it.

It is now **refused unless named**: omitting `OSPREY_ALLOW_UNFIXED_RESIDENT=resume-survivor-handoff` fails with an actionable message, naming it proceeds with a warning stating what was granted. Runs already resident under a token of their own are exempt, so one decision never costs two variables. Tracked by #4536.

The token is **dedicated, not borrowed**. `compacted-entries-buffer` names the same physical buffer, but sharing it would mean any run admitting this unfixed resume also admitted an `OSPREY_STAGE6_STREAM_SURVIVORS=0` regression that #4530 already closed. Both directions are pinned in `ResidentPoolGuardTest`.

`regression.ps1` now clears an *inherited* allowance at startup (keeping it when a deliberate A/B switch needs it, restoring it afterwards) and prints its outstanding gaps in every run summary, so a required token is visible on every green run:

```
=== Known O(files) resident paths this gate still traverses ===
  #4536  token: resume-survivor-handoff
      Stage 6 post-compaction survivor buffer on a resume (28 GB at 163 files)
  Tokens REQUIRED by this gate: 1 (target: 0). Each must have an open issue to remove it.
```

## Test plan

- [x] Mode 5 verified RED on unmodified master before any C# change (`Osprey exited 1`, on Stellar with mdiag off)
- [x] `regression.ps1 -Dataset All` - all four datasets, every leg
- [x] `Astral mode5` - rehydrate entered, blib==straight at 1e-9, diagnostics vs golden, FDR sanity bounds
- [x] `Build-Osprey -RunTests -RunInspection` - 575/575, zero inspections
- [x] `ResidentPoolGuardTest` - token required/admitted both ways, cross-token isolation, single-file and already-tokened exemptions
- [x] `IOTest` - batch overlay refuses lean stub lists (the trap that broke #4533)
- [x] Two `/code-review max` rounds, every finding reproduced or refuted individually

## Follow-ups

* #4536 - give the rehydrate its own survivor loader; removes the token, the guard and the warning
* #4535 - rename the task classes to their task Names (`FirstJoinTask` -> `FirstPassFdrTask`, `MergeNodeTask` -> `SecondPassFdrTask`)

Co-Authored-By: Claude <noreply@anthropic.com>
