### PR TITLE
skyline: Fixed intermittent TestLayoutExportImport failure opening a native file dialog

### DIFF
--- a/pwiz_tools/Skyline/TestFunctional/NativeMessageBoxTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/NativeMessageBoxTest.cs
@@ -63,7 +63,7 @@ namespace pwiz.SkylineTestFunctional
 
             // 1) First Save As: save to a name that does not exist yet -- no confirmation.
             McpConnector.ClickMainMenuItem(saveAsMenu);
-            var fileDialogId = WaitForNativeFileDialog();
+            var fileDialogId = WaitForNativeDlg<NativeFileDialog>().FormId;
             AssertComplete(McpConnector.SetFormValue(fileDialogId, @"FileName", savePath));
             AssertComplete(McpConnector.DismissWithAcceptButton(fileDialogId));
             WaitForCondition(() => !McpConnector.GetOpenForms().Any(form => form.IsNative));

--- a/pwiz_tools/Skyline/TestFunctional/NativeMessageBoxTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/NativeMessageBoxTest.cs
@@ -81,9 +81,9 @@ namespace pwiz.SkylineTestFunctional
             fileDialogId = actionResult.FormId;
             Assert.IsNotNull(fileDialogId);
             Assert.AreEqual(modalNestingCount, GetModalNestingCount(fileDialogId));
-            // The id is reported as soon as the window exists, which is before the shell has shown the file-name
-            // field; typing into it in that window throws "The file dialog is still opening".
-            WaitForNativeFileDialogReady(fileDialogId);
+            // Set straight away, with no readiness wait: a file dialog is not named in an ActionResult (nor listed
+            // by GetOpenForms) until the shell has shown the field this types into -- see NativeDialog.Create. This
+            // set failing with "The file dialog is still opening" would mean that gate had regressed.
             AssertComplete(McpConnector.SetFormValue(fileDialogId, @"FileName", savePath));
             actionResult = McpConnector.DismissWithAcceptButton(fileDialogId);
             Assert.IsFalse(actionResult.Completed);

--- a/pwiz_tools/Skyline/TestFunctional/PrmMcpConnectorTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/PrmMcpConnectorTest.cs
@@ -71,12 +71,12 @@ namespace pwiz.SkylineTestFunctional
             var wizard = WaitForOpenForm<ImportPeptideSearchDlg>();
             string wizardId = GetOpenFormId<ImportPeptideSearchDlg>();
 
-            // 2) Click "Add Files" -> the native "Add Input Files" dialog appears.
-            // Wait for it the way the AI Connector would: poll GetOpenForms (the discovery method
-            // IJsonToolService exposes) until the native FileDialog shows up, rather than the
-            // internal NativeDialog helper.
+            // 2) Click "Add Files" -> the native "Add Input Files" dialog appears. Wait for it by TYPE and take
+            // its FormId: everything the test then does to it goes through the connector by that id, which is the
+            // part an AI Connector client actually exercises. Waiting on GetOpenForms instead bought nothing --
+            // the only thing it could match on is IsNative, which a message box and a folder browser wear too.
             McpConnector.ClickFormButton(wizardId, GetLocalizedText<BuildPeptideSearchLibraryControl>(@"btnAddFile"));
-            string addFilesId = WaitForNativeFileDialog();
+            string addFilesId = WaitForNativeDlg<NativeFileDialog>().FormId;
 
             // 3) Select the two files and Open -- the tutorial's "hold Ctrl, click the two files,
             // click Open". A native dialog has no caption-addressable buttons, so it is confirmed with the

--- a/pwiz_tools/Skyline/TestPerf/DiaFragPipeTutorialTest.cs
+++ b/pwiz_tools/Skyline/TestPerf/DiaFragPipeTutorialTest.cs
@@ -93,7 +93,7 @@ namespace TestPerf
         {
             // File > Open opens the native Open dialog, so the menu click does not complete -- take the dialog
             // straight from the action's ActionResult.FormId.
-            var openDlg = ResolveNativeFileDialog(McpConnector.ClickMainMenuItem(
+            var openDlg = ResolveModal(McpConnector.ClickMainMenuItem(
                 MenuPath<SkylineWindow>("fileToolStripMenuItem", "openMenuItem")));
             McpConnector.SetFormValue(openDlg, "FileName",
                 GetTestPath(Path.Combine("backup", "skyline_files", "fragpipe.sky")));

--- a/pwiz_tools/Skyline/TestPerf/DiaToSrmTutorialTest.cs
+++ b/pwiz_tools/Skyline/TestPerf/DiaToSrmTutorialTest.cs
@@ -163,7 +163,7 @@ namespace TestPerf
             // The Start Page tile sets DialogResult and returns; the "must save" prompt and this Save dialog are then
             // shown by the startup frame (StartupActions), NOT by a counted connector gesture -- so accepting the
             // prompt completes (its window is gone) before the Save dialog appears. Wait for it rather than assume it.
-            var saveDlg = WaitForNativeFileDialog();
+            var saveDlg = WaitForNativeDlg<NativeFileDialog>().FormId;
             McpConnector.SetFormValue(saveDlg, "FileName", GetTestPath("DIA_to_SRM_Tutorial.sky"));
             McpConnector.DismissWithAcceptButton(saveDlg);
 
@@ -188,8 +188,6 @@ namespace TestPerf
             AssertComplete(McpConnector.ClickFormButton(wizard, GetLocalizedText<ImportPeptideSearchDlg>("btnNext")));
 
             // Extract Chromatograms page: nothing to add here (results are imported later), so just capture it.
-            // Clicking Next above loaded the library and swaps this page in; the experiment assumes the click has
-            // fully settled that transition on return (no WaitForControl), which the screenshot then relies on.
             PauseForMcpScreenShot(wizard, "Extract Chromatograms"); // s-03
         }
 
@@ -209,8 +207,7 @@ namespace TestPerf
             McpConnector.ClickFormButton(wizard, WizardNextButton);
             AssertComplete(McpConnector.DismissWithAcceptButton(WaitForMcpConnectorForm<MultiButtonMsgDlg>()));
 
-            // 1.3 Add Modifications: no modifications were used in the search, so just move on. No WaitForControl --
-            // the accept above is assumed to have settled the Add Modifications page.
+            // 1.3 Add Modifications: no modifications were used in the search, so just move on.
             PauseForMcpScreenShot(wizard, "Add Modifications"); // s-04
             AssertComplete(McpConnector.ClickFormButton(wizard, WizardNextButton));
 
@@ -260,7 +257,7 @@ namespace TestPerf
             AssertComplete(McpConnector.SetFormValue(wizard, GetLocalizedText<ImportFastaControl>("label2"), "0"));                  // max missed cleavages
             // Browse opens the native Open dialog (a dialog, so it does not complete); accept it to load the FASTA.
             McpConnector.ClickFormButton(wizard, GetLocalizedText<ImportFastaControl>("browseFastaBtn"));
-            var fastaDlg = WaitForNativeFileDialog();
+            var fastaDlg = WaitForNativeDlg<NativeFileDialog>().FormId;
             McpConnector.SetFormValue(fastaDlg, "FileName", GetTestPath("uniprot_human_25apr2019.fasta"));
             McpConnector.DismissWithAcceptButton(fastaDlg);
             PauseForMcpScreenShot(wizard, "Import FASTA"); // s-07

--- a/pwiz_tools/Skyline/TestPerf/DiaToSrmTutorialTest.cs
+++ b/pwiz_tools/Skyline/TestPerf/DiaToSrmTutorialTest.cs
@@ -317,7 +317,7 @@ namespace TestPerf
         {
             // Import Document opens the native Open dialog (a dialog), so it does not complete; resolve it from the
             // menu action's ActionResult, then accept it to import.
-            var importDlg = ResolveNativeFileDialog(McpConnector.ClickMainMenuItem(MenuPath<SkylineWindow>(
+            var importDlg = ResolveModal(McpConnector.ClickMainMenuItem(MenuPath<SkylineWindow>(
                 "fileToolStripMenuItem", "importToolStripMenuItem", "importDocumentMenuItem")));
             McpConnector.SetFormValue(importDlg, "FileName", GetTestPath("PRTC.sky"));
             McpConnector.DismissWithAcceptButton(importDlg);
@@ -432,7 +432,7 @@ namespace TestPerf
 
             // Save As opens the native Save dialog (a dialog), so the menu-item verb does not complete -- resolve the
             // dialog from its ActionResult.FormId.
-            var saveDlg = ResolveNativeFileDialog(McpConnector.ClickMainMenuItem(
+            var saveDlg = ResolveModal(McpConnector.ClickMainMenuItem(
                 MenuPath<SkylineWindow>("fileToolStripMenuItem", "saveAsMenuItem")));
             McpConnector.SetFormValue(saveDlg, "FileName", GetTestPath("DIA_to_SRM_Tutorial-filtered.sky"));
             McpConnector.DismissWithAcceptButton(saveDlg);
@@ -498,7 +498,7 @@ namespace TestPerf
 
             // Save As opens the native Save dialog (a dialog), so the menu-item verb does not complete -- resolve the
             // dialog from its ActionResult.FormId.
-            var saveDlg = ResolveNativeFileDialog(McpConnector.ClickMainMenuItem(
+            var saveDlg = ResolveModal(McpConnector.ClickMainMenuItem(
                 MenuPath<SkylineWindow>("fileToolStripMenuItem", "saveAsMenuItem")));
             McpConnector.SetFormValue(saveDlg, "FileName", GetTestPath("SRM_targets.sky"));
             McpConnector.DismissWithAcceptButton(saveDlg);

--- a/pwiz_tools/Skyline/TestUtil/McpConnectorTest.cs
+++ b/pwiz_tools/Skyline/TestUtil/McpConnectorTest.cs
@@ -94,57 +94,10 @@ namespace pwiz.SkylineTestUtil
                                     && true == form.Title?.Contains(titleSubstring));
 
         /// <summary>
-        /// Waits for the native common file dialog (Open / Save As) to appear -- it is enumerated by GetOpenForms
-        /// with IsNative=true -- and returns its form id. A native dialog's reported type is the generic
-        /// "Dialog" (its file-dialog nature is not known the instant it appears), so this matches on IsNative; the
-        /// caller knows it triggered a file dialog rather than a folder dialog.
+        /// Waits for the native common file dialog (Open / Save As) to appear.
         /// </summary>
         protected string WaitForNativeFileDialog() =>
-            WaitForNativeFileDialogReady(ResolveWhenOpen(form => form.IsNative));
-
-        /// <summary>
-        /// Resolves the native file dialog a connector action just opened -- straight from its
-        /// <see cref="ActionResult"/>, for a verb whose own gesture blocks in the dialog and so names it (a menu
-        /// click that shows Open/Save As) -- and waits until it is ready to be typed into. The
-        /// <see cref="ResolveModal"/> counterpart for a file dialog, and the one to use for it: ResolveModal alone
-        /// returns the instant the window is reported, which is too early (see
-        /// <see cref="WaitForNativeFileDialogReady"/>).
-        /// </summary>
-        protected string ResolveNativeFileDialog(ActionResult actionResult) =>
-            WaitForNativeFileDialogReady(ResolveModal(actionResult));
-
-        /// <summary>
-        /// Waits until the native file dialog with the given id has finished opening -- i.e. the shell has created
-        /// and shown its file-name field -- and returns that id.
-        ///
-        /// <para>A native dialog becomes discoverable (its window exists, GetOpenForms reports it, and it
-        /// classifies as a file dialog) a moment BEFORE the shell has finished showing and populating it. Setting
-        /// the file name in that window fails with "The file dialog is still opening", because
-        /// <see cref="NativeFileDialog.FileNameTextBox"/> deliberately does NOT block polling for the field -- it
-        /// throws a retryable instruction so the wait lives with the DRIVER rather than inside the primitive that
-        /// every caller shares. This is that wait, for the driver that is a test.</para>
-        ///
-        /// <para>Readiness is the file-name box appearing in GetControls under its
-        /// <see cref="NativeFileDialog.FILE_NAME_FIELD"/> label -- the same field EnterPath needs, and listed only
-        /// once it is visible, so this waits for exactly the condition that would otherwise throw.</para>
-        /// </summary>
-        protected string WaitForNativeFileDialogReady(string formId)
-        {
-            WaitForCondition(() =>
-            {
-                try
-                {
-                    return McpConnector.GetControls(formId)
-                        ?.Any(control => Equals(control.Path.Text, NativeFileDialog.FILE_NAME_FIELD)) ?? false;
-                }
-                catch (InvalidOperationException)
-                {
-                    // The dialog can be momentarily unreadable while the shell is still bringing it up.
-                    return false;
-                }
-            }, @"The native file dialog did not finish opening.");
-            return formId;
-        }
+            ResolveWhenOpen(form => form.IsNative);
 
         /// <summary>
         /// Waits for the native Browse-For-Folder dialog (enumerated by GetOpenForms with IsNative=true) and

--- a/pwiz_tools/Skyline/TestUtil/McpConnectorTest.cs
+++ b/pwiz_tools/Skyline/TestUtil/McpConnectorTest.cs
@@ -80,37 +80,11 @@ namespace pwiz.SkylineTestUtil
             WaitForMcpConnectorForm(typeof(TForm).Name);
 
         /// <summary>Waits for a form by its connector type name (see <see cref="WaitForMcpConnectorForm{TForm}"/>).</summary>
-        protected string WaitForMcpConnectorForm(string typeName) =>
-            ResolveWhenOpen(form => form.Type == typeName);
-
-        /// <summary>
-        /// Waits for the summary graph whose window title contains <paramref name="titleSubstring"/> -- the way
-        /// an MCP client tells several open graphs apart through GetOpenForms (each GraphSummary reports its
-        /// title, e.g. "...CV Histogram", "...Scheduling") -- and returns its form id. Pass the
-        /// localized graph name (a GraphsResources string) so it matches in any UI language.
-        /// </summary>
-        protected string WaitForMcpConnectorGraph(string titleSubstring) =>
-            ResolveWhenOpen(form => form.Type == @"GraphSummary" && form.HasGraph
-                                    && true == form.Title?.Contains(titleSubstring));
-
-        /// <summary>
-        /// Waits for the native common file dialog (Open / Save As) to appear.
-        /// </summary>
-        protected string WaitForNativeFileDialog() =>
-            ResolveWhenOpen(form => form.IsNative);
-
-        /// <summary>
-        /// Waits for the native Browse-For-Folder dialog (enumerated by GetOpenForms with IsNative=true) and
-        /// returns its form id; SetValue selects a folder by its path. Like the file dialog it reports
-        /// the generic "Dialog" type, so this matches on IsNative.
-        /// </summary>
-        protected string WaitForNativeFolderDialog() =>
-            ResolveWhenOpen(form => form.IsNative);
-
-        private string ResolveWhenOpen(Func<FormInfo, bool> predicate)
+        protected string WaitForMcpConnectorForm(string typeName)
         {
             string id = null;
-            WaitForCondition(() => null != (id = McpConnector.GetOpenForms().FirstOrDefault(predicate)?.Id));
+            WaitForCondition(() => null != (id = McpConnector.GetOpenForms()
+                .FirstOrDefault(form => form.Type == typeName)?.Id));
             return id;
         }
 
@@ -153,61 +127,29 @@ namespace pwiz.SkylineTestUtil
             GetOpenFormId(typeof(TForm).Name);
 
         /// <summary>Resolves a form by its connector type name right now (see <see cref="GetOpenFormId{TForm}"/>).</summary>
-        protected string GetOpenFormId(string typeName) =>
-            ResolveNow(form => form.Type == typeName, "a form of type " + typeName);
-
-        /// <summary>Resolves the summary graph whose title contains <paramref name="titleSubstring"/> right now
-        /// (the immediate counterpart to <see cref="WaitForMcpConnectorGraph"/>).</summary>
-        protected string GetMcpConnectorGraph(string titleSubstring) =>
-            ResolveNow(form => form.Type == @"GraphSummary" && form.HasGraph && true == form.Title?.Contains(titleSubstring),
-                "a graph whose title contains '" + titleSubstring + "'");
-
-        /// <summary>Resolves the native file dialog right now (the immediate counterpart to
-        /// <see cref="WaitForNativeFileDialog"/>).</summary>
-        protected string GetNativeFileDialog() =>
-            ResolveNow(form => form.IsNative, "the native file dialog");
-
-        /// <summary>Resolves the native folder dialog right now (the immediate counterpart to
-        /// <see cref="WaitForNativeFolderDialog"/>).</summary>
-        protected string GetNativeFolderDialog() =>
-            ResolveNow(form => form.IsNative, "the native folder dialog");
-
-        private string ResolveNow(Func<FormInfo, bool> predicate, string description)
+        protected string GetOpenFormId(string typeName)
         {
             var openForms = McpConnector.GetOpenForms();
-            var match = openForms.FirstOrDefault(predicate);
+            var match = openForms.FirstOrDefault(form => form.Type == typeName);
             if (match == null)
-            {
-                Assert.Fail("Expected {0} to be open, but it was not. Open forms: {1}", description, TextUtil.SpaceSeparate(openForms.Select(form=>form.Id)));
-            }
-
+                Assert.Fail("Expected a form of type {0} to be open, but it was not. Open forms: {1}",
+                    typeName, TextUtil.SpaceSeparate(openForms.Select(form => form.Id)));
             return match.Id;
         }
 
-        /// <summary>
-        /// Waits until the form shows a control of the given type -- e.g. a wizard page's UserControl that swaps
-        /// in after a transition (clicking "Next" can advance the page asynchronously). A screenshot taken right
-        /// after then captures the settled page rather than a mid-transition frame. Uses the connector's
-        /// GetControls, which lists only the controls currently shown (a not-yet-displayed page is not listed).
-        /// </summary>
-        protected void WaitForControl(string formId, string controlType)
+        /// <summary>Resolves the summary graph whose title contains <paramref name="titleSubstring"/> right now --
+        /// the way an MCP client tells several open graphs apart through GetOpenForms (each GraphSummary reports
+        /// its title, e.g. "...CV Histogram", "...Scheduling"). Pass the localized graph name (a GraphsResources
+        /// string) so it matches in any UI language.</summary>
+        protected string GetMcpConnectorGraph(string titleSubstring)
         {
-            WaitForCondition(() =>
-            {
-                try
-                {
-                    // GetControls can return null while the form is mid-gesture / re-laying-out; treat that (and a
-                    // no-match) as "not ready yet" and keep polling.
-                    return McpConnector.GetControls(formId)?.Any(control => Equals(control.Path.Type, controlType)) ?? false;
-                }
-                catch (InvalidOperationException)
-                {
-                    // While the page is transitioning, the form can be briefly blocked by a transient dialog
-                    // (e.g. the long-wait progress dialog shown while a spectral library loads), which makes
-                    // GetControls throw. Treat that as "not ready yet" and keep polling until it clears.
-                    return false;
-                }
-            });
+            var openForms = McpConnector.GetOpenForms();
+            var match = openForms.FirstOrDefault(form => form.Type == @"GraphSummary" && form.HasGraph
+                                                         && true == form.Title?.Contains(titleSubstring));
+            if (match == null)
+                Assert.Fail("Expected a graph whose title contains '{0}' to be open, but it was not. Open forms: {1}",
+                    titleSubstring, TextUtil.SpaceSeparate(openForms.Select(form => form.Id)));
+            return match.Id;
         }
 
         /// <summary>

--- a/pwiz_tools/Skyline/TestUtil/TestFunctional.cs
+++ b/pwiz_tools/Skyline/TestUtil/TestFunctional.cs
@@ -434,8 +434,7 @@ namespace pwiz.SkylineTestUtil
 
         /// <summary>
         /// Waits for a native dialog (a Win32 "#32770") of the given type to appear in this process and returns its
-        /// automation wrapper -- the native-dialog analog of <see cref="WaitForOpenForm{TDlg}(int)"/>. A test is the
-        /// driver of a native dialog, so the wait lives here in the test rather than baked into the dialog itself.
+        /// automation wrapper -- the native-dialog analog of <see cref="WaitForOpenForm{TDlg}(int)"/>.
         /// </summary>
         protected static TDlg WaitForNativeDlg<TDlg>() where TDlg : NativeDialog
         {

--- a/pwiz_tools/Skyline/ToolsUI/NativeDialog.cs
+++ b/pwiz_tools/Skyline/ToolsUI/NativeDialog.cs
@@ -90,6 +90,20 @@ namespace pwiz.Skyline.ToolsUI
         /// <summary>The dialog's message body (its Static-control text) else its caption.</summary>
         public override string DetailedMessage => NativeBodyText(Hwnd) ?? User32.GetWindowTextNoBlock(Hwnd);
 
+        /// <summary>
+        /// Whether the shell has finished bringing this dialog up, so it can be driven. <see cref="Create"/> gates
+        /// on this, so a dialog that is still opening is reported by NOTHING -- not <see cref="GetOpenDialogs"/>,
+        /// not the connector's form list, not the modal watch. That is the point: a window a caller cannot act on
+        /// is not worth telling anyone about, and reporting it made whoever acted first fail (see
+        /// <see cref="NativeFileDialog.FileNameTextBox"/>).
+        ///
+        /// <para>The window becomes classifiable a moment BEFORE the shell has SHOWN the controls that classified
+        /// it -- they are created, then displayed -- which is the gap this closes. A dialog whose classification
+        /// already proves its controls are shown needs nothing more, which is the default here; only
+        /// <see cref="NativeFileDialog"/>, classified by a field that exists before it appears, overrides it.</para>
+        /// </summary>
+        protected virtual bool IsOpenComplete => true;
+
         // The message body of a native dialog box (a Win32 #32770, e.g. a system message box), read from its child
         // controls, or null when none is found. The body is a "Static" control with text -- the icon's Static has
         // none -- so among the Static children with non-empty text, take the LONGEST, so the message wins over any
@@ -107,12 +121,22 @@ namespace pwiz.Skyline.ToolsUI
 
         /// <summary>
         /// The wrapper that drives the "#32770" at <paramref name="handle"/>: a file-dialog subclass when it is
-        /// one, otherwise a generic <see cref="NativeDialog"/>. Null when the window is not a dialog (or is gone).
+        /// one, otherwise a generic <see cref="NativeDialog"/>. Null when the window is not a dialog (or is gone),
+        /// AND null while it is still opening (see <see cref="IsOpenComplete"/>) -- a dialog is not reported until
+        /// it can be driven, so no caller ever holds one it cannot act on.
         ///
         /// <para>Every test is a window-manager read (a control id, a window class), so classifying is safe from any
         /// thread: it cannot deadlock against the modal loop running on the UI thread.</para>
         /// </summary>
         public static NativeDialog Create(IntPtr handle, CancellationToken cancellationToken)
+        {
+            var dialog = Classify(handle, cancellationToken);
+            return dialog?.IsOpenComplete == true ? dialog : null;
+        }
+
+        // The subclass that drives the window, by what its controls say it is, or null when it is not a "#32770".
+        // Says only WHICH dialog it is -- whether it is ready to be driven is Create's separate question.
+        private static NativeDialog Classify(IntPtr handle, CancellationToken cancellationToken)
         {
             if (handle == IntPtr.Zero || User32.GetClassName(handle) != DIALOG_CLASS_NAME)
                 return null;
@@ -132,7 +156,8 @@ namespace pwiz.Skyline.ToolsUI
             return new NativeDialog(handle, cancellationToken);
         }
 
-        /// <summary>The native dialogs currently open in this process, each wrapped as the class that drives it.</summary>
+        /// <summary>The native dialogs currently open in this process AND ready to be driven, each wrapped as the
+        /// class that drives it -- see <see cref="Create"/>, which drops one the shell is still bringing up.</summary>
         public static IList<NativeDialog> GetOpenDialogs(CancellationToken cancellationToken)
         {
             var result = new List<NativeDialog>();

--- a/pwiz_tools/Skyline/ToolsUI/NativeDialog.cs
+++ b/pwiz_tools/Skyline/ToolsUI/NativeDialog.cs
@@ -98,9 +98,11 @@ namespace pwiz.Skyline.ToolsUI
         /// <see cref="NativeFileDialog.FileNameTextBox"/>).
         ///
         /// <para>The window becomes classifiable a moment BEFORE the shell has SHOWN the controls that classified
-        /// it -- they are created, then displayed -- which is the gap this closes. A dialog whose classification
-        /// already proves its controls are shown needs nothing more, which is the default here; only
-        /// <see cref="NativeFileDialog"/>, classified by a field that exists before it appears, overrides it.</para>
+        /// it -- they are created, then displayed -- which is the gap this closes. Every dialog classified by a
+        /// control it later acts on has that gap and overrides this (<see cref="NativeFileDialog"/> by its
+        /// file-name field, <see cref="NativeFolderBrowserDialog"/> by its tree). The default is for the generic
+        /// message box, which is classified by nothing and driven through buttons the caller reads by caption --
+        /// so it has no control whose appearance it could wait on, and is ready when its window is shown.</para>
         /// </summary>
         protected virtual bool IsOpenComplete => true;
 

--- a/pwiz_tools/Skyline/ToolsUI/NativeFileDialog.cs
+++ b/pwiz_tools/Skyline/ToolsUI/NativeFileDialog.cs
@@ -102,29 +102,37 @@ namespace pwiz.Skyline.ToolsUI
         /// 1001 for the Save dialog's DirectUI-hosted field.</summary>
         protected abstract int FileNameControlId { get; }
 
-        /// <summary>The dialog's file-name field, found by its CONTROL ID, or a RETRYABLE error if the shell has
-        /// not shown it yet.
+        /// <summary>The dialog's file-name field, found by its CONTROL ID -- by id, because the field is not "the
+        /// dialog's only text box": the address bar carries a second, collapsed Edit.
         ///
-        /// <para>By control id, because the field is not "the dialog's only text box": the address bar carries a
-        /// second, collapsed Edit. Not-shown-yet is possible because a native dialog becomes discoverable -- its
-        /// window exists, GetOpenForms reports it, and it classifies as a file dialog -- a moment BEFORE the shell
-        /// has finished showing and populating it, and typing into the field in that window does nothing (the shell
-        /// overwrites the text as it initializes, and the dialog then accepts an empty name).</para>
-        ///
-        /// <para>Rather than BLOCK here polling for the field, this throws an instruction the caller acts on, so the
-        /// wait lives with the DRIVER, not inside the primitive both drivers share: the model waits and re-issues
-        /// the call, and a test driving the dialog waits on its own state. A single tool call never sits inside a
-        /// 30-second sleep.</para></summary>
+        /// <para>The throw is a GUARD, not a wait a caller is expected to retry: a dialog whose field the shell has
+        /// not shown is not handed out at all (<see cref="NativeDialog.Create"/> gates on
+        /// <see cref="IsOpenComplete"/>, which is this same condition), so nobody holding this dialog should reach
+        /// it. It stands because the alternative is silent: typing into a field the shell is still initializing
+        /// does nothing -- the shell overwrites the text, and the dialog then accepts an empty name.</para></summary>
         protected NativeTextBox FileNameTextBox
         {
             get
             {
-                var hwnd = FindFileNameEdit();
-                if (hwnd == IntPtr.Zero || !User32.IsWindowVisible(hwnd))
+                var hwnd = FindShownFileNameEdit();
+                if (hwnd == IntPtr.Zero)
                     throw new InvalidOperationException(LlmInstruction.Format(
                         @"The file dialog is still opening. Wait a moment and try again."));
                 return new NativeTextBox(hwnd, CancellationToken);
             }
+        }
+
+        /// <summary>A file dialog has finished opening once the shell has SHOWN its file-name field -- the field
+        /// every gesture here needs. Existence is not enough, and is exactly the trap: the field is what
+        /// <see cref="NativeDialog.Create"/> classifies the dialog by, so it is already there (created, still
+        /// hidden) throughout the window in which typing into the dialog does nothing.</summary>
+        protected override bool IsOpenComplete => FindShownFileNameEdit() != IntPtr.Zero;
+
+        // The file-name Edit once the shell has shown it, else IntPtr.Zero.
+        private IntPtr FindShownFileNameEdit()
+        {
+            var hwnd = FindFileNameEdit();
+            return hwnd != IntPtr.Zero && User32.IsWindowVisible(hwnd) ? hwnd : IntPtr.Zero;
         }
 
         /// <summary>The window handle of the file-name Edit, or IntPtr.Zero until it exists. By default the Edit

--- a/pwiz_tools/Skyline/ToolsUI/NativeFolderBrowserDialog.cs
+++ b/pwiz_tools/Skyline/ToolsUI/NativeFolderBrowserDialog.cs
@@ -60,6 +60,15 @@ namespace pwiz.Skyline.ToolsUI
                 .FindDescendants(NativeControl.TREE_CLASS).Any();
         }
 
+        /// <summary>The folder browser has finished opening once the shell has SHOWN its folder tree -- the
+        /// control it is classified by, and the one <see cref="SetValueCore"/> acts on. Existence is not enough,
+        /// for the same reason it is not for the file dialogs: <see cref="NativeDialog.FindDescendants"/> matches
+        /// on class alone, so the tree it finds was created but may not be displayed yet. Selecting a folder in
+        /// that window fails SILENTLY -- BFFM_SETSELECTION has no read-back to catch it, unlike
+        /// <see cref="NativeFileDialog.EnterPath"/> -- and the dialog is then accepted on the default folder.</summary>
+        protected override bool IsOpenComplete =>
+            FindDescendants(NativeControl.TREE_CLASS).Any(User32.IsWindowVisible);
+
         // set_value selects the folder at the given path in the tree. BFFM_SETSELECTION must be SENT (not
         // posted), so the dialog reads the path string while this blocks and the string stays valid until it
         // returns; it merely navigates the tree (no nested modal), so the synchronous send does not wedge.


### PR DESCRIPTION
## Summary

Fixes the intermittent `TestLayoutExportImport` failure seen in nightly:

```
System.InvalidOperationException: The file dialog is still opening. Wait a moment and try again.
   at pwiz.Skyline.ToolsUI.NativeFileDialog.get_FileNameTextBox()
   at pwiz.Skyline.ToolsUI.NativeFileDialog.EnterPath(String path)
   at pwiz.SkylineTestFunctional.LayoutExportImportTest.ExportLayout(String baseName)
```

A native dialog was reported the instant its window was classifiable, which is a
moment before the shell has SHOWN the controls that classified it. `NativeSaveFileDialog`
is recognized by its file-name Edit *existing*, while typing into it needs that Edit
*visible*, so a driver acting immediately could land in the gap.

* Gated `NativeDialog.Create` on a new `IsOpenComplete`, so a dialog that is still
  opening is reported by nothing -- not `GetOpenDialogs`, not the connector's form
  list, not the modal watch. A window nothing can act on is not worth reporting.
* `IsOpenComplete` is overridden by every dialog classified by a control it later
  acts on: `NativeFileDialog` by its file-name field, `NativeFolderBrowserDialog` by
  its tree. The generic message box keeps the default.
* Removed the test-side readiness waits this made dead
  (`WaitForNativeFileDialogReady`, `ResolveNativeFileDialog`).

The folder-browser half came from `/code-review max`, which pointed out that
`IsFolderBrowserDialog` matches its tree by class alone and so had the same gap --
and that it fails SILENTLY there, since `BFFM_SETSELECTION` has no read-back and
`SetValue` returns Completed=true regardless.

`NativeMessageBoxTest` now sets the file name immediately off `ActionResult.FormId`,
with no readiness wait, so a regression of the gate fails that test.

### Note for review

`DialogWatcher`'s no-progress watchdog (10 polls x 30 ms) now has to wait out the
shell's created-to-shown step for an accept verb whose gesture raises a file dialog
(`ExportMethodDlg.OkDialog` is the live example). That exposure is not new -- a
dialog only entered `GetOpenModals` once its window was visible, so the whole
pre-visible bring-up already ran against the same budget -- but it is slightly
longer now.

## Test plan

- [x] TestLayoutExportImport - the reported failure; 4 loops
- [x] TestNativeFileDialog, TestNativeMessageBox - native dialog verbs
- [x] TestLibraryBuild - drives the native folder browser
- [x] TestPrmMcpConnector, TestMcpConnectorFormThreading - connector modal handling
- [x] CodeInspection
- [ ] TestDiaToSrmTutorial, TestDiaFragPipeTutorial - compile-checked only
      (mechanical ResolveNativeFileDialog -> ResolveModal rename); need perf data

Co-Authored-By: Claude <noreply@anthropic.com>
