### PR TITLE
Give stacked PRs master's validations in smartBuildTrigger

### DIFF
--- a/scripts/misc/smartBuildTrigger.py
+++ b/scripts/misc/smartBuildTrigger.py
@@ -107,6 +107,19 @@ print(f"Changed files ({len(changed_files)}):\n", changed_files_str)
 
 # substitute "release" for specific skyline_##.# versions
 base_branch = re.sub("(Skyline/)?skyline_.*", "release", base_branch)
+
+# A stacked PR is based on a work branch rather than master, but it is ultimately headed for
+# master and should get master's validations. Without this, base_branch matches none of
+# possible_base_branches, so the promotion loop below never flattens any target group - every
+# group in this config is nested under "master" (and sometimes "release") - and the trigger
+# loop then skips them all as isBaseBranchDict. The result is a PR whose only check is this
+# script reporting that it triggered nothing.
+#
+# Only target promotion is affected. The change list is still computed as base...FETCH_HEAD
+# against the REAL base ref, so a stacked PR still sees only its own commits' files.
+if base_branch.startswith("Skyline/work/"):
+    base_branch = "master"
+
 print("Base branch: '%s'" % base_branch)
 
 possible_base_branches = ["master", "release"]


### PR DESCRIPTION
## The problem

A PR based on a `Skyline/work/*` branch gets exactly one check: the trigger script itself, reporting that it decided to trigger nothing. Seen on #4588.

## Root cause

Every target group in `vcs_trigger_and_paths_config.py` is nested under a base-branch key:

```python
targets['OspreyWindowsNet'] = {'master': {"ProteoWizard_OspreyWindowsNet": "Osprey Windows .NET"}}
```

and is only flattened to top level when the base branch matches:

```python
possible_base_branches = ["master", "release"]
if base_branch in tuple[1]:
    tuple[1].update(tuple[1][base_branch])
```

`skyline_##.#` bases are rewritten to `release`, but there is no case for a `Skyline/work/*` base. The promotion never happens, the target stays a dict, and the trigger loop skips it because `isBaseBranchDict` is true.

## The effect is total, not partial

Evaluating the config on this branch's parent:

```
MASTER config: 15 target groups
  branch-gated : 15
  ungated      : 0

matchPaths rules losing ALL targets on a work-branch base: 20
rules still firing: 0
```

Every group is gated, so every rule that carries targets loses all of them. A stacked PR triggers **nothing at all**, whatever files it touches. #4588 was not unlucky in matching only the Osprey rule.

## The fix

Rewrite a `Skyline/work/*` base to `master` right after the existing `release` rewrite. A stacked PR is ultimately headed for master, so it should get master's validations.

Only target promotion changes. The change list is still `git diff base...FETCH_HEAD` against the real base ref, so a stacked PR still sees only its own commits' files.

## Verification

Evaluated against the real config, comparing what fires per base branch:

| base | changed path | triggers |
|---|---|---|
| `master` | `pwiz_tools/Osprey/...` | `ProteoWizard_OspreyWindowsNet` |
| `Skyline/work/...` | `pwiz_tools/Osprey/...` | `ProteoWizard_OspreyWindowsNet` (was nothing) |
| `Skyline/skyline_25_1` | `pwiz_tools/Osprey/...` | nothing, via `release` - unchanged |
| `master` | `pwiz_tools/Skyline/...` | bt209 + code inspection + container |
| `Skyline/work/...` | `pwiz_tools/Skyline/...` | bt209 + code inspection + container (was nothing) |
| `Skyline/work/...` | `scripts/misc/smartBuildTrigger.py` | nothing - self-edit guard intact |

Work-branch bases now match master exactly; release bases and the self-edit guard are unaffected. `py_compile` clean.

Note this PR is based on master, so it gets normal validations and cannot exercise the fixed path itself. A PR stacked on a work branch (e.g. #4588) confirms it once this merges.

Credit to Brendan for spotting that a normal PR should show ~17 validations rather than one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0182oRXbeKQGEpF1kTkdQAsr