### PR TITLE
Sciex ZT Scan: report each bin's collision energy instead of the ramp midpoint

### DIFF
--- a/pwiz/data/vendor_readers/ABI/Reader_ABI_Detail.cpp
+++ b/pwiz/data/vendor_readers/ABI/Reader_ABI_Detail.cpp
@@ -102,6 +102,7 @@ InstrumentConfigurationPtr translateAsInstrumentConfiguration(InstrumentModel in
         case X500QTOF:
         case NlxTof:
         case ZenoTOF7600:
+        case ZenoTOF8600:
             ic.componentList.push_back(source);
             ic.componentList.push_back(Component(MS_quadrupole, 2));
             ic.componentList.push_back(Component(MS_quadrupole, 3));
@@ -154,6 +155,7 @@ PWIZ_API_DECL CVID translateAsInstrumentModel(InstrumentModel instrumentModel)
         case API5600TripleTOF:  return MS_TripleTOF_5600;
         case API6600TripleTOF:  return MS_TripleTOF_6600;
         case ZenoTOF7600:       return MS_ZenoTOF_7600;
+        case ZenoTOF8600:       return MS_ZenoTOF_8600;
         case QStar:             return MS_QSTAR;
         case QStarPulsarI:      return MS_QSTAR_Pulsar;
         case QStarXL:           return MS_QSTAR_XL;

--- a/pwiz_aux/msrc/utility/vendor_api/ABI/WiffFile.cpp
+++ b/pwiz_aux/msrc/utility/vendor_api/ABI/WiffFile.cpp
@@ -105,9 +105,36 @@ class WiffFileImpl : public WiffFile
     void setExperiment(int sample, int period, int experiment) const;
     void setCycle(int sample, int period, int experiment, int cycle) const;
 
+    /// The ZT Scan sweep bin for a 1-based experiment, or NULL when the acquisition is not a
+    /// ZT Scan (in which case the SDK's collision energy is used unchanged). See ZtScanBin.
+    const ZtScanBin* getZtScanBin(int sample, int period, int experiment) const;
+
     mutable int currentSample, currentPeriod, currentExperiment, currentCycle;
 
     private:
+    /// Detects a ZT Scan acquisition and maps each Product experiment to its bin within the
+    /// quadrupole sweep. The result (empty for a non-ZT Scan) is cached per (sample, period) so
+    /// an ordinary acquisition is probed only once.
+    ///
+    /// A legacy WIFF flags the mode with the sample-level custom field "Is ZT Scan", and carries
+    /// the CE ramp only as the legacy CE / CES pair, which encodes it as midpoint -/+ half-range.
+    /// That is a lossy projection - an 18 -> 43 eV ramp round-trips as 30 / 12, i.e. 18 -> 42 - so
+    /// the reconstructed top end is up to 1 eV low. The wiff2 container stores the true endpoints
+    /// (see WiffFile2.ipp) and is preferred where available.
+    void initializeZtScanBins(int sample, int period) const;
+
+    /// True when the sample carries SCIEX OS's "Is ZT Scan" custom field set to true. The field
+    /// name is matched loosely because it is a rendered method label, not a programmatic key; a
+    /// localized acquisition that fails to match simply falls back to the SDK's flat value.
+    static bool isZtScanSample(Clearcore2::Data::DataAccess::SampleData::Sample^ sample);
+
+    /// Recovers the sweep's CE ramp endpoints from an experiment's legacy CE / CES pair. Both are
+    /// taken as magnitudes so a negative-polarity method (which stores CE negative) yields the
+    /// same increasing ramp as positive mode.
+    static bool tryReadZtCeRamp(MSExperiment^ msExperiment, double& rampStart, double& rampEnd);
+
+    mutable map<pair<int, int>, vector<ZtScanBin> > ztScanBinsByPeriod_;
+
     // on first access, sample names are made unique (giving duplicates a count suffix) and cached
     mutable vector<string> sampleNames;
     string wiffpath;
@@ -150,6 +177,9 @@ struct ExperimentImpl : public Experiment
     gcroot<MSExperiment^> msExperiment;
     int sample, period, experiment;
     bool hasHalfSizeRTWindow;
+
+    /// Valid only when this experiment is one encoded bin of a ZT Scan quadrupole sweep.
+    ZtScanBin ztScanBin;
 
     ExperimentType experimentType;
     size_t simCount;
@@ -380,6 +410,7 @@ InstrumentModel WiffFileImpl::getInstrumentModel() const
         if (modelName->Contains("365"))             return API365; // predicted
         if (modelName->Contains("X500QTOF"))        return X500QTOF;
         if (modelName->Contains("ZENOTOF7600"))     return ZenoTOF7600;
+        if (modelName->Contains("ZENOTOF8600"))     return ZenoTOF8600;
         throw gcnew Exception("unknown instrument type: " + sample->Details->InstrumentName);
     }
     CATCH_AND_FORWARD
@@ -442,6 +473,10 @@ ExperimentImpl::ExperimentImpl(const WiffFileImpl* wifffile, int sample, int per
             transitionCount = msExperiment->Details->MassRangeInfo->Length;
         else if (experimentType == SIM)
             simCount = msExperiment->Details->MassRangeInfo->Length;
+
+        const ZtScanBin* bin = wifffile_->getZtScanBin(sample, period, experiment);
+        if (bin != NULL)
+            ztScanBin = *bin;
 
         hasHalfSizeRTWindow = false;
         try
@@ -775,20 +810,28 @@ void SpectrumImpl::getIsolationInfo(double& centerMz, double& lowerLimit, double
         lowerLimit = centerMz - isolationWidth / 2;
         upperLimit = centerMz + isolationWidth / 2;
 
-        auto parameters = experiment->msExperiment->Details->Parameters;
-        if (parameters->ContainsKey("CE"))
-        {
-            auto ceRamp = parameters["CE"];
-            if (ceRamp->Start == 0)
-                collisionEnergy = fabs(ceRamp->Stop);
-            else if (ceRamp->Stop == 0)
-                collisionEnergy = ceRamp->Start;
-            else
-                collisionEnergy = (ceRamp->Stop + ceRamp->Start) / 2;
-            collisionEnergy = fabs(collisionEnergy);
-        }
+        // A ZT Scan bin's CE is a point on a hardware ramp the SDK does not record per bin:
+        // Details->Parameters["CE"] is the ramp MIDPOINT on every bin of the sweep. Reconstruct
+        // it instead. See ZtScanBin.
+        if (experiment->ztScanBin.isValid())
+            collisionEnergy = experiment->ztScanBin.collisionEnergy();
         else
-            collisionEnergy = 0;
+        {
+            auto parameters = experiment->msExperiment->Details->Parameters;
+            if (parameters->ContainsKey("CE"))
+            {
+                auto ceRamp = parameters["CE"];
+                if (ceRamp->Start == 0)
+                    collisionEnergy = fabs(ceRamp->Stop);
+                else if (ceRamp->Stop == 0)
+                    collisionEnergy = ceRamp->Start;
+                else
+                    collisionEnergy = (ceRamp->Stop + ceRamp->Start) / 2;
+                collisionEnergy = fabs(collisionEnergy);
+            }
+            else
+                collisionEnergy = 0;
+        }
         
         fragmentationMode = FragmentationMode_CID;        
     }
@@ -978,6 +1021,92 @@ void WiffFileImpl::getTWC(int sample, ADCTrace& totalWavelengthChromatogram) con
     CATCH_AND_FORWARD
 }
 
+
+bool WiffFileImpl::isZtScanSample(Clearcore2::Data::DataAccess::SampleData::Sample^ sample)
+{
+    SampleInfo^ details = sample->Details;
+    for (int i = 0; i < details->NumCustomFields; ++i)
+    {
+        String^ name = details->GetCustomFieldName(i);
+        if (name == nullptr)
+            continue;
+        if (!String::Equals(name->Replace(" ", String::Empty), "IsZTScan", StringComparison::OrdinalIgnoreCase))
+            continue;
+        bool isZt = false;
+        return Boolean::TryParse(details->GetCustomFieldValue(i), isZt) && isZt;
+    }
+    return false;
+}
+
+bool WiffFileImpl::tryReadZtCeRamp(MSExperiment^ msExperiment, double& rampStart, double& rampEnd)
+{
+    rampStart = rampEnd = 0;
+    auto parameters = msExperiment->Details->Parameters;
+    if (parameters == nullptr || !parameters->ContainsKey("CE") || !parameters->ContainsKey("CES"))
+        return false;
+    double centre = fabs((double) parameters["CE"]->Start);
+    double halfRange = fabs((double) parameters["CES"]->Start);
+    if (centre <= 0 || halfRange <= 0)
+        return false; // no ramp to interpolate
+    rampStart = centre - halfRange;
+    rampEnd = centre + halfRange;
+    return true;
+}
+
+void WiffFileImpl::initializeZtScanBins(int sample, int period) const
+{
+    pair<int, int> key = make_pair(sample, period);
+    if (ztScanBinsByPeriod_.count(key) > 0)
+        return;
+
+    // Insert (possibly empty) up front so a non-ZT acquisition is probed only once.
+    vector<ZtScanBin>& bins = ztScanBinsByPeriod_[key];
+
+    try
+    {
+        setPeriod(sample, period);
+        if (!isZtScanSample(this->sample.get()))
+            return;
+
+        int experimentCount = msSample->ExperimentCount;
+        vector<int> productExperiments;
+        for (int i = 0; i < experimentCount; ++i)
+            if ((ExperimentType) msSample->GetMSExperiment(i)->Details->ExperimentType == Product)
+                productExperiments.push_back(i);
+
+        // One bin is not a sweep; leave such a file on the SDK's value.
+        if (productExperiments.size() < 2)
+            return;
+
+        double rampStart, rampEnd;
+        if (!tryReadZtCeRamp(msSample->GetMSExperiment(productExperiments[0]), rampStart, rampEnd))
+            return;
+
+        bins.resize(experimentCount);
+        for (size_t bin = 0; bin < productExperiments.size(); ++bin)
+        {
+            ZtScanBin& ztBin = bins[productExperiments[bin]];
+            ztBin.ceRampStart = rampStart;
+            ztBin.ceRampEnd = rampEnd;
+            ztBin.binIndex = (int) bin;
+            ztBin.binCount = (int) productExperiments.size();
+        }
+    }
+    catch (...)
+    {
+        bins.clear(); // any trouble reading the method: fall back to the SDK's collision energy
+    }
+}
+
+const ZtScanBin* WiffFileImpl::getZtScanBin(int sample, int period, int experiment) const
+{
+    initializeZtScanBins(sample, period);
+    const vector<ZtScanBin>& bins = ztScanBinsByPeriod_[make_pair(sample, period)];
+    int index = experiment - 1; // experiment is 1-based
+    if (index < 0 || index >= (int) bins.size())
+        return NULL;
+    return bins[index].isValid() ? &bins[index] : NULL;
+}
 
 void WiffFileImpl::setSample(int sample) const
 {

--- a/pwiz_aux/msrc/utility/vendor_api/ABI/WiffFile.hpp
+++ b/pwiz_aux/msrc/utility/vendor_api/ABI/WiffFile.hpp
@@ -89,6 +89,7 @@ PWIZ_API_DECL enum InstrumentModel
     TripleQuad7500,
     X500QTOF,
     ZenoTOF7600,
+    ZenoTOF8600,
     GenericQTrap,
     InstrumentModel_Count
 };
@@ -129,6 +130,51 @@ enum PWIZ_API_DECL FragmentationMode
 {
     FragmentationMode_CID,
     FragmentationMode_EAD
+};
+
+
+/// One "encoded bin" of a Sciex ZT Scan quadrupole sweep.
+///
+/// ZT Scan (ZenoTOF 8600) scans Q1 continuously across the precursor range instead of stepping it.
+/// The whole sweep is a single acquisition - the method stores one MS/MS experiment whose
+/// accumulation time is the entire sweep (e.g. 0.86 s) - and the instrument ramps the collision
+/// energy in hardware from one end of the precursor range to the other as the quadrupole moves.
+/// The sweep is then digitized into hundreds of narrow bins, and both SDKs surface each bin as its
+/// own experiment.
+///
+/// Neither SDK records a per-bin collision energy: both report the ramp MIDPOINT on every bin
+/// (30 eV for an 18 -> 43 eV ramp), which is off by roughly half the ramp at either end. This
+/// carries the endpoints so the per-bin value can be reconstructed.
+///
+/// Interpolation is on the bin ORDINAL rather than the bin's quadrupole m/z. The quadrupole scans
+/// at a constant Da/s, so the two axes are equivalent, but the ordinal needs no extra method
+/// parameters - the precursor start/stop masses are exposed by only one of the two APIs - and it
+/// lands exactly on the stated endpoints at the first and last bin.
+///
+/// NOTE: that the hardware ramp is LINEAR is an assumption. The files state only the endpoints,
+/// never the shape. If Sciex confirms a different profile, collisionEnergy() is the only place
+/// that needs to change.
+struct PWIZ_API_DECL ZtScanBin
+{
+    double ceRampStart; // collision energy at the low-m/z end of the sweep (eV)
+    double ceRampEnd;   // collision energy at the high-m/z end of the sweep (eV)
+    int binIndex;       // 0-based ordinal of this bin within the sweep; -1 when not a ZT Scan bin
+    int binCount;       // total bins in the sweep
+
+    ZtScanBin() : ceRampStart(0), ceRampEnd(0), binIndex(-1), binCount(0) {}
+
+    bool isValid() const {return binIndex >= 0 && binCount > 0;}
+
+    /// This bin's collision energy, linearly interpolated between the ramp endpoints. A sweep of
+    /// fewer than two bins has no ramp to interpolate, so it falls back to the midpoint - the same
+    /// value the SDKs report.
+    double collisionEnergy() const
+    {
+        if (binCount < 2) return (ceRampStart + ceRampEnd) / 2;
+        if (binIndex <= 0) return ceRampStart;
+        if (binIndex >= binCount - 1) return ceRampEnd;
+        return ceRampStart + (ceRampEnd - ceRampStart) * binIndex / (binCount - 1);
+    }
 };
 
 

--- a/pwiz_aux/msrc/utility/vendor_api/ABI/WiffFile2.ipp
+++ b/pwiz_aux/msrc/utility/vendor_api/ABI/WiffFile2.ipp
@@ -110,7 +110,28 @@ class WiffFile2Impl : public WiffFile
 
     mutable int currentSampleIndex, currentPeriod, currentExperiment, currentCycle;
 
+    /// The ZT Scan sweep bin for a 1-based experiment of the current sample, or NULL when the
+    /// acquisition is not a ZT Scan (in which case the SDK's collision energy is used
+    /// unchanged). See ZtScanBin.
+    const ZtScanBin* getZtScanBin(int experiment) const;
+
     private:
+    /// Detects a ZT Scan acquisition and maps each TOFMSMS experiment to its bin within the
+    /// quadrupole sweep; leaves the cache empty for anything else. Called once per sample, from
+    /// setSample, after currentSampleExperiments has been populated.
+    ///
+    /// Unlike the legacy container, wiff2 stores the CE ramp endpoints verbatim
+    /// (CERampStart / CERampStop) alongside a "ZTScan" group name, so no reconstruction from the
+    /// lossy CE / CES pair is needed here. Both are programmatic method keys rather than rendered
+    /// labels, so this detection is not sensitive to the acquisition software's language.
+    void initializeZtScanBins() const;
+
+    /// Reads a named MS-method parameter as a double; false when absent or unparsable.
+    static bool tryReadMethodParameter(SCIEX::Apis::Data::v1::Contracts::MethodParameters::IExperiment^ methodExperiment,
+                                       System::String^ key, double& value);
+
+    mutable vector<ZtScanBin> currentSampleZtScanBins;
+
     std::string wiffpath_;
     // on first access, sample names are made unique (giving duplicates a count suffix) and cached
     mutable vector<string> sampleNames;
@@ -154,6 +175,9 @@ struct Experiment2Impl : public Experiment
     int sample, period, experiment;
 
     ExperimentType experimentType;
+
+    /// Valid only when this experiment is one encoded bin of a ZT Scan quadrupole sweep.
+    ZtScanBin ztScanBin;
 
     const vector<double>& cycleTimes() const {initializeTIC(); return cycleTimes_;}
     const vector<double>& cycleIntensities() const {initializeTIC(); return cycleIntensities_;}
@@ -450,6 +474,7 @@ InstrumentModel WiffFile2Impl::getInstrumentModel() const
         if (modelName->Contains("365"))             return API365; // predicted
         if (modelName->Contains("X500QTOF"))        return X500QTOF;
         if (modelName->Contains("ZENOTOF7600"))     return ZenoTOF7600;
+        if (modelName->Contains("ZENOTOF8600"))     return ZenoTOF8600;
         throw gcnew Exception("unknown instrument type: " + instrumentDetails->DeviceModelName);
     }
     CATCH_AND_FORWARD
@@ -523,6 +548,9 @@ Experiment2Impl::Experiment2Impl(const WiffFile2Impl* wiffFile, int sample, int 
 
         experimentType = getExperimentType();
 
+        const ZtScanBin* bin = wiffFile_->getZtScanBin(experiment);
+        if (bin != NULL)
+            ztScanBin = *bin;
     }
     CATCH_AND_FORWARD
 }
@@ -745,15 +773,23 @@ void Spectrum2Impl::getIsolationInfo(double& centerMz, double& lowerLimit, doubl
         lowerLimit = isolationWindow->LowerOffset;
         upperLimit = isolationWindow->UpperOffset;
 
-        auto collisionEnergyRamp = precursor->CollisionEnergy;
-        if (collisionEnergyRamp == nullptr)
-            return;
-        if (collisionEnergyRamp->CollisionEnergyRampStart == 0)
-            collisionEnergy = collisionEnergyRamp->CollisionEnergyRampEnd;
-        else if (collisionEnergyRamp->CollisionEnergyRampEnd == 0)
-            collisionEnergy = collisionEnergyRamp->CollisionEnergyRampStart;
+        // A ZT Scan bin's CE is a point on a hardware ramp the SDK does not record per bin:
+        // ISpectrum's Precursor->CollisionEnergy reports the ramp MIDPOINT on every bin of the
+        // sweep. Reconstruct it from the method's endpoints instead. See ZtScanBin.
+        if (experiment->ztScanBin.isValid())
+            collisionEnergy = experiment->ztScanBin.collisionEnergy();
         else
-            collisionEnergy = (collisionEnergyRamp->CollisionEnergyRampEnd + collisionEnergyRamp->CollisionEnergyRampStart) / 2;
+        {
+            auto collisionEnergyRamp = precursor->CollisionEnergy;
+            if (collisionEnergyRamp == nullptr)
+                return;
+            if (collisionEnergyRamp->CollisionEnergyRampStart == 0)
+                collisionEnergy = collisionEnergyRamp->CollisionEnergyRampEnd;
+            else if (collisionEnergyRamp->CollisionEnergyRampEnd == 0)
+                collisionEnergy = collisionEnergyRamp->CollisionEnergyRampStart;
+            else
+                collisionEnergy = (collisionEnergyRamp->CollisionEnergyRampEnd + collisionEnergyRamp->CollisionEnergyRampStart) / 2;
+        }
             
         fragmentationMode = FragmentationMode_CID;
         IExperiment^ msExperiment = experiment->msExperiment;
@@ -854,9 +890,99 @@ void WiffFile2Impl::setSample(int sample) const
 
             currentSampleIndex = sample;
             currentPeriod = currentExperiment = currentCycle = -1;
+
+            initializeZtScanBins();
         }
     }
     CATCH_AND_FORWARD
+}
+
+bool WiffFile2Impl::tryReadMethodParameter(SCIEX::Apis::Data::v1::Contracts::MethodParameters::IExperiment^ methodExperiment,
+                                           System::String^ key, double& value)
+{
+    value = 0;
+    if (methodExperiment->Parameters == nullptr)
+        return false;
+    for each (SCIEX::Apis::Data::v1::Contracts::MethodParameters::IParameter^ parameter in methodExperiment->Parameters)
+    {
+        if (!System::String::Equals(parameter->Key, key, System::StringComparison::OrdinalIgnoreCase))
+            continue;
+        if (parameter->Values == nullptr)
+            continue;
+        for each (System::Object^ raw in parameter->Values)
+        {
+            if (raw == nullptr)
+                continue;
+            try
+            {
+                value = System::Convert::ToDouble(raw, System::Globalization::CultureInfo::InvariantCulture);
+                return true;
+            }
+            catch (System::Exception^) {}
+        }
+    }
+    return false;
+}
+
+void WiffFile2Impl::initializeZtScanBins() const
+{
+    currentSampleZtScanBins.clear();
+
+    try
+    {
+        auto method = DataReader()->GetMsMethodParameters(DataReader()->RequestFactory->CreateMethodParametersReadRequest(msSample->Id));
+        if (method == nullptr || method->Experiments == nullptr)
+            return;
+
+        double rampStart = 0, rampEnd = 0;
+        bool isZtScan = false, haveRamp = false;
+        for each (SCIEX::Apis::Data::v1::Contracts::MethodParameters::IExperiment^ methodExperiment in method->Experiments)
+        {
+            if (!System::String::Equals(methodExperiment->GroupName, "ZTScan", System::StringComparison::OrdinalIgnoreCase))
+                continue;
+            isZtScan = true;
+            if (tryReadMethodParameter(methodExperiment, "CERampStart", rampStart) &&
+                tryReadMethodParameter(methodExperiment, "CERampStop", rampEnd))
+            {
+                haveRamp = true;
+                break;
+            }
+        }
+        if (!isZtScan || !haveRamp || rampStart == rampEnd)
+            return;
+
+        IList<IExperiment^>^ experiments = currentSampleExperiments;
+        vector<int> productExperiments;
+        for (int i = 0; i < experiments->Count; ++i)
+            if (experiments[i]->ScanType == "TOFMSMS")
+                productExperiments.push_back(i);
+
+        // One bin is not a sweep; leave such a file on the SDK's value.
+        if (productExperiments.size() < 2)
+            return;
+
+        currentSampleZtScanBins.resize(experiments->Count);
+        for (size_t bin = 0; bin < productExperiments.size(); ++bin)
+        {
+            ZtScanBin& ztBin = currentSampleZtScanBins[productExperiments[bin]];
+            ztBin.ceRampStart = rampStart;
+            ztBin.ceRampEnd = rampEnd;
+            ztBin.binIndex = (int) bin;
+            ztBin.binCount = (int) productExperiments.size();
+        }
+    }
+    catch (...)
+    {
+        currentSampleZtScanBins.clear(); // fall back to the SDK's collision energy
+    }
+}
+
+const ZtScanBin* WiffFile2Impl::getZtScanBin(int experiment) const
+{
+    int index = experiment - 1; // experiment is 1-based
+    if (index < 0 || index >= (int) currentSampleZtScanBins.size())
+        return NULL;
+    return currentSampleZtScanBins[index].isValid() ? &currentSampleZtScanBins[index] : NULL;
 }
 
 void WiffFile2Impl::setPeriod(int sample, int period) const


### PR DESCRIPTION
## What

ZT Scan is a new Sciex acquisition mode on the ZenoTOF 8600. Q1 scans **continuously** across the precursor range rather than stepping it — the method stores a single MS/MS experiment whose accumulation time is the entire sweep (0.86 s on the example file) — and the instrument ramps the collision energy in hardware from one end of the precursor range to the other as the quadrupole moves. The sweep is then digitized into hundreds of narrow "encoded" bins, and both SDKs surface each bin as its own experiment.

**Neither SDK records a per-bin collision energy.** Both report the ramp *midpoint* on every bin. On the example file that means all 429 bins came out as `collision energy 30.0` for a ramp that actually runs 18 → 43 eV — wrong by up to 12 eV at either end of the sweep.

This reconstructs the per-bin value.

## How

`ZtScanBin` (`WiffFile.hpp`) carries the ramp endpoints and interpolates on the bin's **ordinal** within the sweep.

Ordinal rather than quadrupole m/z because the quadrupole scans at a constant Da/s, which makes the two axes equivalent, while the ordinal needs no extra method parameters (the precursor start/stop masses are exposed by only one of the two APIs) and lands exactly on the stated endpoints at the first and last bin.

Detection and endpoint sourcing necessarily differ per container:

| | `.wiff` (`WiffFileImpl`) | `.wiff2` (`WiffFile2Impl`) |
|---|---|---|
| Detect | sample custom field `Is ZT Scan` | method group name `ZTScan` |
| Endpoints | `CE ∓ CES` | `CERampStart` / `CERampStop` |

The legacy container only encodes the ramp as midpoint ∓ half-range, so an 18 → 43 eV ramp round-trips as `30 / 12` = 18 → 42 and the top end lands up to **1 eV low**. `.wiff2` stores the true endpoints. The two containers therefore disagree by ≤1 eV at the top of the sweep for the same acquisition; that is a limitation of what the legacy container records, not an implementation divergence. `.wiff2` is what SCIEX OS writes as the primary file.

The wiff2 detection uses programmatic method keys rather than rendered labels, so it is not sensitive to the acquisition software's language. The legacy `Is ZT Scan` field *is* a rendered label, so a localized acquisition degrades to the old flat value rather than misbehaving.

Anything that is not a ZT Scan — and any failure to read the method, too few bins, missing CE/CES — falls back to the SDK's value unchanged.

## Also: ZenoTOF 8600 instrument model

`MS:1003443` already existed in the CV but the reader had no enum entry, so these files could not be converted at all without `--ignoreUnknownInstrumentError`, and got the generic `MS:1000495` term. Note the model-name ladder is duplicated between `WiffFileImpl` and `WiffFile2Impl`, so both needed the new entry — `Reader_ABI_Test` does not catch that, because it validates the enum→CV mapping but never exercises name matching against a real instrument string.

## Verification

Against a 300,570-spectrum ZT Scan acquisition (430 experiments × 699 cycles, quad sweeping 392.76–899.78 in 429 bins of 1.1819 Da):

- `.wiff2` ramps **18.0 → 43.0**, `.wiff` ramps **18.0 → 42.0**, 0.0584 eV per bin, resetting each cycle, MS1 untouched.
- Both containers now emit `MS:1003443 ZenoTOF 8600` with the full Q-q-TOF component list, with no `--ignoreUnknownInstrumentError`.
- `Reader_ABI_Test` passes (the checked-in corpus has no ZT Scan file, so this is a regression check on ordinary Sciex acquisitions rather than a check of the new path).

## Open questions

- **The linear-ramp assumption is unconfirmed.** The files state only the endpoints, never the shape. Linear is the natural reading of a start/stop pair over a constant-speed sweep, and it reproduces the reported midpoint (0.05 × 650 − 2 = 30.5 → 30), but it is worth confirming with Sciex. `ZtScanBin::collisionEnergy()` is the only place that would need to change.
- **No test fixture guards this.** The example acquisition is 8.6 GB; a trimmed one would be needed.
- The equivalent change for the managed pwiz-sharp reader is not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0182oRXbeKQGEpF1kTkdQAsr
