### PR TITLE
pwiz: Fixed off-by-one in spectrum and chromatogram list index bounds checks

### DIFF
--- a/pwiz/analysis/proteome_processing/ProteinList_DecoyGenerator.cpp
+++ b/pwiz/analysis/proteome_processing/ProteinList_DecoyGenerator.cpp
@@ -82,7 +82,7 @@ PWIZ_API_DECL size_t ProteinList_DecoyGenerator::find(const string& id) const
 
 PWIZ_API_DECL ProteinPtr ProteinList_DecoyGenerator::protein(size_t index, bool getSequence) const
 {
-    if (index > size())
+    if (index >= size())
         throw out_of_range("[ProteinList_DecoyGenerator::protein] Index out of range");
 
     size_t originalIndex = index % impl_->original->size();

--- a/pwiz/analysis/proteome_processing/ProteinList_DecoyGeneratorTest.cpp
+++ b/pwiz/analysis/proteome_processing/ProteinList_DecoyGeneratorTest.cpp
@@ -54,6 +54,10 @@ void testReversedList(ProteinListPtr pl)
         unit_assert(decoy->description.empty());
         unit_assert(string(target->sequence().rbegin(), target->sequence().rend()) == decoy->sequence());
     }
+
+    // an out of bounds index must throw rather than wrapping around to the first decoy
+    unit_assert_throws_what(decoyList.protein(decoyList.size()), out_of_range, "[ProteinList_DecoyGenerator::protein] Index out of range");
+    unit_assert_throws_what(decoyList.protein(decoyList.size() + 1), out_of_range, "[ProteinList_DecoyGenerator::protein] Index out of range");
 }
 
 

--- a/pwiz/data/msdata/SpectrumList_BTDX.cpp
+++ b/pwiz/data/msdata/SpectrumList_BTDX.cpp
@@ -79,7 +79,7 @@ SpectrumList_BTDXImpl::SpectrumList_BTDXImpl(shared_ptr<istream> is, const MSDat
 
 const SpectrumIdentity& SpectrumList_BTDXImpl::spectrumIdentity(size_t index) const
 {
-    if (index > index_.size())
+    if (index >= index_.size())
         throw runtime_error("[SpectrumList_BTDX::spectrumIdentity()] Index out of bounds.");
 
     return index_[index];
@@ -286,7 +286,7 @@ class HandlerCompound : public SAXParser::Handler
 SpectrumPtr SpectrumList_BTDXImpl::spectrum(size_t index, bool getBinaryData) const
 {
     boost::lock_guard<boost::mutex> lock(readMutex);  // lock_guard will unlock mutex when out of scope or when exception thrown (during destruction)
-    if (index > index_.size())
+    if (index >= index_.size())
         throw runtime_error("[SpectrumList_BTDX::spectrum()] Index out of bounds.");
 
     // returned cached Spectrum if possible

--- a/pwiz/data/msdata/SpectrumList_MGF.cpp
+++ b/pwiz/data/msdata/SpectrumList_MGF.cpp
@@ -57,6 +57,9 @@ class SpectrumList_MGFImpl : public SpectrumList_MGF
     
     const SpectrumIdentity& spectrumIdentity(size_t index) const
     {
+        if (index >= index_.size())
+            throw runtime_error("[SpectrumList_MGF::spectrumIdentity] Index out of bounds");
+
         return index_[index];
     }
 

--- a/pwiz/data/msdata/SpectrumList_MGF.cpp
+++ b/pwiz/data/msdata/SpectrumList_MGF.cpp
@@ -95,7 +95,7 @@ class SpectrumList_MGFImpl : public SpectrumList_MGF
     SpectrumPtr spectrum(size_t index, bool getBinaryData) const
     {
         boost::lock_guard<boost::mutex> lock(readMutex);  // lock_guard will unlock mutex when out of scope or when exception thrown (during destruction)
-        if (index > index_.size())
+        if (index >= index_.size())
             throw runtime_error("[SpectrumList_MGF::spectrum] Index out of bounds");
 
         // allocate Spectrum object and read it in

--- a/pwiz/data/msdata/SpectrumList_MGF_Test.cpp
+++ b/pwiz/data/msdata/SpectrumList_MGF_Test.cpp
@@ -209,6 +209,12 @@ void test()
     unit_assert_equal(precursor2.selectedIons[0].cvParam(MS_selected_ion_m_z).valueAs<double>(), 123.45, 1e-5);
     unit_assert_operator_equal("2", precursor2.selectedIons[0].cvParamChildren(MS_possible_charge_state)[0].value);
     unit_assert_operator_equal("3", precursor2.selectedIons[0].cvParamChildren(MS_possible_charge_state)[1].value);
+
+    // an out of bounds index must throw, including the size() sentinel returned by find() for an unknown id
+
+    unit_assert(sl->find("index=42") == sl->size());
+    unit_assert_throws_what(sl->spectrum(sl->size(), false), runtime_error, "[SpectrumList_MGF::spectrum] Index out of bounds");
+    unit_assert_throws_what(sl->spectrum(sl->size() + 1, false), runtime_error, "[SpectrumList_MGF::spectrum] Index out of bounds");
 }
 
 

--- a/pwiz/data/msdata/SpectrumList_MGF_Test.cpp
+++ b/pwiz/data/msdata/SpectrumList_MGF_Test.cpp
@@ -213,6 +213,8 @@ void test()
     // an out of bounds index must throw, including the size() sentinel returned by find() for an unknown id
 
     unit_assert(sl->find("index=42") == sl->size());
+    unit_assert_throws_what(sl->spectrumIdentity(sl->size()), runtime_error, "[SpectrumList_MGF::spectrumIdentity] Index out of bounds");
+    unit_assert_throws_what(sl->spectrumIdentity(sl->size() + 1), runtime_error, "[SpectrumList_MGF::spectrumIdentity] Index out of bounds");
     unit_assert_throws_what(sl->spectrum(sl->size(), false), runtime_error, "[SpectrumList_MGF::spectrum] Index out of bounds");
     unit_assert_throws_what(sl->spectrum(sl->size() + 1, false), runtime_error, "[SpectrumList_MGF::spectrum] Index out of bounds");
 }

--- a/pwiz/data/msdata/SpectrumList_MSn.cpp
+++ b/pwiz/data/msdata/SpectrumList_MSn.cpp
@@ -138,6 +138,9 @@ class SpectrumList_MSnImpl : public SpectrumList_MSn
   
   const SpectrumIdentity& spectrumIdentity(size_t index) const
   {
+    if (index >= index_.size())
+      throw runtime_error("[SpectrumList_MSn::spectrumIdentity] Index out of bounds");
+
     return index_[index];
   }
   

--- a/pwiz/data/msdata/SpectrumList_MSn.cpp
+++ b/pwiz/data/msdata/SpectrumList_MSn.cpp
@@ -168,7 +168,7 @@ class SpectrumList_MSnImpl : public SpectrumList_MSn
   SpectrumPtr spectrum(size_t index, bool getBinaryData) const
   {
     boost::lock_guard<boost::mutex> lock(readMutex);  // lock_guard will unlock mutex when out of scope or when exception thrown (during destruction)
-    if (index > index_.size())
+    if (index >= index_.size())
       throw runtime_error("[SpectrumList_MSn::spectrum] Index out of bounds");
     
     // allocate Spectrum object and read it in

--- a/pwiz/data/msdata/SpectrumList_MSn_Test.cpp
+++ b/pwiz/data/msdata/SpectrumList_MSn_Test.cpp
@@ -685,6 +685,8 @@ void test(SpectrumListPtr sl, int msLevel)
     // an out of bounds index must throw, including the size() sentinel returned by find() for an unknown id
 
     unit_assert(sl->find("scan=999") == sl->size());
+    unit_assert_throws_what(sl->spectrumIdentity(sl->size()), runtime_error, "[SpectrumList_MSn::spectrumIdentity] Index out of bounds");
+    unit_assert_throws_what(sl->spectrumIdentity(sl->size() + 1), runtime_error, "[SpectrumList_MSn::spectrumIdentity] Index out of bounds");
     unit_assert_throws_what(sl->spectrum(sl->size(), false), runtime_error, "[SpectrumList_MSn::spectrum] Index out of bounds");
     unit_assert_throws_what(sl->spectrum(sl->size() + 1, false), runtime_error, "[SpectrumList_MSn::spectrum] Index out of bounds");
 }

--- a/pwiz/data/msdata/SpectrumList_MSn_Test.cpp
+++ b/pwiz/data/msdata/SpectrumList_MSn_Test.cpp
@@ -681,9 +681,15 @@ void test(SpectrumListPtr sl, int msLevel)
         copy(pairs.begin(), pairs.end(), ostream_iterator<MZIntensityPair>(*os_, "\n"));
         *os_ << endl;
     }
+
+    // an out of bounds index must throw, including the size() sentinel returned by find() for an unknown id
+
+    unit_assert(sl->find("scan=999") == sl->size());
+    unit_assert_throws_what(sl->spectrum(sl->size(), false), runtime_error, "[SpectrumList_MSn::spectrum] Index out of bounds");
+    unit_assert_throws_what(sl->spectrum(sl->size() + 1, false), runtime_error, "[SpectrumList_MSn::spectrum] Index out of bounds");
 }
 
-void test_v3(SpectrumListPtr sl, int msLevel) 
+void test_v3(SpectrumListPtr sl, int msLevel)
 {
     if (os_)
     {

--- a/pwiz/data/msdata/SpectrumList_mzXML.cpp
+++ b/pwiz/data/msdata/SpectrumList_mzXML.cpp
@@ -99,7 +99,7 @@ SpectrumList_mzXMLImpl::SpectrumList_mzXMLImpl(shared_ptr<istream> is, const MSD
 
 const SpectrumIdentity& SpectrumList_mzXMLImpl::spectrumIdentity(size_t index) const
 {
-    if (index > index_.size())
+    if (index >= index_.size())
         throw runtime_error("[SpectrumList_mzXML::spectrumIdentity()] Index out of bounds.");
 
     return index_[index];
@@ -621,7 +621,7 @@ SpectrumPtr SpectrumList_mzXMLImpl::spectrum(size_t index, IO::BinaryDataFlag bi
 SpectrumPtr SpectrumList_mzXMLImpl::spectrum(size_t index, IO::BinaryDataFlag binaryDataFlag, DetailLevel detailLevel, const SpectrumPtr *defaults, bool isRecursiveCall) const
 {
     boost::lock_guard<boost::recursive_mutex> lock(readMutex);  // lock_guard will unlock mutex when out of scope or when exception thrown (during destruction)
-    if (index > index_.size())
+    if (index >= index_.size())
         throw runtime_error("[SpectrumList_mzXML::spectrum()] Index out of bounds.");
 
     // allocate Spectrum object and read it in

--- a/pwiz/data/msdata/SpectrumList_mzXML_Test.cpp
+++ b/pwiz/data/msdata/SpectrumList_mzXML_Test.cpp
@@ -223,6 +223,14 @@ void test(bool indexed)
     unit_assert(precursor22.activation.hasCVParam(MS_ETD));
     unit_assert(precursor22.activation.hasCVParam(MS_CID));
     unit_assert(precursor22.activation.hasCVParam(MS_collision_energy));
+
+    // an out of bounds index must throw, including the size() sentinel returned by find() for an unknown id
+
+    unit_assert(sl->find("scan=42") == sl->size());
+    unit_assert_throws_what(sl->spectrumIdentity(sl->size()), runtime_error, "[SpectrumList_mzXML::spectrumIdentity()] Index out of bounds.");
+    unit_assert_throws_what(sl->spectrumIdentity(sl->size() + 1), runtime_error, "[SpectrumList_mzXML::spectrumIdentity()] Index out of bounds.");
+    unit_assert_throws_what(sl->spectrum(sl->size(), false), runtime_error, "[SpectrumList_mzXML::spectrum()] Index out of bounds.");
+    unit_assert_throws_what(sl->spectrum(sl->size() + 1, false), runtime_error, "[SpectrumList_mzXML::spectrum()] Index out of bounds.");
 }
 
 

--- a/pwiz/data/vendor_readers/ABI/ChromatogramList_ABI.cpp
+++ b/pwiz/data/vendor_readers/ABI/ChromatogramList_ABI.cpp
@@ -63,7 +63,7 @@ PWIZ_API_DECL size_t ChromatogramList_ABI::size() const
 PWIZ_API_DECL const ChromatogramIdentity& ChromatogramList_ABI::chromatogramIdentity(size_t index) const
 {
     boost::call_once(indexInitialized_.flag, boost::bind(&ChromatogramList_ABI::createIndex, this));
-    if (index>size_)
+    if (index>=size_)
         throw runtime_error(("[ChromatogramList_ABI::chromatogramIdentity()] Bad index: " 
                             + lexical_cast<string>(index)).c_str());
     return index_[index];
@@ -90,7 +90,7 @@ PWIZ_API_DECL ChromatogramPtr ChromatogramList_ABI::chromatogram(size_t index, b
 PWIZ_API_DECL ChromatogramPtr ChromatogramList_ABI::chromatogram(size_t index, DetailLevel detailLevel) const
 {
     boost::call_once(indexInitialized_.flag, boost::bind(&ChromatogramList_ABI::createIndex, this));
-    if (index>size_)
+    if (index>=size_)
         throw runtime_error(("[ChromatogramList_ABI::chromatogram()] Bad index: " 
                             + lexical_cast<string>(index)).c_str());
 

--- a/pwiz/data/vendor_readers/Agilent/ChromatogramList_Agilent.cpp
+++ b/pwiz/data/vendor_readers/Agilent/ChromatogramList_Agilent.cpp
@@ -55,7 +55,7 @@ PWIZ_API_DECL size_t ChromatogramList_Agilent::size() const
 PWIZ_API_DECL const ChromatogramIdentity& ChromatogramList_Agilent::chromatogramIdentity(size_t index) const
 {
     boost::call_once(indexInitialized_.flag, boost::bind(&ChromatogramList_Agilent::createIndex, this));
-    if (index>size())
+    if (index>=size())
         throw runtime_error(("[ChromatogramList_Agilent::chromatogramIdentity()] Bad index: " 
                             + lexical_cast<string>(index)).c_str());
     return reinterpret_cast<const ChromatogramIdentity&>(index_[index]);
@@ -82,7 +82,7 @@ PWIZ_API_DECL ChromatogramPtr ChromatogramList_Agilent::chromatogram(size_t inde
 PWIZ_API_DECL ChromatogramPtr ChromatogramList_Agilent::chromatogram(size_t index, DetailLevel detailLevel) const
 {
     boost::call_once(indexInitialized_.flag, boost::bind(&ChromatogramList_Agilent::createIndex, this));
-    if (index>size())
+    if (index>=size())
         throw runtime_error(("[ChromatogramList_Agilent::chromatogram()] Bad index: " 
                             + lexical_cast<string>(index)).c_str());
 

--- a/pwiz/data/vendor_readers/Agilent/SpectrumList_Agilent.cpp
+++ b/pwiz/data/vendor_readers/Agilent/SpectrumList_Agilent.cpp
@@ -122,7 +122,7 @@ PWIZ_API_DECL size_t SpectrumList_Agilent::size() const
 PWIZ_API_DECL const SpectrumIdentity& SpectrumList_Agilent::spectrumIdentity(size_t index) const
 {
     boost::call_once(indexInitialized_.flag, boost::bind(&SpectrumList_Agilent::createIndex, this));
-    if (index>size_)
+    if (index>=size_)
         throw runtime_error(("[SpectrumList_Agilent::spectrumIdentity] Bad index: " 
                             + lexical_cast<string>(index)).c_str());
     return index_[index];

--- a/pwiz/data/vendor_readers/Bruker/ChromatogramList_Bruker.cpp
+++ b/pwiz/data/vendor_readers/Bruker/ChromatogramList_Bruker.cpp
@@ -71,7 +71,7 @@ PWIZ_API_DECL size_t ChromatogramList_Bruker::size() const
 
 PWIZ_API_DECL const ChromatogramIdentity& ChromatogramList_Bruker::chromatogramIdentity(size_t index) const
 {
-    if (index > size_)
+    if (index >= size_)
         throw runtime_error(("[ChromatogramList_Bruker::chromatogramIdentity()] Bad index: " 
                             + lexical_cast<string>(index)).c_str());
     return index_[index];
@@ -95,7 +95,7 @@ PWIZ_API_DECL ChromatogramPtr ChromatogramList_Bruker::chromatogram(size_t index
 
 PWIZ_API_DECL ChromatogramPtr ChromatogramList_Bruker::chromatogram(size_t index, DetailLevel detailLevel) const
 {
-    if (index > size_)
+    if (index >= size_)
         throw runtime_error(("[ChromatogramList_Bruker::chromatogram()] Bad index: " 
                             + lexical_cast<string>(index)).c_str());
 

--- a/pwiz/data/vendor_readers/Mobilion/ChromatogramList_Mobilion.cpp
+++ b/pwiz/data/vendor_readers/Mobilion/ChromatogramList_Mobilion.cpp
@@ -61,7 +61,7 @@ PWIZ_API_DECL size_t ChromatogramList_Mobilion::size() const
 PWIZ_API_DECL const ChromatogramIdentity& ChromatogramList_Mobilion::chromatogramIdentity(size_t index) const
 {
     boost::call_once(indexInitialized_.flag, boost::bind(&ChromatogramList_Mobilion::createIndex, this));
-    if (index>size_)
+    if (index>=size_)
         throw runtime_error(("[ChromatogramList_Mobilion::chromatogramIdentity()] Bad index: " 
                             + lexical_cast<string>(index)).c_str());
     return index_[index];
@@ -88,7 +88,7 @@ PWIZ_API_DECL ChromatogramPtr ChromatogramList_Mobilion::chromatogram(size_t ind
 PWIZ_API_DECL ChromatogramPtr ChromatogramList_Mobilion::chromatogram(size_t index, DetailLevel detailLevel) const
 {
     boost::call_once(indexInitialized_.flag, boost::bind(&ChromatogramList_Mobilion::createIndex, this));
-    if (index>size_)
+    if (index>=size_)
         throw runtime_error(("[ChromatogramList_Mobilion::chromatogram()] Bad index: " 
                             + lexical_cast<string>(index)).c_str());
 

--- a/pwiz/data/vendor_readers/Shimadzu/ChromatogramList_Shimadzu.cpp
+++ b/pwiz/data/vendor_readers/Shimadzu/ChromatogramList_Shimadzu.cpp
@@ -52,7 +52,7 @@ PWIZ_API_DECL size_t ChromatogramList_Shimadzu::size() const
 PWIZ_API_DECL const ChromatogramIdentity& ChromatogramList_Shimadzu::chromatogramIdentity(size_t index) const
 {
     boost::call_once(indexInitialized_.flag, boost::bind(&ChromatogramList_Shimadzu::createIndex, this));
-    if (index>size())
+    if (index>=size())
         throw runtime_error(("[ChromatogramList_Shimadzu::chromatogramIdentity()] Bad index: " 
                             + lexical_cast<string>(index)).c_str());
     return reinterpret_cast<const ChromatogramIdentity&>(index_[index]);
@@ -79,7 +79,7 @@ PWIZ_API_DECL ChromatogramPtr ChromatogramList_Shimadzu::chromatogram(size_t ind
 PWIZ_API_DECL ChromatogramPtr ChromatogramList_Shimadzu::chromatogram(size_t index, DetailLevel detailLevel) const
 {
     boost::call_once(indexInitialized_.flag, boost::bind(&ChromatogramList_Shimadzu::createIndex, this));
-    if (index>size())
+    if (index>=size())
         throw runtime_error(("[ChromatogramList_Shimadzu::chromatogram()] Bad index: " 
                             + lexical_cast<string>(index)).c_str());
 

--- a/pwiz/data/vendor_readers/Thermo/ChromatogramList_Thermo.cpp
+++ b/pwiz/data/vendor_readers/Thermo/ChromatogramList_Thermo.cpp
@@ -62,7 +62,7 @@ PWIZ_API_DECL size_t ChromatogramList_Thermo::size() const
 PWIZ_API_DECL const ChromatogramIdentity& ChromatogramList_Thermo::chromatogramIdentity(size_t index) const
 {
     boost::call_once(indexInitialized_.flag, boost::bind(&ChromatogramList_Thermo::createIndex, this));
-    if (index>size())
+    if (index>=size())
         throw runtime_error(("[ChromatogramList_Thermo::chromatogramIdentity()] Bad index: " 
                             + lexical_cast<string>(index)).c_str());
     return reinterpret_cast<const ChromatogramIdentity&>(index_[index]);
@@ -89,7 +89,7 @@ PWIZ_API_DECL ChromatogramPtr ChromatogramList_Thermo::chromatogram(size_t index
 PWIZ_API_DECL ChromatogramPtr ChromatogramList_Thermo::chromatogram(size_t index, DetailLevel detailLevel) const
 {
     boost::call_once(indexInitialized_.flag, boost::bind(&ChromatogramList_Thermo::createIndex, this));
-    if (index>size())
+    if (index>=size())
         throw runtime_error(("[ChromatogramList_Thermo::chromatogram()] Bad index: " 
                             + lexical_cast<string>(index)).c_str());
 

--- a/pwiz/data/vendor_readers/Thermo/SpectrumList_Thermo.cpp
+++ b/pwiz/data/vendor_readers/Thermo/SpectrumList_Thermo.cpp
@@ -99,7 +99,7 @@ PWIZ_API_DECL size_t SpectrumList_Thermo::size() const
 
 PWIZ_API_DECL const SpectrumIdentity& SpectrumList_Thermo::spectrumIdentity(size_t index) const
 {
-    if (index>size_)
+    if (index>=size_)
         throw runtime_error(("[SpectrumList_Thermo::spectrumIdentity()] Bad index: " 
                             + lexical_cast<string>(index)).c_str());
     return index_[index];

--- a/pwiz/data/vendor_readers/UIMF/ChromatogramList_UIMF.cpp
+++ b/pwiz/data/vendor_readers/UIMF/ChromatogramList_UIMF.cpp
@@ -52,7 +52,7 @@ PWIZ_API_DECL size_t ChromatogramList_UIMF::size() const
 PWIZ_API_DECL const ChromatogramIdentity& ChromatogramList_UIMF::chromatogramIdentity(size_t index) const
 {
     boost::call_once(indexInitialized_.flag, boost::bind(&ChromatogramList_UIMF::createIndex, this));
-    if (index>size())
+    if (index>=size())
         throw runtime_error(("[ChromatogramList_UIMF::chromatogramIdentity()] Bad index: "
                             + lexical_cast<string>(index)).c_str());
     return reinterpret_cast<const ChromatogramIdentity&>(index_[index]);
@@ -79,7 +79,7 @@ PWIZ_API_DECL ChromatogramPtr ChromatogramList_UIMF::chromatogram(size_t index, 
 PWIZ_API_DECL ChromatogramPtr ChromatogramList_UIMF::chromatogram(size_t index, DetailLevel detailLevel) const
 {
     boost::call_once(indexInitialized_.flag, boost::bind(&ChromatogramList_UIMF::createIndex, this));
-    if (index>size())
+    if (index>=size())
         throw runtime_error(("[ChromatogramList_UIMF::chromatogram()] Bad index: "
                             + lexical_cast<string>(index)).c_str());
 

--- a/pwiz/data/vendor_readers/UIMF/SpectrumList_UIMF.cpp
+++ b/pwiz/data/vendor_readers/UIMF/SpectrumList_UIMF.cpp
@@ -60,7 +60,7 @@ PWIZ_API_DECL size_t SpectrumList_UIMF::size() const
 PWIZ_API_DECL const SpectrumIdentity& SpectrumList_UIMF::spectrumIdentity(size_t index) const
 {
     boost::call_once(indexInitialized_.flag, boost::bind(&SpectrumList_UIMF::createIndex, this));
-    if (index>size_)
+    if (index>=size_)
         throw runtime_error(("[SpectrumList_UIMF::spectrumIdentity] Bad index: " 
                             + lexical_cast<string>(index)).c_str());
     return index_[index];

--- a/pwiz/data/vendor_readers/UNIFI/ChromatogramList_UNIFI.cpp
+++ b/pwiz/data/vendor_readers/UNIFI/ChromatogramList_UNIFI.cpp
@@ -60,7 +60,7 @@ PWIZ_API_DECL size_t ChromatogramList_UNIFI::size() const
 PWIZ_API_DECL const ChromatogramIdentity& ChromatogramList_UNIFI::chromatogramIdentity(size_t index) const
 {
     boost::call_once(indexInitialized_.flag, boost::bind(&ChromatogramList_UNIFI::createIndex, this));
-    if (index>size_)
+    if (index>=size_)
         throw runtime_error(("[ChromatogramList_UNIFI::chromatogramIdentity()] Bad index: " 
                             + lexical_cast<string>(index)).c_str());
     return index_[index];
@@ -147,7 +147,7 @@ PWIZ_API_DECL void ChromatogramList_UNIFI::makeFullFileChromatogram(pwiz::msdata
 PWIZ_API_DECL ChromatogramPtr ChromatogramList_UNIFI::chromatogram(size_t index, DetailLevel detailLevel) const
 {
     boost::call_once(indexInitialized_.flag, boost::bind(&ChromatogramList_UNIFI::createIndex, this));
-    if (index>size_)
+    if (index>=size_)
         throw runtime_error(("[ChromatogramList_UNIFI::chromatogram()] Bad index: " 
                             + lexical_cast<string>(index)).c_str());
 

--- a/pwiz/data/vendor_readers/Waters/ChromatogramList_Waters.cpp
+++ b/pwiz/data/vendor_readers/Waters/ChromatogramList_Waters.cpp
@@ -59,7 +59,7 @@ PWIZ_API_DECL size_t ChromatogramList_Waters::size() const
 PWIZ_API_DECL const ChromatogramIdentity& ChromatogramList_Waters::chromatogramIdentity(size_t index) const
 {
     boost::call_once(indexInitialized_.flag, boost::bind(&ChromatogramList_Waters::createIndex, this));
-    if (index>size_)
+    if (index>=size_)
         throw runtime_error(("[ChromatogramList_Waters::chromatogramIdentity()] Bad index: " 
                             + lexical_cast<string>(index)).c_str());
     return index_[index];
@@ -91,7 +91,7 @@ PWIZ_API_DECL ChromatogramPtr ChromatogramList_Waters::chromatogram(size_t index
 PWIZ_API_DECL ChromatogramPtr ChromatogramList_Waters::chromatogram(size_t index, DetailLevel detailLevel, double lockmassMzPosScans, double lockmassMzNegScans, double lockmassTolerance) const
 {
     boost::call_once(indexInitialized_.flag, boost::bind(&ChromatogramList_Waters::createIndex, this));
-    if (index>size_)
+    if (index>=size_)
         throw runtime_error(("[ChromatogramList_Waters::chromatogram()] Bad index: " 
                             + lexical_cast<string>(index)).c_str());
 

--- a/pwiz/data/vendor_readers/Waters/SpectrumList_Waters.cpp
+++ b/pwiz/data/vendor_readers/Waters/SpectrumList_Waters.cpp
@@ -66,7 +66,7 @@ PWIZ_API_DECL size_t SpectrumList_Waters::size() const
 
 PWIZ_API_DECL const SpectrumIdentity& SpectrumList_Waters::spectrumIdentity(size_t index) const
 {
-    if (index>size_)
+    if (index>=size_)
         throw runtime_error("[SpectrumList_Waters::spectrumIdentity()] Bad index: "
                             + lexical_cast<string>(index));
     return index_[index];


### PR DESCRIPTION
## Summary

* Index bounds guards for several varieties of SpectrumList and ChromatogramList tested `index > size` instead of `>=`, but of course index[size()] is just as wrong as index[size()+1]. In practice this hasn't been a runtime issue (that we have noticed?), but code inspection is right in flagging it.  Seen in 29 places across 18 files.
* Completes 18e8ba470 (2009), which applied this same fix, but to only four instances.
* MGF and MSn `spectrumIdentity()` had no guard at all — added.

While we were in there, I decided to normalize line endings for the files we were already touching - tired of being warned about that.  Review with `git diff --ignore-cr-at-eol`; the logic change is 31 one-character edits.

## Test plan

- [x] SpectrumList_mzXML_Test, _MGF_Test, _MSn_Test, ProteinList_DecoyGeneratorTest - new out-of-bounds assertions, verified red before the fix
- [x] pwiz/data and pwiz/analysis suites - green

Co-Authored-By: Claude <noreply@anthropic.com>
