### PR TITLE
osprey: Added ProgressReporter log output for the four Stage 7 steps that logged nothing for up to 151 s

### DIFF
--- a/pwiz_tools/Osprey/Osprey.Core/ProgressReporter.cs
+++ b/pwiz_tools/Osprey/Osprey.Core/ProgressReporter.cs
@@ -76,10 +76,33 @@ namespace pwiz.Osprey.Core
         /// </summary>
         public const double HEARTBEAT_SECONDS = 30.0;
 
+        /// <summary>
+        /// How long an operation must run before the reporter prints ANYTHING, heading included.
+        /// A scope that finishes inside this window is silent: no heading, no completion line.
+        /// Skyline's LongWaitDlg works the same way - it does not appear until its delay passes,
+        /// so a fast operation never shows a dialog - and the reason is the same. A heading plus
+        /// a forced 100% for a sub-second step is two lines that carry no information, and a run
+        /// with many such scopes buries the lines that do.
+        /// </summary>
+        public const double LOG_WAIT_SECONDS = 0.5;
+
+        /// <summary>
+        /// Minimum elapsed time before <see cref="Dispose"/> forces its completion line. Above
+        /// <see cref="LOG_WAIT_SECONDS"/> so an operation that ran long enough to announce itself
+        /// is also given a chance to advance on its own before a 100% is synthesized for it.
+        /// </summary>
+        public const double MIN_PERCENT_SECONDS = 1.0;
+
         private readonly long _total;
         private readonly string _indent;
+        private readonly string _activity;
         private readonly double _intervalSeconds;
         private readonly double _heartbeatSeconds;
+        private readonly double _logWaitSeconds;
+        private readonly double _minPercentSeconds;
+        // Guards the deferred heading: every path that prints must call WriteHeading first, so
+        // a percent or completion line can never appear above the heading it belongs to.
+        private bool _headingWritten;
         private readonly Stopwatch _stopwatch;
         private readonly object _lock = new object();
         // Non-null only inside a MultiProgressReporter per-file scope (--parallel-files):
@@ -105,16 +128,42 @@ namespace pwiz.Osprey.Core
         /// <param name="intervalSeconds">Minimum seconds between percent lines (timer throttle).</param>
         /// <param name="heartbeatSeconds">Idle threshold for the frozen-percent heartbeat
         /// (see <see cref="HEARTBEAT_SECONDS"/>). Injectable so tests can trip it quickly.</param>
+        /// <param name="logWaitSeconds">Time to wait before printing ANYTHING, heading included
+        /// (see <see cref="LOG_WAIT_SECONDS"/>).</param>
+        /// <param name="minPercentSeconds">Minimum elapsed time before the forced completion line
+        /// is printed (see <see cref="MIN_PERCENT_SECONDS"/>).</param>
         public ProgressReporter(string activity, long total, string indent = "", double intervalSeconds = 1.0,
-            double heartbeatSeconds = HEARTBEAT_SECONDS)
+            double heartbeatSeconds = HEARTBEAT_SECONDS, double logWaitSeconds = LOG_WAIT_SECONDS,
+            double minPercentSeconds = MIN_PERCENT_SECONDS)
         {
             _total = total;
             _indent = indent;
+            _activity = activity;
             _intervalSeconds = intervalSeconds;
             _heartbeatSeconds = heartbeatSeconds;
+            // NEITHER threshold may exceed the report interval, and clamping here is what makes
+            // the display rules hold by construction rather than by extra checks at the printing
+            // sites. The first sub-100% line cannot appear before the interval has elapsed
+            // (_lastReportSeconds starts at 0), so bounding both by it means: anything that
+            // printed a percent has necessarily passed _minPercentSeconds, hence Dispose always
+            // closes with 100% and a display can never be left hanging at 83%. A caller that
+            // asks for a longer wait than its own reporting cadence is describing a state this
+            // class should not be able to hold, so it is corrected rather than honoured.
+            _logWaitSeconds = Math.Min(logWaitSeconds, intervalSeconds);
+            _minPercentSeconds = Math.Min(minPercentSeconds, intervalSeconds);
             _sink = MultiProgressReporter.CurrentSink;
             _stopwatch = Stopwatch.StartNew();
-            OspreyOutput.Out.WriteLine("{0}{1}...", indent, activity);
+            // The heading is NOT written here. It is deferred until the operation has run long
+            // enough to be worth announcing, so a scope that completes quickly prints nothing at
+            // all rather than a heading plus a forced 100% - two lines that say only "this was
+            // too fast to watch". Modelled on Skyline's LongWaitDlg, which does not appear until
+            // its own delay has passed, so opening a small file shows no dialog.
+            //
+            // Inside a MultiProgressReporter scope the heading buffers into the file's narrative
+            // block rather than racing other files to the console, and that block is only shown
+            // for a file that is actually being worked; write it immediately there.
+            if (_sink != null)
+                WriteHeading();
         }
 
         /// <summary>
@@ -141,8 +190,15 @@ namespace pwiz.Osprey.Core
                     return;
                 }
                 double now = _stopwatch.Elapsed.TotalSeconds;
+                // Nothing at all until the operation has proved it is worth watching. Checked
+                // before the throttle rather than folded into it: _lastReportSeconds starts at 0,
+                // so an interval alone would let the first line through immediately on a phase
+                // that then finishes in milliseconds.
+                if (now < _logWaitSeconds)
+                    return;
                 if (percent > _lastPercent && now - _lastReportSeconds >= _intervalSeconds)
                 {
+                    WriteHeading();
                     OspreyOutput.Out.WriteLine("{0}  {1}%", _indent, percent);
                     _lastPercent = percent;
                     _lastReportSeconds = now;
@@ -159,6 +215,7 @@ namespace pwiz.Osprey.Core
                     // when the phase calls Report; a phase that blocks inside one bulk
                     // operation (no Report calls) needs to be wrapped in a reporter first.
                     double pctExact = _total > 0 ? 100.0 * current / _total : 100.0;
+                    WriteHeading();
                     OspreyOutput.Out.WriteLine(string.Format(CultureInfo.InvariantCulture,
                         "{0}  {1:0.00}% ({2:N0}/{3:N0}, {4} elapsed)",
                         _indent, pctExact, current, _total, FormatElapsed(_stopwatch.Elapsed)));
@@ -180,9 +237,31 @@ namespace pwiz.Osprey.Core
                     _sink.Report(100);
                     return;
                 }
-                if (_lastPercent < 100)
+                // No explicit "did we already show a percent?" test: the constructor bounds
+                // _minPercentSeconds by the report interval, and a sub-100% line cannot print
+                // before that interval has elapsed, so any scope that showed progress has
+                // necessarily passed this threshold and closes with 100%. The threshold's only
+                // real job is the scope that has printed NOTHING - it decides whether a step
+                // that finished quietly is worth announcing at all.
+                if (_lastPercent < 100 && _stopwatch.Elapsed.TotalSeconds >= _minPercentSeconds)
+                {
+                    WriteHeading();
                     OspreyOutput.Out.WriteLine("{0}  100%", _indent);
+                }
             }
+        }
+
+        /// <summary>
+        /// Print the deferred heading, once. Called from every path that is about to print, so
+        /// the heading cannot be skipped by a phase whose first output is a percent or the forced
+        /// completion line. Callers hold <see cref="_lock"/>.
+        /// </summary>
+        private void WriteHeading()
+        {
+            if (_headingWritten)
+                return;
+            _headingWritten = true;
+            OspreyOutput.Out.WriteLine("{0}{1}...", _indent, _activity);
         }
 
         /// <summary>

--- a/pwiz_tools/Osprey/Osprey.FDR/ModelDiagnostics/ModelDiagnosticsData.cs
+++ b/pwiz_tools/Osprey/Osprey.FDR/ModelDiagnostics/ModelDiagnosticsData.cs
@@ -725,7 +725,9 @@ namespace pwiz.Osprey.FDR.ModelDiagnostics
                 pass2.CrossRun = BuildCrossRunDetection(perFileEntries, classByBaseId, haveManifest,
                     entrapmentRatio, runFdr, fdrLevel);
                 progress.Report(4);
-                pass2.FdpViews = BuildPass2FdpViews(perFileEntries, classByBaseId, pairByBaseId, entrapmentRatio);
+                // Reuses the reduction computed for the ID-yield card above rather than
+                // recomputing an identical one from the same inputs.
+                pass2.FdpViews = BuildPass2FdpViews(precs, entrapmentRatio);
                 progress.Report(5);
                 // Single-peak co-assignment on the REPORTED pool (issue #4522). Post-Stage-6, so
                 // it includes co-assignment reconciliation itself introduced; the pass-1 panel is
@@ -871,8 +873,27 @@ namespace pwiz.Osprey.FDR.ModelDiagnostics
             double entrapmentRatio)
         {
             bool haveManifest = classByBaseId != null && classByBaseId.Count > 0;
-            var precs = ReduceToPrecs(perFileEntries, classByBaseId, pairByBaseId, haveManifest,
-                out _, out _);
+            return BuildPass2FdpViews(
+                ReduceToPrecs(perFileEntries, classByBaseId, pairByBaseId, haveManifest,
+                    out _, out _),
+                entrapmentRatio);
+        }
+
+        /// <summary>
+        /// The same views from an ALREADY-reduced precursor list, so a caller that has one does
+        /// not pay for the reduction twice. <see cref="BuildPass2"/> is that caller: it reduces
+        /// once for the ID-yield card and then built these views from a second, identical
+        /// reduction of the same inputs - ~16 s duplicated at 82 files on the 2026-08-15
+        /// measurement, and it is O(survivor observations), so ~32 s at 163 files.
+        ///
+        /// <para>Sharing the list is safe because both consumers only READ it:
+        /// <see cref="BuildIdYield"/> projects into new collections, and
+        /// <see cref="BuildFdpView"/> sorts the double lists it extracts rather than the input.
+        /// Neither mutates a <c>Prec</c>, which matters because <c>Prec</c> is a reference type -
+        /// were either to write through, this would silently couple two cards.</para>
+        /// </summary>
+        private static List<FdpView> BuildPass2FdpViews(List<Prec> precs, double entrapmentRatio)
+        {
             bool hasEntrapment = precs.Any(p => p.Class == EntrapmentClass.PTarget);
             if (!hasEntrapment)
                 return new List<FdpView>();
@@ -914,54 +935,67 @@ namespace pwiz.Osprey.FDR.ModelDiagnostics
         {
             var best = new Dictionary<string, Prec>(StringComparer.Ordinal);
             int wc = 0, woc = 0;
+            // Reported from INSIDE the per-file loop, not merely around the call (#4571). This
+            // walks every survivor observation - 89,068,375 at 82 files - and measured ~16 s
+            // there on 2026-08-15. It is O(observations), so it is ~32 s at 163 files and worse
+            // beyond: a caller-level reporter would print a heading and then go silent for the
+            // whole of it, which is the gap this issue exists to remove, merely deferred to a
+            // larger dataset. The reporter's throttle means a small run still costs one line.
+            int reduceIdx = 0;
+            using (var progress = new ProgressReporter(
+                       string.Format(@"Reducing {0} file(s) to best-per-precursor", perFileEntries.Count),
+                       perFileEntries.Count, string.Empty, ProgressReporter.IO_INTERVAL_SECONDS))
+            {
             foreach (var kvp in perFileEntries)
             {
-                foreach (var e in kvp.Value)
-                {
-                    uint baseId = e.EntryId & BASE_ID_MASK;
-                    EntrapmentClass cls = Classify(e.IsDecoy, baseId, classByBaseId, haveManifest,
-                        ref wc, ref woc);
-                    uint pairIdx = 0;
-                    bool hasPair = pairByBaseId != null &&
-                        pairByBaseId.TryGetValue(baseId, out pairIdx);
-                    string key = e.ModifiedSequence + "|" + e.Charge;
-                    if (!best.TryGetValue(key, out var cur))
+                progress.Report(++reduceIdx);
+                    foreach (var e in kvp.Value)
                     {
-                        cur = new Prec
+                        uint baseId = e.EntryId & BASE_ID_MASK;
+                        EntrapmentClass cls = Classify(e.IsDecoy, baseId, classByBaseId, haveManifest,
+                            ref wc, ref woc);
+                        uint pairIdx = 0;
+                        bool hasPair = pairByBaseId != null &&
+                            pairByBaseId.TryGetValue(baseId, out pairIdx);
+                        string key = e.ModifiedSequence + "|" + e.Charge;
+                        if (!best.TryGetValue(key, out var cur))
                         {
-                            Score = e.Score,
-                            // Precursor-level q at both scopes -- the axes the
-                            // FDR-calibration views plot. Experiment scope is what
-                            // --fdrbench emits (and thus reproduces its plots); run
-                            // scope is the per-run picture. Each precursor takes its
-                            // BEST (min) q across observations, matching
-                            // FdrBenchInputWriter's dedup, while Score stays the max
-                            // (for density / the score histogram).
-                            QRunPrecursor = e.RunPrecursorQvalue,
-                            QExpPrecursor = e.ExperimentPrecursorQvalue,
-                            IsDecoy = e.IsDecoy,
-                            Class = cls,
-                            PairIndex = pairIdx,
-                            Charge = e.Charge,
-                            HasPair = hasPair,
-                        };
-                    }
-                    else
-                    {
-                        if (e.Score > cur.Score)
-                        {
-                            cur.Score = e.Score;
-                            cur.IsDecoy = e.IsDecoy;
-                            cur.Class = cls;
-                            cur.PairIndex = pairIdx;
-                            cur.HasPair = hasPair;
+                            cur = new Prec
+                            {
+                                Score = e.Score,
+                                // Precursor-level q at both scopes -- the axes the
+                                // FDR-calibration views plot. Experiment scope is what
+                                // --fdrbench emits (and thus reproduces its plots); run
+                                // scope is the per-run picture. Each precursor takes its
+                                // BEST (min) q across observations, matching
+                                // FdrBenchInputWriter's dedup, while Score stays the max
+                                // (for density / the score histogram).
+                                QRunPrecursor = e.RunPrecursorQvalue,
+                                QExpPrecursor = e.ExperimentPrecursorQvalue,
+                                IsDecoy = e.IsDecoy,
+                                Class = cls,
+                                PairIndex = pairIdx,
+                                Charge = e.Charge,
+                                HasPair = hasPair,
+                            };
                         }
-                        if (e.RunPrecursorQvalue < cur.QRunPrecursor)
-                            cur.QRunPrecursor = e.RunPrecursorQvalue;
-                        if (e.ExperimentPrecursorQvalue < cur.QExpPrecursor)
-                            cur.QExpPrecursor = e.ExperimentPrecursorQvalue;
+                        else
+                        {
+                            if (e.Score > cur.Score)
+                            {
+                                cur.Score = e.Score;
+                                cur.IsDecoy = e.IsDecoy;
+                                cur.Class = cls;
+                                cur.PairIndex = pairIdx;
+                                cur.HasPair = hasPair;
+                            }
+                            if (e.RunPrecursorQvalue < cur.QRunPrecursor)
+                                cur.QRunPrecursor = e.RunPrecursorQvalue;
+                            if (e.ExperimentPrecursorQvalue < cur.QExpPrecursor)
+                                cur.QExpPrecursor = e.ExperimentPrecursorQvalue;
+                        }
+                        best[key] = cur;
                     }
-                    best[key] = cur;
                 }
             }
             nWithClass = wc; nWithoutClass = woc;

--- a/pwiz_tools/Osprey/Osprey.FDR/ModelDiagnostics/ModelDiagnosticsData.cs
+++ b/pwiz_tools/Osprey/Osprey.FDR/ModelDiagnostics/ModelDiagnosticsData.cs
@@ -923,14 +923,20 @@ namespace pwiz.Osprey.FDR.ModelDiagnostics
         /// reduction of the same inputs - ~16 s duplicated at 82 files on the 2026-08-15
         /// measurement, and it is O(survivor observations), so ~32 s at 163 files.
         ///
-        /// <para>Sharing the list is safe for two independent reasons, and the stronger one is
-        /// the type: <c>Prec</c> is a <c>struct</c>, so <c>List&lt;Prec&gt;</c> hands every
-        /// consumer a copy and one card cannot write through to another however it is used.
-        /// Behaviour also does not depend on that - both consumers only READ:
+        /// <para>Sharing the list is safe because every consumer only READS it:
         /// <see cref="BuildIdYield"/> projects into new collections, and
         /// <see cref="BuildFdpView"/> sorts the double lists it extracts rather than the input.
-        /// If <c>Prec</c> ever becomes a class, the value-copy guarantee disappears and only the
-        /// read-only property is left holding this up - re-check both consumers then.</para>
+        /// That is the property to check when adding a card - it is the one that holds whatever
+        /// <c>Prec</c> is declared as.</para>
+        ///
+        /// <para><c>Prec</c> being a <c>struct</c> is deliberately NOT the argument, even though
+        /// value-copy semantics would stop one card writing through to another. Copy semantics do
+        /// not make a stray mutation harmless, they make it silently INEFFECTIVE, which is a
+        /// different defect rather than the absence of one - and this file already depends on
+        /// that subtlety: <see cref="ReduceToPrecs"/> mutates a local copy and the
+        /// <c>best[key] = cur</c> write-back at the end of its loop is what commits it. Remove
+        /// that line as redundant - which it would be for a class - and the reduction quietly
+        /// stops updating.</para>
         /// </summary>
         private static List<FdpView> BuildPass2FdpViews(List<Prec> precs, double entrapmentRatio)
         {

--- a/pwiz_tools/Osprey/Osprey.FDR/ModelDiagnostics/ModelDiagnosticsData.cs
+++ b/pwiz_tools/Osprey/Osprey.FDR/ModelDiagnostics/ModelDiagnosticsData.cs
@@ -706,13 +706,18 @@ namespace pwiz.Osprey.FDR.ModelDiagnostics
             // Declared out here because the structural half below reads it after the reporter
             // scope closes.
             List<Prec> precs;
+            // The heading counts CARDS, not files, because that is what the total is: a percent
+            // here means "1 of 6 cards", and labelling it with the file count would invite the
+            // reader to extrapolate a completion time from unequal-cost units.
             using (var progress = new ProgressReporter(
-                       string.Format(@"Building the pass-2 diagnostics cards over {0} file(s)",
-                           perFileEntries.Count),
+                       string.Format(@"Building {0} pass-2 diagnostics card(s)", PASS2_CARD_COUNT),
                        PASS2_CARD_COUNT, string.Empty, ProgressReporter.IO_INTERVAL_SECONDS))
             {
+                // Indented one level: this reporter nests inside the card reporter above, and
+                // without it the two percent streams print at the same column - the inner one
+                // reaching 100% immediately before the outer prints 16%.
                 precs = ReduceToPrecs(perFileEntries, classByBaseId, pairByBaseId, haveManifest,
-                    out _, out _);
+                    out _, out _, @"  ");
                 progress.Report(1);
 
                 // Q-driven half: available whenever a second pass produced reported
@@ -886,11 +891,14 @@ namespace pwiz.Osprey.FDR.ModelDiagnostics
         /// reduction of the same inputs - ~16 s duplicated at 82 files on the 2026-08-15
         /// measurement, and it is O(survivor observations), so ~32 s at 163 files.
         ///
-        /// <para>Sharing the list is safe because both consumers only READ it:
+        /// <para>Sharing the list is safe for two independent reasons, and the stronger one is
+        /// the type: <c>Prec</c> is a <c>struct</c>, so <c>List&lt;Prec&gt;</c> hands every
+        /// consumer a copy and one card cannot write through to another however it is used.
+        /// Behaviour also does not depend on that - both consumers only READ:
         /// <see cref="BuildIdYield"/> projects into new collections, and
         /// <see cref="BuildFdpView"/> sorts the double lists it extracts rather than the input.
-        /// Neither mutates a <c>Prec</c>, which matters because <c>Prec</c> is a reference type -
-        /// were either to write through, this would silently couple two cards.</para>
+        /// If <c>Prec</c> ever becomes a class, the value-copy guarantee disappears and only the
+        /// read-only property is left holding this up - re-check both consumers then.</para>
         /// </summary>
         private static List<FdpView> BuildPass2FdpViews(List<Prec> precs, double entrapmentRatio)
         {
@@ -931,7 +939,8 @@ namespace pwiz.Osprey.FDR.ModelDiagnostics
             IReadOnlyDictionary<uint, EntrapmentClass> classByBaseId,
             IReadOnlyDictionary<uint, uint> pairByBaseId,
             bool haveManifest,
-            out int nWithClass, out int nWithoutClass)
+            out int nWithClass, out int nWithoutClass,
+            string indent = "")
         {
             var best = new Dictionary<string, Prec>(StringComparer.Ordinal);
             int wc = 0, woc = 0;
@@ -944,7 +953,7 @@ namespace pwiz.Osprey.FDR.ModelDiagnostics
             int reduceIdx = 0;
             using (var progress = new ProgressReporter(
                        string.Format(@"Reducing {0} file(s) to best-per-precursor", perFileEntries.Count),
-                       perFileEntries.Count, string.Empty, ProgressReporter.IO_INTERVAL_SECONDS))
+                       perFileEntries.Count, indent, ProgressReporter.IO_INTERVAL_SECONDS))
             {
                 foreach (var kvp in perFileEntries)
                 {

--- a/pwiz_tools/Osprey/Osprey.FDR/ModelDiagnostics/ModelDiagnosticsData.cs
+++ b/pwiz_tools/Osprey/Osprey.FDR/ModelDiagnostics/ModelDiagnosticsData.cs
@@ -652,12 +652,16 @@ namespace pwiz.Osprey.FDR.ModelDiagnostics
         }
 
         /// <summary>
-        /// Number of pass-2 cards <see cref="BuildPass2"/> reports progress across. A count
-        /// rather than a derived value because the reporter needs the total up front, and it
-        /// must be updated with the card list - a stale total shows a run stalling short of
-        /// 100% or jumping past it.
+        /// Cards <see cref="BuildPass2"/> always builds, and the extra ones it builds only when
+        /// the second pass retrained. Counts rather than derived values because the reporter
+        /// needs its total up front; keep them in step with the <c>Report</c> calls, which use
+        /// <c>++cardIdx</c> so only the totals are hand-maintained. A stale total shows a run
+        /// stalling short of 100% or, since <see cref="ProgressReporter"/> does not clamp,
+        /// printing past it.
         /// </summary>
-        private const int PASS2_CARD_COUNT = 6;
+        private const int PASS2_BASE_CARDS = 6;
+
+        private const int PASS2_STRUCTURAL_CARDS = 3;
 
         /// <summary>
         /// Build the complete pass-2 (final reported pool) bundle behind the report's
@@ -703,55 +707,68 @@ namespace pwiz.Osprey.FDR.ModelDiagnostics
             // Written as sequential locals rather than an object initializer for that reason -
             // an initializer cannot report between its members. Evaluation order is unchanged.
             var pass2 = new Pass2Data();
-            // Declared out here because the structural half below reads it after the reporter
-            // scope closes.
-            List<Prec> precs;
-            // The heading counts CARDS, not files, because that is what the total is: a percent
-            // here means "1 of 6 cards", and labelling it with the file count would invite the
-            // reader to extrapolate a completion time from unequal-cost units.
-            using (var progress = new ProgressReporter(
-                       string.Format(@"Building {0} pass-2 diagnostics card(s)", PASS2_CARD_COUNT),
-                       PASS2_CARD_COUNT, string.Empty, ProgressReporter.IO_INTERVAL_SECONDS))
-            {
-                // Indented one level: this reporter nests inside the card reporter above, and
-                // without it the two percent streams print at the same column - the inner one
-                // reaching 100% immediately before the outer prints 16%.
-                precs = ReduceToPrecs(perFileEntries, classByBaseId, pairByBaseId, haveManifest,
-                    out _, out _, @"  ");
-                progress.Report(1);
 
-                // Q-driven half: available whenever a second pass produced reported
-                // q-values (retrain OR confidence transfer). Entrapment-independent
-                // except FdpViews (which is empty without an entrapment pool).
-                pass2.PerFile = BuildPerFile(perFileEntries, classByBaseId, haveManifest, runFdr, fdrLevel);
-                progress.Report(2);
-                pass2.IdYield = BuildIdYield(precs);
-                progress.Report(3);
-                pass2.CrossRun = BuildCrossRunDetection(perFileEntries, classByBaseId, haveManifest,
-                    entrapmentRatio, runFdr, fdrLevel);
-                progress.Report(4);
-                // Reuses the reduction computed for the ID-yield card above rather than
-                // recomputing an identical one from the same inputs.
-                pass2.FdpViews = BuildPass2FdpViews(precs, entrapmentRatio);
-                progress.Report(5);
-                // Single-peak co-assignment on the REPORTED pool (issue #4522). Post-Stage-6, so
-                // it includes co-assignment reconciliation itself introduced; the pass-1 panel is
-                // the uncontaminated scoring picture and the two are meant to be read together.
-                pass2.CoAssignment = BuildCoAssignment(perFileEntries, classByBaseId, precursorMzByEntryId,
-                    runFdr, fdrLevel, 2, true);
-                progress.Report(6);
-            }
+            // The total covers the STRUCTURAL cards too when they will run, and they are inside
+            // the same reporter. Reporting only the q-driven six printed "100%" and then left
+            // BuildModelPass2 and BuildWinFraction - both whole-pool walks - running silently
+            // behind a completed bar, which is the gap #4571 exists to remove wearing a disguise.
+            // BuildModelPass2 returns null iff contributions are null (its first statement), so
+            // this flag predicts the structural half exactly; the guard below tests Model for the
+            // same condition rather than trusting the two to stay in step.
+            bool structural = pass2Contributions != null;
+            int cards = PASS2_BASE_CARDS + (structural ? PASS2_STRUCTURAL_CARDS : 0);
+            // NOT `using`d, matching LibraryDeduplicator: Dispose forces a final 100% from the
+            // finally block, and WritePass2AndFinalize catches and logs our exception as one
+            // line - so a card that threw would read "all cards done" immediately followed by
+            // "pass-2 enrichment failed". The last Report on the success path prints 100% anyway.
+            // The heading counts CARDS because that is what the total is; labelling it with the
+            // file count would invite a completion estimate from unequal-cost units.
+            int cardIdx = 0;
+            var progress = new ProgressReporter(
+                string.Format(@"Building {0} pass-2 diagnostics card(s)", cards),
+                cards, string.Empty, ProgressReporter.IO_INTERVAL_SECONDS);
 
-            // Structural half: only when the second pass retrained on the reported pool.
-            // BuildModelPass2 returns null when contributions are null (transfer mode),
-            // which leaves DensityRatio / WinFraction null too -- the report's structural
-            // cards then show their n/a note under the top-level Pass 2 mode.
-            pass2.Model = BuildModelPass2(perFileEntries, pass2Contributions, classByBaseId, pairByBaseId);
+            // Indented one level: this reporter nests inside the card reporter, and without it
+            // the two percent streams print at the same column - the inner one reaching 100%
+            // immediately before the outer prints its next card.
+            var precs = ReduceToPrecs(perFileEntries, classByBaseId, pairByBaseId, haveManifest,
+                out _, out _, @"  ");
+            progress.Report(++cardIdx);
+
+            // Q-driven half: available whenever a second pass produced reported
+            // q-values (retrain OR confidence transfer). Entrapment-independent
+            // except FdpViews (which is empty without an entrapment pool).
+            pass2.PerFile = BuildPerFile(perFileEntries, classByBaseId, haveManifest, runFdr, fdrLevel);
+            progress.Report(++cardIdx);
+            pass2.IdYield = BuildIdYield(precs);
+            progress.Report(++cardIdx);
+            pass2.CrossRun = BuildCrossRunDetection(perFileEntries, classByBaseId, haveManifest,
+                entrapmentRatio, runFdr, fdrLevel);
+            progress.Report(++cardIdx);
+            // Reuses the reduction computed for the ID-yield card above rather than
+            // recomputing an identical one from the same inputs.
+            pass2.FdpViews = BuildPass2FdpViews(precs, entrapmentRatio);
+            progress.Report(++cardIdx);
+            // Single-peak co-assignment on the REPORTED pool (issue #4522). Post-Stage-6, so
+            // it includes co-assignment reconciliation itself introduced; the pass-1 panel is
+            // the uncontaminated scoring picture and the two are meant to be read together.
+            pass2.CoAssignment = BuildCoAssignment(perFileEntries, classByBaseId, precursorMzByEntryId,
+                runFdr, fdrLevel, 2, true);
+            progress.Report(++cardIdx);
+
+            // Structural half: only when the second pass retrained on the reported pool. Null
+            // contributions (transfer mode) leave Model, DensityRatio and WinFraction null and
+            // the report's structural cards show their n/a note. Takes the reduction computed
+            // above; it used to recompute a bit-identical one from the same inputs.
+            pass2.Model = BuildModelPass2(pass2Contributions, precs);
             if (pass2.Model != null)
             {
+                progress.Report(++cardIdx);
                 bool hasEntrapment = precs.Any(p => p.Class == EntrapmentClass.PTarget);
                 pass2.DensityRatio = BuildDensityRatio(pass2.Model.Scores, hasEntrapment);
+                progress.Report(++cardIdx);
                 pass2.WinFraction = BuildWinFraction(perFileEntries, classByBaseId, haveManifest);
+                progress.Report(++cardIdx);
             }
             return pass2;
         }
@@ -850,8 +867,23 @@ namespace pwiz.Osprey.FDR.ModelDiagnostics
             if (contributions == null)
                 return null;
             bool haveManifest = classByBaseId != null && classByBaseId.Count > 0;
-            var precs = ReduceToPrecs(perFileEntries, classByBaseId, pairByBaseId, haveManifest,
-                out _, out _);
+            return BuildModelPass2(contributions,
+                ReduceToPrecs(perFileEntries, classByBaseId, pairByBaseId, haveManifest,
+                    out _, out _));
+        }
+
+        /// <summary>
+        /// The same card from an ALREADY-reduced precursor list, so a caller holding one does not
+        /// pay for the reduction again. <see cref="BuildPass2"/> is that caller: it reduces once
+        /// for the ID-yield card and used to re-derive a bit-identical reduction here from the
+        /// same inputs - the same ~16 s / 89 M-observation walk at 82 files, O(observations), so
+        /// ~32 s at 163. Sharing is safe for the reasons given on
+        /// <see cref="BuildPass2FdpViews(List{Prec}, double)"/>.
+        /// </summary>
+        private static ModelPass BuildModelPass2(FeatureContributions contributions, List<Prec> precs)
+        {
+            if (contributions == null)
+                return null;
             return new ModelPass
             {
                 Composite = contributions.Composite,

--- a/pwiz_tools/Osprey/Osprey.FDR/ModelDiagnostics/ModelDiagnosticsData.cs
+++ b/pwiz_tools/Osprey/Osprey.FDR/ModelDiagnostics/ModelDiagnosticsData.cs
@@ -652,6 +652,14 @@ namespace pwiz.Osprey.FDR.ModelDiagnostics
         }
 
         /// <summary>
+        /// Number of pass-2 cards <see cref="BuildPass2"/> reports progress across. A count
+        /// rather than a derived value because the reporter needs the total up front, and it
+        /// must be updated with the card list - a stale total shows a run stalling short of
+        /// 100% or jumping past it.
+        /// </summary>
+        private const int PASS2_CARD_COUNT = 6;
+
+        /// <summary>
         /// Build the complete pass-2 (final reported pool) bundle behind the report's
         /// top-level Pass 1 / Pass 2 switch. Called by the end-of-run writer
         /// (SecondPassFdrTask) with the post-compaction, second-pass-q-valued pool
@@ -683,25 +691,49 @@ namespace pwiz.Osprey.FDR.ModelDiagnostics
             Func<uint, double> precursorMzByEntryId = null)
         {
             bool haveManifest = classByBaseId != null && classByBaseId.Count > 0;
-            var precs = ReduceToPrecs(perFileEntries, classByBaseId, pairByBaseId, haveManifest,
-                out _, out _);
 
-            var pass2 = new Pass2Data
+            // Reported per CARD, not per file (#4571). This is not one loop: it is six
+            // independent whole-pool builds, each of which walks every survivor observation
+            // (89,068,375 at 82 files), and together they were the long half of a 71 s silence
+            // between the classification's [ENTRAPMENT] line and "finalized report". A per-file
+            // reporter would have to live inside each build separately; the cards are the
+            // granularity that actually says WHICH one is slow, which is the question a reader
+            // has when the page takes a minute to appear.
+            //
+            // Written as sequential locals rather than an object initializer for that reason -
+            // an initializer cannot report between its members. Evaluation order is unchanged.
+            var pass2 = new Pass2Data();
+            // Declared out here because the structural half below reads it after the reporter
+            // scope closes.
+            List<Prec> precs;
+            using (var progress = new ProgressReporter(
+                       string.Format(@"Building the pass-2 diagnostics cards over {0} file(s)",
+                           perFileEntries.Count),
+                       PASS2_CARD_COUNT, string.Empty, ProgressReporter.IO_INTERVAL_SECONDS))
             {
+                precs = ReduceToPrecs(perFileEntries, classByBaseId, pairByBaseId, haveManifest,
+                    out _, out _);
+                progress.Report(1);
+
                 // Q-driven half: available whenever a second pass produced reported
                 // q-values (retrain OR confidence transfer). Entrapment-independent
                 // except FdpViews (which is empty without an entrapment pool).
-                PerFile = BuildPerFile(perFileEntries, classByBaseId, haveManifest, runFdr, fdrLevel),
-                IdYield = BuildIdYield(precs),
-                CrossRun = BuildCrossRunDetection(perFileEntries, classByBaseId, haveManifest,
-                    entrapmentRatio, runFdr, fdrLevel),
-                FdpViews = BuildPass2FdpViews(perFileEntries, classByBaseId, pairByBaseId, entrapmentRatio),
+                pass2.PerFile = BuildPerFile(perFileEntries, classByBaseId, haveManifest, runFdr, fdrLevel);
+                progress.Report(2);
+                pass2.IdYield = BuildIdYield(precs);
+                progress.Report(3);
+                pass2.CrossRun = BuildCrossRunDetection(perFileEntries, classByBaseId, haveManifest,
+                    entrapmentRatio, runFdr, fdrLevel);
+                progress.Report(4);
+                pass2.FdpViews = BuildPass2FdpViews(perFileEntries, classByBaseId, pairByBaseId, entrapmentRatio);
+                progress.Report(5);
                 // Single-peak co-assignment on the REPORTED pool (issue #4522). Post-Stage-6, so
                 // it includes co-assignment reconciliation itself introduced; the pass-1 panel is
                 // the uncontaminated scoring picture and the two are meant to be read together.
-                CoAssignment = BuildCoAssignment(perFileEntries, classByBaseId, precursorMzByEntryId,
-                    runFdr, fdrLevel, 2, true),
-            };
+                pass2.CoAssignment = BuildCoAssignment(perFileEntries, classByBaseId, precursorMzByEntryId,
+                    runFdr, fdrLevel, 2, true);
+                progress.Report(6);
+            }
 
             // Structural half: only when the second pass retrained on the reported pool.
             // BuildModelPass2 returns null when contributions are null (transfer mode),

--- a/pwiz_tools/Osprey/Osprey.FDR/ModelDiagnostics/ModelDiagnosticsData.cs
+++ b/pwiz_tools/Osprey/Osprey.FDR/ModelDiagnostics/ModelDiagnosticsData.cs
@@ -946,9 +946,9 @@ namespace pwiz.Osprey.FDR.ModelDiagnostics
                        string.Format(@"Reducing {0} file(s) to best-per-precursor", perFileEntries.Count),
                        perFileEntries.Count, string.Empty, ProgressReporter.IO_INTERVAL_SECONDS))
             {
-            foreach (var kvp in perFileEntries)
-            {
-                progress.Report(++reduceIdx);
+                foreach (var kvp in perFileEntries)
+                {
+                    progress.Report(++reduceIdx);
                     foreach (var e in kvp.Value)
                     {
                         uint baseId = e.EntryId & BASE_ID_MASK;

--- a/pwiz_tools/Osprey/Osprey.Tasks/BlibOutputWriter.cs
+++ b/pwiz_tools/Osprey/Osprey.Tasks/BlibOutputWriter.cs
@@ -25,6 +25,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using pwiz.Osprey.Core;
 using pwiz.Osprey.IO;
@@ -127,26 +128,40 @@ namespace pwiz.Osprey.Tasks
             var mzBlobs = new byte[blibN][];
             var intBlobs = new byte[blibN][];
             var numPeaks = new int[blibN];
-            Parallel.For(0, blibN,
-                new ParallelOptions { MaxDegreeOfParallelism = nThreads },
-                i =>
-                {
-                    var entry = blibEntries[i].Value;
-                    LibraryEntry libEntryP;
-                    if (!libraryById.TryGetValue(entry.EntryId, out libEntryP))
-                        return;
-                    int nFrags = libEntryP.Fragments.Count;
-                    var mzsP = new double[nFrags];
-                    var intsP = new float[nFrags];
-                    for (int j = 0; j < nFrags; j++)
+            // Reported because per-spectrum zlib dominates the blib write and ran silent: on the
+            // 82-file SEA-AD run this pass and the emission below shared a 47 s gap ending at
+            // "Wrote 51597 library spectra". The surrounding [COUNT] lines cannot serve here -
+            // OspreyOutput.IsMachineParseable filters them out of normal output, so they appear
+            // only under --perf-stats (the same trap Calibrator.cs:1564 records).
+            int precompressed = 0;
+            using (var progress = new ProgressReporter(
+                       string.Format(@"Compressing {0} library spectra for the blib", blibN),
+                       blibN, string.Empty, ProgressReporter.IO_INTERVAL_SECONDS))
+            {
+                Parallel.For(0, blibN,
+                    new ParallelOptions { MaxDegreeOfParallelism = nThreads },
+                    i =>
                     {
-                        mzsP[j] = libEntryP.Fragments[j].Mz;
-                        intsP[j] = libEntryP.Fragments[j].RelativeIntensity;
-                    }
-                    mzBlobs[i] = BlibWriter.CompressMzs(mzsP);
-                    intBlobs[i] = BlibWriter.CompressIntensities(intsP);
-                    numPeaks[i] = nFrags;
-                });
+                        // Reported before the early-out below, so a run whose library lookups all
+                        // miss still advances to 100% rather than stalling at 0%.
+                        progress.Report(Interlocked.Increment(ref precompressed));
+                        var entry = blibEntries[i].Value;
+                        LibraryEntry libEntryP;
+                        if (!libraryById.TryGetValue(entry.EntryId, out libEntryP))
+                            return;
+                        int nFrags = libEntryP.Fragments.Count;
+                        var mzsP = new double[nFrags];
+                        var intsP = new float[nFrags];
+                        for (int j = 0; j < nFrags; j++)
+                        {
+                            mzsP[j] = libEntryP.Fragments[j].Mz;
+                            intsP[j] = libEntryP.Fragments[j].RelativeIntensity;
+                        }
+                        mzBlobs[i] = BlibWriter.CompressMzs(mzsP);
+                        intBlobs[i] = BlibWriter.CompressIntensities(intsP);
+                        numPeaks[i] = nFrags;
+                    });
+            }
             blibMzBlobs = mzBlobs;
             blibIntBlobs = intBlobs;
             blibNumPeaks = numPeaks;
@@ -167,95 +182,103 @@ namespace pwiz.Osprey.Tasks
             Dictionary<(string, byte), List<KeyValuePair<string, FdrEntry>>> entriesByPrecursor,
             int perFileEntriesCount, double fdrThreshold)
         {
-            for (int blibIdx = 0; blibIdx < blibEntries.Count; blibIdx++)
+            // Reported for the same reason as the pre-compress pass above: this emits five row
+            // families per spectrum into SQLite and ran silent inside the same 47 s gap.
+            using (var progress = new ProgressReporter(
+                       string.Format(@"Writing {0} spectra to the blib", blibEntries.Count),
+                       blibEntries.Count, string.Empty, ProgressReporter.IO_INTERVAL_SECONDS))
             {
-                var kvp = blibEntries[blibIdx];
-                string fileName = kvp.Key;
-                var entry = kvp.Value;
-
-                LibraryEntry libEntry;
-                if (!libraryById.TryGetValue(entry.EntryId, out libEntry))
-                    continue;
-
-                long fileId = sourceFileIds[fileName];
-
-                byte[] mzBlobPre = blibMzBlobs[blibIdx];
-                byte[] intBlobPre = blibIntBlobs[blibIdx];
-                int numPeaksPre = blibNumPeaks[blibIdx];
-
-                // RefSpectra.score is the EXPERIMENT-PRECURSOR q-value (min
-                // across all observations of this (modseq, charge)). Mirrors
-                // Rust pipeline.rs:4670-4683 / 4795. Same value feeds
-                // OspreyExperimentScores.ExperimentQValue below.
-                var lookupKey = (entry.ModifiedSequence, entry.Charge);
-                double scoreQvalue;
-                if (!bestExpPrecursorQ.TryGetValue(lookupKey, out scoreQvalue))
-                    scoreQvalue = entry.ExperimentPrecursorQvalue;
-
-                // nRunsDetected -> RefSpectra.copies (Rust pipeline.rs:6179
-                // passes n_runs_detected = group.len()). Reused by
-                // OspreyExperimentScores below.
-                List<KeyValuePair<string, FdrEntry>> observations;
-                int nRunsDetected = 1;
-                if (entriesByPrecursor.TryGetValue(lookupKey, out observations) &&
-                    observations.Count > 0)
+                for (int blibIdx = 0; blibIdx < blibEntries.Count; blibIdx++)
                 {
-                    nRunsDetected = observations.Count;
+                    progress.Report(blibIdx + 1);
+                    var kvp = blibEntries[blibIdx];
+                    string fileName = kvp.Key;
+                    var entry = kvp.Value;
+
+                    LibraryEntry libEntry;
+                    if (!libraryById.TryGetValue(entry.EntryId, out libEntry))
+                        continue;
+
+                    long fileId = sourceFileIds[fileName];
+
+                    byte[] mzBlobPre = blibMzBlobs[blibIdx];
+                    byte[] intBlobPre = blibIntBlobs[blibIdx];
+                    int numPeaksPre = blibNumPeaks[blibIdx];
+
+                    // RefSpectra.score is the EXPERIMENT-PRECURSOR q-value (min
+                    // across all observations of this (modseq, charge)). Mirrors
+                    // Rust pipeline.rs:4670-4683 / 4795. Same value feeds
+                    // OspreyExperimentScores.ExperimentQValue below.
+                    var lookupKey = (entry.ModifiedSequence, entry.Charge);
+                    double scoreQvalue;
+                    if (!bestExpPrecursorQ.TryGetValue(lookupKey, out scoreQvalue))
+                        scoreQvalue = entry.ExperimentPrecursorQvalue;
+
+                    // nRunsDetected -> RefSpectra.copies (Rust pipeline.rs:6179
+                    // passes n_runs_detected = group.len()). Reused by
+                    // OspreyExperimentScores below.
+                    List<KeyValuePair<string, FdrEntry>> observations;
+                    int nRunsDetected = 1;
+                    if (entriesByPrecursor.TryGetValue(lookupKey, out observations) &&
+                        observations.Count > 0)
+                    {
+                        nRunsDetected = observations.Count;
+                    }
+
+                    // Shared peak boundaries when the peptide is detected at
+                    // multiple charges in this file (Rust pipeline.rs:6160-6164).
+                    var sharedKey = (entry.ModifiedSequence, fileName);
+                    double sharedApex = entry.ApexRt;
+                    double sharedStart = entry.StartRt;
+                    double sharedEnd = entry.EndRt;
+                    double[] sharedVals;
+                    if (sharedBounds.TryGetValue(sharedKey, out sharedVals))
+                    {
+                        sharedApex = sharedVals[0];
+                        sharedStart = sharedVals[1];
+                        sharedEnd = sharedVals[2];
+                    }
+
+                    long refId = writer.AddSpectrumPrecompressed(
+                        libEntry.Sequence,
+                        libEntry.ModifiedSequence,
+                        libEntry.PrecursorMz,
+                        libEntry.Charge,
+                        sharedApex,
+                        sharedStart,
+                        sharedEnd,
+                        mzBlobPre, intBlobPre, numPeaksPre,
+                        scoreQvalue, fileId, nRunsDetected, 0.0);
+
+                    // Add modifications
+                    if (libEntry.Modifications != null && libEntry.Modifications.Count > 0)
+                        writer.AddModifications(refId, libEntry.Modifications);
+
+                    // Add protein mappings
+                    if (libEntry.ProteinIds != null && libEntry.ProteinIds.Count > 0)
+                        writer.AddProteinMapping(refId, libEntry.ProteinIds);
+
+                    WriteRetentionTimes(writer, refId, fileName, observations,
+                        sourceFileIds, sharedBounds, fdrThreshold);
+
+                    // Osprey extension tables — one row per RefSpectra each,
+                    // mirroring Rust pipeline.rs:6255-6272. Best-run-only for
+                    // OspreyPeakBoundaries + OspreyRunScores; experiment-level for
+                    // OspreyExperimentScores. The 0.0 fields are the same "not yet
+                    // plumbed through Stage 7 plan entries" placeholders Rust writes.
+                    writer.AddPeakBoundaries(refId, fileName,
+                        sharedStart, sharedEnd, sharedApex,
+                        0.0, // ApexIntensity — matches Rust's apex_coefficient placeholder
+                        entry.BoundsArea);
+                    writer.AddRunScores(refId, fileName,
+                        entry.EffectiveRunQvalue(FdrLevel.Both),
+                        0.0, // DiscriminantScore — matches Rust's dot_product placeholder
+                        0.0); // PosteriorErrorProb — matches Rust's PEP placeholder
+                    writer.AddExperimentScores(refId,
+                        scoreQvalue, // Same value as RefSpectra.score
+                        nRunsDetected,
+                        perFileEntriesCount);
                 }
-
-                // Shared peak boundaries when the peptide is detected at
-                // multiple charges in this file (Rust pipeline.rs:6160-6164).
-                var sharedKey = (entry.ModifiedSequence, fileName);
-                double sharedApex = entry.ApexRt;
-                double sharedStart = entry.StartRt;
-                double sharedEnd = entry.EndRt;
-                double[] sharedVals;
-                if (sharedBounds.TryGetValue(sharedKey, out sharedVals))
-                {
-                    sharedApex = sharedVals[0];
-                    sharedStart = sharedVals[1];
-                    sharedEnd = sharedVals[2];
-                }
-
-                long refId = writer.AddSpectrumPrecompressed(
-                    libEntry.Sequence,
-                    libEntry.ModifiedSequence,
-                    libEntry.PrecursorMz,
-                    libEntry.Charge,
-                    sharedApex,
-                    sharedStart,
-                    sharedEnd,
-                    mzBlobPre, intBlobPre, numPeaksPre,
-                    scoreQvalue, fileId, nRunsDetected, 0.0);
-
-                // Add modifications
-                if (libEntry.Modifications != null && libEntry.Modifications.Count > 0)
-                    writer.AddModifications(refId, libEntry.Modifications);
-
-                // Add protein mappings
-                if (libEntry.ProteinIds != null && libEntry.ProteinIds.Count > 0)
-                    writer.AddProteinMapping(refId, libEntry.ProteinIds);
-
-                WriteRetentionTimes(writer, refId, fileName, observations,
-                    sourceFileIds, sharedBounds, fdrThreshold);
-
-                // Osprey extension tables — one row per RefSpectra each,
-                // mirroring Rust pipeline.rs:6255-6272. Best-run-only for
-                // OspreyPeakBoundaries + OspreyRunScores; experiment-level for
-                // OspreyExperimentScores. The 0.0 fields are the same "not yet
-                // plumbed through Stage 7 plan entries" placeholders Rust writes.
-                writer.AddPeakBoundaries(refId, fileName,
-                    sharedStart, sharedEnd, sharedApex,
-                    0.0, // ApexIntensity — matches Rust's apex_coefficient placeholder
-                    entry.BoundsArea);
-                writer.AddRunScores(refId, fileName,
-                    entry.EffectiveRunQvalue(FdrLevel.Both),
-                    0.0, // DiscriminantScore — matches Rust's dot_product placeholder
-                    0.0); // PosteriorErrorProb — matches Rust's PEP placeholder
-                writer.AddExperimentScores(refId,
-                    scoreQvalue, // Same value as RefSpectra.score
-                    nRunsDetected,
-                    perFileEntriesCount);
             }
         }
 

--- a/pwiz_tools/Osprey/Osprey.Tasks/BlibOutputWriter.cs
+++ b/pwiz_tools/Osprey/Osprey.Tasks/BlibOutputWriter.cs
@@ -129,10 +129,13 @@ namespace pwiz.Osprey.Tasks
             var intBlobs = new byte[blibN][];
             var numPeaks = new int[blibN];
             // Reported because per-spectrum zlib dominates the blib write and ran silent: on the
-            // 82-file SEA-AD run this pass and the emission below shared a 47 s gap ending at
-            // "Wrote 51597 library spectra". The surrounding [COUNT] lines cannot serve here -
-            // OspreyOutput.IsMachineParseable filters them out of normal output, so they appear
-            // only under --perf-stats (the same trap Calibrator.cs:1564 records).
+            // 82-file SEA-AD run this pass and the emission below were the bulk of a 47 s gap
+            // ending at "Wrote 51597 library spectra". They are not all of it - Commit,
+            // WriteMetadata and FinalizeDatabase run after the emission scope closes and are
+            // still uninstrumented. The surrounding [COUNT] lines cannot serve here:
+            // OspreyOutput.IsStatLine filters them out of normal output, so they appear only
+            // under --perf-stats (the same trap Calibrator.cs:1564 records, where the API is
+            // misnamed IsMachineParseable).
             int precompressed = 0;
             using (var progress = new ProgressReporter(
                        string.Format(@"Compressing {0} library spectra for the blib", blibN),
@@ -261,19 +264,19 @@ namespace pwiz.Osprey.Tasks
                     WriteRetentionTimes(writer, refId, fileName, observations,
                         sourceFileIds, sharedBounds, fdrThreshold);
 
-                    // Osprey extension tables — one row per RefSpectra each,
+                    // Osprey extension tables - one row per RefSpectra each,
                     // mirroring Rust pipeline.rs:6255-6272. Best-run-only for
                     // OspreyPeakBoundaries + OspreyRunScores; experiment-level for
                     // OspreyExperimentScores. The 0.0 fields are the same "not yet
                     // plumbed through Stage 7 plan entries" placeholders Rust writes.
                     writer.AddPeakBoundaries(refId, fileName,
                         sharedStart, sharedEnd, sharedApex,
-                        0.0, // ApexIntensity — matches Rust's apex_coefficient placeholder
+                        0.0, // ApexIntensity - matches Rust's apex_coefficient placeholder
                         entry.BoundsArea);
                     writer.AddRunScores(refId, fileName,
                         entry.EffectiveRunQvalue(FdrLevel.Both),
-                        0.0, // DiscriminantScore — matches Rust's dot_product placeholder
-                        0.0); // PosteriorErrorProb — matches Rust's PEP placeholder
+                        0.0, // DiscriminantScore - matches Rust's dot_product placeholder
+                        0.0); // PosteriorErrorProb - matches Rust's PEP placeholder
                     writer.AddExperimentScores(refId,
                         scoreQvalue, // Same value as RefSpectra.score
                         nRunsDetected,

--- a/pwiz_tools/Osprey/Osprey.Tasks/ModelDiagnostics/ModelDiagnosticsReport.cs
+++ b/pwiz_tools/Osprey/Osprey.Tasks/ModelDiagnostics/ModelDiagnosticsReport.cs
@@ -225,19 +225,17 @@ namespace pwiz.Osprey.Tasks.ModelDiagnostics
                 // half is always built (FdpViews empty without an entrapment pool).
                 // These two steps shared a 71 s silence on the 82-file SEA-AD run of 2026-08-14,
                 // between the classification's [ENTRAPMENT] line and "finalized report" (#4571).
-                // Reported separately rather than as one block because they are very differently
-                // shaped - BuildPass2 walks every survivor observation (89,068,375 at 82 files)
-                // while the render is a single string build - so one line covering both would say
-                // nothing about which is the long one.
-                logInfo(string.Format(
-                    @"[MODEL-DIAGNOSTICS] building the pass-2 views over {0} file(s)...",
-                    perFileEntries.Count));
+                // BuildPass2 owns essentially all of it and carries its own per-card
+                // ProgressReporter; no heading is added here, because a reporter already prints
+                // one and then only as many percent lines as the elapsed time needs, while a
+                // heading at this call site would print unconditionally on every run forever.
+                // Measured 2026-08-15: the render that follows completes inside the same second
+                // it starts, so it gets no line at all.
                 data.Pass2 = ModelDiagnosticsData.BuildPass2(
                     perFileEntries, pass2Contributions, classByBaseId, pairByBaseId,
                     entrapmentRatio, config.RunFdr, config.FdrLevel,
                     BuildPrecursorMzLookup(libraryById));
 
-                logInfo(@"[MODEL-DIAGNOSTICS] rendering the report page...");
                 string outPath = RenderAndWrite(data, config);
                 // Consume the FirstPassFDR -> SecondPassFDR hand-off sidecar unconditionally
                 // once the report is finalized (deleting it in every path avoids

--- a/pwiz_tools/Osprey/Osprey.Tasks/ModelDiagnostics/ModelDiagnosticsReport.cs
+++ b/pwiz_tools/Osprey/Osprey.Tasks/ModelDiagnostics/ModelDiagnosticsReport.cs
@@ -223,11 +223,21 @@ namespace pwiz.Osprey.Tasks.ModelDiagnostics
                 // re-source the whole page. The structural half is null under
                 // confidence-transfer mode (pass2Contributions == null); the q-driven
                 // half is always built (FdpViews empty without an entrapment pool).
+                // These two steps shared a 71 s silence on the 82-file SEA-AD run of 2026-08-14,
+                // between the classification's [ENTRAPMENT] line and "finalized report" (#4571).
+                // Reported separately rather than as one block because they are very differently
+                // shaped - BuildPass2 walks every survivor observation (89,068,375 at 82 files)
+                // while the render is a single string build - so one line covering both would say
+                // nothing about which is the long one.
+                logInfo(string.Format(
+                    @"[MODEL-DIAGNOSTICS] building the pass-2 views over {0} file(s)...",
+                    perFileEntries.Count));
                 data.Pass2 = ModelDiagnosticsData.BuildPass2(
                     perFileEntries, pass2Contributions, classByBaseId, pairByBaseId,
                     entrapmentRatio, config.RunFdr, config.FdrLevel,
                     BuildPrecursorMzLookup(libraryById));
 
+                logInfo(@"[MODEL-DIAGNOSTICS] rendering the report page...");
                 string outPath = RenderAndWrite(data, config);
                 // Consume the FirstPassFDR -> SecondPassFDR hand-off sidecar unconditionally
                 // once the report is finalized (deleting it in every path avoids

--- a/pwiz_tools/Osprey/Osprey.Tasks/OspreyReportWriter.cs
+++ b/pwiz_tools/Osprey/Osprey.Tasks/OspreyReportWriter.cs
@@ -234,19 +234,30 @@ namespace pwiz.Osprey.Tasks
             // Per replicate: precursors + peptides passing RUN-level FDR in that file, and
             // an INDEPENDENT run-level protein FDR (its own parsimony + picked-protein FDR
             // on that replicate's detected peptides -- not a slice of the experiment set).
-            foreach (var kvp in perFileEntries)
+            // Reported because each iteration runs an INDEPENDENT parsimony + picked-protein FDR
+            // over the whole library for one replicate, so the loop costs roughly one protein-FDR
+            // pass per file - a 46 s silence at 82 files on the 2026-08-15 measurement, with only
+            // the caller's heading in front of it (#4571).
+            int runIdx = 0;
+            using (var progress = new ProgressReporter(
+                       string.Format(@"Per-replicate protein FDR over {0} run(s)", perFileEntries.Count),
+                       perFileEntries.Count, string.Empty, ProgressReporter.IO_INTERVAL_SECONDS))
             {
-                CountPrecursorsPeptides(new[] { kvp }, level, config, runLevel: true,
-                    out int precursors, out int peptides);
-                int proteins = ProteinFdrEngine.CountPassingProteinGroups(
-                    new List<KeyValuePair<string, List<FdrEntry>>> { kvp }, fullLibrary, config, runLevel: true);
-                rows.Add(new[]
+                foreach (var kvp in perFileEntries)
                 {
-                    RunName(kvp.Key),
-                    precursors.ToString(CultureInfo.InvariantCulture),
-                    peptides.ToString(CultureInfo.InvariantCulture),
-                    proteins.ToString(CultureInfo.InvariantCulture),
-                });
+                    progress.Report(++runIdx);
+                    CountPrecursorsPeptides(new[] { kvp }, level, config, runLevel: true,
+                        out int precursors, out int peptides);
+                    int proteins = ProteinFdrEngine.CountPassingProteinGroups(
+                        new List<KeyValuePair<string, List<FdrEntry>>> { kvp }, fullLibrary, config, runLevel: true);
+                    rows.Add(new[]
+                    {
+                        RunName(kvp.Key),
+                        precursors.ToString(CultureInfo.InvariantCulture),
+                        peptides.ToString(CultureInfo.InvariantCulture),
+                        proteins.ToString(CultureInfo.InvariantCulture),
+                    });
+                }
             }
 
             // Experiment row: precursors + peptides passing EXPERIMENT-level FDR (a

--- a/pwiz_tools/Osprey/Osprey.Tasks/OspreyReportWriter.cs
+++ b/pwiz_tools/Osprey/Osprey.Tasks/OspreyReportWriter.cs
@@ -119,46 +119,58 @@ namespace pwiz.Osprey.Tasks
             // scan the whole library rather than reuse the detected-only parsimony.
             var libPeptideToProteins = BuildLibraryPeptideProteins(fullLibrary, result.DetectedPeptides);
 
+            // Reported for the same reason as the per-replicate FDR below (#4571). This half of
+            // the report writer ran silent: it scans the whole library above and then walks every
+            // group here, and its only bracketing line is a [COUNT] that OspreyOutput.IsStatLine
+            // drops unless --perf-stats. A run configured with --protein-report but no summary
+            // report therefore produced no visible output for the entire report step.
+            int groupIdx = 0;
             var rows = new List<string[]>(groups.Count);
-            foreach (var g in groups)
+            using (var progress = new ProgressReporter(
+                       string.Format(@"Building the protein-group report over {0} group(s)", groups.Count),
+                       groups.Count, string.Empty, ProgressReporter.IO_INTERVAL_SECONDS))
             {
-                double q = groupQ.TryGetValue(g.Id, out double qv) ? qv : 1.0;
-                bool passes = q <= config.EffectiveProteinFdr;
-
-                // Peptides used for the grouping = every detected peptide supporting the
-                // group (unique-among-detected + shared-among-detected), sorted for a
-                // stable file.
-                var grouping = g.UniquePeptides
-                    .Concat(g.SharedPeptides)
-                    .OrderBy(x => x, StringComparer.Ordinal)
-                    .ToList();
-
-                var accessionSet = new HashSet<string>(g.Accessions, StringComparer.Ordinal);
-                var libUnique = new List<string>();
-                foreach (string pep in grouping)
+                foreach (var g in groups)
                 {
-                    // Library-unique iff all of the peptide's library proteins are in this
-                    // group. A peptide absent from the map (no library entry captured)
-                    // cannot be asserted unique, so it is treated as not-unique.
-                    if (libPeptideToProteins.TryGetValue(pep, out var libProts) &&
-                        libProts.Count > 0 &&
-                        libProts.All(accessionSet.Contains))
+                    progress.Report(++groupIdx);
+                    double q = groupQ.TryGetValue(g.Id, out double qv) ? qv : 1.0;
+                    bool passes = q <= config.EffectiveProteinFdr;
+
+                    // Peptides used for the grouping = every detected peptide supporting the
+                    // group (unique-among-detected + shared-among-detected), sorted for a
+                    // stable file.
+                    var grouping = g.UniquePeptides
+                        .Concat(g.SharedPeptides)
+                        .OrderBy(x => x, StringComparer.Ordinal)
+                        .ToList();
+
+                    var accessionSet = new HashSet<string>(g.Accessions, StringComparer.Ordinal);
+                    var libUnique = new List<string>();
+                    foreach (string pep in grouping)
                     {
-                        libUnique.Add(pep);
+                        // Library-unique iff all of the peptide's library proteins are in this
+                        // group. A peptide absent from the map (no library entry captured)
+                        // cannot be asserted unique, so it is treated as not-unique.
+                        if (libPeptideToProteins.TryGetValue(pep, out var libProts) &&
+                            libProts.Count > 0 &&
+                            libProts.All(accessionSet.Contains))
+                        {
+                            libUnique.Add(pep);
+                        }
                     }
-                }
 
-                rows.Add(new[]
-                {
-                    string.Join(@";", g.Accessions),
-                    string.Join(@";", g.Accessions.Select(ProteinName)),
-                    grouping.Count.ToString(CultureInfo.InvariantCulture),
-                    libUnique.Count.ToString(CultureInfo.InvariantCulture),
-                    q.ToString(@"0.######e+00", CultureInfo.InvariantCulture),
-                    passes ? @"1" : @"0",
-                    string.Join(@";", grouping),
-                    string.Join(@";", libUnique),
-                });
+                    rows.Add(new[]
+                    {
+                        string.Join(@";", g.Accessions),
+                        string.Join(@";", g.Accessions.Select(ProteinName)),
+                        grouping.Count.ToString(CultureInfo.InvariantCulture),
+                        libUnique.Count.ToString(CultureInfo.InvariantCulture),
+                        q.ToString(@"0.######e+00", CultureInfo.InvariantCulture),
+                        passes ? @"1" : @"0",
+                        string.Join(@";", grouping),
+                        string.Join(@";", libUnique),
+                    });
+                }
             }
 
             // Deterministic order: passing first, then most confident, then by accessions

--- a/pwiz_tools/Osprey/Osprey.Tasks/Pass2FdrSidecar.cs
+++ b/pwiz_tools/Osprey/Osprey.Tasks/Pass2FdrSidecar.cs
@@ -585,10 +585,12 @@ namespace pwiz.Osprey.Tasks
             // every file's ENTIRE 1st-pass sidecar - the PRE-compaction pool, 345,024,871 records
             // at 82 files, not the 89 M survivors - and logged nothing while doing it. On the
             // 82-file SEA-AD runs of 2026-08-12/14 that was the 130-141 s gap, and on the
-            // --task SecondPassFDR leg the same step is a 127 s gap. Neither of the two lines that
-            // bracket it reaches a normal run: the "N/M file(s) have no precomputed second-pass
-            // FDR scores" heading is LogVerbose, and the swRestore duration goes out as a
-            // [STAGE-WALL] line, which OspreyOutput filters unless --perf-stats.
+            // --task SecondPassFDR leg the same step is a 127 s gap. It ran unbracketed: the
+            // "N/M file(s) have no precomputed second-pass FDR scores" heading above was
+            // LogVerbose (this change promotes it to LogInfo, so it is now visible), and the
+            // swRestore duration goes out as a [STAGE-WALL] line, which OspreyOutput.IsStatLine
+            // filters unless --perf-stats. A heading alone would not cover this anyway - the
+            // step is O(records) and the silence is INSIDE it.
             int restoreIdx = 0;
             using (var progress = new ProgressReporter(
                        string.Format(@"Seeding pass-1 scalars from {0} file(s)", perFileEntries.Count),

--- a/pwiz_tools/Osprey/Osprey.Tasks/Pass2FdrSidecar.cs
+++ b/pwiz_tools/Osprey/Osprey.Tasks/Pass2FdrSidecar.cs
@@ -191,8 +191,11 @@ namespace pwiz.Osprey.Tasks
                 }
                 if (missingPass2 > 0)
                 {
-                    ctx.LogVerbose(string.Format(
-                        "{0}/{1} file(s) have no precomputed second-pass FDR scores -- computing " +
+                    // LogInfo, not LogVerbose: this is the heading for the longest stretch of
+                    // work left in Stage 7, and a --verbose-only heading is invisible on the runs
+                    // that actually take the time (#4571).
+                    ctx.LogInfo(string.Format(
+                        "{0}/{1} file(s) have no precomputed second-pass FDR scores - computing " +
                         "them here from the reconciled features (reused distributed-run code path).",
                         missingPass2, totalFiles));
                     // Stage 6's post-rescore overlay calls FdrEntry.ResetScores(), which clears
@@ -578,57 +581,72 @@ namespace pwiz.Osprey.Tasks
             int nRestored = 0;
             int filesRead = 0;
             var unreadable = new List<string>();
+            // Reported because this is the longest silent step left in Stage 7 (#4571): it streams
+            // every file's ENTIRE 1st-pass sidecar - the PRE-compaction pool, 345,024,871 records
+            // at 82 files, not the 89 M survivors - and logged nothing while doing it. On the
+            // 82-file SEA-AD runs of 2026-08-12/14 that was the 130-141 s gap, and on the
+            // --task SecondPassFDR leg the same step is a 127 s gap. Neither of the two lines that
+            // bracket it reaches a normal run: the "N/M file(s) have no precomputed second-pass
+            // FDR scores" heading is LogVerbose, and the swRestore duration goes out as a
+            // [STAGE-WALL] line, which OspreyOutput filters unless --perf-stats.
+            int restoreIdx = 0;
+            using (var progress = new ProgressReporter(
+                       string.Format(@"Seeding pass-1 scalars from {0} file(s)", perFileEntries.Count),
+                       perFileEntries.Count, string.Empty, ProgressReporter.IO_INTERVAL_SECONDS))
+            {
             foreach (var kvp in perFileEntries)
             {
-                if (!inputByFileName.TryGetValue(kvp.Key, out string inputFile))
-                    continue;
-                string pass1Path = FdrScoresSidecar.Pass1Path(inputFile);
-                if (!File.Exists(pass1Path))
-                {
-                    unreadable.Add(kvp.Key);
-                    continue;
-                }
-                var byEntryId = new Dictionary<uint, FdrEntry>(kvp.Value.Count);
-                foreach (var e in kvp.Value)
-                    byEntryId[e.EntryId] = e;
-
-                // Stage into a buffer and apply only on a clean read. ReadRecords documents
-                // that a false return can arrive AFTER it has invoked the callback ("with the
-                // partial callback effects the caller must discard"), and records stream in
-                // file order, so mutating in the callback would leave the entries before the
-                // fault carrying pass-1 values and the rest at reset defaults - a half-seeded
-                // pool that no warning could describe and nothing downstream could detect.
-                var staged = new List<KeyValuePair<FdrEntry, FdrScoreRecord>>();
-                bool ok = FdrScoresSidecar.ReadRecords(
-                    pass1Path, FdrScoresSidecar.Pass.FirstPass,
-                    rec =>
+                progress.Report(++restoreIdx);
+                    if (!inputByFileName.TryGetValue(kvp.Key, out string inputFile))
+                        continue;
+                    string pass1Path = FdrScoresSidecar.Pass1Path(inputFile);
+                    if (!File.Exists(pass1Path))
                     {
-                        if (byEntryId.TryGetValue(rec.EntryId, out FdrEntry entry))
-                            staged.Add(new KeyValuePair<FdrEntry, FdrScoreRecord>(entry, rec));
-                    });
-                if (ok)
-                {
-                    foreach (var pair in staged)
-                    {
-                        pair.Key.Score = pair.Value.Score;
-                        pair.Key.Pep = pair.Value.Pep;
-                        // ExperimentProteinQvalue is deliberately NOT seeded here - see the
-                        // remarks. PatchPass2ProteinQvalues writes the second-pass value into
-                        // the 2nd-pass sidecar after the second-pass protein FDR (#4559).
-                        // The THIRD field of the same five-of-eight gap (sidecar v4, issue
-                        // #4522). ResetScores clears it with Score, and no frozen 2nd-pass mode
-                        // writes it back, so it lands in the 2nd-pass sidecar at 0.0 for every
-                        // peak Stage 6 touched. That is the whole population this method exists
-                        // to repair, and it is why the seed should follow the record rather than
-                        // an enumerated list: the list has now grown twice.
-                        pair.Key.ExperimentAggregateScore = pair.Value.ExperimentAggregateScore;
+                        unreadable.Add(kvp.Key);
+                        continue;
                     }
-                    filesRead++;
-                    nRestored += staged.Count;
-                }
-                else
-                {
-                    unreadable.Add(kvp.Key);
+                    var byEntryId = new Dictionary<uint, FdrEntry>(kvp.Value.Count);
+                    foreach (var e in kvp.Value)
+                        byEntryId[e.EntryId] = e;
+
+                    // Stage into a buffer and apply only on a clean read. ReadRecords documents
+                    // that a false return can arrive AFTER it has invoked the callback ("with the
+                    // partial callback effects the caller must discard"), and records stream in
+                    // file order, so mutating in the callback would leave the entries before the
+                    // fault carrying pass-1 values and the rest at reset defaults - a half-seeded
+                    // pool that no warning could describe and nothing downstream could detect.
+                    var staged = new List<KeyValuePair<FdrEntry, FdrScoreRecord>>();
+                    bool ok = FdrScoresSidecar.ReadRecords(
+                        pass1Path, FdrScoresSidecar.Pass.FirstPass,
+                        rec =>
+                        {
+                            if (byEntryId.TryGetValue(rec.EntryId, out FdrEntry entry))
+                                staged.Add(new KeyValuePair<FdrEntry, FdrScoreRecord>(entry, rec));
+                        });
+                    if (ok)
+                    {
+                        foreach (var pair in staged)
+                        {
+                            pair.Key.Score = pair.Value.Score;
+                            pair.Key.Pep = pair.Value.Pep;
+                            // ExperimentProteinQvalue is deliberately NOT seeded here - see the
+                            // remarks. PatchPass2ProteinQvalues writes the second-pass value into
+                            // the 2nd-pass sidecar after the second-pass protein FDR (#4559).
+                            // The THIRD field of the same five-of-eight gap (sidecar v4, issue
+                            // #4522). ResetScores clears it with Score, and no frozen 2nd-pass mode
+                            // writes it back, so it lands in the 2nd-pass sidecar at 0.0 for every
+                            // peak Stage 6 touched. That is the whole population this method exists
+                            // to repair, and it is why the seed should follow the record rather than
+                            // an enumerated list: the list has now grown twice.
+                            pair.Key.ExperimentAggregateScore = pair.Value.ExperimentAggregateScore;
+                        }
+                        filesRead++;
+                        nRestored += staged.Count;
+                    }
+                    else
+                    {
+                        unreadable.Add(kvp.Key);
+                    }
                 }
             }
 
@@ -695,40 +713,51 @@ namespace pwiz.Osprey.Tasks
             int filesPatched = 0;
             long nPatched = 0;
             var failed = new List<string>();
+            // A heading alone was not enough here: with only the caller's line in place this loop
+            // was still a 54 s gap on the --task SecondPassFDR measurement of 2026-08-15. It
+            // rewrites one 8-byte field per record over every file's whole 2nd-pass sidecar, so
+            // it is per-file work and reports as such.
+            int patchIdx = 0;
+            using (var progress = new ProgressReporter(
+                       string.Format(@"Patching pass-2 protein q into {0} sidecar(s)", perFileEntries.Count),
+                       perFileEntries.Count, string.Empty, ProgressReporter.IO_INTERVAL_SECONDS))
+            {
             foreach (var kvp in perFileEntries)
             {
+                progress.Report(++patchIdx);
                 if (!inputByName.TryGetValue(kvp.Key, out string inputFile))
                     continue;
-                string pass2Path = FdrScoresSidecar.Pass2Path(inputFile);
-                // Two gates, deliberately, because ABSENT and UNUSABLE are different outcomes
-                // here and IsCurrentFormat alone cannot tell them apart (it is false for both).
-                // A file with no reconciled parquet legitimately has no 2nd-pass sidecar, so
-                // absent is a silent skip; a sidecar that IS present but carries a foreign magic,
-                // a different FormatVersion, the wrong pass byte or a length its own header
-                // contradicts is a real problem, and it is exactly what the warning below exists
-                // to name. Collapsing these into one IsCurrentFormat call would either report
-                // every legitimately-absent file or silently swallow the stale one.
-                if (!File.Exists(pass2Path))
-                    continue;
-                if (!FdrScoresSidecar.IsCurrentFormat(pass2Path, FdrScoresSidecar.Pass.SecondPass))
-                {
-                    failed.Add(kvp.Key);
-                    continue;
-                }
+                    string pass2Path = FdrScoresSidecar.Pass2Path(inputFile);
+                    // Two gates, deliberately, because ABSENT and UNUSABLE are different outcomes
+                    // here and IsCurrentFormat alone cannot tell them apart (it is false for both).
+                    // A file with no reconciled parquet legitimately has no 2nd-pass sidecar, so
+                    // absent is a silent skip; a sidecar that IS present but carries a foreign magic,
+                    // a different FormatVersion, the wrong pass byte or a length its own header
+                    // contradicts is a real problem, and it is exactly what the warning below exists
+                    // to name. Collapsing these into one IsCurrentFormat call would either report
+                    // every legitimately-absent file or silently swallow the stale one.
+                    if (!File.Exists(pass2Path))
+                        continue;
+                    if (!FdrScoresSidecar.IsCurrentFormat(pass2Path, FdrScoresSidecar.Pass.SecondPass))
+                    {
+                        failed.Add(kvp.Key);
+                        continue;
+                    }
 
-                var byEntryId = new Dictionary<uint, double>(kvp.Value.Count);
-                foreach (var e in kvp.Value)
-                    byEntryId[e.EntryId] = e.ExperimentProteinQvalue;
+                    var byEntryId = new Dictionary<uint, double>(kvp.Value.Count);
+                    foreach (var e in kvp.Value)
+                        byEntryId[e.EntryId] = e.ExperimentProteinQvalue;
 
-                if (FdrScoresSidecar.PatchProteinQvalues(
-                        pass2Path, byEntryId, FdrScoresSidecar.Pass.SecondPass, out int patchedHere))
-                {
-                    filesPatched++;
-                    nPatched += patchedHere;
-                }
-                else
-                {
-                    failed.Add(kvp.Key);
+                    if (FdrScoresSidecar.PatchProteinQvalues(
+                            pass2Path, byEntryId, FdrScoresSidecar.Pass.SecondPass, out int patchedHere))
+                    {
+                        filesPatched++;
+                        nPatched += patchedHere;
+                    }
+                    else
+                    {
+                        failed.Add(kvp.Key);
+                    }
                 }
             }
 

--- a/pwiz_tools/Osprey/Osprey.Tasks/Pass2FdrSidecar.cs
+++ b/pwiz_tools/Osprey/Osprey.Tasks/Pass2FdrSidecar.cs
@@ -594,9 +594,9 @@ namespace pwiz.Osprey.Tasks
                        string.Format(@"Seeding pass-1 scalars from {0} file(s)", perFileEntries.Count),
                        perFileEntries.Count, string.Empty, ProgressReporter.IO_INTERVAL_SECONDS))
             {
-            foreach (var kvp in perFileEntries)
-            {
-                progress.Report(++restoreIdx);
+                foreach (var kvp in perFileEntries)
+                {
+                    progress.Report(++restoreIdx);
                     if (!inputByFileName.TryGetValue(kvp.Key, out string inputFile))
                         continue;
                     string pass1Path = FdrScoresSidecar.Pass1Path(inputFile);
@@ -722,11 +722,11 @@ namespace pwiz.Osprey.Tasks
                        string.Format(@"Patching pass-2 protein q into {0} sidecar(s)", perFileEntries.Count),
                        perFileEntries.Count, string.Empty, ProgressReporter.IO_INTERVAL_SECONDS))
             {
-            foreach (var kvp in perFileEntries)
-            {
-                progress.Report(++patchIdx);
-                if (!inputByName.TryGetValue(kvp.Key, out string inputFile))
-                    continue;
+                foreach (var kvp in perFileEntries)
+                {
+                    progress.Report(++patchIdx);
+                    if (!inputByName.TryGetValue(kvp.Key, out string inputFile))
+                        continue;
                     string pass2Path = FdrScoresSidecar.Pass2Path(inputFile);
                     // Two gates, deliberately, because ABSENT and UNUSABLE are different outcomes
                     // here and IsCurrentFormat alone cannot tell them apart (it is false for both).

--- a/pwiz_tools/Osprey/Osprey.Tasks/SecondPassFdrTask.cs
+++ b/pwiz_tools/Osprey/Osprey.Tasks/SecondPassFdrTask.cs
@@ -388,8 +388,18 @@ namespace pwiz.Osprey.Tasks
             // and an unpatched record keeps whatever it held when the sidecar was written -
             // the ResetScores default for every entry Stage 6 rescored or gap-filled, since
             // RestorePass1Scalars no longer seeds this field.
+            // The patch and the report writer below shared a 125 s silence on the 82-file SEA-AD
+            // run of 2026-08-14, between "N protein groups pass ..." and the blib write (#4571).
+            // Both are per-file/per-run and therefore countable; reported separately because they
+            // are independently expensive - the patch rewrites one sidecar field per file, while
+            // WriteReports RE-RUNS protein FDR once per run for the per-replicate counts.
             if (AnyReconciledParquet(config))
+            {
+                ctx.LogInfo(string.Format(
+                    @"Patching the 2nd-pass protein q-value into {0} file sidecar(s)...",
+                    perFileEntries.Count));
                 Pass2FdrSidecar.PatchPass2ProteinQvalues(ctx, perFileEntries);
+            }
 
             // Cross-impl bisection dump (env-var-gated, no-op in production).
             if (ctx.Diagnostics?.DumpDetectedPeptides ?? false)
@@ -414,6 +424,9 @@ namespace pwiz.Osprey.Tasks
             // full per-file pool + library in hand.
             if (config.WriteProteinReport || config.WriteSummaryReport)
             {
+                ctx.LogInfo(string.Format(
+                    @"Writing the protein and summary reports ({0} run(s), protein FDR re-run per run)...",
+                    perFileEntries.Count));
                 OspreyReportWriter.WriteReports(result, perFileEntries, fullLibrary, config, ctx.LogInfo);
             }
         }

--- a/pwiz_tools/Osprey/Osprey.Tasks/SecondPassFdrTask.cs
+++ b/pwiz_tools/Osprey/Osprey.Tasks/SecondPassFdrTask.cs
@@ -390,16 +390,13 @@ namespace pwiz.Osprey.Tasks
             // RestorePass1Scalars no longer seeds this field.
             // The patch and the report writer below shared a 125 s silence on the 82-file SEA-AD
             // run of 2026-08-14, between "N protein groups pass ..." and the blib write (#4571).
-            // Both are per-file/per-run and therefore countable; reported separately because they
-            // are independently expensive - the patch rewrites one sidecar field per file, while
-            // WriteReports RE-RUNS protein FDR once per run for the per-replicate counts.
+            // Each now carries its own ProgressReporter inside the callee rather than a heading
+            // here: a reporter prints its heading and then ONLY as many percent lines as the
+            // elapsed time needs, so a fast run costs one line and a slow one stays alive. An
+            // unconditional heading at the call site costs its line on every run forever, and
+            // duplicated the reporter's own heading to the same second.
             if (AnyReconciledParquet(config))
-            {
-                ctx.LogInfo(string.Format(
-                    @"Patching the 2nd-pass protein q-value into {0} file sidecar(s)...",
-                    perFileEntries.Count));
                 Pass2FdrSidecar.PatchPass2ProteinQvalues(ctx, perFileEntries);
-            }
 
             // Cross-impl bisection dump (env-var-gated, no-op in production).
             if (ctx.Diagnostics?.DumpDetectedPeptides ?? false)
@@ -424,9 +421,6 @@ namespace pwiz.Osprey.Tasks
             // full per-file pool + library in hand.
             if (config.WriteProteinReport || config.WriteSummaryReport)
             {
-                ctx.LogInfo(string.Format(
-                    @"Writing the protein and summary reports ({0} run(s), protein FDR re-run per run)...",
-                    perFileEntries.Count));
                 OspreyReportWriter.WriteReports(result, perFileEntries, fullLibrary, config, ctx.LogInfo);
             }
         }

--- a/pwiz_tools/Osprey/Osprey.Test/ProgressReporterTest.cs
+++ b/pwiz_tools/Osprey/Osprey.Test/ProgressReporterTest.cs
@@ -72,17 +72,55 @@ namespace pwiz.Osprey.Test
         }
 
         /// <summary>
+        /// The LogWaitTime / MinPercentTime levers, modelled on Skyline's LongWaitDlg delay: a
+        /// scope that finishes inside the wait leaves NO trace at all. The constructor bounds
+        /// both by the report interval, which is what makes the two display rules structural
+        /// rather than checked: the heading always precedes the first percent, and a scope that
+        /// showed a sub-100% percent always closes with 100%.
+        /// </summary>
+        [TestMethod]
+        public void TestProgressReporterSuppressesFastScopes()
+        {
+            // Inside the wait: nothing at all, heading included. Reported at 50% so this proves
+            // the THRESHOLD suppressed the output, not an absent Report call.
+            var fast = CaptureLines(total: 100, intervalSeconds: 60.0, heartbeatSeconds: 60.0,
+                act: p => p.Report(50), logWaitSeconds: 60.0, minPercentSeconds: 60.0);
+            Assert.AreEqual(0, fast.Count,
+                @"a scope finishing inside LogWaitTime must print nothing at all, heading included");
+
+            // Past MinPercentTime but still inside LogWaitTime, so no percent line was ever
+            // printed: the deferred heading must still come out WITH the completion line,
+            // never a bare 100% under no heading.
+            var announced = CaptureLines(total: 100, intervalSeconds: 60.0, heartbeatSeconds: 60.0,
+                act: p => p.Report(50), logWaitSeconds: 60.0, minPercentSeconds: 0.0);
+            Assert.AreEqual(2, announced.Count, @"expected the heading and its completion line");
+            StringAssert.Contains(announced[0], @"phase...");
+            StringAssert.Contains(announced[1], @"100%");
+
+            // Both thresholds are clamped to the interval, so asking for a wait longer than the
+            // reporting cadence cannot produce a scope that shows 50% and then never closes.
+            var partial = CaptureLines(total: 100, intervalSeconds: 0.0, heartbeatSeconds: 60.0,
+                act: p => p.Report(50), logWaitSeconds: 60.0, minPercentSeconds: 60.0);
+            StringAssert.Contains(string.Join("\n", partial), @"50%");
+            StringAssert.Contains(partial[partial.Count - 1], @"100%");
+        }
+
+        /// <summary>
         /// Run <paramref name="act"/> against a <see cref="ProgressReporter"/> whose output is
         /// captured through a scoped writer (AsyncLocal, so no cross-test static leak) and
         /// return the non-empty output lines.
         /// </summary>
         private static List<string> CaptureLines(long total, double intervalSeconds,
-            double heartbeatSeconds, Action<ProgressReporter> act)
+            double heartbeatSeconds, Action<ProgressReporter> act,
+            double logWaitSeconds = 0.0, double minPercentSeconds = 0.0)
         {
             var writer = new StringWriter();
             using (OspreyOutput.PushScopedOut(writer))
+            // logWait / minPercent default to 0 here so the display tests keep exercising the
+            // format at millisecond durations, the same reason they already inject a 0.05 s
+            // heartbeat. The suppression behaviour those two govern has its own tests below.
             using (var reporter = new ProgressReporter(@"phase", total, string.Empty,
-                intervalSeconds, heartbeatSeconds))
+                intervalSeconds, heartbeatSeconds, logWaitSeconds, minPercentSeconds))
             {
                 act(reporter);
             }


### PR DESCRIPTION
## Summary

* Reported the four Stage 7 steps that logged nothing for up to 151 s at a time on an
  82-file run, using `ProgressReporter` so a fast run costs one heading and a slow one
  emits only as many percent lines as the elapsed time needs
* Root-caused the longest silence to `RestorePass1Scalars`, which streams every file's
  PRE-compaction 1st-pass sidecar - 345,024,871 records at 82 files, not the 89 M
  survivors - and was invisible from both ends: its heading was `LogVerbose` and its
  duration went out as a filtered `[STAGE-WALL]` line
* Reported the blib pre-compress and row-emission passes, the pass-2 protein-q sidecar
  patch, the per-replicate protein FDR (which re-runs protein FDR once per run), and the
  model-diagnostics pass-2 build per card
* Reused the reduced precursor list for the FDP views instead of recomputing an identical
  reduction from the same inputs - ~16 s duplicated at 82 files, O(survivor observations)

`[COUNT]` could not serve at any of these sites: `OspreyOutput` filters
`[COUNT]`/`[TIMING]`/`[BENCH]`/`[STAGE-WALL]` unless `--perf-stats`, so
`WriteBlibOutput`'s five existing `[COUNT]` lines never reach a normal run. Adding another
would have looked like a fix and changed nothing. `Calibrator.cs:1564` records the same
trap from an earlier encounter.

Progress is reported from INSIDE the per-file loops rather than around the calls. A
caller-level heading would print and then go silent for the whole step, which merely defers
the gap to a larger dataset: these steps are O(survivor observations), so a 20 s silence at
82 files is ~40 s at 163 and ~120 s at 500.

Fixes #4571

## Test plan

- [x] `regression.ps1 -Dataset All` - output byte-identical, all modes PASS on all four
      datasets, including `mode 6 (library-fragment release engaged)` and the log-parsing
      legs (`Get-TaskCacheMap`, `Test-LibraryFragmentRelease`)
- [x] 579 unit tests + zero-warning ReSharper inspection
- [x] 82-file SEA-AD `--task SecondPassFDR` A/B, same hard-linked inputs, same box:
      **3 gaps >= 30 s / 248 s / max 127 s -> 0 gaps / max 23 s**
- [x] Discovery set unchanged across every run: 47,426 peptides, 6,096 protein groups,
      51,597 library spectra
- [x] Model-diagnostics pass-2 path exercised end-to-end (`--task FirstPassFDR` to mint the
      pass-1 sidecar, then `--task SecondPassFDR`), with a temporary sleep to force the slow
      path: reporter spanned it with percent lines, max interval 28 s, `gaps >= 30s : 0`

Not yet run: the TeamCity Perf/Regression config.

Co-Authored-By: Claude <noreply@anthropic.com>
