### PR TITLE
skyline: Fixed nightly failure in TestAlphaPeptDeepBuildLibrary

### DIFF
--- a/pwiz_tools/Skyline/Model/Lib/AlphaPeptDeep/AlphapeptdeepLibraryBuilder.cs
+++ b/pwiz_tools/Skyline/Model/Lib/AlphaPeptDeep/AlphapeptdeepLibraryBuilder.cs
@@ -104,7 +104,14 @@ namespace pwiz.Skyline.Model.Lib.AlphaPeptDeep
                 // We manually set numpy to the latest version before 2.0 because of a backward incompatibility issue
                 // See details for tracking issue in AlphaPeptDeep repo: https://github.com/MannLabs/alphapeptdeep/issues/190
                 // TODO: delete the following line after the issue above is resolved
-                new PythonPackage { Name = @"numpy", Version = @"1.26.4" }
+                new PythonPackage { Name = @"numpy", Version = @"1.26.4" },
+
+                // xxhash 4.0.0 (2026-08-12) stopped accepting str and now requires bytes, which breaks
+                // alphabase.peptide.precursor.hash_mod_seq_df ("TypeError: Strings must be encoded before hashing").
+                // alphabase only requires an unpinned "xxhash", so pip picks up 4.0.0. Pin to the version
+                // alphabase itself pins in its requirements.txt.
+                // TODO: delete the following line once alphabase encodes its strings before hashing
+                new PythonPackage { Name = @"xxhash", Version = @"3.5.0" }
             };
 
             return new PythonInstaller(packages, writer, AlphapeptdeepLibraryBuilder.ALPHAPEPTDEEP);


### PR DESCRIPTION
## Summary

* Pinned `xxhash` to 3.5.0 for the AlphaPeptDeep Python environment, fixing the nightly failure in `TestAlphaPeptDeepBuildLibrary`
* python-xxhash 4.0.0 (released 2026-08-12) stopped accepting `str` and now requires `bytes`, so alphabase's `hash_mod_seq_df` fails with `TypeError: Strings must be encoded before hashing` when `peptdeep cmd-flow` saves the library
* alphabase's install-time requirements list a bare, uncapped `xxhash` and Skyline installs `peptdeep` unpinned, so the first environment built after 2026-08-12 resolved to the broken version
* 3.5.0 is the version alphabase pins in its own `requirements.txt`. Same pattern as the existing numpy 1.26.4 workaround: `PipInstall` installs in list order, so peptdeep pulls 4.0.0 and the following entry downgrades it

This is not a Skyline regression, and neither Python nor AlphaPeptDeep changed. The embeddable interpreter is pinned at 3.9.13, and the offending alphabase line is unchanged since July 2024. Upgrading AlphaPeptDeep does not help either: the nightly already installs the newest peptdeep (1.5.1) and alphabase (1.9.1, released 2026-08-06), and no release fixes the unencoded hash call — `main` still has it. The pin can come out once alphabase encodes before hashing or caps `xxhash<4`.

Note that existing environments do not self-heal: `PipInstallPackagesTask.IsTaskComplete` returns true early when the virtual-env directory is signed, before it checks any versions. The nightly builds its tools directory fresh per run so it picks up the pin, but a dev machine with an already-signed AlphaPeptDeep environment needs it deleted.

## Test plan

- [x] `TestAlphaPeptDeepBuildLibrary` - passes, 0 failures, 193 sec (en-US, offscreen, internet on). The test sets `IsCleanPythonMode => true`, so it deletes the tools Python directory and rebuilds the virtual environment from scratch, meaning the pin is genuinely exercised rather than short-circuited by the signed-directory check
- [x] Rebuilt environment verified to contain `xxhash==3.5.0`, `alphabase==1.9.1`, `peptdeep==1.5.1`, `numpy==1.26.4`
- [x] Counterfactual verified: `pip install --dry-run xxhash` on the same Python 3.9 still reports "Would install xxhash-4.0.0"

Co-Authored-By: Claude <noreply@anthropic.com>
