### PR TITLE
skyline: Fixed TestWatersConnectExportMethodDlg failing on the second in-process run

### DIFF
--- a/pwiz_tools/Shared/CommonMsData/RemoteApi/WatersConnect/WatersConnectAccount.cs
+++ b/pwiz_tools/Shared/CommonMsData/RemoteApi/WatersConnect/WatersConnectAccount.cs
@@ -1,5 +1,6 @@
 /*
  * Original author: Matt Chambers <matt.chambers42 .at. gmail.com>
+ * AI assistance: Claude Code (Claude Fable 5) <noreply .at. anthropic.com>
  *
  * Copyright 2024 University of Washington - Seattle, WA
  *
@@ -336,7 +337,15 @@ namespace pwiz.CommonMsData.RemoteApi.WatersConnect
         public HttpClient GetAuthenticatedHttpClient()
         {
             var tokenResponse = Authenticate();
-            var httpClient = _httpClientFactory.CreateClient(@"customClient");
+            // A registered mock handler must take effect immediately. IHttpClientFactory pools
+            // the primary handler pipeline for its default lifetime (2 minutes), so within that
+            // window CreateClient keeps serving a previously registered mock even after a test
+            // installs a replacement. Building the client directly on the registered handler
+            // avoids the pool; production requests (no registered handler) still use the factory.
+            var mockHandler = CommonApplicationSettings.HttpMessageHandlerFactory.GetRegisteredHandler(HANDLER_NAME);
+            var httpClient = mockHandler != null
+                ? new HttpClient(mockHandler, false)
+                : _httpClientFactory.CreateClient(@"customClient");
             httpClient.SetBearerToken(tokenResponse.AccessToken);
             //httpClient.DefaultRequestHeaders.Remove(@"Accept");
             //httpClient.DefaultRequestHeaders.Add(@"Accept", @"application/json");

--- a/pwiz_tools/Shared/CommonUtil/Mock/HttpMessageHandlerFactory.cs
+++ b/pwiz_tools/Shared/CommonUtil/Mock/HttpMessageHandlerFactory.cs
@@ -1,6 +1,7 @@
 /*
  * Original author: Rita Chupalov <ritach .at. uw.edu>
  *                  MacCoss Lab, Department of Genome Sciences, UW
+ * AI assistance: Claude Code (Claude Fable 5) <noreply .at. anthropic.com>
  *
  * Copyright 2025 University of Washington - Seattle, WA
  *
@@ -38,6 +39,18 @@ namespace pwiz.Common.Mock
         public void CreateReplaceHandler(string handlerName, HttpMessageHandler handler)
         {
             _handlers[handlerName] = handler;
+        }
+
+        /// <summary>
+        /// Returns the handler registered under the given name, or null if none is registered.
+        /// Callers that cache HttpClient pipelines (e.g. through IHttpClientFactory) should use
+        /// this to detect a registered test handler and build their client on it directly, so a
+        /// replacement installed by <see cref="CreateReplaceHandler"/> takes effect immediately
+        /// instead of being masked by a pooled pipeline built around a previous handler.
+        /// </summary>
+        public HttpMessageHandler GetRegisteredHandler(string handlerName)
+        {
+            return _handlers.TryGetValue(handlerName, out var handler) ? handler : null;
         }
 
         public HttpMessageHandler getMessageHandler(string handlerName, Func<HttpMessageHandler> defaultHandlerFactory = null)

--- a/pwiz_tools/Shared/CommonUtil/Mock/HttpMessageHandlerFactory.cs
+++ b/pwiz_tools/Shared/CommonUtil/Mock/HttpMessageHandlerFactory.cs
@@ -19,7 +19,7 @@
  */
 
 using System;
-using System.Collections.Generic;
+using System.Collections.Concurrent;
 using System.Net.Http;
 
 namespace pwiz.Common.Mock
@@ -34,7 +34,8 @@ namespace pwiz.Common.Mock
             // Can create a handler here for quick testing. Otherwise, they should be created by the test code.
         }
 
-        private readonly Dictionary<string, HttpMessageHandler> _handlers = new Dictionary<string, HttpMessageHandler>();
+        // Written by tests and read on session-creation paths from other threads.
+        private readonly ConcurrentDictionary<string, HttpMessageHandler> _handlers = new ConcurrentDictionary<string, HttpMessageHandler>();
 
         public void CreateReplaceHandler(string handlerName, HttpMessageHandler handler)
         {
@@ -55,9 +56,10 @@ namespace pwiz.Common.Mock
 
         public HttpMessageHandler getMessageHandler(string handlerName, Func<HttpMessageHandler> defaultHandlerFactory = null)
         {
-            if (_handlers.TryGetValue(handlerName, out var handler))
+            var handler = GetRegisteredHandler(handlerName);
+            if (handler != null)
                 return handler;
-            else if (defaultHandlerFactory != null)
+            if (defaultHandlerFactory != null)
             {
                 var defaultHandler = defaultHandlerFactory();
                 if (defaultHandler != null)

--- a/pwiz_tools/Skyline/TestFunctional/WatersConnectMethodExportTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/WatersConnectMethodExportTest.cs
@@ -272,13 +272,14 @@ namespace pwiz.SkylineTestFunctional
         /// kept serving the previously installed handler (with its stale created-folder state), so the
         /// next run's fresh handler was silently ignored and FolderA listed 13 items instead of 11.
         /// See <see cref="WatersConnectAccount.GetAuthenticatedHttpClient"/>.
+        /// Premise: the guard only detects a regression while the pooled pipeline entry is inside
+        /// its default 2-minute lifetime. This method runs well under a minute into the test, so
+        /// the entry created by the earlier phases is still live; a machine slow enough to void
+        /// that margin would be timing out the test's other waits first.
         /// </summary>
         private void VerifyHandlerReplacement()
         {
             const string extraMethodName = "HandlerSwapMethod";
-            // Both the old and the replacement handler close over this test instance's created-folder
-            // list; clear it so their FolderA listings differ only by the replacement's extra method.
-            _createdFolders.Clear();
             InstallWcHandler(extraMethodName);
 
             var exportMethodDlg = ShowDialog<ExportMethodDlg>(() =>
@@ -286,15 +287,19 @@ namespace pwiz.SkylineTestFunctional
             var warningDlg = ShowDialog<MultiButtonMsgDlg>(() => exportMethodDlg.OkDialog(), 1000);
             var schedulingDataDlg = ShowDialog<SchedulingOptionsDlg>(() => warningDlg.ClickOk(), 1000);
             var methodFileDlg = ShowDialog<WatersConnectSaveMethodFileDialog>(() => schedulingDataDlg.OkDialog());
-            // The dialog reopens in the last-used folder. The replacement handler serves the same
-            // methods listing for every folder, so wherever the dialog opens, its extra method must
-            // appear - unless the pooled pipeline is still serving the old handler.
+            // The dialog opens in the template's folder (ExportMethodDlg.OkDialog sets
+            // InitialDirectory from the template URL). The replacement handler serves the same
+            // methods listing for every folder, so its extra method must appear - unless the
+            // pooled pipeline is still serving the old handler.
             WaitForConditionUI(5000, () => methodFileDlg.ListViewItems.Any(i => i.Text == extraMethodName),
                 () => string.Format(@"The replacement handler's extra method did not appear; the previously installed handler is still being served. Listing ({0} items): {1}",
                     methodFileDlg.ListViewItems.Count,
                     string.Join(@"; ", methodFileDlg.ListViewItems.Select(i => i.Text))));
             CancelDialog(methodFileDlg);
             CancelDialog(exportMethodDlg);
+
+            // Restore the standard handler so later phases do not see the extra method.
+            InstallWcHandler();
         }
 
         /// <summary>
@@ -552,17 +557,18 @@ namespace pwiz.SkylineTestFunctional
             }
             else
             {
-                wcHandler.AddMatcher(new RequestMatcherFunction(
+                // Build the augmented listing once at install time so a bad fixture fails fast
+                // here instead of surfacing as an HTTP 400 and a misleading listing timeout.
+                var methods = JArray.Parse(File.ReadAllText(TestFilesDir.GetTestPath("MockHttpData\\WCMethods.json")));
+                var extraMethod = (JObject) methods[0].DeepClone();
+                extraMethod["name"] = extraMethodName;
+                var readOnlyProperties = (JObject) extraMethod["readOnlyProperties"];
+                Assert.IsNotNull(readOnlyProperties, "WCMethods.json fixture is missing readOnlyProperties.");
+                readOnlyProperties["methodVersionId"] = "00000000-0000-0000-0000-000000000def";
+                methods.Add(extraMethod);
+                wcHandler.AddMatcher(new RequestMatcherString(
                     req => req.RequestUri.ToString().IndexOf(WatersConnectSessionAcquisitionMethod.GET_METHODS_ENDPOINT) >= 0,
-                    req =>
-                    {
-                        var methods = JArray.Parse(File.ReadAllText(TestFilesDir.GetTestPath("MockHttpData\\WCMethods.json")));
-                        var extraMethod = (JObject) methods[0].DeepClone();
-                        extraMethod["name"] = extraMethodName;
-                        extraMethod["readOnlyProperties"]["methodVersionId"] = "00000000-0000-0000-0000-000000000def";
-                        methods.Add(extraMethod);
-                        return methods.ToString();
-                    }));
+                    methods.ToString()));
             }
             // Method upload request
             wcHandler.AddMatcher(new RequestMatcherFunction(

--- a/pwiz_tools/Skyline/TestFunctional/WatersConnectMethodExportTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/WatersConnectMethodExportTest.cs
@@ -1,6 +1,7 @@
 /*
  * Original author: Rita Chupalov <ritach .at. uw.edu>
  *                  MacCoss Lab, Department of Genome Sciences, UW
+ * AI assistance: Claude Code (Claude Fable 5) <noreply .at. anthropic.com>
  *
  * Copyright 2025 University of Washington - Seattle, WA
  *
@@ -65,6 +66,8 @@ namespace pwiz.SkylineTestFunctional
                 SkylineWindow.ShowExportMethodDialog(ExportFileType.Method));
             TestTemplateSelection(exportMethodDlg);
             TestMethodExport(exportMethodDlg);
+
+            VerifyHandlerReplacement();
 
             SetAuthenticationErrorHandler();
             exportMethodDlg = ShowDialog<ExportMethodDlg>(() =>
@@ -208,14 +211,7 @@ namespace pwiz.SkylineTestFunctional
             var schedulingDataDlg = ShowDialog<SchedulingOptionsDlg>(() => warningDlg.ClickOk(), 1000);
             var methodFileDlg = ShowDialog<WatersConnectSaveMethodFileDialog>(() => schedulingDataDlg.OkDialog());
             ValidateSkylineFolder(methodFileDlg);
-            RunUI(() =>
-            {
-                var folderToSelect = methodFileDlg.ListViewItems.FirstOrDefault(item => item.Text == @"FolderA");
-                Assert.IsNotNull(folderToSelect, "FolderA not found in the list of folders.");
-                folderToSelect.Selected = true;
-                methodFileDlg.KeyPressHandler(Keys.Enter);
-            });
-            WaitForConditionUI(1000, () => methodFileDlg.ListViewItems.Count == 11, () => "Template selection dialog is not populated within allotted time.");
+            NavigateIntoFolderA(methodFileDlg, 11);
             RunUI(() =>
             {
                 Assert.AreEqual(0, methodFileDlg.ListViewItems.Count(item => item.ImageIndex == (int)BaseFileDialogNE.ImageIndex.ReadOnlyFolder));
@@ -247,6 +243,58 @@ namespace pwiz.SkylineTestFunctional
                 uploadResultDlg.OkDialog();
             });
             WaitForClosedForm<ExportMethodDlg>();
+        }
+
+        /// <summary>
+        /// Selects FolderA in the current listing, enters it, and waits for the expected number of
+        /// items. On timeout the message reports the actual listing so a count mismatch (e.g. stale
+        /// mock data leaking between runs) is diagnosable from the failure alone.
+        /// </summary>
+        private void NavigateIntoFolderA(WatersConnectSaveMethodFileDialog methodFileDlg, int expectedItemCount)
+        {
+            RunUI(() =>
+            {
+                var folderToSelect = methodFileDlg.ListViewItems.FirstOrDefault(item => item.Text == @"FolderA");
+                Assert.IsNotNull(folderToSelect, "FolderA not found in the list of folders.");
+                folderToSelect.Selected = true;
+                methodFileDlg.KeyPressHandler(Keys.Enter);
+            });
+            WaitForConditionUI(1000, () => methodFileDlg.ListViewItems.Count == expectedItemCount,
+                () => string.Format(@"FolderA listing is not populated within allotted time. Expected {0} items, found {1}: {2}",
+                    expectedItemCount, methodFileDlg.ListViewItems.Count,
+                    string.Join(@"; ", methodFileDlg.ListViewItems.Select(i => i.Text))));
+        }
+
+        /// <summary>
+        /// Verifies that a replacement mock handler registered mid-process (CreateReplaceHandler)
+        /// takes effect for the next waters_connect client. Reproduces in a single pass the
+        /// state leak the nightly hit across language passes: the pooled IHttpClientFactory pipeline
+        /// kept serving the previously installed handler (with its stale created-folder state), so the
+        /// next run's fresh handler was silently ignored and FolderA listed 13 items instead of 11.
+        /// See <see cref="WatersConnectAccount.GetAuthenticatedHttpClient"/>.
+        /// </summary>
+        private void VerifyHandlerReplacement()
+        {
+            const string extraMethodName = "HandlerSwapMethod";
+            // Both the old and the replacement handler close over this test instance's created-folder
+            // list; clear it so their FolderA listings differ only by the replacement's extra method.
+            _createdFolders.Clear();
+            InstallWcHandler(extraMethodName);
+
+            var exportMethodDlg = ShowDialog<ExportMethodDlg>(() =>
+                SkylineWindow.ShowExportMethodDialog(ExportFileType.Method));
+            var warningDlg = ShowDialog<MultiButtonMsgDlg>(() => exportMethodDlg.OkDialog(), 1000);
+            var schedulingDataDlg = ShowDialog<SchedulingOptionsDlg>(() => warningDlg.ClickOk(), 1000);
+            var methodFileDlg = ShowDialog<WatersConnectSaveMethodFileDialog>(() => schedulingDataDlg.OkDialog());
+            // The dialog reopens in the last-used folder. The replacement handler serves the same
+            // methods listing for every folder, so wherever the dialog opens, its extra method must
+            // appear - unless the pooled pipeline is still serving the old handler.
+            WaitForConditionUI(5000, () => methodFileDlg.ListViewItems.Any(i => i.Text == extraMethodName),
+                () => string.Format(@"The replacement handler's extra method did not appear; the previously installed handler is still being served. Listing ({0} items): {1}",
+                    methodFileDlg.ListViewItems.Count,
+                    string.Join(@"; ", methodFileDlg.ListViewItems.Select(i => i.Text))));
+            CancelDialog(methodFileDlg);
+            CancelDialog(exportMethodDlg);
         }
 
         /// <summary>
@@ -443,9 +491,12 @@ namespace pwiz.SkylineTestFunctional
         /// <summary>
         /// Installs the waters_connect request handler. Folder creation (PUT) returns Forbidden while
         /// <see cref="_folderCreateForbidden"/> is set, otherwise success; the flag is read per request
-        /// so tests can toggle it on the live handler.
+        /// so tests can toggle it on the live handler. When <paramref name="extraMethodName"/> is set,
+        /// the methods listing carries one additional method with that name, so
+        /// <see cref="VerifyHandlerReplacement"/> can tell this handler's responses from a previously
+        /// installed handler's.
         /// </summary>
-        private void InstallWcHandler()
+        private void InstallWcHandler(string extraMethodName = null)
         {
             var wcHandler = new MockHttpMessageHandler();
             // ReSharper disable StringIndexOfIsCultureSpecific.1
@@ -493,9 +544,26 @@ namespace pwiz.SkylineTestFunctional
                     return root.ToString();
                 }));
             // Methods enumeration request
-            wcHandler.AddMatcher(new RequestMatcherFile(
-                req => req.RequestUri.ToString().IndexOf(WatersConnectSessionAcquisitionMethod.GET_METHODS_ENDPOINT) >= 0,
-                TestFilesDir.GetTestPath("MockHttpData\\WCMethods.json")));
+            if (extraMethodName == null)
+            {
+                wcHandler.AddMatcher(new RequestMatcherFile(
+                    req => req.RequestUri.ToString().IndexOf(WatersConnectSessionAcquisitionMethod.GET_METHODS_ENDPOINT) >= 0,
+                    TestFilesDir.GetTestPath("MockHttpData\\WCMethods.json")));
+            }
+            else
+            {
+                wcHandler.AddMatcher(new RequestMatcherFunction(
+                    req => req.RequestUri.ToString().IndexOf(WatersConnectSessionAcquisitionMethod.GET_METHODS_ENDPOINT) >= 0,
+                    req =>
+                    {
+                        var methods = JArray.Parse(File.ReadAllText(TestFilesDir.GetTestPath("MockHttpData\\WCMethods.json")));
+                        var extraMethod = (JObject) methods[0].DeepClone();
+                        extraMethod["name"] = extraMethodName;
+                        extraMethod["readOnlyProperties"]["methodVersionId"] = "00000000-0000-0000-0000-000000000def";
+                        methods.Add(extraMethod);
+                        return methods.ToString();
+                    }));
+            }
             // Method upload request
             wcHandler.AddMatcher(new RequestMatcherFunction(
                 req => req.RequestUri.ToString().IndexOf(WatersConnectSessionAcquisitionMethod.UPLOAD_METHOD_ENDPOINT) >= 0,


### PR DESCRIPTION
## Summary

* Built the waters_connect HttpClient directly on a registered mock handler; the pooled IHttpClientFactory pipeline (default 2-minute handler lifetime) kept serving the previous run's handler, so the nightly's French pass - the second run in the same process - saw stale created-folder state and timed out waiting for FolderA's 11-item listing (it actually held 13)
* Added a VerifyHandlerReplacement regression guard that fails in a single English pass, so TeamCity's en-only runs cover it too
* Applied /code-review max findings: ConcurrentDictionary handler registry, install-time build of the augmented mock listing (fail fast), corrected save-dialog folder comment, standard handler restored after the guard

## Test plan

- [x] TestWatersConnectExportMethodDlg en,fr in one process (the nightly failure mode) - red on master, green with the fix
- [x] VerifyHandlerReplacement guard - red on master's WatersConnectAccount in a single en pass, green with the fix
- [x] QuickInspection (0/0) and CodeInspection test

Co-Authored-By: Claude <noreply@anthropic.com>