### PR TITLE
Fix UI Mode of Group Comparison default reports

### DIFF
--- a/pwiz_tools/Skyline/Controls/GroupComparison/FoldChangeBindingSource.cs
+++ b/pwiz_tools/Skyline/Controls/GroupComparison/FoldChangeBindingSource.cs
@@ -202,6 +202,7 @@ namespace pwiz.Skyline.Controls.GroupComparison
             var viewSpec = new ViewSpec()
                 .SetName(AbstractViewContext.DefaultViewName)
                 .SetRowType(typeof(FoldChangeRow))
+                .SetUiMode(_skylineDataSchema.DefaultUiMode)
                 .SetColumns(columns.Select(col => new ColumnSpec(col)));
             return viewSpec;
         }


### PR DESCRIPTION
Fixed can't see customized Group Comparison report in small molecule document (reported by Guadelupe)