### PR TITLE
pwiz: Added opt-in parallel decoding to the pwiz-sharp mzML reader

### DIFF
--- a/pwiz-sharp/pwiz/src/MsData/IReader.cs
+++ b/pwiz-sharp/pwiz/src/MsData/IReader.cs
@@ -217,9 +217,13 @@ public sealed class ReaderConfig
     ///     its own parallelism.
     ///   </item>
     ///   <item>
-    ///     A host that reads one file at a time wants this near the core count. Osprey funnels
-    ///     its reads through a one-permit gate for exactly that reason, so the read phase has
-    ///     the machine to itself and nothing competes with the decode.
+    ///     A host that reads one file at a time should set it, but modestly: measured on a
+    ///     5.99 GB Astral mzML, 1 thread takes 83.4s and 8 takes 54.6s, after which the curve
+    ///     is flat - 16, 24 and 32 all land within a second of 8. The floor is the XML parse,
+    ///     which stays serial, so past the knee extra threads only add memory pressure (each
+    ///     batch holds 64 spectra). 8 is a reasonable default; core count buys nothing.
+    ///     Osprey funnels its reads through a one-permit gate, so its read phase has the
+    ///     machine to itself and nothing competes with the decode.
     ///   </item>
     /// </list>
     /// <para>

--- a/pwiz-sharp/pwiz/src/MsData/IReader.cs
+++ b/pwiz-sharp/pwiz/src/MsData/IReader.cs
@@ -200,6 +200,41 @@ public sealed class ReaderConfig
     public bool VerifyNonEmptySpectraAtIndex { get; set; }
 
     /// <summary>
+    /// Threads used to decode mzML binary arrays. 1 (the default) decodes inline on the
+    /// read thread, which is the original behaviour; higher values parse a batch of spectra
+    /// with decoding deferred and then decode them in parallel.
+    /// </summary>
+    /// <remarks>
+    /// Off by default because the host, not this library, knows what else is already running.
+    /// The two shapes differ enough that neither default suits both:
+    /// <list type="bullet">
+    ///   <item>
+    ///     Skyline and MsConvertGUI process multiple FILES at once. That is the established
+    ///     answer for vendor formats, which are not purely I/O bound and go faster several at
+    ///     a time - and where per-file threading is the only safe axis, since a vendor reader
+    ///     is thread-safe on its own thread but not necessarily for concurrent spectrum
+    ///     retrieval. A host doing that should leave this at 1 rather than go wide underneath
+    ///     its own parallelism.
+    ///   </item>
+    ///   <item>
+    ///     A host that reads one file at a time wants this near the core count. Osprey funnels
+    ///     its reads through a one-permit gate for exactly that reason, so the read phase has
+    ///     the machine to itself and nothing competes with the decode.
+    ///   </item>
+    /// </list>
+    /// <para>
+    /// Note what this does and does not parallelise. The XML parse stays single-threaded on
+    /// the one stream; only the base64/zlib decode of already-extracted payloads goes wide. So
+    /// no reader is ever asked for spectra concurrently, and this composes with a host's
+    /// per-file parallelism rather than contending with it for thread-safety. It is honoured
+    /// by the mzML reader alone, in the same way <see cref="VerifyNonEmptySpectraAtIndex"/> is
+    /// read by one reader. Values below 1 are treated as 1, and the count is clamped to the
+    /// processor count.
+    /// </para>
+    /// </remarks>
+    public int MzmlDecodeThreads { get; set; } = 1;
+
+    /// <summary>
     /// When true, MS2+ spectra without precursor info are kept rather than dropped. The
     /// default (false) drops them, matching pwiz cpp. Port of
     /// <c>pwiz::msdata::Reader::Config::allowMsMsWithoutPrecursor</c>.

--- a/pwiz-sharp/pwiz/src/MsData/IReader.cs
+++ b/pwiz-sharp/pwiz/src/MsData/IReader.cs
@@ -227,6 +227,13 @@ public sealed class ReaderConfig
     ///   </item>
     /// </list>
     /// <para>
+    /// Read-ahead engages only for a caller walking indices FORWARD. Anything else - reading
+    /// backward, by permutation, strided, or metadata-then-peaks for the same index - falls
+    /// back to the original per-spectrum path. Measured on the same 5.99 GB file, a reverse
+    /// walk takes 81.2s and a random walk 82.4s whether this is 1 or 8, so a non-linear
+    /// reader pays nothing for having it on; it simply gains nothing.
+    /// </para>
+    /// <para>
     /// Note what this does and does not parallelise. The XML parse stays single-threaded on
     /// the one stream; only the base64/zlib decode of already-extracted payloads goes wide. So
     /// no reader is ever asked for spectra concurrently, and this composes with a host's

--- a/pwiz-sharp/pwiz/src/MsData/MzMlbReaderAdapter.cs
+++ b/pwiz-sharp/pwiz/src/MsData/MzMlbReaderAdapter.cs
@@ -114,7 +114,8 @@ public sealed class MzMlbReaderAdapter : IReader
                     ids: idx.Value.SpectrumIds,
                     offsets: idx.Value.SpectrumOffsets,
                     dp: dpPwiz,
-                    source: filename);
+                    source: filename,
+                    decodeThreads: config?.MzmlDecodeThreads ?? 1);
                 conn = null!; // ownership transferred to SpectrumList_Mzml
                 return;
             }

--- a/pwiz-sharp/pwiz/src/MsData/Mzml/SpectrumList_Mzml.cs
+++ b/pwiz-sharp/pwiz/src/MsData/Mzml/SpectrumList_Mzml.cs
@@ -73,10 +73,28 @@ public sealed class SpectrumList_Mzml : SpectrumListBase
     private const int BatchSize = 64;
     private readonly System.Collections.Generic.Dictionary<int, Spectrum> _batch = new();
 
+    // The index a forward-walking caller would ask for next; -1 until the first read.
+    // Read-ahead only engages when the request matches, so a random-access caller pays
+    // nothing beyond the original per-spectrum path.
+    private int _nextSequential = -1;
+
     private static int ReadThreadSetting()
     {
         var raw = System.Environment.GetEnvironmentVariable("PWIZ_SHARP_MZML_DECODE_THREADS");
-        return int.TryParse(raw, out int n) && n > 1 ? n : 1;
+        if (string.IsNullOrEmpty(raw))
+            return 1;
+
+        // 0 and -1 are the natural spellings of "all cores" and .NET's "unlimited", so
+        // silently treating them as "off" would leave someone reporting that the speedup
+        // does not reproduce. Map them to the core count instead, and clamp the top end:
+        // this work is CPU-bound inflate-plus-convert, so more threads than cores only
+        // adds contention - and the host may already be parallelising across files.
+        if (!int.TryParse(raw, System.Globalization.NumberStyles.Integer,
+                          System.Globalization.CultureInfo.InvariantCulture, out int n))
+            return 1;
+        if (n <= 0)
+            return System.Environment.ProcessorCount;
+        return System.Math.Min(n, System.Environment.ProcessorCount);
     }
 
     /// <summary>Constructs a lazy spectrum list backed by an arbitrary seekable stream.
@@ -163,12 +181,29 @@ public sealed class SpectrumList_Mzml : SpectrumListBase
             if (threads > 1 && getBinaryData)
             {
                 if (_batch.Remove(index, out var cached))
+                {
+                    _nextSequential = index + 1;
                     return cached;
-                FillBatch(index, threads);
-                if (_batch.Remove(index, out cached))
-                    return cached;
+                }
+
+                // Only read ahead when the caller is actually walking forward. Filters that
+                // read backward (SpectrumList_PrecursorRefine), by permutation
+                // (SpectrumListSorter) or scattered across the run (SpectrumListScanSummer)
+                // would otherwise parse and decode a fresh 64-spectrum batch for every
+                // single spectrum served - turning the feature into a large slowdown rather
+                // than, as an earlier comment here wrongly claimed, merely "not benefiting".
+                if (index == _nextSequential || _nextSequential < 0)
+                {
+                    FillBatch(index, threads);
+                    if (_batch.Remove(index, out cached))
+                    {
+                        _nextSequential = index + 1;
+                        return cached;
+                    }
+                }
             }
 
+            _nextSequential = index + 1;
             return ReadOne(index, getBinaryData);
         }
     }
@@ -177,8 +212,6 @@ public sealed class SpectrumList_Mzml : SpectrumListBase
     /// whole batch in parallel. Caller holds <see cref="_streamLock"/>.</summary>
     private void FillBatch(int start, int threads)
     {
-        // Anything still buffered belongs to a previous, non-sequential position; a reader
-        // that jumps around gets correctness from ReadOne and simply stops benefiting.
         _batch.Clear();
 
         int end = System.Math.Min(start + BatchSize, _offsets.Length);
@@ -188,21 +221,50 @@ public sealed class SpectrumList_Mzml : SpectrumListBase
         {
             for (int i = start; i < end; i++)
                 _batch[i] = ReadOne(i, getBinaryData: true);
+
+            if (pending.Count > 0)
+                DecodeInParallel(pending, threads);
+        }
+        catch
+        {
+            // EVERY entry in _batch is parsed but NOT yet decoded until DecodeInParallel
+            // returns, so a failure anywhere above leaves spectra whose binary arrays are
+            // empty. Serving those would be silent data loss rather than an error - a host
+            // with ContinueOnError would write a whole batch of spectra with no peaks and
+            // report only the one failure. Dropping the batch makes the next read take the
+            // single-spectrum path, which fails honestly on the spectrum that is actually
+            // broken.
+            _batch.Clear();
+            throw;
         }
         finally
         {
-            // Must clear even on a parse failure, or the next non-batched read would
-            // silently produce spectra with empty arrays.
             _context.PendingDecodes = null;
         }
+    }
 
-        if (pending.Count == 0)
-            return;
-
-        System.Threading.Tasks.Parallel.ForEach(
-            pending,
-            new System.Threading.Tasks.ParallelOptions { MaxDegreeOfParallelism = threads },
-            item => item.Run());
+    /// <summary>Runs the deferred decodes, preserving the exception a sequential read would
+    /// have thrown.</summary>
+    private static void DecodeInParallel(
+        System.Collections.Generic.List<MzmlReader.PendingDecode> pending, int threads)
+    {
+        try
+        {
+            System.Threading.Tasks.Parallel.ForEach(
+                pending,
+                new System.Threading.Tasks.ParallelOptions { MaxDegreeOfParallelism = threads },
+                item => item.Run());
+        }
+        catch (System.AggregateException ex) when (ex.InnerException is not null)
+        {
+            // Parallel.ForEach wraps everything in AggregateException, so a caller
+            // catching FormatException from a corrupt base64 payload - which is what the
+            // sequential path throws - would stop matching the moment decoding went
+            // parallel. Rethrow the original with its stack intact so turning threads on
+            // cannot change which handler fires.
+            System.Runtime.ExceptionServices.ExceptionDispatchInfo
+                .Capture(ex.InnerException).Throw();
+        }
     }
 
     /// <summary>The original single-spectrum read. Caller holds <see cref="_streamLock"/>.</summary>
@@ -242,6 +304,9 @@ public sealed class SpectrumList_Mzml : SpectrumListBase
         {
             if (_disposed) return;
             _disposed = true;
+            // A batch of profile MS1 spectra is gigabytes; without this they stay reachable
+            // from a disposed list for as long as anything holds a reference to it.
+            _batch.Clear();
             _stream?.Dispose();
             _stream = null;
             _ownedResource?.Dispose();

--- a/pwiz-sharp/pwiz/src/MsData/Mzml/SpectrumList_Mzml.cs
+++ b/pwiz-sharp/pwiz/src/MsData/Mzml/SpectrumList_Mzml.cs
@@ -55,21 +55,15 @@ public sealed class SpectrumList_Mzml : SpectrumListBase
     // wide. Results are identical and order is unchanged - decode is a pure function of
     // payload plus config, and each spectrum is keyed by its own index.
     //
-    /// <summary>
-    /// Maximum threads used to decode binary arrays. 1 (the default) keeps the original
-    /// fully sequential behaviour, so this changes nothing until a host opts in.
-    ///
-    /// The host decides, not this class: a caller that already parallelises across FILES -
-    /// Osprey scores several at once - would oversubscribe the machine if the library went
-    /// wide on its own. Seeded from PWIZ_SHARP_MZML_DECODE_THREADS so it can be set for a
-    /// process that cannot easily be recompiled (benchmarks, msconvert runs), but the
-    /// property is the real interface.
-    ///
-    /// A static rather than a per-read option deliberately: it is a machine-level resource
-    /// decision, set once at startup, and threading it through ReaderConfig would touch
-    /// every reader for a setting only this one honours. Easy to move if that is preferred.
-    /// </summary>
-    public static int DecodeThreads { get; set; } = ReadThreadSetting();
+    // Threads used to decode binary arrays, from ReaderConfig.MzmlDecodeThreads. 1 keeps the
+    // original fully sequential behaviour, so this changes nothing until a host opts in.
+    private readonly int _decodeThreads;
+
+    /// <summary>The decode-thread count actually in effect, after clamping. Exposed so a
+    /// test can prove the ReaderConfig value reached this far: comparing one-thread output
+    /// against eight-thread output cannot tell a correctly wired setting apart from one that
+    /// never arrived, since both would then decode sequentially and agree.</summary>
+    internal int DecodeThreadsInEffect => _decodeThreads;
     private const int BatchSize = 64;
     private readonly System.Collections.Generic.Dictionary<int, Spectrum> _batch = new();
 
@@ -78,24 +72,6 @@ public sealed class SpectrumList_Mzml : SpectrumListBase
     // nothing beyond the original per-spectrum path.
     private int _nextSequential = -1;
 
-    private static int ReadThreadSetting()
-    {
-        var raw = System.Environment.GetEnvironmentVariable("PWIZ_SHARP_MZML_DECODE_THREADS");
-        if (string.IsNullOrEmpty(raw))
-            return 1;
-
-        // 0 and -1 are the natural spellings of "all cores" and .NET's "unlimited", so
-        // silently treating them as "off" would leave someone reporting that the speedup
-        // does not reproduce. Map them to the core count instead, and clamp the top end:
-        // this work is CPU-bound inflate-plus-convert, so more threads than cores only
-        // adds contention - and the host may already be parallelising across files.
-        if (!int.TryParse(raw, System.Globalization.NumberStyles.Integer,
-                          System.Globalization.CultureInfo.InvariantCulture, out int n))
-            return 1;
-        if (n <= 0)
-            return System.Environment.ProcessorCount;
-        return System.Math.Min(n, System.Environment.ProcessorCount);
-    }
 
     /// <summary>Constructs a lazy spectrum list backed by an arbitrary seekable stream.
     /// <paramref name="openStream"/> is invoked once on first access — for plain mzML
@@ -105,8 +81,9 @@ public sealed class SpectrumList_Mzml : SpectrumListBase
     /// for the list's lifetime).</summary>
     internal SpectrumList_Mzml(System.Func<Stream> openStream, System.IDisposable? ownedResource,
                                 MzmlReader context, string[] ids, long[] offsets,
-                                DataProcessing? dp, string source)
+                                DataProcessing? dp, string source, int decodeThreads = 1)
     {
+        _decodeThreads = System.Math.Max(1, System.Math.Min(decodeThreads, System.Environment.ProcessorCount));
         _openStream = openStream;
         _ownedResource = ownedResource;
         _context = context;
@@ -118,12 +95,14 @@ public sealed class SpectrumList_Mzml : SpectrumListBase
 
     /// <summary>File-backed convenience overload used by <c>MzmlReaderAdapter</c>.</summary>
     internal SpectrumList_Mzml(string filename, MzmlReader context,
-                                string[] ids, long[] offsets, DataProcessing? dp)
+                                string[] ids, long[] offsets, DataProcessing? dp,
+                                int decodeThreads = 1)
         : this(
               openStream: () => new FileStream(filename, FileMode.Open, FileAccess.Read, FileShare.Read,
                                                 bufferSize: 1 << 16, FileOptions.RandomAccess),
               ownedResource: null,
-              context: context, ids: ids, offsets: offsets, dp: dp, source: filename)
+              context: context, ids: ids, offsets: offsets, dp: dp, source: filename,
+              decodeThreads: decodeThreads)
     { }
 
     /// <inheritdoc/>
@@ -177,7 +156,7 @@ public sealed class SpectrumList_Mzml : SpectrumListBase
 
             // Only worth batching when the caller actually wants peaks: a metadata-only
             // read decodes nothing, so there is nothing to parallelise.
-            int threads = DecodeThreads;
+            int threads = _decodeThreads;
             if (threads > 1 && getBinaryData)
             {
                 if (_batch.Remove(index, out var cached))

--- a/pwiz-sharp/pwiz/src/MsData/Mzml/SpectrumList_Mzml.cs
+++ b/pwiz-sharp/pwiz/src/MsData/Mzml/SpectrumList_Mzml.cs
@@ -44,6 +44,30 @@ public sealed class SpectrumList_Mzml : SpectrumListBase
     private readonly object _streamLock = new();
     private bool _disposed;
 
+    // Parallel-decode batch. Sequential readers (every search engine, and Skyline's
+    // chromatogram extraction) walk indices in order, so when one asks for spectrum i we
+    // parse i..i+BatchSize-1 in one pass - cheap, the XML scan is not the expensive part -
+    // deferring every base64/zlib decode, then run those decodes on the thread pool and
+    // hand out the batch from here.
+    //
+    // Parsing stays single-threaded and keeps using the one stream, so this needs no
+    // reentrancy work in MzmlReader and no second file handle; only the pure decode goes
+    // wide. Results are identical and order is unchanged - decode is a pure function of
+    // payload plus config, and each spectrum is keyed by its own index.
+    //
+    // Opt-in and off by default: PWIZ_SHARP_MZML_DECODE_THREADS=<n>. A host that already
+    // parallelises across FILES (Osprey scores several at once) would otherwise oversubscribe
+    // the machine, so the decision belongs to the host, not to this class.
+    private static readonly int DecodeThreads = ReadThreadSetting();
+    private const int BatchSize = 64;
+    private readonly System.Collections.Generic.Dictionary<int, Spectrum> _batch = new();
+
+    private static int ReadThreadSetting()
+    {
+        var raw = System.Environment.GetEnvironmentVariable("PWIZ_SHARP_MZML_DECODE_THREADS");
+        return int.TryParse(raw, out int n) && n > 1 ? n : 1;
+    }
+
     /// <summary>Constructs a lazy spectrum list backed by an arbitrary seekable stream.
     /// <paramref name="openStream"/> is invoked once on first access — for plain mzML
     /// it returns a new FileStream; for mzMLb it returns the mzML dataset stream from
@@ -121,6 +145,58 @@ public sealed class SpectrumList_Mzml : SpectrumListBase
         lock (_streamLock)
         {
             System.ObjectDisposedException.ThrowIf(_disposed, this);
+
+            // Only worth batching when the caller actually wants peaks: a metadata-only
+            // read decodes nothing, so there is nothing to parallelise.
+            if (DecodeThreads > 1 && getBinaryData)
+            {
+                if (_batch.Remove(index, out var cached))
+                    return cached;
+                FillBatch(index);
+                if (_batch.Remove(index, out cached))
+                    return cached;
+            }
+
+            return ReadOne(index, getBinaryData);
+        }
+    }
+
+    /// <summary>Parses [start, start+BatchSize) with decoding deferred, then decodes the
+    /// whole batch in parallel. Caller holds <see cref="_streamLock"/>.</summary>
+    private void FillBatch(int start)
+    {
+        // Anything still buffered belongs to a previous, non-sequential position; a reader
+        // that jumps around gets correctness from ReadOne and simply stops benefiting.
+        _batch.Clear();
+
+        int end = System.Math.Min(start + BatchSize, _offsets.Length);
+        var pending = new System.Collections.Generic.List<MzmlReader.PendingDecode>();
+        _context.PendingDecodes = pending;
+        try
+        {
+            for (int i = start; i < end; i++)
+                _batch[i] = ReadOne(i, getBinaryData: true);
+        }
+        finally
+        {
+            // Must clear even on a parse failure, or the next non-batched read would
+            // silently produce spectra with empty arrays.
+            _context.PendingDecodes = null;
+        }
+
+        if (pending.Count == 0)
+            return;
+
+        System.Threading.Tasks.Parallel.ForEach(
+            pending,
+            new System.Threading.Tasks.ParallelOptions { MaxDegreeOfParallelism = DecodeThreads },
+            item => item.Run());
+    }
+
+    /// <summary>The original single-spectrum read. Caller holds <see cref="_streamLock"/>.</summary>
+    private Spectrum ReadOne(int index, bool getBinaryData)
+    {
+        {
             _stream ??= _openStream();
             _stream.Position = _offsets[index];
 

--- a/pwiz-sharp/pwiz/src/MsData/Mzml/SpectrumList_Mzml.cs
+++ b/pwiz-sharp/pwiz/src/MsData/Mzml/SpectrumList_Mzml.cs
@@ -55,10 +55,21 @@ public sealed class SpectrumList_Mzml : SpectrumListBase
     // wide. Results are identical and order is unchanged - decode is a pure function of
     // payload plus config, and each spectrum is keyed by its own index.
     //
-    // Opt-in and off by default: PWIZ_SHARP_MZML_DECODE_THREADS=<n>. A host that already
-    // parallelises across FILES (Osprey scores several at once) would otherwise oversubscribe
-    // the machine, so the decision belongs to the host, not to this class.
-    private static readonly int DecodeThreads = ReadThreadSetting();
+    /// <summary>
+    /// Maximum threads used to decode binary arrays. 1 (the default) keeps the original
+    /// fully sequential behaviour, so this changes nothing until a host opts in.
+    ///
+    /// The host decides, not this class: a caller that already parallelises across FILES -
+    /// Osprey scores several at once - would oversubscribe the machine if the library went
+    /// wide on its own. Seeded from PWIZ_SHARP_MZML_DECODE_THREADS so it can be set for a
+    /// process that cannot easily be recompiled (benchmarks, msconvert runs), but the
+    /// property is the real interface.
+    ///
+    /// A static rather than a per-read option deliberately: it is a machine-level resource
+    /// decision, set once at startup, and threading it through ReaderConfig would touch
+    /// every reader for a setting only this one honours. Easy to move if that is preferred.
+    /// </summary>
+    public static int DecodeThreads { get; set; } = ReadThreadSetting();
     private const int BatchSize = 64;
     private readonly System.Collections.Generic.Dictionary<int, Spectrum> _batch = new();
 
@@ -148,11 +159,12 @@ public sealed class SpectrumList_Mzml : SpectrumListBase
 
             // Only worth batching when the caller actually wants peaks: a metadata-only
             // read decodes nothing, so there is nothing to parallelise.
-            if (DecodeThreads > 1 && getBinaryData)
+            int threads = DecodeThreads;
+            if (threads > 1 && getBinaryData)
             {
                 if (_batch.Remove(index, out var cached))
                     return cached;
-                FillBatch(index);
+                FillBatch(index, threads);
                 if (_batch.Remove(index, out cached))
                     return cached;
             }
@@ -163,7 +175,7 @@ public sealed class SpectrumList_Mzml : SpectrumListBase
 
     /// <summary>Parses [start, start+BatchSize) with decoding deferred, then decodes the
     /// whole batch in parallel. Caller holds <see cref="_streamLock"/>.</summary>
-    private void FillBatch(int start)
+    private void FillBatch(int start, int threads)
     {
         // Anything still buffered belongs to a previous, non-sequential position; a reader
         // that jumps around gets correctness from ReadOne and simply stops benefiting.
@@ -189,7 +201,7 @@ public sealed class SpectrumList_Mzml : SpectrumListBase
 
         System.Threading.Tasks.Parallel.ForEach(
             pending,
-            new System.Threading.Tasks.ParallelOptions { MaxDegreeOfParallelism = DecodeThreads },
+            new System.Threading.Tasks.ParallelOptions { MaxDegreeOfParallelism = threads },
             item => item.Run());
     }
 

--- a/pwiz-sharp/pwiz/src/MsData/MzmlReader.cs
+++ b/pwiz-sharp/pwiz/src/MsData/MzmlReader.cs
@@ -76,6 +76,45 @@ public sealed class MzmlReader
     /// </summary>
     private bool _skipBinaryData;
 
+    /// <summary>
+    /// When non-null, <see cref="ReadBinaryDataArray"/> records the base64 payload and its
+    /// encoder config here INSTEAD of decoding it, so the caller can run the decodes
+    /// elsewhere - in practice on a thread pool, across a batch of spectra.
+    ///
+    /// This is sound because decoding is already a pure function of (payload, config):
+    /// <see cref="BinaryDataEncoder"/> holds nothing but a readonly config and its decode
+    /// helpers are static, and a fresh encoder is constructed per array. Nothing in the
+    /// decode path touches the reader's reference maps or <see cref="_skipBinaryData"/>,
+    /// so deferring it changes only WHERE the work happens, never the result.
+    ///
+    /// XML parsing itself stays single-threaded - the collector is filled during a
+    /// sequential parse - so this needs no reentrancy work on the reader and no second
+    /// stream. That is deliberately the cheap half of the problem: on an mzML with 64-bit
+    /// zlib arrays the inflate-plus-convert dominates, and it is the half that parallelises.
+    /// </summary>
+    internal List<PendingDecode>? PendingDecodes { get; set; }
+
+    /// <summary>One deferred binary-array decode: everything needed to produce the values,
+    /// and nothing shared with any other pending decode.</summary>
+    internal sealed class PendingDecode
+    {
+        internal BinaryDataArray? DoubleArray;
+        internal IntegerDataArray? IntegerArray;
+        internal string Base64 = string.Empty;
+        internal BinaryEncoderConfig Config = new();
+
+        /// <summary>Decodes into the target array. Safe to call concurrently with other
+        /// PendingDecode instances: each owns its own target array and encoder.</summary>
+        internal void Run()
+        {
+            var encoder = new BinaryDataEncoder(Config);
+            if (IntegerArray is not null)
+                IntegerArray.Data.AddRange(encoder.DecodeIntegers(Base64));
+            else if (DoubleArray is not null)
+                DoubleArray.Data.AddRange(encoder.DecodeDoubles(Base64));
+        }
+    }
+
     /// <summary>Parses mzML from a string.</summary>
     public MSData Read(string mzml)
     {
@@ -826,7 +865,13 @@ public sealed class MzmlReader
             var arr = new IntegerDataArray { DataProcessing = dp };
             CopyParams(tempParams, arr);
             if (!_skipBinaryData && base64 is not null && base64.Length > 0)
-                arr.Data.AddRange(new BinaryDataEncoder(encoderConfig).DecodeIntegers(base64));
+            {
+                if (PendingDecodes is not null)
+                    PendingDecodes.Add(new PendingDecode
+                        { IntegerArray = arr, Base64 = base64, Config = encoderConfig });
+                else
+                    arr.Data.AddRange(new BinaryDataEncoder(encoderConfig).DecodeIntegers(base64));
+            }
             integerArrays.Add(arr);
         }
         else
@@ -834,7 +879,13 @@ public sealed class MzmlReader
             var arr = new BinaryDataArray { DataProcessing = dp };
             CopyParams(tempParams, arr);
             if (!_skipBinaryData && base64 is not null && base64.Length > 0)
-                arr.Data.AddRange(new BinaryDataEncoder(encoderConfig).DecodeDoubles(base64));
+            {
+                if (PendingDecodes is not null)
+                    PendingDecodes.Add(new PendingDecode
+                        { DoubleArray = arr, Base64 = base64, Config = encoderConfig });
+                else
+                    arr.Data.AddRange(new BinaryDataEncoder(encoderConfig).DecodeDoubles(base64));
+            }
             doubleArrays.Add(arr);
         }
         r.Read();

--- a/pwiz-sharp/pwiz/src/MsData/MzmlReaderAdapter.cs
+++ b/pwiz-sharp/pwiz/src/MsData/MzmlReaderAdapter.cs
@@ -70,7 +70,8 @@ public sealed class MzmlReaderAdapter : IReader
             // at the same spot (DefaultReaderList.cpp:168).
             var dpPwiz = MSDataFile.FillInCommonMetadata(filename, result);
             result.Run.SpectrumList = new SpectrumList_Mzml(filename, lazyReader,
-                idx.SpectrumIds, idx.SpectrumOffsets, dpPwiz);
+                idx.SpectrumIds, idx.SpectrumOffsets, dpPwiz,
+                config?.MzmlDecodeThreads ?? 1);
             return;
         }
 

--- a/pwiz-sharp/pwiz/test/MsData.Tests/Mzml/MzmlParallelDecodeTests.cs
+++ b/pwiz-sharp/pwiz/test/MsData.Tests/Mzml/MzmlParallelDecodeTests.cs
@@ -1,6 +1,8 @@
 using System.IO;
+using Pwiz.Data.Common.Cv;
 using Pwiz.Data.MsData.Mzml;
 using Pwiz.Data.MsData.Readers;
+using Pwiz.Data.MsData.Spectra;
 
 namespace Pwiz.Data.MsData.Tests.Mzml;
 
@@ -12,83 +14,201 @@ namespace Pwiz.Data.MsData.Tests.Mzml;
 /// That holds because decoding is a pure function of (base64 payload, encoder config) -
 /// <c>BinaryDataEncoder</c> carries nothing but a readonly config and its helpers are
 /// static - but "it should be pure" is an argument, and this is the check. Exact equality,
-/// not a tolerance: the same bytes through the same decoder must give the same doubles, and
-/// any tolerance here would hide the reordering bug this test exists to catch.
+/// not a tolerance: any tolerance here would hide the reordering bug the test exists to
+/// catch.
+///
+/// The peak fixture is <c>tiny.pwiz.1.1.mzML</c>, which the test project already copies to
+/// the output directory, so this cannot silently skip on a machine lacking the cpp test
+/// tree, and it is indexed so the lazy list is genuinely used. It carries no INTEGER binary
+/// array, so the integer half of the deferral code gets a written fixture of its own below.
 /// </summary>
 [TestClass]
 public class MzmlParallelDecodeTests
 {
-    private static string? FindCppTestDataDir()
+    private static string FixturePath()
     {
-        string? dir = AppContext.BaseDirectory;
-        while (!string.IsNullOrEmpty(dir))
-        {
-            string candidate = Path.Combine(dir, "pwiz", "analysis", "spectrum_processing",
-                "SpectrumList_DiaUmpireTest.data");
-            if (Directory.Exists(candidate)) return candidate;
-            dir = Path.GetDirectoryName(dir);
-        }
-        return null;
+        string path = Path.Combine(AppContext.BaseDirectory, "example_data", "tiny.pwiz.1.1.mzML");
+        Assert.IsTrue(File.Exists(path), $"fixture missing: {path}");
+        return path;
     }
 
     [TestMethod]
     public void ParallelDecode_ProducesIdenticalSpectraToSequential()
     {
-        string? dataDir = FindCppTestDataDir();
-        if (dataDir is null) { Assert.Inconclusive("cpp test data dir not found"); return; }
-        string path = Path.Combine(dataDir,
-            "Hoofnagle_10xDil_SWATH_01-20130327_Hoofnagle_10xDil_SWATH_1_01-diaumpire.mzML");
-        if (!File.Exists(path)) { Assert.Inconclusive($"fixture missing: {path}"); return; }
+        string path = FixturePath();
 
         var sequential = ReadAll(path, threads: 1);
         var parallel = ReadAll(path, threads: 8);
 
-        Assert.IsTrue(sequential.Count > 1, "fixture produced too few spectra to be a real check");
         Assert.AreEqual(sequential.Count, parallel.Count, "spectrum count differs");
+        Assert.IsTrue(sequential.Count > 1, "fixture produced too few spectra to be a real check");
+
+        // Without this the comparison below can pass while comparing nothing: if every array
+        // came back empty, each length assert would be AreEqual(0, 0) and each loop body
+        // would execute zero times. Assert up front that there is real data to compare.
+        int totalValues = 0;
+        foreach (var s in sequential)
+            totalValues += s.Mz.Length + s.Intensity.Length + s.Integers.Length;
+        Assert.IsTrue(totalValues > 0, "fixture decoded no binary data, so this test proves nothing");
 
         for (int i = 0; i < sequential.Count; i++)
         {
-            var (seqId, seqMz, seqIntensity) = sequential[i];
-            var (parId, parMz, parIntensity) = parallel[i];
+            var seq = sequential[i];
+            var par = parallel[i];
 
-            // Identity first: a batch served out of order would show up here rather than as
-            // a confusing array mismatch.
-            Assert.AreEqual(seqId, parId, $"spectrum {i} id differs");
-            Assert.AreEqual(seqMz.Length, parMz.Length, $"spectrum {i} m/z length differs");
-            Assert.AreEqual(seqIntensity.Length, parIntensity.Length,
-                $"spectrum {i} intensity length differs");
+            // Identity first: a batch served out of order shows up here rather than as a
+            // confusing array mismatch.
+            Assert.AreEqual(seq.Id, par.Id, $"spectrum {i} id differs");
+            AssertArraysEqual(seq.Mz, par.Mz, i, "m/z");
+            AssertArraysEqual(seq.Intensity, par.Intensity, i, "intensity");
 
-            for (int j = 0; j < seqMz.Length; j++)
-                Assert.AreEqual(seqMz[j], parMz[j], 0.0, $"spectrum {i} m/z[{j}] differs");
-            for (int j = 0; j < seqIntensity.Length; j++)
-                Assert.AreEqual(seqIntensity[j], parIntensity[j], 0.0,
-                    $"spectrum {i} intensity[{j}] differs");
+            Assert.AreEqual(seq.Integers.Length, par.Integers.Length, $"spectrum {i} integer length");
+            for (int j = 0; j < seq.Integers.Length; j++)
+                Assert.AreEqual(seq.Integers[j], par.Integers[j], $"spectrum {i} integer[{j}] differs");
         }
     }
+
+    /// <summary>
+    /// Covers the half of the deferral code the peak arrays never reach:
+    /// <c>PendingDecode.IntegerArray</c>. No shipped mzML fixture carries an integer binary
+    /// array - the assertion that first went looking for one failed - so this writes an
+    /// indexed mzML that does, then reads it back both ways.
+    /// </summary>
+    [TestMethod]
+    public void ParallelDecode_IntegerArraysMatchSequential()
+    {
+        var msd = new MSData();
+        var simple = new SpectrumListSimple();
+        for (int i = 0; i < 8; i++)
+        {
+            var spectrum = new Spectrum { Index = i, Id = $"scan={i + 1}" };
+            spectrum.Params.Set(CVID.MS_ms_level, 1);
+            var mz = new BinaryDataArray();
+            mz.Params.Set(CVID.MS_m_z_array);
+            var intensity = new BinaryDataArray();
+            intensity.Params.Set(CVID.MS_intensity_array);
+            var counts = new IntegerDataArray();
+            counts.Params.Set(CVID.MS_non_standard_data_array, "drift bin");
+            for (int j = 0; j < 32; j++)
+            {
+                mz.Data.Add(100.0 + i + (j * 0.25));
+                intensity.Data.Add(1000.0 + j);
+                counts.Data.Add((i * 100L) + j);
+            }
+            spectrum.BinaryDataArrays.Add(mz);
+            spectrum.BinaryDataArrays.Add(intensity);
+            spectrum.IntegerDataArrays.Add(counts);
+            simple.Spectra.Add(spectrum);
+        }
+        msd.Run.SpectrumList = simple;
+
+        string path = Path.Combine(Path.GetTempPath(),
+            $"pwiz-parallel-decode-{Guid.NewGuid():N}.mzML");
+        try
+        {
+            File.WriteAllText(path, new MzmlWriter().Write(msd));
+
+            var sequential = ReadAll(path, threads: 1);
+            var parallel = ReadAll(path, threads: 8);
+
+            int integerValues = 0;
+            foreach (var spectrum in sequential)
+                integerValues += spectrum.Integers.Length;
+            Assert.IsTrue(integerValues > 0, "written fixture carried no integer array");
+
+            Assert.AreEqual(sequential.Count, parallel.Count);
+            for (int i = 0; i < sequential.Count; i++)
+            {
+                Assert.AreEqual(sequential[i].Integers.Length, parallel[i].Integers.Length,
+                    $"spectrum {i} integer length differs");
+                for (int j = 0; j < sequential[i].Integers.Length; j++)
+                    Assert.AreEqual(sequential[i].Integers[j], parallel[i].Integers[j],
+                        $"spectrum {i} integer[{j}] differs");
+            }
+        }
+        finally
+        {
+            if (File.Exists(path)) File.Delete(path);
+        }
+    }
+
+    /// <summary>
+    /// Read-ahead must not change what a caller reading BACKWARD sees. That path skips the
+    /// batch entirely, so this pins that the fallback still returns correct spectra rather
+    /// than whatever a stale batch happens to hold.
+    /// </summary>
+    [TestMethod]
+    public void ParallelDecode_ReverseOrderMatchesSequential()
+    {
+        string path = FixturePath();
+        var expected = ReadAll(path, threads: 1);
+
+        int previous = SpectrumList_Mzml.DecodeThreads;
+        SpectrumList_Mzml.DecodeThreads = 8;
+        try
+        {
+            using var msd = new MSData();
+            ReaderList.Default.Read(path, msd, 0, new ReaderConfig());
+            var list = msd.Run.SpectrumList;
+            Assert.IsNotNull(list);
+
+            for (int i = expected.Count - 1; i >= 0; i--)
+            {
+                var spectrum = list.GetSpectrum(i, getBinaryData: true);
+                Assert.AreEqual(expected[i].Id, spectrum.Id, $"spectrum {i} id differs in reverse order");
+                AssertArraysEqual(expected[i].Mz, ToArray(spectrum.GetMZArray()), i, "m/z (reverse)");
+            }
+        }
+        finally
+        {
+            SpectrumList_Mzml.DecodeThreads = previous;
+        }
+    }
+
+    private static void AssertArraysEqual(double[] expected, double[] actual, int index, string what)
+    {
+        Assert.AreEqual(expected.Length, actual.Length, $"spectrum {index} {what} length differs");
+        for (int j = 0; j < expected.Length; j++)
+            Assert.AreEqual(expected[j], actual[j], 0.0, $"spectrum {index} {what}[{j}] differs");
+    }
+
+    private static double[] ToArray(BinaryDataArray? array) =>
+        array is null ? Array.Empty<double>() : array.Data.ToArray();
 
     /// <summary>
     /// Reads every spectrum with binary data at the given thread setting. Restores the
     /// previous setting so the test cannot leak a global into whatever runs next.
     /// </summary>
-    private static List<(string Id, double[] Mz, double[] Intensity)> ReadAll(string path, int threads)
+    private static List<(string Id, double[] Mz, double[] Intensity, long[] Integers)> ReadAll(
+        string path, int threads)
     {
         int previous = SpectrumList_Mzml.DecodeThreads;
         SpectrumList_Mzml.DecodeThreads = threads;
         try
         {
-            var result = new List<(string, double[], double[])>();
+            var result = new List<(string, double[], double[], long[])>();
             using var msd = new MSData();
             ReaderList.Default.Read(path, msd, 0, new ReaderConfig());
             var list = msd.Run.SpectrumList;
             Assert.IsNotNull(list, "fixture has no spectrum list");
 
+            // The batching lives in SpectrumList_Mzml; an eager SpectrumListSimple fallback
+            // would make every assertion below pass without the new code running at all.
+            Assert.IsInstanceOfType<SpectrumList_Mzml>(list,
+                "expected the lazy indexed reader - the parallel path would not be exercised otherwise");
+
             for (int i = 0; i < list.Count; i++)
             {
                 var spectrum = list.GetSpectrum(i, getBinaryData: true);
+                var integers = new List<long>();
+                foreach (var arr in spectrum.IntegerDataArrays)
+                    integers.AddRange(arr.Data);
+
                 result.Add((
                     spectrum.Id,
-                    spectrum.GetMZArray()?.Data.ToArray() ?? Array.Empty<double>(),
-                    spectrum.GetIntensityArray()?.Data.ToArray() ?? Array.Empty<double>()));
+                    ToArray(spectrum.GetMZArray()),
+                    ToArray(spectrum.GetIntensityArray()),
+                    integers.ToArray()));
             }
             return result;
         }

--- a/pwiz-sharp/pwiz/test/MsData.Tests/Mzml/MzmlParallelDecodeTests.cs
+++ b/pwiz-sharp/pwiz/test/MsData.Tests/Mzml/MzmlParallelDecodeTests.cs
@@ -1,0 +1,100 @@
+using System.IO;
+using Pwiz.Data.MsData.Mzml;
+using Pwiz.Data.MsData.Readers;
+
+namespace Pwiz.Data.MsData.Tests.Mzml;
+
+/// <summary>
+/// Pins the one property <see cref="SpectrumList_Mzml.DecodeThreads"/> rests on: decoding
+/// binary arrays on a thread pool must produce exactly the values the sequential path
+/// produces, in the same order.
+///
+/// That holds because decoding is a pure function of (base64 payload, encoder config) -
+/// <c>BinaryDataEncoder</c> carries nothing but a readonly config and its helpers are
+/// static - but "it should be pure" is an argument, and this is the check. Exact equality,
+/// not a tolerance: the same bytes through the same decoder must give the same doubles, and
+/// any tolerance here would hide the reordering bug this test exists to catch.
+/// </summary>
+[TestClass]
+public class MzmlParallelDecodeTests
+{
+    private static string? FindCppTestDataDir()
+    {
+        string? dir = AppContext.BaseDirectory;
+        while (!string.IsNullOrEmpty(dir))
+        {
+            string candidate = Path.Combine(dir, "pwiz", "analysis", "spectrum_processing",
+                "SpectrumList_DiaUmpireTest.data");
+            if (Directory.Exists(candidate)) return candidate;
+            dir = Path.GetDirectoryName(dir);
+        }
+        return null;
+    }
+
+    [TestMethod]
+    public void ParallelDecode_ProducesIdenticalSpectraToSequential()
+    {
+        string? dataDir = FindCppTestDataDir();
+        if (dataDir is null) { Assert.Inconclusive("cpp test data dir not found"); return; }
+        string path = Path.Combine(dataDir,
+            "Hoofnagle_10xDil_SWATH_01-20130327_Hoofnagle_10xDil_SWATH_1_01-diaumpire.mzML");
+        if (!File.Exists(path)) { Assert.Inconclusive($"fixture missing: {path}"); return; }
+
+        var sequential = ReadAll(path, threads: 1);
+        var parallel = ReadAll(path, threads: 8);
+
+        Assert.IsTrue(sequential.Count > 1, "fixture produced too few spectra to be a real check");
+        Assert.AreEqual(sequential.Count, parallel.Count, "spectrum count differs");
+
+        for (int i = 0; i < sequential.Count; i++)
+        {
+            var (seqId, seqMz, seqIntensity) = sequential[i];
+            var (parId, parMz, parIntensity) = parallel[i];
+
+            // Identity first: a batch served out of order would show up here rather than as
+            // a confusing array mismatch.
+            Assert.AreEqual(seqId, parId, $"spectrum {i} id differs");
+            Assert.AreEqual(seqMz.Length, parMz.Length, $"spectrum {i} m/z length differs");
+            Assert.AreEqual(seqIntensity.Length, parIntensity.Length,
+                $"spectrum {i} intensity length differs");
+
+            for (int j = 0; j < seqMz.Length; j++)
+                Assert.AreEqual(seqMz[j], parMz[j], 0.0, $"spectrum {i} m/z[{j}] differs");
+            for (int j = 0; j < seqIntensity.Length; j++)
+                Assert.AreEqual(seqIntensity[j], parIntensity[j], 0.0,
+                    $"spectrum {i} intensity[{j}] differs");
+        }
+    }
+
+    /// <summary>
+    /// Reads every spectrum with binary data at the given thread setting. Restores the
+    /// previous setting so the test cannot leak a global into whatever runs next.
+    /// </summary>
+    private static List<(string Id, double[] Mz, double[] Intensity)> ReadAll(string path, int threads)
+    {
+        int previous = SpectrumList_Mzml.DecodeThreads;
+        SpectrumList_Mzml.DecodeThreads = threads;
+        try
+        {
+            var result = new List<(string, double[], double[])>();
+            using var msd = new MSData();
+            ReaderList.Default.Read(path, msd, 0, new ReaderConfig());
+            var list = msd.Run.SpectrumList;
+            Assert.IsNotNull(list, "fixture has no spectrum list");
+
+            for (int i = 0; i < list.Count; i++)
+            {
+                var spectrum = list.GetSpectrum(i, getBinaryData: true);
+                result.Add((
+                    spectrum.Id,
+                    spectrum.GetMZArray()?.Data.ToArray() ?? Array.Empty<double>(),
+                    spectrum.GetIntensityArray()?.Data.ToArray() ?? Array.Empty<double>()));
+            }
+            return result;
+        }
+        finally
+        {
+            SpectrumList_Mzml.DecodeThreads = previous;
+        }
+    }
+}

--- a/pwiz-sharp/pwiz/test/MsData.Tests/Mzml/MzmlParallelDecodeTests.cs
+++ b/pwiz-sharp/pwiz/test/MsData.Tests/Mzml/MzmlParallelDecodeTests.cs
@@ -7,7 +7,7 @@ using Pwiz.Data.MsData.Spectra;
 namespace Pwiz.Data.MsData.Tests.Mzml;
 
 /// <summary>
-/// Pins the one property <see cref="SpectrumList_Mzml.DecodeThreads"/> rests on: decoding
+/// Pins the one property <see cref="ReaderConfig.MzmlDecodeThreads"/> rests on: decoding
 /// binary arrays on a thread pool must produce exactly the values the sequential path
 /// produces, in the same order.
 ///
@@ -143,12 +143,10 @@ public class MzmlParallelDecodeTests
         string path = FixturePath();
         var expected = ReadAll(path, threads: 1);
 
-        int previous = SpectrumList_Mzml.DecodeThreads;
-        SpectrumList_Mzml.DecodeThreads = 8;
-        try
         {
             using var msd = new MSData();
-            ReaderList.Default.Read(path, msd, 0, new ReaderConfig());
+            ReaderList.Default.Read(path, msd, 0,
+                new ReaderConfig { MzmlDecodeThreads = 8 });
             var list = msd.Run.SpectrumList;
             Assert.IsNotNull(list);
 
@@ -158,10 +156,6 @@ public class MzmlParallelDecodeTests
                 Assert.AreEqual(expected[i].Id, spectrum.Id, $"spectrum {i} id differs in reverse order");
                 AssertArraysEqual(expected[i].Mz, ToArray(spectrum.GetMZArray()), i, "m/z (reverse)");
             }
-        }
-        finally
-        {
-            SpectrumList_Mzml.DecodeThreads = previous;
         }
     }
 
@@ -176,19 +170,17 @@ public class MzmlParallelDecodeTests
         array is null ? Array.Empty<double>() : array.Data.ToArray();
 
     /// <summary>
-    /// Reads every spectrum with binary data at the given thread setting. Restores the
-    /// previous setting so the test cannot leak a global into whatever runs next.
+    /// Reads every spectrum with binary data at the given thread setting. The setting rides
+    /// on the ReaderConfig for this read alone, so nothing leaks into another test.
     /// </summary>
     private static List<(string Id, double[] Mz, double[] Intensity, long[] Integers)> ReadAll(
         string path, int threads)
     {
-        int previous = SpectrumList_Mzml.DecodeThreads;
-        SpectrumList_Mzml.DecodeThreads = threads;
-        try
         {
             var result = new List<(string, double[], double[], long[])>();
             using var msd = new MSData();
-            ReaderList.Default.Read(path, msd, 0, new ReaderConfig());
+            ReaderList.Default.Read(path, msd, 0,
+                new ReaderConfig { MzmlDecodeThreads = threads });
             var list = msd.Run.SpectrumList;
             Assert.IsNotNull(list, "fixture has no spectrum list");
 
@@ -196,6 +188,13 @@ public class MzmlParallelDecodeTests
             // would make every assertion below pass without the new code running at all.
             Assert.IsInstanceOfType<SpectrumList_Mzml>(list,
                 "expected the lazy indexed reader - the parallel path would not be exercised otherwise");
+
+            // Prove the ReaderConfig value actually arrived. Without this the comparison
+            // below passes whether or not the setting is plumbed through, because an
+            // unwired setting leaves BOTH runs sequential and therefore identical.
+            Assert.AreEqual(Math.Min(threads, Environment.ProcessorCount),
+                ((SpectrumList_Mzml)list).DecodeThreadsInEffect,
+                "MzmlDecodeThreads did not reach the spectrum list");
 
             for (int i = 0; i < list.Count; i++)
             {
@@ -211,10 +210,6 @@ public class MzmlParallelDecodeTests
                     integers.ToArray()));
             }
             return result;
-        }
-        finally
-        {
-            SpectrumList_Mzml.DecodeThreads = previous;
         }
     }
 }

--- a/pwiz_tools/Shared/ProteowizardWrapper.PwizSharp/MsDataFileImpl.cs
+++ b/pwiz_tools/Shared/ProteowizardWrapper.PwizSharp/MsDataFileImpl.cs
@@ -190,7 +190,8 @@ namespace pwiz.ProteowizardWrapper
             int preferOnlyMsLevel = 0,
             bool combineIonMobilitySpectra = true, // Ask for IMS data in 3-array format by default (not guaranteed)
             bool trimNativeId = true,
-            bool passEntireDiaPasefFrame = false // Ask for Bruker DiaPASEF frames as a single chunk
+            bool passEntireDiaPasefFrame = false, // Ask for Bruker DiaPASEF frames as a single chunk
+            int mzmlDecodeThreads = 1 // >1 decodes mzML binary arrays on a thread pool
             )
         {
 
@@ -218,7 +219,14 @@ namespace pwiz.ProteowizardWrapper
                     ReportSonarBins = true, // For Waters SONAR data, report bin number instead of false drift time
                     IncludeIsolationArrays = false, // For Bruker TIMS data, don't pass the isolation arrays (we infer from WindowGroup and IM)
                     PassEntireDiaPasefFrame = passEntireDiaPasefFrame && combineIonMobilitySpectra && path.EndsWith(@".d"), // For Bruker TIMS data, pass the entire frame at once if we have window group table (ie not mzML)
-                    GlobalChromatogramsAreMs1Only = true
+                    GlobalChromatogramsAreMs1Only = true,
+                    // Only the mzML reader honours this. 1 keeps the original inline decode;
+                    // above that, a batch of spectra is parsed with decoding deferred and the
+                    // decodes run on the thread pool. Left to the caller because the right
+                    // value depends on what ELSE the host is already parallelising: a caller
+                    // reading several files at once should leave it at 1, while one that reads
+                    // a file at a time wants it near the core count.
+                    MzmlDecodeThreads = mzmlDecodeThreads
                 };
                 _lockmassParameters = lockmassParameters;
                 FULL_READER_LIST.Read(path, _msDataFile, sampleIndex, _config);


### PR DESCRIPTION
## Summary

* Deferred base64/zlib decoding behind an optional collector on `MzmlReader`, so the decode
  of a binary array can happen somewhere other than inline in the parse
* Parsed a batch of spectra with decoding deferred in `SpectrumList_Mzml`, then ran those
  decodes on the thread pool and served the batch from an index-keyed cache
* Added `ReaderConfig.MzmlDecodeThreads`, default 1, forwarded through both mzML adapters
  and surfaced as an optional `MsDataFileImpl` parameter, so nothing changes until a host
  asks for it

Measured **82.6s -> 53.8s** reading a 5.99 GB Astral mzML (204,149 MS2 + 1,223 MS1), output
byte-identical.

Base is `chambem2/pwiz-sharp`, not master.

## Why

Osprey deleted its hand-written mzML reader in favour of ProteoWizard's (#4497). That reader
overlapped a sequential XML parse with a `Parallel.ForEach` base64/zlib decode, and losing it
cost 40-95% of read throughput depending on the file - measured against the same file with
byte-identical output. The parallel decompression was ours; this puts it where every
consumer gets it rather than re-growing it inside Osprey.

## How, and why it is safe

Decoding was already separable and pure: `ReadBinaryDataArray` extracts the payload with
`ReadElementContentAsString` and only then calls `new BinaryDataEncoder(config).DecodeDoubles(...)`.
`BinaryDataEncoder` holds nothing but a readonly config and its decode helpers are `static`,
and a fresh encoder is constructed per array. Nothing in the decode path touches the reader's
reference maps or `_skipBinaryData`. So deferring changes only WHERE the work happens.

**XML parsing stays single-threaded on the one existing stream.** That is the deliberate
choice, and it is what keeps the change small:

* no reentrancy work on `MzmlReader` - the non-reentrant `_skipBinaryData` field is untouched
* no second file handle, so nothing breaks for mzMLb, whose `openStream` cannot be called twice
* non-sequential access and metadata-only reads (`getBinaryData: false`) fall back to the
  original path unchanged

**mzMLb gets no speedup**, to be clear about a claim an earlier draft of this description
overstated. Its external-HDF5 branch in `ReadBinaryDataArray` returns before reaching the
deferral hook, so an mzMLb file pays the read-ahead's costs and gains nothing. Its inline
`DecodeDoublesFromRawBytes` is equally deferrable if you want that path covered too.

## Numbers

Measured through the shipping path - Osprey to `MsDataFileImpl` to `ReaderConfig` - on a
5.99 GB Astral mzML (204,149 MS2 + 1,223 MS1), 3 repeats per point, idle machine, medians:

| decode threads | 1 | 2 | 4 | **8** | 12 | 16 | 24 | 32 |
|---|---|---|---|---|---|---|---|---|
| seconds | 83.4 | 66.2 | 59.0 | **54.6** | 54.8 | 54.0 | 53.6 | 54.2 |

**Returns end at 8** - 35% off the sequential time - and the curve is flat from there to the
core count on this 32-core machine. Solving `parse + decode/N` puts the serial XML parse at
roughly 53s and the decode at 30s, so ~53s is the floor no amount of decode parallelism gets
below. That is also why this does not fully close the gap to a purpose-built reader: Osprey's
deleted `MzmlReader` managed 42.5s on this file, so its parse was cheaper too, not just its
decode parallel.

Practical consequence: 8 is a sensible value to recommend, and core count buys nothing while
multiplying peak memory, since each batch holds 64 spectra.

Output is byte-identical at every thread count.

## Open questions for you

* **Knob shape - resolved, thank you.** This started as an environment variable, which was
  convenient for an A/B but is not a ProteoWizard idiom. It is now
  `ReaderConfig.MzmlDecodeThreads`, alongside `VerifyNonEmptySpectraAtIndex`, forwarded by
  both mzML adapters and exposed as an optional `MsDataFileImpl` parameter. No statics, and
  two hosts in one process can differ.
* **Default of 1.** A host that already parallelises across FILES (Osprey scores several at
  once) would oversubscribe if the library went wide on its own, so the default is off and
  the host opts in. If you would rather it default to something like
  `Environment.ProcessorCount / 2`, that is a one-line change.
* **Batch size 64** is a guess that measured well; nothing depends on the exact value.
* **`MsDataFileImpl` change included.** Surfacing the parameter means this PR touches
  `pwiz_tools/Shared/ProteowizardWrapper.PwizSharp`, not only `pwiz-sharp`. Kept together so
  the route is usable end to end rather than landing half a feature; say the word if you would
  rather review pwiz-sharp alone and take the wrapper half separately.

## Already reviewed, and what is still open

An adversarial review ran over this branch; its correctness findings are fixed in
`fa7d0de460`:

* **Failure atomicity** - `FillBatch` kept parsed-but-undecoded spectra in the batch when a
  parse or decode threw, so a host with `ContinueOnError` (which MsConvertGUI sets
  unconditionally) would have written whole batches of spectra with empty binary arrays and
  reported only the single failure. The batch is now dropped on any failure.
* **Exception fidelity** - `Parallel.ForEach` wrapped every decode error in
  `AggregateException`, so a `catch (FormatException)` that worked at one thread stopped
  matching at eight. The original is now rethrown with its stack.
* **Random access** - a comment claimed a non-sequential reader "simply stops benefiting".
  Wrong: `SpectrumList_PrecursorRefine` reads backward, `SpectrumListSorter` by permutation,
  `SpectrumListScanSummer` scattered - each would have triggered a fresh 64-spectrum parse
  and decode per spectrum served. Read-ahead now engages only when the caller walks forward.
* Batch cleared on dispose; thread count validated and clamped, with 0 and -1 meaning all
  cores rather than silently disabling the feature.

Deliberately NOT changed, because they are design calls in your library rather than defects:

* **Fixed batch of 64 with no byte budget.** For profile MS1 spectra this can hold multiple
  GB live at the barrier, against the "only the spectrum being read is in memory" invariant
  your class doc states. A byte-budgeted batch would keep the speedup without the cliff.
* **`_streamLock` is held across the parallel decode**, so a second caller waits for a whole
  batch, and a host that parallelises across FILES blocks a pool thread inside a nested
  parallel loop - which could invert the win for exactly the consumer this was built for.
* **Read-ahead as a `SpectrumListWrapper` decorator** rather than inside the concrete mzML
  reader, so mzXML, mzMLb and the vendor readers could benefit too. `DemuxSpectrumCache` is
  the existing precedent and is bounded and non-destructive where this batch is neither.

## Test plan

- [x] `ParallelDecode_ProducesIdenticalSpectraToSequential` - reads every spectrum of
      `tiny.pwiz.1.1.mzML` at 1 and 8 threads and asserts identical ids, lengths and values at
      exact tolerance. Asserts the lazy `SpectrumList_Mzml` actually fired and that there is
      non-zero data to compare, since an earlier version of this test could pass while
      comparing nothing. Restores the setting in a `finally`
- [x] `ParallelDecode_IntegerArraysMatchSequential` - writes an indexed mzML carrying an
      `IntegerDataArray` (no shipped fixture has one) and checks the integer half of the
      deferral code, which the peak arrays never reach
- [x] `ParallelDecode_ReverseOrderMatchesSequential` - pins the non-batched fallback
- [x] `build.bat Debug --i-agree-to-the-vendor-licenses` - **662 tests, 21 suites, 0 failures**
- [x] Byte parity on a real 5.99 GB acquisition: `PARITY: 6,333,591,188 bytes identical`
      between the sequential and 8-thread caches
- [x] Default path unchanged - `DecodeThreads` defaults to 1, and Osprey's own four-dataset
      regression passes with it unset

Co-Authored-By: Claude <noreply@anthropic.com>
