### PR TITLE
osprey: Pin LangVersion to 14, which the tree already requires

### DIFF
--- a/pwiz_tools/Osprey/Directory.Build.props
+++ b/pwiz_tools/Osprey/Directory.Build.props
@@ -11,7 +11,19 @@
            * the .NET 8.0 target can still be built AnyCPU on other hosts
              (e.g. Arm64 macOS/Linux) without touching any csproj. -->
     <Platforms>AnyCPU;x64</Platforms>
-    <LangVersion>latest</LangVersion>
+    <!-- Osprey requires C# 14. Osprey.Scoring/PickLdaModel.cs calls
+         string[].SequenceEqual(string[]) with only "using System;" imported, which
+         binds to System.MemoryExtensions.SequenceEqual through the C# 14 implicit
+         span conversion in extension receiver position. Under C# 13 and earlier the
+         only candidate is System.Linq.Enumerable.SequenceEqual, which that file does
+         not import, so the build fails.
+         "latest" silently meant whatever the installed SDK happened to offer, so a
+         .NET 9 SDK build failed with CS1061 in unrelated source rather than saying
+         the language version was wrong. Naming the version turns an SDK mismatch
+         into "CS1617: Invalid option '14' for /langversion", which points at the
+         cause. Building Osprey therefore needs the .NET 10 SDK (VS 2026); bump this
+         deliberately rather than by way of an SDK upgrade. -->
+    <LangVersion>14</LangVersion>
     <Nullable>disable</Nullable>
     <ImplicitUsings>disable</ImplicitUsings>
     <Company>University of Washington</Company>


### PR DESCRIPTION
## What changed since the first version of this PR

The original premise was wrong, and Brendan was right to push back: **master is not
broken.** It builds and tests green on TeamCity, in VS 2026, and on his machine. The
failure was mine, from building with the .NET 9 SDK.

This PR is now a one-property change that makes the real requirement explicit.

## Diagnosis

`Osprey.Scoring/PickLdaModel.cs` validates a pick model's feature list:

```csharp
if (dto.Features == null || dto.Features.Length != N ||
    !dto.Features.SequenceEqual(ExpectedFeatures))
```

Both operands are `string[]`, and the file imports `System` but not `System.Linq`.

- Under **C# 14**, `string[]` implicitly converts to `ReadOnlySpan<string>` in extension
  receiver position (the "first-class span types" feature), so this binds to
  `System.MemoryExtensions.SequenceEqual`, already covered by `using System;`. Adding
  `using System.Linq;` is redundant, which is why ReSharper flags it.
- Under **C# 13 and earlier**, that conversion does not exist. The only candidate is
  `System.Linq.Enumerable.SequenceEqual`, which the file does not import, so it fails.

So Osprey has required C# 14, and therefore the .NET 10 SDK, since dd9e84581 introduced
the file. `<LangVersion>latest</LangVersion>` concealed that: it means "whatever this SDK
supports", so the requirement was never stated and never checked.

Reproduced both directions on a clean `origin/master` worktree, no other change:

| SDK | `latest` resolves to | Result |
|---|---|---|
| 10.0.400 | C# 14 | builds clean, net472 and net8.0 |
| 9.0.315 | C# 13 | `CS1061: 'string[]' does not contain a definition for 'SequenceEqual'` |

The diagnostic is the real problem here. It points at source that looks correct and says
nothing about language versions, so it reads as "master is broken" rather than "your SDK
is too old". That is exactly the wrong conclusion to hand a new contributor, or an agent.

## The change

`pwiz_tools/Osprey/Directory.Build.props`: `<LangVersion>latest</LangVersion>` becomes
`<LangVersion>14</LangVersion>`, with a comment recording what requires it.

Now an SDK that cannot build Osprey says so directly:

```
error CS1617: Invalid option '14' for /langversion. Use '/langversion:?' to list supported values.
```

This also matches how the rest of the tree declares it. `pwiz_tools/Directory.Build.props`
pins `8.0`; `CommonFileDialogs`, `CommonMsData`, `PanoramaClient` and `BullseyeSharp` pin
`8.0` or `7.3`. Osprey was the outlier in tracking whatever SDK was installed.

I have upgraded to the .NET 10.0.400 SDK, and everything below was re-verified on it.

## Verification

- .NET 10.0.400 SDK: `Osprey.sln` builds clean, 0 warnings, 0 errors
- .NET 10.0.400 SDK: `Osprey.Test` 586/586 on net8.0, 586/586 on net472
- .NET 9.0.315 SDK: build stops at CS1617, naming the actual cause

## Not done here, worth deciding separately

- A repo-root `global.json` would state the SDK floor once instead of leaving each project
  to imply it through `LangVersion`. That is a repo-wide call, not an Osprey one.
- The other `<LangVersion>latest</LangVersion>` users (`PortableUtil`, the `DevTools`
  projects) may have picked up C# 13/14 dependencies the same way, without anyone
  choosing to. Worth an audit.

#4595 is stacked on this branch and has been rebased onto it.

See `ai/todos/active/TODO-20260820_osprey_scoring_linq_build_fix.md`.
