### PR TITLE
osprey: Collapsed the protein q-values into one field written per pass

### DIFF
--- a/pwiz_tools/Osprey/Osprey.Core/FdrEntry.cs
+++ b/pwiz_tools/Osprey/Osprey.Core/FdrEntry.cs
@@ -70,12 +70,27 @@ namespace pwiz.Osprey.Core
         public double Score { get; set; }
         public double RunPrecursorQvalue { get; set; }
         public double RunPeptideQvalue { get; set; }
-        public double RunProteinQvalue { get; set; }
         public double ExperimentPrecursorQvalue { get; set; }
         public double ExperimentPeptideQvalue { get; set; }
-        public double ExperimentProteinQvalue { get; set; }
         public double Pep { get; set; }
         public string ModifiedSequence { get; set; }
+
+        /// <summary>
+        /// Picked-protein q-value for the protein group this entry's peptide maps to.
+        /// EXPERIMENT-scope in both passes: the first-pass protein FDR pools the detected
+        /// peptides over every file, computes one picked-protein FDR, and propagates one value
+        /// per <see cref="ModifiedSequence"/> to every entry in every file. There is no per-run
+        /// protein q anywhere in the pipeline.
+        ///
+        /// <para>Which PASS produced the value is encoded by the sidecar it is written to, not
+        /// by a second field - exactly as it is for the precursor and peptide q-values. The
+        /// 1st-pass sidecar carries the pass-1 value (the compaction protein-rescue gate reads
+        /// it back from there); the 2nd-pass sidecar carries the pass-2 value, patched in after
+        /// the second-pass protein FDR. Splitting the two passes across a
+        /// <c>RunProteinQvalue</c> / <c>ExperimentProteinQvalue</c> pair is what made a pass-1
+        /// value land in a pass-2 file and produced issue #4559.</para>
+        /// </summary>
+        public double ExperimentProteinQvalue { get; set; }
 
         /// <summary>
         /// The per-entry score the EXPERIMENT-scope competitions ranked this entry on (sidecar
@@ -160,7 +175,6 @@ namespace pwiz.Osprey.Core
         {
             RunPrecursorQvalue = 1.0;
             RunPeptideQvalue = 1.0;
-            RunProteinQvalue = 1.0;
             ExperimentPrecursorQvalue = 1.0;
             ExperimentPeptideQvalue = 1.0;
             ExperimentProteinQvalue = 1.0;
@@ -173,10 +187,10 @@ namespace pwiz.Osprey.Core
         /// state a Stage 6 rescore target is left in for the 2nd pass to fill, and the state a
         /// fresh gap-fill stub is appended in.
         ///
-        /// <para>One method because the same eight assignments had been written out five
-        /// times - the rescore overlay, both gap-fill passes, and the rebuild-from-disk - and
-        /// the paths are compared against each other for byte identity. A field added to the
-        /// set in four places out of five is a divergence nothing would catch.</para>
+        /// <para>One method because the same assignments had been written out five times -
+        /// the rescore overlay, both gap-fill passes, and the rebuild-from-disk - and the
+        /// paths are compared against each other for byte identity. A field added to the set
+        /// in four places out of five is a divergence nothing would catch.</para>
         /// </summary>
         public void ResetScores()
         {
@@ -184,7 +198,6 @@ namespace pwiz.Osprey.Core
             ExperimentAggregateScore = 0.0;
             RunPrecursorQvalue = 1.0;
             RunPeptideQvalue = 1.0;
-            RunProteinQvalue = 1.0;
             ExperimentPrecursorQvalue = 1.0;
             ExperimentPeptideQvalue = 1.0;
             ExperimentProteinQvalue = 1.0;

--- a/pwiz_tools/Osprey/Osprey.FDR/FdrProjectionOutput.cs
+++ b/pwiz_tools/Osprey/Osprey.FDR/FdrProjectionOutput.cs
@@ -32,7 +32,7 @@ namespace pwiz.Osprey.FDR
     /// FdrProjection struct-shrink S0). These are the outputs the lean
     /// <see cref="FdrProjection"/> no longer stores: the score pass hands each row's
     /// values to a per-pass <see cref="IFdrOutputSink"/> instead of overlaying them
-    /// onto the struct. <c>RunProteinQvalue</c> is NOT here -- it is produced by
+    /// onto the struct. <c>ExperimentProteinQvalue</c> is NOT here -- it is produced by
     /// first-pass protein FDR AFTER the score pass, not by the score pass.
     /// </summary>
     public readonly struct FdrQValues
@@ -106,7 +106,7 @@ namespace pwiz.Osprey.FDR
     /// each row's freshly computed <see cref="FdrQValues"/> + <see cref="FdrProjection.Score"/>
     /// to a caller-supplied sink. Both passes stream every row straight to the per-file
     /// <c>.fdr_scores.bin</c> sidecar (never stored -> 32 B resident): the 2nd pass writes
-    /// the final record, the 1st pass writes a phase-1 record whose <c>run_protein_qvalue</c>
+    /// the final record, the 1st pass writes a phase-1 record whose <c>experiment_protein_qvalue</c>
     /// first-pass protein FDR patches from disk afterward (issue #4355 struct-shrink S2; S1
     /// still kept a 16 B/row 1st-pass {RunPeptideQ, RunProteinQ} array, since removed). The
     /// sink also OWNS the tail <c>[COUNT]</c> tally (<see cref="Finish"/>),

--- a/pwiz_tools/Osprey/Osprey.FDR/ProteinFdr.cs
+++ b/pwiz_tools/Osprey/Osprey.FDR/ProteinFdr.cs
@@ -133,7 +133,7 @@ namespace pwiz.Osprey.FDR
     /// The computed artifacts of a first-pass protein-FDR run, returned by
     /// <c>ProteinFdr.RunFirstPassProteinFdr</c> so the caller can log
     /// summary counts and emit the Stage-6 diagnostic dump WITHOUT recomputing
-    /// parsimony / FDR. The run has already propagated <c>RunProteinQvalue</c>
+    /// parsimony / FDR. The run has already propagated <c>ExperimentProteinQvalue</c>
     /// onto the stubs; these are the same intermediate objects it used.
     /// </summary>
     public class FirstPassProteinFdrResult
@@ -175,9 +175,9 @@ namespace pwiz.Osprey.FDR
     /// (detected-gate + best max-score / min-q) are order-independent and a modified sequence
     /// maps to a single target/decoy label, so any streaming order reproduces the resident
     /// <see cref="ProteinFdr.CollectBestPeptideScores(IList{KeyValuePair{string, List{FdrEntry}}})"/>
-    /// path byte-identically. The caller then patches each entry's <c>run_protein_qvalue</c>
+    /// path byte-identically. The caller then patches each entry's <c>experiment_protein_qvalue</c>
     /// onto the sidecar from <see cref="FirstPassProteinFdrResult.ProteinFdr"/>'s
-    /// <c>PeptideQvalues</c> (replacing the resident <c>PropagateRunProteinQvalues</c> +
+    /// <c>PeptideQvalues</c> (replacing the resident <c>PropagateProteinQvalues</c> +
     /// phase-2 patch with one streaming pass).
     /// </summary>
     public sealed class FirstPassProteinFdrAccumulator
@@ -224,7 +224,7 @@ namespace pwiz.Osprey.FDR
         /// <summary>
         /// Run the identical parsimony + picked-protein FDR the buffer path runs and return
         /// the artifacts (the caller logs summary counts + patches the sidecar's
-        /// <c>run_protein_qvalue</c> from <see cref="ProteinFdrResult.PeptideQvalues"/>). The
+        /// <c>experiment_protein_qvalue</c> from <see cref="ProteinFdrResult.PeptideQvalues"/>). The
         /// cross-impl best-peptide-scores dump fires here, at the same point the resident
         /// <see cref="ProteinFdr.CollectBestPeptideScores(IList{KeyValuePair{string, List{FdrEntry}}})"/>
         /// emits it (after the reduction is complete).
@@ -248,7 +248,7 @@ namespace pwiz.Osprey.FDR
     /// by <see cref="ProteinFdrEngine.RunSecondPass"/> so the Tasks-layer caller can
     /// emit the Stage-7 detected-peptides and protein-FDR diagnostic dumps (and the
     /// <c>Stage7ProteinFdrOnly</c> early-exit decision) WITHOUT recomputing parsimony
-    /// / FDR. The run has already propagated <c>RunProteinQvalue</c> and
+    /// / FDR. The run has already propagated <c>ExperimentProteinQvalue</c> and
     /// <c>ExperimentProteinQvalue</c> onto the stubs; these are the same intermediate
     /// objects it used.
     /// </summary>
@@ -888,13 +888,16 @@ namespace pwiz.Osprey.FDR
         }
 
         /// <summary>
-        /// Propagate protein q-values to FdrEntry stubs.
+        /// Propagate protein q-values to FdrEntry stubs. Assigns by
+        /// <see cref="FdrEntry.ModifiedSequence"/> over EVERY entry, whether or not it passed
+        /// anything - a peptide's protein q is a property of the peptide, so an entry that lost
+        /// its own competition still carries its protein's value. Both passes call this; which
+        /// pass a value came from is recorded by the sidecar it is written to, not by writing a
+        /// second field (see <see cref="FdrEntry.ExperimentProteinQvalue"/>).
         /// </summary>
         public static void PropagateProteinQvalues(
             IList<KeyValuePair<string, List<FdrEntry>>> perFileEntries,
-            ProteinFdrResult proteinFdr,
-            bool setRun,
-            bool setExperiment)
+            ProteinFdrResult proteinFdr)
         {
             foreach (var file in perFileEntries)
             {
@@ -903,10 +906,7 @@ namespace pwiz.Osprey.FDR
                     double q;
                     if (!proteinFdr.PeptideQvalues.TryGetValue(entry.ModifiedSequence, out q))
                         q = 1.0;
-                    if (setRun)
-                        entry.RunProteinQvalue = q;
-                    if (setExperiment)
-                        entry.ExperimentProteinQvalue = q;
+                    entry.ExperimentProteinQvalue = q;
                 }
             }
         }
@@ -914,20 +914,24 @@ namespace pwiz.Osprey.FDR
         /// <summary>
         /// First-pass protein FDR: build parsimony from peptides passing peptide-level
         /// run FDR, run picked-protein FDR at <see cref="OspreyConfig.RunFdr"/> (1x Savitski
-        /// gate), and write the resulting q-values into <see cref="FdrEntry.RunProteinQvalue"/>
-        /// on every stub. Mirrors Rust <c>pipeline.rs::run_analysis</c> first-pass block
-        /// (around line 4292). Caller is responsible for any logging, dump diagnostics,
-        /// and downstream consumption.
+        /// gate), and write the resulting q-values into
+        /// <see cref="FdrEntry.ExperimentProteinQvalue"/> on every stub. Mirrors Rust
+        /// <c>pipeline.rs::run_analysis</c> first-pass block (around line 4292). Caller is
+        /// responsible for any logging, dump diagnostics, and downstream consumption.
+        ///
+        /// The result is EXPERIMENT-scope even though its detected-peptide gate is run-level:
+        /// the detected set is pooled over every file, one picked-protein FDR runs, and one
+        /// value per peptide reaches every entry in every file. What makes it the FIRST-PASS
+        /// value is when it runs, not what it is scoped to.
         ///
         /// Used by FirstPassFdrTask for the in-process pipeline (runs after first-pass FDR,
         /// before compaction) and by PerFileRescoreTask for the <c>--task SecondPassFDR</c>
         /// rehydration path (runs after sidecar load, before compaction) so the protein-
-        /// rescue branch of compaction has fresh <c>RunProteinQvalue</c> values matching
-        /// what Rust computes inline. Without it, the rehydrated C# pipeline used only
-        /// the <c>RunProteinQvalue</c> values stored in the 1st-pass FDR sidecar; for
-        /// single-file <c>--task SecondPassFDR</c> runs that left 19 peptides outside Rust's
-        /// post-compaction detected set on Stellar Single, causing a 1-protein delta in
-        /// Stage 7 picked-protein output.
+        /// rescue branch of compaction has fresh values matching what Rust computes inline.
+        /// Without it, the rehydrated C# pipeline used only the values stored in the 1st-pass
+        /// FDR sidecar; for single-file <c>--task SecondPassFDR</c> runs that left 19 peptides
+        /// outside Rust's post-compaction detected set on Stellar Single, causing a 1-protein
+        /// delta in Stage 7 picked-protein output.
         /// </summary>
         public static FirstPassProteinFdrResult RunFirstPassProteinFdr(
             IList<KeyValuePair<string, List<FdrEntry>>> perFileEntries,
@@ -951,10 +955,9 @@ namespace pwiz.Osprey.FDR
             var bestScores = CollectBestPeptideScores(perFileEntries);
             var proteinFdr = ComputeProteinFdr(parsimony, bestScores, config.RunFdr);
 
-            // Set RunProteinQvalue ONLY. ExperimentProteinQvalue is set by the
-            // post-output Stage 7 second-pass protein FDR (Rust's second-pass).
-            PropagateProteinQvalues(perFileEntries, proteinFdr,
-                setRun: true, setExperiment: false);
+            // The Stage 7 second-pass protein FDR overwrites this with its own value; the
+            // pass-1 value is captured on the way past, into the 1st-pass sidecar.
+            PropagateProteinQvalues(perFileEntries, proteinFdr);
 
             // Return the computed artifacts so the caller can log summary counts
             // and emit the Stage-6 diagnostic dump without recomputing them.

--- a/pwiz_tools/Osprey/Osprey.FDR/ProteinFdr.cs
+++ b/pwiz_tools/Osprey/Osprey.FDR/ProteinFdr.cs
@@ -248,8 +248,8 @@ namespace pwiz.Osprey.FDR
     /// by <see cref="ProteinFdrEngine.RunSecondPass"/> so the Tasks-layer caller can
     /// emit the Stage-7 detected-peptides and protein-FDR diagnostic dumps (and the
     /// <c>Stage7ProteinFdrOnly</c> early-exit decision) WITHOUT recomputing parsimony
-    /// / FDR. The run has already propagated <c>ExperimentProteinQvalue</c> and
-    /// <c>ExperimentProteinQvalue</c> onto the stubs; these are the same intermediate
+    /// / FDR. The run has already propagated <c>ExperimentProteinQvalue</c>
+    /// onto the stubs; these are the same intermediate
     /// objects it used.
     /// </summary>
     public class SecondPassProteinFdrResult

--- a/pwiz_tools/Osprey/Osprey.FDR/ProteinFdrEngine.cs
+++ b/pwiz_tools/Osprey/Osprey.FDR/ProteinFdrEngine.cs
@@ -50,7 +50,7 @@ namespace pwiz.Osprey.FDR
         /// First-pass protein FDR (pre-Stage-6, full pre-compaction pool): builds
         /// parsimony from peptides passing peptide-level run FDR, runs picked-protein
         /// FDR at <see cref="OspreyConfig.RunFdr"/>, and writes
-        /// <see cref="FdrEntry.RunProteinQvalue"/> on every stub. The pure computation
+        /// <see cref="FdrEntry.ExperimentProteinQvalue"/> on every stub. The pure computation
         /// lives in <c>ProteinFdr.RunFirstPassProteinFdr</c>; this adds the
         /// summary logging and returns the artifacts so the Tasks facade can emit the
         /// Stage-6 diagnostic dump + <c>ProteinFdrOnly</c> early-exit WITHOUT
@@ -103,9 +103,10 @@ namespace pwiz.Osprey.FDR
         /// Second-pass / run-wide protein FDR (SecondPassFDR, post Stage-6): collects
         /// best peptide scores, gates the detected-peptide set on experiment-level
         /// q-value, builds parsimony, runs picked-protein FDR at
-        /// <see cref="OspreyConfig.RunFdr"/>, and propagates both
-        /// <see cref="FdrEntry.RunProteinQvalue"/> and
-        /// <see cref="FdrEntry.ExperimentProteinQvalue"/> onto every stub. Logs
+        /// <see cref="OspreyConfig.RunFdr"/>, and propagates
+        /// <see cref="FdrEntry.ExperimentProteinQvalue"/> onto every stub, OVERWRITING the
+        /// first-pass value the Stage-5 run left there (the pass-1 value has already been
+        /// captured into the 1st-pass sidecar by then). Logs
         /// summary counts via <paramref name="logInfo"/> (which may be null for a
         /// silent run, like <c>RunFirstPass</c>) and returns the parsimony /
         /// FDR artifacts so the Tasks facade can emit the Stage-7 detected-peptides
@@ -196,7 +197,7 @@ namespace pwiz.Osprey.FDR
             // the dumps do not read, so emitting the dump after propagation is
             // output-invariant -- and matches the first-pass ordering, where
             // RunFirstPassProteinFdr likewise propagates before the facade dump.
-            ProteinFdr.PropagateProteinQvalues(perFileEntries, proteinFdr, true, true);
+            ProteinFdr.PropagateProteinQvalues(perFileEntries, proteinFdr);
 
             return new SecondPassProteinFdrResult(detectedPeptides, parsimony, proteinFdr);
         }

--- a/pwiz_tools/Osprey/Osprey.FDR/Reconciliation/ConsensusRts.cs
+++ b/pwiz_tools/Osprey/Osprey.FDR/Reconciliation/ConsensusRts.cs
@@ -246,7 +246,7 @@ namespace pwiz.Osprey.FDR.Reconciliation
             if (entry.RunPrecursorQvalue > consensusFdr)
                 return false;
             return entry.RunPeptideQvalue <= consensusFdr ||
-                   (proteinFdrThreshold > 0.0 && entry.RunProteinQvalue <= proteinFdrThreshold);
+                   (proteinFdrThreshold > 0.0 && entry.ExperimentProteinQvalue <= proteinFdrThreshold);
         }
 
         private static bool IsFinite(double d)

--- a/pwiz_tools/Osprey/Osprey.IO/FdrScoreRecord.cs
+++ b/pwiz_tools/Osprey/Osprey.IO/FdrScoreRecord.cs
@@ -75,7 +75,7 @@ namespace pwiz.Osprey.IO
             uint entryId, double score,
             double runPrecursorQvalue, double runPeptideQvalue,
             double experimentPrecursorQvalue, double experimentPeptideQvalue,
-            double pep, double runProteinQvalue, double experimentAggregateScore)
+            double pep, double experimentProteinQvalue, double experimentAggregateScore)
         {
             EntryId = entryId;
             Score = score;
@@ -84,7 +84,7 @@ namespace pwiz.Osprey.IO
             ExperimentPrecursorQvalue = experimentPrecursorQvalue;
             ExperimentPeptideQvalue = experimentPeptideQvalue;
             Pep = pep;
-            ExperimentProteinQvalue = runProteinQvalue;
+            ExperimentProteinQvalue = experimentProteinQvalue;
             ExperimentAggregateScore = experimentAggregateScore;
         }
     }

--- a/pwiz_tools/Osprey/Osprey.IO/FdrScoreRecord.cs
+++ b/pwiz_tools/Osprey/Osprey.IO/FdrScoreRecord.cs
@@ -25,12 +25,12 @@ namespace pwiz.Osprey.IO
 {
     /// <summary>
     /// One <c>.fdr_scores.bin</c> record's payload (entry_id + SVM score + 4 q-values +
-    /// PEP + run_protein_qvalue + experiment_aggregate_score), decoupled from any resident
+    /// PEP + experiment_protein_qvalue + experiment_aggregate_score), decoupled from any resident
     /// buffer (issue #4355 struct-shrink S0). Since the lean <c>FdrProjection</c> no longer
     /// carries the q-value outputs, the projection sidecar writers assemble records of this
     /// shape -- the 1st pass from the lean row's <c>EntryId</c>/<c>Score</c> plus the parallel
     /// outputs array, the 2nd pass from the streamed q-values plus the survivor's
-    /// <c>RunProteinQvalue</c> lookup -- and hand them to
+    /// <c>ExperimentProteinQvalue</c> lookup -- and hand them to
     /// <see cref="FdrScoresSidecar.Write(string, System.Collections.Generic.IReadOnlyList{FdrScoreRecord}, FdrScoresSidecar.Pass)"/>.
     /// The 68-byte byte layout stays single-sourced through
     /// <c>FdrScoresSidecar.WriteRecord</c>.
@@ -44,7 +44,7 @@ namespace pwiz.Osprey.IO
         public readonly double ExperimentPrecursorQvalue;
         public readonly double ExperimentPeptideQvalue;
         public readonly double Pep;
-        public readonly double RunProteinQvalue;
+        public readonly double ExperimentProteinQvalue;
 
         /// <summary>
         /// The per-entry score the EXPERIMENT-scope competitions ranked this entry on, beside
@@ -84,7 +84,7 @@ namespace pwiz.Osprey.IO
             ExperimentPrecursorQvalue = experimentPrecursorQvalue;
             ExperimentPeptideQvalue = experimentPeptideQvalue;
             Pep = pep;
-            RunProteinQvalue = runProteinQvalue;
+            ExperimentProteinQvalue = runProteinQvalue;
             ExperimentAggregateScore = experimentAggregateScore;
         }
     }

--- a/pwiz_tools/Osprey/Osprey.IO/FdrScoresSidecar.cs
+++ b/pwiz_tools/Osprey/Osprey.IO/FdrScoresSidecar.cs
@@ -349,7 +349,7 @@ namespace pwiz.Osprey.IO
         /// record from the lean row's EntryId + Score plus the parked / streamed
         /// q-values (1st pass) or the streamed q-values + the survivor's
         /// <c>ExperimentProteinQvalue</c> lookup (2nd pass), then pass them here. Single-phase
-        /// write producing byte-identical 60-byte records in the given
+        /// write producing byte-identical <see cref="RecordLength"/>-byte records in the given
         /// (per-file, projection) order (risk #8). Header + record layout are
         /// single-sourced with the FdrEntry overload via
         /// <see cref="WriteInternal"/> / <see cref="WriteRecord"/>.
@@ -453,7 +453,7 @@ namespace pwiz.Osprey.IO
 
                         dst.Write(header, 0, HeaderLength);
 
-                        // Stream one 60-byte record at a time: overwrite ONLY the
+                        // Stream one RecordLength-byte record at a time: overwrite ONLY the
                         // experiment_protein_qvalue bytes [52..60] with the finalized value
                         // looked up by entry_id [0..4], in the identical little-endian f64
                         // encoding BinaryWriter.Write(double) produced for every other
@@ -512,7 +512,7 @@ namespace pwiz.Osprey.IO
         /// <summary>
         /// Shared header + atomic-write scaffold for both <c>Write</c>
         /// overloads. The caller supplies the body writer, which emits exactly
-        /// <paramref name="entryCount"/> 60-byte records via
+        /// <paramref name="entryCount"/> <see cref="RecordLength"/>-byte records via
         /// <see cref="WriteRecord"/>. Atomic write via FileSaver: write to a unique
         /// sibling temp file and promote it to the destination on Commit; on
         /// exception the FileSaver disposes and deletes the temp without touching
@@ -758,8 +758,9 @@ namespace pwiz.Osprey.IO
         /// file), not O(all files)) and key them into a per-file map. Same header validation
         /// as <see cref="TryRead(string,IList{FdrEntry},Pass)"/> (magic / version / pass /
         /// size); returns <c>false</c> (with the partial callback effects the caller must
-        /// discard) on any mismatch or IO failure. Streams one 60-byte record at a time from
-        /// the source (one record resident, not an O(file-size) whole-file buffer), matching
+        /// discard) on any mismatch or IO failure. Streams one <see cref="RecordLength"/>-byte
+        /// record at a time from the source (one record resident, not an O(file-size)
+        /// whole-file buffer), matching
         /// <see cref="PatchProteinQvalues"/>. Records are delivered in stored (file) order.
         /// </summary>
         public static bool ReadRecords(string path, Pass expectedPass, Action<FdrScoreRecord> onRecord)

--- a/pwiz_tools/Osprey/Osprey.IO/FdrScoresSidecar.cs
+++ b/pwiz_tools/Osprey/Osprey.IO/FdrScoresSidecar.cs
@@ -32,7 +32,7 @@ namespace pwiz.Osprey.IO
     /// Reader / writer for the per-file <c>.&lt;phase&gt;-pass.fdr_scores.bin</c>
     /// sidecar: the v4 binary format that persists the full FDR statistics
     /// for an entry (SVM discriminant + 4 q-values + PEP +
-    /// <c>run_protein_qvalue</c> + <c>experiment_aggregate_score</c>). Used at
+    /// <c>experiment_protein_qvalue</c> + <c>experiment_aggregate_score</c>). Used at
     /// the Stage 5 → Stage 6 boundary so a Stage 6 worker can run without
     /// re-running first-pass Percolator AND apply the same protein-rescue
     /// compaction predicate the in-process pipeline uses.
@@ -58,14 +58,14 @@ namespace pwiz.Osprey.IO
     ///                            [28..36] f64 experiment_precursor_qvalue
     ///                            [36..44] f64 experiment_peptide_qvalue
     ///                            [44..52] f64 pep
-    ///                            [52..60] f64 run_protein_qvalue
+    ///                            [52..60] f64 experiment_protein_qvalue
     ///                            [60..68] f64 experiment_aggregate_score
     /// </code>
     /// Records are written pre-compaction but POST first-pass protein
     /// FDR at the Stage 5 → Stage 6 boundary: every input entry
     /// contributes one record so q-values are preserved even for
     /// entries that may not survive later compaction, AND so
-    /// <c>run_protein_qvalue</c> carries real values rather than the
+    /// <c>experiment_protein_qvalue</c> carries real values rather than the
     /// default 1.0. Mirrors the post-protein-FDR
     /// <c>persist_fdr_scores</c> call site in Rust's
     /// <c>pipeline.rs</c>. Each record carries the entry's
@@ -80,11 +80,11 @@ namespace pwiz.Osprey.IO
     /// so a 2nd-pass sidecar can never silently scramble 1st-pass
     /// stubs (or vice versa).
     ///
-    /// v2 → v3 (2026-05-02): added <c>run_protein_qvalue</c> to
+    /// v2 → v3 (2026-05-02): added <c>experiment_protein_qvalue</c> to
     /// support the Stage 6 worker's compaction step. The in-process
     /// pipeline filters pre-Stage-6 entries by
     /// <c>run_peptide_qvalue ≤ 0.01</c> OR
-    /// <c>run_protein_qvalue ≤ 0.01</c> (the protein-rescue branch);
+    /// <c>experiment_protein_qvalue ≤ 0.01</c> (the protein-rescue branch);
     /// the v2 sidecar carried only the first half of that predicate,
     /// so a rehydrated worker couldn't reproduce the protein-rescue
     /// half of in-process compaction. v3 closes that gap.
@@ -100,7 +100,7 @@ namespace pwiz.Osprey.IO
     /// where the aggregation is under study. See
     /// <see cref="FdrScoreRecord.ExperimentAggregateScore"/>. Appended at
     /// the END so every v3 field offset is unchanged and
-    /// <see cref="PatchRunProteinQvalues"/>'s <c>[52..60]</c> patch is
+    /// <see cref="PatchProteinQvalues"/>'s <c>[52..60]</c> patch is
     /// untouched.
     /// </summary>
     public static class FdrScoresSidecar
@@ -335,7 +335,7 @@ namespace pwiz.Osprey.IO
                     WriteRecord(bw, e.EntryId, e.Score,
                         e.RunPrecursorQvalue, e.RunPeptideQvalue,
                         e.ExperimentPrecursorQvalue, e.ExperimentPeptideQvalue,
-                        e.Pep, e.RunProteinQvalue, e.ExperimentAggregateScore);
+                        e.Pep, e.ExperimentProteinQvalue, e.ExperimentAggregateScore);
                 }
             });
         }
@@ -348,7 +348,7 @@ namespace pwiz.Osprey.IO
         /// carries the q-value outputs, the projection sidecar writers assemble each
         /// record from the lean row's EntryId + Score plus the parked / streamed
         /// q-values (1st pass) or the streamed q-values + the survivor's
-        /// <c>RunProteinQvalue</c> lookup (2nd pass), then pass them here. Single-phase
+        /// <c>ExperimentProteinQvalue</c> lookup (2nd pass), then pass them here. Single-phase
         /// write producing byte-identical 60-byte records in the given
         /// (per-file, projection) order (risk #8). Header + record layout are
         /// single-sourced with the FdrEntry overload via
@@ -366,25 +366,25 @@ namespace pwiz.Osprey.IO
                     WriteRecord(bw, r.EntryId, r.Score,
                         r.RunPrecursorQvalue, r.RunPeptideQvalue,
                         r.ExperimentPrecursorQvalue, r.ExperimentPeptideQvalue,
-                        r.Pep, r.RunProteinQvalue, r.ExperimentAggregateScore);
+                        r.Pep, r.ExperimentProteinQvalue, r.ExperimentAggregateScore);
                 }
             });
         }
 
         /// <summary>
         /// Phase 2 of the two-phase 1st-pass sidecar write (issue #4355 struct-shrink
-        /// S1): patch each record's <c>run_protein_qvalue</c> field <c>[52..60]</c> in
+        /// S1): patch each record's <c>experiment_protein_qvalue</c> field <c>[52..60]</c> in
         /// place on an already-written (phase-1 partial) sidecar, locating each record
         /// by its <c>entry_id</c> at <c>[0..4]</c> in
         /// <paramref name="runProteinByEntryId"/>. The phase-1 write (via the second
         /// <see cref="Write(string, IReadOnlyList{FdrScoreRecord}, Pass)"/> overload)
-        /// emits a byte-identical file EXCEPT for the <c>run_protein_qvalue</c> column,
+        /// emits a byte-identical file EXCEPT for the <c>experiment_protein_qvalue</c> column,
         /// which carries the 1.0 placeholder until first-pass protein FDR is known; this
         /// patch overwrites only those 8 bytes per record with the finalized value, so
         /// the resulting file is byte-identical to a single-phase <c>Write</c> whose
-        /// records already carried the real <c>run_protein_qvalue</c> (risk R2). Records
+        /// records already carried the real <c>experiment_protein_qvalue</c> (risk R2). Records
         /// whose <c>entry_id</c> is absent from the map keep their placeholder (every
-        /// 1st-pass row has a resident <c>run_protein_qvalue</c>, so that is defensive
+        /// 1st-pass row has a resident <c>experiment_protein_qvalue</c>, so that is defensive
         /// only). The 8-byte little-endian f64 encoding matches
         /// <see cref="WriteRecord"/>'s <c>BinaryWriter.Write(double)</c> (the platform is
         /// little-endian, as the <see cref="BitConverter.ToDouble(byte[], int)"/> reads
@@ -395,7 +395,7 @@ namespace pwiz.Osprey.IO
         /// (bounded memory -- one record resident, not an O(file-size) whole-file buffer;
         /// issue #4355) and promotes it atomically on Commit, matching the <c>Write</c> path.
         /// </summary>
-        public static bool PatchRunProteinQvalues(
+        public static bool PatchProteinQvalues(
             string path,
             IReadOnlyDictionary<uint, double> runProteinByEntryId,
             Pass expectedPass)
@@ -444,7 +444,7 @@ namespace pwiz.Osprey.IO
                         dst.Write(header, 0, HeaderLength);
 
                         // Stream one 60-byte record at a time: overwrite ONLY the
-                        // run_protein_qvalue bytes [52..60] with the finalized value
+                        // experiment_protein_qvalue bytes [52..60] with the finalized value
                         // looked up by entry_id [0..4], in the identical little-endian f64
                         // encoding BinaryWriter.Write(double) produced for every other
                         // field; every other byte is copied straight through. A record
@@ -662,7 +662,7 @@ namespace pwiz.Osprey.IO
                 e.ExperimentPrecursorQvalue   = BitConverter.ToDouble(data, off + 28);
                 e.ExperimentPeptideQvalue     = BitConverter.ToDouble(data, off + 36);
                 e.Pep                         = BitConverter.ToDouble(data, off + 44);
-                e.RunProteinQvalue            = BitConverter.ToDouble(data, off + 52);
+                e.ExperimentProteinQvalue            = BitConverter.ToDouble(data, off + 52);
                 e.ExperimentAggregateScore    = BitConverter.ToDouble(data, off + 60);
             }
             return true;
@@ -730,7 +730,7 @@ namespace pwiz.Osprey.IO
                 e.ExperimentPrecursorQvalue   = BitConverter.ToDouble(data, off + 28);
                 e.ExperimentPeptideQvalue     = BitConverter.ToDouble(data, off + 36);
                 e.Pep                         = BitConverter.ToDouble(data, off + 44);
-                e.RunProteinQvalue            = BitConverter.ToDouble(data, off + 52);
+                e.ExperimentProteinQvalue            = BitConverter.ToDouble(data, off + 52);
                 e.ExperimentAggregateScore    = BitConverter.ToDouble(data, off + 60);
             }
             return true;
@@ -748,7 +748,7 @@ namespace pwiz.Osprey.IO
         /// size); returns <c>false</c> (with the partial callback effects the caller must
         /// discard) on any mismatch or IO failure. Streams one 60-byte record at a time from
         /// the source (one record resident, not an O(file-size) whole-file buffer), matching
-        /// <see cref="PatchRunProteinQvalues"/>. Records are delivered in stored (file) order.
+        /// <see cref="PatchProteinQvalues"/>. Records are delivered in stored (file) order.
         /// </summary>
         public static bool ReadRecords(string path, Pass expectedPass, Action<FdrScoreRecord> onRecord)
         {
@@ -811,7 +811,7 @@ namespace pwiz.Osprey.IO
                 BitConverter.ToDouble(rec, 28),   // [28..36] experiment_precursor_qvalue
                 BitConverter.ToDouble(rec, 36),   // [36..44] experiment_peptide_qvalue
                 BitConverter.ToDouble(rec, 44),   // [44..52] pep
-                BitConverter.ToDouble(rec, 52),   // [52..60] run_protein_qvalue
+                BitConverter.ToDouble(rec, 52),   // [52..60] experiment_protein_qvalue
                 BitConverter.ToDouble(rec, 60));  // [60..68] experiment_aggregate_score
         }
     }

--- a/pwiz_tools/Osprey/Osprey.IO/FdrScoresSidecar.cs
+++ b/pwiz_tools/Osprey/Osprey.IO/FdrScoresSidecar.cs
@@ -376,7 +376,7 @@ namespace pwiz.Osprey.IO
         /// S1): patch each record's <c>experiment_protein_qvalue</c> field <c>[52..60]</c> in
         /// place on an already-written (phase-1 partial) sidecar, locating each record
         /// by its <c>entry_id</c> at <c>[0..4]</c> in
-        /// <paramref name="runProteinByEntryId"/>. The phase-1 write (via the second
+        /// <paramref name="proteinQByEntryId"/>. The phase-1 write (via the second
         /// <see cref="Write(string, IReadOnlyList{FdrScoreRecord}, Pass)"/> overload)
         /// emits a byte-identical file EXCEPT for the <c>experiment_protein_qvalue</c> column,
         /// which carries the 1.0 placeholder until first-pass protein FDR is known; this
@@ -391,17 +391,27 @@ namespace pwiz.Osprey.IO
         /// in <see cref="TryRead"/> already assume). Same header validation as
         /// <see cref="TryRead"/> (magic / version / pass / size); returns <c>false</c> on
         /// any mismatch or IO failure, leaving the file unchanged. Streams the source one
-        /// 60-byte record at a time straight into the <see cref="FileSaver"/> temp stream
-        /// (bounded memory -- one record resident, not an O(file-size) whole-file buffer;
-        /// issue #4355) and promotes it atomically on Commit, matching the <c>Write</c> path.
+        /// <see cref="RecordLength"/>-byte record at a time straight into the
+        /// <see cref="FileSaver"/> temp stream (bounded memory -- one record resident, not an
+        /// O(file-size) whole-file buffer; issue #4355) and promotes it atomically on Commit,
+        /// matching the <c>Write</c> path.
+        /// <para><paramref name="recordsPatched"/> counts records actually rewritten, NOT the
+        /// size of <paramref name="proteinQByEntryId"/>: the two differ exactly when the map
+        /// carries entry_ids the file does not, which is the coverage hole worth seeing. The
+        /// Rust twin counts the same way.</para>
         /// </summary>
         public static bool PatchProteinQvalues(
             string path,
-            IReadOnlyDictionary<uint, double> runProteinByEntryId,
-            Pass expectedPass)
+            IReadOnlyDictionary<uint, double> proteinQByEntryId,
+            Pass expectedPass,
+            out int recordsPatched)
         {
+            recordsPatched = 0;
+            // Accumulated locally and published only after Commit, so a failed patch reports
+            // zero rather than a count for records the caller's file never actually kept.
+            int nPatchedHere = 0;
             if (path == null) throw new ArgumentNullException(nameof(path));
-            if (runProteinByEntryId == null) throw new ArgumentNullException(nameof(runProteinByEntryId));
+            if (proteinQByEntryId == null) throw new ArgumentNullException(nameof(proteinQByEntryId));
 
             try
             {
@@ -459,10 +469,11 @@ namespace pwiz.Osprey.IO
                             if (!ReadFully(src, record, RecordLength))
                                 return false;
                             uint recordEntryId = BitConverter.ToUInt32(record, 0);
-                            if (runProteinByEntryId.TryGetValue(recordEntryId, out double runProteinQvalue))
+                            if (proteinQByEntryId.TryGetValue(recordEntryId, out double experimentProteinQvalue))
                             {
-                                byte[] bytes = BitConverter.GetBytes(runProteinQvalue);
+                                byte[] bytes = BitConverter.GetBytes(experimentProteinQvalue);
                                 Buffer.BlockCopy(bytes, 0, record, 52, 8);
+                                nPatchedHere++;
                             }
                             dst.Write(record, 0, RecordLength);
                         }
@@ -474,6 +485,7 @@ namespace pwiz.Osprey.IO
             {
                 return false;
             }
+            recordsPatched = nPatchedHere;
             return true;
         }
 
@@ -542,7 +554,7 @@ namespace pwiz.Osprey.IO
             BinaryWriter bw, uint entryId, double score,
             double runPrecursorQvalue, double runPeptideQvalue,
             double experimentPrecursorQvalue, double experimentPeptideQvalue,
-            double pep, double runProteinQvalue, double experimentAggregateScore)
+            double pep, double experimentProteinQvalue, double experimentAggregateScore)
         {
             bw.Write(entryId);                          // [0..4]
             bw.Write(score);                            // [4..12]
@@ -551,7 +563,7 @@ namespace pwiz.Osprey.IO
             bw.Write(experimentPrecursorQvalue);        // [28..36]
             bw.Write(experimentPeptideQvalue);          // [36..44]
             bw.Write(pep);                              // [44..52]
-            bw.Write(runProteinQvalue);                 // [52..60]
+            bw.Write(experimentProteinQvalue);                 // [52..60]
             bw.Write(experimentAggregateScore);         // [60..68]
         }
 
@@ -662,7 +674,7 @@ namespace pwiz.Osprey.IO
                 e.ExperimentPrecursorQvalue   = BitConverter.ToDouble(data, off + 28);
                 e.ExperimentPeptideQvalue     = BitConverter.ToDouble(data, off + 36);
                 e.Pep                         = BitConverter.ToDouble(data, off + 44);
-                e.ExperimentProteinQvalue            = BitConverter.ToDouble(data, off + 52);
+                e.ExperimentProteinQvalue     = BitConverter.ToDouble(data, off + 52);
                 e.ExperimentAggregateScore    = BitConverter.ToDouble(data, off + 60);
             }
             return true;
@@ -730,7 +742,7 @@ namespace pwiz.Osprey.IO
                 e.ExperimentPrecursorQvalue   = BitConverter.ToDouble(data, off + 28);
                 e.ExperimentPeptideQvalue     = BitConverter.ToDouble(data, off + 36);
                 e.Pep                         = BitConverter.ToDouble(data, off + 44);
-                e.ExperimentProteinQvalue            = BitConverter.ToDouble(data, off + 52);
+                e.ExperimentProteinQvalue     = BitConverter.ToDouble(data, off + 52);
                 e.ExperimentAggregateScore    = BitConverter.ToDouble(data, off + 60);
             }
             return true;

--- a/pwiz_tools/Osprey/Osprey.IO/FdrScoresSidecar.cs
+++ b/pwiz_tools/Osprey/Osprey.IO/FdrScoresSidecar.cs
@@ -194,7 +194,7 @@ namespace pwiz.Osprey.IO
                 if (header[8] != FormatVersion || header[9] != (byte)expectedPass)
                     return false;
                 // And the length must match the header's own entry_count, exactly as TryRead,
-                // TryReadOverlay, ReadRecords and PatchRunProteinQvalues all require. Without it
+                // TryReadOverlay, ReadRecords and PatchProteinQvalues all require. Without it
                 // this pre-flight passed a file truncated mid-record - which is precisely what
                 // ReadScalars throws on, so the caller that added this gate to refuse BEFORE
                 // mutating any survivor would still have thrown mid-stream with the pool half

--- a/pwiz_tools/Osprey/Osprey.Tasks/FdrProjectionSinks.cs
+++ b/pwiz_tools/Osprey/Osprey.Tasks/FdrProjectionSinks.cs
@@ -301,15 +301,15 @@ namespace pwiz.Osprey.Tasks
                 _curFileIdx = fileIdx;
                 _curProteinQ = _resolveProteinQ(Projections.PerFile[fileIdx].Key);
             }
-            double runProteinQvalue;
-            if (_curProteinQ == null || !_curProteinQ.TryGetValue(entryId, out runProteinQvalue))
-                runProteinQvalue = 1.0;
+            double experimentProteinQvalue;
+            if (_curProteinQ == null || !_curProteinQ.TryGetValue(entryId, out experimentProteinQvalue))
+                experimentProteinQvalue = 1.0;
 
             _buffer.Add(new FdrScoreRecord(
                 entryId, score,
                 q.RunPrecursorQvalue, q.RunPeptideQvalue,
                 q.ExperimentPrecursorQvalue, q.ExperimentPeptideQvalue,
-                q.Pep, runProteinQvalue, experimentAggregateScore));
+                q.Pep, experimentProteinQvalue, experimentAggregateScore));
 
             // Last row of this file: flush its sidecar and release the buffer. RowCount
             // (not the row list) so the 2nd-pass resident projection and the 1st-pass

--- a/pwiz_tools/Osprey/Osprey.Tasks/FdrProjectionSinks.cs
+++ b/pwiz_tools/Osprey/Osprey.Tasks/FdrProjectionSinks.cs
@@ -163,12 +163,12 @@ namespace pwiz.Osprey.Tasks
     /// score pass's per-row output straight to disk -- it keeps NO resident q-value array.
     /// During the score pass (phase 1) it buffers each file's 60-byte
     /// <see cref="FdrScoreRecord"/>s in projection order -- with the
-    /// <c>run_protein_qvalue</c> field held at its 1.0 placeholder -- and flushes the
+    /// <c>experiment_protein_qvalue</c> field held at its 1.0 placeholder -- and flushes the
     /// per-file <c>.1st-pass.fdr_scores.bin</c> via the caller's <c>flushPartial</c>
     /// callback at the file's last row, so a full pass's worth of q-values is never held
     /// resident (one file's buffer at a time). Empty survivor files are flushed with a
     /// 0-record sidecar in <see cref="OnFinish"/>. First-pass protein FDR + compaction now
-    /// stream <c>run_peptide_qvalue</c> / <c>run_protein_qvalue</c> back off this sidecar
+    /// stream <c>run_peptide_qvalue</c> / <c>experiment_protein_qvalue</c> back off this sidecar
     /// (see <c>FirstPassFdrTask.RunFirstPassProteinFdrStreaming</c>), so the resident
     /// <c>FdrProjectionOutputs</c> array the pre-S2 sink kept is gone; protein FDR patches
     /// each record's <c>[52..60]</c> straight onto the sidecar. The byte layout is
@@ -206,12 +206,12 @@ namespace pwiz.Osprey.Tasks
             bool isDecoy, double score, double experimentAggregateScore, in FdrQValues q)
         {
             // Phase 1 of the two-phase sidecar: buffer this row's PARTIAL record
-            // (run_protein_qvalue = 1.0 placeholder) in projection order and flush the
+            // (experiment_protein_qvalue = 1.0 placeholder) in projection order and flush the
             // per-file .1st-pass.fdr_scores.bin at the file's last row. All five score-pass
             // q-values (incl. run_peptide_qvalue) go straight to disk here and are never
             // kept resident; first-pass protein FDR streams them back + patches [52..60].
             // experiment_aggregate_score [60..68] is final at write time - unlike
-            // run_protein_qvalue it comes from the score pass, so it needs no patch phase.
+            // experiment_protein_qvalue it comes from the score pass, so it needs no patch phase.
             _buffer.Add(new FdrScoreRecord(
                 entryId, score,
                 q.RunPrecursorQvalue, q.RunPeptideQvalue,
@@ -260,7 +260,7 @@ namespace pwiz.Osprey.Tasks
     /// <summary>
     /// 2nd-pass sink (issue #4355 struct-shrink S0, delivers C1): assembles each
     /// <see cref="FdrScoreRecord"/> during the score pass from the streamed q-values +
-    /// the survivor's <c>RunProteinQvalue</c> looked up by entry_id (it is no longer
+    /// the survivor's <c>ExperimentProteinQvalue</c> looked up by entry_id (it is no longer
     /// carried on the lean struct), buffers one file at a time in projection order, and
     /// flushes the per-file <c>.2nd-pass.fdr_scores.bin</c> directly via the caller's
     /// <c>flushFile</c> callback -- so the q-values are NEVER stored on the projection
@@ -292,7 +292,7 @@ namespace pwiz.Osprey.Tasks
         protected override void AcceptOutput(int fileIdx, int rowIdx, uint entryId,
             bool isDecoy, double score, double experimentAggregateScore, in FdrQValues q)
         {
-            // Resolve this file's entry_id -> RunProteinQvalue map once, at its first
+            // Resolve this file's entry_id -> ExperimentProteinQvalue map once, at its first
             // row (rows are contiguous per file in Accept order). This is the value
             // BuildFromEntries used to carry onto the struct; the survivor buffer is
             // not mutated between projection build and here, so the lookup reproduces it.

--- a/pwiz_tools/Osprey/Osprey.Tasks/FirstPassFdrTask.cs
+++ b/pwiz_tools/Osprey/Osprey.Tasks/FirstPassFdrTask.cs
@@ -2108,9 +2108,10 @@ namespace pwiz.Osprey.Tasks
 
         /// <summary>
         /// First-pass protein FDR run BEFORE Stage 6 reconciliation, on the
-        /// full pre-compaction peptide pool. Sets only ExperimentProteinQvalue
-        /// (leaves ExperimentProteinQvalue at its 1.0 default for the
-        /// second-pass to overwrite). Detected-peptide filter uses
+        /// full pre-compaction peptide pool. Sets the one experiment-wide
+        /// ExperimentProteinQvalue; the second-pass protein FDR overwrites it
+        /// later, and PatchPass2ProteinQvalues writes that pass-2 value into
+        /// the 2nd-pass sidecar (#4559). Detected-peptide filter uses
         /// run_peptide_qvalue, the strict peptide-level gate, matching Rust
         /// pipeline.rs:3045-3049 exactly. Protein-FDR gate is config.RunFdr
         /// (1x), the Savitski-2015 convention applied at first pass, NOT the

--- a/pwiz_tools/Osprey/Osprey.Tasks/FirstPassFdrTask.cs
+++ b/pwiz_tools/Osprey/Osprey.Tasks/FirstPassFdrTask.cs
@@ -417,7 +417,7 @@ namespace pwiz.Osprey.Tasks
 
                 // First-pass protein FDR: runs on the full pre-compaction
                 // peptide pool so target and decoy proteins compete on a
-                // symmetric set. Sets RunProteinQvalue on every FdrEntry,
+                // symmetric set. Sets ExperimentProteinQvalue on every FdrEntry,
                 // which Stage 6 reconciliation reads via the protein-rescue
                 // gate in ConsensusRts.Compute. Runs unconditionally (not gated
                 // on --protein-fdr), matching Rust where config.protein_fdr is a
@@ -1444,7 +1444,7 @@ namespace pwiz.Osprey.Tasks
                             // last clause admits present-protein peptides that failed 1st-pass
                             // FDR so they get reconciled + rescored + reported.
                             if (entry.RunPeptideQvalue <= peptideGate ||
-                                entry.RunProteinQvalue <= proteinGate ||
+                                entry.ExperimentProteinQvalue <= proteinGate ||
                                 (_proteinCompactStratum != null && _proteinCompactStratum.Contains(baseId)))
                             {
                                 firstPassBaseIds.Add(baseId);
@@ -2108,7 +2108,7 @@ namespace pwiz.Osprey.Tasks
 
         /// <summary>
         /// First-pass protein FDR run BEFORE Stage 6 reconciliation, on the
-        /// full pre-compaction peptide pool. Sets only RunProteinQvalue
+        /// full pre-compaction peptide pool. Sets only ExperimentProteinQvalue
         /// (leaves ExperimentProteinQvalue at its 1.0 default for the
         /// second-pass to overwrite). Detected-peptide filter uses
         /// run_peptide_qvalue, the strict peptide-level gate, matching Rust
@@ -2301,7 +2301,7 @@ namespace pwiz.Osprey.Tasks
             //
             // Two-phase 1st-pass sidecar (issue #4355 struct-shrink S1). Phase 1: the
             // StoringSink writes each file's PARTIAL .1st-pass.fdr_scores.bin during the
-            // score pass (run_protein_qvalue = 1.0 placeholder), so the four streamed
+            // score pass (experiment_protein_qvalue = 1.0 placeholder), so the four streamed
             // q-values are never held resident. This flush resolves the per-file sidecar
             // path the same way the pre-S1 single-phase write did, so the survivor reload
             // and the Stage 6 worker read identical bytes; it returns a per-file failure
@@ -2439,7 +2439,7 @@ namespace pwiz.Osprey.Tasks
             // (issue #4355 struct-shrink S2): read each file's Score / run_peptide_qvalue
             // from the just-written .1st-pass.fdr_scores.bin, joined by entry_id with the
             // modseq / IsDecoy from the parquet scalars, run the identical parsimony +
-            // picked-protein FDR, and patch each row's run_protein_qvalue [52..60] straight
+            // picked-protein FDR, and patch each row's experiment_protein_qvalue [52..60] straight
             // back onto the sidecar -- so the resident FdrProjectionOutputs array is gone.
             // The Stage-6 diagnostic dump reads the returned artifacts, exactly as the
             // FdrEntry path's RunFirstPassProteinFdr does. Runs unconditionally (not gated
@@ -2472,7 +2472,7 @@ namespace pwiz.Osprey.Tasks
                     BuildAndPublishProteinCompactStratum(proteinResult, fullLibrary, ctx);
             }
 
-            // The streaming protein FDR above already patched run_protein_qvalue [52..60]
+            // The streaming protein FDR above already patched experiment_protein_qvalue [52..60]
             // onto each file's sidecar (folding the pre-S2 resident-outputs propagate + the
             // separate phase-2 patch into one streaming pass). Combine the phase-1
             // partial-write failures the sink accumulated during the score pass with those
@@ -2556,13 +2556,13 @@ namespace pwiz.Osprey.Tasks
         /// run_peptide_qvalue keyed by entry_id) joined with the parquet scalars (the modseq
         /// PeptideById was interned from + IsDecoy) into a pure
         /// <see cref="FirstPassProteinFdrAccumulator"/>, which runs the identical parsimony +
-        /// picked-protein FDR. Pass 2 patches each file's <c>run_protein_qvalue</c>
+        /// picked-protein FDR. Pass 2 patches each file's <c>experiment_protein_qvalue</c>
         /// <c>[52..60]</c> from the reducer's peptide -> q map (folding the resident
-        /// <c>PropagateRunProteinQvalues</c> + the old phase-2 patch into one streaming pass).
+        /// <c>PropagateProteinQvalues</c> + the old phase-2 patch into one streaming pass).
         /// Returns <c>null</c> (ExitCode set) on any sidecar / parquet read fault -- the task
         /// just wrote these files, so a read failure is a genuine fault (the survivor reload
         /// below would fail on the same file). <paramref name="patchFailures"/> counts files
-        /// whose run_protein_qvalue patch failed, for the StopAfterStage5 boundary gate.
+        /// whose experiment_protein_qvalue patch failed, for the StopAfterStage5 boundary gate.
         /// </summary>
         private FirstPassProteinFdrResult RunFirstPassProteinFdrStreaming(
             FdrProjectionSet projections,
@@ -2594,9 +2594,9 @@ namespace pwiz.Osprey.Tasks
             var result = accumulator.Finish(fullLibrary, config);
             ProteinFdrEngine.LogFirstPassSummary(result, config, ctx.LogInfo);
 
-            // Pass 2: patch each file's run_protein_qvalue from peptide -> q. entry_id is
+            // Pass 2: patch each file's experiment_protein_qvalue from peptide -> q. entry_id is
             // unique within a file, so a per-file entry_id -> q map (one file resident at a
-            // time; bounded) reproduces the resident PropagateRunProteinQvalues + the phase-2
+            // time; bounded) reproduces the resident PropagateProteinQvalues + the phase-2
             // patch byte-for-byte. The modseq MUST come from the parquet scalars (the same
             // value the pass-1 PeptideQvalues keys were built from), not re-derived from the
             // library, so the peptide -> q lookup matches.
@@ -2628,11 +2628,11 @@ namespace pwiz.Osprey.Tasks
                                 q = 1.0;
                             runProteinByEntryId[entryId] = q;
                         });
-                    if (!FdrScoresSidecar.PatchRunProteinQvalues(
+                    if (!FdrScoresSidecar.PatchProteinQvalues(
                             fdrPath, runProteinByEntryId, FdrScoresSidecar.Pass.FirstPass))
                     {
                         ctx.LogWarning(string.Format(
-                            "Failed to patch run_protein_qvalue in 1st-pass fdr_scores.bin for {0} " +
+                            "Failed to patch experiment_protein_qvalue in 1st-pass fdr_scores.bin for {0} " +
                             "(expected at {1})", fileName, fdrPath));
                         patchFailures++;
                     }
@@ -2744,7 +2744,7 @@ namespace pwiz.Osprey.Tasks
             // Protein-rescue gate is always active (default 0.01), matching Rust
             // pipeline.rs:4651/4658 (protein_compaction_gate = config.protein_fdr, a
             // plain f64, never a null switch). First-pass protein FDR runs unconditionally
-            // on this path too, so run_protein_qvalue is populated in the finalized sidecar.
+            // on this path too, so experiment_protein_qvalue is populated in the finalized sidecar.
             double proteinGate = config.EffectiveProteinFdr;
             int compactFiles = 0;
             using (var compactProgress = new ProgressReporter(string.Format(
@@ -2774,7 +2774,7 @@ namespace pwiz.Osprey.Tasks
                             // (>=2 first-pass-detected-peptide proteins) that failed 1st-pass FDR --
                             // identical to the legacy CompactFirstPass twin.
                             if (record.RunPeptideQvalue <= peptideGate ||
-                                record.RunProteinQvalue <= proteinGate ||
+                                record.ExperimentProteinQvalue <= proteinGate ||
                                 (stratum != null && stratum.Contains(baseId)))
                             {
                                 firstPassBaseIds.Add(baseId);

--- a/pwiz_tools/Osprey/Osprey.Tasks/FirstPassFdrTask.cs
+++ b/pwiz_tools/Osprey/Osprey.Tasks/FirstPassFdrTask.cs
@@ -2614,7 +2614,7 @@ namespace pwiz.Osprey.Tasks
                 string parquetPath = perFileParquetPaths[fileName];  // present: pass 1 read it
                 string fdrPath = FdrScoresSidecar.Pass1Path(sidecarBase);
 
-                var runProteinByEntryId = new Dictionary<uint, double>();
+                var proteinQByEntryId = new Dictionary<uint, double>();
                 try
                 {
                     ParquetScoreCache.ReadFdrStubScalars(parquetPath,
@@ -2626,10 +2626,10 @@ namespace pwiz.Osprey.Tasks
                             // a null Dictionary key would otherwise throw. See StreamFirstPassFileScores.
                             if (!peptideQvalues.TryGetValue(modseq ?? string.Empty, out q))
                                 q = 1.0;
-                            runProteinByEntryId[entryId] = q;
+                            proteinQByEntryId[entryId] = q;
                         });
                     if (!FdrScoresSidecar.PatchProteinQvalues(
-                            fdrPath, runProteinByEntryId, FdrScoresSidecar.Pass.FirstPass))
+                            fdrPath, proteinQByEntryId, FdrScoresSidecar.Pass.FirstPass, out _))
                     {
                         ctx.LogWarning(string.Format(
                             "Failed to patch experiment_protein_qvalue in 1st-pass fdr_scores.bin for {0} " +

--- a/pwiz_tools/Osprey/Osprey.Tasks/ModelDiagnostics/PeakCoAssignmentSource.cs
+++ b/pwiz_tools/Osprey/Osprey.Tasks/ModelDiagnostics/PeakCoAssignmentSource.cs
@@ -296,7 +296,7 @@ namespace pwiz.Osprey.Tasks.ModelDiagnostics
                 return 0;
             }
             // The same path the score-pass sink wrote, so the panel reads exactly what this run
-            // produced. At this point the records are the PARTIAL ones (run_protein_qvalue is
+            // produced. At this point the records are the PARTIAL ones (experiment_protein_qvalue is
             // still the 1.0 placeholder that first-pass protein FDR patches later) - harmless
             // here, since the panel reads only the score and the precursor/peptide q-values.
             string sidecarPath = FdrScoresSidecar.Pass1Path(sidecarBase);

--- a/pwiz_tools/Osprey/Osprey.Tasks/Pass2FdrSidecar.cs
+++ b/pwiz_tools/Osprey/Osprey.Tasks/Pass2FdrSidecar.cs
@@ -700,8 +700,21 @@ namespace pwiz.Osprey.Tasks
                 if (!inputByName.TryGetValue(kvp.Key, out string inputFile))
                     continue;
                 string pass2Path = FdrScoresSidecar.Pass2Path(inputFile);
+                // Two gates, deliberately, because ABSENT and UNUSABLE are different outcomes
+                // here and IsCurrentFormat alone cannot tell them apart (it is false for both).
+                // A file with no reconciled parquet legitimately has no 2nd-pass sidecar, so
+                // absent is a silent skip; a sidecar that IS present but carries a foreign magic,
+                // a different FormatVersion, the wrong pass byte or a length its own header
+                // contradicts is a real problem, and it is exactly what the warning below exists
+                // to name. Collapsing these into one IsCurrentFormat call would either report
+                // every legitimately-absent file or silently swallow the stale one.
                 if (!File.Exists(pass2Path))
                     continue;
+                if (!FdrScoresSidecar.IsCurrentFormat(pass2Path, FdrScoresSidecar.Pass.SecondPass))
+                {
+                    failed.Add(kvp.Key);
+                    continue;
+                }
 
                 var byEntryId = new Dictionary<uint, double>(kvp.Value.Count);
                 foreach (var e in kvp.Value)

--- a/pwiz_tools/Osprey/Osprey.Tasks/Pass2FdrSidecar.cs
+++ b/pwiz_tools/Osprey/Osprey.Tasks/Pass2FdrSidecar.cs
@@ -196,20 +196,22 @@ namespace pwiz.Osprey.Tasks
                         "them here from the reconciled features (reused distributed-run code path).",
                         missingPass2, totalFiles));
                     // Stage 6's post-rescore overlay calls FdrEntry.ResetScores(), which clears
-                    // eight fields. Of the seven the sidecar carries, three can reach it at
-                    // their reset defaults (issue #4553):
-                    //   Score              - neither COMPETITION mode wrote one back
-                    //                        (transfer-compete, protein-compact). The transfer
-                    //                        mode's AssignPerRunQ does set it, on all three of
-                    //                        its branches.
-                    //   Pep                - written only on the on-stratum path
-                    //   ExperimentProteinQvalue   - written by NO mode; first-pass protein FDR is its
-                    //                        only producer, and the second-pass one writes
-                    //                        ExperimentProteinQvalue instead
-                    // (ResetScores' eighth field, ExperimentProteinQvalue, has no slot in the
-                    // v3 record and is written after this by RunProteinFdr, so it is out of
-                    // scope here rather than recomputed.)
-                    // Seeding all three from the 1st-pass sidecar reproduces exactly what the
+                    // eight fields - one for every scalar the v4 record carries. Three of them
+                    // can reach the sidecar at their reset defaults (issue #4553):
+                    //   Score                    - neither COMPETITION mode wrote one back
+                    //                              (transfer-compete, protein-compact). The
+                    //                              transfer mode's AssignPerRunQ does set it,
+                    //                              on all three of its branches.
+                    //   Pep                      - written only on the on-stratum path
+                    //   ExperimentAggregateScore - the third field of the same gap (sidecar v4,
+                    //                              issue #4522); no frozen 2nd-pass mode writes
+                    //                              it back, so it lands at 0.0 for every peak
+                    //                              Stage 6 touched.
+                    // ExperimentProteinQvalue is the fourth field ResetScores clears that no
+                    // 2nd-pass mode writes back, and it is deliberately NOT seeded here: its
+                    // pass-2 producer is PatchPass2ProteinQvalues, which writes the second-pass
+                    // value into the 2nd-pass sidecar after the second-pass protein FDR (#4559).
+                    // Seeding those three from the 1st-pass sidecar reproduces exactly what the
                     // distributed route has in hand at this point, which is why that route never
                     // showed the loss: it must rehydrate from that same sidecar, and the sidecar
                     // carries all seven scalars. Whatever pass 2 genuinely recomputes then
@@ -345,11 +347,12 @@ namespace pwiz.Osprey.Tasks
             // Persist post-Stage-6 per-file 2nd-pass FDR scores
             // BEFORE RunProteinFdr. The sidecar holds Score +
             // run/experiment precursor/peptide q-values + Pep +
-            // ExperimentProteinQvalue (the latter set by
-            // RunFirstPassProteinFdr earlier); none of those
-            // fields are mutated by RunProteinFdr, which only
-            // sets ExperimentProteinQvalue via
-            // PropagateProteinQvalues. Writing here lets the
+            // ExperimentAggregateScore + ExperimentProteinQvalue
+            // (the last set by RunFirstPassProteinFdr earlier).
+            // RunProteinFdr mutates exactly one of them --
+            // ExperimentProteinQvalue, via PropagateProteinQvalues --
+            // which is why that column is patched back into this file
+            // there rather than written here (#4559). Writing here lets the
             // OSPREY_STAGE7_PROTEIN_FDR_ONLY early exit (used
             // by stage6 isolation in Test-Regression) leave the
             // sidecar on disk for downstream rehydration.
@@ -705,10 +708,10 @@ namespace pwiz.Osprey.Tasks
                     byEntryId[e.EntryId] = e.ExperimentProteinQvalue;
 
                 if (FdrScoresSidecar.PatchProteinQvalues(
-                        pass2Path, byEntryId, FdrScoresSidecar.Pass.SecondPass))
+                        pass2Path, byEntryId, FdrScoresSidecar.Pass.SecondPass, out int patchedHere))
                 {
                     filesPatched++;
-                    nPatched += byEntryId.Count;
+                    nPatched += patchedHere;
                 }
                 else
                 {
@@ -718,16 +721,18 @@ namespace pwiz.Osprey.Tasks
 
             // Reported, not thrown on: nothing in this process reads the 2nd-pass sidecar's
             // protein column, so a failed patch cannot corrupt this run's output. It DOES leave
-            // a file whose protein column is a pass-1 value while its header says pass 2, which
-            // is precisely the state #4559 existed to remove - so the warning names that rather
-            // than implying the file is merely missing an optional extra.
+            // a file whose protein column is not a pass-2 value while its header says pass 2,
+            // which is precisely the state #4559 existed to remove - so the warning names that
+            // rather than implying the file is merely missing an optional extra.
             if (failed.Count > 0)
             {
                 ctx.LogWarning(string.Format(
                     "Could not patch the second-pass protein q-value into the 2nd-pass FDR " +
-                    "sidecar for {0} file(s): [{1}]. Those files keep a FIRST-pass protein " +
-                    "q-value in a pass-2 file; any consumer joining on it is reading the wrong " +
-                    "pass.",
+                    "sidecar for {0} file(s): [{1}]. Those files carry no pass-2 protein " +
+                    "q-value: each record keeps what it held when the sidecar was written, " +
+                    "which is the reset default for every entry Stage 6 rescored or gap-filled " +
+                    "and a pass-1 value only for entries Stage 6 left alone. Any consumer " +
+                    "joining on that column is reading the wrong pass.",
                     failed.Count, string.Join(", ", failed)));
             }
             ctx.LogVerbose(string.Format(

--- a/pwiz_tools/Osprey/Osprey.Tasks/Pass2FdrSidecar.cs
+++ b/pwiz_tools/Osprey/Osprey.Tasks/Pass2FdrSidecar.cs
@@ -540,16 +540,14 @@ namespace pwiz.Osprey.Tasks
         }
 
         /// <summary>
-        /// Re-seed each survivor's <see cref="FdrEntry.Score"/>, <see cref="FdrEntry.Pep"/> and
-        /// <see cref="FdrEntry.ExperimentProteinQvalue"/> from that file's
-        /// <c>.1st-pass.fdr_scores.bin</c>.
+        /// Re-seed each survivor's <see cref="FdrEntry.Score"/> and <see cref="FdrEntry.Pep"/>
+        /// from that file's <c>.1st-pass.fdr_scores.bin</c>.
         ///
-        /// <para>These are the three sidecar fields <see cref="FdrEntry.ResetScores"/> clears
-        /// that pass 2 does not reliably recompute: neither COMPETITION mode wrote
-        /// <c>Score</c> back (the <c>transfer</c> mode's <c>AssignPerRunQ</c> does, on all
-        /// three branches), <c>Pep</c> is written only for on-stratum survivors, and
-        /// <c>ExperimentProteinQvalue</c> is written by no mode at all. Left unseeded they reach the
-        /// 2nd-pass sidecar at their reset defaults, where a q-value of 1.0 reads as a
+        /// <para>These are the sidecar fields <see cref="FdrEntry.ResetScores"/> clears that
+        /// pass 2 does not reliably recompute: neither COMPETITION mode wrote <c>Score</c>
+        /// back (the <c>transfer</c> mode's <c>AssignPerRunQ</c> does, on all three branches),
+        /// and <c>Pep</c> is written only for on-stratum survivors. Left unseeded they reach
+        /// the 2nd-pass sidecar at their reset defaults, where a q-value of 1.0 reads as a
         /// confident rejection and a <c>Score</c> of 0 sits exactly ON the discriminant's
         /// accept/reject boundary (issue #4553).</para>
         ///
@@ -558,10 +556,16 @@ namespace pwiz.Osprey.Tasks
         /// distributed route holds at the same point - it rehydrates from this same sidecar -
         /// so the two routes agree by construction rather than by coincidence.</para>
         ///
+        /// <para><see cref="FdrEntry.ExperimentProteinQvalue"/> was seeded here too until
+        /// issue #4559. It should not be: the 2nd-pass sidecar's protein column is a
+        /// SECOND-pass value, written by <see cref="PatchPass2ProteinQvalues"/> after the
+        /// second-pass protein FDR has run. Seeding it here made a pass-1 value the one it
+        /// carried on every route - and because both routes copied the same wrong value, no
+        /// two-route comparison could see it. One producer, not two.</para>
+        ///
         /// <para>An entry Stage 6 did not touch already holds these values, so the write is a
-        /// no-op for it; a gap-fill entry is absent from the sidecar and correctly keeps the
-        /// defaults, which is where the distributed route leaves it too (its own overlay runs
-        /// before gap-fill appends). One file's records stream at a time.</para>
+        /// no-op for it; a gap-fill entry is absent from the sidecar and keeps the reset
+        /// defaults until pass 2 scores it. One file's records stream at a time.</para>
         /// </summary>
         private static void RestorePass1Scalars(
             PipelineContext ctx,
@@ -605,8 +609,10 @@ namespace pwiz.Osprey.Tasks
                     {
                         pair.Key.Score = pair.Value.Score;
                         pair.Key.Pep = pair.Value.Pep;
-                        pair.Key.ExperimentProteinQvalue = pair.Value.ExperimentProteinQvalue;
-                        // The FOURTH field of the same five-of-eight gap (sidecar v4, issue
+                        // ExperimentProteinQvalue is deliberately NOT seeded here - see the
+                        // remarks. PatchPass2ProteinQvalues writes the second-pass value into
+                        // the 2nd-pass sidecar after the second-pass protein FDR (#4559).
+                        // The THIRD field of the same five-of-eight gap (sidecar v4, issue
                         // #4522). ResetScores clears it with Score, and no frozen 2nd-pass mode
                         // writes it back, so it lands in the 2nd-pass sidecar at 0.0 for every
                         // peak Stage 6 touched. That is the whole population this method exists
@@ -639,7 +645,7 @@ namespace pwiz.Osprey.Tasks
             if (unreadable.Count > 0)
             {
                 ctx.LogWarning(string.Format(
-                    "1st-pass Score/Pep/ExperimentProteinQvalue/ExperimentAggregateScore could not be " +
+                    "1st-pass Score/Pep/ExperimentAggregateScore could not be " +
                     "restored for {0} file(s) (no readable 1st-pass sidecar): [{1}]. Peaks Stage 6 " +
                     "changed in those files keep reset defaults, so their 2nd-pass sidecars are " +
                     "wrong AND a Score of 0 enters the second-pass protein FDR null unfiltered. " +
@@ -647,8 +653,86 @@ namespace pwiz.Osprey.Tasks
                     unreadable.Count, string.Join(", ", unreadable)));
             }
             ctx.LogVerbose(string.Format(
-                "Restored 1st-pass Score/Pep/ExperimentProteinQvalue/ExperimentAggregateScore onto {0} survivor(s) across {1} file(s).",
+                "Restored 1st-pass Score/Pep/ExperimentAggregateScore onto {0} survivor(s) across {1} file(s).",
                 nRestored, filesRead));
+        }
+
+        /// <summary>
+        /// Patch every file's <c>.2nd-pass.fdr_scores.bin</c> with the SECOND-pass
+        /// <see cref="FdrEntry.ExperimentProteinQvalue"/>, so that column is a pass-2 value like
+        /// every other column in that file (issue #4559).
+        ///
+        /// <para>Must be called AFTER the second-pass protein FDR has propagated onto the
+        /// entries (<c>SecondPassFdrTask.RunProteinFdr</c>), which is necessarily after the
+        /// sidecar itself is written - the sidecar write feeds that protein FDR. Hence a patch
+        /// rather than a reordering: the same two-phase shape the first-pass path already uses,
+        /// where the score pass writes a placeholder and
+        /// <c>FdrScoresSidecar.PatchProteinQvalues</c> fills the column in once the protein FDR
+        /// is known.</para>
+        ///
+        /// <para>Why the column was a pass-1 value before: no pass-2 q-value mode writes a
+        /// protein q at all - the first- and second-pass protein FDRs are its only producers -
+        /// so the value present at sidecar-write time was whatever pass 1 left on the stub. Both
+        /// routes copied it identically, which is why no two-route comparison could see it; the
+        /// guard that can is <c>Test-Pass2ProteinQvalue</c> in
+        /// <c>Regression/FdrSidecars.ps1</c>.</para>
+        ///
+        /// <para>One file's map is resident at a time, released before the next. A file with no
+        /// 2nd-pass sidecar is skipped silently: the sidecar exists only where Stage 6 produced
+        /// a reconciled parquet, and the caller runs on the same condition.</para>
+        /// </summary>
+        internal static void PatchPass2ProteinQvalues(
+            PipelineContext ctx,
+            IList<KeyValuePair<string, List<FdrEntry>>> perFileEntries)
+        {
+            var inputByName = new Dictionary<string, string>();
+            foreach (var inputFile in ctx.Config.InputFiles)
+                inputByName[Path.GetFileNameWithoutExtension(inputFile)] = inputFile;
+
+            int filesPatched = 0;
+            long nPatched = 0;
+            var failed = new List<string>();
+            foreach (var kvp in perFileEntries)
+            {
+                if (!inputByName.TryGetValue(kvp.Key, out string inputFile))
+                    continue;
+                string pass2Path = FdrScoresSidecar.Pass2Path(inputFile);
+                if (!File.Exists(pass2Path))
+                    continue;
+
+                var byEntryId = new Dictionary<uint, double>(kvp.Value.Count);
+                foreach (var e in kvp.Value)
+                    byEntryId[e.EntryId] = e.ExperimentProteinQvalue;
+
+                if (FdrScoresSidecar.PatchProteinQvalues(
+                        pass2Path, byEntryId, FdrScoresSidecar.Pass.SecondPass))
+                {
+                    filesPatched++;
+                    nPatched += byEntryId.Count;
+                }
+                else
+                {
+                    failed.Add(kvp.Key);
+                }
+            }
+
+            // Reported, not thrown on: nothing in this process reads the 2nd-pass sidecar's
+            // protein column, so a failed patch cannot corrupt this run's output. It DOES leave
+            // a file whose protein column is a pass-1 value while its header says pass 2, which
+            // is precisely the state #4559 existed to remove - so the warning names that rather
+            // than implying the file is merely missing an optional extra.
+            if (failed.Count > 0)
+            {
+                ctx.LogWarning(string.Format(
+                    "Could not patch the second-pass protein q-value into the 2nd-pass FDR " +
+                    "sidecar for {0} file(s): [{1}]. Those files keep a FIRST-pass protein " +
+                    "q-value in a pass-2 file; any consumer joining on it is reading the wrong " +
+                    "pass.",
+                    failed.Count, string.Join(", ", failed)));
+            }
+            ctx.LogVerbose(string.Format(
+                "Patched the second-pass protein q-value onto {0} record(s) across {1} file(s).",
+                nPatched, filesPatched));
         }
 
         /// <summary>

--- a/pwiz_tools/Osprey/Osprey.Tasks/Pass2FdrSidecar.cs
+++ b/pwiz_tools/Osprey/Osprey.Tasks/Pass2FdrSidecar.cs
@@ -203,7 +203,7 @@ namespace pwiz.Osprey.Tasks
                     //                        mode's AssignPerRunQ does set it, on all three of
                     //                        its branches.
                     //   Pep                - written only on the on-stratum path
-                    //   RunProteinQvalue   - written by NO mode; first-pass protein FDR is its
+                    //   ExperimentProteinQvalue   - written by NO mode; first-pass protein FDR is its
                     //                        only producer, and the second-pass one writes
                     //                        ExperimentProteinQvalue instead
                     // (ResetScores' eighth field, ExperimentProteinQvalue, has no slot in the
@@ -254,16 +254,16 @@ namespace pwiz.Osprey.Tasks
                         // 21-feature vector resident. The lean projection no longer stores
                         // the q-values (2nd-pass peak 80 -> 32 B); a StreamingSink assembles
                         // each .2nd-pass.fdr_scores.bin record DURING the score pass (from
-                        // the streamed q-values + the survivor's RunProteinQvalue looked up
+                        // the streamed q-values + the survivor's ExperimentProteinQvalue looked up
                         // by entry_id) and flushes the per-file sidecar + validity sidecar
                         // directly, so the resident write block below is skipped for this
                         // path. The existing entry_id overlay still carries the 2nd-pass
                         // q-values onto the resident survivor buffer afterward (unchanged).
 
-                        // Survivor RunProteinQvalue by entry_id, per file: the value
+                        // Survivor ExperimentProteinQvalue by entry_id, per file: the value
                         // BuildFromEntries used to carry onto the struct. All survivors
                         // sharing an entry_id share a precursor (hence a ModifiedSequence,
-                        // hence a run_protein_qvalue), so the last-write map is exact.
+                        // hence a experiment_protein_qvalue), so the last-write map is exact.
                         var survivorsByFile =
                             new Dictionary<string, List<FdrEntry>>(StringComparer.Ordinal);
                         foreach (var kvp in perFileEntries)
@@ -275,7 +275,7 @@ namespace pwiz.Osprey.Tasks
                             if (survivorsByFile.TryGetValue(fileName, out var survivors))
                             {
                                 foreach (var e in survivors)
-                                    map[e.EntryId] = e.RunProteinQvalue;
+                                    map[e.EntryId] = e.ExperimentProteinQvalue;
                             }
                             return map;
                         }
@@ -345,7 +345,7 @@ namespace pwiz.Osprey.Tasks
             // Persist post-Stage-6 per-file 2nd-pass FDR scores
             // BEFORE RunProteinFdr. The sidecar holds Score +
             // run/experiment precursor/peptide q-values + Pep +
-            // RunProteinQvalue (the latter set by
+            // ExperimentProteinQvalue (the latter set by
             // RunFirstPassProteinFdr earlier); none of those
             // fields are mutated by RunProteinFdr, which only
             // sets ExperimentProteinQvalue via
@@ -541,14 +541,14 @@ namespace pwiz.Osprey.Tasks
 
         /// <summary>
         /// Re-seed each survivor's <see cref="FdrEntry.Score"/>, <see cref="FdrEntry.Pep"/> and
-        /// <see cref="FdrEntry.RunProteinQvalue"/> from that file's
+        /// <see cref="FdrEntry.ExperimentProteinQvalue"/> from that file's
         /// <c>.1st-pass.fdr_scores.bin</c>.
         ///
         /// <para>These are the three sidecar fields <see cref="FdrEntry.ResetScores"/> clears
         /// that pass 2 does not reliably recompute: neither COMPETITION mode wrote
         /// <c>Score</c> back (the <c>transfer</c> mode's <c>AssignPerRunQ</c> does, on all
         /// three branches), <c>Pep</c> is written only for on-stratum survivors, and
-        /// <c>RunProteinQvalue</c> is written by no mode at all. Left unseeded they reach the
+        /// <c>ExperimentProteinQvalue</c> is written by no mode at all. Left unseeded they reach the
         /// 2nd-pass sidecar at their reset defaults, where a q-value of 1.0 reads as a
         /// confident rejection and a <c>Score</c> of 0 sits exactly ON the discriminant's
         /// accept/reject boundary (issue #4553).</para>
@@ -605,7 +605,7 @@ namespace pwiz.Osprey.Tasks
                     {
                         pair.Key.Score = pair.Value.Score;
                         pair.Key.Pep = pair.Value.Pep;
-                        pair.Key.RunProteinQvalue = pair.Value.RunProteinQvalue;
+                        pair.Key.ExperimentProteinQvalue = pair.Value.ExperimentProteinQvalue;
                         // The FOURTH field of the same five-of-eight gap (sidecar v4, issue
                         // #4522). ResetScores clears it with Score, and no frozen 2nd-pass mode
                         // writes it back, so it lands in the 2nd-pass sidecar at 0.0 for every
@@ -639,7 +639,7 @@ namespace pwiz.Osprey.Tasks
             if (unreadable.Count > 0)
             {
                 ctx.LogWarning(string.Format(
-                    "1st-pass Score/Pep/RunProteinQvalue/ExperimentAggregateScore could not be " +
+                    "1st-pass Score/Pep/ExperimentProteinQvalue/ExperimentAggregateScore could not be " +
                     "restored for {0} file(s) (no readable 1st-pass sidecar): [{1}]. Peaks Stage 6 " +
                     "changed in those files keep reset defaults, so their 2nd-pass sidecars are " +
                     "wrong AND a Score of 0 enters the second-pass protein FDR null unfiltered. " +
@@ -647,7 +647,7 @@ namespace pwiz.Osprey.Tasks
                     unreadable.Count, string.Join(", ", unreadable)));
             }
             ctx.LogVerbose(string.Format(
-                "Restored 1st-pass Score/Pep/RunProteinQvalue/ExperimentAggregateScore onto {0} survivor(s) across {1} file(s).",
+                "Restored 1st-pass Score/Pep/ExperimentProteinQvalue/ExperimentAggregateScore onto {0} survivor(s) across {1} file(s).",
                 nRestored, filesRead));
         }
 
@@ -1307,7 +1307,7 @@ namespace pwiz.Osprey.Tasks
         /// per file and streams the q-value outputs straight to the per-file
         /// <c>.2nd-pass.fdr_scores.bin</c> via <paramref name="flushFile"/> (the lean
         /// projection never stores them -> 32 B). <paramref name="resolveProteinQ"/>
-        /// supplies each row's <c>RunProteinQvalue</c> (looked up from the resident
+        /// supplies each row's <c>ExperimentProteinQvalue</c> (looked up from the resident
         /// survivor by entry_id, no longer carried on the struct). Returns the scored
         /// projection as the flag that the sink wrote the sidecars; the survivor buffer
         /// is intentionally left unscored (the entry_id overlay carries the q-values
@@ -1431,7 +1431,7 @@ namespace pwiz.Osprey.Tasks
             // The caller gates on FdrMethod.Percolator, so the projection path is only
             // ever Percolator; the projection engine always streams via load2. The
             // StreamingSink assembles + writes each file's .2nd-pass.fdr_scores.bin from
-            // the streamed q-values + the survivor's RunProteinQvalue during the score
+            // the streamed q-values + the survivor's ExperimentProteinQvalue during the score
             // pass, so the q-values are never stored on the projection (issue #4355 / C1).
             var sink = new FdrStreamingSink(
                 projections, config, "Second-pass", resolveProteinQ, flushFile);

--- a/pwiz_tools/Osprey/Osprey.Tasks/PerFileRescoreTask.cs
+++ b/pwiz_tools/Osprey/Osprey.Tasks/PerFileRescoreTask.cs
@@ -478,7 +478,7 @@ namespace pwiz.Osprey.Tasks
             if (bundle != null)
             {
                 // First-pass protein FDR BEFORE compaction. The 1st-pass FDR
-                // sidecar v3 already carries RunProteinQvalue from the original
+                // sidecar v3 already carries ExperimentProteinQvalue from the original
                 // straight-through pipeline, but Rust pipeline.rs:4292 (gated by
                 // `!can_skip_fdr || config.expect_reconciled_input`) recomputes
                 // it inline in the --task SecondPassFDR path. The recompute uses the
@@ -487,8 +487,8 @@ namespace pwiz.Osprey.Tasks
                 // upstream rebuild has nudged peptide q-values or score values
                 // even at the ULP level). RescoreCompaction below now retains the
                 // persisted global first-pass base_id set and does NOT consult
-                // RunProteinQvalue, so this recompute no longer affects the
-                // compacted set; it is kept to hold RunProteinQvalue byte-consistent
+                // ExperimentProteinQvalue, so this recompute no longer affects the
+                // compacted set; it is kept to hold ExperimentProteinQvalue byte-consistent
                 // with the straight-through pipeline for the downstream 2nd-pass
                 // protein FDR and cross-impl parity (before recon-v3 read the
                 // persisted set, omitting it diverged the post-compaction set from
@@ -522,7 +522,7 @@ namespace pwiz.Osprey.Tasks
                 //     decoy side comes from q-gated detected peptides either way), so the skip
                 //     is a conservative choice, not a bug fix. It moves 740 records (0.28%)
                 //     upward and changes no output.
-                //   * That the 1st-pass sidecar's RunProteinQvalue is "what the straight-through
+                //   * That the 1st-pass sidecar's ExperimentProteinQvalue is "what the straight-through
                 //     pipeline computed". It is not: the join node's value differs from
                 //     straight-through for 12.46% of records (1.57% at 82 files), always lower.
                 //     That divergence is PRE-EXISTING - master's routing differs by 12.74% - and

--- a/pwiz_tools/Osprey/Osprey.Tasks/RescoreHydration.cs
+++ b/pwiz_tools/Osprey/Osprey.Tasks/RescoreHydration.cs
@@ -45,7 +45,7 @@ namespace pwiz.Osprey.Tasks
         /// <summary>
         /// Per-file <see cref="FdrEntry"/> stubs from
         /// <c>&lt;stem&gt;.scores.parquet</c>, with SVM scores + 4 q-values
-        /// + PEP + <c>RunProteinQvalue</c> overlaid from the
+        /// + PEP + <c>ExperimentProteinQvalue</c> overlaid from the
         /// <c>&lt;stem&gt;.1st-pass.fdr_scores.bin</c> sidecar. File order
         /// matches the order of <c>parquetPaths</c> passed to
         /// <see cref="RescoreHydration.HydrateForRescore"/>.
@@ -563,7 +563,7 @@ namespace pwiz.Osprey.Tasks
         }
 
         /// <summary>
-        /// Overlay SVM scores + 4 q-values + PEP + RunProteinQvalue from
+        /// Overlay SVM scores + 4 q-values + PEP + ExperimentProteinQvalue from
         /// <c>&lt;stem&gt;.1st-pass.fdr_scores.bin</c> v3 onto <paramref name="stubs"/>.
         /// <c>expected_pass = FirstPass</c>: the planner's actions were computed against
         /// first-pass FDR, and the compaction predicate uses first-pass q-values. The stub

--- a/pwiz_tools/Osprey/Osprey.Tasks/SecondPassFdrTask.cs
+++ b/pwiz_tools/Osprey/Osprey.Tasks/SecondPassFdrTask.cs
@@ -130,8 +130,18 @@ namespace pwiz.Osprey.Tasks
             // makes above - one arm's .blib must never be reused as another's.
             // And the sidecar format version, for the same reason FirstPassFdrTask carries it:
             // this task writes the 2nd-pass sidecars, so a record-layout change invalidates them.
+            // And the MEANING of the 2nd-pass sidecar's protein column, which issue #4559
+            // changed from a pass-1 to a pass-2 value without moving a byte. The format version
+            // cannot carry that: no offset, width or type changed, so a v4 record written before
+            // #4559 is structurally valid and silently holds the wrong pass. Without this token
+            // a post-#4559 build resuming into a pre-#4559 output directory finds every declared
+            // output present and the validity key unchanged, skips this task entirely, and keeps
+            // the stale column - which then reds regression mode 1c against a build that is in
+            // fact correct. A key token forces the regeneration a version bump would have forced,
+            // without breaking any reader or moving a golden.
             return base.ValidityKey(ctx)
                 + @";fdrsidecar=" + FdrScoresSidecar.FormatVersion
+                + @";pass2proteinq=2"
                 + @";reconciliation=" + ctx.Config.Identity.ReconciliationParameterHash()
                 + OspreyEnvironment.ExperimentAggValidityKeySuffix()
                 + OspreyEnvironment.Pass2QValueValidityKeySuffix()

--- a/pwiz_tools/Osprey/Osprey.Tasks/SecondPassFdrTask.cs
+++ b/pwiz_tools/Osprey/Osprey.Tasks/SecondPassFdrTask.cs
@@ -223,13 +223,6 @@ namespace pwiz.Osprey.Tasks
             var swProtein = Stopwatch.StartNew();
             RunProteinFdr(perFileEntries, fullLibrary, config, ctx);
             swProtein.Stop();
-            // The 2nd-pass sidecar was written above, BEFORE this protein FDR ran - it is one of
-            // its inputs - so the protein column it carries is still the pass-1 value at this
-            // point. Patch it now that the pass-2 value exists, so every column in that file is
-            // a pass-2 value (issue #4559). Cheap: 8 bytes per record, one file at a time, and
-            // only where a 2nd-pass sidecar was written.
-            if (AnyReconciledParquet(config))
-                Pass2FdrSidecar.PatchPass2ProteinQvalues(ctx, perFileEntries);
             ctx.LogInfo(string.Format(@"[STAGE-WALL] stage7: {0:F1}s",
                 swProtein.Elapsed.TotalSeconds));
             // Parsimony + picked-protein TDC are genuinely whole-run, so this probe is what
@@ -375,6 +368,18 @@ namespace pwiz.Osprey.Tasks
         {
             var result = ProteinFdrEngine.RunSecondPass(
                 perFileEntries, fullLibrary, config, ctx.LogInfo);
+
+            // The 2nd-pass sidecar was written BEFORE this protein FDR ran - it is one of its
+            // inputs - so the protein column it carries is still the pass-1 value at this point.
+            // Patch it now that the pass-2 value exists, so every column in that file is a
+            // pass-2 value (issue #4559). Cheap: 8 bytes per record, one file at a time, and
+            // only where a 2nd-pass sidecar was written.
+            // This MUST precede the dumps below: Stage7ProteinFdrOnly ends the process there,
+            // and an unpatched record keeps whatever it held when the sidecar was written -
+            // the ResetScores default for every entry Stage 6 rescored or gap-filled, since
+            // RestorePass1Scalars no longer seeds this field.
+            if (AnyReconciledParquet(config))
+                Pass2FdrSidecar.PatchPass2ProteinQvalues(ctx, perFileEntries);
 
             // Cross-impl bisection dump (env-var-gated, no-op in production).
             if (ctx.Diagnostics?.DumpDetectedPeptides ?? false)

--- a/pwiz_tools/Osprey/Osprey.Tasks/SecondPassFdrTask.cs
+++ b/pwiz_tools/Osprey/Osprey.Tasks/SecondPassFdrTask.cs
@@ -223,6 +223,13 @@ namespace pwiz.Osprey.Tasks
             var swProtein = Stopwatch.StartNew();
             RunProteinFdr(perFileEntries, fullLibrary, config, ctx);
             swProtein.Stop();
+            // The 2nd-pass sidecar was written above, BEFORE this protein FDR ran - it is one of
+            // its inputs - so the protein column it carries is still the pass-1 value at this
+            // point. Patch it now that the pass-2 value exists, so every column in that file is
+            // a pass-2 value (issue #4559). Cheap: 8 bytes per record, one file at a time, and
+            // only where a 2nd-pass sidecar was written.
+            if (AnyReconciledParquet(config))
+                Pass2FdrSidecar.PatchPass2ProteinQvalues(ctx, perFileEntries);
             ctx.LogInfo(string.Format(@"[STAGE-WALL] stage7: {0:F1}s",
                 swProtein.Elapsed.TotalSeconds));
             // Parsimony + picked-protein TDC are genuinely whole-run, so this probe is what

--- a/pwiz_tools/Osprey/Osprey.Test/FdrTest.cs
+++ b/pwiz_tools/Osprey/Osprey.Test/FdrTest.cs
@@ -921,7 +921,7 @@ namespace pwiz.Osprey.Test
                 Score = -2.5,
                 RunPrecursorQvalue = 0.011,
                 RunPeptideQvalue = 0.022,
-                RunProteinQvalue = 0.033,
+                ExperimentProteinQvalue = 0.033,
                 ExperimentPrecursorQvalue = 0.044,
                 ExperimentPeptideQvalue = 0.055,
                 Pep = 0.066,

--- a/pwiz_tools/Osprey/Osprey.Test/IOTest.cs
+++ b/pwiz_tools/Osprey/Osprey.Test/IOTest.cs
@@ -3245,6 +3245,65 @@ namespace pwiz.Osprey.Test
         }
 
         /// <summary>
+        /// The SECOND-pass sidecar's experiment_protein_qvalue is patched the same two-phase
+        /// way the first-pass one is (issue #4559): the sidecar is written before the
+        /// second-pass protein FDR runs - it is one of that FDR's inputs - so the pass-2
+        /// protein q can only be filled in afterwards.
+        ///
+        /// <para>The test above proves the patch mechanism on a 1st-pass file and proves a
+        /// MISMATCHED pass byte is rejected. This proves the other half: a Pass.SecondPass
+        /// patch of a genuine 2nd-pass file is accepted and lands the pass-2 value. Without
+        /// it, "the pass byte is validated" is only ever exercised in the rejecting
+        /// direction, and a validator that rejected everything would look correct.</para>
+        /// </summary>
+        [TestMethod]
+        public void TestFdrScoresSidecarPass2ProteinQvaluePatched()
+        {
+            string dir = Path.Combine(Path.GetTempPath(), "fdr_sidecar_p2q_" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(dir);
+            try
+            {
+                // What SecondPassFdrTask writes before the second-pass protein FDR runs: the
+                // protein column still holds pass-1 values (0.40 / 0.50 here).
+                var written = new List<FdrScoreRecord>
+                {
+                    new FdrScoreRecord(10, -3.5, 0.001, 0.0011, 0.0012, 0.0013, 0.02, 0.40, -1.25),
+                    new FdrScoreRecord(7,  -3.4, 0.002, 0.0021, 0.0022, 0.0023, 0.05, 0.50, -0.75),
+                };
+                string path = Path.Combine(dir, "s.2nd-pass.fdr_scores.bin");
+                FdrScoresSidecar.Write(path, written, FdrScoresSidecar.Pass.SecondPass);
+
+                // What the second-pass protein FDR then produces for those same entries.
+                var pass2 = new Dictionary<uint, double> { { 10, 0.0031 }, { 7, 0.77 } };
+                Assert.IsTrue(FdrScoresSidecar.PatchProteinQvalues(
+                    path, pass2, FdrScoresSidecar.Pass.SecondPass));
+
+                var loaded = new List<FdrEntry> { MakeFdrEntry(10, 0.0, 0.0, 0.0), MakeFdrEntry(7, 0.0, 0.0, 0.0) };
+                Assert.IsTrue(FdrScoresSidecar.TryRead(path, loaded, FdrScoresSidecar.Pass.SecondPass));
+                var byId = new Dictionary<uint, FdrEntry>();
+                foreach (var e in loaded)
+                    byId[e.EntryId] = e;
+                Assert.AreEqual(BitConverter.DoubleToInt64Bits(0.0031),
+                                BitConverter.DoubleToInt64Bits(byId[10].ExperimentProteinQvalue));
+                Assert.AreEqual(BitConverter.DoubleToInt64Bits(0.77),
+                                BitConverter.DoubleToInt64Bits(byId[7].ExperimentProteinQvalue));
+
+                // Every other column must survive the patch untouched - a miscomputed stride
+                // would corrupt the neighbouring pep [44..52] or aggregate score [60..68].
+                Assert.AreEqual(BitConverter.DoubleToInt64Bits(0.02),
+                                BitConverter.DoubleToInt64Bits(byId[10].Pep));
+                Assert.AreEqual(BitConverter.DoubleToInt64Bits(-1.25),
+                                BitConverter.DoubleToInt64Bits(byId[10].ExperimentAggregateScore));
+                Assert.AreEqual(BitConverter.DoubleToInt64Bits(-3.4),
+                                BitConverter.DoubleToInt64Bits(byId[7].Score));
+            }
+            finally
+            {
+                try { Directory.Delete(dir, true); } catch (IOException) { }
+            }
+        }
+
+        /// <summary>
         /// Pre-v2 sidecar files (no magic header, just raw f64 scores)
         /// must be rejected by the v2 reader.
         /// </summary>

--- a/pwiz_tools/Osprey/Osprey.Test/IOTest.cs
+++ b/pwiz_tools/Osprey/Osprey.Test/IOTest.cs
@@ -3188,7 +3188,7 @@ namespace pwiz.Osprey.Test
 
                 // Map entry_id -> finalized experiment_protein_qvalue, inserted out of record
                 // order to prove entry_id-keyed (order-independent) patching.
-                var runProteinByEntryId = new Dictionary<uint, double>
+                var proteinQByEntryId = new Dictionary<uint, double>
                 {
                     { 42, 0.95 },
                     { 3, 1.0 },
@@ -3205,7 +3205,9 @@ namespace pwiz.Osprey.Test
                 // Two-phase: phase-1 partial + phase-2 [52..60] patch.
                 FdrScoresSidecar.Write(twoPhasePath, partial, FdrScoresSidecar.Pass.FirstPass);
                 Assert.IsTrue(FdrScoresSidecar.PatchProteinQvalues(
-                    twoPhasePath, runProteinByEntryId, FdrScoresSidecar.Pass.FirstPass));
+                    twoPhasePath, proteinQByEntryId, FdrScoresSidecar.Pass.FirstPass,
+                    out int nPatchedTwoPhase));
+                Assert.AreEqual(proteinQByEntryId.Count, nPatchedTwoPhase);
 
                 // The finalized two-phase file must be byte-for-byte identical to the
                 // single-phase reference (risk R2 -- what mode3 compares cross-process).
@@ -3234,7 +3236,9 @@ namespace pwiz.Osprey.Test
 
                 // A patch with the wrong pass byte must be rejected and leave bytes intact.
                 Assert.IsFalse(FdrScoresSidecar.PatchProteinQvalues(
-                    twoPhasePath, runProteinByEntryId, FdrScoresSidecar.Pass.SecondPass));
+                    twoPhasePath, proteinQByEntryId, FdrScoresSidecar.Pass.SecondPass,
+                    out int nPatchedRejected));
+                Assert.AreEqual(0, nPatchedRejected);
                 CollectionAssert.AreEqual(refBytes, File.ReadAllBytes(twoPhasePath),
                     "A rejected patch must not modify the sidecar");
             }
@@ -3276,7 +3280,8 @@ namespace pwiz.Osprey.Test
                 // What the second-pass protein FDR then produces for those same entries.
                 var pass2 = new Dictionary<uint, double> { { 10, 0.0031 }, { 7, 0.77 } };
                 Assert.IsTrue(FdrScoresSidecar.PatchProteinQvalues(
-                    path, pass2, FdrScoresSidecar.Pass.SecondPass));
+                    path, pass2, FdrScoresSidecar.Pass.SecondPass, out int nPatchedPass2));
+                Assert.AreEqual(pass2.Count, nPatchedPass2);
 
                 var loaded = new List<FdrEntry> { MakeFdrEntry(10, 0.0, 0.0, 0.0), MakeFdrEntry(7, 0.0, 0.0, 0.0) };
                 Assert.IsTrue(FdrScoresSidecar.TryRead(path, loaded, FdrScoresSidecar.Pass.SecondPass));
@@ -4235,11 +4240,11 @@ namespace pwiz.Osprey.Test
             {
                 new KeyValuePair<string, List<FdrEntry>>(fileName, new List<FdrEntry>
                 {
-                    MakeFdrEntryWithProteinQ(1u,           runPeptideQ: 0.005, runProteinQ: 1.0),
-                    MakeFdrEntryWithProteinQ(0x80000001u,  runPeptideQ: 0.5,   runProteinQ: 1.0),
-                    MakeFdrEntryWithProteinQ(2u,           runPeptideQ: 0.5,   runProteinQ: 1.0),
-                    MakeFdrEntryWithProteinQ(0x80000002u,  runPeptideQ: 0.5,   runProteinQ: 1.0),
-                    MakeFdrEntryWithProteinQ(3u,           runPeptideQ: 0.5,   runProteinQ: 0.005),
+                    MakeFdrEntryWithProteinQ(1u,           runPeptideQ: 0.005, experimentProteinQ: 1.0),
+                    MakeFdrEntryWithProteinQ(0x80000001u,  runPeptideQ: 0.5,   experimentProteinQ: 1.0),
+                    MakeFdrEntryWithProteinQ(2u,           runPeptideQ: 0.5,   experimentProteinQ: 1.0),
+                    MakeFdrEntryWithProteinQ(0x80000002u,  runPeptideQ: 0.5,   experimentProteinQ: 1.0),
+                    MakeFdrEntryWithProteinQ(3u,           runPeptideQ: 0.5,   experimentProteinQ: 0.005),
                 }),
             };
 
@@ -4319,8 +4324,8 @@ namespace pwiz.Osprey.Test
             {
                 new KeyValuePair<string, List<FdrEntry>>(fileName, new List<FdrEntry>
                 {
-                    MakeFdrEntryWithProteinQ(1u, runPeptideQ: 0.005, runProteinQ: 1.0),
-                    MakeFdrEntryWithProteinQ(2u, runPeptideQ: 0.5,   runProteinQ: 0.005),
+                    MakeFdrEntryWithProteinQ(1u, runPeptideQ: 0.005, experimentProteinQ: 1.0),
+                    MakeFdrEntryWithProteinQ(2u, runPeptideQ: 0.5,   experimentProteinQ: 0.005),
                 }),
             };
 
@@ -4369,7 +4374,7 @@ namespace pwiz.Osprey.Test
                 new KeyValuePair<string, List<FdrEntry>>(fileName, new List<FdrEntry>
                 {
                     // Lone decoy with a passing protein_q. No paired target.
-                    MakeFdrEntryWithProteinQ(0x80000007u, runPeptideQ: 0.5, runProteinQ: 0.005),
+                    MakeFdrEntryWithProteinQ(0x80000007u, runPeptideQ: 0.5, experimentProteinQ: 0.005),
                 }),
             };
 
@@ -4399,7 +4404,7 @@ namespace pwiz.Osprey.Test
         /// rest at their defaults.
         /// </summary>
         private static FdrEntry MakeFdrEntryWithProteinQ(uint id, double runPeptideQ,
-            double runProteinQ)
+            double experimentProteinQ)
         {
             return new FdrEntry
             {
@@ -4408,7 +4413,7 @@ namespace pwiz.Osprey.Test
                 IsDecoy = (id & 0x80000000u) != 0,
                 Charge = 2,
                 RunPeptideQvalue = runPeptideQ,
-                ExperimentProteinQvalue = runProteinQ,
+                ExperimentProteinQvalue = experimentProteinQ,
                 ModifiedSequence = "PEPTIDE",
             };
         }

--- a/pwiz_tools/Osprey/Osprey.Test/IOTest.cs
+++ b/pwiz_tools/Osprey/Osprey.Test/IOTest.cs
@@ -3049,7 +3049,7 @@ namespace pwiz.Osprey.Test
         }
 
         private static FdrEntry MakeFdrEntry(uint id, double score, double q, double pep,
-            double runProteinQvalue = 1.0)
+            double proteinQvalue = 1.0)
         {
             return new FdrEntry
             {
@@ -3061,10 +3061,9 @@ namespace pwiz.Osprey.Test
                 Score = score,
                 RunPrecursorQvalue = q,
                 RunPeptideQvalue = q + 1.0e-9,
-                RunProteinQvalue = runProteinQvalue,
                 ExperimentPrecursorQvalue = q + 2.0e-9,
                 ExperimentPeptideQvalue = q + 3.0e-9,
-                ExperimentProteinQvalue = 1.0,
+                ExperimentProteinQvalue = proteinQvalue,
                 Pep = pep,
                 ModifiedSequence = "PEPTIDE",
             };
@@ -3082,16 +3081,16 @@ namespace pwiz.Osprey.Test
             try
             {
                 string path = Path.Combine(dir, "test.1st-pass.fdr_scores.bin");
-                // Distinct run_protein_qvalue per entry catches a writer that
+                // Distinct experiment_protein_qvalue per entry catches a writer that
                 // drops the v3 field. Values match Rust's
                 // fdr_scores_sidecar_v3_round_trip exactly so the
                 // OSPREY_CROSS_IMPL_FDR_SIDECAR_OUT byte-parity gate compares
                 // identical inputs on both sides.
                 var entries = new List<FdrEntry>
                 {
-                    MakeFdrEntry(0, -3.5, 0.001, 0.02, runProteinQvalue: 0.0042),
-                    MakeFdrEntry(1, -3.4, 0.002, 0.05, runProteinQvalue: 0.0123),
-                    MakeFdrEntry(2, -3.3, 0.003, 0.08, runProteinQvalue: 0.95),
+                    MakeFdrEntry(0, -3.5, 0.001, 0.02, proteinQvalue: 0.0042),
+                    MakeFdrEntry(1, -3.4, 0.002, 0.05, proteinQvalue: 0.0123),
+                    MakeFdrEntry(2, -3.3, 0.003, 0.08, proteinQvalue: 0.95),
                 };
 
                 FdrScoresSidecar.Write(path, entries, FdrScoresSidecar.Pass.FirstPass);
@@ -3134,8 +3133,8 @@ namespace pwiz.Osprey.Test
                                     BitConverter.DoubleToInt64Bits(loaded[i].ExperimentPeptideQvalue));
                     Assert.AreEqual(BitConverter.DoubleToInt64Bits(entries[i].Pep),
                                     BitConverter.DoubleToInt64Bits(loaded[i].Pep));
-                    Assert.AreEqual(BitConverter.DoubleToInt64Bits(entries[i].RunProteinQvalue),
-                                    BitConverter.DoubleToInt64Bits(loaded[i].RunProteinQvalue));
+                    Assert.AreEqual(BitConverter.DoubleToInt64Bits(entries[i].ExperimentProteinQvalue),
+                                    BitConverter.DoubleToInt64Bits(loaded[i].ExperimentProteinQvalue));
                 }
             }
             finally
@@ -3146,10 +3145,10 @@ namespace pwiz.Osprey.Test
 
         /// <summary>
         /// Two-phase 1st-pass sidecar write (issue #4355 struct-shrink S1, risk R2):
-        /// a phase-1 partial write (every record's run_protein_qvalue held at the 1.0
-        /// placeholder) followed by <see cref="FdrScoresSidecar.PatchRunProteinQvalues"/>
+        /// a phase-1 partial write (every record's experiment_protein_qvalue held at the 1.0
+        /// placeholder) followed by <see cref="FdrScoresSidecar.PatchProteinQvalues"/>
         /// must produce a file that is BYTE-IDENTICAL to a single-phase reference write
-        /// whose records already carried the finalized run_protein_qvalue. The map is
+        /// whose records already carried the finalized experiment_protein_qvalue. The map is
         /// entry_id-keyed and deliberately built out of record order (and the records
         /// carry non-sequential entry_ids) to prove the patch locates each record's
         /// [52..60] by entry_id, not by position.
@@ -3161,7 +3160,7 @@ namespace pwiz.Osprey.Test
             Directory.CreateDirectory(dir);
             try
             {
-                // Finalized records with a distinct real run_protein_qvalue each (the
+                // Finalized records with a distinct real experiment_protein_qvalue each (the
                 // second-to-last arg). entry_ids are non-sequential so a positional patch
                 // would land the wrong value. Each record also carries a DISTINCT
                 // experiment_aggregate_score in the trailing [60..68] field, which the patch
@@ -3175,7 +3174,7 @@ namespace pwiz.Osprey.Test
                     new FdrScoreRecord(3,  -3.2, 0.004, 0.0041, 0.0042, 0.0043, 0.11, 1.0,     2.125),
                 };
 
-                // Phase-1 partial records: identical EXCEPT run_protein_qvalue = 1.0. The
+                // Phase-1 partial records: identical EXCEPT experiment_protein_qvalue = 1.0. The
                 // aggregate score is already final at phase 1 (it comes from the score pass,
                 // not from protein FDR), so it is carried through unchanged.
                 var partial = new List<FdrScoreRecord>(real.Count);
@@ -3187,7 +3186,7 @@ namespace pwiz.Osprey.Test
                         r.ExperimentAggregateScore));
                 }
 
-                // Map entry_id -> finalized run_protein_qvalue, inserted out of record
+                // Map entry_id -> finalized experiment_protein_qvalue, inserted out of record
                 // order to prove entry_id-keyed (order-independent) patching.
                 var runProteinByEntryId = new Dictionary<uint, double>
                 {
@@ -3205,7 +3204,7 @@ namespace pwiz.Osprey.Test
 
                 // Two-phase: phase-1 partial + phase-2 [52..60] patch.
                 FdrScoresSidecar.Write(twoPhasePath, partial, FdrScoresSidecar.Pass.FirstPass);
-                Assert.IsTrue(FdrScoresSidecar.PatchRunProteinQvalues(
+                Assert.IsTrue(FdrScoresSidecar.PatchProteinQvalues(
                     twoPhasePath, runProteinByEntryId, FdrScoresSidecar.Pass.FirstPass));
 
                 // The finalized two-phase file must be byte-for-byte identical to the
@@ -3215,7 +3214,7 @@ namespace pwiz.Osprey.Test
                 CollectionAssert.AreEqual(refBytes, twoPhaseBytes,
                     "Two-phase (partial + [52..60] patch) sidecar diverged from the single-phase write");
 
-                // Sanity: the patch actually finalized run_protein_qvalue (a pre-patch
+                // Sanity: the patch actually finalized experiment_protein_qvalue (a pre-patch
                 // read would have seen the 1.0 placeholder for entries 10/7/42).
                 var loaded = new List<FdrEntry>
                 {
@@ -3229,12 +3228,12 @@ namespace pwiz.Osprey.Test
                 foreach (var e in loaded)
                     byId[e.EntryId] = e;
                 Assert.AreEqual(BitConverter.DoubleToInt64Bits(0.0042),
-                                BitConverter.DoubleToInt64Bits(byId[10].RunProteinQvalue));
+                                BitConverter.DoubleToInt64Bits(byId[10].ExperimentProteinQvalue));
                 Assert.AreEqual(BitConverter.DoubleToInt64Bits(0.95),
-                                BitConverter.DoubleToInt64Bits(byId[42].RunProteinQvalue));
+                                BitConverter.DoubleToInt64Bits(byId[42].ExperimentProteinQvalue));
 
                 // A patch with the wrong pass byte must be rejected and leave bytes intact.
-                Assert.IsFalse(FdrScoresSidecar.PatchRunProteinQvalues(
+                Assert.IsFalse(FdrScoresSidecar.PatchProteinQvalues(
                     twoPhasePath, runProteinByEntryId, FdrScoresSidecar.Pass.SecondPass));
                 CollectionAssert.AreEqual(refBytes, File.ReadAllBytes(twoPhasePath),
                     "A rejected patch must not modify the sidecar");
@@ -3717,9 +3716,9 @@ namespace pwiz.Osprey.Test
                 //    sidecar.
                 var sidecarEntries = new List<FdrEntry>
                 {
-                    MakeFdrEntry(100, -3.5, 0.001, 0.02, runProteinQvalue: 0.42),
-                    MakeFdrEntry(101, -3.4, 0.002, 0.05, runProteinQvalue: 0.43),
-                    MakeFdrEntry(102, -3.3, 0.003, 0.08, runProteinQvalue: 0.44),
+                    MakeFdrEntry(100, -3.5, 0.001, 0.02, proteinQvalue: 0.42),
+                    MakeFdrEntry(101, -3.4, 0.002, 0.05, proteinQvalue: 0.43),
+                    MakeFdrEntry(102, -3.3, 0.003, 0.08, proteinQvalue: 0.44),
                 };
                 FdrScoresSidecar.Write(sidecarPath, sidecarEntries,
                     FdrScoresSidecar.Pass.FirstPass);
@@ -3774,7 +3773,7 @@ namespace pwiz.Osprey.Test
                 var inputs = RescoreHydration.HydrateForRescore(new[] { parquetPath });
 
                 // 5. Assert per-file entries: same fileName, same count,
-                //    Score / RunProteinQvalue overlaid bit-exactly.
+                //    Score / ExperimentProteinQvalue overlaid bit-exactly.
                 Assert.AreEqual(1, inputs.PerFileEntries.Count);
                 Assert.AreEqual(stem, inputs.PerFileEntries[0].Key);
                 var got = inputs.PerFileEntries[0].Value;
@@ -3785,8 +3784,8 @@ namespace pwiz.Osprey.Test
                     Assert.AreEqual(BitConverter.DoubleToInt64Bits(sidecarEntries[i].Score),
                                     BitConverter.DoubleToInt64Bits(got[i].Score));
                     Assert.AreEqual(
-                        BitConverter.DoubleToInt64Bits(sidecarEntries[i].RunProteinQvalue),
-                        BitConverter.DoubleToInt64Bits(got[i].RunProteinQvalue));
+                        BitConverter.DoubleToInt64Bits(sidecarEntries[i].ExperimentProteinQvalue),
+                        BitConverter.DoubleToInt64Bits(got[i].ExperimentProteinQvalue));
                 }
 
                 // 6. Assert reconciliation actions: keyed by
@@ -4350,7 +4349,7 @@ namespace pwiz.Osprey.Test
                 IsDecoy = (id & 0x80000000u) != 0,
                 Charge = 2,
                 RunPeptideQvalue = runPeptideQ,
-                RunProteinQvalue = runProteinQ,
+                ExperimentProteinQvalue = runProteinQ,
                 ModifiedSequence = "PEPTIDE",
             };
         }

--- a/pwiz_tools/Osprey/Osprey.Test/OspreyConfigTest.cs
+++ b/pwiz_tools/Osprey/Osprey.Test/OspreyConfigTest.cs
@@ -95,13 +95,13 @@ namespace pwiz.Osprey.Test
         }
 
         // NOTE: A direct compaction protein-rescue test (a non-decoy entry whose
-        // RunPeptideQvalue is above config.RunFdr but whose RunProteinQvalue <= 0.01
+        // RunPeptideQvalue is above config.RunFdr but whose ExperimentProteinQvalue <= 0.01
         // still survives first-pass compaction) is intentionally NOT added here.
         // The predicate lives in FirstPassFdrTask.CompactFirstPass, a private instance
         // method that consumes a PipelineContext (DI container + logging) and either
         // a full RescoreInputs bundle or a constructed per-file entry list; there is
         // no pure/public seam exposing the
-        // "RunPeptideQvalue <= RunFdr || RunProteinQvalue <= EffectiveProteinFdr"
+        // "RunPeptideQvalue <= RunFdr || ExperimentProteinQvalue <= EffectiveProteinFdr"
         // gate without that heavy setup. TestEffectiveProteinFdr above guards the
         // exact value (0.01) that CompactFirstPass reads as its always-on
         // proteinGate, so the always-on threshold semantics are covered at the

--- a/pwiz_tools/Osprey/Osprey.Test/Pass2FdrSidecarTest.cs
+++ b/pwiz_tools/Osprey/Osprey.Test/Pass2FdrSidecarTest.cs
@@ -357,7 +357,7 @@ namespace pwiz.Osprey.Test
                 entryId: 1, score: 10.0,
                 runPrecursorQvalue: 0.001, runPeptideQvalue: 0.002,
                 experimentPrecursorQvalue: 0.0005, experimentPeptideQvalue: 0.0006,
-                pep: 0.03, runProteinQvalue: 0.004, experimentAggregateScore: 12.5);
+                pep: 0.03, experimentProteinQvalue: 0.004, experimentAggregateScore: 12.5);
 
             // (a) UNCHANGED: recomputed score == the record's score -> carry the whole record.
             var unchanged = new FdrEntry { EntryId = 1 };

--- a/pwiz_tools/Osprey/Osprey.Test/ReconciliationTest.cs
+++ b/pwiz_tools/Osprey/Osprey.Test/ReconciliationTest.cs
@@ -229,7 +229,7 @@ namespace pwiz.Osprey.Test
                 Score = 3.0,
                 RunPrecursorQvalue = 0.20,  // fails hard gate
                 RunPeptideQvalue = 0.02,    // fails peptide too
-                RunProteinQvalue = 0.001,   // would rescue if allowed
+                ExperimentProteinQvalue = 0.001,   // would rescue if allowed
                 ModifiedSequence = @"PEPTIDE1",
             };
             var goodTarget = PassingTarget(@"PEPTIDE2", apexRt: 20.0, score: 3.0);
@@ -270,7 +270,7 @@ namespace pwiz.Osprey.Test
                 Score = 3.0,
                 RunPrecursorQvalue = 0.005, // passes hard gate
                 RunPeptideQvalue = 0.05,    // fails borderline
-                RunProteinQvalue = 0.005,   // rescues
+                ExperimentProteinQvalue = 0.005,   // rescues
                 ModifiedSequence = @"PEPTIDE1",
             };
 
@@ -1267,7 +1267,7 @@ namespace pwiz.Osprey.Test
                 Score = score,
                 RunPrecursorQvalue = precursorQ,
                 RunPeptideQvalue = peptideQ,
-                RunProteinQvalue = 1.0,
+                ExperimentProteinQvalue = 1.0,
                 ModifiedSequence = modifiedSequence,
             };
         }

--- a/pwiz_tools/Osprey/Osprey/OspreyFileDiagnostics.cs
+++ b/pwiz_tools/Osprey/Osprey/OspreyFileDiagnostics.cs
@@ -325,7 +325,7 @@ namespace pwiz.Osprey
         /// FDR state (gate input + ranking input + propagated output) to
         /// cs_stage6_protein_fdr.tsv after RunFirstPassProteinFdr completes.
         /// Used to bisect the SQC[UniMod:4]LQVPER borderline cross-impl
-        /// divergence in run_protein_qvalue: matching against
+        /// divergence in experiment_protein_qvalue: matching against
         /// rust_stage6_protein_fdr.tsv shows whether the gate input
         /// (best_qvalue), the ranking input (score), or the algorithm output
         /// (protein_qvalue) is responsible.
@@ -1521,7 +1521,7 @@ namespace pwiz.Osprey
                     sw.Write('\t'); sw.Write(Diagnostics.FormatF64Roundtrip(e.Pep));
                     sw.Write('\t'); sw.Write(Diagnostics.FormatF64Roundtrip(e.RunPrecursorQvalue));
                     sw.Write('\t'); sw.Write(Diagnostics.FormatF64Roundtrip(e.RunPeptideQvalue));
-                    sw.Write('\t'); sw.Write(Diagnostics.FormatF64Roundtrip(e.RunProteinQvalue));
+                    sw.Write('\t'); sw.Write(Diagnostics.FormatF64Roundtrip(e.ExperimentProteinQvalue));
                     sw.Write('\t'); sw.Write(Diagnostics.FormatF64Roundtrip(e.ExperimentPrecursorQvalue));
                     sw.Write('\t'); sw.WriteLine(Diagnostics.FormatF64Roundtrip(e.ExperimentPeptideQvalue));
                 }
@@ -1589,7 +1589,7 @@ namespace pwiz.Osprey
                     sw.Write('\t'); sw.Write(Diagnostics.FormatF64Roundtrip(e.Pep));
                     sw.Write('\t'); sw.Write(Diagnostics.FormatF64Roundtrip(e.RunPrecursorQvalue));
                     sw.Write('\t'); sw.Write(Diagnostics.FormatF64Roundtrip(e.RunPeptideQvalue));
-                    sw.Write('\t'); sw.Write(Diagnostics.FormatF64Roundtrip(e.RunProteinQvalue));
+                    sw.Write('\t'); sw.Write(Diagnostics.FormatF64Roundtrip(e.ExperimentProteinQvalue));
                     sw.Write('\t'); sw.Write(Diagnostics.FormatF64Roundtrip(e.ExperimentPrecursorQvalue));
                     sw.Write('\t'); sw.WriteLine(Diagnostics.FormatF64Roundtrip(e.ExperimentPeptideQvalue));
                 }
@@ -1904,7 +1904,7 @@ namespace pwiz.Osprey
         /// run q-value, min across files). score is the input ranking
         /// (max SVM discriminant across files). protein_qvalue is the
         /// propagated output -- the value PropagateProteinQvalues will
-        /// write to FdrEntry.RunProteinQvalue (1.0 if the peptide is
+        /// write to FdrEntry.ExperimentProteinQvalue (1.0 if the peptide is
         /// not in proteinFdr.PeptideQvalues, matching the
         /// PropagateProteinQvalues default). Rows sorted by
         /// (is_decoy, modified_sequence) for stable diff.

--- a/pwiz_tools/Osprey/Osprey/OspreyFileDiagnostics.cs
+++ b/pwiz_tools/Osprey/Osprey/OspreyFileDiagnostics.cs
@@ -1508,7 +1508,7 @@ namespace pwiz.Osprey
             using (var sw = new StreamWriter(path))
             {
                 sw.NewLine = "\n";
-                sw.WriteLine(@"file_name	entry_id	charge	modified_sequence	is_decoy	score	pep	run_precursor_q	run_peptide_q	run_protein_q	experiment_precursor_q	experiment_peptide_q");
+                sw.WriteLine(@"file_name	entry_id	charge	modified_sequence	is_decoy	score	pep	run_precursor_q	run_peptide_q	experiment_protein_q	experiment_precursor_q	experiment_peptide_q");
                 foreach (var row in rows)
                 {
                     var e = row.Value;
@@ -1576,7 +1576,7 @@ namespace pwiz.Osprey
             using (var sw = new StreamWriter(path))
             {
                 sw.NewLine = "\n";
-                sw.WriteLine(@"file_name	entry_id	charge	modified_sequence	is_decoy	score	pep	run_precursor_q	run_peptide_q	run_protein_q	experiment_precursor_q	experiment_peptide_q");
+                sw.WriteLine(@"file_name	entry_id	charge	modified_sequence	is_decoy	score	pep	run_precursor_q	run_peptide_q	experiment_protein_q	experiment_precursor_q	experiment_peptide_q");
                 foreach (var row in rows)
                 {
                     var e = row.Value;

--- a/pwiz_tools/Osprey/Regression/FdrSidecars.ps1
+++ b/pwiz_tools/Osprey/Regression/FdrSidecars.ps1
@@ -6,23 +6,26 @@ Two consumers, one decoder:
   * ai/scripts/Osprey/Compare/Compare-FdrSidecars-Crossimpl.ps1 - C# vs Rust.
 
 The four-task chain leg asserted only Compare-BlibFull, and the blib carries no protein
-q-value, so a route that writes a different RunProteinQvalue into every
+q-value, so a route that writes a different ExperimentProteinQvalue into every
 <stem>.2nd-pass.fdr_scores.bin passed green (issue #4553: 32,450 of 260,419 records differ
 on StellarGenDecoyEntrap, 1.57% at 82 files). Peptide counts, protein-group counts and the
 blib are all identical while it happens, so nothing the gate already reads can see it.
 
 The cross-impl gate had the same blind spot from the other direction: it compares the
 Stage 7 protein FDR dump (per-protein-GROUP columns) and the blib, neither of which carries
-a per-entry SVM score or run protein q. Both implementations dropped the same fields, so
+a per-entry SVM score or protein q. Both implementations dropped the same fields, so
 they agreed on the wrong value and nothing was red.
 
 This compares the sidecars themselves, which is where the distributed tasks' per-file
 output actually lands.
 
+Test-Pass2ProteinQvalue (below) covers the case a two-route comparison structurally CANNOT:
+a value both routes copy identically from pass 1. See issue #4559.
+
 Record layout (Osprey.IO\FdrScoresSidecar.cs), v4: 32-byte header, 68-byte records,
   entry_id u32 @0, score f64 @4, run_precursor_q @12, run_peptide_q @20,
-  experiment_precursor_q @28, experiment_peptide_q @36, pep @44, run_protein_q @52,
-  experiment_aggregate_score @60 (issue #4522).
+  experiment_precursor_q @28, experiment_peptide_q @36, pep @44,
+  experiment_protein_q @52, experiment_aggregate_score @60 (issue #4522).
 Header: magic @0..8, version @8, pass @9, record count u64 @16.
 
 The decode + compare runs as compiled C#, not PowerShell. A per-record PowerShell loop
@@ -65,6 +68,15 @@ public class FdrSidecarDiff
     public string[] FirstExample;
 }
 
+public class Pass2ProteinQLiveness
+{
+    public bool Readable;
+    public string Problem;
+    public long Matched;
+    public long Differing;
+    public long AbsentFromPass1;
+}
+
 public static class OspreyFdrSidecarComparer
 {
     private const int HeaderLen = 32;
@@ -85,9 +97,70 @@ public static class OspreyFdrSidecarComparer
         new FdrSidecarField { Name = "experiment_precursor_qvalue", Offset = 28 },
         new FdrSidecarField { Name = "experiment_peptide_qvalue",   Offset = 36 },
         new FdrSidecarField { Name = "pep",                         Offset = 44 },
-        new FdrSidecarField { Name = "experiment_protein_qvalue",          Offset = 52 },
+        new FdrSidecarField { Name = "experiment_protein_qvalue",   Offset = 52 },
         new FdrSidecarField { Name = "experiment_aggregate_score",  Offset = 60 },
     };
+
+    /// Byte offset of a field, by name, so a caller cannot hardcode an offset that the next
+    /// layout change silently moves out from under it.
+    public static int OffsetOf(string name)
+    {
+        foreach (var f in Fields)
+        {
+            if (f.Name == name)
+                return f.Offset;
+        }
+        throw new ArgumentException("no such sidecar field: " + name);
+    }
+
+    /// Is the 2nd-pass sidecar's experiment_protein_qvalue a SECOND-PASS value, or a verbatim
+    /// copy of the first pass? Issue #4559: no pass-2 mode wrote the column, so it reached the
+    /// 2nd-pass file carrying whatever pass 1 put there - the one column in that file that was
+    /// unconditionally a pass-1 value. Nothing could see it: the two-route comparison above is
+    /// blind because BOTH routes copied it, and the golden reads the per-GROUP protein dump,
+    /// never this per-entry column.
+    ///
+    /// This is a LIVENESS check, not an equivalence one. It cannot say the pass-2 value is
+    /// correct; it says the pass-2 protein FDR result reached the file at all. That is exactly
+    /// the failure class that hid here, and it is checkable from one run's own output with no
+    /// baseline. Records absent from pass 1 (gap-fill) cannot be compared and are counted
+    /// separately rather than silently skipped.
+    public static Pass2ProteinQLiveness CheckPass2ProteinQ(string pass1Path, string pass2Path)
+    {
+        var result = new Pass2ProteinQLiveness();
+        byte[] a = ReadIfValid(pass1Path, 1, out long na, out string problemA);
+        byte[] b = ReadIfValid(pass2Path, 2, out long nb, out string problemB);
+        if (a == null || b == null)
+        {
+            result.Problem = a == null ? problemA : problemB;
+            return result;
+        }
+        result.Readable = true;
+
+        int off = OffsetOf("experiment_protein_qvalue");
+        var pass1ById = new Dictionary<uint, double>();
+        for (long i = 0; i < na; i++)
+        {
+            int o = HeaderLen + (int)(i * RecordLen);
+            pass1ById[BitConverter.ToUInt32(a, o)] = BitConverter.ToDouble(a, o + off);
+        }
+        for (long i = 0; i < nb; i++)
+        {
+            int o = HeaderLen + (int)(i * RecordLen);
+            uint id = BitConverter.ToUInt32(b, o);
+            double q2 = BitConverter.ToDouble(b, o + off);
+            double q1;
+            if (!pass1ById.TryGetValue(id, out q1))
+            {
+                result.AbsentFromPass1++;
+                continue;
+            }
+            result.Matched++;
+            if (BitConverter.DoubleToInt64Bits(q1) != BitConverter.DoubleToInt64Bits(q2))
+                result.Differing++;
+        }
+        return result;
+    }
 
     public static FdrSidecarDiff Compare(
         string pathExpected, string pathActual, double tolerance, int expectedPass)
@@ -349,4 +422,66 @@ function Compare-FdrSidecars {
     }
 
     return @{ Pass = ($issues.Count -eq 0); Issues = $issues; Compared = $nCompared }
+}
+
+function Test-Pass2ProteinQvalue {
+    <#
+    Assert that each <stem>.2nd-pass.fdr_scores.bin carries a SECOND-PASS
+    experiment_protein_qvalue rather than a verbatim copy of the 1st-pass column.
+
+    Single-run property, so it needs no baseline and no second route - which is the point.
+    Issue #4559: no pass-2 mode wrote that column, so it reached the 2nd-pass file holding
+    whatever pass 1 put there, and nothing could see it. Compare-FdrSidecars is blind because
+    both routes copied the same wrong value (the shared-defect blind spot), and the golden
+    reads the per-GROUP Stage 7 dump, never this per-entry column.
+
+    LIVENESS, not equivalence: this cannot say the pass-2 value is right, only that the
+    second-pass protein FDR reached the file. Records absent from pass 1 (gap-fill) cannot be
+    compared and are reported separately rather than silently skipped.
+    #>
+    param(
+        [Parameter(Mandatory = $true)][string]$RunDir
+    )
+
+    $issues = [System.Collections.Generic.List[string]]::new()
+    $suffix = '.2nd-pass.fdr_scores.bin'
+    $files = @(Get-ChildItem -File -Path $RunDir -Filter "*$suffix" -ErrorAction SilentlyContinue)
+    if ($files.Count -eq 0) {
+        $issues.Add("no $suffix files in $RunDir")
+        return @{ Pass = $false; Issues = $issues; Matched = 0 }
+    }
+
+    $totalMatched = 0
+    $totalDiffering = 0
+    foreach ($f in ($files | Sort-Object Name)) {
+        $stem = $f.Name.Substring(0, $f.Name.Length - $suffix.Length)
+        $pass1 = Join-Path $RunDir "$stem.1st-pass.fdr_scores.bin"
+        if (-not (Test-Path $pass1)) {
+            $issues.Add("$stem : no 1st-pass sidecar to compare against at $pass1")
+            continue
+        }
+        $r = [OspreyFdrSidecarComparer]::CheckPass2ProteinQ($pass1, $f.FullName)
+        if (-not $r.Readable) {
+            $issues.Add("$stem : $($r.Problem)")
+            continue
+        }
+        if ($r.Matched -eq 0) {
+            $issues.Add("$stem : no entry_id present in both passes - verified nothing")
+            continue
+        }
+        if ($r.Differing -eq 0) {
+            $issues.Add((("{0}: experiment_protein_qvalue is identical to the 1st-pass column " +
+                "on all {1} shared record(s) - the second-pass protein FDR result never " +
+                "reached the 2nd-pass sidecar (issue #4559)") -f $stem, $r.Matched))
+        }
+        $totalMatched += $r.Matched
+        $totalDiffering += $r.Differing
+    }
+
+    return @{
+        Pass = ($issues.Count -eq 0)
+        Issues = $issues
+        Matched = $totalMatched
+        Differing = $totalDiffering
+    }
 }

--- a/pwiz_tools/Osprey/Regression/FdrSidecars.ps1
+++ b/pwiz_tools/Osprey/Regression/FdrSidecars.ps1
@@ -453,6 +453,7 @@ function Test-Pass2ProteinQvalue {
 
     $totalMatched = 0
     $totalDiffering = 0
+    $totalGapFill = 0
     foreach ($f in ($files | Sort-Object Name)) {
         $stem = $f.Name.Substring(0, $f.Name.Length - $suffix.Length)
         $pass1 = Join-Path $RunDir "$stem.1st-pass.fdr_scores.bin"
@@ -476,6 +477,7 @@ function Test-Pass2ProteinQvalue {
         }
         $totalMatched += $r.Matched
         $totalDiffering += $r.Differing
+        $totalGapFill += $r.AbsentFromPass1
     }
 
     return @{
@@ -483,5 +485,6 @@ function Test-Pass2ProteinQvalue {
         Issues = $issues
         Matched = $totalMatched
         Differing = $totalDiffering
+        GapFill = $totalGapFill
     }
 }

--- a/pwiz_tools/Osprey/Regression/FdrSidecars.ps1
+++ b/pwiz_tools/Osprey/Regression/FdrSidecars.ps1
@@ -37,7 +37,22 @@ returns a NAMED problem rather than a silent skip, and the comparison refuses to
 file pair equal on the strength of records it never read.
 #>
 
-if (-not ([System.Management.Automation.PSTypeName]'OspreyFdrSidecarComparer').Type) {
+# A .NET type cannot be replaced once loaded into a PowerShell session, and the guard below
+# keys on the type NAME - so a session that already dot-sourced an older copy of this file keeps
+# that older type. This branch added CheckPass2ProteinQ to it, so such a session would throw
+# "does not contain a method named CheckPass2ProteinQ" from inside Test-Pass2ProteinQvalue,
+# aborting a multi-hour gate mid-dataset with an error that names neither the cause nor the cure.
+# Reloading is impossible, so say so immediately instead. Reachable via a second regression.ps1
+# invocation in one session, or Compare-FdrSidecars-Crossimpl.ps1 dot-sourcing a sibling
+# checkout's copy first.
+$ospreyComparerType = ([System.Management.Automation.PSTypeName]'OspreyFdrSidecarComparer').Type
+if ($ospreyComparerType -and -not $ospreyComparerType.GetMethod('CheckPass2ProteinQ')) {
+    throw ("An older OspreyFdrSidecarComparer is already loaded in this PowerShell session and " +
+           "has no CheckPass2ProteinQ method. A loaded .NET type cannot be replaced, so this " +
+           "session cannot run the 2nd-pass protein q gate (mode 1c). Start a fresh pwsh " +
+           "session and re-run.")
+}
+if (-not $ospreyComparerType) {
     Add-Type -TypeDefinition @'
 using System;
 using System.Collections.Generic;
@@ -74,6 +89,7 @@ public class Pass2ProteinQLiveness
     public string Problem;
     public long Matched;
     public long Differing;
+    public long DifferingAtDefault;
     public long AbsentFromPass1;
 }
 
@@ -157,7 +173,17 @@ public static class OspreyFdrSidecarComparer
             }
             result.Matched++;
             if (BitConverter.DoubleToInt64Bits(q1) != BitConverter.DoubleToInt64Bits(q2))
+            {
                 result.Differing++;
+                // "Differs from pass 1" alone stopped being sufficient when #4559 also removed
+                // the pass-1 seed from RestorePass1Scalars: an UNPATCHED record now reads 1.0,
+                // the ResetScores default, which also differs from the pass-1 value. So a run
+                // with the patch reverted would still show Differing > 0 and pass. Counting the
+                // defaults separately lets the caller tell a real pass-2 value from the patch
+                // never having run.
+                if (q2 == 1.0)
+                    result.DifferingAtDefault++;
+            }
         }
         return result;
     }
@@ -453,6 +479,7 @@ function Test-Pass2ProteinQvalue {
 
     $totalMatched = 0
     $totalDiffering = 0
+    $totalDefault = 0
     $totalGapFill = 0
     foreach ($f in ($files | Sort-Object Name)) {
         $stem = $f.Name.Substring(0, $f.Name.Length - $suffix.Length)
@@ -470,14 +497,31 @@ function Test-Pass2ProteinQvalue {
             $issues.Add("$stem : no entry_id present in both passes - verified nothing")
             continue
         }
-        if ($r.Differing -eq 0) {
-            $issues.Add((("{0}: experiment_protein_qvalue is identical to the 1st-pass column " +
-                "on all {1} shared record(s) - the second-pass protein FDR result never " +
-                "reached the 2nd-pass sidecar (issue #4559)") -f $stem, $r.Matched))
-        }
         $totalMatched += $r.Matched
         $totalDiffering += $r.Differing
+        $totalDefault += $r.DifferingAtDefault
         $totalGapFill += $r.AbsentFromPass1
+    }
+
+    # Asserted at RUN level, not per file. The property - "the second-pass protein FDR reached
+    # the sidecar" - is a property of the run, and PropagateProteinQvalues legitimately assigns
+    # 1.0 to every entry whose ModifiedSequence is absent from PeptideQvalues in BOTH passes
+    # (ProteinFdr.cs), so a file dominated by those produces bit-identical columns without
+    # anything being wrong. Asserting per file reddened the whole dataset for that.
+    if ($files.Count -gt 0 -and $totalMatched -gt 0) {
+        if ($totalDiffering -eq 0) {
+            $issues.Add((("experiment_protein_qvalue is identical to the 1st-pass column on all " +
+                "{0} shared record(s) across {1} file(s) - the second-pass protein FDR result " +
+                "never reached the 2nd-pass sidecar (issue #4559)") -f $totalMatched, $files.Count))
+        }
+        elseif ($totalDiffering -eq $totalDefault) {
+            # Every record that moved, moved to the ResetScores default. That is what a run with
+            # PatchPass2ProteinQvalues reverted or failing looks like, and it is NOT what a
+            # populated pass-2 column looks like - so it must not read as liveness.
+            $issues.Add((("all {0} differing record(s) hold the 1.0 reset default rather than a " +
+                "computed second-pass value - the patch did not run, or wrote nothing (#4559)") `
+                -f $totalDiffering))
+        }
     }
 
     return @{

--- a/pwiz_tools/Osprey/Regression/FdrSidecars.ps1
+++ b/pwiz_tools/Osprey/Regression/FdrSidecars.ps1
@@ -85,7 +85,7 @@ public static class OspreyFdrSidecarComparer
         new FdrSidecarField { Name = "experiment_precursor_qvalue", Offset = 28 },
         new FdrSidecarField { Name = "experiment_peptide_qvalue",   Offset = 36 },
         new FdrSidecarField { Name = "pep",                         Offset = 44 },
-        new FdrSidecarField { Name = "run_protein_qvalue",          Offset = 52 },
+        new FdrSidecarField { Name = "experiment_protein_qvalue",          Offset = 52 },
         new FdrSidecarField { Name = "experiment_aggregate_score",  Offset = 60 },
     };
 

--- a/pwiz_tools/Osprey/docs/08-protein-parsimony.md
+++ b/pwiz_tools/Osprey/docs/08-protein-parsimony.md
@@ -193,11 +193,27 @@ compaction (`Osprey.Tasks/FirstPassFdrTask.cs:305-313`; the comment confirms it 
   passed precursor FDR), giving a symmetric target+decoy null.
 - Picked-protein FDR runs at the **1× Savitski gate** `config.RunFdr`
   (`ProteinFdr.cs:824`).
-- Only `RunProteinQvalue` is set (`setRun: true, setExperiment: false`,
-  `ProteinFdr.cs:828`) via `PropagateProteinQvalues` (`ProteinFdr.cs:765`).
+- `ExperimentProteinQvalue` is set via `PropagateProteinQvalues`, which assigns by
+  `ModifiedSequence` over **every** entry, passing or not — a peptide's protein q is a
+  property of the peptide, not of a detection.
 
-`RunProteinQvalue` then feeds protein-aware compaction and the reconciliation
-consensus rescue gate (`10-cross-run-reconciliation.md`).
+There is ONE protein q-value field, and it is experiment-scope in both passes: the detected
+set is gated on run-level peptide q, but it is pooled over every file, one picked-protein FDR
+runs, and one value per peptide reaches every entry in every file. The field was called
+`RunProteinQvalue` until issue #4559, which was a misnomer — measured over a Stellar 3-file
+run, 483,820 of 483,820 precursors appearing in 2+ files carried an identical value in all of
+them.
+
+**The pass is recorded by the sidecar, not by a second field.** The first-pass value is
+captured into `.1st-pass.fdr_scores.bin`, where the streaming compaction gate reads it back;
+the second-pass protein FDR then overwrites it in memory, and `PatchPass2ProteinQvalues`
+writes that into `.2nd-pass.fdr_scores.bin`. Before #4559 the second pass wrote a separate
+`ExperimentProteinQvalue` that nothing read, while the 2nd-pass sidecar kept a **pass-1**
+value — the one column in that file that was not a pass-2 quantity.
+
+The first-pass value feeds protein-aware compaction and the reconciliation
+consensus rescue gate (`10-cross-run-reconciliation.md`). Both run before the second-pass
+protein FDR exists, which is why one field can serve both passes.
 
 ### Second pass — post-reconciliation, authoritative (`experiment_protein_qvalue`)
 

--- a/pwiz_tools/Osprey/docs/08-protein-parsimony.md
+++ b/pwiz_tools/Osprey/docs/08-protein-parsimony.md
@@ -177,7 +177,7 @@ Ranking is by raw SVM discriminant (`FdrEntry.Score`), never by q-value or PEP �
 the class doc (`ProteinFdr.cs:496-534`) reproduces the Rust rationale that q/PEP
 collapse the decoy null.
 
-### First pass — pre-compaction, gating (`run_protein_qvalue`)
+### First pass — pre-compaction, gating (`experiment_protein_qvalue`)
 
 `ProteinFdr.RunFirstPassProteinFdr` (`ProteinFdr.cs:804`), wrapped by
 `ProteinFdrEngine.RunFirstPass` (`ProteinFdrEngine.cs:61`), is invoked from

--- a/pwiz_tools/Osprey/docs/14-intermediate-files.md
+++ b/pwiz_tools/Osprey/docs/14-intermediate-files.md
@@ -18,7 +18,7 @@ resume mechanisms the port adds (a per-task `.osprey.task` validity sidecar and 
 | `<stem>.spectra.bin` | Custom binary v3 | `Osprey.IO/SpectraCache.cs` | Decoded MS1/MS2 spectra for fast reload |
 | `<stem>.scores.parquet` | Apache Parquet (ZSTD) | `Osprey.IO/ParquetScoreCache.cs` | Scored entries: 21 PIN features, fragments, CWT candidates + footer metadata |
 | `<stem>.scores-reconciled.parquet` | Apache Parquet (ZSTD) | `Osprey.Tasks/ReconciledParquetWriter.cs` | Stage 6 reconciled rewrite (separate file, not in-place) |
-| `<stem>.1st-pass.fdr_scores.bin` | Custom binary v4 | `Osprey.IO/FdrScoresSidecar.cs` | SVM score + 4 q-values + PEP + run_protein_qvalue + experiment_aggregate_score after first-pass Percolator |
+| `<stem>.1st-pass.fdr_scores.bin` | Custom binary v4 | `Osprey.IO/FdrScoresSidecar.cs` | SVM score + 4 q-values + PEP + experiment_protein_qvalue + experiment_aggregate_score after first-pass Percolator |
 | `<stem>.2nd-pass.fdr_scores.bin` | Custom binary v4 | `Osprey.IO/FdrScoresSidecar.cs` | Same record shape after second-pass Percolator |
 | `<stem>.reconciliation.json` | JSON (Newtonsoft) | `Osprey.IO/ReconciliationFile.cs` | Stage 5 planner output: actions, gap-fill targets, refined RT calibration |
 | `<output>.<TaskName>.osprey.task` | JSON (hand-rolled) | `Osprey.Tasks/TaskValiditySidecar.cs` | **C# addition**: per-(output, task) resume validity record |
@@ -64,7 +64,7 @@ local-temp → NAS cross-volume copy, which sidesteps the truncation risk `copy_
 guards against. Callers that use it: `ParquetScoreCache.WriteScoresParquet`
 (`ParquetScoreCache.cs:265`, `:457`), `SpectraCache.SaveSpectraCache` (`SpectraCache.cs:85`),
 `CalibrationIO.SaveCalibration` (`CalibrationIO.cs:50`), `FdrScoresSidecar.WriteInternal`
-(`FdrScoresSidecar.cs:366`) and `PatchRunProteinQvalues` (`FdrScoresSidecar.cs:257`),
+(`FdrScoresSidecar.cs:366`) and `PatchProteinQvalues` (`FdrScoresSidecar.cs:257`),
 `ReconciliationFile.Save` (`ReconciliationFile.cs:203`), `LibraryCache.SaveCache`
 (`LibraryCache.cs:77`), and `TaskValiditySidecar.Write` (`TaskValiditySidecar.cs:130`).
 
@@ -319,14 +319,14 @@ Record (68 bytes):
   [28..36] experiment_precursor_qvalue  f64 LE
   [36..44] experiment_peptide_qvalue    f64 LE
   [44..52] pep                          f64 LE
-  [52..60] run_protein_qvalue           f64 LE
+  [52..60] experiment_protein_qvalue           f64 LE
   [60..68] experiment_aggregate_score   f64 LE
 ```
 
 Field order and offsets are single-sourced in `WriteRecord` (`FdrScoresSidecar.cs:390`).
 The v2→v3 bump (dated 2026-05-02 in the C# comment, `FdrScoresSidecar.cs:82`) added
-`run_protein_qvalue` so a Stage 6 worker can reproduce the in-process compaction predicate
-`run_peptide_qvalue ≤ 0.01 OR run_protein_qvalue ≤ 0.01`; records are written pre-compaction but
+`experiment_protein_qvalue` so a Stage 6 worker can reproduce the in-process compaction predicate
+`run_peptide_qvalue ≤ 0.01 OR experiment_protein_qvalue ≤ 0.01`; records are written pre-compaction but
 post first-pass protein FDR so the value is real, not the default 1.0. Cross-impl byte parity is
 checked by a harness via the `OSPREY_CROSS_IMPL_FDR_SIDECAR_OUT` hook (`FdrScoresSidecar.cs:43`).
 
@@ -346,10 +346,10 @@ Two caveats worth keeping straight. It is **not** a general q→score inverse: t
 clamp (`ClampExperimentQToBestRunFlat`, issue #4390) floors an experiment q up to a run q, so
 after clamping the experiment q is not a monotone function of this score. And the field was
 appended at the END specifically so every v3 offset is unchanged, which is what keeps
-`PatchRunProteinQvalues`'s `[52..60]` patch valid without modification.
+`PatchProteinQvalues`'s `[52..60]` patch valid without modification.
 
 A two-phase write exists for the lean projection path (issue #4355): phase 1 writes records with
-a 1.0 placeholder `run_protein_qvalue`; `PatchRunProteinQvalues` (`FdrScoresSidecar.cs:247`)
+a 1.0 placeholder `experiment_protein_qvalue`; `PatchProteinQvalues` (`FdrScoresSidecar.cs:247`)
 then streams the file one record at a time and overwrites only bytes `[52..60]` per entry_id,
 producing a file byte-identical to a single-phase write.
 

--- a/pwiz_tools/Osprey/docs/14-intermediate-files.md
+++ b/pwiz_tools/Osprey/docs/14-intermediate-files.md
@@ -319,9 +319,18 @@ Record (68 bytes):
   [28..36] experiment_precursor_qvalue  f64 LE
   [36..44] experiment_peptide_qvalue    f64 LE
   [44..52] pep                          f64 LE
-  [52..60] experiment_protein_qvalue           f64 LE
+  [52..60] experiment_protein_qvalue    f64 LE
   [60..68] experiment_aggregate_score   f64 LE
 ```
+
+`experiment_protein_qvalue` is the one column whose value depends on WHICH sidecar it is in:
+the `.1st-pass` file carries the first-pass picked-protein result, the `.2nd-pass` file the
+second-pass one. That is the same rule the precursor and peptide q-values follow - the pass is
+recorded by the file, not by a second field - and `FdrEntry` carries a single
+`ExperimentProteinQvalue` accordingly. It is experiment-scope in both passes: the first-pass
+protein FDR pools its detected peptides over every file and propagates one value per peptide,
+so there is no per-run protein q despite the `run_protein_qvalue` name this column carried
+until issue #4559.
 
 Field order and offsets are single-sourced in `WriteRecord` (`FdrScoresSidecar.cs:390`).
 The v2→v3 bump (dated 2026-05-02 in the C# comment, `FdrScoresSidecar.cs:82`) added

--- a/pwiz_tools/Osprey/regression.ps1
+++ b/pwiz_tools/Osprey/regression.ps1
@@ -1290,6 +1290,23 @@ foreach ($name in $selected) {
         $summaryLines.Add("$name mode1 (vs golden): FAIL ($($m1.Issues.Count) issues)")
     }
 
+    # ---- mode 1c: the 2nd-pass sidecar carries a SECOND-pass protein q -------
+    # Single-run property of the straight-through output, so it runs on the DEFAULT arm that
+    # TeamCity exercises - no baseline, no second route. It covers the one failure a two-route
+    # comparison structurally cannot see: a column both routes copy identically out of pass 1.
+    # That is what issue #4559 was, and mode 3 was green on the default arm throughout.
+    Write-Progress-Tc "${name}: 2nd-pass protein q liveness (mode 1c)"
+    $m1c = Test-Pass2ProteinQvalue -RunDir $straightDir
+    if ($m1c.Pass) {
+        $summaryLines.Add(("$name mode1c (2nd-pass protein q is pass-2): PASS " +
+            "($('{0:N0}' -f $m1c.Differing) of $('{0:N0}' -f $m1c.Matched) shared records moved)"))
+    } else {
+        $overallFail = $true
+        Write-Problem-Tc "$name mode1c (2nd-pass protein q is pass-2): FAIL -- $($m1c.Issues.Count) issue(s)"
+        $m1c.Issues | Select-Object -First 15 | ForEach-Object { Write-Host "    $_" -ForegroundColor Red }
+        $summaryLines.Add("$name mode1c (2nd-pass protein q is pass-2): FAIL ($($m1c.Issues.Count) issues)")
+    }
+
     # ---- mode 1b: FDR-calibration spot checks -------------------------------
     # Two independent tiers. The golden compare catches drift; the sanity bounds
     # catch a regression that a -CreateGolden rebaseline would otherwise bless

--- a/pwiz_tools/Osprey/regression.ps1
+++ b/pwiz_tools/Osprey/regression.ps1
@@ -1295,6 +1295,17 @@ foreach ($name in $selected) {
     # TeamCity exercises - no baseline, no second route. It covers the one failure a two-route
     # comparison structurally cannot see: a column both routes copy identically out of pass 1.
     # That is what issue #4559 was, and mode 3 was green on the default arm throughout.
+    # Guarded like its siblings (mode 1b on ModelDiagnostics, mode 3 on SkipHpcChain). The
+    # 2nd-pass sidecars only exist when Stage 6 rescored something -- SecondPassFdrTask writes
+    # them on AnyReconciledParquet -- so an arm that legitimately does no reconciliation work has
+    # nothing for this gate to assert on. Without the guard, "no .2nd-pass.fdr_scores.bin files"
+    # is reported as a hard failure and reds a run that is entirely correct.
+    $pass2Sidecars = @(Get-ChildItem -File -Path $straightDir -Filter '*.2nd-pass.fdr_scores.bin' `
+        -ErrorAction SilentlyContinue)
+    if ($pass2Sidecars.Count -eq 0) {
+        $summaryLines.Add("$name mode1c (2nd-pass protein q is pass-2): SKIPPED (no 2nd-pass sidecars - Stage 6 rescored nothing)")
+    }
+    else {
     Write-Progress-Tc "${name}: 2nd-pass protein q liveness (mode 1c)"
     $m1c = Test-Pass2ProteinQvalue -RunDir $straightDir
     if ($m1c.Pass) {
@@ -1310,6 +1321,7 @@ foreach ($name in $selected) {
         Write-Problem-Tc "$name mode1c (2nd-pass protein q is pass-2): FAIL -- $($m1c.Issues.Count) issue(s)"
         $m1c.Issues | Select-Object -First 15 | ForEach-Object { Write-Host "    $_" -ForegroundColor Red }
         $summaryLines.Add("$name mode1c (2nd-pass protein q is pass-2): FAIL ($($m1c.Issues.Count) issues)")
+    }
     }
 
     # ---- mode 1b: FDR-calibration spot checks -------------------------------

--- a/pwiz_tools/Osprey/regression.ps1
+++ b/pwiz_tools/Osprey/regression.ps1
@@ -1298,8 +1298,13 @@ foreach ($name in $selected) {
     Write-Progress-Tc "${name}: 2nd-pass protein q liveness (mode 1c)"
     $m1c = Test-Pass2ProteinQvalue -RunDir $straightDir
     if ($m1c.Pass) {
+        # The gap-fill count is reported, not asserted on: those records have no 1st-pass
+        # value to compare against, so they cannot contribute to the liveness check - and a
+        # count that is computed but never printed is a claim the gate does not actually make.
+        # It is also the population #4559 was originally filed about, so it is worth seeing.
         $summaryLines.Add(("$name mode1c (2nd-pass protein q is pass-2): PASS " +
-            "($('{0:N0}' -f $m1c.Differing) of $('{0:N0}' -f $m1c.Matched) shared records moved)"))
+            "($('{0:N0}' -f $m1c.Differing) of $('{0:N0}' -f $m1c.Matched) shared records moved; " +
+            "$('{0:N0}' -f $m1c.GapFill) gap-fill record(s) absent from pass 1)"))
     } else {
         $overallFail = $true
         Write-Problem-Tc "$name mode1c (2nd-pass protein q is pass-2): FAIL -- $($m1c.Issues.Count) issue(s)"


### PR DESCRIPTION
## Summary

* Collapsed the two per-entry protein q-value fields on `FdrEntry` into one experiment-wide
  `ExperimentProteinQvalue`, and renamed the sidecar column `run_protein_qvalue` ->
  `experiment_protein_qvalue`. The field was per-run in name only - measured on
  straight-through 1st-pass sidecars, 483,820 of 483,820 multi-file precursors carry ONE
  value across every file they appear in, and 0 carry different values.
* The **2nd-pass** FDR sidecar now carries the **pass-2** protein q, patched in after the
  second-pass protein FDR. It previously carried a pass-1 value unconditionally - the only
  column in that file that did. Protein q now follows the rule precursor and peptide q
  already follow: one field, with the pass recorded by *which sidecar* it lives in rather
  than by which field.
* Removed a latent C#/Rust divergence in the process. C#'s second-pass
  `PropagateProteinQvalues` passed `(setRun: true, setExperiment: true)`; Rust's passed
  `set_run: false`. After Stage 7 the two implementations therefore held **different**
  values in that field - C# the pass-2 value, Rust the pass-1 one - and every parity gate
  was green through it, because `effective_run_qvalue(Protein)` has no caller on either
  side. The collapse makes the disagreement unrepresentable rather than merely fixed.
* Added a `mode1c` leg to `regression.ps1` (`Test-Pass2ProteinQvalue` in
  `Regression/FdrSidecars.ps1`) asserting that the 2nd-pass sidecar's protein column really
  is a pass-2 value. Mode 3 cannot see this class of defect - it compares the two routes
  against each other, and both routes copied the same pass-1 value.
* The gate found the defect was much larger than #4559 reported. #4559 described a
  390-record sliver where the two routes disagreed; on the arm CI actually runs, the column
  was never a pass-2 value for **any** record - all 994,509 shared records on Stellar were
  identical to the 1st-pass column. That is what `mode1c` was red on before the fix.
* This dissolves #4559's original question rather than answering it. "Should a gap-fill entry
  carry 0.0 or 1.0?" only arises because a pass-1 quantity was stored in a pass-2 file and
  then asked what it says about rows that did not exist in pass 1. A gap-fill row now gets
  whatever the second-pass protein FDR computes for it, from a pool that includes it.

* Hardened the patch itself after a review pass over the branch. The Stage-7
  `OSPREY_STAGE7_PROTEIN_FDR_ONLY` early exit calls `Environment.Exit(0)` inside
  `RunProteinFdr`, which is *before* the patch call that sat in the caller - so on that
  diagnostic path the 2nd-pass sidecar was left with its protein column at the `ResetScores`
  default, and the comment above the sidecar write says that exit deliberately leaves the file
  on disk for downstream rehydration. Both implementations now order it
  **propagate -> patch -> dump**; the dump reads only the parsimony / FDR result and never the
  stubs, so its content is unchanged. This also removes a cross-impl ordering difference (Rust
  dumped before propagation, C# after). No production path and no reported output is affected.
* Also from that pass: the patch-failure warning claimed unpatched files "keep a FIRST-pass
  protein q-value", which stopped being true when the seed was removed; the remaining
  `runProtein*` identifiers are gone, so the "run" framing is now unrepresentable rather than
  merely unused; and `PatchProteinQvalues` reports how many records it actually rewrote
  (`out int`, asserted in three tests) instead of the caller assuming the map size, which is
  what the Rust side already counted.

**Sidecar version: decided, NOT bumping (Brendan, 2026-08-13).** The question was whether the
2nd-pass protein column changing meaning warrants v4 -> v5. It does not, for now:

* **Nothing structural changes.** No offset, width or type moves; `experiment_protein_qvalue`
  stays at `[52..60]`. A v4 and a v5 reader would parse identical bytes identically. The
  1st-pass sidecar is unchanged in meaning as well as layout.
* **The scenario a bump would guard is already guarded, harder and earlier.**
  `ParquetScoreCache` hard-fails on any osprey version mismatch ("different daily build" /
  "incompatible release identity"), and `.scores.parquet` is read before any sidecar - so a
  cross-build resume never reaches this file. What remains is same-version-stamp-different-code,
  i.e. same-day dev builds or a run pinned under `OSPREY_VERSION_OVERRIDE`.
* **The version byte gates the whole record, but only 1 of 8 columns changed meaning.**
  Rejecting a v4 sidecar discards `Score`, `Pep`, run/experiment precursor and peptide q and
  `ExperimentAggregateScore` - all still correct - to protect the one column that
  `PropagateProteinQvalues` overwrites unconditionally in Stage 7 before anything reads it.
  (This point was originally stronger and is now partly overtaken: it also said the read path
  warns and proceeds rather than recomputing. #4558's `FdrScoresSidecar.IsCurrentFormat` has
  since replaced the bare `File.Exists` gates at `Pass2FdrSidecar.cs:188`/`:511` and
  `PerFileRescoreTask.cs:268`, so a stale-version sidecar now fails the "already done" test and
  is **regenerated**. A bump would do the right thing rather than the awkward thing. The
  decision below is unchanged, but it rests on the first and last bullets, not this one.)
* **Osprey is pre-first-public-release**, so the only consumers of these artifacts are
  development sessions, which will take fresh runs over `-LinkFrom` while this much is moving.
  The cost of a stale artifact is a re-run, not a wrong answer shipped to a user.

**Revisit when either of these lands**: the first public release, or #4561 (`--fdr-level
protein` in C#), which is what gives the 2nd-pass protein column a real consumer - at which
point a stale pass-1 value becomes a wrong reported q rather than one that gets overwritten.
The bump should then be paired with making the sidecar read hard-fail instead of
warn-and-proceed, since a version guard that warns and continues is not really a guard.

Stacked on #4558 - review that one first. Retargeting to `master` and rebasing once it merges.

Fixes #4559

## Test plan

- [x] `regression.ps1 -Dataset All` - **52 legs, 52 PASS, 0 FAIL**, run against #4558's
      rebaselined goldens
- [x] `mode1 (vs golden)` PASS on all four datasets - the change is sidecar-only and moves
      no reported output, which the code reading predicted (Stage 7 reports
      `ProteinFdrResult.GroupQvalues`, per GROUP, not either per-entry field) and this
      measures
- [x] `mode1c` (new) red -> green on Stellar with the same command both ways: FAIL (all
      994,509 shared records identical to the 1st-pass column) -> PASS. Movement on every
      dataset: Stellar 25,006/994,509, StellarLibDecoy 6,486/923,246, StellarGenDecoyEntrap
      89,116/259,678, Astral 19,008/3,449,774
- [x] `mode1b` FDR sanity bounds PASS on all three datasets that carry it - those are the
      entrapment-measured true-FDP ceilings `-CreateGolden` deliberately does not
      regenerate, so calibration is unmoved on evidence independent of the golden
- [x] `mode3` (sidecars == straight-through) PASS everywhere, up to 9,685,318 records on
      Astral - both routes still agree after the change
- [x] `Osprey.Test` 579 tests pass; zero-warning ReSharper inspection
- [x] The hardening commit on top was gated separately: build + 579 tests + inspection, and
      `regression.ps1 -Dataset Stellar` re-run to confirm the golden still does not move.
      It changes ordering only on the `OSPREY_STAGE7_PROTEIN_FDR_ONLY` diagnostic path plus
      comments, a log message and identifier names, so it cannot move production output -
      but the full `-Dataset All` figures above were measured on the commit below it, and
      the TeamCity Perf/Regression run on this PR covers the final tree.

Co-Authored-By: Claude <noreply@anthropic.com>
