### PR TITLE
osprey: Bounded and instrumented the Stage 7 join

### DIFF
--- a/pwiz_tools/Osprey/Osprey.Core/OspreyEnvironment.cs
+++ b/pwiz_tools/Osprey/Osprey.Core/OspreyEnvironment.cs
@@ -537,6 +537,17 @@ namespace pwiz.Osprey.Core
                     t => string.Equals(t, v, StringComparison.OrdinalIgnoreCase)));
 
         /// <summary>
+        /// Just the unrecognized tokens of <see cref="AllowUnfixedResident"/>, comma separated.
+        /// The warning names THESE rather than the whole value: the flag is a list and
+        /// <c>NamesResidentPath</c> tests each token independently, so a value pairing a retired
+        /// token with a live one still grants the live one. Empty when every token is known.
+        /// </summary>
+        public static readonly string UnrecognizedResidentTokens =
+            string.Join(@", ", SplitResidentTokens(AllowUnfixedResident).Where(
+                v => !ResidentPaths.KNOWN_UNFIXED.Any(
+                    t => string.Equals(t, v, StringComparison.OrdinalIgnoreCase))));
+
+        /// <summary>
         /// Whether <paramref name="allowValue"/> (an OSPREY_ALLOW_UNFIXED_RESIDENT setting) names
         /// <paramref name="token"/>. Case-insensitive, matching how the rest of the CLI parses
         /// tokens: the guard's message names the exact token to set, so rejecting the operator's

--- a/pwiz_tools/Osprey/Osprey.Core/OspreyEnvironment.cs
+++ b/pwiz_tools/Osprey/Osprey.Core/OspreyEnvironment.cs
@@ -491,7 +491,7 @@ namespace pwiz.Osprey.Core
 
         /// <summary>
         /// OSPREY_ALLOW_UNFIXED_RESIDENT: name the known-unfixed resident path(s) this run may
-        /// take, e.g. <c>OSPREY_ALLOW_UNFIXED_RESIDENT=hpc-merge</c>. Legal values are
+        /// take, e.g. <c>OSPREY_ALLOW_UNFIXED_RESIDENT=fdrbench-pass1</c>. Legal values are
         /// exactly <see cref="ResidentPaths.KNOWN_UNFIXED"/>; anything else, and any resident path
         /// that is not on that list, is refused no matter what this is set to.
         ///

--- a/pwiz_tools/Osprey/Osprey.Core/ResidentPaths.cs
+++ b/pwiz_tools/Osprey/Osprey.Core/ResidentPaths.cs
@@ -45,11 +45,14 @@ namespace pwiz.Osprey.Core
     /// </summary>
     public static class ResidentPaths
     {
-        /// <summary>
-        /// The HPC reconciled-input merge (<c>--task SecondPassFDR</c>), which loads every
-        /// worker's entries to reconcile them. Tracked by issue #4486.
-        /// </summary>
-        public static readonly string HPC_MERGE = @"hpc-merge";
+        // hpc-merge was removed here by #4486, which put the HPC reconciled-input merge
+        // (--task SecondPassFDR) on the same file-count-bounded streaming hydrate every other
+        // reconciled-bundle path already used. It never named a real consumer: FirstPassFdrTask
+        // is excluded on that node, and each pass-2 consumer streams from disk one file at a
+        // time, so the pool it forced was loaded and discarded - 2.07 GB per file, ~186 GB
+        // projected at 82 files, which made the final join impossible on any HPC node. Not to
+        // be re-added: a join that cannot stream its input is a defect to fix, not a path to
+        // name.
 
         /// <summary>
         /// <c>--fdrbench-pass 1</c>, which reads the full pre-compaction first-pass pool
@@ -115,8 +118,7 @@ namespace pwiz.Osprey.Core
         /// </summary>
         public static readonly IReadOnlyList<string> KNOWN_UNFIXED = new[]
         {
-            HPC_MERGE, FDRBENCH_PASS1, NON_PERCOLATOR_FDR, PROJECTION_OFF,
-            COMPACTED_ENTRIES_BUFFER
+            FDRBENCH_PASS1, NON_PERCOLATOR_FDR, PROJECTION_OFF, COMPACTED_ENTRIES_BUFFER
         };
     }
 }

--- a/pwiz_tools/Osprey/Osprey.Core/ResidentPaths.cs
+++ b/pwiz_tools/Osprey/Osprey.Core/ResidentPaths.cs
@@ -49,8 +49,9 @@ namespace pwiz.Osprey.Core
         // (--task SecondPassFDR) on the same file-count-bounded streaming hydrate every other
         // reconciled-bundle path already used. It never named a real consumer: FirstPassFdrTask
         // is excluded on that node, and each pass-2 consumer streams from disk one file at a
-        // time, so the pool it forced was loaded and discarded - 2.07 GB per file, ~186 GB
-        // projected at 82 files, which made the final join impossible on any HPC node. Not to
+        // time, so the pool it forced was loaded and discarded - a measured 2.21 GB/file
+        // (7.6 GB after file 1 to 40.8 GB after file 16), i.e. ~186 GB projected at 82 files,
+        // which made the final join impossible on any HPC node. Not to
         // be re-added: a join that cannot stream its input is a defect to fix, not a path to
         // name.
 

--- a/pwiz_tools/Osprey/Osprey.FDR/StreamingFdr.cs
+++ b/pwiz_tools/Osprey/Osprey.FDR/StreamingFdr.cs
@@ -131,32 +131,44 @@ namespace pwiz.Osprey.FDR
         /// OSPREY_PASS2_QVALUE=transfer-compete. Streams one file's 1st-pass population at a time
         /// (run-level competition + conservative q per file) while accumulating only the
         /// per-base_id best target/decoy observation for the experiment-level competition.
-        /// Resident footprint is therefore O(distinct precursors + largest single file +
-        /// survivors) -- flat in file count -- where the resident overload is O(total
-        /// observations). Emits run/experiment precursor q and PEP identical to the resident
-        /// method for the reported survivors (verified byte-for-byte on the 3-file Stellar
-        /// entrapment set). File reading is injected so this assembly needs no IO dependency.
+        ///
+        /// NOTHING per-observation outlives the file that produced it. Each file's run q is handed
+        /// to <paramref name="onFileRunQ"/> and then dropped, and the experiment-level values come
+        /// back as the bounded <see cref="StreamedCompetitionState"/>, which derives a survivor's
+        /// experiment q and PEP on demand from O(distinct) state, so the caller emits those one
+        /// file at a time as well. Resident footprint is O(distinct precursors + distinct survivor
+        /// entry_ids + largest single file), flat in file count, where the resident overload is
+        /// O(total observations). The earlier streaming form was flat in its ACCUMULATORS but
+        /// still returned three whole-run (file, entry_id)-keyed dictionaries, which measured
+        /// ~16 GB of the 82-file Stage 7 peak (#4486); the roll-up order was already right, the
+        /// retention was not.
+        ///
+        /// Emits run/experiment precursor q and PEP identical to the resident method for the
+        /// reported survivors (verified byte-for-byte on the 3-file Stellar entrapment set). File
+        /// reading is injected so this assembly needs no IO dependency.
         /// </summary>
         /// <param name="fileKeys">Stable per-file keys to stream, in any order.</param>
-        /// <param name="readFileScalars">Reads one file's full population as (entryIds, scores);
-        ///   invoked once per file, arrays released before the next file is read.</param>
-        /// <param name="survivorScoreOverride">Frozen-model score to substitute for a reconciled
-        ///   survivor observation, keyed (fileKey, entryId). Observations absent here keep their
-        ///   stored 1st-pass score.</param>
-        /// <param name="survivors">Every reported survivor (fileKey, entryId) to emit q/PEP for.</param>
-        /// <param name="survivorRunQ">Out: run-level precursor q per reported (fileKey, entryId).</param>
-        /// <param name="survivorExpQ">Out: experiment-level precursor q per reported (fileKey, entryId).</param>
-        /// <param name="survivorPep">Out: PEP per reported (fileKey, entryId).</param>
+        /// <param name="readFile">Reads one file's full population as (entryIds, scores) plus the
+        ///   frozen-model score to substitute for each of THAT FILE's reconciled survivors, keyed
+        ///   by entry_id (observations absent from it keep their stored 1st-pass score). Invoked
+        ///   once per file; everything it returns is released before the next file is read, so the
+        ///   caller loads that file's features inside it rather than pre-building a whole-run
+        ///   score map.</param>
+        /// <param name="survivorEntryIds">Every reported survivor entry_id, across all files. The
+        ///   best-of-runs floor is a per-entry_id minimum over every file the entry won in, so
+        ///   this one set is genuinely global, but it is O(distinct entry_ids), not
+        ///   O(files x entry_ids).</param>
+        /// <param name="onFileRunQ">Receives each file's run-level precursor q by entry_id as soon
+        ///   as that file's competition finishes, for the survivor entry_ids that won in it. The
+        ///   map is the caller's to consume and is not retained here; an entry the caller holds
+        ///   for this file that is absent from it won no competition and takes run q 1.0.</param>
         /// <param name="stratumBaseIds">Null for the full-population competition; non-null restricts
         ///   the competition to these base_ids (protein-compact).</param>
-        public static void ComputeFullPopulationPrecursorFdrStreaming(
+        public static StreamedCompetitionState ComputeFullPopulationPrecursorFdrStreaming(
             IReadOnlyList<string> fileKeys,
-            Func<string, (uint[] entryIds, double[] scores)> readFileScalars,
-            IReadOnlyDictionary<(string, uint), double> survivorScoreOverride,
-            IReadOnlyCollection<(string, uint)> survivors,
-            out Dictionary<(string, uint), double> survivorRunQ,
-            out Dictionary<(string, uint), double> survivorExpQ,
-            out Dictionary<(string, uint), double> survivorPep,
+            Func<string, (uint[] entryIds, double[] scores, IReadOnlyDictionary<uint, double> survivorScores)> readFile,
+            IReadOnlyCollection<uint> survivorEntryIds,
+            Action<string, IReadOnlyDictionary<uint, double>> onFileRunQ,
             HashSet<uint> stratumBaseIds = null)
         {
             // stratumBaseIds == null -> full-population competition (transfer-compete).
@@ -165,13 +177,7 @@ namespace pwiz.Osprey.FDR
             // off-stratum decoys leave the null (reduced multiple testing). The per-base_id
             // maps hold only stratum members, so peak memory stays flat in file count -- it
             // only shrinks relative to the full-population path.
-            var survivorSet = new HashSet<(string, uint)>(survivors);
-            var survivorEntryIds = new HashSet<uint>();
-            foreach (var s in survivorSet) survivorEntryIds.Add(s.Item2);
-
-            survivorRunQ = new Dictionary<(string, uint), double>(survivorSet.Count);
-            survivorExpQ = new Dictionary<(string, uint), double>(survivorSet.Count);
-            survivorPep = new Dictionary<(string, uint), double>(survivorSet.Count);
+            var survivorIds = survivorEntryIds as HashSet<uint> ?? new HashSet<uint>(survivorEntryIds);
 
             // Experiment-level per-base_id best target/decoy observation (score + locator),
             // accumulated across every file. Bounded by the number of distinct precursors.
@@ -180,12 +186,12 @@ namespace pwiz.Osprey.FDR
 
             // Best (min) run q per SURVIVOR entry_id across the files it won in -- the
             // best-of-runs monotonicity floor for the experiment q (only survivors are emitted).
-            var minRunQ = new Dictionary<uint, double>(survivorEntryIds.Count);
+            var minRunQ = new Dictionary<uint, double>(survivorIds.Count);
 
             for (int fileIdx = 0; fileIdx < fileKeys.Count; fileIdx++)
             {
                 string fileKey = fileKeys[fileIdx];
-                var (entryIds, scores) = readFileScalars(fileKey);
+                var (entryIds, scores, survivorScores) = readFile(fileKey);
                 int m = entryIds.Length;
                 var labels = new bool[m];
                 // Non-null only when stratified: the base_ids whose observations Stage 6 actually
@@ -200,7 +206,7 @@ namespace pwiz.Osprey.FDR
                 {
                     uint eid = entryIds[i];
                     labels[i] = (eid & ~PercolatorEntry.BASE_ID_MASK) != 0u; // decoy high bit set
-                    if (survivorScoreOverride.TryGetValue((fileKey, eid), out double ov))
+                    if (survivorScores.TryGetValue(eid, out double ov))
                     {
                         // BIT-EXACT inequality is the "changed" discriminator, the same one
                         // Pass2FdrSidecar.AssignPerRunQ uses to separate Moved from Unchanged: an
@@ -267,13 +273,18 @@ namespace pwiz.Osprey.FDR
                     out int[] wi, out double[] ws, out bool[] wd);
                 var q = new double[wi.Length];
                 PercolatorQValues.ComputeConservativeQvalues(ws, wd, q);
+                // This file's run q, handed to the caller at the end of the iteration and then
+                // dropped. Sized by the survivors that won a competition HERE, not by the survivor
+                // set across all files, which is what makes the phase flat in file count. The
+                // caller filters to the survivors it actually holds for this file, so the old
+                // (fileKey, entryId) membership test is now the caller's own per-file list.
+                var fileRunQ = new Dictionary<uint, double>();
                 for (int rank = 0; rank < wi.Length; rank++)
                 {
                     uint eid = entryIds[wi[rank]];
-                    if (!survivorEntryIds.Contains(eid)) continue;
+                    if (!survivorIds.Contains(eid)) continue;
                     double qv = q[rank];
-                    var key = (fileKey, eid);
-                    if (survivorSet.Contains(key)) survivorRunQ[key] = qv;
+                    fileRunQ[eid] = qv;
                     if (!minRunQ.TryGetValue(eid, out double cur) || qv < cur) minRunQ[eid] = qv;
                 }
 
@@ -309,7 +320,12 @@ namespace pwiz.Osprey.FDR
                             bestTarget[bid] = (s, fileIdx, eid);
                     }
                 }
-                // entryIds/scores/labels/allIdx released here before the next file is read.
+
+                // Hand this file's run q over and let it go. Called after the experiment fold so
+                // the caller cannot observe a partially-folded file.
+                onFileRunQ(fileKey, fileRunQ);
+                // entryIds/scores/labels/allIdx/fileRunQ and the caller's per-file survivor scores
+                // are all released here, before the next file is read.
             }
 
             // Experiment competition: one winner per base_id, conservative q, PEP fit over
@@ -358,37 +374,75 @@ namespace pwiz.Osprey.FDR
 
             var pepEstimator = PepEstimator.FitDefault(expScore, expIsDecoy);
 
-            bool multiFile = fileKeys.Count > 1;
-            foreach (var key in survivorSet)
+            // The per-survivor loop that used to live here - one iteration per (file, entry_id),
+            // filling three whole-run dictionaries - is now the caller's per-file emit pass. Every
+            // value it produced is a function of the bounded state below plus the survivor's own
+            // run q, so handing that state back costs O(distinct) instead of O(files x entries).
+            return new StreamedCompetitionState(
+                baseIdExpQ, minRunQ, winnerLoc, pepEstimator, fileKeys, fileKeys.Count > 1);
+        }
+
+        /// <summary>
+        /// The bounded cross-file result of <see cref="ComputeFullPopulationPrecursorFdrStreaming"/>:
+        /// everything needed to finish a survivor's q-values, held as O(distinct base_id) /
+        /// O(distinct survivor entry_id) maps rather than one entry per observation. The caller
+        /// walks its own per-file survivor lists and asks for each value in turn, so no
+        /// (file, entry_id)-keyed buffer is ever materialized (#4486).
+        /// </summary>
+        public sealed class StreamedCompetitionState
+        {
+            private readonly Dictionary<uint, double> _baseIdExpQ;
+            private readonly Dictionary<uint, double> _minRunQ;
+            private readonly Dictionary<uint, (int fileIdx, uint entryId, double score)> _winnerLoc;
+            private readonly PepEstimator _pepEstimator;
+            private readonly IReadOnlyList<string> _fileKeys;
+            private readonly bool _multiFile;
+
+            internal StreamedCompetitionState(
+                Dictionary<uint, double> baseIdExpQ,
+                Dictionary<uint, double> minRunQ,
+                Dictionary<uint, (int fileIdx, uint entryId, double score)> winnerLoc,
+                PepEstimator pepEstimator,
+                IReadOnlyList<string> fileKeys,
+                bool multiFile)
             {
-                string fileKey = key.Item1;
-                uint eid = key.Item2;
-                uint bid = eid & PercolatorEntry.BASE_ID_MASK;
+                _baseIdExpQ = baseIdExpQ;
+                _minRunQ = minRunQ;
+                _winnerLoc = winnerLoc;
+                _pepEstimator = pepEstimator;
+                _fileKeys = fileKeys;
+                _multiFile = multiFile;
+            }
 
-                if (!survivorRunQ.ContainsKey(key)) survivorRunQ[key] = 1.0;
+            /// <summary>
+            /// Experiment-level precursor q for one survivor observation: the base_id winner's q,
+            /// floored up to that precursor's best (min-over-runs) run q. An entry_id that won no
+            /// within-file competition has best run q 1.0 (every observation stayed at the q=1.0
+            /// default), matching the resident bestRunQ. A single-file run short-circuits to the
+            /// run q, as the resident path does.
+            /// </summary>
+            public double ExperimentQ(uint entryId, double runQ)
+            {
+                if (!_multiFile)
+                    return runQ;
+                uint baseId = entryId & PercolatorEntry.BASE_ID_MASK;
+                double eq = _baseIdExpQ.TryGetValue(baseId, out double bq) ? bq : 1.0;
+                double floorQ = _minRunQ.TryGetValue(entryId, out double mrq) ? mrq : 1.0;
+                return eq < floorQ ? floorQ : eq;
+            }
 
-                if (multiFile)
-                {
-                    // Experiment q = base_id winner q, floored up to this precursor's best run q.
-                    // An entry_id that won no within-file competition has best run q = 1.0 (every
-                    // observation stayed at the q=1.0 default), matching the resident bestRunQ.
-                    double eq = baseIdExpQ.TryGetValue(bid, out double bq) ? bq : 1.0;
-                    double floorQ = minRunQ.TryGetValue(eid, out double mrq) ? mrq : 1.0;
-                    if (eq < floorQ) eq = floorQ;
-                    survivorExpQ[key] = eq;
-                }
-                else
-                {
-                    // Single file: experiment q == run q (resident short-circuit).
-                    survivorExpQ[key] = survivorRunQ[key];
-                }
-
-                // PEP is real only on the single experiment-winner observation of each base_id.
-                double pep = 1.0;
-                if (winnerLoc.TryGetValue(bid, out var loc) &&
-                    loc.entryId == eid && fileKeys[loc.fileIdx] == fileKey)
-                    pep = pepEstimator.PosteriorError(loc.score);
-                survivorPep[key] = pep;
+            /// <summary>
+            /// PEP for one survivor observation. Real only on the single experiment-winner
+            /// observation of each base_id - the winner set the estimator was fit over - so every
+            /// other observation of that precursor reports 1.0.
+            /// </summary>
+            public double Pep(string fileKey, uint entryId)
+            {
+                uint baseId = entryId & PercolatorEntry.BASE_ID_MASK;
+                if (_winnerLoc.TryGetValue(baseId, out var loc) &&
+                    loc.entryId == entryId && _fileKeys[loc.fileIdx] == fileKey)
+                    return _pepEstimator.PosteriorError(loc.score);
+                return 1.0;
             }
         }
 

--- a/pwiz_tools/Osprey/Osprey.Tasks/FirstPassFdrTask.cs
+++ b/pwiz_tools/Osprey/Osprey.Tasks/FirstPassFdrTask.cs
@@ -78,9 +78,22 @@ namespace pwiz.Osprey.Tasks
         /// (stops at Stage 1-4), --task PerFileRescoring, and the --task SecondPassFDR
         /// stage (where it rehydrates the bundle rather than recomputing).
         /// </summary>
-        public override bool IsIncluded(PipelineContext ctx)
+        public override bool IsIncluded(PipelineContext ctx) => IsIncludedFor(ctx.Config);
+
+        /// <summary>
+        /// Pure membership predicate behind <see cref="IsIncluded"/>, exposed so a caller
+        /// that needs to know whether first-pass Percolator trains in THIS process asks the
+        /// one definition instead of re-deriving it.
+        ///
+        /// <para><see cref="PerFileScoringTask"/>'s pre-compaction-pool decision used
+        /// <c>!NoJoin</c> as a proxy for exactly this question. That proxy is right for every
+        /// task except <c>--task SecondPassFDR</c>, which leaves <c>NoJoin</c> false while
+        /// setting <c>ExpectReconciledInput</c> - so this task is EXCLUDED, nothing trains,
+        /// and the resident pre-compaction pool the proxy forced was pure waste at O(files)
+        /// (issue #4486). Calling the predicate keeps the two from drifting again.</para>
+        /// </summary>
+        internal static bool IsIncludedFor(OspreyConfig c)
         {
-            var c = ctx.Config;
             bool inputs = c.InputScores != null && c.InputScores.Count > 0;
             // The (inputs && StopAfterStage5) clause leans on a CLI-enforced
             // invariant: StopAfterStage5 is set by --task FirstPassFDR, which

--- a/pwiz_tools/Osprey/Osprey.Tasks/Pass2FdrSidecar.cs
+++ b/pwiz_tools/Osprey/Osprey.Tasks/Pass2FdrSidecar.cs
@@ -569,16 +569,24 @@ namespace pwiz.Osprey.Tasks
             //
             //    Two --input-scores paths in different directories CAN share a stem
             //    (RescoreHydration.PreCompactionTallies is index-keyed for exactly that reason),
-            //    so a same-stem pair is MERGED here rather than last-wins. The whole-run map
-            //    this replaced merged them implicitly - it was keyed (file, entry_id) and the
-            //    map-back walked perFileEntries - so keeping only one list would have left the
-            //    other's entries with a mixture of refreshed and stale q-values, which is worse
-            //    than the pre-existing hazard. Merging reproduces the old disposition. A hard
-            //    throw was tried here and removed: it fired at Stage 7, after hours of Stages
-            //    1-6, for a condition knowable at argument-parse time, while the sibling
-            //    sidecarByKey below and the projection path's own per-file map stayed
-            //    last-wins - so it converted one silent inconsistency into a late abort
-            //    without making the class of input any safer.
+            //    so a same-stem pair is MERGED here rather than last-wins.
+            //
+            //    Merging REPRODUCES the old disposition; it does NOT make duplicate stems
+            //    correct, and must not be read as fixing them (#4555). The lookups this method
+            //    performs are still stem-keyed and last-wins - sidecarByKey and
+            //    perFileParquetPaths below, and the projection second pass's own
+            //    survivorsByFile - so a duplicate stem still reads ONE file's scalars and
+            //    applies the result to both files' entries. That is exactly what the whole-run
+            //    map this replaced did (keyed (file, entry_id), map-back over perFileEntries),
+            //    so this is the pre-existing hazard carried forward, not a new one; keeping
+            //    only the last list would have been WORSE, leaving the other's entries with a
+            //    mixture of refreshed and stale q-values. The real fix is path-hashed identity
+            //    across artifact naming and every per-file map at once, tracked in #4555.
+            //
+            //    A hard throw was tried here and removed: it fired at Stage 7, after hours of
+            //    Stages 1-6, for a condition knowable at argument-parse time, while the sibling
+            //    maps stayed last-wins - so it converted one silent inconsistency into a late
+            //    abort without making the class of input any safer.
             var entriesByFile = new Dictionary<string, List<FdrEntry>>(
                 perFileEntries.Count, StringComparer.Ordinal);
             var survivorEntryIds = new HashSet<uint>();

--- a/pwiz_tools/Osprey/Osprey.Tasks/Pass2FdrSidecar.cs
+++ b/pwiz_tools/Osprey/Osprey.Tasks/Pass2FdrSidecar.cs
@@ -371,47 +371,58 @@ namespace pwiz.Osprey.Tasks
                 // summary log below.
                 if (pass2Projections == null)
                 {
-                    foreach (var kvp in perFileEntries)
+                    // Per-file progress: this writes one .2nd-pass.fdr_scores.bin per file
+                    // (~4.8 GB across 82) and was silent, which with the reload loop below is
+                    // the 38s gap perfviz reports between the competition's [STAGE-WALL] line
+                    // and the next probe (#4486). IO-paced, like the other disk loops here.
+                    using (var writeProgress = new ProgressReporter(
+                        string.Format(@"Writing 2nd-pass FDR scores for {0} file(s)", perFileEntries.Count),
+                        perFileEntries.Count, string.Empty, ProgressReporter.IO_INTERVAL_SECONDS))
                     {
-                        string fileName = kvp.Key;
-                        if (!inputByFileName.TryGetValue(fileName, out string inputFile3))
-                            continue;
-                        string pass2Path = FdrScoresSidecar.Pass2Path(inputFile3);
-                        if (File.Exists(pass2Path))
+                        long nWrittenReported = 0;
+                        foreach (var kvp in perFileEntries)
                         {
-                            pass2Tally.AlreadyOnDisk++;
-                            continue;
-                        }
-                        try
-                        {
-                            FdrScoresSidecar.Write(
-                                pass2Path, kvp.Value, FdrScoresSidecar.Pass.SecondPass);
-                            pass2Tally.Written++;
-                        }
-                        catch (Exception ex)
-                        {
-                            ctx.LogWarning(string.Format(
-                                @"Failed to write 2nd-pass FDR sidecar for {0}: {1}",
-                                fileName, ex.Message));
-                            pass2Tally.Failures++;
-                            continue;
-                        }
-                        // Inline per-file validity sidecar: same content
-                        // the end-of-Run WriteTaskSidecars would produce,
-                        // written immediately so an early Environment.Exit
-                        // does not strand the binary without its metadata.
-                        try
-                        {
-                            TaskValiditySidecar.Write(pass2Path, taskName, OspreyVersion.Current,
-                                taskValidityKey,
-                                new[] { ParquetScoreCache.EffectiveScoresPathFromScoresPath(
-                                    ParquetScoreCache.GetScoresPath(inputFile3)) });
-                        }
-                        catch (Exception ex)
-                        {
-                            ctx.LogWarning(string.Format(
-                                @"Failed to write {0} sidecar for {1}: {2}",
-                                taskName, pass2Path, ex.Message));
+                            writeProgress.Report(++nWrittenReported);
+                            string fileName = kvp.Key;
+                            if (!inputByFileName.TryGetValue(fileName, out string inputFile3))
+                                continue;
+                            string pass2Path = FdrScoresSidecar.Pass2Path(inputFile3);
+                            if (File.Exists(pass2Path))
+                            {
+                                pass2Tally.AlreadyOnDisk++;
+                                continue;
+                            }
+                            try
+                            {
+                                FdrScoresSidecar.Write(
+                                    pass2Path, kvp.Value, FdrScoresSidecar.Pass.SecondPass);
+                                pass2Tally.Written++;
+                            }
+                            catch (Exception ex)
+                            {
+                                ctx.LogWarning(string.Format(
+                                    @"Failed to write 2nd-pass FDR sidecar for {0}: {1}",
+                                    fileName, ex.Message));
+                                pass2Tally.Failures++;
+                                continue;
+                            }
+                            // Inline per-file validity sidecar: same content
+                            // the end-of-Run WriteTaskSidecars would produce,
+                            // written immediately so an early Environment.Exit
+                            // does not strand the binary without its metadata.
+                            try
+                            {
+                                TaskValiditySidecar.Write(pass2Path, taskName, OspreyVersion.Current,
+                                    taskValidityKey,
+                                    new[] { ParquetScoreCache.EffectiveScoresPathFromScoresPath(
+                                        ParquetScoreCache.GetScoresPath(inputFile3)) });
+                            }
+                            catch (Exception ex)
+                            {
+                                ctx.LogWarning(string.Format(
+                                    @"Failed to write {0} sidecar for {1}: {2}",
+                                    taskName, pass2Path, ex.Message));
+                            }
                         }
                     }
                 }
@@ -446,31 +457,42 @@ namespace pwiz.Osprey.Tasks
                     inputByName[Path.GetFileNameWithoutExtension(inputFile)] = inputFile;
                 int filesReloaded = 0;
                 int filesMissing = 0;
-                foreach (var kvp in perFileEntries)
+                // Per-file progress: reads back every file's just-written sidecar and rebuilds
+                // an entry_id map over that file's survivors. Silent, and the second half of
+                // the 38s gap between the competition's [STAGE-WALL] line and the next probe
+                // (#4486); the write loop above is the first half.
+                using (var reloadProgress = new ProgressReporter(
+                    string.Format(@"Reloading 2nd-pass FDR scores for {0} file(s)", perFileEntries.Count),
+                    perFileEntries.Count, string.Empty, ProgressReporter.IO_INTERVAL_SECONDS))
                 {
-                    if (!inputByName.TryGetValue(kvp.Key, out string inputFile4))
-                        continue;
-                    string pass2Path = FdrScoresSidecar.Pass2Path(inputFile4);
-                    if (!File.Exists(pass2Path))
+                    long nReloadReported = 0;
+                    foreach (var kvp in perFileEntries)
                     {
-                        filesMissing++;
-                        continue;
-                    }
-                    var byEntryId = new Dictionary<uint, FdrEntry>(kvp.Value.Count);
-                    foreach (var e in kvp.Value)
-                        byEntryId[e.EntryId] = e;
-                    if (FdrScoresSidecar.TryReadOverlay(
-                            pass2Path, byEntryId, FdrScoresSidecar.Pass.SecondPass))
-                    {
-                        filesReloaded++;
-                    }
-                    else
-                    {
-                        filesMissing++;
-                        ctx.LogWarning(string.Format(
-                            "Failed to reload 2nd-pass FDR sidecar for {0} ({1}); " +
-                            "protein FDR will use stale 1st-pass q-values",
-                            kvp.Key, pass2Path));
+                        reloadProgress.Report(++nReloadReported);
+                        if (!inputByName.TryGetValue(kvp.Key, out string inputFile4))
+                            continue;
+                        string pass2Path = FdrScoresSidecar.Pass2Path(inputFile4);
+                        if (!File.Exists(pass2Path))
+                        {
+                            filesMissing++;
+                            continue;
+                        }
+                        var byEntryId = new Dictionary<uint, FdrEntry>(kvp.Value.Count);
+                        foreach (var e in kvp.Value)
+                            byEntryId[e.EntryId] = e;
+                        if (FdrScoresSidecar.TryReadOverlay(
+                                pass2Path, byEntryId, FdrScoresSidecar.Pass.SecondPass))
+                        {
+                            filesReloaded++;
+                        }
+                        else
+                        {
+                            filesMissing++;
+                            ctx.LogWarning(string.Format(
+                                "Failed to reload 2nd-pass FDR sidecar for {0} ({1}); " +
+                                "protein FDR will use stale 1st-pass q-values",
+                                kvp.Key, pass2Path));
+                        }
                     }
                 }
                 if (filesReloaded > 0)

--- a/pwiz_tools/Osprey/Osprey.Tasks/Pass2FdrSidecar.cs
+++ b/pwiz_tools/Osprey/Osprey.Tasks/Pass2FdrSidecar.cs
@@ -514,10 +514,17 @@ namespace pwiz.Osprey.Tasks
         /// in (the FROZEN 1st-pass model applied to their reconciled features). Because &gt;99% of
         /// scores are unchanged, the recomputed q lands on the calibrated 1st-pass value; the
         /// reconciled minority get honest full-population q. No 2nd-pass retrain and no
-        /// reduced-pool null (the null is the full 1st-pass decoy set). No features are held
-        /// resident -- only flat scalar arrays. Writes q/PEP onto the reported survivor entries in
-        /// place. Returns false (caller falls back to the retrain) when the frozen model or any
-        /// 1st-pass scalar sidecar is missing.
+        /// reduced-pool null (the null is the full 1st-pass decoy set). ONE FILE's PIN feature
+        /// map is resident at a time - the frozen-model scoring moved inside this method's
+        /// per-file read (#4486), so it is the largest allocation on the path, released before
+        /// the next file; the cross-file state is flat scalar arrays and O(distinct) maps.
+        /// Writes q/PEP onto the reported survivor entries in
+        /// place. Returns false when the frozen model or any 1st-pass scalar sidecar is missing;
+        /// the caller then THROWS with actionable guidance - an explicitly requested frozen mode
+        /// must never silently degrade to the anti-conservative retrain. (This said "caller falls
+        /// back to the retrain", which is the opposite of the fail-fast the caller implements.)
+        /// Every `return false` is placed BEFORE any survivor is mutated, so a refusal leaves the
+        /// pool untouched.
         /// </summary>
         private static bool ComputePass2TransferCompeteFull(
             PipelineContext ctx,
@@ -560,30 +567,37 @@ namespace pwiz.Osprey.Tasks
             //    (EntryId,Charge,ScanNumber)), same scores, one file's worth resident, and one
             //    fewer pass over the reconciled parquets.
             //
-            //    Distinct file keys are an INVARIANT here, asserted rather than assumed. Two
-            //    --input-scores paths in different directories can share a stem
+            //    Two --input-scores paths in different directories CAN share a stem
             //    (RescoreHydration.PreCompactionTallies is index-keyed for exactly that reason),
-            //    and every per-file structure on this path is name-keyed: a duplicate stem would
-            //    silently give one of the two the other's sidecar and leave its entries with a
-            //    mixture of refreshed and stale q-values. The same guard sits at the head of
-            //    PercolatorScorer.ScoreProjectionAndComputeFdrInPlace, for the same reason - a
-            //    bounded per-file pass cannot tolerate what a whole-run keyed map merged. This
-            //    hazard predates the per-file emit (sidecarByKey was already last-wins); the
-            //    assert is what makes it visible instead of silent (see #4486 review finding 4).
+            //    so a same-stem pair is MERGED here rather than last-wins. The whole-run map
+            //    this replaced merged them implicitly - it was keyed (file, entry_id) and the
+            //    map-back walked perFileEntries - so keeping only one list would have left the
+            //    other's entries with a mixture of refreshed and stale q-values, which is worse
+            //    than the pre-existing hazard. Merging reproduces the old disposition. A hard
+            //    throw was tried here and removed: it fired at Stage 7, after hours of Stages
+            //    1-6, for a condition knowable at argument-parse time, while the sibling
+            //    sidecarByKey below and the projection path's own per-file map stayed
+            //    last-wins - so it converted one silent inconsistency into a late abort
+            //    without making the class of input any safer.
             var entriesByFile = new Dictionary<string, List<FdrEntry>>(
                 perFileEntries.Count, StringComparer.Ordinal);
             var survivorEntryIds = new HashSet<uint>();
             long survivorObservations = 0;
             foreach (var kvp in perFileEntries)
             {
-                if (entriesByFile.ContainsKey(kvp.Key))
+                if (entriesByFile.TryGetValue(kvp.Key, out var merged))
                 {
-                    throw new InvalidOperationException(string.Format(
-                        @"{0}: duplicate per-file key '{1}'; the streamed per-file competition " +
-                        @"requires one entry list per file.",
-                        mode, kvp.Key));
+                    // New list, never AddRange onto the caller's: perFileEntries is the live
+                    // Stage 7 survivor buffer and must not gain entries as a side effect.
+                    var combined = new List<FdrEntry>(merged.Count + kvp.Value.Count);
+                    combined.AddRange(merged);
+                    combined.AddRange(kvp.Value);
+                    entriesByFile[kvp.Key] = combined;
                 }
-                entriesByFile[kvp.Key] = kvp.Value;
+                else
+                {
+                    entriesByFile[kvp.Key] = kvp.Value;
+                }
                 survivorObservations += kvp.Value.Count;
                 foreach (var e in kvp.Value)
                     survivorEntryIds.Add(e.EntryId);
@@ -708,13 +722,40 @@ namespace pwiz.Osprey.Tasks
                     // features, score with the frozen 1st-pass weights, keep only the scalar
                     // score, and release the features on the way out. Same loader and identity
                     // key the resident reload used, so each survivor's score is byte-identical.
-                    var fileScores = new Dictionary<uint, double>();
+                    // Both lookups are established by the validation loop above (every file has
+                    // a parquet path or this method already returned false; entriesByFile is
+                    // built from the same perFileEntries fileKeys comes from). Resolved OUTSIDE
+                    // the try so a key miss cannot be reported as a parquet failure.
                     string effectiveParquetPath = ParquetScoreCache.EffectiveScoresPathFromScoresPath(
                         perFileParquetPaths[fileKey]);
+                    var fileEntries = entriesByFile[fileKey];
+
+                    // ONLY the load is guarded, as it was before this method took over the
+                    // scoring. Widening the try over the scoring loop would let a mid-loop
+                    // throw leave a PARTIALLY swapped-in map: the competition would then run
+                    // on a mixed population, and under protein-compact the unscored remainder
+                    // would also be missing from changedBaseIds, so those peaks would never be
+                    // admitted and would be stamped run q 1.0 - all under a warning blaming a
+                    // load that succeeded. Failure here is all-or-nothing per file.
+                    Dictionary<(uint, byte, uint), double[]> featByIdentity;
                     try
                     {
-                        var featByIdentity = LoadReconciledFeaturesByIdentity(effectiveParquetPath);
-                        foreach (var e in entriesByFile[fileKey])
+                        featByIdentity = LoadReconciledFeaturesByIdentity(effectiveParquetPath);
+                    }
+                    catch (Exception ex)
+                    {
+                        // Same disposition as the old whole-run pass: this file contributes no
+                        // swapped-in scores and competes on its stored 1st-pass ones.
+                        ctx.LogWarning(string.Format(
+                            "{0}: failed to reload PIN features from {1}: {2}",
+                            mode, effectiveParquetPath, ex.Message));
+                        featByIdentity = null;
+                    }
+
+                    var fileScores = new Dictionary<uint, double>();
+                    if (featByIdentity != null)
+                    {
+                        foreach (var e in fileEntries)
                         {
                             if (featByIdentity.TryGetValue(
                                     (e.EntryId, e.Charge, e.ScanNumber), out double[] feats) &&
@@ -724,14 +765,6 @@ namespace pwiz.Osprey.Tasks
                             }
                         }
                         // featByIdentity released here (one file resident at a time).
-                    }
-                    catch (Exception ex)
-                    {
-                        // Same disposition as the old whole-run pass: this file contributes no
-                        // swapped-in scores and competes on its stored 1st-pass ones.
-                        ctx.LogWarning(string.Format(
-                            "{0}: failed to reload PIN features from {1}: {2}",
-                            mode, effectiveParquetPath, ex.Message));
                     }
                     nScored += fileScores.Count;
 

--- a/pwiz_tools/Osprey/Osprey.Tasks/Pass2FdrSidecar.cs
+++ b/pwiz_tools/Osprey/Osprey.Tasks/Pass2FdrSidecar.cs
@@ -525,67 +525,50 @@ namespace pwiz.Osprey.Tasks
             var sw = Stopwatch.StartNew();
             int nFeatures = scorer.NumFeatures;
 
-            // 1. Frozen-model score for each reconciled survivor, STREAMED one file at a
-            //    time: load that file's reconciled PIN features, score with the frozen 1st-pass
-            //    weights, keep only the scalar score, and release the features before the next
-            //    file. The ~300k paired targets+decoys are never all resident -- peak memory is
-            //    one file's features (flat in file count, <= the retrain's streaming ingest).
-            //    Uses the SAME loader + identity key the resident reload used
-            //    (LoadReconciledFeaturesByIdentity keyed by (EntryId,Charge,ScanNumber), the
-            //    MapFeaturesByIdentity key), so each survivor's score is byte-identical to the
-            //    old resident path. Keyed by (file, entry_id); entry_id is unique per file.
-            var survivorScore = new Dictionary<(string, uint), double>();
-            // Announce BEFORE the loop, not after it. This reads one reconciled parquet per file
-            // and on a 163-file Astral set that is ~212 GB off disk - measured at 34.9 min with
-            // no console output at all, because the summary line below is only reached once the
-            // loop finishes. A silent phase that long is indistinguishable from a hang, and it
-            // was read as one during the first 163-file run.
-            using (var progress = new ProgressReporter(
-                string.Format("{0}: reloading frozen-model features from {1} file(s)",
-                    mode, perFileEntries.Count),
-                perFileEntries.Count, string.Empty, ProgressReporter.IO_INTERVAL_SECONDS))
+            // 1. Reported survivors indexed by file for the per-file emit below, plus the one
+            //    genuinely global set: every survivor entry_id. The best-of-runs floor is a
+            //    per-entry_id minimum across files, so that set has to span the run - but it is
+            //    O(distinct entry_ids), not O(files x entry_ids).
+            //
+            //    What used to sit here was a separate whole-run pass that loaded EVERY file's
+            //    reconciled PIN features and stashed all of their frozen-model scores in one
+            //    Dictionary<(file, entry_id), double> (~3.8 GB at 82 files, #4486). The scoring
+            //    is per file by nature, so it now happens one file at a time inside ReadFile
+            //    below: same loader and identity key (LoadReconciledFeaturesByIdentity keyed by
+            //    (EntryId,Charge,ScanNumber)), same scores, one file's worth resident, and one
+            //    fewer pass over the reconciled parquets.
+            //
+            //    Distinct file keys are an INVARIANT here, asserted rather than assumed. Two
+            //    --input-scores paths in different directories can share a stem
+            //    (RescoreHydration.PreCompactionTallies is index-keyed for exactly that reason),
+            //    and every per-file structure on this path is name-keyed: a duplicate stem would
+            //    silently give one of the two the other's sidecar and leave its entries with a
+            //    mixture of refreshed and stale q-values. The same guard sits at the head of
+            //    PercolatorScorer.ScoreProjectionAndComputeFdrInPlace, for the same reason - a
+            //    bounded per-file pass cannot tolerate what a whole-run keyed map merged. This
+            //    hazard predates the per-file emit (sidecarByKey was already last-wins); the
+            //    assert is what makes it visible instead of silent (see #4486 review finding 4).
+            var entriesByFile = new Dictionary<string, List<FdrEntry>>(
+                perFileEntries.Count, StringComparer.Ordinal);
+            var survivorEntryIds = new HashSet<uint>();
+            long survivorObservations = 0;
+            foreach (var kvp in perFileEntries)
             {
-                long nDone = 0;
-                foreach (var kvp in perFileEntries)
+                if (entriesByFile.ContainsKey(kvp.Key))
                 {
-                    progress.Report(++nDone);
-                    if (!perFileParquetPaths.TryGetValue(kvp.Key, out string scoreParquetPath))
-                        continue;
-                    string effectiveParquetPath =
-                        ParquetScoreCache.EffectiveScoresPathFromScoresPath(scoreParquetPath);
-                    Dictionary<(uint, byte, uint), double[]> featByIdentity;
-                    try
-                    {
-                        featByIdentity = LoadReconciledFeaturesByIdentity(effectiveParquetPath);
-                    }
-                    catch (Exception ex)
-                    {
-                        ctx.LogWarning(string.Format(
-                            "{0}: failed to reload PIN features from {1}: {2}",
-                            mode, effectiveParquetPath, ex.Message));
-                        continue;
-                    }
-                    foreach (var e in kvp.Value)
-                    {
-                        if (featByIdentity.TryGetValue(
-                                (e.EntryId, e.Charge, e.ScanNumber), out double[] feats) &&
-                            feats != null && feats.Length == nFeatures)
-                        {
-                            survivorScore[(kvp.Key, e.EntryId)] = scorer.Score(feats);
-                        }
-                    }
-                    // featByIdentity released here (one file resident at a time).
+                    throw new InvalidOperationException(string.Format(
+                        @"{0}: duplicate per-file key '{1}'; the streamed per-file competition " +
+                        @"requires one entry list per file.",
+                        mode, kvp.Key));
                 }
+                entriesByFile[kvp.Key] = kvp.Value;
+                survivorObservations += kvp.Value.Count;
+                foreach (var e in kvp.Value)
+                    survivorEntryIds.Add(e.EntryId);
             }
 
-            // 2. Reported survivors to emit (every post-reconciliation entry) + per-file scalar
-            //    sidecar paths. Validate every sidecar up front so we fail fast (and fall back to
-            //    the retrain) before streaming any file.
-            var survivors = new List<(string, uint)>();
-            foreach (var kvp in perFileEntries)
-                foreach (var e in kvp.Value)
-                    survivors.Add((kvp.Key, e.EntryId));
-
+            // 2. Per-file scalar sidecar paths. Validate every sidecar up front so we fail fast
+            //    (and fall back to the retrain) before streaming any file.
             var fileKeys = new List<string>(perFileEntries.Count);
             // Pass-1 experiment q for the OFF-STRATUM peaks Stage 6 changed, read from the
             // sidecar because the post-rescore overlay already zeroed the in-memory value. Only
@@ -614,9 +597,9 @@ namespace pwiz.Osprey.Tasks
 
             ctx.LogInfo(string.Format(
                 "OSPREY_PASS2_QVALUE={0}: recomputing q/PEP by streaming {1} file(s), frozen-model " +
-                "scores swapped in for {2} reconciled survivors -- no retrain, one file resident at a " +
-                "time{3}.",
-                mode, fileKeys.Count, survivorScore.Count,
+                "scores swapped in for up to {2} reconciled survivor observations - no retrain, one " +
+                "file resident at a time{3}.",
+                mode, fileKeys.Count, survivorObservations,
                 proteinCompact ? ", competition CONSTRAINED to the " + stratumBaseIds.Count + "-base_id protein stratum"
                                : ", full-population null"));
 
@@ -676,30 +659,82 @@ namespace pwiz.Osprey.Tasks
                     OspreyEnvironment.PASS2_QVALUE_TRANSFER));
             }
 
-            // 3. Streamed full-population competition + run/experiment precursor q + PEP. Only one
-            //    file's scalars are resident at a time; the cross-file state is bounded by the
-            //    number of distinct precursors, not the total observation count -- so peak memory
-            //    is flat in file count (the 32/64 GB many-file target).
-            Dictionary<(string, uint), double> runQ, expQ, pep;
-            // The streaming competition reads one file's scalars per call and is otherwise silent;
-            // at 163 files that was a 9.6 min gap immediately after the line above announced it.
-            // readFileScalars is invoked exactly once per file (StreamingFdr.cs:180, single pass),
-            // so counting calls here is an honest per-file progress signal without threading a
-            // callback through the FDR layer.
+            // 3. Streamed full-population competition + run/experiment precursor q + PEP. One
+            //    file's features, scalars and run q are resident at a time; the cross-file state
+            //    is bounded by the number of distinct precursors and distinct survivor entry_ids,
+            //    so peak memory is flat in file count (the 32/64 GB many-file target). Run q is
+            //    written onto each file's entries as that file finishes; experiment q and PEP are
+            //    derived per entry afterwards from the bounded state this returns, so no
+            //    (file, entry_id)-keyed result map is ever built.
+            StreamingFdr.StreamedCompetitionState competition;
+            long nScored = 0;
+            // The streamed phase is otherwise silent; at 163 files that was a 9.6 min gap
+            // immediately after the line above announced it. ReadFile is invoked exactly once per
+            // file, so counting calls here is an honest per-file progress signal without threading
+            // a callback through the FDR layer. It now covers the frozen-model feature reload too
+            // (folded in below), which is the expensive half and used to have its own reporter.
             using (var progress = new ProgressReporter(
-                string.Format("{0}: reading per-file scalars for the streamed competition ({1} file(s))",
-                    mode, fileKeys.Count),
+                string.Format("{0}: streaming the competition over {1} file(s)", mode, fileKeys.Count),
                 fileKeys.Count, string.Empty, ProgressReporter.IO_INTERVAL_SECONDS))
             {
                 long nRead = 0;
 
-                (uint[] entryIds, double[] scores) ReadFile(string fileKey)
+                (uint[] entryIds, double[] scores, IReadOnlyDictionary<uint, double> survivorScores)
+                    ReadFile(string fileKey)
                 {
+                    // Frozen-model score for THIS file's reconciled survivors: load its PIN
+                    // features, score with the frozen 1st-pass weights, keep only the scalar
+                    // score, and release the features on the way out. Same loader and identity
+                    // key the resident reload used, so each survivor's score is byte-identical.
+                    var fileScores = new Dictionary<uint, double>();
+                    string effectiveParquetPath = ParquetScoreCache.EffectiveScoresPathFromScoresPath(
+                        perFileParquetPaths[fileKey]);
+                    try
+                    {
+                        var featByIdentity = LoadReconciledFeaturesByIdentity(effectiveParquetPath);
+                        foreach (var e in entriesByFile[fileKey])
+                        {
+                            if (featByIdentity.TryGetValue(
+                                    (e.EntryId, e.Charge, e.ScanNumber), out double[] feats) &&
+                                feats != null && feats.Length == nFeatures)
+                            {
+                                fileScores[e.EntryId] = scorer.Score(feats);
+                            }
+                        }
+                        // featByIdentity released here (one file resident at a time).
+                    }
+                    catch (Exception ex)
+                    {
+                        // Same disposition as the old whole-run pass: this file contributes no
+                        // swapped-in scores and competes on its stored 1st-pass ones.
+                        ctx.LogWarning(string.Format(
+                            "{0}: failed to reload PIN features from {1}: {2}",
+                            mode, effectiveParquetPath, ex.Message));
+                    }
+                    nScored += fileScores.Count;
+
                     FdrScoresSidecar.ReadScalars(sidecarByKey[fileKey], out uint[] eids, out double[] scs);
                     if (stratumBaseIds != null)
-                        StashOffStratumPass1ExperimentQ(fileKey, sidecarByKey[fileKey], eids, scs);
+                        StashOffStratumPass1ExperimentQ(fileKey, sidecarByKey[fileKey], eids, scs, fileScores);
                     progress.Report(++nRead);
-                    return (eids, scs);
+                    return (eids, scs, fileScores);
+                }
+
+                // Write this file's run q onto its entries while the map is still in hand, then
+                // let it go. Those entries are already resident (they are Stage 7's input), so
+                // this costs nothing, where holding every file's run q to the end of the run cost
+                // ~3.8 GB at 82 files. An entry absent from the map won no competition in this
+                // file and takes the 1.0 default the streamed form used to fill in centrally.
+                void ApplyFileRunQ(string fileKey, IReadOnlyDictionary<uint, double> fileRunQ)
+                {
+                    foreach (var e in entriesByFile[fileKey])
+                    {
+                        double rq = fileRunQ.TryGetValue(e.EntryId, out double v) ? v : 1.0;
+                        e.RunPrecursorQvalue = rq;
+                        // Precursor-level path: keep peptide q in step with precursor q for the
+                        // reported set (peptide-level FDR is not the target here).
+                        e.RunPeptideQvalue = rq;
+                    }
                 }
 
                 // Capture the pass-1 experiment q of the off-stratum peaks Stage 6 changed, so
@@ -707,13 +742,13 @@ namespace pwiz.Osprey.Tasks
                 // uses: the recomputed frozen-model score differs from the sidecar score. The
                 // set is small, and the second sidecar pass is skipped entirely when it is empty.
                 void StashOffStratumPass1ExperimentQ(string fileKey, string sidecarPath,
-                    uint[] eids, double[] scs)
+                    uint[] eids, double[] scs, IReadOnlyDictionary<uint, double> fileScores)
                 {
                     var wanted = new HashSet<uint>();
                     for (int i = 0; i < eids.Length; i++)
                     {
                         if (!stratumBaseIds.Contains(eids[i] & 0x7FFFFFFFu) &&
-                            survivorScore.TryGetValue((fileKey, eids[i]), out double ov) &&
+                            fileScores.TryGetValue(eids[i], out double ov) &&
                             ov != scs[i])
                             wanted.Add(eids[i]);
                     }
@@ -729,39 +764,32 @@ namespace pwiz.Osprey.Tasks
                     });
                 }
 
-                StreamingFdr.ComputeFullPopulationPrecursorFdrStreaming(
-                    fileKeys, ReadFile, survivorScore, survivors,
-                    out runQ, out expQ, out pep, stratumBaseIds);
+                competition = StreamingFdr.ComputeFullPopulationPrecursorFdrStreaming(
+                    fileKeys, ReadFile, survivorEntryIds, ApplyFileRunQ, stratumBaseIds);
             }
 
-            // 4. Map the recomputed q/PEP back onto the reported survivor entries. Under
-            //    protein-compact, an OFF-stratum survivor got q=1.0 from the (constrained)
-            //    competition -- skip it so it KEEPS its already-passing 1st-pass q rather
-            //    than being dropped (report = pass1 U stratum passers).
+            // 4. Finish each reported survivor from the bounded competition state, one file at a
+            //    time. Run q was written per file as the stream advanced, so what is left here is
+            //    experiment q and PEP - both derived per entry from O(distinct) maps instead of
+            //    read out of a whole-run (file, entry_id)-keyed result dictionary.
             int nMapped = 0;
             foreach (var kvp in perFileEntries)
                 foreach (var e in kvp.Value)
                 {
-                    var key = (kvp.Key, e.EntryId);
                     if (proteinCompact && !stratumBaseIds.Contains(e.EntryId & 0x7FFFFFFFu))
                     {
-                        // Off-stratum survivors keep their 1st-pass q (report = pass1 U stratum
-                        // passers). Only the RUN-level q of a peak Stage 6 changed is refreshed:
-                        // that peak competed above on its recalculated score, and leaving it on
-                        // the q=1 sentinel the overlay wrote would read as a confident rejection
-                        // rather than "not yet computed". An unchanged one never competed, so it
-                        // is absent from runQ and keeps everything.
+                        // Off-stratum survivors keep their 1st-pass EXPERIMENT q (report = pass1 U
+                        // stratum passers). That q is a pass-1 property anchored on the
+                        // best-scoring peak, and reconciliation corrects peaks TOWARD that anchor
+                        // rather than moving it, so a changed peak was not the one that set the
+                        // maximum and cannot become it. Carrying the pass-1 value is therefore
+                        // exact, and it is what keeps the re-scoping additive.
                         //
-                        // The EXPERIMENT q is never recomputed here. It is a pass-1 property
-                        // anchored on the best-scoring peak, and reconciliation corrects peaks
-                        // TOWARD that anchor rather than moving it, so a changed peak was not the
-                        // one that set the maximum and cannot become it. Carrying the pass-1
-                        // value is therefore exact, and it is what keeps the re-scoping additive.
-                        if (!runQ.TryGetValue(key, out double rqOff))
-                            continue;
-                        e.RunPrecursorQvalue = rqOff;
-                        e.RunPeptideQvalue = rqOff;
-                        if (pass1ExpQByKey.TryGetValue(key, out var q1))
+                        // Their RUN q was refreshed with everyone else's: a peak Stage 6 changed
+                        // competed above on its recalculated score, and one that did not compete
+                        // takes the 1.0 that says so, rather than a stale q describing a peak that
+                        // no longer exists (the post-rescore overlay zeroes it for that reason).
+                        if (pass1ExpQByKey.TryGetValue((kvp.Key, e.EntryId), out var q1))
                         {
                             e.ExperimentPrecursorQvalue = q1.prec;
                             e.ExperimentPeptideQvalue = q1.pep;
@@ -769,20 +797,18 @@ namespace pwiz.Osprey.Tasks
                         nMapped++;
                         continue;
                     }
-                    if (!runQ.TryGetValue(key, out double rq))
-                        continue;
-                    e.RunPrecursorQvalue = rq;
-                    e.ExperimentPrecursorQvalue = expQ[key];
-                    e.Pep = pep[key];
+                    double eq = competition.ExperimentQ(e.EntryId, e.RunPrecursorQvalue);
+                    e.ExperimentPrecursorQvalue = eq;
                     // Precursor-level path: keep peptide q in step with precursor q for the
                     // reported set (peptide-level FDR is not the target here).
-                    e.RunPeptideQvalue = rq;
-                    e.ExperimentPeptideQvalue = expQ[key];
+                    e.ExperimentPeptideQvalue = eq;
+                    e.Pep = competition.Pep(kvp.Key, e.EntryId);
                     nMapped++;
                 }
             ctx.LogInfo(string.Format(
-                "{0}: mapped recomputed q onto {1} reported survivors in {2:F1}s.",
-                mode, nMapped, sw.Elapsed.TotalSeconds));
+                "{0}: mapped recomputed q onto {1} reported survivors ({2} frozen-model scores " +
+                "swapped in) in {3:F1}s.",
+                mode, nMapped, nScored, sw.Elapsed.TotalSeconds));
             return true;
         }
 

--- a/pwiz_tools/Osprey/Osprey.Tasks/PerFileRescoreTask.cs
+++ b/pwiz_tools/Osprey/Osprey.Tasks/PerFileRescoreTask.cs
@@ -486,7 +486,30 @@ namespace pwiz.Osprey.Tasks
                 // Runs unconditionally (not gated on --protein-fdr), matching Rust where
                 // first-pass protein FDR is gated only on !can_skip_fdr || expect_reconciled_input
                 // (pipeline.rs:4529). Mirrors Rust pipeline.rs:4292-4358.
-                if (bundle.PerFileEntries.Count > 0)
+                //
+                // SKIPPED when the bundle arrives ALREADY COMPACTED (#4486). The streaming
+                // hydrate compacts each file as it loads - RescoreHydration's
+                // stubs.RemoveAll(...) runs before perFileEntries.Add(...) - so on that path
+                // "BEFORE compaction" above is no longer true and this call would recompute
+                // over survivors only. That is not a smaller sample of the same thing: the
+                // target side is q-gated (ProteinFdr.RunFirstPass) while the decoy side is
+                // deliberately NOT, because the decoys ARE the null. Compaction retains only
+                // passing base_ids, so the null loses most of its members and every
+                // propagated protein q comes out anti-conservatively LOW.
+                //
+                // Skipping is not a loss of information. OverlayFirstPassSidecar has already
+                // written RunProteinQvalue onto every stub from the 1st-pass sidecar
+                // (FdrScoresSidecar offset 52), and that is the value the straight-through
+                // pipeline itself computed pre-compaction - i.e. exactly what this recompute
+                // exists to reproduce. What is given up is only Rust's inline re-derivation
+                // absorbing ULP-level drift in the post-rehydration inputs; a
+                // straight-through-consistent value beats a wrong-population one.
+                //
+                // PreCompactionTallies is the same "was this pre-compacted" signal
+                // RescoreCompaction.Apply keys its own invariant on, so the two cannot
+                // disagree about which path they are on.
+                bool preCompacted = bundle.PreCompactionTallies != null;
+                if (bundle.PerFileEntries.Count > 0 && !preCompacted)
                 {
                     var fullLibrary = ctx.Get<FullLibrary>().Value;
                     // Silent (logInfo: null) -- the rehydration recompute runs
@@ -496,9 +519,19 @@ namespace pwiz.Osprey.Tasks
                         bundle.PerFileEntries, fullLibrary, ctx.Config, null);
                 }
                 var stats = RescoreCompaction.Apply(bundle);
+                // On the streaming hydrate stats.EntriesBefore EQUALS EntriesAfter by
+                // construction - RescoreCompaction sums an already-compacted pool and makes
+                // "removes nothing" a hard invariant - so reporting it raw prints
+                // "N -> N entries" where ~350 M stubs were actually reduced, which is
+                // indistinguishable from a broken retain set. TotalPreCompactionStubs is the
+                // real figure on that path, and FirstPassFdrTask reads it for the same
+                // reason (#4486).
+                long entriesBefore = preCompacted
+                    ? bundle.TotalPreCompactionStubs
+                    : stats.EntriesBefore;
                 ctx.LogInfo(string.Format(
                     @"--task SecondPassFDR compaction: {0} -> {1} entries ({2} passing base_ids; {3} action(s) dropped)",
-                    stats.EntriesBefore, stats.EntriesAfter,
+                    entriesBefore, stats.EntriesAfter,
                     stats.FirstPassBaseIds, stats.DroppedActions));
             }
             return true;

--- a/pwiz_tools/Osprey/Osprey.Tasks/PerFileRescoreTask.cs
+++ b/pwiz_tools/Osprey/Osprey.Tasks/PerFileRescoreTask.cs
@@ -491,19 +491,32 @@ namespace pwiz.Osprey.Tasks
                 // hydrate compacts each file as it loads - RescoreHydration's
                 // stubs.RemoveAll(...) runs before perFileEntries.Add(...) - so on that path
                 // "BEFORE compaction" above is no longer true and this call would recompute
-                // over survivors only. That is not a smaller sample of the same thing: the
-                // target side is q-gated (ProteinFdr.RunFirstPass) while the decoy side is
-                // deliberately NOT, because the decoys ARE the null. Compaction retains only
-                // passing base_ids, so the null loses most of its members and every
-                // propagated protein q comes out anti-conservatively LOW.
+                // over survivors only.
                 //
-                // Skipping is not a loss of information. OverlayFirstPassSidecar has already
-                // written RunProteinQvalue onto every stub from the 1st-pass sidecar
-                // (FdrScoresSidecar offset 52), and that is the value the straight-through
-                // pipeline itself computed pre-compaction - i.e. exactly what this recompute
-                // exists to reproduce. What is given up is only Rust's inline re-derivation
-                // absorbing ULP-level drift in the post-rehydration inputs; a
-                // straight-through-consistent value beats a wrong-population one.
+                // The reason to skip is the SHAPE of that subset, not a measured defect. The
+                // retained set is driven by which TARGETS passed, and a target and its paired
+                // decoy share a base_id, so retaining a base_id retains both. That drops the
+                // high-scoring decoys whose own targets did not pass - precisely the ones that
+                // would compete near the threshold - which biases any FDR recomputed on the
+                // survivors OPTIMISTIC. Subsetting without that bias needs a composite-score
+                // cutoff admitting targets AND decoys above it plus their pairs, which this
+                // pool is not. So do not run an FDR over it.
+                //
+                // Two things this comment previously asserted are MEASURED FALSE (#4486), and
+                // must not be restored:
+                //   * That recomputing here over the compacted pool drives protein q
+                //     anti-conservatively low. A/B on StellarGenDecoyEntrap: recompute over the
+                //     compacted pool vs over the uncompacted pool is BYTE-IDENTICAL across all
+                //     260,419 records. This statistic is insensitive to the bias above (its
+                //     decoy side comes from q-gated detected peptides either way), so the skip
+                //     is a conservative choice, not a bug fix. It moves 740 records (0.28%)
+                //     upward and changes no output.
+                //   * That the 1st-pass sidecar's RunProteinQvalue is "what the straight-through
+                //     pipeline computed". It is not: the join node's value differs from
+                //     straight-through for 12.46% of records (1.57% at 82 files), always lower.
+                //     That divergence is PRE-EXISTING - master's routing differs by 12.74% - and
+                //     is tracked separately in #4553, which also covers the regression.ps1 gap
+                //     that lets it pass green (mode 3 compares the blib, never these sidecars).
                 //
                 // PreCompactionTallies is the same "was this pre-compacted" signal
                 // RescoreCompaction.Apply keys its own invariant on, so the two cannot

--- a/pwiz_tools/Osprey/Osprey.Tasks/PerFileScoringTask.cs
+++ b/pwiz_tools/Osprey/Osprey.Tasks/PerFileScoringTask.cs
@@ -643,8 +643,6 @@ namespace pwiz.Osprey.Tasks
             // rehydrate now feeds that accumulator from the per-file load it already performs
             // (FirstPassFdrTask.StreamOwnReconciliationBundle), off the same PRE-compaction rows,
             // so the report emits from this lean load at any file count.
-            bool needsResidentPool = NeedsResidentPool(config);
-            GuardResidentPool(config, needsResidentPool);
             FdrProjectionSet projections = null;
 
             var swAllFiles = Stopwatch.StartNew();
@@ -660,10 +658,20 @@ namespace pwiz.Osprey.Tasks
             // (Run routes InputScores runs away from Rehydrate), but re-deriving the rule at
             // one call site and importing it at the other is precisely the drift this change
             // exists to remove. hasReconSidecars is false here: this path has no bundle.
+            // ARM THE GUARD ON THE SAME DECISION, for the reason the branch below states: the
+            // fat path IS the resident pool here, so guarding on a separate NeedsResidentPool
+            // let a config with needsResidentPool false but builder null (ExpectReconciledInput)
+            // take the O(files) fat load with the guard disarmed and no warning. Two predicates
+            // that can disagree about one choice is the drift this change removes; the guard is
+            // the third reader of that choice and has to key off it too. Placed inside the
+            // InputFiles block because with no input files nothing loads and a guard here would
+            // only produce a false positive.
             var builder = CanUseLeanProjection(config, hasReconSidecars: false,
                                                OspreyEnvironment.UseFdrProjection)
                 ? new FdrProjectionSet.Builder(countsOnly: true)
                 : null;
+                GuardResidentPool(config, needsResidentPool: builder == null);
+
                 // Per-file progress so this all-files load is not a silent multi-minute
                 // stall on a large resume (the phase that looked hung on the 82-file run).
                 using (var loadProgress = new ProgressReporter(@"Loading scored entries", config.InputFiles.Count))
@@ -1253,6 +1261,18 @@ namespace pwiz.Osprey.Tasks
             // The reconciled-bundle hydration (hasReconSidecars) needs the STUBS but not
             // their PIN features, so only a genuine resident pool loads features. See the
             // stubs-only branch below for why that is safe.
+            //
+            // This one KEEPS NeedsResidentPool deliberately, where the fat/lean choice above
+            // moved to the builder. They answer different questions and the predicates diverged
+            // when ExpectReconciledInput left NeedsResidentPool (#4486): "does a consumer read
+            // Features off THESE stubs" (fdrbench-pass1, a non-Percolator FdrMethod,
+            // OSPREY_FDR_PROJECTION=0) is still exactly NeedsResidentPool, while "may this load
+            // go lean" additionally excludes the reconciled-input merge. Do not "fix" this by
+            // copying the builder decision: the merge does not read Features off these stubs -
+            // both pass-2 shapes reload them per file from the reconciled parquet
+            // (ComputePass2TransferCompeteFull's own read, or ComputePass2Resident's), and
+            // EffectiveScoresPathFromScoresPath falls back to the original parquet when no
+            // reconciled one exists, so the reload does not depend on hasReconSidecars either.
             bool loadFeatures = needsResidentPool;
 
             // The --input-files paths at :381 and :644 THROW on the same O(files) situation.
@@ -1292,41 +1312,10 @@ namespace pwiz.Osprey.Tasks
                 // projection path uses, one file at a time, so FirstPassFDR's rehydrate can emit
                 // the identical report without the O(files) resident pool. Null (nothing
                 // constructed, nothing folded) off the report path.
-                // Built only when its READER will run in this process (#4486). The one
-                // reader/nuller pair is FirstPassFdrTask's rehydrate, and on
-                // --task SecondPassFDR that task is excluded - which this branch newly
-                // reaches, since before #4486 the merge never streamed. Building it there
-                // folds every pre-compaction row of every file into an accumulator nothing
-                // will ever read, and nothing will ever null: it travels on a published
-                // byproduct slot that lives for the whole process, so it would pin the
-                // ~1-2 GB FirstPassFdrTask documents straight through Stage 7 - on the exact
-                // node this streaming change exists to shrink.
-                bool mdiagHasReader = config.ModelDiagnostics &&
-                                      FirstPassFdrTask.IsIncludedFor(config);
-                // Guarded like the sibling call in FirstPassFdrTask: reading the decoy-pairing
-                // manifest can throw (IO, OOM), and an opt-in HTML report must not take the
-                // search down with it. Here it would kill the run for a report that cannot
-                // even be written.
-                ModelDiagnosticsData.Accumulator mdiagAccumulator = null;
-                if (mdiagHasReader)
-                {
-                    try
-                    {
-                        mdiagAccumulator = FirstPassFdrTask.BuildModelDiagnosticsAccumulator(
-                            JoinOnlyFileNames(config), _libraryById, config, ctx.LogInfo);
-                    }
-                    catch (Exception ex)
-                    {
-                        ctx.LogWarning(string.Format(
-                            @"--model-diagnostics: could not build the pass-1 report accumulator ({0}); the report will be omitted.",
-                            ex.Message));
-                    }
-                }
-                else if (config.ModelDiagnostics)
-                {
-                    ctx.LogInfo(
-                        @"--model-diagnostics: no pass-1 report on this node (FirstPassFDR does not run here); skipping its accumulator.");
-                }
+                var mdiagAccumulator = config.ModelDiagnostics
+                    ? FirstPassFdrTask.BuildModelDiagnosticsAccumulator(
+                        JoinOnlyFileNames(config), _libraryById, config, ctx.LogInfo)
+                    : null;
                 // Same graceful handling as the batch twin in HydrateRescoreBundleIfPresent:
                 // a corrupt or mismatched sidecar is an operator-facing error line and a
                 // non-zero exit code, not an unhandled stack trace.
@@ -1338,16 +1327,7 @@ namespace pwiz.Osprey.Tasks
                             perFileCalibrations, perFileIsolationMz, ctx),
                         (fileIdx, fileName, stubs, tally) =>
                         {
-                            // PassingTargets has the same single reader as the accumulator
-                            // above - FirstPassFdrTask's per-file Stage 5 result line - so on
-                            // a node where that task is excluded this evaluates
-                            // EffectiveRunQvalue <= RunFdr for every stub (~4.2 M per file,
-                            // ~344 M at 82 files) to fill a field nothing reads, touching each
-                            // file's pool a second time while it is the resident working set
-                            // (#4486). tally.Stubs is set by the hydrate itself, so the count
-                            // the compaction line reports is unaffected.
-                            if (mdiagHasReader || FirstPassFdrTask.IsIncludedFor(config))
-                                ScoringTaskShared.TallyPreCompaction(config, stubs, tally);
+                            ScoringTaskShared.TallyPreCompaction(config, stubs, tally);
                             if (mdiagAccumulator != null)
                                 ScoringTaskShared.FeedModelDiagnostics(mdiagAccumulator, fileIdx, stubs);
                         }), ctx);

--- a/pwiz_tools/Osprey/Osprey.Tasks/PerFileScoringTask.cs
+++ b/pwiz_tools/Osprey/Osprey.Tasks/PerFileScoringTask.cs
@@ -1231,7 +1231,7 @@ namespace pwiz.Osprey.Tasks
             // only per-file row counts; the 1st-pass streaming score path re-reads identity +
             // features from parquet, so the resident FdrProjection[] buffer is never allocated.
             bool needsResidentPool = NeedsResidentPool(config);
-            var builder = (!needsResidentPool && !hasReconSidecars)
+            var builder = CanUseLeanProjection(config, hasReconSidecars, OspreyEnvironment.UseFdrProjection)
                 ? new FdrProjectionSet.Builder(countsOnly: true)
                 : null;
             // The reconciled-bundle hydration (hasReconSidecars) needs the STUBS but not
@@ -1860,6 +1860,33 @@ namespace pwiz.Osprey.Tasks
             return !useFdrProjection ||
                    !config.FdrMethod.UsesPercolatorFramework() ||
                    (!string.IsNullOrEmpty(config.OutputFdrBench) && config.FdrBenchPass == 1);
+        }
+
+        /// <summary>
+        /// Whether the <c>--input-scores</c> load may take the LEAN counts-only
+        /// <see cref="FdrProjection"/> path, which streams 32 B rows and adds an EMPTY
+        /// <see cref="FdrEntry"/> list per file. Two consumers need real stubs and so exclude it:
+        /// a reconciled bundle (<paramref name="hasReconSidecars"/>), whose overlay reads them,
+        /// and the reconciled-input merge, whose Stage 7 IS the consumer of the entry lists.
+        ///
+        /// <para>The <c>ExpectReconciledInput</c> term looks redundant with
+        /// <paramref name="hasReconSidecars"/> - a <c>--task SecondPassFDR</c> node normally has
+        /// both sidecars per input - and it is not. <see cref="AllHaveReconSidecars"/> is false if
+        /// even ONE input is missing a <c>.reconciliation.json</c>, e.g. a partially copied HPC
+        /// chain. Before #4486 that case was covered accidentally, because
+        /// <see cref="NeedsResidentPool(OspreyConfig, bool)"/> returned true for the merge and
+        /// suppressed the lean path; taking <c>ExpectReconciledInput</c> out of it made the lean
+        /// newly reachable there, and it would have handed Stage 7 empty per-file lists - a
+        /// near-empty <c>.blib</c>, written with no error. Stated explicitly here so the
+        /// exclusion survives on its own reasoning rather than as a side effect of another
+        /// predicate.</para>
+        /// </summary>
+        internal static bool CanUseLeanProjection(
+            OspreyConfig config, bool hasReconSidecars, bool useFdrProjection)
+        {
+            return !NeedsResidentPool(config, useFdrProjection)
+                   && !hasReconSidecars
+                   && !config.ExpectReconciledInput;
         }
 
         /// <summary>

--- a/pwiz_tools/Osprey/Osprey.Tasks/PerFileScoringTask.cs
+++ b/pwiz_tools/Osprey/Osprey.Tasks/PerFileScoringTask.cs
@@ -1291,10 +1291,41 @@ namespace pwiz.Osprey.Tasks
                 // projection path uses, one file at a time, so FirstPassFDR's rehydrate can emit
                 // the identical report without the O(files) resident pool. Null (nothing
                 // constructed, nothing folded) off the report path.
-                var mdiagAccumulator = config.ModelDiagnostics
-                    ? FirstPassFdrTask.BuildModelDiagnosticsAccumulator(
-                        JoinOnlyFileNames(config), _libraryById, config, ctx.LogInfo)
-                    : null;
+                // Built only when its READER will run in this process (#4486). The one
+                // reader/nuller pair is FirstPassFdrTask's rehydrate, and on
+                // --task SecondPassFDR that task is excluded - which this branch newly
+                // reaches, since before #4486 the merge never streamed. Building it there
+                // folds every pre-compaction row of every file into an accumulator nothing
+                // will ever read, and nothing will ever null: it travels on a published
+                // byproduct slot that lives for the whole process, so it would pin the
+                // ~1-2 GB FirstPassFdrTask documents straight through Stage 7 - on the exact
+                // node this streaming change exists to shrink.
+                bool mdiagHasReader = config.ModelDiagnostics &&
+                                      FirstPassFdrTask.IsIncludedFor(config);
+                // Guarded like the sibling call in FirstPassFdrTask: reading the decoy-pairing
+                // manifest can throw (IO, OOM), and an opt-in HTML report must not take the
+                // search down with it. Here it would kill the run for a report that cannot
+                // even be written.
+                ModelDiagnosticsData.Accumulator mdiagAccumulator = null;
+                if (mdiagHasReader)
+                {
+                    try
+                    {
+                        mdiagAccumulator = FirstPassFdrTask.BuildModelDiagnosticsAccumulator(
+                            JoinOnlyFileNames(config), _libraryById, config, ctx.LogInfo);
+                    }
+                    catch (Exception ex)
+                    {
+                        ctx.LogWarning(string.Format(
+                            @"--model-diagnostics: could not build the pass-1 report accumulator ({0}); the report will be omitted.",
+                            ex.Message));
+                    }
+                }
+                else if (config.ModelDiagnostics)
+                {
+                    ctx.LogInfo(
+                        @"--model-diagnostics: no pass-1 report on this node (FirstPassFDR does not run here); skipping its accumulator.");
+                }
                 // Same graceful handling as the batch twin in HydrateRescoreBundleIfPresent:
                 // a corrupt or mismatched sidecar is an operator-facing error line and a
                 // non-zero exit code, not an unhandled stack trace.

--- a/pwiz_tools/Osprey/Osprey.Tasks/PerFileScoringTask.cs
+++ b/pwiz_tools/Osprey/Osprey.Tasks/PerFileScoringTask.cs
@@ -1337,7 +1337,16 @@ namespace pwiz.Osprey.Tasks
                             perFileCalibrations, perFileIsolationMz, ctx),
                         (fileIdx, fileName, stubs, tally) =>
                         {
-                            ScoringTaskShared.TallyPreCompaction(config, stubs, tally);
+                            // PassingTargets has the same single reader as the accumulator
+                            // above - FirstPassFdrTask's per-file Stage 5 result line - so on
+                            // a node where that task is excluded this evaluates
+                            // EffectiveRunQvalue <= RunFdr for every stub (~4.2 M per file,
+                            // ~344 M at 82 files) to fill a field nothing reads, touching each
+                            // file's pool a second time while it is the resident working set
+                            // (#4486). tally.Stubs is set by the hydrate itself, so the count
+                            // the compaction line reports is unaffected.
+                            if (mdiagHasReader || FirstPassFdrTask.IsIncludedFor(config))
+                                ScoringTaskShared.TallyPreCompaction(config, stubs, tally);
                             if (mdiagAccumulator != null)
                                 ScoringTaskShared.FeedModelDiagnostics(mdiagAccumulator, fileIdx, stubs);
                         }), ctx);

--- a/pwiz_tools/Osprey/Osprey.Tasks/PerFileScoringTask.cs
+++ b/pwiz_tools/Osprey/Osprey.Tasks/PerFileScoringTask.cs
@@ -1466,8 +1466,6 @@ namespace pwiz.Osprey.Tasks
         private static string PreCompactionPoolReason(
             OspreyConfig config, bool hasReconSidecars, PipelineContext ctx)
         {
-            if (config.ExpectReconciledInput)
-                return @"The reconciled-input merge (--task SecondPassFDR, tracked in #4486)";
             if (ctx.Diagnostics?.DumpPercolator ?? false)
                 return @"OSPREY_DUMP_PERCOLATOR";
             if (!string.IsNullOrEmpty(config.OutputFdrBench) && config.FdrBenchPass == 1)
@@ -1485,8 +1483,15 @@ namespace pwiz.Osprey.Tasks
             // survivors the streaming hydrate would leave. Unconditional on
             // hasReconSidecars: every reason above is a resident-pool consumer and returns
             // first, so reaching here means none of them applies.
-            if (!config.NoJoin)
-                return @"A reconciled-bundle rehydrate outside the streaming gate";
+            //
+            // Ask the task's own membership predicate rather than the former `!NoJoin` proxy
+            // (#4486). The two agree on every task but --task SecondPassFDR, which leaves
+            // NoJoin false while setting ExpectReconciledInput: FirstPassFdrTask is excluded
+            // there, so nothing trains, and the proxy was forcing an O(files) resident pool
+            // for a consumer that does not exist. Re-deriving membership here is what let
+            // them drift, so this defers to the one definition.
+            if (FirstPassFdrTask.IsIncludedFor(config))
+                return @"First-pass Percolator training in this process";
             // No bundle at all. The reconciliation envelope is what carries the compaction
             // predicate, so without it there is nothing to compact against at load time and
             // streaming cannot run. Last because every reason above names a real consumer,
@@ -1844,8 +1849,15 @@ namespace pwiz.Osprey.Tasks
         /// </summary>
         internal static bool NeedsResidentPool(OspreyConfig config, bool useFdrProjection)
         {
-            return config.ExpectReconciledInput ||
-                   !useFdrProjection ||
+            // ExpectReconciledInput (--task SecondPassFDR) was the first entry here and is
+            // GONE (#4486). It never named a consumer: FirstPassFdrTask is excluded on that
+            // node so nothing trains, and every pass-2 consumer streams from disk one file at
+            // a time - the frozen transfer-compete / protein-compact competition off each
+            // file's .1st-pass.fdr_scores.bin scalars, the feature reload off each file's
+            // reconciled parquet. It forced the fat load whose features
+            // HydrateRescoreBundleIfPresent then nulls unread, so the node paid ~800 MB per
+            // file to throw it away, on top of holding every file's pre-compaction stubs.
+            return !useFdrProjection ||
                    !config.FdrMethod.UsesPercolatorFramework() ||
                    (!string.IsNullOrEmpty(config.OutputFdrBench) && config.FdrBenchPass == 1);
         }
@@ -1998,8 +2010,9 @@ namespace pwiz.Osprey.Tasks
         {
             if (!useFdrProjection)
                 return ResidentPaths.PROJECTION_OFF;
-            if (config.ExpectReconciledInput)
-                return ResidentPaths.HPC_MERGE;
+            // ExpectReconciledInput -> HPC_MERGE was here and is GONE with the token (#4486):
+            // --task SecondPassFDR now streams its load, so it never reaches this method at
+            // all. See NeedsResidentPool for why nothing on that node reads the pool.
             if (!config.FdrMethod.UsesPercolatorFramework())
                 return ResidentPaths.NON_PERCOLATOR_FDR;
             if (!string.IsNullOrEmpty(config.OutputFdrBench) && config.FdrBenchPass == 1)

--- a/pwiz_tools/Osprey/Osprey.Tasks/PerFileScoringTask.cs
+++ b/pwiz_tools/Osprey/Osprey.Tasks/PerFileScoringTask.cs
@@ -653,7 +653,17 @@ namespace pwiz.Osprey.Tasks
                 // Counts-only (issue #4355 struct-shrink S3, Stage B): the resume lean path builds
                 // only per-file row counts; the 1st-pass streaming score path re-reads identity +
                 // features from parquet, so no resident FdrProjection[] buffer is allocated.
-                var builder = needsResidentPool ? null : new FdrProjectionSet.Builder(countsOnly: true);
+                // Same predicate as the --input-scores loader, not a re-derivation of it (#4486).
+            // This site gated on bare NeedsResidentPool, which no longer excludes
+            // ExpectReconciledInput, so an ExpectReconciledInput config arriving here would
+            // take the lean branch and add an EMPTY entry list per file. Not reachable today
+            // (Run routes InputScores runs away from Rehydrate), but re-deriving the rule at
+            // one call site and importing it at the other is precisely the drift this change
+            // exists to remove. hasReconSidecars is false here: this path has no bundle.
+            var builder = CanUseLeanProjection(config, hasReconSidecars: false,
+                                               OspreyEnvironment.UseFdrProjection)
+                ? new FdrProjectionSet.Builder(countsOnly: true)
+                : null;
                 // Per-file progress so this all-files load is not a silent multi-minute
                 // stall on a large resume (the phase that looked hung on the 82-file run).
                 using (var loadProgress = new ProgressReporter(@"Loading scored entries", config.InputFiles.Count))
@@ -665,7 +675,13 @@ namespace pwiz.Osprey.Tasks
                     {
                         string fileName = Path.GetFileNameWithoutExtension(inputFile);
                         string scoresPath = ParquetScoreCache.GetScoresPath(inputFile);
-                        if (needsResidentPool)
+                        // Branch on the BUILDER, not on needsResidentPool. The two used to be
+                        // exact complements here; CanUseLeanProjection has a third term, so a
+                        // config with needsResidentPool false that still may not go lean
+                        // (ExpectReconciledInput) would otherwise take the lean branch with a
+                        // null builder and throw. Keying both off one value is what makes the
+                        // fat/lean choice a single decision rather than two that can disagree.
+                        if (builder == null)
                         {
                             // Fat path: an opt-in output reads every entry's resident
                             // features. Strict load: CanRehydrate already certified these
@@ -1248,7 +1264,16 @@ namespace pwiz.Osprey.Tasks
             // all three. Warn with the consumer named instead, so an operator who meets the
             // O(files) peak at scale knows which knob put them on it. When the streaming
             // hydrate below takes the load the pool is bounded and there is nothing to say.
-            if (needsResidentPool || (hasReconSidecars && !streamCompaction))
+            // Warn on exactly the condition that SELECTS the resident loop below, rather than
+            // on a hand-listed set of configs that can drift from it (#4486). The old test
+            // was `needsResidentPool || (hasReconSidecars && !streamCompaction)`, and the new
+            // CanUseLeanProjection term opened a case it does not cover: a reconciled-input
+            // merge whose inputs are missing a .reconciliation.json takes the resident loop
+            // with needsResidentPool false, hasReconSidecars false and streamCompaction
+            // false, so every term was false and the O(files) load happened SILENTLY. The
+            // resident loop runs iff it neither streams nor takes the lean builder, so that
+            // is what this asks.
+            if (!streamCompaction && builder == null)
                 WarnPreCompactionPool(config, hasReconSidecars, ctx);
 
             // Bounded reconciled-bundle rehydrate: hand the per-file stub load to the
@@ -1402,13 +1427,14 @@ namespace pwiz.Osprey.Tasks
         /// 2. Nothing in the run reads the PRE-compaction pool
         ///    (<see cref="PreCompactionPoolReason"/> finds no consumer).
         ///
-        /// Term 2 folds in what used to be a separate <c>NoJoin</c> condition: FirstPassFDR must
+        /// Term 2 asks <see cref="FirstPassFdrTask.IsIncludedFor"/> directly: FirstPassFDR must
         /// be EXCLUDED from this pipeline and reachable only through its bundle-adopt
         /// Rehydrate, because a FirstPassFDR that Ran would train first-pass Percolator on
         /// whatever <c>ScoredEntries</c> holds - which must be the full pre-compaction pool.
-        /// With <c>InputScores</c> set and <c>StopAfterStage5</c> false, <c>NoJoin</c> is
-        /// exactly FirstPassFDR's exclusion condition, so a reconciled bundle WITHOUT it is one
-        /// of the reasons the helper reports.
+        /// It used to test <c>!NoJoin</c> as a stand-in for that, which was right for every
+        /// task except <c>--task SecondPassFDR</c> - NoJoin false, ExpectReconciledInput true,
+        /// FirstPassFdrTask excluded - so the proxy forced an O(files) resident pool for a
+        /// consumer that does not exist (#4486).
         ///
         /// What the resident-pool terms still filter that <c>NoJoin</c> does not: the
         /// OSPREY_DUMP_PERCOLATOR bisection dump (emitted by FirstPassFDR's rehydrate before it
@@ -1416,10 +1442,9 @@ namespace pwiz.Osprey.Tasks
         /// silently post-compaction one), OSPREY_FDR_PROJECTION=0, a non-Percolator
         /// FdrMethod, and --fdrbench-pass 1. OSPREY_PASS2_QVALUE=transfer is NOT among them:
         /// the per-run-only redesign (#4438) resolves each adjusted peak against that file's
-        /// own on-disk sidecar. The
-        /// --task SecondPassFDR is NOT among them: it sets ExpectReconciledInput, which
-        /// <c>--task</c> selection makes mutually exclusive with <c>NoJoin</c>, so term 2's
-        /// NoJoin clause already excludes it.
+        /// own on-disk sidecar. <c>--task SecondPassFDR</c> is not among them either, and
+        /// since #4486 that is the point rather than an aside: it is the one task that
+        /// reaches here with FirstPassFdrTask excluded, so it STREAMS.
         ///
         /// --model-diagnostics needs no exclusion at all any more. It needs the same
         /// pre-compaction rows, but it consumes them one at a time:
@@ -1666,8 +1691,10 @@ namespace pwiz.Osprey.Tasks
                 // Already hydrated when the loader took the file-count-bounded streaming
                 // path (ShouldStreamCompaction): it has to own the hydrate, because the
                 // sidecar overlay and the compaction have to happen inside its per-file
-                // loop for the pre-compaction pool to stay one-file-at-a-time. The tail
-                // below (feature null-out + the summary line) is shared by both paths.
+                // loop for the pre-compaction pool to stay one-file-at-a-time. The summary
+                // line below is shared by both paths; the feature null-out is NOT - see
+                // where it is guarded.
+                bool streamed = _rescoreInputs != null;
                 if (_rescoreInputs == null)
                 {
                     _rescoreInputs = HydrateRescoreBundleOrNull(
@@ -1686,9 +1713,20 @@ namespace pwiz.Osprey.Tasks
                 // Bundle path doesn't need PIN features downstream:
                 // FirstPassFdrTask skips Percolator on this path, so the
                 // SVM training input is irrelevant.
-                foreach (var kvp in perFileEntries)
-                    foreach (var entry in kvp.Value)
-                        entry.Features = null;
+                // Skipped on the streaming arm, where it is provably a no-op (#4486):
+                // LoadJoinOnlyScoresForFile never loads features and OverlayFirstPassSidecar
+                // writes only scores / q-values, so Features is already null on every entry.
+                // It is not free to run anyway - FirstPassFdrTask guards the identical loop
+                // for the same reason, at "~88.9 M reference writes at 163 files, each
+                // tripping the GC write barrier and dirtying the card table over the whole
+                // survivor buffer" - and here it would run immediately before Stage 7 adopts
+                // that buffer and the stage7-inherited probe tries to measure it.
+                if (!streamed)
+                {
+                    foreach (var kvp in perFileEntries)
+                        foreach (var entry in kvp.Value)
+                            entry.Features = null;
+                }
                 ctx.LogInfo(string.Format(
                     @"Hydrated rescore bundle for {0} file(s) ({1} reconciliation actions, " +
                     @"{2} refined RT calibration(s), {3} gap-fill target(s))",

--- a/pwiz_tools/Osprey/Osprey.Tasks/PerFileScoringTask.cs
+++ b/pwiz_tools/Osprey/Osprey.Tasks/PerFileScoringTask.cs
@@ -652,24 +652,24 @@ namespace pwiz.Osprey.Tasks
                 // only per-file row counts; the 1st-pass streaming score path re-reads identity +
                 // features from parquet, so no resident FdrProjection[] buffer is allocated.
                 // Same predicate as the --input-scores loader, not a re-derivation of it (#4486).
-            // This site gated on bare NeedsResidentPool, which no longer excludes
-            // ExpectReconciledInput, so an ExpectReconciledInput config arriving here would
-            // take the lean branch and add an EMPTY entry list per file. Not reachable today
-            // (Run routes InputScores runs away from Rehydrate), but re-deriving the rule at
-            // one call site and importing it at the other is precisely the drift this change
-            // exists to remove. hasReconSidecars is false here: this path has no bundle.
-            // ARM THE GUARD ON THE SAME DECISION, for the reason the branch below states: the
-            // fat path IS the resident pool here, so guarding on a separate NeedsResidentPool
-            // let a config with needsResidentPool false but builder null (ExpectReconciledInput)
-            // take the O(files) fat load with the guard disarmed and no warning. Two predicates
-            // that can disagree about one choice is the drift this change removes; the guard is
-            // the third reader of that choice and has to key off it too. Placed inside the
-            // InputFiles block because with no input files nothing loads and a guard here would
-            // only produce a false positive.
-            var builder = CanUseLeanProjection(config, hasReconSidecars: false,
-                                               OspreyEnvironment.UseFdrProjection)
-                ? new FdrProjectionSet.Builder(countsOnly: true)
-                : null;
+                // This site gated on bare NeedsResidentPool, which no longer excludes
+                // ExpectReconciledInput, so an ExpectReconciledInput config arriving here would
+                // take the lean branch and add an EMPTY entry list per file. Not reachable today
+                // (Run routes InputScores runs away from Rehydrate), but re-deriving the rule at
+                // one call site and importing it at the other is precisely the drift this change
+                // exists to remove. hasReconSidecars is false here: this path has no bundle.
+                // ARM THE GUARD ON THE SAME DECISION, for the reason the branch below states: the
+                // fat path IS the resident pool here, so guarding on a separate NeedsResidentPool
+                // let a config with needsResidentPool false but builder null (ExpectReconciledInput)
+                // take the O(files) fat load with the guard disarmed and no warning. Two predicates
+                // that can disagree about one choice is the drift this change removes; the guard is
+                // the third reader of that choice and has to key off it too. Placed inside the
+                // InputFiles block because with no input files nothing loads and a guard here would
+                // only produce a false positive.
+                var builder = CanUseLeanProjection(config, hasReconSidecars: false,
+                                                   OspreyEnvironment.UseFdrProjection)
+                    ? new FdrProjectionSet.Builder(countsOnly: true)
+                    : null;
                 GuardResidentPool(config, needsResidentPool: builder == null);
 
                 // Per-file progress so this all-files load is not a silent multi-minute

--- a/pwiz_tools/Osprey/Osprey.Tasks/PerFileScoringTask.cs
+++ b/pwiz_tools/Osprey/Osprey.Tasks/PerFileScoringTask.cs
@@ -1256,12 +1256,13 @@ namespace pwiz.Osprey.Tasks
             bool loadFeatures = needsResidentPool;
 
             // The --input-files paths at :381 and :644 THROW on the same O(files) situation.
-            // This one must not: every configuration that reaches this loader worked before
-            // the streaming hydrate landed - the --task SecondPassFDR reconciled-input merge
-            // (Stage 7, deliberately deferred to issue #4486), a --task FirstPassFDR re-run
-            // over parquets whose sidecars are already on disk, and the OSPREY_DUMP_PERCOLATOR
-            // bisection dump, which by design keeps the resident path. Throwing would break
-            // all three. Warn with the consumer named instead, so an operator who meets the
+            // This one must not: every configuration that still reaches the resident branches
+            // worked before the streaming hydrate landed - a --task FirstPassFDR re-run over
+            // parquets whose sidecars are already on disk, and the OSPREY_DUMP_PERCOLATOR
+            // bisection dump, which by design keeps the resident path. (The --task
+            // SecondPassFDR merge was the third of these until #4486 streamed it; it is listed
+            // here only because that is what this justification used to rest on.) Throwing
+            // would break the rest. Warn with the consumer named instead, so an operator who meets the
             // O(files) peak at scale knows which knob put them on it. When the streaming
             // hydrate below takes the load the pool is bounded and there is nothing to say.
             // Warn on exactly the condition that SELECTS the resident loop below, rather than
@@ -1429,8 +1430,14 @@ namespace pwiz.Osprey.Tasks
                     // 21 doubles per row here only to null them cost ~800 MB per file at
                     // ~4.2M rows, the dominant term in the O(files) rehydrate peak.
                     //
-                    // Only safe because NeedsResidentPool is false: that is what says no
-                    // resident 2nd-pass Percolator will read entry.Features later.
+                    // Safe because nothing on this path reads entry.Features afterwards. That
+                    // USED to be phrased as "NeedsResidentPool is false says so", which stopped
+                    // being true when #4486 took ExpectReconciledInput out of that predicate:
+                    // the merge node now has NeedsResidentPool false AND does run a 2nd-pass
+                    // Percolator. It is still safe there, for a different reason - Pass2FdrSidecar
+                    // reloads the features it needs from each reconciled parquet rather than
+                    // reading them off these stubs - so state the reason rather than a predicate
+                    // that no longer implies it.
                     var stubs = ParquetScoreCache.LoadFdrStubsFromParquet(parquetPath);
                     // Keep the fail-fast the feature load used to provide: a foreign or
                     // truncated parquet missing the PIN schema must stop here, not surface

--- a/pwiz_tools/Osprey/Osprey.Tasks/PerFileScoringTask.cs
+++ b/pwiz_tools/Osprey/Osprey.Tasks/PerFileScoringTask.cs
@@ -1950,9 +1950,10 @@ namespace pwiz.Osprey.Tasks
         /// set the per-file loader needs. Those runs are exempt HERE because they are already
         /// resident for a reason with its own token
         /// (<see cref="ResidentPaths.PROJECTION_OFF"/> above all), so demanding a second token
-        /// would mean two variables for one decision, and would fire on the plain
-        /// <c>--task SecondPassFDR</c> run that <see cref="ResidentPaths.HPC_MERGE"/> already
-        /// covers.</para>
+        /// would mean two variables for one decision. The example this clause used to give -
+        /// the plain <c>--task SecondPassFDR</c> run, covered by the former hpc-merge token -
+        /// is gone with #4486: that node streams its reconciled-input load, so it needs no
+        /// token at all and never reaches this exemption as a resident run.</para>
         ///
         /// <para>The exemption used to leave a gap it could not see: a lean straight-through
         /// resume needs no first-pass token at all since #4505, so "already resident under

--- a/pwiz_tools/Osprey/Osprey.Tasks/PerFileScoringTask.cs
+++ b/pwiz_tools/Osprey/Osprey.Tasks/PerFileScoringTask.cs
@@ -1896,8 +1896,10 @@ namespace pwiz.Osprey.Tasks
         /// Whether Stage 5 needs the resident fat-stub first-pass pool rather than the
         /// lean streamed <see cref="FdrProjection"/> set (#4400). True when an opt-in
         /// output reads every entry's in-memory features/scores (FDRBench pass 1),
-        /// when the projection path is off (OSPREY_FDR_PROJECTION=0 / non-Percolator FDR),
-        /// or on the reconciled-input worker join. OSPREY_PASS2_QVALUE=transfer no longer
+        /// or when the projection path is off (OSPREY_FDR_PROJECTION=0 / non-Percolator
+        /// FDR). The reconciled-input worker join is NO LONGER one of them (#4486): it
+        /// takes the streaming compacted hydrate, one file's pool resident at a time.
+        /// OSPREY_PASS2_QVALUE=transfer no longer
         /// forces the resident pool -- the per-run-only redesign maps each adjusted peak
         /// through that file's own 1st-pass (score -> run q) sidecar table at pass 2, so
         /// transfer takes the SAME lean projection first-pass path as the default (see

--- a/pwiz_tools/Osprey/Osprey.Tasks/ScoringTaskShared.cs
+++ b/pwiz_tools/Osprey/Osprey.Tasks/ScoringTaskShared.cs
@@ -275,10 +275,12 @@ namespace pwiz.Osprey.Tasks
         /// <see cref="RescoreHydration.HydrateCompactedStreaming"/> -- the
         /// <c>--task PerFileRescoring</c> worker load in <see cref="PerFileScoringTask"/>
         /// and the straight-through resume in <see cref="FirstPassFdrTask"/> - so the two
-        /// cannot drift into reporting per-file counts under different predicates. NOT the
-        /// <c>--task SecondPassFDR</c> run: that sets <c>ExpectReconciledInput</c>, the
-        /// first branch of <c>PreCompactionPoolReason</c>, so it always takes the resident
-        /// batch twin and is still O(files) (issue #4486).</para>
+        /// cannot drift into reporting per-file counts under different predicates. The
+        /// <c>--task SecondPassFDR</c> merge takes that SAME streaming hydrate since #4486
+        /// (it no longer routes to the resident batch twin), but it skips this tally: the
+        /// only reader of <c>PassingTargets</c> is FirstPassFDR's per-file Stage 5 result
+        /// line, and that task is excluded on the merge node, so filling the field there
+        /// would walk every stub to produce a number nothing reads.</para>
         /// </summary>
         internal static void TallyPreCompaction(
             OspreyConfig config, List<FdrEntry> stubs, PreCompactionTally tally)

--- a/pwiz_tools/Osprey/Osprey.Tasks/SecondPassFdrTask.cs
+++ b/pwiz_tools/Osprey/Osprey.Tasks/SecondPassFdrTask.cs
@@ -138,6 +138,19 @@ namespace pwiz.Osprey.Tasks
             var libraryById = ctx.Get<LibraryById>().Value;
             var perFileParquetPaths = ctx.Get<PerFileParquetPaths>().Value;
 
+            // Stage 7's INHERITED baseline, post-GC, before this stage does any work
+            // (#4486). Every figure that issue has ever quoted came from --memstamp, i.e.
+            // GC.GetTotalMemory(false), which includes uncollected garbage and so cannot
+            // tell a live survivor pool from Server-GC committed-but-free gray - which is
+            // precisely the question. The demand above has already materialized
+            // RescoredEntries, so this measures what Stage 7 is handed rather than what it
+            // builds; the probes below then attribute each substep's own contribution.
+            int nFiles = perFileEntries.Count;
+            string memDetail = string.Format(@"(files={0})", nFiles);
+            ProfilerHooks.LogMemoryStatsIfEnabled(ctx.LogInfo, @"stage7 start (pre-GC)");
+            ProfilerHooks.LogManagedHeapAfterGcIfEnabled(ctx.LogInfo, @"stage7-inherited",
+                string.Format(@"(post-GC, entering Stage 7, files={0})", nFiles));
+
             ReleaseUnscorableLibraryFragments(perFileEntries, fullLibrary, ctx);
 
             // The 2nd-pass Percolator model, captured for the model-diagnostics
@@ -162,6 +175,12 @@ namespace pwiz.Osprey.Tasks
                 pass2Contributions = Pass2FdrSidecar.ComputeAndPersist(
                     ctx, perFileEntries, perFileParquetPaths,
                     Name, ValidityKey(ctx));
+                // The substep the 2026-07-31 characterization on #4486 located the churn in:
+                // it reloads every file's reconciled features, so the pre-GC line carries the
+                // transient reload peak and the post-GC line what survives it.
+                ProfilerHooks.LogMemoryStatsIfEnabled(ctx.LogInfo, @"stage7 pass-2 scored (pre-GC)");
+                ProfilerHooks.LogManagedHeapAfterGcIfEnabled(ctx.LogInfo, @"stage7-pass2-scored",
+                    memDetail);
             }
 
             // Protein-level FDR. Always runs (parsimony + picked-protein at the
@@ -179,6 +198,11 @@ namespace pwiz.Osprey.Tasks
             swProtein.Stop();
             ctx.LogInfo(string.Format(@"[STAGE-WALL] stage7: {0:F1}s",
                 swProtein.Elapsed.TotalSeconds));
+            // Parsimony + picked-protein TDC are genuinely whole-run, so this probe is what
+            // decides whether they are a REASON Stage 7 must hold every file at once or
+            // merely a consumer of a pool held for other reasons (#4486).
+            ProfilerHooks.LogManagedHeapAfterGcIfEnabled(ctx.LogInfo, @"stage7-protein-fdr",
+                memDetail);
 
             // Re-clamp experiment q to each entry's best run q on the FINAL post-Stage-6
             // pool. The pass-1 (and any pass-2) Percolator already clamped, but Stage 6
@@ -196,6 +220,12 @@ namespace pwiz.Osprey.Tasks
             swBlib.Stop();
             ctx.LogInfo(string.Format(@"[STAGE-WALL] blib: {0:F1}s",
                 swBlib.Elapsed.TotalSeconds));
+            // The blib write builds several whole-run indexes over the pool (passing
+            // precursors, best-per-precursor, shared boundaries, cross-file observations),
+            // so it is the other candidate reason the pool cannot be consumed per file.
+            ProfilerHooks.LogMemoryStatsIfEnabled(ctx.LogInfo, @"stage7 blib written (pre-GC)");
+            ProfilerHooks.LogManagedHeapAfterGcIfEnabled(ctx.LogInfo, @"stage7-blib-written",
+                memDetail);
 
             // FDRBench input TSV (pass 2): the peptides we report - the final merged/rescored set
             // written to the output - each with its final second-pass q-value and raw SVM
@@ -279,6 +309,11 @@ namespace pwiz.Osprey.Tasks
                 @"Released library fragments for {0} of {1} entries ({2} base_ids retained for the reported pool)",
                 released, fullLibrary.Count, retained.Count));
             ProfilerHooks.LogMemoryStatsIfEnabled(ctx.LogInfo, @"after library-fragment release");
+            // Post-GC counterpart, so the release's actual recovery is attributable rather
+            // than inferred: the pre-GC line above cannot show it, because the dropped
+            // fragment arrays are garbage that has not been collected yet (#4486).
+            ProfilerHooks.LogManagedHeapAfterGcIfEnabled(ctx.LogInfo, @"stage7-fragments-released",
+                string.Format(@"(files={0}, released={1})", perFileEntries.Count, released));
         }
 
         /// <summary>

--- a/pwiz_tools/Osprey/Osprey.Tasks/SecondPassFdrTask.cs
+++ b/pwiz_tools/Osprey/Osprey.Tasks/SecondPassFdrTask.cs
@@ -200,7 +200,12 @@ namespace pwiz.Osprey.Tasks
                 swProtein.Elapsed.TotalSeconds));
             // Parsimony + picked-protein TDC are genuinely whole-run, so this probe is what
             // decides whether they are a REASON Stage 7 must hold every file at once or
-            // merely a consumer of a pool held for other reasons (#4486).
+            // merely a consumer of a pool held for other reasons (#4486). The pre-GC line is
+            // not optional here: parsimony builds whole-run scratch (best score per peptide,
+            // protein groups, the target/decoy competition) and the forced collection below
+            // destroys it, so without this the substep reports a ~0 delta and gets written
+            // off as a consumer even if it transiently doubled the heap.
+            ProfilerHooks.LogMemoryStatsIfEnabled(ctx.LogInfo, @"stage7 protein FDR (pre-GC)");
             ProfilerHooks.LogManagedHeapAfterGcIfEnabled(ctx.LogInfo, @"stage7-protein-fdr",
                 memDetail);
 

--- a/pwiz_tools/Osprey/Osprey.Test/FdrTest.cs
+++ b/pwiz_tools/Osprey/Osprey.Test/FdrTest.cs
@@ -3501,6 +3501,110 @@ namespace pwiz.Osprey.Test
         }
 
         /// <summary>
+        /// The MULTI-FILE branches of <c>StreamingFdr.StreamedCompetitionState</c>, which the
+        /// single-file test above cannot reach: with one file <c>ExperimentQ</c> short-circuits
+        /// to the run q it was handed and <c>Pep</c> is never consulted, so the clamp and the
+        /// winner-locator both go unexercised. Those two methods are where the retired
+        /// per-survivor loop's arithmetic now lives, so they need coverage that fails when
+        /// either is wrong.
+        ///
+        /// Pins three properties the deleted loop guaranteed:
+        /// experiment q is the base_id winner's q FLOORED UP to that entry's best run q
+        /// (issue #4390); an entry that won no competition anywhere floors at 1.0; and PEP is
+        /// real ONLY on the single experiment-winner observation of a base_id, 1.0 on every
+        /// other file's observation of the same precursor.
+        ///
+        /// VERIFIED BY MUTATION, so the coverage claim is measured rather than asserted:
+        /// dropping the <c>_fileKeys[loc.fileIdx] == fileKey</c> term from <c>Pep</c> turns this
+        /// test RED. Deleting the <c>eq &lt; floorQ</c> clamp does NOT - on this population the
+        /// base_id winner's q never lands below the entry's best run q, so the clamp assertion
+        /// below is true but not discriminating. Forcing it to bind needs an experiment q
+        /// strictly better than every per-file run q, which cannot happen for a target survivor
+        /// here: the target's experiment score IS its max across files, so it also won in that
+        /// file and carries the matching run q. The clamp therefore remains covered only by the
+        /// byte-parity gate (regression.ps1 mode 1/3); do not read this test as pinning it.
+        /// </summary>
+        [TestMethod]
+        public void TestStreamedCompetitionStateMultiFile()
+        {
+            // Two files, same 12 precursors. File B scores every target higher, so B holds the
+            // experiment winner for each base_id and A's observations must report PEP 1.0.
+            const string FA = "a";
+            const string FB = "b";
+            var eids = new List<uint>();
+            var scoresA = new List<double>();
+            var scoresB = new List<double>();
+            // base_ids 1-8 are target-winners; 9-12 are decoy-winners, so the PEP estimator
+            // is fit over BOTH classes. With an all-target winner set the KDE is degenerate
+            // and PosteriorError returns 1.0 for everything, which would make the assertions
+            // below vacuous rather than failing - the first draft of this test did exactly that.
+            for (uint b = 1; b <= 12; b++)
+            {
+                bool decoyWins = b > 8;
+                eids.Add(b);                        // target: entryId == base_id
+                scoresA.Add((decoyWins ? 0.1 : 1.0) + b * 0.1);
+                scoresB.Add((decoyWins ? 0.2 : 3.0) + b * 0.1);   // B wins the experiment competition
+                eids.Add(b | 0x80000000u);          // paired decoy
+                scoresA.Add((decoyWins ? 2.0 : 0.2) + b * 0.01);
+                scoresB.Add((decoyWins ? 4.0 : 0.3) + b * 0.01);
+            }
+            var idArr = eids.ToArray();
+            var survivorIds = new HashSet<uint>();
+            for (uint b = 1; b <= 12; b++) survivorIds.Add(b);
+
+            (uint[] e, double[] s, IReadOnlyDictionary<uint, double> ov) Read(string key)
+                => ((uint[])idArr.Clone(),
+                    (key == FA ? scoresA : scoresB).ToArray(),
+                    new Dictionary<uint, double>());
+
+            var runQByFile = new Dictionary<string, Dictionary<uint, double>>();
+            void OnFileRunQ(string key, IReadOnlyDictionary<uint, double> fileRunQ)
+            {
+                runQByFile[key] = new Dictionary<uint, double>(fileRunQ.Count);
+                foreach (var kv in fileRunQ) runQByFile[key][kv.Key] = kv.Value;
+            }
+
+            var competition = StreamingFdr.ComputeFullPopulationPrecursorFdrStreaming(
+                new[] { FA, FB }, Read, survivorIds, OnFileRunQ);
+
+            Assert.IsTrue(runQByFile.ContainsKey(FA) && runQByFile.ContainsKey(FB),
+                "each file must receive its own run q");
+
+            int pepReal = 0;
+            for (uint b = 1; b <= 8; b++)       // the target-winner base_ids
+            {
+                double rqA = runQByFile[FA].TryGetValue(b, out double a) ? a : 1.0;
+                double rqB = runQByFile[FB].TryGetValue(b, out double v) ? v : 1.0;
+                double best = Math.Min(rqA, rqB);
+
+                // The clamp: experiment q is never better than the entry's best run q. A
+                // swapped floor/eq, or returning the base_id q unfloored, breaks this.
+                double eqA = competition.ExperimentQ(b, rqA);
+                double eqB = competition.ExperimentQ(b, rqB);
+                Assert.AreEqual(eqA, eqB, 1e-12,
+                    "experiment q must not depend on which file's run q is passed in");
+                Assert.IsTrue(eqA >= best - 1e-12,
+                    string.Format("experiment q {0} must be floored up to best run q {1}", eqA, best));
+
+                // PEP is real on exactly one file's observation of each base_id.
+                double pepA = competition.Pep(FA, b);
+                double pepB = competition.Pep(FB, b);
+                Assert.IsTrue(pepA == 1.0 || pepB == 1.0,
+                    "PEP must be 1.0 on at least one of the two files for base_id " + b);
+                if (pepA != 1.0 || pepB != 1.0) pepReal++;
+                // B holds the winner for every base_id here, so A must report the 1.0 default.
+                Assert.AreEqual(1.0, pepA, 1e-12,
+                    "the losing file's observation must report PEP 1.0 for base_id " + b);
+            }
+            Assert.IsTrue(pepReal > 0,
+                "at least one base_id must carry a real PEP, or the winner locator is dead");
+
+            // An entry_id that is a survivor but won nothing anywhere floors at 1.0.
+            Assert.AreEqual(1.0, competition.ExperimentQ(9999u, 1.0), 1e-12,
+                "an entry with no competition anywhere must report experiment q 1.0");
+        }
+
+        /// <summary>
         /// The summary report's per-replicate protein count is a REAL run-level protein
         /// FDR (its own parsimony + picked-protein FDR on that replicate), not a slice of
         /// the experiment set -- the property a reviewer asks for. Verify the run-scoped

--- a/pwiz_tools/Osprey/Osprey.Test/FdrTest.cs
+++ b/pwiz_tools/Osprey/Osprey.Test/FdrTest.cs
@@ -3471,24 +3471,30 @@ namespace pwiz.Osprey.Test
             // Resident oracle: q per observation (winner obs carry the competition q).
             var residentQ = PercolatorQValues.ComputeStratifiedCompetitionQvalues(sc, lb, ids, stratum);
 
-            // Streaming: single file, no score override, survivors = the stratum targets.
+            // Streaming: single file, no score override, survivors = the stratum targets. The
+            // streamed form emits per file rather than returning whole-run maps, so the run q
+            // arrives through the callback and experiment q is asked for per survivor.
             const string F = "f";
-            var survivors = new List<(string, uint)>();
-            for (uint b = 1; b <= 20; b++) survivors.Add((F, b));   // target entryId == base_id
-            (uint[] eids, double[] scs) Read(string _)
-                => ((uint[])ids.Clone(), (double[])sc.Clone());
-            StreamingFdr.ComputeFullPopulationPrecursorFdrStreaming(
-                new[] { F }, Read,
-                new Dictionary<(string, uint), double>(), survivors,
-                out _, out var expQ, out _, stratum);
+            var survivorIds = new HashSet<uint>();
+            for (uint b = 1; b <= 20; b++) survivorIds.Add(b);   // target entryId == base_id
+            (uint[] eids, double[] scs, IReadOnlyDictionary<uint, double> ov) Read(string _)
+                => ((uint[])ids.Clone(), (double[])sc.Clone(), new Dictionary<uint, double>());
+            var runQ = new Dictionary<uint, double>();
+            void OnFileRunQ(string _, IReadOnlyDictionary<uint, double> fileRunQ)
+            {
+                foreach (var kv in fileRunQ) runQ[kv.Key] = kv.Value;
+            }
+            var competition = StreamingFdr.ComputeFullPopulationPrecursorFdrStreaming(
+                new[] { F }, Read, survivorIds, OnFileRunQ, stratum);
 
             for (uint b = 1; b <= 20; b++)
             {
                 int win = -1;
                 for (int i = 0; i < ids.Length; i++)
                     if ((ids[i] & 0x7FFFFFFFu) == b && !lb[i]) win = i;   // target obs = the winner
-                Assert.IsTrue(expQ.TryGetValue((F, b), out double sq),
-                    "streaming must report exp q for stratum survivor " + b);
+                Assert.IsTrue(runQ.TryGetValue(b, out double rq),
+                    "streaming must report run q for stratum survivor " + b);
+                double sq = competition.ExperimentQ(b, rq);
                 Assert.AreEqual(residentQ[win], sq, 1e-9,
                     "streaming stratified exp q must match the resident oracle for base_id " + b);
             }

--- a/pwiz_tools/Osprey/Osprey.Test/ResidentPoolGuardTest.cs
+++ b/pwiz_tools/Osprey/Osprey.Test/ResidentPoolGuardTest.cs
@@ -107,6 +107,22 @@ namespace pwiz.Osprey.Test
                     PerFileScoringTask.ResidentPoolGuardError(hpc, true, token, true), token);
             }
 
+            // Taking ExpectReconciledInput out of NeedsResidentPool made the LEAN counts-only
+            // load newly reachable on the merge, and that path adds an EMPTY entry list per
+            // file - Stage 7 would have written a near-empty .blib with no error. It is
+            // suppressed by its own term, not as a side effect of the resident predicate, and
+            // the case that matters is a merge whose inputs are MISSING a .reconciliation.json
+            // (one partially copied file is enough to make AllHaveReconSidecars false).
+            Assert.IsFalse(PerFileScoringTask.CanUseLeanProjection(hpc, hasReconSidecars: false, useFdrProjection: true),
+                "the reconciled-input merge must never take the lean counts-only load");
+            Assert.IsFalse(PerFileScoringTask.CanUseLeanProjection(hpc, hasReconSidecars: true, useFdrProjection: true));
+            // A reconciled bundle excludes it for the other reason (the overlay reads stubs),
+            // and the plain projection run is exactly what the lean path exists for.
+            Assert.IsFalse(PerFileScoringTask.CanUseLeanProjection(lean, hasReconSidecars: true, useFdrProjection: true));
+            Assert.IsTrue(PerFileScoringTask.CanUseLeanProjection(lean, hasReconSidecars: false, useFdrProjection: true));
+            // A resident-pool consumer keeps the fat load, so the lean path stays off there too.
+            Assert.IsFalse(PerFileScoringTask.CanUseLeanProjection(fdrbench1, hasReconSidecars: false, useFdrProjection: true));
+
             // Each user-reachable trigger names its own token so the failure is diagnosable.
             // --model-diagnostics is NOT among them any more (#4505): it armed the pool on a
             // full resume, where FirstPassFDR skipped its score pass and reported off the resident

--- a/pwiz_tools/Osprey/Osprey.Test/ResidentPoolGuardTest.cs
+++ b/pwiz_tools/Osprey/Osprey.Test/ResidentPoolGuardTest.cs
@@ -95,17 +95,21 @@ namespace pwiz.Osprey.Test
 
             // --task SecondPassFDR takes NO resident pool since #4486: FirstPassFdrTask is
             // excluded on that node, so nothing trains off the pre-compaction pool, and every
-            // pass-2 consumer streams from disk one file at a time. It therefore arms no guard,
-            // and - the ratchet property - no token can admit it if it ever goes resident
-            // again, because 'hpc-merge' is not on the list any more. The old path cost
+            // pass-2 consumer streams from disk one file at a time. The old path cost
             // 2.07 GB per file, which made the final HPC join impossible at 82 files.
+            //
+            // This is the production-reachable assertion, and the ONLY one this config still
+            // supports. A four-token loop over ResidentPoolGuardError(hpc, true, ...) used to
+            // follow and was removed as duplicative: ResidentPoolTrigger no longer reads
+            // ExpectReconciledInput at all, so that loop executed byte-identically to the
+            // `lean` loop below - same branch, same tokens, no new coverage. It also could not
+            // deliver the ratchet it claimed: a future change re-adding a trigger under a NEW
+            // token would be named by none of {null, "", "hpc-merge", "anything"} and every
+            // assertion would still pass. TestFirstPassMembershipAcrossTasks pins the property
+            // that actually guards this - that FirstPassFdrTask is excluded here - and the
+            // retired token is pinned by KNOWN_UNFIXED not containing it.
             var hpc = new OspreyConfig { ExpectReconciledInput = true };
             AssertNeedsResidentPool(false, hpc);
-            foreach (string token in new[] { null, "", "hpc-merge", "anything" })
-            {
-                Assert.IsNotNull(
-                    PerFileScoringTask.ResidentPoolGuardError(hpc, true, token, true), token);
-            }
 
             // Taking ExpectReconciledInput out of NeedsResidentPool made the LEAN counts-only
             // load newly reachable on the merge, and that path adds an EMPTY entry list per
@@ -328,8 +332,17 @@ namespace pwiz.Osprey.Test
                 new OspreyConfig { ExpectReconciledInput = true, InputScores = scores.ToList() }),
                 "--task SecondPassFDR must not be treated as running first-pass Percolator");
 
-            // And the consequence the loader draws from it: that node, and only that node, may
-            // take the file-count-bounded lean/streaming route rather than the resident pool.
+            // And the consequence the loader draws from it: the merge no longer demands the
+            // RESIDENT pool, so it can take the file-count-bounded STREAMING hydrate.
+            //
+            // Two things this must not be read as saying, both of which the assertions above
+            // contradict. It is NOT the only node on the bounded route: --task PerFileRescoring
+            // was the original consumer of HydrateCompactedStreaming, and a straight-through
+            // lean resume takes it too. And it does NOT license the LEAN counts-only projection
+            // for this config - CanUseLeanProjection is asserted FALSE for it earlier in this
+            // file, because that path hands Stage 7 empty per-file lists and would write a
+            // near-empty .blib with no error. Streaming hydrate and lean projection are
+            // different routes; only the first is what this row unlocks.
             Assert.IsFalse(PerFileScoringTask.NeedsResidentPool(
                 new OspreyConfig { ExpectReconciledInput = true, InputScores = scores.ToList() },
                 useFdrProjection: true));

--- a/pwiz_tools/Osprey/Osprey.Test/ResidentPoolGuardTest.cs
+++ b/pwiz_tools/Osprey/Osprey.Test/ResidentPoolGuardTest.cs
@@ -287,5 +287,52 @@ namespace pwiz.Osprey.Test
                 true, false, ResidentPaths.PROJECTION_OFF + "," + ResidentPaths.FDRBENCH_PASS1));
         }
 
+        /// <summary>
+        /// The predicate the pre-compaction-pool decision now defers to (#4486).
+        /// <c>PreCompactionPoolReason</c> used to ask <c>!NoJoin</c> as a stand-in for "will
+        /// first-pass Percolator train in this process", which agreed with the real rule for
+        /// every task except <c>--task SecondPassFDR</c> - and that one disagreement forced an
+        /// O(files) resident pool for a consumer that does not exist.
+        ///
+        /// <para>Pinned as a TRUTH TABLE over the flag combinations <c>Program</c> derives from
+        /// <c>--task</c>, not as a single case, because the defect was a predicate that was
+        /// right four times out of five. A future task flag that re-splits membership has to
+        /// come through here.</para>
+        /// </summary>
+        [TestMethod]
+        public void TestFirstPassMembershipAcrossTasks()
+        {
+            var scores = new[] { "a.scores.parquet" };
+
+            // Straight-through (-i, no --task): FirstPassFDR runs.
+            Assert.IsTrue(FirstPassFdrTask.IsIncludedFor(new OspreyConfig()));
+
+            // --task PerFileScoring / PerFileRescoring set NoJoin: excluded, they stop before
+            // the join.
+            Assert.IsFalse(FirstPassFdrTask.IsIncludedFor(
+                new OspreyConfig { NoJoin = true }));
+            Assert.IsFalse(FirstPassFdrTask.IsIncludedFor(
+                new OspreyConfig { NoJoin = true, InputScores = scores.ToList() }));
+
+            // --task FirstPassFDR sets StopAfterStage5: it IS the first-pass node.
+            Assert.IsTrue(FirstPassFdrTask.IsIncludedFor(
+                new OspreyConfig { StopAfterStage5 = true, InputScores = scores.ToList() }));
+
+            // The full --input-scores pipeline (no --task): runs.
+            Assert.IsTrue(FirstPassFdrTask.IsIncludedFor(
+                new OspreyConfig { InputScores = scores.ToList() }));
+
+            // --task SecondPassFDR: NoJoin FALSE, so the old !NoJoin proxy said "runs" - but
+            // ExpectReconciledInput excludes it. This single row is the whole change.
+            Assert.IsFalse(FirstPassFdrTask.IsIncludedFor(
+                new OspreyConfig { ExpectReconciledInput = true, InputScores = scores.ToList() }),
+                "--task SecondPassFDR must not be treated as running first-pass Percolator");
+
+            // And the consequence the loader draws from it: that node, and only that node, may
+            // take the file-count-bounded lean/streaming route rather than the resident pool.
+            Assert.IsFalse(PerFileScoringTask.NeedsResidentPool(
+                new OspreyConfig { ExpectReconciledInput = true, InputScores = scores.ToList() },
+                useFdrProjection: true));
+        }
     }
 }

--- a/pwiz_tools/Osprey/Osprey.Test/ResidentPoolGuardTest.cs
+++ b/pwiz_tools/Osprey/Osprey.Test/ResidentPoolGuardTest.cs
@@ -57,39 +57,55 @@ namespace pwiz.Osprey.Test
             Assert.IsNull(PerFileScoringTask.ResidentPoolGuardError(lean, needsResidentPool: false,
                 allowUnfixedResident: null, useFdrProjection: true));
 
-            // HPC reconciled-input merge trips the fat pool: guarded (armed), and the message is
+            // --fdrbench-pass 1 trips the fat pool: guarded (armed), and the message is
             // actionable - it names the token the operator would set, not just a symptom.
-            var hpc = new OspreyConfig { ExpectReconciledInput = true };
-            string hpcErr = PerFileScoringTask.ResidentPoolGuardError(hpc, needsResidentPool: true,
+            // This was the HPC reconciled-input merge until #4486 streamed it; the properties
+            // being pinned are the guard's, so any still-listed trigger exercises them.
+            var fdrbench1 = new OspreyConfig { OutputFdrBench = "bench.tsv", FdrBenchPass = 1 };
+            string benchErr = PerFileScoringTask.ResidentPoolGuardError(fdrbench1, needsResidentPool: true,
                 allowUnfixedResident: null, useFdrProjection: true);
-            Assert.IsNotNull(hpcErr);
-            StringAssert.Contains(hpcErr, "OSPREY_ALLOW_UNFIXED_RESIDENT=" + ResidentPaths.HPC_MERGE);
+            Assert.IsNotNull(benchErr);
+            StringAssert.Contains(benchErr, "OSPREY_ALLOW_UNFIXED_RESIDENT=" + ResidentPaths.FDRBENCH_PASS1);
 
             // Naming THIS path exempts it (no error):
-            Assert.IsNull(PerFileScoringTask.ResidentPoolGuardError(hpc, needsResidentPool: true,
-                allowUnfixedResident: ResidentPaths.HPC_MERGE, useFdrProjection: true));
+            Assert.IsNull(PerFileScoringTask.ResidentPoolGuardError(fdrbench1, needsResidentPool: true,
+                allowUnfixedResident: ResidentPaths.FDRBENCH_PASS1, useFdrProjection: true));
             // OSPREY_FDR_PROJECTION=0 (the A/B byte-identity oracle) is NOT an automatic
             // exemption any more - it is its own token. Unnamed it is refused like anything
             // else, which closes the last route to a resident pool nobody had to ask for.
-            Assert.IsNotNull(PerFileScoringTask.ResidentPoolGuardError(hpc, needsResidentPool: true,
+            Assert.IsNotNull(PerFileScoringTask.ResidentPoolGuardError(fdrbench1, needsResidentPool: true,
                 allowUnfixedResident: null, useFdrProjection: false));
-            Assert.IsNull(PerFileScoringTask.ResidentPoolGuardError(hpc, needsResidentPool: true,
+            Assert.IsNull(PerFileScoringTask.ResidentPoolGuardError(fdrbench1, needsResidentPool: true,
                 allowUnfixedResident: ResidentPaths.PROJECTION_OFF, useFdrProjection: false));
             // It outranks a config-driven trigger, because it selects the legacy implementation
             // for the whole run: naming the other reason is not enough.
-            Assert.IsNotNull(PerFileScoringTask.ResidentPoolGuardError(hpc, needsResidentPool: true,
-                allowUnfixedResident: ResidentPaths.HPC_MERGE, useFdrProjection: false));
+            Assert.IsNotNull(PerFileScoringTask.ResidentPoolGuardError(fdrbench1, needsResidentPool: true,
+                allowUnfixedResident: ResidentPaths.FDRBENCH_PASS1, useFdrProjection: false));
 
             // Naming a DIFFERENT path does not: the token grants one exemption, not amnesty.
             // This is the property the former blanket boolean lacked.
-            Assert.IsNotNull(PerFileScoringTask.ResidentPoolGuardError(hpc, needsResidentPool: true,
-                allowUnfixedResident: ResidentPaths.FDRBENCH_PASS1, useFdrProjection: true));
+            Assert.IsNotNull(PerFileScoringTask.ResidentPoolGuardError(fdrbench1, needsResidentPool: true,
+                allowUnfixedResident: ResidentPaths.NON_PERCOLATOR_FDR, useFdrProjection: true));
 
             // Capitalization does not defeat it - the error names the exact token to set, so
             // rejecting the operator's own value for case would read as the guard ignoring them.
-            Assert.IsNull(PerFileScoringTask.ResidentPoolGuardError(hpc, needsResidentPool: true,
-                allowUnfixedResident: ResidentPaths.HPC_MERGE.ToUpperInvariant(),
+            Assert.IsNull(PerFileScoringTask.ResidentPoolGuardError(fdrbench1, needsResidentPool: true,
+                allowUnfixedResident: ResidentPaths.FDRBENCH_PASS1.ToUpperInvariant(),
                 useFdrProjection: true));
+
+            // --task SecondPassFDR takes NO resident pool since #4486: FirstPassFdrTask is
+            // excluded on that node, so nothing trains off the pre-compaction pool, and every
+            // pass-2 consumer streams from disk one file at a time. It therefore arms no guard,
+            // and - the ratchet property - no token can admit it if it ever goes resident
+            // again, because 'hpc-merge' is not on the list any more. The old path cost
+            // 2.07 GB per file, which made the final HPC join impossible at 82 files.
+            var hpc = new OspreyConfig { ExpectReconciledInput = true };
+            AssertNeedsResidentPool(false, hpc);
+            foreach (string token in new[] { null, "", "hpc-merge", "anything" })
+            {
+                Assert.IsNotNull(
+                    PerFileScoringTask.ResidentPoolGuardError(hpc, true, token, true), token);
+            }
 
             // Each user-reachable trigger names its own token so the failure is diagnosable.
             // --model-diagnostics is NOT among them any more (#4505): it armed the pool on a
@@ -122,10 +138,6 @@ namespace pwiz.Osprey.Test
                     string.Format("--model-diagnostics changed disposition under token '{0}'", token));
             }
 
-            var fdrbench1 = new OspreyConfig { OutputFdrBench = "bench.tsv", FdrBenchPass = 1 };
-            StringAssert.Contains(PerFileScoringTask.ResidentPoolGuardError(fdrbench1, true, null, true),
-                ResidentPaths.FDRBENCH_PASS1);
-
             var simple = new OspreyConfig { FdrMethod = FdrMethod.Simple };
             StringAssert.Contains(PerFileScoringTask.ResidentPoolGuardError(simple, true, null, true),
                 ResidentPaths.NON_PERCOLATOR_FDR);
@@ -134,7 +146,7 @@ namespace pwiz.Osprey.Test
             // This is the ratchet: when something we streamed goes resident again, as transfer
             // did, it cannot be waved through. It has to be fixed, or deliberately listed.
             // (lean is the default config: Percolator, no fdrbench, no mdiag, not SecondPassFDR.)
-            foreach (string token in new[] { null, "", ResidentPaths.HPC_MERGE, "anything" })
+            foreach (string token in new[] { null, "", "hpc-merge", "anything" })
             {
                 Assert.IsNotNull(
                     PerFileScoringTask.ResidentPoolGuardError(lean, true, token, true), token);
@@ -148,12 +160,13 @@ namespace pwiz.Osprey.Test
             // membership and order but not the text, and the text is what an operator types
             // into OSPREY_ALLOW_UNFIXED_RESIDENT. Renaming a value would otherwise compile and
             // pass here while silently invalidating every written-down invocation.
-            // 'mdiag-full-resume' is GONE (#4505) and 'resume-survivor-handoff' is GONE (#4536,
-            // the rehydrate got its own survivor loader) - the ratchet shrinking twice.
+            // 'mdiag-full-resume' is GONE (#4505), 'resume-survivor-handoff' is GONE (#4536,
+            // the rehydrate got its own survivor loader), and 'hpc-merge' is GONE (#4486, the
+            // reconciled-input merge streams its load) - the ratchet shrinking three times.
             CollectionAssert.AreEqual(
                 new[]
                 {
-                    "hpc-merge", "fdrbench-pass1", "non-percolator-fdr",
+                    "fdrbench-pass1", "non-percolator-fdr",
                     "projection-off", "compacted-entries-buffer"
                 },
                 ResidentPaths.KNOWN_UNFIXED.ToArray());
@@ -166,7 +179,6 @@ namespace pwiz.Osprey.Test
 
             // The trigger SET itself, not just the message it produces. Each of these takes the
             // O(files) resident pool and so arms the guard above.
-            AssertNeedsResidentPool(true, hpc);
             AssertNeedsResidentPool(true, fdrbench1);
             AssertNeedsResidentPool(true, simple);
             // OSPREY_FDR_PROJECTION=0 is itself an explicit resident opt-in.
@@ -204,7 +216,7 @@ namespace pwiz.Osprey.Test
             Assert.IsNull(PerFileScoringTask.Stage6ResidentHandoffGuardError(
                 streamingAvailable: true, streamingEnabled: true, allowUnfixedResident: null));
             Assert.IsNull(PerFileScoringTask.Stage6ResidentHandoffGuardError(
-                true, true, ResidentPaths.HPC_MERGE));
+                true, true, ResidentPaths.FDRBENCH_PASS1));
 
             // OSPREY_STAGE6_STREAM_SURVIVORS=0 on a run that COULD stream: refused, and the
             // message names the token to set rather than describing a symptom.
@@ -246,17 +258,17 @@ namespace pwiz.Osprey.Test
             // its own reason needs that run's token AND compacted-entries-buffer, so the very
             // A/B that establishes the bound aborted on its own guard. Both guards read the
             // list, and every admitted path is still named individually.
-            string both = ResidentPaths.HPC_MERGE + "," + ResidentPaths.COMPACTED_ENTRIES_BUFFER;
+            string both = ResidentPaths.FDRBENCH_PASS1 + "," + ResidentPaths.COMPACTED_ENTRIES_BUFFER;
             Assert.IsNull(PerFileScoringTask.Stage6ResidentHandoffGuardError(true, false, both));
-            var hpcCfg = new OspreyConfig { ExpectReconciledInput = true };
-            Assert.IsNull(PerFileScoringTask.ResidentPoolGuardError(hpcCfg, true, both, true));
+            var benchCfg = new OspreyConfig { OutputFdrBench = "bench.tsv", FdrBenchPass = 1 };
+            Assert.IsNull(PerFileScoringTask.ResidentPoolGuardError(benchCfg, true, both, true));
             // Separators are interchangeable and surrounding whitespace is tolerated - an
             // operator composing the value in a shell should not have to match a spelling.
             Assert.IsNull(PerFileScoringTask.Stage6ResidentHandoffGuardError(
                 true, false, " projection-off ; compacted-entries-buffer "));
             // A list still admits ONLY what it names: an unnamed path is refused as before.
             Assert.IsNotNull(PerFileScoringTask.Stage6ResidentHandoffGuardError(
-                true, false, ResidentPaths.PROJECTION_OFF + "," + ResidentPaths.HPC_MERGE));
+                true, false, ResidentPaths.PROJECTION_OFF + "," + ResidentPaths.FDRBENCH_PASS1));
         }
 
     }

--- a/pwiz_tools/Osprey/Osprey/Program.cs
+++ b/pwiz_tools/Osprey/Osprey/Program.cs
@@ -289,11 +289,18 @@ namespace pwiz.Osprey
                 // reported number, it can only fail to permit something.
                 if (OspreyEnvironment.AllowUnfixedResidentUnrecognized)
                 {
+                    // Name the UNRECOGNIZED tokens, not the whole value: the flag is a comma
+                    // separated list and NamesResidentPath tests each token independently, so
+                    // 'projection-off,hpc-merge' still grants projection-off. Condemning the
+                    // whole value would push the operator to rewrite or unset a variable whose
+                    // valid half the run still needs, and the run then aborts on a guard the
+                    // warning said was not engaged.
                     LogWarning(string.Format(
-                        "OSPREY_ALLOW_UNFIXED_RESIDENT='{0}' names no known resident path, so it " +
-                        "grants nothing. Recognized: {1}. ('hpc-merge' was retired - the " +
-                        "--task SecondPassFDR reconciled-input load streams and needs no allowance.)",
-                        OspreyEnvironment.AllowUnfixedResident,
+                        "OSPREY_ALLOW_UNFIXED_RESIDENT contains unrecognized token(s) that grant " +
+                        "nothing: {0}. Recognized: {1}. ('hpc-merge' was retired - the " +
+                        "--task SecondPassFDR reconciled-input load streams and needs no allowance.) " +
+                        "Any recognized token in the same value is still honored.",
+                        OspreyEnvironment.UnrecognizedResidentTokens,
                         string.Join(", ", ResidentPaths.KNOWN_UNFIXED)));
                 }
                 LogInfo(string.Format("Protein FDR: {0:P1}", config.EffectiveProteinFdr));

--- a/pwiz_tools/Osprey/Osprey/Program.cs
+++ b/pwiz_tools/Osprey/Osprey/Program.cs
@@ -278,6 +278,24 @@ namespace pwiz.Osprey
                         OspreyEnvironment.PASS2_QVALUE_PROTEIN_COMPACT));
                     return 1;
                 }
+                // A token that names nothing admits nothing, so the run proceeds - but say so
+                // (#4486). 'hpc-merge' was retired when --task SecondPassFDR started streaming
+                // its reconciled-input load, making it the first previously-VALID token to
+                // become invalid, and committed automation still passes it. Silence there is
+                // the bad outcome: the operator believes they granted an allowance, and if the
+                // run later needs a real one the guard says only "does not name this path",
+                // which reads as a typo rather than a retirement. A warning, not an error -
+                // unlike OSPREY_PASS2_QVALUE above, a stale allowance cannot change any
+                // reported number, it can only fail to permit something.
+                if (OspreyEnvironment.AllowUnfixedResidentUnrecognized)
+                {
+                    LogWarning(string.Format(
+                        "OSPREY_ALLOW_UNFIXED_RESIDENT='{0}' names no known resident path, so it " +
+                        "grants nothing. Recognized: {1}. ('hpc-merge' was retired - the " +
+                        "--task SecondPassFDR reconciled-input load streams and needs no allowance.)",
+                        OspreyEnvironment.AllowUnfixedResident,
+                        string.Join(", ", ResidentPaths.KNOWN_UNFIXED)));
+                }
                 LogInfo(string.Format("Protein FDR: {0:P1}", config.EffectiveProteinFdr));
                 LogInfo(string.Format("Threads: {0}", config.NThreads));
                 LogInfo("");

--- a/pwiz_tools/Osprey/regression.ps1
+++ b/pwiz_tools/Osprey/regression.ps1
@@ -214,11 +214,13 @@ $env:OSPREY_VERSION_OVERRIDE = '26.1.1.0'
 # required where a guard demands one, so a resident path that no guard covers is
 # invisible in a token audit. #4536 was exactly that until it landed - the rehydrate
 # published no survivor loader, so Stage6ResidentHandoffGuardError no-oped and nothing
-# asked for a token. The open example now is #4486: the survivor buffer is rebuilt for
+# asked for a token. #4486 was the standing example: the survivor buffer is rebuilt for
 # SecondPassFDR to read, so it is resident from the end of Stage 6 to the end of Stage 7
 # on EVERY path, and no guard covers that because it is not a resume or a mode - it is
-# what Stage 7 takes as input. Zero tokens therefore does NOT mean zero gaps, and this
-# table is what keeps the difference legible.
+# what Stage 7 takes as input. It is still uncovered, and now MEASURED: 0.196 GB/file
+# live, post-GC, which is not what fails at scale. What did was the --task SecondPassFDR
+# pre-compaction RELOAD at 2.07 GB/file (~186 GB projected at 82 files), streamed by
+# #4486. Zero tokens therefore does NOT mean zero gaps, and this table keeps that legible.
 #
 # Printed in the run summary (not just parked in a comment) so every CI log states the
 # outstanding gaps, and so a fixed entry left here shows up as a stale line in output
@@ -236,8 +238,9 @@ $env:OSPREY_VERSION_OVERRIDE = '26.1.1.0'
 #     to justify in review, not a line to add and move on.
 $knownResidentGaps = @()
 # Reachable only outside this gate, tokened, each with an open issue:
-#   #4486  hpc-merge      -- --task SecondPassFDR reconciled-input merge (Stage 7 peak)
 #   #4507  fdrbench-pass1 -- --fdrbench-pass 1 walks the pre-compaction pool
+# hpc-merge is GONE (#4486): --task SecondPassFDR takes the bounded streaming hydrate, so
+# mode 3's join node needs no token. That is the ratchet shrinking a third time.
 # By design rather than unfinished, so no issue: projection-off and
 # compacted-entries-buffer (the A/B byte-identity oracles) and non-percolator-fdr.
 

--- a/pwiz_tools/Osprey/regression.ps1
+++ b/pwiz_tools/Osprey/regression.ps1
@@ -236,7 +236,19 @@ $env:OSPREY_VERSION_OVERRIDE = '26.1.1.0'
 #     like every other leg and resume-survivor-handoff - the last entry here - came out
 #     with it. Zero is the invariant, not a milestone: a new entry below is a regression
 #     to justify in review, not a line to add and move on.
-$knownResidentGaps = @()
+$knownResidentGaps = @(
+    # Untokened by nature, which is exactly why it belongs here: no guard demands a token
+    # for it, so a token audit cannot see it and a green gate printed "none" while every
+    # leg walked it. Measured 2026-08-09 on 82 files rather than estimated - the preamble
+    # above names it, and a table that omits the one gap the preamble names is worse than
+    # no table. Token NONE, so it does not inflate the required-token count below.
+    @{
+        Issue = '#4486'
+        Token = 'NONE'
+        Path  = 'Stage 6 rebuilds the whole-run survivor buffer for SecondPassFDR to read; resident from the end of Stage 6 to the end of Stage 7.'
+        Legs  = 'Every leg of every dataset. 24.43 GB live post-GC at 82 files (0.197 GB/file); ~103 GB projected at 500.'
+    }
+)
 # Reachable only outside this gate, tokened, each with an open issue:
 #   #4507  fdrbench-pass1 -- --fdrbench-pass 1 walks the pre-compaction pool
 # hpc-merge is GONE (#4486): --task SecondPassFDR takes the bounded streaming hydrate, so

--- a/pwiz_tools/Osprey/regression.ps1
+++ b/pwiz_tools/Osprey/regression.ps1
@@ -246,7 +246,11 @@ $knownResidentGaps = @(
         Issue = '#4486'
         Token = 'NONE'
         Path  = 'Stage 6 rebuilds the whole-run survivor buffer for SecondPassFDR to read; resident from the end of Stage 6 to the end of Stage 7.'
-        Legs  = 'Every leg of every dataset. 24.43 GB live post-GC at 82 files (0.197 GB/file); ~103 GB projected at 500.'
+        # One model, stated explicitly: a fixed library term plus a per-file slope, both from
+        # the 4/8/16-file A/B. Quoting a straight-through 82-file endpoint next to that rig's
+        # marginal slope produced three numbers no single model reproduced (24.43/82 = 0.298,
+        # not 0.197), which is unreadable in a summary that prints on every CI run.
+        Legs  = 'Every leg of every dataset. ~4.4 GB library + 0.197 GB/file live post-GC: ~20 GB at 82 files, ~103 GB projected at 500.'
     }
 )
 # Reachable only outside this gate, tokened, each with an open issue:

--- a/pwiz_tools/Osprey/regression.ps1
+++ b/pwiz_tools/Osprey/regression.ps1
@@ -1320,10 +1320,11 @@ foreach ($name in $selected) {
         Write-Progress-Tc "${name}: HPC 4-task chain self-consistency (mode 3)"
         $chainRoot = Join-Path $runRoot "$name\chain"
         $sw3 = [Diagnostics.Stopwatch]::StartNew()
-        # No OSPREY_ALLOW_UNBOUNDED_MEMORY opt-in here. mode 3's SecondPassFDR leg does
-        # still take the RESIDENT first-pass pool (ExpectReconciledInput -- Stage 7, tracked
-        # in #4486), but that path now WARNS naming the consumer instead of throwing, so the
-        # chain runs with nothing suppressed. Keeping the opt-in would be actively harmful:
+        # No OSPREY_ALLOW_UNBOUNDED_MEMORY opt-in here, and mode 3's SecondPassFDR leg no
+        # longer needs one: since #4486 it streams the reconciled-input load (one file's
+        # pre-compaction pool resident at a time) instead of taking the RESIDENT first-pass
+        # pool, so no leg of this chain arms the guard at all. Keeping the opt-in would be
+        # actively harmful:
         # it wrapped the whole chain and would mask a genuine guard regression on any
         # --input-scores worker (--task PerFileScoring / PerFileRescoring), which is exactly
         # what mode 3 exists to exercise.


### PR DESCRIPTION
## Summary

* Added five post-GC memory probes to Stage 7. It had ONE pre-GC probe and zero
  `LogManagedHeapAfterGcIfEnabled` calls (Stage 5 has 6, Stage 6 has 5), so
  `OSPREY_LOG_MEMORY=1` could not produce a Stage 7 live number no matter who set it -
  which is why #4486 went three months on `--memstamp` figures alone
* Streamed the `--task SecondPassFDR` reconciled-input load. It reloaded every input's
  full PRE-compaction stub list before compacting - a measured 2.21 GB/file (7.6 GB after
  file 1 to 40.8 GB after file 16), ~186 GB projected at 82 files - while the bounded
  `HydrateCompactedStreaming` it needed already served every other reconciled-bundle path
* Root cause was a proxy: `PreCompactionPoolReason` tested `!NoJoin` as a stand-in for
  "will `FirstPassFdrTask` run here", which is false for exactly this task
  (`IsIncluded` requires `!ExpectReconciledInput`). It now asks `IsIncludedFor`, so the
  membership rule has one definition and cannot drift again
* Retired the `hpc-merge` token: nothing on that node reads the pre-compaction pool -
  the frozen `transfer-compete` / `protein-compact` competition streams off each file's
  `.1st-pass.fdr_scores.bin` scalars, and the resident load pulled PIN features that
  `HydrateRescoreBundleIfPresent` then nulls unread

* Made the pass-2 competition emit per file instead of retaining per-observation results.
  Its roll-up was already bounded - per-base_id bests, a per-entry_id best-run-q floor - but
  it returned three whole-run `(file, entry_id)`-keyed dictionaries and built three more to
  feed them. Six such structures at ~200 B/observation x 86.6 M observations account for the
  measured +0.214 GB/file with no unexplained remainder. Run q is now written onto each
  file's already-resident entries as that file finishes; experiment q and PEP are derived
  per entry from O(distinct) state (`StreamedCompetitionState`), so neither is materialized
  at all - `survivorExpQ` was provably `max(baseIdExpQ[bid], minRunQ[eid])`, which has no
  fileKey term
* Fused the frozen-model feature scoring into that same streamed loop. It was a separate
  whole-run pass that loaded every file's reconciled PIN features and stashed all of their
  scores (~3.8 GB at 82 files); it is per file by nature, so this bounds it AND removes one
  full pass over the reconciled parquets
* Reported progress through the two silent per-file loops after the competition - the
  2nd-pass sidecar write (~4.8 GB across 82 files) and the reload that follows it. They were
  the only reporting gap over 30 s left in the stage
* Merged same-stem entry lists in the per-file emit. Two `--input-scores` paths in different
  directories can share a stem (`RescoreHydration.PreCompactionTallies` is index-keyed for
  exactly that reason) and every per-file structure here is name-keyed, so last-wins would
  have left one list's entries with a mixture of refreshed and stale q-values. Merging
  reproduces what the whole-run `(file, entry_id)` map did implicitly

## Measured - HPC join node

Same 16-file SEA-AD Astral rig, same Stage 1-5 artifacts, two pinned binaries differing
only in the streaming change.

| files | peak private | pre-GC managed at S7 entry | live (post-GC) | spectra |
|---|---|---|---|---|
| 4 | 18.80 -> 15.96 GB | 15.05 -> 6.90 | 5.19 / 5.19 | 52,084 both |
| 8 | 29.25 -> 19.90 GB | 9.87 -> 8.10 | 5.94 / 5.96 | 54,432 both |
| 16 | 45.73 -> 25.88 GB | 39.64 -> 9.79 | 7.53 / 7.56 | 59,102 both |

Peak-private slope **2.06 -> 0.75 GB/file** (8->16). Peak -43% and pre-GC managed -75% at
16 files; Stage 7 **32% faster** (7:19 -> 5:00) because it stops reading and discarding
~52x the surviving rows. Live set and output identical at every point.

## Measured - straight-through, 82 files

Stages 5-7 in one process (4:26:08, exit 0), current defaults, Stage 1-4 reused.

* The per-file stages are bounded: Stage 6 held a ~4 GB managed floor / ~17 GB private for
  2 h 47 m, ending at `[MEM reconciliation-resident] 2.90 GB (files=82,
  file_parallelism=1)` - against #4526's 28.17 GB for the resident handoff.
* The JOIN stages are not. Stage 5's compaction + planning sustains ~29 GB holding
  86.18 M survivors, and Stage 7's pass-2 competition climbs monotonically
  **+0.214 GB/file** to the run-wide peak (56.8 GB managed / 63.7 GB private;
  `peak_paged` 63.92 GB, i.e. commit at the 64 GB line at 82 files).

## Measured - after, 82-file `--task SecondPassFDR` (the fix)

Stage 7 alone on the `stage5to7-82f-4486` rig, 24:47, exit 0. Post-GC probes:

| probe | managed |
|---|---|
| `stage7-inherited` | 25.97 GB |
| `stage7-fragments-released` | 23.74 GB |
| `stage7-pass2-scored` | **23.73 GB** |
| `stage7-protein-fdr` | 23.73 GB |
| `stage7-blib-written` | 23.73 GB |

The competition enters and leaves at 23.7 GB, against the baseline's monotonic
41.0 -> 56.8 GB. **Deliberately corroborated by a second instrument**, because boundary
probes alone are exactly what produced this issue's retracted claim: the in-phase
`--memstamp` series across the competition reads
`4% 41.6 | 12% 33.0 | 19% 37.1 | 26% 42.2 | 34% 42.7 | 41% 50.6 | 48% 24.1 | 56% 31.8 |
63% 33.6 | 70% 37.2 | 78% 42.6 | 85% 43.2 | 92% 46.7 | 100% 42.0` GB - a sawtooth with
floors at 33.0 / 24.1 / 31.8 / 33.6, flat rather than rising. Both instruments agree.

Output identical to the recorded baseline: 37,078 library spectra from 3,037,028 passing
entries. Stage 7 wall 1486.8 s (baseline 1588.0 s).

Reporting, same rig with the reporters in: `gaps >= 30s : 0 OK` (max 27 s), where the
pre-fix run had one 38 s gap immediately after `[STAGE-WALL] second-pass-fdr`.

**Scope, stated plainly**: this bounds the pass-2 COMPETITION. The Stage 6 -> 7 whole-run
survivor buffer this issue's title names is untouched and still grows ~0.196 GB/file (load
phase, measured +195 MB/file here against the documented 0.197). That remains the 500-file
wall and is not claimed as fixed.

**Earlier drafts of this description claimed "Stage 7's OWN cost is 0.001 GB/file ... there
was never a lever inside SecondPassFdrTask". That was WRONG** and is corrected on the issue
(comment 5229971150). It came from post-GC probes firing at substep BOUNDARIES; the
competition allocates and releases between them, so the phase looked free. Do not
reintroduce that claim.

See #4486

## Test plan

- [x] `regression.ps1 -Dataset All` - byte-identical on every mode and dataset, 44/44,
      including all four mode 3 (HPC 4-task chain) legs, which run `--task SecondPassFDR`
      and are the direct oracle for the load change
- [x] `Build-Osprey.ps1 -RunTests -RunInspection` - 578 tests, 0 errors, 0 warnings
- [x] `ResidentPoolGuardTest.TestResidentPoolGuardError` - verified RED against master's
      predicate and GREEN with the fix, not merely asserted
- [x] Memory A/B on the HPC arm, post-GC probes rather than `--memstamp`
- [x] 82-file Stage-7-only run on the `stage5to7-82f-4486` rig showing the competition flat
      in file count, corroborated by the in-phase `--memstamp` series (post-GC boundary
      probes alone cannot support this claim - that is how the retracted one was made)
- [x] Reporting verified empirically after the change: `gaps >= 30s : 0` via
      `ai/scripts/perfviz.py`, not asserted from the diff
- [x] `regression.ps1 -Dataset All` re-run after the competition change - 44/44, exit 0

## Review

`/code-review max` returned 15 findings; all were verified against the code rather than
auto-applied, and 13 produced changes. Two are worth naming here:

* Two gates added mid-branch (`31af2e17f1`, `72f6ed9c93`) were UNSATISFIABLE inside the
  streaming branch - `streamCompaction` is `PreCompactionPoolReason == null`, which requires
  `IsIncludedFor` false - so instead of skipping work where the reader is excluded they
  disabled the pre-compaction tally and the `--model-diagnostics` accumulator on every
  streaming node, while `PipelineContext.DemandByType` still drove the reader. Both are
  REVERTED. The root cause is a conflation worth avoiding elsewhere: `IsIncludedFor` answers
  driver-loop membership, not "will this artifact be consumed in this process".
* The multi-file coverage added for `StreamedCompetitionState` was mutation-tested. Dropping
  the `fileKey` term from `Pep` turns it red; deleting the `ExperimentQ` clamp does NOT, so
  the clamp stays covered by byte-parity only and the test says so rather than implying
  coverage it does not have.

Two findings were refuted with reasons and left unchanged (a `loadFeatures` predicate that is
correct for the question it answers, and a mid-stream mutation whose failure path aborts
before anything is persisted); one more, the pass-2 sidecar divergence the FDRBench oracle
turned up, is pre-existing and split to #4553 with its own branch and failing check.

One defect found and fixed mid-branch that byte-parity structurally could not catch:
dropping `ExpectReconciledInput` from `NeedsResidentPool` made the LEAN counts-only load
reachable on a merge whose inputs lack a `.reconciliation.json` (one partially copied file
is enough). That path adds EMPTY per-file entry lists, so Stage 7 would have written a
near-empty `.blib` with no error and exit 0. The regression rig always has complete
sidecars, so mode 3 stays green either way. `CanUseLeanProjection` now states the exclusion
on its own reasoning - the same class of mistake as the `!NoJoin` proxy this PR removes.

See ai/todos/active/TODO-20260808_stage7_secondpass_memory.md

Co-Authored-By: Claude <noreply@anthropic.com>
