### PR TITLE
skyline: Removed the net472 targets and fixed the net8 suite's container-only failures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -436,9 +436,16 @@ Version.cpp
 # Skyline generated files
 /pwiz_tools/Skyline/ProtocolBuffers/GeneratedCode/*.cs
 /pwiz_tools/Skyline/ProtocolBuffers/tmp/*.cs
-/pwiz_tools/Skyline/SkylineTester test list.txt
-/pwiz_tools/Skyline/SkylineTester.log
+# Test-run residue. Unanchored on purpose: on net8 these are written from the
+# staging directory and from the test UI's own output directory, not the Skyline
+# root the old entries were pinned to, so anchoring a path just moves the problem.
+SkylineTester test list.txt
+SkylineTester.log
 SkylineTester Results
+TestRunner.log
+SearchControlLog.txt
+DiannSearchControlLog.txt
+*.mzML.log
 /b.bat
 /b64.bat
 /b32.bat
@@ -476,7 +483,6 @@ SkylineTester Results
 /pwiz_tools/Skyline/Test/ProtocolBuffers/GeneratedCode/*.cs
 /pwiz_tools/Skyline/Test/ProtocolBuffers/tmp/*.cs
 /pwiz_tools/Skyline/Test/ProtocolBuffers/tmp
-/SearchControlLog.txt
 
 # created by WIFF2 SDK in working directory
 /UserSettings.data

--- a/pwiz_tools/Shared/BiblioSpec/BiblioSpec.csproj
+++ b/pwiz_tools/Shared/BiblioSpec/BiblioSpec.csproj
@@ -4,7 +4,7 @@
        that shells out to BlibBuild.exe / BlibFilter.exe; depends on Common. -->
   <PropertyGroup>
     <ProjectGuid>{32CC9B1A-9442-4B56-AF34-FB47595278A1}</ProjectGuid>
-    <TargetFrameworks>net472;net8.0-windows</TargetFrameworks>
+    <TargetFrameworks>net8.0-windows</TargetFrameworks>
     <Platforms>AnyCPU;x64</Platforms>
     <LangVersion>latest</LangVersion>
     <Nullable>disable</Nullable>

--- a/pwiz_tools/Shared/Common/Common.csproj
+++ b/pwiz_tools/Shared/Common/Common.csproj
@@ -6,7 +6,7 @@
        equivalents on net8. -->
   <PropertyGroup>
     <ProjectGuid>{A5527BE9-4A62-458F-AE47-F0F9204A5CF9}</ProjectGuid>
-    <TargetFrameworks>net472;net8.0-windows</TargetFrameworks>
+    <TargetFrameworks>net8.0-windows</TargetFrameworks>
     <Platforms>AnyCPU;x64</Platforms>
     <LangVersion>latest</LangVersion>
     <Nullable>disable</Nullable>

--- a/pwiz_tools/Shared/CommonBaseUI/CommonBaseUI.csproj
+++ b/pwiz_tools/Shared/CommonBaseUI/CommonBaseUI.csproj
@@ -16,7 +16,7 @@
        would have forced NHibernate, SQLite, WebView2 and ZedGraph onto all of them. -->
   <PropertyGroup>
     <ProjectGuid>{6C0B2B6E-4C39-4F5A-9E2D-7A1B3C8D5E40}</ProjectGuid>
-    <TargetFrameworks>net472;net8.0-windows</TargetFrameworks>
+    <TargetFrameworks>net8.0-windows</TargetFrameworks>
     <Platforms>AnyCPU;x64</Platforms>
     <LangVersion>latest</LangVersion>
     <Nullable>disable</Nullable>

--- a/pwiz_tools/Shared/CommonBaseUI/GUI/CommonAlertDlg.cs
+++ b/pwiz_tools/Shared/CommonBaseUI/GUI/CommonAlertDlg.cs
@@ -24,6 +24,7 @@ using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Drawing;
 using System.Linq;
+using System.Runtime.ExceptionServices;
 using System.Windows.Forms;
 using pwiz.Common.CommonResources;
 using pwiz.Common.SystemUtil;
@@ -43,6 +44,7 @@ namespace pwiz.Common.GUI
         private readonly int _originalMessageHeight;
         private string _message;
         private string _detailMessage;
+        private Exception _exception;
 
         public CommonAlertDlg() : this(@"Alert dialog for Forms designer")
         {
@@ -124,8 +126,10 @@ namespace pwiz.Common.GUI
 
         public Exception Exception
         {
+            get { return _exception; }
             set
             {
+                _exception = value;
                 if (null == value)
                 {
                     DetailMessage = null;
@@ -469,6 +473,16 @@ namespace pwiz.Common.GUI
 
             if (TestMode && !PauseMode && !Debugger.IsAttached)
             {
+                // Never display an earlier unattended-dialog failure. Showing it starts a second
+                // watchdog over text nobody is going to dismiss either, and that second timeout
+                // escapes through a reentrant WndProc where WinForms cannot route it. Rethrow so
+                // the failure reaches the test harness naming the dialog it was really about.
+                // See DialogTimeoutException.
+                if (_exception is DialogTimeoutException previousTimeout)
+                {
+                    ExceptionDispatchInfo.Capture(previousTimeout).Throw();
+                }
+
                 bool timeout = false;
                 var timeoutTimer = new Timer { Interval = TIMEOUT_SECONDS * 1000 };
                 timeoutTimer.Tick += (sender, args) =>
@@ -485,11 +499,13 @@ namespace pwiz.Common.GUI
                 var result = base.ShowDialog(parent);
                 timeoutTimer.Stop();
                 if (timeout)
-                    throw new TimeoutException(
+                {
+                    throw new DialogTimeoutException(
                         string.Format(@"{0} not closed for {1} seconds. Message = {2}",
                             GetType(),
                             TIMEOUT_SECONDS,
                             message));
+                }
                 return result;
             }
 
@@ -497,5 +513,17 @@ namespace pwiz.Common.GUI
         }
 
         #endregion
+    }
+
+    /// <summary>
+    /// Thrown when a functional test leaves an alert dialog unattended past its timeout. The
+    /// distinct type is what lets <see cref="CommonAlertDlg.ShowWithTimeout"/> rethrow it rather
+    /// than display it in a dialog that would time out in turn.
+    /// </summary>
+    public class DialogTimeoutException : TimeoutException
+    {
+        public DialogTimeoutException(string message) : base(message)
+        {
+        }
     }
 }

--- a/pwiz_tools/Shared/CommonFileDialogs/CommonFileDialogs.csproj
+++ b/pwiz_tools/Shared/CommonFileDialogs/CommonFileDialogs.csproj
@@ -4,7 +4,7 @@
        file-picker dialogs, depends on CommonUtil + CommonMsData + ProteowizardWrapper. -->
   <PropertyGroup>
     <ProjectGuid>{B8E3F4A1-7C2D-4E5F-9A1B-3C6D8E0F2A4B}</ProjectGuid>
-    <TargetFrameworks>net472;net8.0-windows</TargetFrameworks>
+    <TargetFrameworks>net8.0-windows</TargetFrameworks>
     <Platforms>AnyCPU;x64</Platforms>
     <LangVersion>latest</LangVersion>
     <Nullable>disable</Nullable>

--- a/pwiz_tools/Shared/CommonMsData/CommonMsData.csproj
+++ b/pwiz_tools/Shared/CommonMsData/CommonMsData.csproj
@@ -5,7 +5,7 @@
        219 Skyline files import this namespace. -->
   <PropertyGroup>
     <ProjectGuid>{86F8E7F5-A3ED-4519-9AD9-BF9ABD6DD69F}</ProjectGuid>
-    <TargetFrameworks>net472;net8.0-windows</TargetFrameworks>
+    <TargetFrameworks>net8.0-windows</TargetFrameworks>
     <Platforms>AnyCPU;x64</Platforms>
     <LangVersion>latest</LangVersion>
     <Nullable>disable</Nullable>

--- a/pwiz_tools/Shared/CommonUtil/CommonUtil.csproj
+++ b/pwiz_tools/Shared/CommonUtil/CommonUtil.csproj
@@ -16,7 +16,7 @@
        Osprey share through CommonUtil directly now. -->
   <PropertyGroup>
     <ProjectGuid>{13BF2FFB-50A1-4AB1-83A4-5733E36905CE}</ProjectGuid>
-    <TargetFrameworks>net472;net8.0</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
     <Platforms>AnyCPU;x64</Platforms>
     <LangVersion>latest</LangVersion>
     <Nullable>disable</Nullable>

--- a/pwiz_tools/Shared/CommonUtil/SystemUtil/Assume.cs
+++ b/pwiz_tools/Shared/CommonUtil/SystemUtil/Assume.cs
@@ -129,7 +129,7 @@ namespace pwiz.Common.SystemUtil
                         if (File.Exists(skylineTesterSln))
                             File.Delete(skylineTesterSln);
                         File.Copy(skylineSln, skylineTesterSln);
-                        Process.Start(skylineTesterSln);
+                        ProcessEx.OpenInShell(skylineTesterSln);
                         Thread.Sleep(20000); // Wait for it to fire up sp it's offered in the list of debuggers
                     }
                 }

--- a/pwiz_tools/Shared/CommonUtil/SystemUtil/IExplainDiff.cs
+++ b/pwiz_tools/Shared/CommonUtil/SystemUtil/IExplainDiff.cs
@@ -1,0 +1,54 @@
+/*
+ * Original author: Brendan MacLean <brendanx .at. uw.edu>,
+ *                  MacCoss Lab, Department of Genome Sciences, UW
+ * AI assistance: Claude Code (Claude Opus 5) <noreply .at. anthropic.com>
+ *
+ * Copyright 2026 University of Washington - Seattle, WA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace pwiz.Common.SystemUtil
+{
+    /// <summary>
+    /// Implement to say WHY this object is not <see cref="object.Equals(object)"/> to another.
+    ///
+    /// <para>Exists because an assertion that two objects differ is useless when neither overrides
+    /// ToString: the failure message renders both sides as the bare type name and carries no
+    /// information. That has repeatedly cost a diagnosis - an intermittent failure reproduces once
+    /// in hundreds of runs, reports nothing usable, and is thrown away. A type that knows what its
+    /// Equals compares can say which member differed, and the difference is then obvious from the
+    /// first occurrence.</para>
+    ///
+    /// <para>Deliberately declared next to the Equals it explains rather than discovered by
+    /// reflection over properties. Equals implementations here compare private fields, which do not
+    /// map onto public properties - <see cref="object.Equals(object)"/> on PeptideLibraries
+    /// compares a _rankIdName with no public accessor at all - so a reflective differ can report
+    /// "no difference found" while Equals says otherwise. Some property getters also assert on
+    /// internal state, which a blind walk would trip precisely when things are already wrong.</para>
+    /// </summary>
+    public interface IExplainDiff
+    {
+        /// <summary>
+        /// Returns a human readable account of how this object differs from
+        /// <paramref name="other"/>, or null when no difference is found.
+        ///
+        /// <para>Takes object rather than a type parameter, and does its own type check, for the
+        /// same reason <see cref="object.Equals(object)"/> does: callers hold the values loosely.
+        /// Only called after Equals has already returned false, so returning null means this
+        /// implementation has fallen out of step with Equals - callers report that rather than
+        /// silently passing.</para>
+        /// </summary>
+        string ExplainDiff(object other);
+    }
+}

--- a/pwiz_tools/Shared/CommonUtil/SystemUtil/ProcessEx.cs
+++ b/pwiz_tools/Shared/CommonUtil/SystemUtil/ProcessEx.cs
@@ -19,6 +19,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Reflection;
 using pwiz.Common.SystemUtil.PInvoke;
@@ -27,6 +28,21 @@ namespace pwiz.Common.SystemUtil
 {
     public static class ProcessEx 
     {
+        /// <summary>
+        /// Hands a URL or a document to the shell, which opens it in whatever the user has
+        /// registered for it - a browser, a PDF reader. Use this rather than
+        /// <see cref="System.Diagnostics.Process.Start(string)"/>, whose UseShellExecute
+        /// default is true on .NET Framework but FALSE on .NET Core and later. With it
+        /// false the runtime tries to CreateProcess the target itself, so a URL raises
+        /// Win32Exception "The system cannot find the file specified" and a document
+        /// raises 193 "not a valid Win32 application". Callers keep their own error
+        /// handling: exceptions propagate exactly as they did before.
+        /// </summary>
+        public static void OpenInShell(string urlOrPath)
+        {
+            Process.Start(new ProcessStartInfo(urlOrPath) { UseShellExecute = true });
+        }
+
         /// <summary>
         /// Returns true iff the process is running under Wine (the "wine_get_version" function is exported by ntdll.dll)
         /// </summary>

--- a/pwiz_tools/Shared/MSGraph/MSGraph.csproj
+++ b/pwiz_tools/Shared/MSGraph/MSGraph.csproj
@@ -4,7 +4,7 @@
        library over the ZedGraph fork. -->
   <PropertyGroup>
     <ProjectGuid>{26CFD1FF-F4F7-4F66-B5B4-E686BDB9B34E}</ProjectGuid>
-    <TargetFrameworks>net472;net8.0-windows</TargetFrameworks>
+    <TargetFrameworks>net8.0-windows</TargetFrameworks>
     <Platforms>AnyCPU;x64</Platforms>
     <LangVersion>latest</LangVersion>
     <Nullable>disable</Nullable>

--- a/pwiz_tools/Shared/PanoramaClient/PanoramaClient.csproj
+++ b/pwiz_tools/Shared/PanoramaClient/PanoramaClient.csproj
@@ -4,7 +4,7 @@
        client wrapping the Panorama / LabKey REST API. -->
   <PropertyGroup>
     <ProjectGuid>{BF849CF8-25D7-4619-B001-9ED8E3771C44}</ProjectGuid>
-    <TargetFrameworks>net472;net8.0-windows</TargetFrameworks>
+    <TargetFrameworks>net8.0-windows</TargetFrameworks>
     <Platforms>AnyCPU;x64</Platforms>
     <LangVersion>latest</LangVersion>
     <Nullable>disable</Nullable>

--- a/pwiz_tools/Shared/PanoramaClient/PanoramaDirectoryPicker.cs
+++ b/pwiz_tools/Shared/PanoramaClient/PanoramaDirectoryPicker.cs
@@ -222,7 +222,7 @@ namespace pwiz.PanoramaClient
                     contextMenuStrip.Show(Cursor.Position);
                     break;
                 case MouseButtons.Left:
-                    Process.Start(urlLink.Text);
+                    ProcessEx.OpenInShell(urlLink.Text);
                     break;
             }
         }

--- a/pwiz_tools/Shared/PanoramaClient/PanoramaFilePicker.cs
+++ b/pwiz_tools/Shared/PanoramaClient/PanoramaFilePicker.cs
@@ -668,7 +668,7 @@ namespace pwiz.PanoramaClient
                     contextMenuStrip.Show();
                     break;
                 case MouseButtons.Left:
-                    Process.Start(urlLink.Text);
+                    ProcessEx.OpenInShell(urlLink.Text);
                     break;
             }
         }

--- a/pwiz_tools/Shared/ProteomeDb/ProteomeDb.csproj
+++ b/pwiz_tools/Shared/ProteomeDb/ProteomeDb.csproj
@@ -4,7 +4,7 @@
        CommonUtil. NHibernate + SQLite proteome layer. -->
   <PropertyGroup>
     <ProjectGuid>{09FC3CB3-FCCD-4906-A370-160B28725936}</ProjectGuid>
-    <TargetFrameworks>net472;net8.0-windows</TargetFrameworks>
+    <TargetFrameworks>net8.0-windows</TargetFrameworks>
     <Platforms>AnyCPU;x64</Platforms>
     <LangVersion>latest</LangVersion>
     <Nullable>disable</Nullable>

--- a/pwiz_tools/Shared/ProteowizardWrapper/ProteowizardWrapper.csproj
+++ b/pwiz_tools/Shared/ProteowizardWrapper/ProteowizardWrapper.csproj
@@ -32,7 +32,7 @@
        on net8 with zero call-site changes. -->
   <PropertyGroup>
     <ProjectGuid>{DACEE7D5-5A6A-4001-9602-FAB1A9A2DE59}</ProjectGuid>
-    <TargetFrameworks>net472;net8.0</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
     <Platforms>AnyCPU;x64</Platforms>
     <LangVersion>latest</LangVersion>
     <Nullable>disable</Nullable>

--- a/pwiz_tools/Shared/zedgraph/ZedGraph.csproj
+++ b/pwiz_tools/Shared/zedgraph/ZedGraph.csproj
@@ -5,7 +5,7 @@
        named via the existing ZedGraph.snk. -->
   <PropertyGroup>
     <ProjectGuid>{B99650EE-AF46-47B4-A4A9-212ADE7809B7}</ProjectGuid>
-    <TargetFrameworks>net472;net8.0-windows</TargetFrameworks>
+    <TargetFrameworks>net8.0-windows</TargetFrameworks>
     <Platforms>AnyCPU;x64</Platforms>
     <LangVersion>latest</LangVersion>
     <Nullable>disable</Nullable>

--- a/pwiz_tools/Shared/zedgraph/ZedGraph.csproj.user
+++ b/pwiz_tools/Shared/zedgraph/ZedGraph.csproj.user
@@ -15,4 +15,24 @@
     <FallbackCulture>en-US</FallbackCulture>
     <VerifyUploadedFiles>false</VerifyUploadedFiles>
   </PropertyGroup>
+  <ItemGroup>
+    <Compile Update="ZedGraph\ZedGraphControl.ContextMenu.cs">
+      <SubType>UserControl</SubType>
+    </Compile>
+    <Compile Update="ZedGraph\ZedGraphControl.cs">
+      <SubType>UserControl</SubType>
+    </Compile>
+    <Compile Update="ZedGraph\ZedGraphControl.Events.cs">
+      <SubType>UserControl</SubType>
+    </Compile>
+    <Compile Update="ZedGraph\ZedGraphControl.Printing.cs">
+      <SubType>UserControl</SubType>
+    </Compile>
+    <Compile Update="ZedGraph\ZedGraphControl.Properties.cs">
+      <SubType>UserControl</SubType>
+    </Compile>
+    <Compile Update="ZedGraph\ZedGraphControl.ScrollBars.cs">
+      <SubType>UserControl</SubType>
+    </Compile>
+  </ItemGroup>
 </Project>

--- a/pwiz_tools/Shared/zedgraph/ZedGraph/ZedGraphControl.Events.cs
+++ b/pwiz_tools/Shared/zedgraph/ZedGraph/ZedGraphControl.Events.cs
@@ -470,7 +470,11 @@ namespace ZedGraph
 
 						if ( url != string.Empty )
 						{
-							System.Diagnostics.Process.Start( url );
+							// UseShellExecute must be set: it defaults to true on .NET Framework but false
+							// on .NET Core and later, where a URL then fails with Win32Exception. ZedGraph
+							// cannot use pwiz.Common's ProcessEx.OpenInShell - it references no pwiz code.
+							System.Diagnostics.Process.Start( new System.Diagnostics.ProcessStartInfo( url )
+								{ UseShellExecute = true } );
 							// linkable objects override any other actions with mouse
 							return;
 						}

--- a/pwiz_tools/Skyline/CommonTest/CommonTest.csproj
+++ b/pwiz_tools/Skyline/CommonTest/CommonTest.csproj
@@ -5,7 +5,7 @@
        net472 + net8.0-windows to match Test/TestData porting cadence. -->
   <PropertyGroup>
     <ProjectGuid>{3F077244-13E5-4815-BA55-31F030042E06}</ProjectGuid>
-    <TargetFrameworks>net472;net8.0-windows</TargetFrameworks>
+    <TargetFrameworks>net8.0-windows</TargetFrameworks>
     <Platforms>AnyCPU;x64;x86</Platforms>
     <LangVersion>latest</LangVersion>
     <Nullable>disable</Nullable>

--- a/pwiz_tools/Skyline/Controls/Startup/ActionTutorial.cs
+++ b/pwiz_tools/Skyline/Controls/Startup/ActionTutorial.cs
@@ -176,7 +176,7 @@ namespace pwiz.Skyline.Controls.Startup
 
                     try
                     {
-                        Process.Start(PdfFileLocation); // Opens Tutorial PDF in users default browser.
+                        ProcessEx.OpenInShell(PdfFileLocation); // Opens Tutorial PDF in users default browser.
                     }
                     catch (Exception e)
                     {

--- a/pwiz_tools/Skyline/Executables/AutoQC/AutoQC/AutoQC.csproj
+++ b/pwiz_tools/Skyline/Executables/AutoQC/AutoQC/AutoQC.csproj
@@ -11,7 +11,7 @@
   <PropertyGroup>
     <ProjectGuid>{87D6B185-C2D3-48A9-95B3-A0F528F3F446}</ProjectGuid>
     <OutputType>WinExe</OutputType>
-    <TargetFrameworks>net472;net8.0-windows</TargetFrameworks>
+    <TargetFrameworks>net8.0-windows</TargetFrameworks>
     <Platforms>AnyCPU;x64;x86</Platforms>
     <LangVersion>latest</LangVersion>
     <Nullable>disable</Nullable>

--- a/pwiz_tools/Skyline/Executables/AutoQC/AutoQCTest/AutoQCTest.csproj
+++ b/pwiz_tools/Skyline/Executables/AutoQC/AutoQCTest/AutoQCTest.csproj
@@ -7,7 +7,7 @@
   <PropertyGroup>
     <ProjectGuid>{4955F974-381E-4902-8BAD-BAC7174CFC9F}</ProjectGuid>
     <OutputType>Library</OutputType>
-    <TargetFrameworks>net472;net8.0-windows</TargetFrameworks>
+    <TargetFrameworks>net8.0-windows</TargetFrameworks>
     <Platforms>AnyCPU;x64;x86</Platforms>
     <LangVersion>latest</LangVersion>
     <Nullable>disable</Nullable>

--- a/pwiz_tools/Skyline/Executables/DevTools/UniModCompiler/UniModCompiler.csproj
+++ b/pwiz_tools/Skyline/Executables/DevTools/UniModCompiler/UniModCompiler.csproj
@@ -7,7 +7,7 @@
   <PropertyGroup>
     <ProjectGuid>{B507CA19-F083-4C0D-B321-49F6E6F6D004}</ProjectGuid>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net472;net8.0-windows</TargetFrameworks>
+    <TargetFrameworks>net8.0-windows</TargetFrameworks>
     <Platforms>AnyCPU;x64;x86</Platforms>
     <LangVersion>latest</LangVersion>
     <Nullable>disable</Nullable>

--- a/pwiz_tools/Skyline/Executables/SharedBatch/SharedBatch/SharedBatch.csproj
+++ b/pwiz_tools/Skyline/Executables/SharedBatch/SharedBatch/SharedBatch.csproj
@@ -7,7 +7,7 @@
   <PropertyGroup>
     <ProjectGuid>{9660E7B1-A0AD-4C2B-A395-350D4055640A}</ProjectGuid>
     <OutputType>Library</OutputType>
-    <TargetFrameworks>net472;net8.0-windows</TargetFrameworks>
+    <TargetFrameworks>net8.0-windows</TargetFrameworks>
     <Platforms>AnyCPU;x64;x86</Platforms>
     <LangVersion>latest</LangVersion>
     <Nullable>disable</Nullable>

--- a/pwiz_tools/Skyline/Executables/SharedBatch/SharedBatchTest/SharedBatchTest.csproj
+++ b/pwiz_tools/Skyline/Executables/SharedBatch/SharedBatchTest/SharedBatchTest.csproj
@@ -7,7 +7,7 @@
   <PropertyGroup>
     <ProjectGuid>{69531D2C-BAD8-4E79-9DF3-482A74D6D0BF}</ProjectGuid>
     <OutputType>Library</OutputType>
-    <TargetFrameworks>net472;net8.0-windows</TargetFrameworks>
+    <TargetFrameworks>net8.0-windows</TargetFrameworks>
     <Platforms>AnyCPU;x64;x86</Platforms>
     <LangVersion>latest</LangVersion>
     <Nullable>disable</Nullable>

--- a/pwiz_tools/Skyline/Executables/SkylineBatch/SkylineBatch/SkylineBatch.csproj
+++ b/pwiz_tools/Skyline/Executables/SkylineBatch/SkylineBatch/SkylineBatch.csproj
@@ -9,7 +9,7 @@
   <PropertyGroup>
     <ProjectGuid>{7AB2D7AD-6760-450E-BCCD-B08502307B99}</ProjectGuid>
     <OutputType>WinExe</OutputType>
-    <TargetFrameworks>net472;net8.0-windows</TargetFrameworks>
+    <TargetFrameworks>net8.0-windows</TargetFrameworks>
     <Platforms>AnyCPU;x64;x86</Platforms>
     <LangVersion>latest</LangVersion>
     <Nullable>disable</Nullable>

--- a/pwiz_tools/Skyline/Executables/SkylineBatch/SkylineBatchTest/SkylineBatchTest.csproj
+++ b/pwiz_tools/Skyline/Executables/SkylineBatch/SkylineBatchTest/SkylineBatchTest.csproj
@@ -7,7 +7,7 @@
   <PropertyGroup>
     <ProjectGuid>{415D56D0-D83D-45D2-A833-E2D7E46E7A69}</ProjectGuid>
     <OutputType>Library</OutputType>
-    <TargetFrameworks>net472;net8.0-windows</TargetFrameworks>
+    <TargetFrameworks>net8.0-windows</TargetFrameworks>
     <Platforms>AnyCPU;x64;x86</Platforms>
     <LangVersion>latest</LangVersion>
     <Nullable>disable</Nullable>

--- a/pwiz_tools/Skyline/Executables/SkylineProcessRunner/SkylineProcessRunner/SkylineProcessRunner.csproj
+++ b/pwiz_tools/Skyline/Executables/SkylineProcessRunner/SkylineProcessRunner/SkylineProcessRunner.csproj
@@ -7,7 +7,7 @@
   <PropertyGroup>
     <ProjectGuid>{591C1CC4-2821-4CB3-B666-EFE9AF879CAD}</ProjectGuid>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net472;net8.0-windows</TargetFrameworks>
+    <TargetFrameworks>net8.0-windows</TargetFrameworks>
     <Platforms>AnyCPU;x64;x86</Platforms>
     <LangVersion>latest</LangVersion>
     <Nullable>disable</Nullable>

--- a/pwiz_tools/Skyline/Model/DocSettings/PeptideSettings.cs
+++ b/pwiz_tools/Skyline/Model/DocSettings/PeptideSettings.cs
@@ -40,6 +40,7 @@ using pwiz.Skyline.Model.Results;
 using pwiz.Skyline.Model.Results.Scoring;
 using pwiz.Skyline.Properties;
 using pwiz.Skyline.Util;
+using pwiz.Skyline.Util.Extensions;
 
 namespace pwiz.Skyline.Model.DocSettings
 {
@@ -1934,7 +1935,7 @@ namespace pwiz.Skyline.Model.DocSettings
     public enum PeptidePick { library, filter, both, either }
 
     [XmlRoot("peptide_libraries")]
-    public sealed class PeptideLibraries : Immutable, IValidating, IXmlSerializable
+    public sealed class PeptideLibraries : Immutable, IValidating, IXmlSerializable, IExplainDiff
     {
         public const int MIN_PEPTIDE_COUNT = 1;
         public const int MAX_PEPTIDE_COUNT = 20;
@@ -2753,6 +2754,46 @@ namespace pwiz.Skyline.Model.DocSettings
         #endregion
 
         #region object overrides
+
+        /// <summary>
+        /// Names the member that makes this unequal to <paramref name="other"/>. Kept beside
+        /// <see cref="Equals(PeptideLibraries)"/> because only that method knows what it compares -
+        /// note _rankIdName has no public accessor, so nothing outside this class can report it.
+        ///
+        /// <para>Library load state is included because it is the difference that actually shows up:
+        /// a document and its round-trip copy can hold the same library with only one of them
+        /// finished loading, which compared unequal in either direction and looked like an
+        /// unreproducible flake.</para>
+        /// </summary>
+        public string ExplainDiff(object other)
+        {
+            if (!(other is PeptideLibraries libraries))
+                return string.Format(@"other is {0}, not PeptideLibraries", other?.GetType().Name ?? @"null");
+            var differences = new List<string>();
+            if (!ArrayUtil.EqualsDeep(_librarySpecs, libraries._librarySpecs))
+                differences.Add(string.Format(@"LibrarySpecs [{0}] vs [{1}]",
+                    string.Join(@", ", _librarySpecs.Select(s => s == null ? @"(null)" : s.Name)),
+                    string.Join(@", ", libraries._librarySpecs.Select(s => s == null ? @"(null)" : s.Name))));
+            if (!ArrayUtil.EqualsDeep(_libraries, libraries._libraries))
+                differences.Add(string.Format(@"Libraries [{0}] vs [{1}] (unloadedSpecs {2} vs {3})",
+                    string.Join(@", ", _libraries.Select(ExplainLibrary)),
+                    string.Join(@", ", libraries._libraries.Select(ExplainLibrary)),
+                    LibrarySpecsUnloaded.Count(), libraries.LibrarySpecsUnloaded.Count()));
+            if (!Equals(_rankIdName, libraries._rankIdName))
+                differences.Add(string.Format(@"RankIdName {0} vs {1}", _rankIdName, libraries._rankIdName));
+            if (!Equals(Pick, libraries.Pick))
+                differences.Add(string.Format(@"Pick {0} vs {1}", Pick, libraries.Pick));
+            if (!Equals(RankId, libraries.RankId))
+                differences.Add(string.Format(@"RankId {0} vs {1}", RankId, libraries.RankId));
+            if (!Equals(PeptideCount, libraries.PeptideCount))
+                differences.Add(string.Format(@"PeptideCount {0} vs {1}", PeptideCount, libraries.PeptideCount));
+            return differences.Count == 0 ? null : TextUtil.LineSeparate(differences);
+        }
+
+        private static string ExplainLibrary(Library lib)
+        {
+            return lib == null ? @"(null)" : string.Format(@"{0}/loaded={1}", lib.Name, lib.IsLoaded);
+        }
 
         public bool Equals(PeptideLibraries obj)
         {

--- a/pwiz_tools/Skyline/Model/Results/DocNodeChromInfo.cs
+++ b/pwiz_tools/Skyline/Model/Results/DocNodeChromInfo.cs
@@ -28,6 +28,7 @@ using pwiz.Skyline.Model.DocSettings;
 using pwiz.Skyline.Model.Results.Scoring;
 using pwiz.Skyline.Model.Serialization;
 using pwiz.Skyline.Util;
+using pwiz.Skyline.Util.Extensions;
 
 namespace pwiz.Skyline.Model.Results
 {
@@ -167,7 +168,7 @@ namespace pwiz.Skyline.Model.Results
     /// Chromatogram results summary of a single <see cref="TransitionGroupDocNode"/> from
     /// a single raw file of a single replicate.
     /// </summary>
-    public sealed class TransitionGroupChromInfo : ChromInfo
+    public sealed class TransitionGroupChromInfo : ChromInfo, IExplainDiff
     {
         [Flags]
         private enum Flags
@@ -466,6 +467,54 @@ namespace pwiz.Skyline.Model.Results
         #endregion
 
         #region object overrides
+
+        /// <summary>
+        /// Names the members that make this unequal to <paramref name="other"/>. Kept beside
+        /// <see cref="Equals(TransitionGroupChromInfo)"/> so the two stay in step; the list below
+        /// is exactly what that method compares.
+        ///
+        /// <para>FileIndex is deliberately NOT reported: <see cref="ChromInfo.Equals(ChromInfo)"/>
+        /// treats all FileIds as equal, so a differing index is not what made these unequal, and
+        /// naming it sends the reader after the wrong thing.</para>
+        /// </summary>
+        public string ExplainDiff(object other)
+        {
+            if (!(other is TransitionGroupChromInfo info))
+                return string.Format(@"other is {0}, not TransitionGroupChromInfo", other?.GetType().Name ?? @"null");
+            var members = new (string Name, object Mine, object Theirs)[]
+            {
+                (@"PeakCountRatio", PeakCountRatio, info.PeakCountRatio),
+                (@"RetentionTime", RetentionTime, info.RetentionTime),
+                (@"StartRetentionTime", StartRetentionTime, info.StartRetentionTime),
+                (@"EndRetentionTime", EndRetentionTime, info.EndRetentionTime),
+                (@"IonMobilityInfo", IonMobilityInfo, info.IonMobilityInfo),
+                (@"Fwhm", Fwhm, info.Fwhm),
+                (@"Area", Area, info.Area),
+                (@"AreaMs1", AreaMs1, info.AreaMs1),
+                (@"AreaFragment", AreaFragment, info.AreaFragment),
+                (@"BackgroundArea", BackgroundArea, info.BackgroundArea),
+                (@"BackgroundAreaMs1", BackgroundAreaMs1, info.BackgroundAreaMs1),
+                (@"BackgroundAreaFragment", BackgroundAreaFragment, info.BackgroundAreaFragment),
+                (@"Height", Height, info.Height),
+                (@"Truncated", Truncated, info.Truncated),
+                (@"Identified", Identified, info.Identified),
+                (@"LibraryDotProduct", LibraryDotProduct, info.LibraryDotProduct),
+                (@"IsotopeDotProduct", IsotopeDotProduct, info.IsotopeDotProduct),
+                (@"QValue", QValue, info.QValue),
+                (@"ZScore", ZScore, info.ZScore),
+                (@"Annotations", Annotations, info.Annotations),
+                (@"OptimizationStep", OptimizationStep, info.OptimizationStep),
+                (@"UserSet", UserSet, info.UserSet),
+                (@"OriginalPeak", OriginalPeak, info.OriginalPeak),
+                (@"ReintegratedPeak", ReintegratedPeak, info.ReintegratedPeak)
+            };
+            var differences = members
+                .Where(m => !Equals(m.Mine, m.Theirs))
+                .Select(m => string.Format(@"{0} {1} vs {2}",
+                    m.Name, m.Mine ?? (object)@"(null)", m.Theirs ?? (object)@"(null)"))
+                .ToList();
+            return differences.Count == 0 ? null : TextUtil.LineSeparate(differences);
+        }
 
         public bool Equals(TransitionGroupChromInfo other)
         {

--- a/pwiz_tools/Skyline/Model/Results/DocNodeChromInfo.cs
+++ b/pwiz_tools/Skyline/Model/Results/DocNodeChromInfo.cs
@@ -1612,11 +1612,12 @@ namespace pwiz.Skyline.Model.Results
         {
             if (ReferenceEquals(null, other)) return false;
             if (ReferenceEquals(this, other)) return true;
-            // TODO: This is not very strong equality, since all FileIds are equal
-            //       It would be better to check reference equality, but this would
-            //       break document equality tests across serialization/deserialization
-            //       At the momement, we rely on it being very unlikely that two
-            //       peaks from different files are exactly equal.
+            // All ChromFileInfoIds compare equal, so this contributes nothing on its own and the
+            // derived class's members do the real work. That is deliberate, not a shortcoming:
+            // Equals is content equality throughout Skyline, because a document saved to disk and
+            // read back must come out Equals to the original, and no reference comparison could
+            // satisfy that. We rely on it being very unlikely that two peaks from different files
+            // are exactly equal in every other member.
             return Equals(other.FileId, FileId);
         }
 

--- a/pwiz_tools/Skyline/Model/Results/DocNodeChromInfo.cs
+++ b/pwiz_tools/Skyline/Model/Results/DocNodeChromInfo.cs
@@ -473,9 +473,11 @@ namespace pwiz.Skyline.Model.Results
         /// <see cref="Equals(TransitionGroupChromInfo)"/> so the two stay in step; the list below
         /// is exactly what that method compares.
         ///
-        /// <para>FileIndex is deliberately NOT reported: <see cref="ChromInfo.Equals(ChromInfo)"/>
-        /// treats all FileIds as equal, so a differing index is not what made these unequal, and
-        /// naming it sends the reader after the wrong thing.</para>
+        /// <para>FileIndex is deliberately NOT reported. Equals here is content equality, as it is
+        /// throughout Skyline - a document saved and read back must come out Equals, which no
+        /// reference comparison could satisfy - so <see cref="ChromInfo.Equals(ChromInfo)"/>
+        /// compares all FileIds as equal. A differing index therefore is not what made these
+        /// unequal, and naming it sends the reader after the wrong thing.</para>
         /// </summary>
         public string ExplainDiff(object other)
         {

--- a/pwiz_tools/Skyline/Program.cs
+++ b/pwiz_tools/Skyline/Program.cs
@@ -157,6 +157,7 @@ namespace pwiz.Skyline
         public static bool MultiProcImport { get; set; }
  
         private static bool _initialized;                           // Flag to do some initialization just once per process.
+        [ThreadStatic] private static bool _uiExceptionHandlingInitialized;   // Per-THREAD, see InitUiThreadExceptionHandling
         private static string _name;                                // Program name.
 
         /// <summary>
@@ -755,6 +756,25 @@ namespace pwiz.Skyline
             Settings.Default.SearchToolList = SearchToolList.CopyTools(toolList);
         }
 
+        /// <summary>
+        /// Routes unhandled UI-thread exceptions to Skyline's handler, which hands them to the
+        /// test harness when one is running and reports them otherwise.
+        /// <para>Both the exception mode and the ThreadException subscription are PER-THREAD in
+        /// WinForms. A message loop started on a thread that has not called this shows the
+        /// framework's own modal ThreadExceptionDialog instead, which under a test harness is an
+        /// indefinite hang rather than a reported failure. <see cref="Init"/> covers the first
+        /// thread; anything starting a message loop on a NEW thread must call this there too.</para>
+        /// <para>Idempotent per thread, so a caller need not know whether Init already ran on it.</para>
+        /// </summary>
+        public static void InitUiThreadExceptionHandling()
+        {
+            if (_uiExceptionHandlingInitialized)
+                return;
+            _uiExceptionHandlingInitialized = true;
+            Application.SetUnhandledExceptionMode(UnhandledExceptionMode.CatchException);
+            Application.ThreadException += ThreadExceptionEventHandler;
+        }
+
         public static void Init()
         {
             if (!_initialized)
@@ -763,8 +783,7 @@ namespace pwiz.Skyline
                 CommonActionUtil.ExceptionReporter = ReportException;
                 Application.EnableVisualStyles();
                 Application.SetCompatibleTextRenderingDefault(false);
-                Application.SetUnhandledExceptionMode(UnhandledExceptionMode.CatchException);
-                Application.ThreadException += ThreadExceptionEventHandler;
+                InitUiThreadExceptionHandling();
 
                 // Add handler for non-UI thread exceptions. 
                 AppDomain.CurrentDomain.UnhandledException += CurrentDomain_UnhandledException;

--- a/pwiz_tools/Skyline/Program.cs
+++ b/pwiz_tools/Skyline/Program.cs
@@ -162,9 +162,48 @@ namespace pwiz.Skyline
         /// <summary>
         /// The main entry point for the application.
         /// </summary>
+        private static bool _defaultFontSet;
+
+        /// <summary>
+        /// Pins the WinForms default font to the one .NET Framework used.
+        ///
+        /// .NET Core 3.0 changed <see cref="Control.DefaultFont"/> from Microsoft Sans Serif
+        /// 8.25pt to Segoe UI 9pt. Nearly every Skyline form uses AutoScaleMode.Font, so that
+        /// one change silently resizes all of them - which moves graph chart areas, changes how
+        /// many labels a plot can fit (see LabelLayoutTest), and would alter essentially every
+        /// recorded tutorial screenshot. Pinning the font keeps the UI identical across the
+        /// net472 -> net8 port, so the port is not entangled with a UI redesign.
+        ///
+        /// Adopting a modern font is a deliberate UI change to make on its own terms, alongside
+        /// DPI awareness and a re-recording of the tutorial screenshots.
+        ///
+        /// Must run before the first window is created. The flag is because a functional test
+        /// process re-enters Main once per test, and SetDefaultFont throws after the first
+        /// window exists.
+        /// </summary>
+        public static void SetDefaultFont()
+        {
+            if (_defaultFontSet)
+                return;
+            _defaultFontSet = true;
+            try
+            {
+                Application.SetDefaultFont(new Font(@"Microsoft Sans Serif", 8.25f));
+            }
+            catch (InvalidOperationException)
+            {
+                // Reachable only when something in this process already created a window - a test
+                // host that ran other tests first, for example. The font cannot be changed at that
+                // point, and throwing would fail an unrelated test with a baffling message. The
+                // test runner calls this at process start so the harness never lands here.
+            }
+        }
+
         [STAThread]
         public static int Main(string[] args = null)
         {
+            SetDefaultFont();
+
             if (String.IsNullOrEmpty(Settings.Default.InstallationId)) // Each instance to have GUID
                 Settings.Default.InstallationId = Guid.NewGuid().ToString();
 

--- a/pwiz_tools/Skyline/Skyline.csproj
+++ b/pwiz_tools/Skyline/Skyline.csproj
@@ -11,7 +11,7 @@
   <PropertyGroup>
     <ProjectGuid>{DDA2EA4C-B632-4FDF-94BA-F71E4C152056}</ProjectGuid>
     <OutputType>WinExe</OutputType>
-    <TargetFrameworks>net472;net8.0-windows</TargetFrameworks>
+    <TargetFrameworks>net8.0-windows</TargetFrameworks>
     <Platforms>AnyCPU;x64;x86</Platforms>
     <LangVersion>latest</LangVersion>
     <Nullable>disable</Nullable>

--- a/pwiz_tools/Skyline/Skyline.sln
+++ b/pwiz_tools/Skyline/Skyline.sln
@@ -11,7 +11,6 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Skyline", "Skyline.csproj", "{DDA2EA4C-B632-4FDF-94BA-F71E4C152056}"
 	ProjectSection(ProjectDependencies) = postProject
-		{4F4C2045-4C86-46F2-A297-C05FC4A48A15} = {4F4C2045-4C86-46F2-A297-C05FC4A48A15}
 		{FA16A0EF-EDF7-4515-BD93-44BADD7AB98A} = {FA16A0EF-EDF7-4515-BD93-44BADD7AB98A}
 	EndProjectSection
 EndProject
@@ -76,8 +75,6 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SkylineNightlyShim", "SkylineNightlyShim\SkylineNightlyShim.csproj", "{3C7F5209-6507-42C5-80CE-472AE6A51CD1}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PanoramaClient", "..\Shared\PanoramaClient\PanoramaClient.csproj", "{BF849CF8-25D7-4619-B001-9ED8E3771C44}"
-EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BullseyeSharp", "BullseyeSharp\BullseyeSharp.csproj", "{4F4C2045-4C86-46F2-A297-C05FC4A48A15}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CommonMsData", "..\Shared\CommonMsData\CommonMsData.csproj", "{86F8E7F5-A3ED-4519-9AD9-BF9ABD6DD69F}"
 EndProject
@@ -291,14 +288,6 @@ Global
 		{BF849CF8-25D7-4619-B001-9ED8E3771C44}.Release|x64.Build.0 = Release|x64
 		{BF849CF8-25D7-4619-B001-9ED8E3771C44}.Release|x86.ActiveCfg = Release|Any CPU
 		{BF849CF8-25D7-4619-B001-9ED8E3771C44}.Release|x86.Build.0 = Release|Any CPU
-		{4F4C2045-4C86-46F2-A297-C05FC4A48A15}.Debug|x64.ActiveCfg = Debug|x64
-		{4F4C2045-4C86-46F2-A297-C05FC4A48A15}.Debug|x64.Build.0 = Debug|x64
-		{4F4C2045-4C86-46F2-A297-C05FC4A48A15}.Debug|x86.ActiveCfg = Debug|x64
-		{4F4C2045-4C86-46F2-A297-C05FC4A48A15}.Debug|x86.Build.0 = Debug|x64
-		{4F4C2045-4C86-46F2-A297-C05FC4A48A15}.Release|x64.ActiveCfg = Release|x64
-		{4F4C2045-4C86-46F2-A297-C05FC4A48A15}.Release|x64.Build.0 = Release|x64
-		{4F4C2045-4C86-46F2-A297-C05FC4A48A15}.Release|x86.ActiveCfg = Release|x64
-		{4F4C2045-4C86-46F2-A297-C05FC4A48A15}.Release|x86.Build.0 = Release|x64
 		{86F8E7F5-A3ED-4519-9AD9-BF9ABD6DD69F}.Debug|x64.ActiveCfg = Debug|x64
 		{86F8E7F5-A3ED-4519-9AD9-BF9ABD6DD69F}.Debug|x64.Build.0 = Debug|x64
 		{86F8E7F5-A3ED-4519-9AD9-BF9ABD6DD69F}.Debug|x86.ActiveCfg = Debug|x86

--- a/pwiz_tools/Skyline/SkylineCmd/SkylineCmd.csproj
+++ b/pwiz_tools/Skyline/SkylineCmd/SkylineCmd.csproj
@@ -8,7 +8,7 @@
   <PropertyGroup>
     <ProjectGuid>{FA16A0EF-EDF7-4515-BD93-44BADD7AB98A}</ProjectGuid>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net472;net8.0-windows</TargetFrameworks>
+    <TargetFrameworks>net8.0-windows</TargetFrameworks>
     <Platforms>AnyCPU;x64;x86</Platforms>
     <LangVersion>latest</LangVersion>
     <Nullable>disable</Nullable>

--- a/pwiz_tools/Skyline/SkylineNightly/SkylineNightly.csproj
+++ b/pwiz_tools/Skyline/SkylineNightly/SkylineNightly.csproj
@@ -11,7 +11,7 @@
   <PropertyGroup>
     <ProjectGuid>{32A40878-3053-4FFA-96C1-23FC27D46B65}</ProjectGuid>
     <OutputType>WinExe</OutputType>
-    <TargetFrameworks>net472;net8.0-windows</TargetFrameworks>
+    <TargetFrameworks>net8.0-windows</TargetFrameworks>
     <Platforms>AnyCPU;x64;x86</Platforms>
     <LangVersion>latest</LangVersion>
     <Nullable>disable</Nullable>

--- a/pwiz_tools/Skyline/SkylineNightlyShim/SkylineNightlyShim.csproj
+++ b/pwiz_tools/Skyline/SkylineNightlyShim/SkylineNightlyShim.csproj
@@ -7,7 +7,7 @@
   <PropertyGroup>
     <ProjectGuid>{3C7F5209-6507-42C5-80CE-472AE6A51CD1}</ProjectGuid>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net472;net8.0</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
     <Platforms>AnyCPU;x64;x86</Platforms>
     <LangVersion>latest</LangVersion>
     <Nullable>disable</Nullable>

--- a/pwiz_tools/Skyline/SkylineTester/AboutWindow.cs
+++ b/pwiz_tools/Skyline/SkylineTester/AboutWindow.cs
@@ -31,7 +31,9 @@ namespace SkylineTester
 
         private void linkLabel1_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)
         {
-            Process.Start(@"https://skyline.ms/funding.url");
+            // UseShellExecute is required for a URL on net8 (defaults false there, true on net472).
+            Process.Start(new ProcessStartInfo(@"https://skyline.ms/funding.url")
+                { UseShellExecute = true });
         }
     }
 }

--- a/pwiz_tools/Skyline/SkylineTester/Main.cs
+++ b/pwiz_tools/Skyline/SkylineTester/Main.cs
@@ -475,7 +475,12 @@ namespace SkylineTester
             var file = GetSelectedLog(combo);
             if (File.Exists(file))
             {
-                var editLogFile = new Process { StartInfo = { FileName = file } };
+                // UseShellExecute must be explicit: it defaults to true on .NET Framework but
+                // FALSE on net8, where Process.Start then tries to CreateProcess the .log itself
+                // and throws Win32Exception 193 ("not a valid application for this OS platform")
+                // instead of opening it in the associated editor.
+                var editLogFile = new Process
+                    { StartInfo = { FileName = file, UseShellExecute = true } };
                 editLogFile.Start();
             }
         }

--- a/pwiz_tools/Skyline/SkylineTester/SkylineTester.csproj
+++ b/pwiz_tools/Skyline/SkylineTester/SkylineTester.csproj
@@ -10,7 +10,7 @@
   <PropertyGroup>
     <ProjectGuid>{65E16E9D-71FC-40D1-B3FF-AD16BEFF9AF4}</ProjectGuid>
     <OutputType>WinExe</OutputType>
-    <TargetFrameworks>net472;net8.0-windows</TargetFrameworks>
+    <TargetFrameworks>net8.0-windows</TargetFrameworks>
     <Platforms>AnyCPU;x64;x86</Platforms>
     <LangVersion>latest</LangVersion>
     <Nullable>disable</Nullable>

--- a/pwiz_tools/Skyline/SkylineTester/SkylineTesterWindow.cs
+++ b/pwiz_tools/Skyline/SkylineTester/SkylineTesterWindow.cs
@@ -748,8 +748,12 @@ namespace SkylineTester
                 return null;
             try
             {
+                // Check BOTH configurations: Stage-Net8Tests.ps1 defaults to -Configuration
+                // Debug, and looking only under "Release" made a correctly staged Debug build
+                // invisible. The slot then came back null, GetTestInfos fell back to ExeDir
+                // (which holds no test DLLs), and every tab rendered empty with no hint why.
                 var candidates = Directory.GetDirectories(binDir, "staging-net8*")
-                    .Select(d => Path.Combine(d, "Release"))
+                    .SelectMany(d => new[] { Path.Combine(d, "Release"), Path.Combine(d, "Debug") })
                     .Where(d => File.Exists(Path.Combine(d, "TestRunner.exe")))
                     .ToList();
                 // Prefer the canonical "staging-net8" (the full default staging) over workflow-specific
@@ -1294,7 +1298,8 @@ namespace SkylineTester
         {
             try
             {
-                Process.Start(DocumentationLink);
+                // UseShellExecute is required for a URL on net8 (defaults false there, true on net472).
+                Process.Start(new ProcessStartInfo(DocumentationLink) { UseShellExecute = true });
             }
             catch (Exception)
             {

--- a/pwiz_tools/Skyline/SkylineTool/SkylineTool.csproj
+++ b/pwiz_tools/Skyline/SkylineTool/SkylineTool.csproj
@@ -7,7 +7,7 @@
        extra package needed there. -->
   <PropertyGroup>
     <ProjectGuid>{3FD4E167-8F9C-4116-8122-67C7AD143490}</ProjectGuid>
-    <TargetFrameworks>net472;net8.0-windows</TargetFrameworks>
+    <TargetFrameworks>net8.0-windows</TargetFrameworks>
     <Platforms>AnyCPU;x64;x86</Platforms>
     <LangVersion>latest</LangVersion>
     <Nullable>disable</Nullable>

--- a/pwiz_tools/Skyline/Stage-Net8Tests.ps1
+++ b/pwiz_tools/Skyline/Stage-Net8Tests.ps1
@@ -52,13 +52,14 @@ function Get-ProjectOutput([string] $project) {
 # build.bat deliberately excludes TestPerf and TestTutorial from the standard build while this
 # script stages them by default, which makes that easy to hit.
 #
-# Note this does NOT catch a stale *dependency*. robocopy /XO below means "exclude older", so a
-# file whose source copy has an older timestamp than the staged one is skipped - which is how a
-# NuGet DLL, carrying the package's original timestamp, can lose to an older assembly already in
-# the staging directory and stay there through any number of re-stages.
-function Warn-IfOutputStale([string] $project, [string] $outputDir) {
+# It no longer has to catch a stale *dependency*. The copies below used to pass /XO ("exclude
+# older"), which skipped any file whose source was older than the staged copy - so a NuGet DLL,
+# carrying the package's original timestamp, lost to whatever assembly was already staged and
+# survived every re-stage. Without /XO a file that differs from its source is replaced whatever
+# the timestamps say.
+function Test-OutputStale([string] $project, [string] $outputDir) {
     $sourceDir = if ($project -eq 'Skyline') { $skylineDir } else { Join-Path $skylineDir $project }
-    if (-not (Test-Path $sourceDir)) { return }
+    if (-not (Test-Path $sourceDir)) { return $false }
     # Skyline's directory contains the test projects as subdirectories; their sources are not its.
     # Only Skyline needs this: its directory physically contains the test projects.
     $siblings = @()
@@ -73,27 +74,45 @@ function Warn-IfOutputStale([string] $project, [string] $outputDir) {
             -not ($siblings | Where-Object { $path.StartsWith($_, [System.StringComparison]::OrdinalIgnoreCase) })
         } |
         Sort-Object LastWriteTime | Select-Object -Last 1
-    if (-not $newestSource) { return }
+    if (-not $newestSource) { return $false }
     $newestOutput = Get-ChildItem -Path $outputDir -File -Filter *.dll -ErrorAction SilentlyContinue |
         Sort-Object LastWriteTime | Select-Object -Last 1
     if ($newestOutput -and $newestSource.LastWriteTime -gt $newestOutput.LastWriteTime) {
         Write-Warning ("$project output looks stale: $($newestSource.Name) changed " +
             "$($newestSource.LastWriteTime.ToString('MM-dd HH:mm')) but the newest built assembly is " +
-            "$($newestOutput.LastWriteTime.ToString('MM-dd HH:mm')). Staging it anyway - rebuild $project if that is not intended.")
+            "$($newestOutput.LastWriteTime.ToString('MM-dd HH:mm')). Staging it first so freshly " +
+            "built projects win any shared file - rebuild $project if that is not intended.")
+        return $true
     }
+    return $false
 }
 
+# Order matters now that /XO is gone: the projects merge into one directory, so the last copy
+# of a shared file wins. A project whose output predates its own sources cannot be the
+# authority on a shared assembly - build.bat excludes TestPerf and TestTutorial from the
+# standard build, so their output routinely carries dependencies several versions old, and
+# staging them last is how a stale ClrMD overwrote the one the rebuilt projects had just
+# staged. Stale first, freshly built last.
+$toStage = @()
 foreach ($project in $Projects) {
     $src = Get-ProjectOutput $project
     if (-not (Test-Path $src)) {
         Write-Warning "Skipping $project - no output at $src (build it first)."
         continue
     }
-    Warn-IfOutputStale $project $src
+    $toStage += [pscustomobject]@{ Project = $project; Src = $src; Stale = (Test-OutputStale $project $src) }
+}
+
+foreach ($item in (@($toStage | Where-Object { $_.Stale }) + @($toStage | Where-Object { -not $_.Stale }))) {
+    $project = $item.Project
+    $src = $item.Src
     Write-Host "Staging $project  ($src)"
-    # /E recurse (satellite resource dirs), /XO keep newest on identical shared deps,
-    # /NP /NDL /NFL /NJH /NJS quiet. robocopy exit codes 0-7 are success.
-    robocopy $src $StagingDir /E /XO /NP /NDL /NFL /NJH /NJS | Out-Null
+    # /E recurse (satellite resource dirs), /NP /NDL /NFL /NJH /NJS quiet. robocopy exit
+    # codes 0-7 are success. No /XO: several projects merge into one staging directory and it
+    # has to end up matching the build output, so a file that differs is replaced rather than
+    # kept for being newer. Identical copies are still skipped on size and timestamp, so the
+    # shared dependencies /XO was protecting are not recopied anyway.
+    robocopy $src $StagingDir /E /NP /NDL /NFL /NJH /NJS | Out-Null
     if ($LASTEXITCODE -ge 8) { throw "robocopy failed staging $project (exit $LASTEXITCODE)" }
 }
 
@@ -130,7 +149,7 @@ if (-not $NoRuntime) {
         @{ Src = $winDesktop.FullName; Dst = Join-Path $runtimeDest "shared\Microsoft.WindowsDesktop.App\$($winDesktop.Name)" }
     )
     foreach ($p in $pairs) {
-        robocopy $p.Src $p.Dst /E /XO /NP /NDL /NFL /NJH /NJS | Out-Null
+        robocopy $p.Src $p.Dst /E /NP /NDL /NFL /NJH /NJS | Out-Null
         if ($LASTEXITCODE -ge 8) { throw "robocopy failed staging runtime $($p.Src) (exit $LASTEXITCODE)" }
     }
 }

--- a/pwiz_tools/Skyline/Stage-Net8Tests.ps1
+++ b/pwiz_tools/Skyline/Stage-Net8Tests.ps1
@@ -47,12 +47,49 @@ function Get-ProjectOutput([string] $project) {
     return Join-Path $skylineDir "$project\bin\$Configuration\$tfm"
 }
 
+# Warn when a project is about to be staged from output older than its own sources. Staging
+# happily copies whatever is on disk, so a project that was not rebuilt is staged silently - and
+# build.bat deliberately excludes TestPerf and TestTutorial from the standard build while this
+# script stages them by default, which makes that easy to hit.
+#
+# Note this does NOT catch a stale *dependency*. robocopy /XO below means "exclude older", so a
+# file whose source copy has an older timestamp than the staged one is skipped - which is how a
+# NuGet DLL, carrying the package's original timestamp, can lose to an older assembly already in
+# the staging directory and stay there through any number of re-stages.
+function Warn-IfOutputStale([string] $project, [string] $outputDir) {
+    $sourceDir = if ($project -eq 'Skyline') { $skylineDir } else { Join-Path $skylineDir $project }
+    if (-not (Test-Path $sourceDir)) { return }
+    # Skyline's directory contains the test projects as subdirectories; their sources are not its.
+    # Only Skyline needs this: its directory physically contains the test projects.
+    $siblings = @()
+    if ($project -eq 'Skyline') {
+        $siblings = $Projects | Where-Object { $_ -ne 'Skyline' } | ForEach-Object { Join-Path $skylineDir $_ }
+    }
+    $newestSource = Get-ChildItem -Path $sourceDir -Recurse -File -Include *.cs, *.resx, *.csproj -ErrorAction SilentlyContinue |
+        Where-Object {
+            $path = $_.FullName
+            if ($path -match '\\(bin|obj)\\') { return $false }
+            # For Skyline, drop anything under a sibling test project - those are not its sources.
+            -not ($siblings | Where-Object { $path.StartsWith($_, [System.StringComparison]::OrdinalIgnoreCase) })
+        } |
+        Sort-Object LastWriteTime | Select-Object -Last 1
+    if (-not $newestSource) { return }
+    $newestOutput = Get-ChildItem -Path $outputDir -File -Filter *.dll -ErrorAction SilentlyContinue |
+        Sort-Object LastWriteTime | Select-Object -Last 1
+    if ($newestOutput -and $newestSource.LastWriteTime -gt $newestOutput.LastWriteTime) {
+        Write-Warning ("$project output looks stale: $($newestSource.Name) changed " +
+            "$($newestSource.LastWriteTime.ToString('MM-dd HH:mm')) but the newest built assembly is " +
+            "$($newestOutput.LastWriteTime.ToString('MM-dd HH:mm')). Staging it anyway - rebuild $project if that is not intended.")
+    }
+}
+
 foreach ($project in $Projects) {
     $src = Get-ProjectOutput $project
     if (-not (Test-Path $src)) {
         Write-Warning "Skipping $project - no output at $src (build it first)."
         continue
     }
+    Warn-IfOutputStale $project $src
     Write-Host "Staging $project  ($src)"
     # /E recurse (satellite resource dirs), /XO keep newest on identical shared deps,
     # /NP /NDL /NFL /NJH /NJS quiet. robocopy exit codes 0-7 are success.

--- a/pwiz_tools/Skyline/Stage-Net8Tests.ps1
+++ b/pwiz_tools/Skyline/Stage-Net8Tests.ps1
@@ -19,7 +19,9 @@
 param(
     [ValidateSet('Debug', 'Release')] [string] $Configuration = 'Debug',
     [string] $StagingDir = '',
-    [string[]] $Projects = @('Skyline', 'CommonTest', 'Test', 'TestData', 'TestFunctional', 'TestConnected', 'TestRunner'),
+    # TestTutorial and TestPerf are in SkylineTester's TEST_DLLS list, so omitting them here left
+    # the Tutorials tab (and the perf tests) empty even after a successful staging run.
+    [string[]] $Projects = @('Skyline', 'CommonTest', 'Test', 'TestData', 'TestFunctional', 'TestConnected', 'TestRunner', 'TestTutorial', 'TestPerf'),
     # Bundle a portable .NET 8 Desktop runtime into <staging>\dotnet so the Docker workers can run
     # the net8 apphost without any runtime installed in the container (pointed at via DOTNET_ROOT).
     [switch] $NoRuntime,

--- a/pwiz_tools/Skyline/Test/Test.csproj
+++ b/pwiz_tools/Skyline/Test/Test.csproj
@@ -7,7 +7,7 @@
        .csv / .zip / .tsv / .blib. Compile items ARE auto-globbed. -->
   <PropertyGroup>
     <ProjectGuid>{E0FA262A-744E-4D98-A43F-4723A4D95827}</ProjectGuid>
-    <TargetFrameworks>net472;net8.0-windows</TargetFrameworks>
+    <TargetFrameworks>net8.0-windows</TargetFrameworks>
     <Platforms>AnyCPU;x64;x86</Platforms>
     <LangVersion>latest</LangVersion>
     <Nullable>disable</Nullable>

--- a/pwiz_tools/Skyline/TestConnected/TestConnected.csproj
+++ b/pwiz_tools/Skyline/TestConnected/TestConnected.csproj
@@ -5,7 +5,7 @@
        fixtures are flat *.zip copied to output; compile items are auto-globbed. -->
   <PropertyGroup>
     <ProjectGuid>{5D4E9180-FD66-4C11-8C16-11921865EDBD}</ProjectGuid>
-    <TargetFrameworks>net472;net8.0-windows</TargetFrameworks>
+    <TargetFrameworks>net8.0-windows</TargetFrameworks>
     <Platforms>AnyCPU;x64;x86</Platforms>
     <LangVersion>latest</LangVersion>
     <Nullable>disable</Nullable>

--- a/pwiz_tools/Skyline/TestData/TestData.csproj
+++ b/pwiz_tools/Skyline/TestData/TestData.csproj
@@ -5,7 +5,7 @@
        data-parity regressions vs. the legacy pwiz C++/CLI path. -->
   <PropertyGroup>
     <ProjectGuid>{F1A6D016-7608-4A7B-8D68-FB32B8344D4B}</ProjectGuid>
-    <TargetFrameworks>net472;net8.0-windows</TargetFrameworks>
+    <TargetFrameworks>net8.0-windows</TargetFrameworks>
     <Platforms>AnyCPU;x64;x86</Platforms>
     <LangVersion>latest</LangVersion>
     <Nullable>disable</Nullable>

--- a/pwiz_tools/Skyline/TestFunctional/AssayLibraryImportTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/AssayLibraryImportTest.cs
@@ -289,7 +289,12 @@ namespace pwiz.SkylineTestFunctional
             var docNanIrt = SkylineWindow.Document;
             var textIrtNan = AsSmallMoleculeTestUtil.AdjustTransitionListForTestMode("PrecursorMz\tProductMz\tTr_recalibrated\tLibraryIntensity\tdecoy\tPeptideSequence\tProteinName\n728.88\t924.539\tBAD_IRT\t3305.3\t0\tADSTGTLVITDPTR\tAQUA4SWATH_HMLangeA\n", 2, _asSmallMolecules);
             RunUI(() => ClipboardEx.SetText(textIrtNan));
-            var mzExpected = _asSmallMolecules ? 723.8753698625 : 728.88;
+            // The small-molecule m/z is computed, and the computed double is one ULP above the
+            // literal 723.8753698625 (bits ...148 vs ...147). That was invisible on net472, whose
+            // default double.ToString() was G15 and rendered both as "723.8753698625". .NET Core 3.0
+            // changed the default to shortest-round-trippable, so the message now carries the extra
+            // digits and the expected literal has to be the value actually computed.
+            var mzExpected = _asSmallMolecules ? 723.8753698625001 : 728.88;
             PasteTransitionListSkipColumnSelectWithMessage(string.Format(
                 Resources.MassListImporter_AddRow_Invalid_iRT_value_at_precusor_m_z__0__for_peptide__1_,
                 mzExpected,

--- a/pwiz_tools/Skyline/TestFunctional/ImmediateWindowWarningsTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/ImmediateWindowWarningsTest.cs
@@ -77,10 +77,20 @@ namespace pwiz.SkylineTestFunctional
 
         private string GetExpectedWarningMessage()
         {
+            // The times must be float, and must be the values a float actually round-trips to,
+            // because that is what the message formats: they come from ChromDataSet.MaxRawTime
+            // and ChromData.Times, both float. .NET Core 3.0 changed float.ToString() from 7
+            // significant digits to the shortest round-trippable form, so the value that used to
+            // render as 89.89957 under net472 now renders as 89.899574. Passing doubles here made
+            // the expected text disagree with the product text in that last digit.
+            //
+            // English hid the disagreement: {3} is the last token of the neutral resource, so
+            // StringAssert.Contains still matched "...and 89.89957" as a prefix of
+            // "...and 89.899574". Chinese and Japanese continue after {3}, so only they failed.
             return string.Format(
                 ResultsResources
                     .PeptideChromDataSets_FilterByRetentionTime_Discarding_chromatograms_for___0___because_the_explicit_retention_time__1__is_not_between__2__and__3_,
-                "TIAQYAR", 100, 0.717615, 89.89957);
+                "TIAQYAR", 100, 0.717615f, 89.899574f);
         }
     }
 }

--- a/pwiz_tools/Skyline/TestFunctional/LabelLayoutTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/LabelLayoutTest.cs
@@ -45,6 +45,14 @@ namespace pwiz.SkylineTestFunctional
             new ExpectedPointSnapshot(13, "WTNPDGTTSK", 84f, 199644.5f),
         };
 
+        /// <summary>
+        /// Set to true to regenerate EXPECTED_POINT_COUNT and EXPECTED_RANDOM_POINTS above:
+        /// the run prints them as pasteable C#, and <see cref="CheckRecordMode"/> then fails the
+        /// test so record mode cannot be committed switched on. Recording requires an on-screen
+        /// run (offscreen=off) - offscreen coordinates are not reproducible.
+        /// </summary>
+        protected override bool IsRecordMode => false;
+
         [TestMethod]
         public void TestLabelLayoutDeterminism()
         {
@@ -136,12 +144,25 @@ namespace pwiz.SkylineTestFunctional
             // that the layout code ran and produced labels.
             if (Program.SkylineOffscreen)
             {
+                Assert.IsFalse(IsRecordMode,
+                    "Cannot record expected values from an offscreen run - screen coordinates are not" +
+                    " reproducible there. Re-run with offscreen=off.");
                 Assert.IsTrue(first.Count > 0, "First snapshot has no labels (offscreen).");
                 Assert.IsTrue(second.Count > 0, "Second snapshot has no labels (offscreen).");
                 return;
             }
 
             Assert.AreEqual(first.Count, second.Count, "Snapshots have different number of points.");
+
+            // Both snapshots agree by here, so the layout is deterministic within this run - which
+            // is what this test is named for. Everything below pins it to absolute values recorded
+            // on one machine, so record mode regenerates them rather than asserting them.
+            if (IsRecordMode)
+            {
+                RecordExpectedValues(first);
+                return;
+            }
+
             Assert.AreEqual(EXPECTED_POINT_COUNT, first.Count, "Plot point count is different from expected.");
             for (var i = 0; i < first.Count; i++)
             {
@@ -154,6 +175,30 @@ namespace pwiz.SkylineTestFunctional
                 AssertExpectedPoint(first, expectedPoint, "first");
                 AssertExpectedPoint(second, expectedPoint, "second");
             }
+        }
+
+        /// <summary>
+        /// Prints the current layout as the two constants at the top of this file, ready to paste.
+        /// The sampled indexes are carried over from the existing EXPECTED_RANDOM_POINTS so a
+        /// re-record keeps spanning the list; any index past the new count is dropped.
+        /// </summary>
+        private static void RecordExpectedValues(IReadOnlyList<PointSnapshot> snapshot)
+        {
+            Console.WriteLine();
+            Console.WriteLine(@"// Paste over the constants at the top of LabelLayoutTest.cs:");
+            Console.WriteLine(string.Format(CultureInfo.InvariantCulture,
+                @"        private const int EXPECTED_POINT_COUNT = {0};", snapshot.Count));
+            Console.WriteLine(@"        private static readonly ExpectedPointSnapshot[] EXPECTED_RANDOM_POINTS =");
+            Console.WriteLine(@"        {");
+            foreach (var index in EXPECTED_RANDOM_POINTS.Select(p => p.Index).Where(i => i < snapshot.Count))
+            {
+                var point = snapshot[index];
+                Console.WriteLine(string.Format(CultureInfo.InvariantCulture,
+                    @"            new ExpectedPointSnapshot({0}, ""{1}"", {2}f, {3}f),",
+                    index, point.LabelText, point.LabelPosition.X, point.LabelPosition.Y));
+            }
+            Console.WriteLine(@"        };");
+            Console.WriteLine();
         }
 
         private void AssertExpectedPoint(IReadOnlyList<PointSnapshot> snapshot, ExpectedPointSnapshot expected, string snapshotName)

--- a/pwiz_tools/Skyline/TestFunctional/TestFunctional.csproj
+++ b/pwiz_tools/Skyline/TestFunctional/TestFunctional.csproj
@@ -5,7 +5,7 @@
        fixtures are flat *.zip files copied to output. Compile items are auto-globbed. -->
   <PropertyGroup>
     <ProjectGuid>{1B7E62FF-463B-4B3E-8E37-72F1A7C2BFD9}</ProjectGuid>
-    <TargetFrameworks>net472;net8.0-windows</TargetFrameworks>
+    <TargetFrameworks>net8.0-windows</TargetFrameworks>
     <Platforms>AnyCPU;x64;x86</Platforms>
     <LangVersion>latest</LangVersion>
     <Nullable>disable</Nullable>

--- a/pwiz_tools/Skyline/TestFunctional/UnattendedDialogTimeoutTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/UnattendedDialogTimeoutTest.cs
@@ -1,0 +1,96 @@
+/*
+ * Original author: Brendan MacLean <brendanx .at. u.washington.edu>,
+ *                  MacCoss Lab, Department of Genome Sciences, UW
+ * AI assistance: Claude Code (Claude Opus 5) <noreply .at. anthropic.com>
+ *
+ * Copyright 2026 University of Washington - Seattle, WA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using pwiz.Skyline.Alerts;
+using pwiz.SkylineTestUtil;
+
+namespace pwiz.SkylineTestFunctional
+{
+    /// <summary>
+    /// Verifies that the unattended-dialog watchdog in CommonAlertDlg reports the dialog it
+    /// actually timed out on, rather than being handed back to the UI in a second dialog that
+    /// nobody dismisses either.
+    /// <para>Before this was fixed, any generic handler that displayed a caught exception turned
+    /// one missed dialog into a cascade: a second timeout whose message quoted the first, thrown
+    /// out of a nested modal loop where WinForms bypasses the Application.ThreadException
+    /// handler and pops its own ThreadExceptionDialog. Tests reported that as a hang, and the
+    /// message naming the dialog they had missed was buried two layers deep. This test drives
+    /// that exact shape: time a dialog out, then hand the failure back to the UI the way a
+    /// catch handler does.</para>
+    /// </summary>
+    [TestClass]
+    public class UnattendedDialogTimeoutTest : AbstractFunctionalTest
+    {
+        private const string MESSAGE_TEXT = @"UnattendedDialogTimeoutTest unattended message";
+        private const int RETHROW_LIMIT_SECONDS = 5;
+
+        [TestMethod]
+        public void TestUnattendedDialogTimeout()
+        {
+            RunFunctionalTest();
+        }
+
+        protected override void DoTest()
+        {
+            RunUI(() =>
+            {
+                // A dialog nobody dismisses fails with the watchdog timeout, and the message
+                // says which dialog was missed.
+                var firstTimeout = CatchDialogTimeout(() =>
+                    MessageDlg.ShowWithException(SkylineWindow, MESSAGE_TEXT, new IOException(MESSAGE_TEXT)));
+                Assert.IsNotNull(firstTimeout);
+                AssertEx.Contains(firstTimeout.Message, MESSAGE_TEXT);
+
+                // Handing that failure back to the UI, the way a generic catch handler does,
+                // must rethrow it untouched instead of showing a dialog that times out in turn.
+                var stopwatch = Stopwatch.StartNew();
+                var rethrown = CatchDialogTimeout(() =>
+                    MessageDlg.ShowWithException(SkylineWindow, firstTimeout.Message, firstTimeout));
+                stopwatch.Stop();
+
+                Assert.IsNotNull(rethrown);
+                Assert.AreSame(firstTimeout, rethrown);     // Not a second timeout wrapping the first
+                AssertEx.IsLessThan(stopwatch.Elapsed, TimeSpan.FromSeconds(RETHROW_LIMIT_SECONDS));
+            });
+        }
+
+        /// <summary>
+        /// Runs an action expected to fail with the unattended-dialog watchdog timeout and
+        /// returns that exception, or null if the action completed without one.
+        /// </summary>
+        private static TimeoutException CatchDialogTimeout(Action act)
+        {
+            try
+            {
+                act();
+            }
+            catch (TimeoutException e)
+            {
+                return e;
+            }
+
+            return null;
+        }
+    }
+}

--- a/pwiz_tools/Skyline/TestPerf/TestPerf.csproj
+++ b/pwiz_tools/Skyline/TestPerf/TestPerf.csproj
@@ -6,7 +6,7 @@
        output. Compile items are auto-globbed. -->
   <PropertyGroup>
     <ProjectGuid>{D0481E9D-BCBF-4DD7-977E-791801871B5B}</ProjectGuid>
-    <TargetFrameworks>net472;net8.0-windows</TargetFrameworks>
+    <TargetFrameworks>net8.0-windows</TargetFrameworks>
     <Platforms>AnyCPU;x64;x86</Platforms>
     <LangVersion>latest</LangVersion>
     <Nullable>disable</Nullable>

--- a/pwiz_tools/Skyline/TestRunner/Program.cs
+++ b/pwiz_tools/Skyline/TestRunner/Program.cs
@@ -285,6 +285,13 @@ namespace TestRunner
         {
             Console.OutputEncoding = Encoding.UTF8;
 
+            // Pin the WinForms default font exactly as shipping Skyline does, before any control
+            // is created. Skyline sets this in its own Main, but by the time the first functional
+            // test calls that, hundreds of unit tests have run in this process and may already
+            // have created a window - after which the font can no longer be set. Doing it here
+            // guarantees every test sees the same metrics as the shipping app.
+            pwiz.Skyline.Program.SetDefaultFont();
+
             // Opt the test runner into the latest WinForms accessibility level by explicitly setting
             // all four UseLegacyAccessibilityFeatures switches to false BEFORE any control is created.
             // This is test-host only -- it does not change shipping Skyline behavior.

--- a/pwiz_tools/Skyline/TestRunner/TestRunner.csproj
+++ b/pwiz_tools/Skyline/TestRunner/TestRunner.csproj
@@ -6,7 +6,7 @@
   <PropertyGroup>
     <ProjectGuid>{B92CA24E-0867-4B99-88F8-EF542A4AFE87}</ProjectGuid>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net472;net8.0-windows</TargetFrameworks>
+    <TargetFrameworks>net8.0-windows</TargetFrameworks>
     <Platforms>AnyCPU;x64;x86</Platforms>
     <LangVersion>latest</LangVersion>
     <Nullable>disable</Nullable>

--- a/pwiz_tools/Skyline/TestRunnerLib/GarbageCollectionTracker.cs
+++ b/pwiz_tools/Skyline/TestRunnerLib/GarbageCollectionTracker.cs
@@ -337,14 +337,39 @@ namespace TestRunnerLib
                 return unhooked;
 
             var isDisposed = controlType.GetProperty(@"IsDisposed");
-            foreach (var info in ((System.Collections.IEnumerable)handlers[key]).Cast<object>().ToArray())
+            // SystemEvents mutates this list under its own private lock whenever a Control is
+            // created or disposed on any thread, so an unsynchronized snapshot can throw
+            // "Collection was modified". Upstream swallows that into "could not check the
+            // hook", which then reports the very GC-LEAK this method exists to suppress -
+            // intermittently, which is the hardest form to diagnose. Retake the snapshot.
+            object[] entries = null;
+            for (int attempt = 0; attempt < 3 && entries == null; attempt++)
+            {
+                try
+                {
+                    entries = ((System.Collections.IEnumerable)handlers[key]).Cast<object>().ToArray();
+                }
+                catch (InvalidOperationException)
+                {
+                    // Modified while reading - fall through and take a fresh snapshot.
+                }
+            }
+            if (entries == null)
+                return unhooked;
+
+            foreach (var info in entries)
             {
                 if (!(info?.GetType().GetField(@"_delegate", inst)?.GetValue(info) is Delegate del))
                     continue;
                 // Only the framework's own per-window hook, only on a survivor, only once disposed.
                 bool isHook = del.Method.DeclaringType == controlType && del.Method.Name == @"UserPreferenceChanged";
                 bool isSurvivor = del.Target != null && survivors.Any(s => ReferenceEquals(s, del.Target));
-                bool disposed = isSurvivor && true.Equals(isDisposed?.GetValue(del.Target));
+                // Check the type first: a tracked survivor need not be a Control (SrmDocument
+                // is registered too), and PropertyInfo.GetValue against a non-Control throws
+                // TargetException, which escapes the loop and skips every remaining entry -
+                // including the genuine framework hooks that would have explained the leak.
+                bool disposed = isSurvivor && controlType.IsInstanceOfType(del.Target) &&
+                                true.Equals(isDisposed?.GetValue(del.Target));
                 if (!isSurvivor)
                     continue;   // static and unrelated subscribers are the normal case, not news
                 // A survivor found in the table is always worth logging, including when it is not

--- a/pwiz_tools/Skyline/TestRunnerLib/GarbageCollectionTracker.cs
+++ b/pwiz_tools/Skyline/TestRunnerLib/GarbageCollectionTracker.cs
@@ -20,6 +20,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using System.Threading;
 
 namespace TestRunnerLib
@@ -199,6 +200,14 @@ namespace TestRunnerLib
             // Phase 3: Still leaking after retries - pin survivors and report. Dump BEFORE pinning,
             // so the only roots in the dump are the ones actually holding the survivors.
             WriteRootPathsIfRequested(log);
+
+            // Phase 3a: a survivor held only by WinForms' own SystemEvents hook is a framework
+            // condition, not a Skyline leak. Unhook it and re-check; if that releases everything,
+            // this was the known condition and the run continues with a warning.
+            leakMessage = ReleaseFrameworkSystemEventsHook(leakMessage, log);
+            if (leakMessage == null)
+                return null;
+
             WriteLeakDumpIfRequested(testName, log);
             PinSurvivors();
 #if NET472
@@ -239,6 +248,120 @@ namespace TestRunnerLib
         /// regardless.</para>
         /// </summary>
         public const string ROOT_PATHS = "SKYLINE_GC_LEAK_ROOTS";
+
+        /// <summary>
+        /// WinForms hooks <c>SystemEvents.UserPreferenceChanged</c> for every top-level window -
+        /// the private <c>Control.UserPreferenceChanged</c> handler, with the window as its target -
+        /// and very occasionally does not remove that hook when the window is disposed. Because
+        /// SystemEvents' handler table is static, the disposed window is then rooted for the life
+        /// of the process, and everything it references with it. Measured at roughly one occurrence
+        /// per 30,000 test executions, on whichever test happens to be running; it is not a property
+        /// of any test, and every root chain captured for it has been this hook.
+        ///
+        /// <para>Rather than trust that pattern match, this DISPROVES the alternative: it unhooks
+        /// only the identified handlers - via the public event accessor, on objects positively
+        /// identified as already-disposed Controls that are already leaking - and then collects
+        /// again. If everything is released, the hook really was the only thing holding them, and
+        /// the test continues with a warning. If anything survives, the message names what is left
+        /// and the test still fails, so a genuine Skyline leak cannot hide behind this.</para>
+        ///
+        /// <para>Returns null when the leak was fully explained and released, otherwise the message
+        /// describing what remains.</para>
+        /// </summary>
+        private static string ReleaseFrameworkSystemEventsHook(string leakMessage, Action<string, object[]> log)
+        {
+            int unhooked;
+            try
+            {
+                // Deliberately a count, not the delegates: a Delegate holds its target, so keeping
+                // the removed handlers around would re-root the very window we are trying to prove
+                // collectable, and the check below would never pass.
+                unhooked = UnhookSystemEventsForSurvivors(log);
+            }
+            catch (Exception x)
+            {
+                log("\n# Could not check the SystemEvents hook ({0}: {1}); reporting the leak.\n",
+                    new object[] { x.GetType().Name, x.Message });
+                return leakMessage;
+            }
+
+            if (unhooked == 0)
+                return leakMessage;   // not the known condition - report it unchanged
+
+            RunTests.MemoryManagement.FlushMemory();
+            var remaining = CheckForLeaks();
+            if (remaining != null)
+            {
+                log("\n# Removed {0} stale SystemEvents hook(s), but objects are still held: {1}\n",
+                    new object[] { unhooked, remaining });
+                return remaining;
+            }
+
+            log("\n# GC-LEAK WARNING {0} - released by removing {1} stale WinForms" +
+                " SystemEvents.UserPreferenceChanged hook(s) on disposed windows. Known framework" +
+                " condition, not a Skyline leak; the root chain is above.\n",
+                new object[] { leakMessage, unhooked });
+            return null;
+        }
+
+        /// <summary>
+        /// Removes the <c>SystemEvents.UserPreferenceChanged</c> hooks whose delegate target is one
+        /// of the current survivors and is an already-disposed Control. Reads the handler table by
+        /// reflection but removes through the public event accessor, so nothing internal is mutated.
+        /// </summary>
+        private static int UnhookSystemEventsForSurvivors(Action<string, object[]> log)
+        {
+            var unhooked = 0;
+            var seType = Type.GetType(@"Microsoft.Win32.SystemEvents, Microsoft.Win32.SystemEvents");
+            var controlType = Type.GetType(@"System.Windows.Forms.Control, System.Windows.Forms");
+            if (seType == null || controlType == null)
+            {
+                log("# GCHOOK types unresolved: SystemEvents={0} Control={1}\n",
+                    new object[] { seType != null, controlType != null });
+                return unhooked;
+            }
+
+            object[] survivors;
+            lock (_lock)
+            {
+                survivors = _trackedObjects.Select(t => t.Reference.Target).Where(o => o != null).ToArray();
+            }
+            if (survivors.Length == 0)
+                return unhooked;
+
+            const BindingFlags stat = BindingFlags.NonPublic | BindingFlags.Static;
+            const BindingFlags inst = BindingFlags.NonPublic | BindingFlags.Instance;
+            var key = seType.GetField(@"s_onUserPreferenceChangedEvent", stat)?.GetValue(null);
+            var handlers = seType.GetField(@"s_handlers", stat)?.GetValue(null) as System.Collections.IDictionary;
+            if (key == null || handlers == null || !handlers.Contains(key))
+                return unhooked;
+
+            var isDisposed = controlType.GetProperty(@"IsDisposed");
+            foreach (var info in ((System.Collections.IEnumerable)handlers[key]).Cast<object>().ToArray())
+            {
+                if (!(info?.GetType().GetField(@"_delegate", inst)?.GetValue(info) is Delegate del))
+                    continue;
+                // Only the framework's own per-window hook, only on a survivor, only once disposed.
+                bool isHook = del.Method.DeclaringType == controlType && del.Method.Name == @"UserPreferenceChanged";
+                bool isSurvivor = del.Target != null && survivors.Any(s => ReferenceEquals(s, del.Target));
+                bool disposed = isSurvivor && true.Equals(isDisposed?.GetValue(del.Target));
+                if (!isSurvivor)
+                    continue;   // static and unrelated subscribers are the normal case, not news
+                // A survivor found in the table is always worth logging, including when it is not
+                // the framework hook - that would be a Skyline subscription that was never removed.
+                log("# GCHOOK survivor in SystemEvents: {0}.{1} target={2} frameworkHook={3} disposed={4}\n",
+                    new object[]
+                    {
+                        del.Method.DeclaringType?.Name, del.Method.Name,
+                        del.Target.GetType().Name, isHook, disposed
+                    });
+                if (!isHook || !disposed)
+                    continue;
+                seType.GetEvent(@"UserPreferenceChanged")?.RemoveEventHandler(null, del);
+                unhooked++;
+            }
+            return unhooked;
+        }
 
         private static void WriteRootPathsIfRequested(Action<string, object[]> log)
         {

--- a/pwiz_tools/Skyline/TestRunnerLib/GarbageCollectionTracker.cs
+++ b/pwiz_tools/Skyline/TestRunnerLib/GarbageCollectionTracker.cs
@@ -154,6 +154,17 @@ namespace TestRunnerLib
         public static string CheckAfterTest(string testName, int dotMemoryWarmupRuns,
             Exception exception, Action<string, object[]> log)
         {
+            // SKYLINE_GC_LEAK_ROOTS=smoke exercises the reporter on every test, whether or not
+            // anything leaked, so the ClrMD snapshot path can be proven to work in an environment
+            // (notably a Windows container) without waiting out the ~30,000 executions it takes to
+            // hit a real leak. RunTests is alive and rooted here, so it should produce a root path;
+            // SkylineWindow should normally report no live instance.
+            if (string.Equals(Environment.GetEnvironmentVariable(ROOT_PATHS), @"smoke", StringComparison.OrdinalIgnoreCase))
+            {
+                foreach (var line in GcRootReporter.DescribeRoots(new[] { @"SkylineWindow", @"RunTests" }))
+                    log("# GCROOT-SMOKE {0}\n", new object[] { line });
+            }
+
             if (dotMemoryWarmupRuns > 0)
             {
                 PinSurvivors();
@@ -187,6 +198,7 @@ namespace TestRunnerLib
 
             // Phase 3: Still leaking after retries - pin survivors and report. Dump BEFORE pinning,
             // so the only roots in the dump are the ones actually holding the survivors.
+            WriteRootPathsIfRequested(log);
             WriteLeakDumpIfRequested(testName, log);
             PinSurvivors();
 #if NET472
@@ -208,6 +220,46 @@ namespace TestRunnerLib
         /// Unset (the normal case) costs one environment read per leak.
         /// </summary>
         public const string LEAK_DUMP_DIR = "SKYLINE_GC_LEAK_DUMP";
+
+        /// <summary>
+        /// Root-chain reporting is ON by default; set this to "off" to suppress it, or to "smoke"
+        /// to exercise it on every test (see <see cref="CheckAfterTest"/>).
+        ///
+        /// <para>On by default deliberately. This is the cheap alternative to
+        /// <see cref="LEAK_DUMP_DIR"/> - it answers the only question a dump gets opened to answer,
+        /// "what is still holding this", in a few lines of text. And it has to be on by default to
+        /// be useful at all in parallel mode: an environment variable cannot reach a Docker worker,
+        /// because TestRunner passes no -e arguments and the AlwaysUp .\TestUser service session
+        /// would not inherit them anyway. Worker stdout IS relayed to the server log, so a default
+        /// -on reporter gets the answer out of a container with no plumbing whatsoever - including
+        /// from TeamCity, which is where most executions happen.</para>
+        ///
+        /// <para>The cost is a PSS snapshot and one heap walk, paid only when a leak has already
+        /// survived every retry - about once per 30,000 test executions - on a test that is failing
+        /// regardless.</para>
+        /// </summary>
+        public const string ROOT_PATHS = "SKYLINE_GC_LEAK_ROOTS";
+
+        private static void WriteRootPathsIfRequested(Action<string, object[]> log)
+        {
+            if (string.Equals(Environment.GetEnvironmentVariable(ROOT_PATHS), @"off", StringComparison.OrdinalIgnoreCase))
+                return;
+            try
+            {
+                var typeNames = new HashSet<string>();
+                lock (_lock)
+                {
+                    foreach (var survivor in _trackedObjects)
+                        typeNames.Add(survivor.TypeName);
+                }
+                foreach (var line in GcRootReporter.DescribeRoots(typeNames))
+                    log("# GCROOT {0}\n", new object[] { line });
+            }
+            catch (Exception x)
+            {
+                log("\n# GC root reporting failed: {0}: {1}\n", new object[] { x.GetType().Name, x.Message });
+            }
+        }
 
         private static void WriteLeakDumpIfRequested(string testName, Action<string, object[]> log)
         {

--- a/pwiz_tools/Skyline/TestRunnerLib/GcRootReporter.cs
+++ b/pwiz_tools/Skyline/TestRunnerLib/GcRootReporter.cs
@@ -1,0 +1,235 @@
+/*
+ * Original author: Brendan MacLean <brendanx .at. uw.edu>,
+ *                  MacCoss Lab, Department of Genome Sciences, UW
+ * AI assistance: Claude Code (Claude Opus 5) <noreply .at. anthropic.com>
+ *
+ * Copyright 2026 University of Washington - Seattle, WA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Text.RegularExpressions;
+using Microsoft.Diagnostics.Runtime;
+
+namespace TestRunnerLib
+{
+    /// <summary>
+    /// Answers "what is still rooting this object" as text, for
+    /// <see cref="GarbageCollectionTracker"/>.
+    ///
+    /// <para>This is deliberately text rather than a memory dump. A GC leak reproduces roughly once
+    /// per 30,000 test executions, and most of those occurrences happen inside a parallel-mode
+    /// Docker worker, where a dump would have to be written to the c:\pwiz mount to survive the
+    /// container and then analyzed offline - hundreds of megabytes for one root chain. Worker
+    /// stdout is already relayed to the server log, so a few lines of text come back with no
+    /// plumbing at all, in both serial and parallel mode.</para>
+    ///
+    /// <para>Uses ClrMD's PSS snapshot rather than attaching to the live process: the snapshot is a
+    /// copy-on-write clone, so walking it cannot deadlock against the very process doing the
+    /// walking, and the heap cannot shift underneath the traversal.</para>
+    /// </summary>
+    public static class GcRootReporter
+    {
+        /// <summary>
+        /// A root chain is only useful if it is short enough to read. Anything longer than this is
+        /// almost certainly walking a collection graph rather than naming the holder.
+        /// </summary>
+        private const int MAX_CHAIN = 24;
+
+        /// <summary>
+        /// The point is to identify the holder, not to enumerate every duplicate path to it.
+        /// </summary>
+        private const int MAX_PATHS_PER_TYPE = 3;
+
+        /// <summary>
+        /// Describes the GC roots holding any live object whose simple type name is in
+        /// <paramref name="typeNames"/>. Returns human-readable lines; never throws for reasons
+        /// intrinsic to the target process, so the caller can log whatever came back.
+        /// </summary>
+        public static IEnumerable<string> DescribeRoots(ICollection<string> typeNames)
+        {
+            if (typeNames == null || typeNames.Count == 0)
+                yield break;
+
+            var lines = new List<string>();
+            try
+            {
+                lines.AddRange(DescribeRootsImpl(typeNames));
+            }
+            catch (Exception x)
+            {
+                // A snapshot can legitimately fail - PSS is unavailable, the runtime is mid-GC,
+                // the container denies the handle. Report it rather than taking down the test run,
+                // which is only reporting a leak in the first place.
+                lines.Add(string.Format(@"unavailable: {0}: {1}", x.GetType().Name, x.Message));
+            }
+
+            foreach (var line in lines)
+                yield return line;
+        }
+
+        private static List<string> DescribeRootsImpl(ICollection<string> typeNames)
+        {
+            var lines = new List<string>();
+            using var dataTarget = DataTarget.CreateSnapshotAndAttach(Process.GetCurrentProcess().Id);
+            var clrInfo = dataTarget.ClrVersions.FirstOrDefault();
+            if (clrInfo == null)
+            {
+                lines.Add(@"unavailable: no CLR found in snapshot");
+                return lines;
+            }
+
+            using var runtime = clrInfo.CreateRuntime();
+            var heap = runtime.Heap;
+            if (!heap.CanWalkHeap)
+            {
+                lines.Add(@"unavailable: heap is not walkable");
+                return lines;
+            }
+
+            // Match on the simple name because that is what GarbageCollectionTracker records
+            // (Type.Name), while ClrType.Name is namespace-qualified.
+            var targetsByType = new Dictionary<string, List<ulong>>();
+            foreach (var obj in heap.EnumerateObjects())
+            {
+                var typeName = obj.Type?.Name;
+                if (typeName == null)
+                    continue;
+                var simpleName = SimpleName(typeName);
+                if (!typeNames.Contains(simpleName))
+                    continue;
+                if (!targetsByType.TryGetValue(simpleName, out var list))
+                    targetsByType[simpleName] = list = new List<ulong>();
+                list.Add(obj.Address);
+            }
+
+            foreach (var typeName in typeNames)
+            {
+                if (!targetsByType.TryGetValue(typeName, out var addresses))
+                {
+                    // Collected between the check and the snapshot, which is worth knowing: it
+                    // means the object was reachable only transiently.
+                    lines.Add(string.Format(@"{0}: no live instance in snapshot", typeName));
+                    continue;
+                }
+
+                lines.Add(string.Format(@"{0}: {1} live instance(s)", typeName, addresses.Count));
+                lines.AddRange(DescribePathsTo(runtime, addresses));
+            }
+
+            return lines;
+        }
+
+        private static IEnumerable<string> DescribePathsTo(ClrRuntime runtime, List<ulong> addresses)
+        {
+            var lines = new List<string>();
+            var gcRoot = new GCRoot(runtime.Heap, addresses);
+            int pathCount = 0;
+            foreach (var (root, chain) in gcRoot.EnumerateRootPaths())
+            {
+                lines.Add(string.Format(@"  root {0} {1}", root.RootKind, DescribeObject(runtime, root.Object.Address)));
+                lines.Add(@"    " + FormatChain(runtime, chain));
+                if (++pathCount >= MAX_PATHS_PER_TYPE)
+                {
+                    lines.Add(string.Format(@"  (stopped after {0} paths)", MAX_PATHS_PER_TYPE));
+                    break;
+                }
+            }
+            if (pathCount == 0)
+            {
+                // The tracker saw it alive, the snapshot finds it unrooted. That is the signature
+                // of a transient root - a pending message, a thread-pool work item, a stack slot in
+                // a frame that has since returned - rather than a durable reference.
+                lines.Add(@"  no root path found - survivor appears transiently rooted");
+            }
+            return lines;
+        }
+
+        private static string FormatChain(ClrRuntime runtime, GCRoot.ChainLink chain)
+        {
+            var parts = new List<string>();
+            for (var link = chain; link != null && parts.Count < MAX_CHAIN; link = link.Next)
+                parts.Add(DescribeObject(runtime, link.Object));
+            if (parts.Count >= MAX_CHAIN)
+                parts.Add(@"...");
+            return string.Join(@" -> ", parts);
+        }
+
+        /// <summary>
+        /// A delegate in a root chain is the whole answer: it names the method whose subscription
+        /// was never removed. Without this the chain stops at the handler's type, which identifies
+        /// the event but not the subscriber - and for events raised by a static table like
+        /// Microsoft.Win32.SystemEvents, the subscriber is the only thing worth knowing.
+        /// </summary>
+        private static string DescribeDelegate(ClrRuntime runtime, ClrHeap heap, ulong address)
+        {
+            try
+            {
+                var obj = heap.GetObject(address);
+                if (!obj.IsValid || !IsDelegate(obj.Type))
+                    return null;
+                if (!obj.TryReadField<ulong>(@"_methodPtr", out var methodPtr) || methodPtr == 0)
+                    return null;
+                var method = runtime.GetMethodByInstructionPointer(methodPtr);
+                if (method == null)
+                    return null;
+                var declaring = method.Type == null ? string.Empty : SimpleName(method.Type.Name) + @".";
+                return declaring + method.Name;
+            }
+            catch (Exception)
+            {
+                // Best effort only - a chain without a method name is still worth printing.
+                return null;
+            }
+        }
+
+        private static bool IsDelegate(ClrType type)
+        {
+            for (var t = type; t != null; t = t.BaseType)
+            {
+                if (t.Name == @"System.MulticastDelegate" || t.Name == @"System.Delegate")
+                    return true;
+            }
+            return false;
+        }
+
+        private static string DescribeObject(ClrRuntime runtime, ulong address)
+        {
+            if (address == 0)
+                return @"(null)";
+            var type = runtime.Heap.GetObjectType(address);
+            if (type == null)
+                return string.Format(@"0x{0:x}", address);
+            var name = SimpleName(type.Name);
+            var method = DescribeDelegate(runtime, runtime.Heap, address);
+            return method == null ? name : string.Format(@"{0}[{1}]", name, method);
+        }
+
+        /// <summary>
+        /// Strips the namespace from every dotted run in the name, rather than just cutting at the
+        /// last dot, so that generic arguments survive readably:
+        /// System.Collections.Generic.List&lt;pwiz.Skyline.SkylineWindow&gt; becomes
+        /// List&lt;SkylineWindow&gt; rather than the meaningless "SkylineWindow&gt;".
+        /// </summary>
+        private static string SimpleName(string typeName)
+        {
+            return DOTTED_RUN.Replace(typeName, m => m.Value.Substring(m.Value.LastIndexOf('.') + 1));
+        }
+
+        private static readonly Regex DOTTED_RUN =
+            new Regex(@"[A-Za-z_][A-Za-z0-9_`]*(\.[A-Za-z_][A-Za-z0-9_`]*)+", RegexOptions.Compiled);
+    }
+}

--- a/pwiz_tools/Skyline/TestRunnerLib/TestRunnerLib.csproj
+++ b/pwiz_tools/Skyline/TestRunnerLib/TestRunnerLib.csproj
@@ -5,7 +5,7 @@
        it under net8.0-windows too. -->
   <PropertyGroup>
     <ProjectGuid>{E3F0E34F-F9E6-4360-996F-E2054E4FA1AE}</ProjectGuid>
-    <TargetFrameworks>net472;net8.0-windows</TargetFrameworks>
+    <TargetFrameworks>net8.0-windows</TargetFrameworks>
     <Platforms>AnyCPU;x64;x86</Platforms>
     <LangVersion>latest</LangVersion>
     <Nullable>disable</Nullable>

--- a/pwiz_tools/Skyline/TestRunnerLib/TestRunnerLib.csproj
+++ b/pwiz_tools/Skyline/TestRunnerLib/TestRunnerLib.csproj
@@ -51,6 +51,10 @@
     <PackageReference Include="log4net" Version="2.0.17" />
     <PackageReference Include="MSTest.TestFramework" Version="3.2.0" />
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="8.0.0" />
+    <!-- Used by GarbageCollectionTracker to report what is still rooting a survivor. Same
+         version as TestUtil and SkylineNightly: staging flattens every project's output into
+         one directory, so a second Microsoft.Diagnostics.Runtime.dll would silently win. -->
+    <PackageReference Include="Microsoft.Diagnostics.Runtime" Version="3.1.512801" />
   </ItemGroup>
 
 </Project>

--- a/pwiz_tools/Skyline/TestTutorial/TestTutorial.csproj
+++ b/pwiz_tools/Skyline/TestTutorial/TestTutorial.csproj
@@ -5,7 +5,7 @@
        copied to output. Compile items are auto-globbed. -->
   <PropertyGroup>
     <ProjectGuid>{6FCD5F27-637B-499A-BB66-F74D5FBBD500}</ProjectGuid>
-    <TargetFrameworks>net472;net8.0-windows</TargetFrameworks>
+    <TargetFrameworks>net8.0-windows</TargetFrameworks>
     <Platforms>AnyCPU;x64;x86</Platforms>
     <LangVersion>latest</LangVersion>
     <Nullable>disable</Nullable>

--- a/pwiz_tools/Skyline/TestUtil/AssertEx.cs
+++ b/pwiz_tools/Skyline/TestUtil/AssertEx.cs
@@ -1841,6 +1841,7 @@ namespace pwiz.SkylineTestUtil
             return null;
         }
 
+
         private static SrmDocument ForceDocumentLoad(SrmDocument target, string testDir)
         {
             string xmlSaved = null;
@@ -1861,6 +1862,15 @@ namespace pwiz.SkylineTestUtil
                 using (var docContainer = new ResultsTestDocumentContainer(null, tmpSky))
                 {
                     docContainer.SetDocument(docLoad, null, true);
+                    // SetDocument's wait ends at MemoryDocumentContainer.IsFinal, which
+                    // deliberately reports final for a document that never flipped to loaded, so
+                    // the test surface fails fast rather than hanging. That leaves the library
+                    // loader still running, and since ForceDocumentLoad is called on BOTH sides of
+                    // a comparison, each side raced independently: when only one had finished,
+                    // PeptideLibraries compared unequal purely on load state, in either direction.
+                    // Wait on the background loaders too, as DocLoadLibraryTest does for the same
+                    // reason. Was about 6% of RefineConvertToSmallMoleculesTest runs.
+                    docContainer.WaitForProcessing();
                     docContainer.AssertComplete();
                     return docContainer.Document;
                 }
@@ -1910,6 +1920,7 @@ namespace pwiz.SkylineTestUtil
             Cloned(target.PeptideSettings.Enzyme, copy.PeptideSettings.Enzyme, defPep.Enzyme);
             Cloned(target.PeptideSettings.DigestSettings, copy.PeptideSettings.DigestSettings, defPep.DigestSettings);
             Cloned(target.PeptideSettings.Filter, copy.PeptideSettings.Filter, defPep.Filter);
+            EqualityExplainer.AssertEqual(target.PeptideSettings.Libraries, copy.PeptideSettings.Libraries, @"PeptideLibraries not cloned equal");
             Cloned(target.PeptideSettings.Libraries, copy.PeptideSettings.Libraries, defPep.Libraries);
             Cloned(target.PeptideSettings.Modifications, copy.PeptideSettings.Modifications, defPep.Modifications);
             Cloned(target.PeptideSettings.Prediction, copy.PeptideSettings.Prediction, defPep.Prediction);
@@ -2080,7 +2091,8 @@ namespace pwiz.SkylineTestUtil
                 return;
             }
             if (!Equals(group.Results, convertedGroup.Results))
-                AreEqual(group.Results, convertedGroup.Results, group + " vs " + convertedGroup);
+                EqualityExplainer.AssertEqual(group.Results, convertedGroup.Results,
+                    string.Format(@"TransitionGroupChromInfo results differ: {0} vs {1}", group, convertedGroup));
         }
 
         private static void ConvertedSmallMoleculeIsSimilar(PeptideDocNode convertedMol, PeptideDocNode mol, RefinementSettings.ConvertToSmallMoleculesMode conversionMode)

--- a/pwiz_tools/Skyline/TestUtil/EqualityExplainer.cs
+++ b/pwiz_tools/Skyline/TestUtil/EqualityExplainer.cs
@@ -1,0 +1,170 @@
+/*
+ * Original author: Brendan MacLean <brendanx .at. uw.edu>,
+ *                  MacCoss Lab, Department of Genome Sciences, UW
+ * AI assistance: Claude Code (Claude Opus 5) <noreply .at. anthropic.com>
+ *
+ * Copyright 2026 University of Washington - Seattle, WA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using pwiz.Common.SystemUtil;
+using pwiz.Skyline.Util.Extensions;
+
+namespace pwiz.SkylineTestUtil
+{
+    /// <summary>
+    /// Turns "these two objects are not equal" into a statement of WHICH member differs, for
+    /// assertion messages.
+    ///
+    /// <para>Prefers the type's own <see cref="IExplainDiff"/>, which is declared next to the
+    /// Equals it explains and so can reach private fields. Falls back to a best-effort walk of
+    /// public properties for types that have not adopted the interface, so an unfamiliar failure
+    /// still says something useful without anyone having to add code first.</para>
+    /// </summary>
+    public static class EqualityExplainer
+    {
+        /// <summary>
+        /// Longer than this and the reader is scrolling rather than diagnosing.
+        /// </summary>
+        private const int MAX_DIFFERENCES = 10;
+
+        /// <summary>
+        /// Returns a description of how <paramref name="expected"/> and <paramref name="actual"/>
+        /// differ, or null when they are equal. Safe to call on anything: it never throws for
+        /// reasons intrinsic to the values being compared.
+        /// </summary>
+        public static string Explain(object expected, object actual)
+        {
+            if (Equals(expected, actual))
+                return null;
+            if (expected == null || actual == null)
+                return string.Format(@"{0} vs {1}", Describe(expected), Describe(actual));
+
+            var explained = expected is IExplainDiff explainer ? Safely(() => explainer.ExplainDiff(actual)) : null;
+            if (!string.IsNullOrEmpty(explained))
+                return explained;
+
+            // Collections are the common case for document comparisons - Results<T> holds
+            // ChromInfoLists which hold the chrom infos that know how to explain themselves - so
+            // recurse to reach the element that actually differs rather than reporting that two
+            // lists are not equal.
+            var elements = ExplainByElements(expected, actual);
+            if (!string.IsNullOrEmpty(elements))
+                return elements;
+
+            var reflected = ExplainByPublicProperties(expected, actual);
+            if (!string.IsNullOrEmpty(reflected))
+                return reflected;
+
+            // Equals said unequal and nothing could say why. For an IExplainDiff type that means
+            // the implementation has drifted from Equals - worth saying out loud, because the
+            // alternative is a message that silently claims there is nothing to see.
+            return string.Format(
+                expected is IExplainDiff
+                    ? @"{0} and {1} are not equal, but ExplainDiff found no difference - it may be out of date with Equals"
+                    : @"{0} and {1} are not equal; no public property differs, so the difference is in state this type does not expose. Implement IExplainDiff on it to say which member.",
+                Describe(expected), Describe(actual));
+        }
+
+        /// <summary>
+        /// Fails with <see cref="AssertEx.Fail(string)"/> when the two differ, leading with
+        /// <paramref name="context"/> so the reader knows what was being compared.
+        /// </summary>
+        public static void AssertEqual(object expected, object actual, string context)
+        {
+            var why = Explain(expected, actual);
+            if (why != null)
+                AssertEx.Fail(TextUtil.LineSeparate(context, string.Empty, why));
+        }
+
+        private static string ExplainByElements(object expected, object actual)
+        {
+            if (expected is string || !(expected is System.Collections.IEnumerable left) ||
+                !(actual is System.Collections.IEnumerable right))
+                return null;
+
+            var mine = left.Cast<object>().ToList();
+            var theirs = right.Cast<object>().ToList();
+            if (mine.Count != theirs.Count)
+                return string.Format(@"count {0} vs {1}", mine.Count, theirs.Count);
+
+            var differences = new List<string>();
+            for (int i = 0; i < mine.Count && differences.Count < MAX_DIFFERENCES; i++)
+            {
+                var why = Explain(mine[i], theirs[i]);
+                if (why != null)
+                    differences.Add(string.Format(@"[{0}] {1}", i, why.Replace(Environment.NewLine, @"; ")));
+            }
+            return differences.Count == 0 ? null : TextUtil.LineSeparate(differences);
+        }
+
+        private static string ExplainByPublicProperties(object expected, object actual)
+        {
+            if (expected.GetType() != actual.GetType())
+                return string.Format(@"types differ: {0} vs {1}", expected.GetType().Name, actual.GetType().Name);
+
+            var differences = new List<string>();
+            foreach (var property in expected.GetType().GetProperties())
+            {
+                if (differences.Count >= MAX_DIFFERENCES || property.GetIndexParameters().Length != 0 || !property.CanRead)
+                    continue;
+                // Getters here can assert on internal state - PeptideLibraries has several that
+                // Assume.IsTrue(IsLoaded) - and this runs precisely when state is already suspect,
+                // so a throwing property is skipped rather than allowed to mask the real failure.
+                var mine = Safely(() => property.GetValue(expected));
+                var theirs = Safely(() => property.GetValue(actual));
+                if (mine is Exception || theirs is Exception || Equals(mine, theirs))
+                    continue;
+                differences.Add(string.Format(@"{0} {1} vs {2}", property.Name, Describe(mine), Describe(theirs)));
+            }
+            return differences.Count == 0 ? null : TextUtil.LineSeparate(differences);
+        }
+
+        private static string Describe(object value)
+        {
+            if (value == null)
+                return @"(null)";
+            var text = value.ToString();
+            // A type whose ToString is just its type name tells the reader nothing, which is the
+            // whole problem this class exists to solve. Say so rather than print it twice.
+            return text == value.GetType().ToString() ? string.Format(@"<{0}>", value.GetType().Name) : text;
+        }
+
+        private static T Safely<T>(Func<T> func) where T : class
+        {
+            try
+            {
+                return func();
+            }
+            catch (Exception)
+            {
+                return null;
+            }
+        }
+
+        private static object Safely(Func<object> func)
+        {
+            try
+            {
+                return func();
+            }
+            catch (Exception x)
+            {
+                return x;
+            }
+        }
+    }
+}

--- a/pwiz_tools/Skyline/TestUtil/HangDetection.cs
+++ b/pwiz_tools/Skyline/TestUtil/HangDetection.cs
@@ -245,7 +245,10 @@ namespace pwiz.SkylineTestUtil
 
         public static IEnumerable<string> GetAllThreadsCallstacks(int processId)
         {
-            using var dataTarget = DataTarget.AttachToProcess(processId, 5000, AttachFlag.Passive);
+            // ClrMD 3.x dropped AttachFlag. A PSS snapshot is the closest equivalent to the old
+            // passive attach - it reads a copy-on-write clone rather than suspending anything -
+            // and it is safe to take of the current process, which is what this is used for.
+            using var dataTarget = DataTarget.CreateSnapshotAndAttach(processId);
             var runtime = dataTarget.ClrVersions[0].CreateRuntime();
 
             foreach (var thread in runtime.Threads)

--- a/pwiz_tools/Skyline/TestUtil/TestFunctional.cs
+++ b/pwiz_tools/Skyline/TestUtil/TestFunctional.cs
@@ -25,6 +25,7 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Runtime.ExceptionServices;
 using System.Runtime.InteropServices;
 using System.Text;
 using System.Text.RegularExpressions;
@@ -2349,6 +2350,20 @@ namespace pwiz.SkylineTestUtil
         /// </summary>
         protected void RunFunctionalTest(string defaultUiMode = UiModes.PROTEOMIC)
         {
+            // WinForms requires an STA thread: creating a TreeView calls SetAcceptDrops, which
+            // makes OLE calls and throws "DragDrop registration did not succeed" from MTA.
+            // The console harness and Skyline both mark Main [STAThread], so harness runs never
+            // hit this. Visual Studio / ReSharper used to match, because VSTest defaults
+            // ExecutionThreadApartmentState to STA on .NET Framework - but that setting is not
+            // supported on net8, so the test host thread is MTA and every functional test failed
+            // there with the DragDrop error. Marshal onto an STA thread instead of requiring
+            // every test class to be attributed (MSTest 3.2 has no [STATestClass] for net8).
+            if (Thread.CurrentThread.GetApartmentState() != ApartmentState.STA)
+            {
+                RunOnStaThread(() => RunFunctionalTest(defaultUiMode));
+                return;
+            }
+
             if (IsPerfTest && !RunPerfTests)
             {
                 return; // Don't want to run this lengthy test right now
@@ -2395,6 +2410,32 @@ namespace pwiz.SkylineTestUtil
                 //Log<AbstractFunctionalTest>.Fail(@"Functional test did not complete");
                 Assert.Fail("Functional test did not complete");
             }
+        }
+
+        /// <summary>
+        /// Runs <paramref name="action"/> on a dedicated STA thread and blocks until it finishes,
+        /// rethrowing any exception with its original stack trace intact so the test framework
+        /// still reports the real failure rather than a wrapper.
+        /// </summary>
+        private static void RunOnStaThread(Action action)
+        {
+            Exception pending = null;
+            var thread = new Thread(() =>
+            {
+                try
+                {
+                    action();
+                }
+                catch (Exception x)
+                {
+                    pending = x;
+                }
+            });
+            thread.SetApartmentState(ApartmentState.STA);
+            thread.Start();
+            thread.Join();
+            if (pending != null)
+                ExceptionDispatchInfo.Capture(pending).Throw();
         }
 
         private void RunFunctionalTestAttempt(string defaultUiMode)

--- a/pwiz_tools/Skyline/TestUtil/TestFunctional.cs
+++ b/pwiz_tools/Skyline/TestUtil/TestFunctional.cs
@@ -2884,6 +2884,63 @@ namespace pwiz.SkylineTestUtil
 #endif
         }
 
+        /// <summary>
+        /// TEMPORARY diagnostic. Dumps Microsoft.Win32.SystemEvents' static handler table, naming
+        /// each subscriber and its delegate target, to identify what subscribes
+        /// UserPreferenceChanged with SkylineWindow as the target. Reflection rather than a
+        /// reference, so TestUtil takes no new dependency. Remove once the leak is understood.
+        /// </summary>
+        /// <summary>
+        /// TEMPORARY verifier. Set SKYLINE_FORCE_SYSEVENTS_LEAK=1 to reproduce, on demand, the
+        /// framework condition that otherwise appears about once per 30,000 test executions:
+        /// a SystemEvents.UserPreferenceChanged hook on SkylineWindow that outlives its disposal.
+        ///
+        /// <para>Adds a second, identical subscription of WinForms' own private
+        /// Control.UserPreferenceChanged handler for the main window. WinForms removes one matching
+        /// entry when the window is disposed, so exactly one is left behind - which is precisely
+        /// the leak that has been observed in the wild.</para>
+        /// </summary>
+        // TEMPORARY. Roots SkylineWindow the way a real Skyline regression would - a static
+        // reference that has nothing to do with SystemEvents - so the counter-case can be checked:
+        // the framework-hook classification must NOT excuse this one.
+        // ReSharper disable once CollectionNeverQueried.Local
+        private static readonly List<object> _forcedRealLeak = new List<object>();
+
+        private static void ForceSystemEventsLeak()
+        {
+            var mode = Environment.GetEnvironmentVariable(@"SKYLINE_FORCE_SYSEVENTS_LEAK");
+            if (mode == null || SkylineWindow == null)
+                return;
+            if (mode.Contains(@"real"))
+            {
+                _forcedRealLeak.Add(SkylineWindow);
+                Console.WriteLine(@"FORCELEAK added static reference to SkylineWindow (genuine leak)");
+            }
+            if (!mode.Contains(@"hook") && mode != @"1")
+                return;
+            try
+            {
+                var seType = Type.GetType(@"Microsoft.Win32.SystemEvents, Microsoft.Win32.SystemEvents");
+                var controlType = typeof(Control);
+                var handlerType = seType?.GetEvent(@"UserPreferenceChanged")?.EventHandlerType;
+                var method = controlType.GetMethod(@"UserPreferenceChanged",
+                    BindingFlags.NonPublic | BindingFlags.Instance);
+                if (handlerType == null || method == null)
+                {
+                    Console.WriteLine(@"FORCELEAK could not find Control.UserPreferenceChanged");
+                    return;
+                }
+                var del = Delegate.CreateDelegate(handlerType, SkylineWindow, method);
+                seType.GetEvent(@"UserPreferenceChanged").AddEventHandler(null, del);
+                Console.WriteLine(@"FORCELEAK added duplicate {0}.{1} hook for SkylineWindow",
+                    method.DeclaringType?.Name, method.Name);
+            }
+            catch (Exception e)
+            {
+                Console.WriteLine(@"FORCELEAK FAILED {0}: {1}", e.GetType().Name, e.Message);
+            }
+        }
+
         private void RunTest()
         {
             if (null != SkylineWindow)
@@ -2924,6 +2981,8 @@ namespace pwiz.SkylineTestUtil
             {
                 RunUI(() => Clipboard.SetText(clipboardCheckText));
             }
+
+            ForceSystemEventsLeak();
 
             DoTest();
 

--- a/pwiz_tools/Skyline/TestUtil/TestFunctional.cs
+++ b/pwiz_tools/Skyline/TestUtil/TestFunctional.cs
@@ -2424,6 +2424,12 @@ namespace pwiz.SkylineTestUtil
             {
                 try
                 {
+                    // This thread is about to run Skyline's message loop, and WinForms keeps the
+                    // exception mode and the ThreadException subscription PER THREAD. Program.Init
+                    // only establishes them once per process, so without this the second and later
+                    // functional tests in a test-host process route no UI exceptions: WinForms shows
+                    // its own modal dialog and Join below waits on it forever.
+                    Program.InitUiThreadExceptionHandling();
                     action();
                 }
                 catch (Exception x)
@@ -2431,6 +2437,7 @@ namespace pwiz.SkylineTestUtil
                     pending = x;
                 }
             });
+            thread.Name = @"Functional test STA thread";   // named so hang dumps identify it
             thread.SetApartmentState(ApartmentState.STA);
             thread.Start();
             thread.Join();

--- a/pwiz_tools/Skyline/TestUtil/TestUtil.csproj
+++ b/pwiz_tools/Skyline/TestUtil/TestUtil.csproj
@@ -7,7 +7,7 @@
        Assert / TestContext types referenced by AbstractUnitTest, AssertEx. -->
   <PropertyGroup>
     <ProjectGuid>{1A76F2B4-353A-4BCF-9D15-70D4B387E480}</ProjectGuid>
-    <TargetFrameworks>net472;net8.0-windows</TargetFrameworks>
+    <TargetFrameworks>net8.0-windows</TargetFrameworks>
     <Platforms>AnyCPU;x64;x86</Platforms>
     <LangVersion>latest</LangVersion>
     <Nullable>disable</Nullable>

--- a/pwiz_tools/Skyline/TestUtil/TestUtil.csproj
+++ b/pwiz_tools/Skyline/TestUtil/TestUtil.csproj
@@ -81,9 +81,11 @@
     <PackageReference Include="ExcelDataReader" Version="3.7.0" />
     <PackageReference Include="ExcelDataReader.DataSet" Version="3.7.0" />
     <PackageReference Include="System.Text.Encoding.CodePages" Version="8.0.0" />
-    <Reference Include="Microsoft.Diagnostics.Runtime">
-      <HintPath>..\..\Shared\Lib\Microsoft.Diagnostics.Runtime\lib\net40\Microsoft.Diagnostics.Runtime.dll</HintPath>
-    </Reference>
+    <!-- The on-disk ClrMD is the net40 build, assembly version 0.8.31, and it was carried into
+         the net8 group unchanged when the other legacy DLLs here moved to packages. It has no
+         GCRoot type at all, so it cannot answer "what is still rooting this object". 3.1.512801
+         is the version SkylineNightly's net8 group already uses. -->
+    <PackageReference Include="Microsoft.Diagnostics.Runtime" Version="3.1.512801" />
     <Reference Include="DigitalRune.Windows.Docking">
       <HintPath>..\..\Shared\Lib\DigitalRune.Windows.Docking.dll</HintPath>
     </Reference>

--- a/pwiz_tools/Skyline/Util/PanoramaPublishUtil.cs
+++ b/pwiz_tools/Skyline/Util/PanoramaPublishUtil.cs
@@ -321,7 +321,7 @@ namespace pwiz.Skyline.Util
                         MultiButtonMsgDlg.BUTTON_NO, false)
                     == DialogResult.Yes)
                 {
-                    Process.Start(result.ToString());
+                    ProcessEx.OpenInShell(result.ToString());
                 }
             }
             catch (Exception x)
@@ -361,7 +361,7 @@ namespace pwiz.Skyline.Util
                             MultiButtonMsgDlg.BUTTON_NO, false)
                         == DialogResult.Yes)
                     {
-                        Process.Start(panoramaEx.JobUrl.ToString());
+                        ProcessEx.OpenInShell(panoramaEx.JobUrl.ToString());
                     }
                 }
                 

--- a/pwiz_tools/Skyline/Util/UtilUI.cs
+++ b/pwiz_tools/Skyline/Util/UtilUI.cs
@@ -275,7 +275,7 @@ namespace pwiz.Skyline.Util
         {
             try
             {
-                Process.Start(link);
+                ProcessEx.OpenInShell(link);
             }
             catch (Exception)
             {
@@ -383,7 +383,7 @@ window.onload = submitForm;
             {
                 // CONSIDER: User could have a configuration that opens html documents
                 //           with a text editor. This would defeat the redirection and post.
-                Process.Start(filePath);
+                ProcessEx.OpenInShell(filePath);
             }
             catch(Exception)
             {


### PR DESCRIPTION
## Summary

* Removed the net472 targets from 28 csproj files and Skyline.sln, and from the seven tool
  projects (AutoQC, SharedBatch, SkylineBatch, UniModCompiler and their tests) whose net472
  leg could no longer restore once CommonUtil, CommonBaseUI and PanoramaClient became
  net8-only - reproduced first as `NU1201 Project PanoramaClient is not compatible with
  net472`
* Fixed a library load race in `AssertEx.ForceDocumentLoad`, which left the two sides of a
  comparison at different load states: 22 failures in 351 `RefineConvertToSmallMoleculesTest`
  runs became 0 in 501. Added `IExplainDiff` so an unequal object names the member that
  differs, rather than both sides rendering as a bare type name and the occurrence being
  discarded as undiagnosable
* Stopped the WinForms `SystemEvents` hook failing tests as a Skyline GC leak, and added GC
  root chain reporting so a leak names its holder in the log. Moved TestUtil and TestRunnerLib
  to ClrMD 3.1.512801, whose `GCRoot` the old net40 0.8.31 build does not have
* Fixed Help links, the tutorial PDF and Panorama links throwing on net8, where
  `UseShellExecute` defaults to false rather than true: nine call sites now go through a new
  `ProcessEx.OpenInShell`
* Fixed staging keeping a stale copy of a shared dependency, which had tests running against
  ClrMD 0.8.31 while compiled against 3.1. `robocopy /XO` skipped the newer NuGet assembly for
  carrying an older timestamp, and TestPerf/TestTutorial - excluded from the standard build -
  were staged last and put the old copy back

## Test plan

- [x] Full 1116-test parallel suite green repeatedly; overnight, 13 full runs with 11 fully green
- [x] 5-language run: 5,585 executions, 0 failures, 44 min - about 6x the coverage of a
      single-language serial run in the same wall clock
- [x] `RefineConvertToSmallMoleculesTest` library race: 22 failures in 351 runs, then 0 in 501
- [x] GC-LEAK classification proven by forced reproduction: framework hook only warns and
      passes, a genuine leak still fails, both still fails
- [x] AutoQC.sln and SkylineBatch.sln build clean after the net472 removal
- [x] Skyline solution and all six test projects build with no errors or warnings
- [x] CodeInspection: 0 failures

## Notes for review

* Stacked on #4587; that branch is green and this targets it rather than master.
* Two of the original commits were dropped when rebasing onto #4587, because Matt landed
  equivalents upstream: the dockPanel fix (his `Dock = Fill` in the designer - ours re-asserted
  `Anchor` after `InitializeComponent`, which would have *undone* his, since the `Anchor`
  setter sets `Dock = None`) and the `ComparePeakPickingDlg` null guard. The app-local CRT
  staging was dropped in favour of his `VendorNativeCrt.targets`.
* Remaining pre-existing flakes were measured with a control - three runs with these changes
  stashed out versus three with them in gave 2 failures in 3 control runs against 1 in 3 with
  the changes, so the suite fails *more* without this work. The residual
  `RefineConvertToSmallMoleculesTest` rate is ~1.76%, now diagnosed to a `LibraryDotProduct`
  that is present on one side and null on the other.
* `/code-review max` was run before opening. Five findings are fixed here; seven remain and
  are recorded in the TODO for a follow-up, the most serious being that `RunOnStaThread`
  creates a thread per functional test while `Application.ThreadException` is subscribed once,
  so the second and later functional tests in a process lose UI-thread exception routing.

See TODO-20260821_net8_test_reliability.md in pwiz-ai/todos

Co-Authored-By: Claude <noreply@anthropic.com>
