### PR TITLE
skyline: Marked TestPeakBoundaryImputationDiaTutorial as unsuitable for parallel testing

### DIFF
--- a/pwiz_tools/Skyline/TestPerf/PeakBoundaryImputationDiaTutorial.cs
+++ b/pwiz_tools/Skyline/TestPerf/PeakBoundaryImputationDiaTutorial.cs
@@ -40,7 +40,7 @@ namespace TestPerf
     [TestClass]
     public class PeakBoundaryImputationDiaTutorial : AbstractFunctionalTest
     {
-        [TestMethod]
+        [TestMethod, NoParallelTesting(TestExclusionReason.RESOURCE_INTENSIVE)] // Exhausts memory when run alongside other workers
         public void TestPeakBoundaryImputationDiaTutorial()
         {
             if (IsTranslationRequired)


### PR DESCRIPTION
## Summary

* Added `NoParallelTesting(TestExclusionReason.RESOURCE_INTENSIVE)` to `TestPeakBoundaryImputationDiaTutorial`
* The test exhausts available memory when run alongside other parallel workers, failing with an unhandled `OutOfMemoryException` and a loader failure ("The system cannot execute the specified program")
* Matches the treatment already given to the other memory-hungry DIA tutorial tests in `DiaSwathTutorialTest.cs`

## Test plan

- [x] Builds clean (verified by developer)
- [ ] TestPeakBoundaryImputationDiaTutorial not re-run; the change only affects how the test is scheduled, not what it does

Co-Authored-By: Claude <noreply@anthropic.com>