### PR TITLE
skyline: Fixed intermittent TestLayoutExportImport failure typing into a native Save dialog

### DIFF
--- a/pwiz_tools/Skyline/TestFunctional/LayoutExportImportTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/LayoutExportImportTest.cs
@@ -270,7 +270,7 @@ namespace pwiz.SkylineTestFunctional
 
         private void ImportLayout(string layoutPath)
         {
-            RunNativeDlg<NativeOpenFileDialog>(SkylineWindow.ShowImportLayoutDlg, dlg =>
+            RunLongNativeDlg<NativeOpenFileDialog>(SkylineWindow.ShowImportLayoutDlg, dlg =>
             {
                 dlg.EnterPath(layoutPath);
                 dlg.Accept();

--- a/pwiz_tools/Skyline/TestFunctional/LibraryBuildTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/LibraryBuildTest.cs
@@ -704,8 +704,8 @@ namespace pwiz.SkylineTestFunctional
         }
 
         // Adds the input files. A SINGLE file is added by driving the real native "Add Input Files" (Open) dialog --
-        // type its full path and accept -- so the build still
-        // exercises the connector's native-dialog automation. MULTIPLE files are added directly through
+        // type its full path and accept -- so the build still exercises the connector's native-dialog automation
+        // (from the test thread, which is where those gestures run). MULTIPLE files are added directly through
         // BuildLibraryDlg.AddInputFiles, which shows no dialog; driving a multiselect Open dialog by name is
         // exercised on its own by NativeFileDialogTest.
         private void AddInputFilesThroughDialog(BuildLibraryDlg buildLibraryDlg, IList<string> inputPaths)

--- a/pwiz_tools/Skyline/TestFunctional/LibraryBuildTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/LibraryBuildTest.cs
@@ -704,7 +704,7 @@ namespace pwiz.SkylineTestFunctional
         }
 
         // Adds the input files. A SINGLE file is added by driving the real native "Add Input Files" (Open) dialog --
-        // type its full path and accept (a simple fire-and-forget gesture, so RunNativeDlg) -- so the build still
+        // type its full path and accept -- so the build still
         // exercises the connector's native-dialog automation. MULTIPLE files are added directly through
         // BuildLibraryDlg.AddInputFiles, which shows no dialog; driving a multiselect Open dialog by name is
         // exercised on its own by NativeFileDialogTest.
@@ -715,7 +715,7 @@ namespace pwiz.SkylineTestFunctional
                 RunUI(() => buildLibraryDlg.AddInputFiles(inputPaths));
                 return;
             }
-            RunNativeDlg<NativeOpenFileDialog>(buildLibraryDlg.ClickAddFile, dlg =>
+            RunLongNativeDlg<NativeOpenFileDialog>(buildLibraryDlg.ClickAddFile, dlg =>
             {
                 dlg.EnterPath(inputPaths[0]);
                 dlg.Accept();

--- a/pwiz_tools/Skyline/TestFunctional/NativeFileDialogTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/NativeFileDialogTest.cs
@@ -23,6 +23,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using pwiz.Common.SystemUtil;
 using pwiz.Skyline.Properties;
 using pwiz.Skyline.ToolsUI;
 using pwiz.Skyline.Util;
@@ -101,12 +102,12 @@ namespace pwiz.SkylineTestFunctional
                 SkylineWindow.NewDocument();
                 Settings.Default.ActiveDirectory = Path.GetTempPath();
             });
-            RunNativeDlg<NativeOpenFileDialog>(SkylineWindow.ShowOpenFileDialog, dlg =>
+            RunLongNativeDlg<NativeOpenFileDialog>(SkylineWindow.ShowOpenFileDialog, dlg =>
             {
                 dlg.EnterPath(savePath);
                 dlg.Accept();
             });
-            // RunNativeDlg has already waited for ShowOpenFileDialog (which opens the file) to complete, so the
+            // RunLongNativeDlg has already waited for ShowOpenFileDialog (which opens the file) to complete, so the
             // document has changed here; only its background loading remains to wait on.
             WaitForDocumentLoaded();
             // Case-insensitive: opening through the native dialog returns the drive letter upper-cased
@@ -115,6 +116,43 @@ namespace pwiz.SkylineTestFunctional
             Assert.AreEqual(savePath, SkylineWindow.DocumentFilePath, true);
 
             TestMultiselectNavigateThenSelect();
+
+            TestSaveDialogNavigateThenName();
+        }
+
+        /// <summary>
+        /// Drives a Save dialog to a folder and then names the file there: <see cref="NativeFileDialog.EnterPath"/>
+        /// the folder, <see cref="NativeFileDialog.Accept"/> to navigate, then EnterPath the name and save.
+        /// </summary>
+        private void TestSaveDialogNavigateThenName()
+        {
+            var saveDir = TestContext.GetTestResultsPath(@"SaveNavigation");
+            Directory.CreateDirectory(saveDir);
+            var savePath = Path.Combine(saveDir, @"Navigated.sky");
+            FileEx.SafeDelete(savePath); // Or a second local run hits the dialog's own overwrite prompt
+
+            string savedPath = null;
+            RunLongNativeDlg<NativeSaveFileDialog>(
+                () =>
+                {
+                    using var dlg = new System.Windows.Forms.SaveFileDialog();
+                    dlg.InitialDirectory = Path.GetTempPath(); // So reaching saveDir takes a real navigation
+                    AssertEx.AreEqual(System.Windows.Forms.DialogResult.OK, dlg.ShowDialog(SkylineWindow),
+                        @"The Save dialog was not accepted.");
+                    savedPath = dlg.FileName;
+                },
+                dlg =>
+                {
+                    dlg.EnterPath(saveDir);
+                    dlg.Accept();
+                    WaitForCondition(() => DialogShowsFolder(dlg, saveDir),
+                        @"The Save dialog did not navigate to the requested folder.");
+                    dlg.EnterPath(Path.GetFileName(savePath));
+                    dlg.DismissWithAcceptButton();
+                });
+
+            // Case-insensitive: the native dialog returns the drive letter upper-cased.
+            Assert.AreEqual(savePath, savedPath, true);
         }
 
         /// <summary>
@@ -189,9 +227,9 @@ namespace pwiz.SkylineTestFunctional
             dlg.Accept();
         }
 
-        // Whether the Open dialog is showing the given folder -- read from its "Address" control with get_value, the
+        // Whether the dialog is showing the given folder -- read from its "Address" control with get_value, the
         // way an MCP client confirms a navigation (trailing separator and case ignored).
-        private static bool DialogShowsFolder(NativeOpenFileDialog dlg, string folder)
+        private static bool DialogShowsFolder(NativeFileDialog dlg, string folder)
         {
             var current = dlg.GetFormValue(@"Address");
             return current != null &&

--- a/pwiz_tools/Skyline/TestFunctional/NativeFileDialogTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/NativeFileDialogTest.cs
@@ -23,7 +23,6 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using pwiz.Common.SystemUtil;
 using pwiz.Skyline.Properties;
 using pwiz.Skyline.ToolsUI;
 using pwiz.Skyline.Util;
@@ -116,43 +115,6 @@ namespace pwiz.SkylineTestFunctional
             Assert.AreEqual(savePath, SkylineWindow.DocumentFilePath, true);
 
             TestMultiselectNavigateThenSelect();
-
-            TestSaveDialogNavigateThenName();
-        }
-
-        /// <summary>
-        /// Drives a Save dialog to a folder and then names the file there: <see cref="NativeFileDialog.EnterPath"/>
-        /// the folder, <see cref="NativeFileDialog.Accept"/> to navigate, then EnterPath the name and save.
-        /// </summary>
-        private void TestSaveDialogNavigateThenName()
-        {
-            var saveDir = TestContext.GetTestResultsPath(@"SaveNavigation");
-            Directory.CreateDirectory(saveDir);
-            var savePath = Path.Combine(saveDir, @"Navigated.sky");
-            FileEx.SafeDelete(savePath); // Or a second local run hits the dialog's own overwrite prompt
-
-            string savedPath = null;
-            RunLongNativeDlg<NativeSaveFileDialog>(
-                () =>
-                {
-                    using var dlg = new System.Windows.Forms.SaveFileDialog();
-                    dlg.InitialDirectory = Path.GetTempPath(); // So reaching saveDir takes a real navigation
-                    AssertEx.AreEqual(System.Windows.Forms.DialogResult.OK, dlg.ShowDialog(SkylineWindow),
-                        @"The Save dialog was not accepted.");
-                    savedPath = dlg.FileName;
-                },
-                dlg =>
-                {
-                    dlg.EnterPath(saveDir);
-                    dlg.Accept();
-                    WaitForCondition(() => DialogShowsFolder(dlg, saveDir),
-                        @"The Save dialog did not navigate to the requested folder.");
-                    dlg.EnterPath(Path.GetFileName(savePath));
-                    dlg.DismissWithAcceptButton();
-                });
-
-            // Case-insensitive: the native dialog returns the drive letter upper-cased.
-            Assert.AreEqual(savePath, savedPath, true);
         }
 
         /// <summary>
@@ -227,9 +189,9 @@ namespace pwiz.SkylineTestFunctional
             dlg.Accept();
         }
 
-        // Whether the dialog is showing the given folder -- read from its "Address" control with get_value, the
+        // Whether the Open dialog is showing the given folder -- read from its "Address" control with get_value, the
         // way an MCP client confirms a navigation (trailing separator and case ignored).
-        private static bool DialogShowsFolder(NativeFileDialog dlg, string folder)
+        private static bool DialogShowsFolder(NativeOpenFileDialog dlg, string folder)
         {
             var current = dlg.GetFormValue(@"Address");
             return current != null &&

--- a/pwiz_tools/Skyline/TestFunctional/NativeMessageBoxTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/NativeMessageBoxTest.cs
@@ -82,8 +82,8 @@ namespace pwiz.SkylineTestFunctional
             Assert.IsNotNull(fileDialogId);
             Assert.AreEqual(modalNestingCount, GetModalNestingCount(fileDialogId));
             // Set straight away, with no readiness wait: a file dialog is not named in an ActionResult (nor listed
-            // by GetOpenForms) until the shell has shown the field this types into -- see NativeDialog.Create. This
-            // set failing with "The file dialog is still opening" would mean that gate had regressed.
+            // by GetOpenForms) until the shell has brought it up (see NativeDialog.Create), and the set itself
+            // waits for the file-name field to be shown. This failing would mean one of those had regressed.
             AssertComplete(McpConnector.SetFormValue(fileDialogId, @"FileName", savePath));
             actionResult = McpConnector.DismissWithAcceptButton(fileDialogId);
             Assert.IsFalse(actionResult.Completed);

--- a/pwiz_tools/Skyline/TestFunctional/NativeMessageBoxTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/NativeMessageBoxTest.cs
@@ -81,9 +81,9 @@ namespace pwiz.SkylineTestFunctional
             fileDialogId = actionResult.FormId;
             Assert.IsNotNull(fileDialogId);
             Assert.AreEqual(modalNestingCount, GetModalNestingCount(fileDialogId));
-            // Set straight away, with no readiness wait: a file dialog is not named in an ActionResult (nor listed
-            // by GetOpenForms) until the shell has brought it up (see NativeDialog.Create), and the set itself
-            // waits for the file-name field to be shown. This failing would mean one of those had regressed.
+            // Set straight away, with no readiness wait of the test's own: a file dialog is not named in an
+            // ActionResult (nor listed by GetOpenForms) until the shell has brought it up (see NativeDialog.Create),
+            // and the set waits for the file-name field to be shown (see NativeFileDialog.EnterPath).
             AssertComplete(McpConnector.SetFormValue(fileDialogId, @"FileName", savePath));
             actionResult = McpConnector.DismissWithAcceptButton(fileDialogId);
             Assert.IsFalse(actionResult.Completed);

--- a/pwiz_tools/Skyline/TestUtil/TestFunctional.cs
+++ b/pwiz_tools/Skyline/TestUtil/TestFunctional.cs
@@ -445,35 +445,11 @@ namespace pwiz.SkylineTestUtil
         }
 
         /// <summary>
-        /// Shows a native dialog and drives it with an action that runs on the UI (event) thread -- for a simple,
-        /// single fire-and-forget gesture (e.g. <see cref="NativeFileDialog.EnterPath"/> then
-        /// <see cref="NativeOpenFileDialog.Accept"/>). A gesture that has to interleave with the dialog's own modal
-        /// loop -- a multi-step navigation, or one that waits on the dialog (a DismissWith... verb) -- must run on
-        /// the test thread instead; use <see cref="RunLongNativeDlg{TDlg}"/> for that (the analog of
-        /// <see cref="RunLongDlg{TDlg}"/>).
-        /// </summary>
-        protected static void RunNativeDlg<TDlg>([InstantHandle] Action showDlgAction,
-            [InstantHandle] [NotNull] Action<TDlg> exerciseDlgAction) where TDlg : NativeDialog
-        {
-            bool showDlgActionCompleted = false;
-            SkylineBeginInvoke(() =>
-            {
-                showDlgAction();
-                showDlgActionCompleted = true;
-            });
-            var dlg = WaitForNativeDlg<TDlg>();
-            SkylineBeginInvoke(() => exerciseDlgAction(dlg));
-            WaitForConditionUI(() => showDlgActionCompleted);
-        }
-
-        /// <summary>
-        /// Shows a native dialog and drives it with an action that runs on the TEST thread -- the native-dialog
-        /// analog of <see cref="RunLongDlg{TDlg}"/>. Use this when the action does more than a single gesture: a
-        /// native dialog is driven by thread-agnostic Win32 messages that its modal loop (running on the UI thread)
-        /// pumps, so a multi-step interaction -- navigate a multiselect Open dialog to a folder and then select
-        /// files in it, or read the dialog's state (GetControls) between steps, or wait on it (a DismissWith...
-        /// verb) -- has to run off the UI thread, leaving that loop free to pump each step. (An action marshaled
-        /// onto the UI thread would block the loop and could never pump between steps.)
+        /// Shows a native dialog and drives it with an action that runs on the TEST thread, the way the connector
+        /// drives one from the pipe thread. A native dialog is driven by thread-agnostic Win32 messages that its
+        /// modal loop (running on the UI thread) pumps, so the action has to run off the UI thread, leaving that
+        /// loop free to pump each step -- an action marshaled onto the UI thread would block the loop instead, and
+        /// the gestures that go through the dialog-watch refuse to run there.
         /// </summary>
         protected static void RunLongNativeDlg<TDlg>([InstantHandle] Action showDlgAction,
             [InstantHandle] [NotNull] Action<TDlg> exerciseDlgAction) where TDlg : NativeDialog
@@ -485,7 +461,9 @@ namespace pwiz.SkylineTestUtil
                 showDlgActionCompleted = true;
             });
             var dlg = WaitForNativeDlg<TDlg>();
-            exerciseDlgAction(dlg);
+            // The gestures wait on the dialog with no deadline of their own (see NativeFileDialog.EnterPath), so a
+            // dialog that never reaches the state one is waiting for would hang the run without a thread dump.
+            HangDetection.InterruptWhenHung(() => exerciseDlgAction(dlg));
             WaitForConditionUI(() => showDlgActionCompleted);
         }
 
@@ -545,7 +523,7 @@ namespace pwiz.SkylineTestUtil
         /// </summary>
         public static void FileOpen(string path)
         {
-            RunNativeDlg<NativeOpenFileDialog>(SkylineWindow.ShowOpenFileDialog, dlg =>
+            RunLongNativeDlg<NativeOpenFileDialog>(SkylineWindow.ShowOpenFileDialog, dlg =>
             {
                 dlg.EnterPath(path);
                 dlg.Accept();

--- a/pwiz_tools/Skyline/ToolsUI/DialogWatcher.cs
+++ b/pwiz_tools/Skyline/ToolsUI/DialogWatcher.cs
@@ -127,8 +127,24 @@ namespace pwiz.Skyline.ToolsUI
         private static ActionResult PerformActionAndWait(IntPtr hwnd, Action action, Func<bool> waitCondition,
             CancellationToken cancellationToken)
         {
-            return PerformActionAndWait(Control.FromHandle(hwnd) ?? UiThreadWindow, action, waitCondition,
-                cancellationToken);
+            var control = Control.FromHandle(hwnd);
+            if (control == null)
+            {
+                var uiThreadWindow = UiThreadWindow;
+                // IntPtr.Zero names no window: the work simply needs the UI thread (JsonToolServer runs a CLI
+                // command that way). A real native window must be ON that thread, because that is the thread the
+                // BeginInvoke below reaches -- marshaling its work anywhere else would run it off the thread that
+                // owns it, silently.
+                if (hwnd != IntPtr.Zero &&
+                    User32.GetWindowThreadProcessId(hwnd, out _) !=
+                    User32.GetWindowThreadProcessId(uiThreadWindow.Handle, out _))
+                {
+                    throw new InvalidOperationException(new LlmInstruction(string.Format(@"Native window {0} is on the wrong thread", hwnd)));
+                }
+
+                control = uiThreadWindow;
+            }
+            return PerformActionAndWait(control, action, waitCondition, cancellationToken);
         }
         /// <summary>
         /// Snapshots -- on the caller thread, FIRST -- the nesting count and open top-level windows (pruning the

--- a/pwiz_tools/Skyline/ToolsUI/DialogWatcher.cs
+++ b/pwiz_tools/Skyline/ToolsUI/DialogWatcher.cs
@@ -131,17 +131,16 @@ namespace pwiz.Skyline.ToolsUI
             if (control == null)
             {
                 var uiThreadWindow = UiThreadWindow;
-                // IntPtr.Zero names no window: the work simply needs the UI thread (JsonToolServer runs a CLI
-                // command that way). A real native window must be ON that thread, because that is the thread the
-                // BeginInvoke below reaches -- marshaling its work anywhere else would run it off the thread that
-                // owns it, silently.
-                if (hwnd != IntPtr.Zero &&
-                    User32.GetWindowThreadProcessId(hwnd, out _) !=
-                    User32.GetWindowThreadProcessId(uiThreadWindow.Handle, out _))
+                if (hwnd != IntPtr.Zero)
                 {
-                    throw new InvalidOperationException(new LlmInstruction(string.Format(@"Native window {0} is on the wrong thread", hwnd)));
+                    // If the hwnd is valid, verify that the UiThreadWindow is actually the appropriate thread for the window.
+                    var windowThreadId = User32.GetWindowThreadProcessId(hwnd, out _);
+                    // Thread ID zero means hwnd already destroyed
+                    if (windowThreadId != 0 && windowThreadId != User32.GetWindowThreadProcessId(uiThreadWindow.Handle, out _))
+                    {
+                        throw new InvalidOperationException(new LlmInstruction(string.Format(@"Native window {0} is on the wrong thread", hwnd)));
+                    }
                 }
-
                 control = uiThreadWindow;
             }
             return PerformActionAndWait(control, action, waitCondition, cancellationToken);

--- a/pwiz_tools/Skyline/ToolsUI/JsonUiService.cs
+++ b/pwiz_tools/Skyline/ToolsUI/JsonUiService.cs
@@ -487,9 +487,10 @@ namespace pwiz.Skyline.ToolsUI
                     dialog.Path = formPath;
                     return dialog;
                 }
-            // The managed form, already built (with its handle) by GetOpenFormElements; recording its path is a
-            // plain field set, so no UI-thread marshal is needed.
-            var formElement = (StandaloneForm) FindFormById(formId, cancellationToken);
+            // Otherwise the window the id names, already built (with its handle) by FindFormById; recording its path
+            // is a plain field set, so no UI-thread marshal is needed. It can still be a native dialog: this walk
+            // enumerates both, and a dialog the shell finishes bringing up between the two walks lands here.
+            var formElement = FindFormById(formId, cancellationToken);
             formElement.Path = formPath;
             return formElement;
         }

--- a/pwiz_tools/Skyline/ToolsUI/JsonUiService.cs
+++ b/pwiz_tools/Skyline/ToolsUI/JsonUiService.cs
@@ -682,9 +682,9 @@ namespace pwiz.Skyline.ToolsUI
         }
 
         /// <summary>
-        /// Finds a managed form by its TypeName:Title identifier -- the main window, a form docked in it, or an
-        /// open dialog -- and returns it as the already-built <see cref="StandaloneForm"/> (its window handle already
-        /// captured). Matches the same set <see cref="GetOpenForms"/> reports, and may be called from any thread.
+        /// Finds a window by its TypeName:Title identifier -- the main window, a form docked in it, an open dialog,
+        /// or a native one -- already built, with its window handle captured. Matches the same set
+        /// <see cref="GetOpenForms"/> reports, and may be called from any thread.
         /// </summary>
         private static StandaloneWindow FindFormById(string formId, CancellationToken cancellationToken)
         {

--- a/pwiz_tools/Skyline/ToolsUI/NativeDialog.cs
+++ b/pwiz_tools/Skyline/ToolsUI/NativeDialog.cs
@@ -95,14 +95,17 @@ namespace pwiz.Skyline.ToolsUI
         /// on this, so a dialog that is still opening is reported by NOTHING -- not <see cref="GetOpenDialogs"/>,
         /// not the connector's form list, not the modal watch. That is the point: a window a caller cannot act on
         /// is not worth telling anyone about, and reporting it made whoever acted first fail (see
-        /// <see cref="NativeFileDialog.FileNameTextBox"/>).
+        /// <see cref="NativeFileDialog.EnterPath"/>).
         ///
         /// <para>The window becomes classifiable a moment BEFORE the shell has SHOWN the controls that classified
         /// it -- they are created, then displayed -- which is the gap this closes. Every dialog classified by a
-        /// control it later acts on has that gap and overrides this (<see cref="NativeFileDialog"/> by its
-        /// file-name field, <see cref="NativeFolderBrowserDialog"/> by its tree). The default is for the generic
-        /// message box, which is classified by nothing and driven through buttons the caller reads by caption --
-        /// so it has no control whose appearance it could wait on, and is ready when its window is shown.</para>
+        /// control it later acts on has that gap and overrides this (<see cref="NativeFileDialog"/> by its commit
+        /// button, <see cref="NativeFolderBrowserDialog"/> by its tree). The default is for the generic message
+        /// box, which is classified by nothing and driven through buttons the caller reads by caption -- so it has
+        /// no control whose appearance it could wait on, and is ready when its window is shown.</para>
+        ///
+        /// <para>An override must key on something that, once true, stays true: this reports a dialog as NOT
+        /// THERE.</para>
         /// </summary>
         protected virtual bool IsOpenComplete => true;
 
@@ -322,11 +325,6 @@ namespace pwiz.Skyline.ToolsUI
             if (!IsEnabled)
                 throw new InvalidOperationException(LlmInstruction.Format(
                     @"Cannot interact with native dialog '{0}' because it is blocked.", FormId));
-        }
-
-        protected void BringToForeground()
-        {
-            User32.SetForegroundWindow(Hwnd);
         }
 
         // Posts Enter (key down then up) to a control. Enter MUST be POSTED, not sent: the dialog's modal message

--- a/pwiz_tools/Skyline/ToolsUI/NativeDialog.cs
+++ b/pwiz_tools/Skyline/ToolsUI/NativeDialog.cs
@@ -32,8 +32,10 @@ namespace pwiz.Skyline.ToolsUI
     /// One open native Windows dialog (window class "#32770" -- a message box, or the common Open/Save/folder
     /// dialog), identified by its window handle. Not a WinForms form, so it is absent from FormUtil.OpenForms and
     /// none of the managed element model reaches it: it is driven entirely by Win32 (EnumChildWindows to find its
-    /// controls, WM_SETTEXT / BM_CLICK / WM_CLOSE to act on them). Those are window-manager calls, so they are safe
-    /// from ANY thread -- which matters, because the dialog's modal loop is running on the UI thread.
+    /// controls, WM_SETTEXT / BM_CLICK / WM_CLOSE to act on them). Those are window-manager calls, so a READ is safe
+    /// from any thread -- which matters, because the dialog's modal loop is running on the UI thread. A gesture that
+    /// rides the dialog-watch (<see cref="NativeFileDialog.EnterPath"/>, the DismissWith... verbs) must run OFF that
+    /// thread, which is where it is posting the work and waiting for it.
     ///
     /// <para>Concrete: this class alone drives any "#32770" (list its buttons, click one by caption, accept by its
     /// default button, cancel by WM_CLOSE). <see cref="NativeFileDialog"/> adds the file-name field. Obtain one

--- a/pwiz_tools/Skyline/ToolsUI/NativeFileDialog.cs
+++ b/pwiz_tools/Skyline/ToolsUI/NativeFileDialog.cs
@@ -23,6 +23,7 @@ using System.Collections.Generic;
 using System.Threading;
 using pwiz.Common.SystemUtil.PInvoke;
 using pwiz.Skyline.Util.Extensions;
+using SkylineTool;
 
 namespace pwiz.Skyline.ToolsUI
 {
@@ -119,15 +120,19 @@ namespace pwiz.Skyline.ToolsUI
             return textBox.GetValueNow() as string ?? string.Empty;
         }
 
-        /// <summary>Commits without waiting for the dialog to close, because it may not: a FOLDER path navigates
-        /// and leaves it open (read the "AddressBar" control to tell), and on the multiselect Open dialog the click
-        /// can be spent closing the combo's autocomplete drop-down instead of committing -- so a caller checks
-        /// whether the dialog closed and clicks again if it did not. Use
-        /// <see cref="NativeDialog.DismissWithAcceptButton"/> when it must close. The BM_CLICK is SENT, so call
-        /// this OFF the UI thread.</summary>
-        public void Accept()
+        /// <summary>Clicks the commit button, which is <see cref="StandaloneWindow.ClickButton"/> by control id
+        /// rather than by the button's localized caption -- the one thing a test cannot key on. Same marshal: ONE
+        /// trip onto the dialog's thread, and a modal the click raises comes back named rather than pinning this
+        /// thread. Must be called off the dialog's own thread.
+        ///
+        /// <para>Does not wait for the dialog to close, because it may not: a FOLDER path navigates and leaves it
+        /// open (read the "AddressBar" control to tell), and on the multiselect Open dialog the click can be spent
+        /// closing the combo's autocomplete drop-down instead of committing -- so a caller checks whether the dialog
+        /// closed and clicks again if it did not. Use <see cref="NativeDialog.DismissWithAcceptButton"/> when it
+        /// must close.</para></summary>
+        public ActionResult Accept()
         {
-            AcceptButton.ClickNow();
+            return PerformAction(() => UiActions.Click.InvokeNow(AcceptButton, null));
         }
 
         protected NativeButton AcceptButton => RequireButton(IDOK, CommitButtonDescription);

--- a/pwiz_tools/Skyline/ToolsUI/NativeFileDialog.cs
+++ b/pwiz_tools/Skyline/ToolsUI/NativeFileDialog.cs
@@ -79,6 +79,8 @@ namespace pwiz.Skyline.ToolsUI
         /// <para>To select several files in a multiselect Open dialog, FIRST navigate to their folder (EnterPath
         /// the folder path, accept), THEN EnterPath their names -- BARE names in that folder, double-quoted and
         /// space-separated (<c>"a.raw" "b.raw"</c>). A list of FULL paths does not work.</para>
+        ///
+        /// <para>Must be called OFF the dialog's own thread: the typing is posted to that thread and waited for.</para>
         /// </summary>
         public void EnterPath(string path)
         {
@@ -118,7 +120,9 @@ namespace pwiz.Skyline.ToolsUI
         }
 
         /// <summary>Commits without waiting for the dialog to close, because it may not: a FOLDER path navigates
-        /// and leaves it open (read the "AddressBar" control to tell). Use
+        /// and leaves it open (read the "AddressBar" control to tell), and on the multiselect Open dialog the click
+        /// can be spent closing the combo's autocomplete drop-down instead of committing -- so a caller checks
+        /// whether the dialog closed and clicks again if it did not. Use
         /// <see cref="NativeDialog.DismissWithAcceptButton"/> when it must close. The BM_CLICK is SENT, so call
         /// this OFF the UI thread.</summary>
         public void Accept()
@@ -132,8 +136,8 @@ namespace pwiz.Skyline.ToolsUI
         protected abstract string CommitButtonDescription { get; }
 
         /// <summary>The label the file-name box is presented under, so a caller can read/set it by name (see
-        /// <see cref="EnumerateChildren"/>). Ours, not the shell's, so it is the same in every UI language -- which
-        /// is also what lets a driver wait for the field to exist by looking for this name in GetControls.</summary>
+        /// <see cref="EnumerateChildren"/>). Ours, not the shell's, so it is the same in every UI language. It names
+        /// the box only while the shell is SHOWING it, since GetControls lists the shown children.</summary>
         public const string FILE_NAME_FIELD = @"File name";
 
         /// <summary>The control id of this dialog's file-name Edit -- 1148 for the Open dialog's classic combo,

--- a/pwiz_tools/Skyline/ToolsUI/NativeFileDialog.cs
+++ b/pwiz_tools/Skyline/ToolsUI/NativeFileDialog.cs
@@ -40,6 +40,9 @@ namespace pwiz.Skyline.ToolsUI
         private const string ADDRESS_BAR_CLASS = @"ToolbarWindow32";
         private const int ADDRESS_BAR_ID = 1001;
 
+        // The commit button's control id, so it is found without matching a localized caption.
+        protected const int IDOK = 1;
+
         protected NativeFileDialog(IntPtr windowHandle, CancellationToken cancellationToken) : base(windowHandle, cancellationToken)
         {
         }
@@ -79,19 +82,54 @@ namespace pwiz.Skyline.ToolsUI
         /// </summary>
         public void EnterPath(string path)
         {
-            BringToForeground();
-            var textBox = FileNameTextBox;
-            textBox.SetText(path);
-            // Read back what the box actually HOLDS, rather than predicting what the shell will make of the path.
+            string actual;
+            // The field is not always shown: the Save dialog's rides the DirectUI surface, which the shell hides
+            // while it lays its view out -- shortly after the dialog appears, and again on every navigation. Ask
+            // again until it is, because nothing the caller can observe says when it comes back. No deadline: the
+            // wait ends when the field is shown or when the client that asked for it disconnects.
+            while (null == (actual = CallFunction(() => TypeFileName(path))))
+            {
+                CancellationToken.WaitHandle.WaitOne(FIELD_POLL_MILLIS);
+                CancellationToken.ThrowIfCancellationRequested();
+            }
             // An EMPTY box means the shell consumed the path to navigate -- the caller confirms that through the
             // "Address" control; the path itself means a file name is staged to open. Anything else means the set
-            // did not take. The read SENDS WM_GETTEXT (NativeTextBox.GetValueNow), which is thread-agnostic.
-            var actual = textBox.GetValueNow() as string;
-            if (string.IsNullOrEmpty(actual) || Equals(actual, path))
+            // did not take.
+            if (actual.Length == 0 || Equals(actual, path))
                 return;
             throw new InvalidOperationException(LlmInstruction.Format(
                 @"Tried to set file path to '{0}' but it says '{1}'", path, actual));
         }
+
+        /// <summary>Types the path into the file-name field and returns what the field then HOLDS, or null when the
+        /// field is not shown and the caller should ask again. Runs on the dialog's OWN thread (see
+        /// <see cref="EnterPath"/>), which is what makes the three steps one step: the shell lays the field out on
+        /// that thread, so it cannot hide the field between finding it and setting it, nor rewrite the text between
+        /// setting it and reading it back.</summary>
+        private string TypeFileName(string path)
+        {
+            var hwnd = FindShownFileNameEdit();
+            if (hwnd == IntPtr.Zero)
+                return null;
+            var textBox = new NativeTextBox(hwnd, CancellationToken);
+            textBox.SetText(path);
+            // What the box HOLDS, rather than what we predict the shell will make of the path.
+            return textBox.GetValueNow() as string ?? string.Empty;
+        }
+
+        /// <summary>Commits without waiting for the dialog to close, because it may not: a FOLDER path navigates
+        /// and leaves it open (read the "AddressBar" control to tell). Use
+        /// <see cref="NativeDialog.DismissWithAcceptButton"/> when it must close. The BM_CLICK is SENT, so call
+        /// this OFF the UI thread.</summary>
+        public void Accept()
+        {
+            AcceptButton.ClickNow();
+        }
+
+        protected NativeButton AcceptButton => RequireButton(IDOK, CommitButtonDescription);
+
+        /// <summary>What the commit button is called, for the message when it cannot be found.</summary>
+        protected abstract string CommitButtonDescription { get; }
 
         /// <summary>The label the file-name box is presented under, so a caller can read/set it by name (see
         /// <see cref="EnumerateChildren"/>). Ours, not the shell's, so it is the same in every UI language -- which
@@ -102,31 +140,13 @@ namespace pwiz.Skyline.ToolsUI
         /// 1001 for the Save dialog's DirectUI-hosted field.</summary>
         protected abstract int FileNameControlId { get; }
 
-        /// <summary>The dialog's file-name field, found by its CONTROL ID -- by id, because the field is not "the
-        /// dialog's only text box": the address bar carries a second, collapsed Edit.
-        ///
-        /// <para>The throw is a GUARD, not a wait a caller is expected to retry: a dialog whose field the shell has
-        /// not shown is not handed out at all (<see cref="NativeDialog.Create"/> gates on
-        /// <see cref="IsOpenComplete"/>, which is this same condition), so nobody holding this dialog should reach
-        /// it. It stands because the alternative is silent: typing into a field the shell is still initializing
-        /// does nothing -- the shell overwrites the text, and the dialog then accepts an empty name.</para></summary>
-        protected NativeTextBox FileNameTextBox
-        {
-            get
-            {
-                var hwnd = FindShownFileNameEdit();
-                if (hwnd == IntPtr.Zero)
-                    throw new InvalidOperationException(LlmInstruction.Format(
-                        @"The file dialog is still opening. Wait a moment and try again."));
-                return new NativeTextBox(hwnd, CancellationToken);
-            }
-        }
+        /// <summary>The commit button rather than the file-name field, which the shell hides again each time it
+        /// lays the dialog's view out (see <see cref="EnterPath"/>).</summary>
+        protected override bool IsOpenComplete =>
+            User32.IsWindowVisible(FindDescendant(NativeControl.BUTTON_CLASS, IDOK));
 
-        /// <summary>A file dialog has finished opening once the shell has SHOWN its file-name field -- the field
-        /// every gesture here needs. Existence is not enough, and is exactly the trap: the field is what
-        /// <see cref="NativeDialog.Create"/> classifies the dialog by, so it is already there (created, still
-        /// hidden) throughout the window in which typing into the dialog does nothing.</summary>
-        protected override bool IsOpenComplete => FindShownFileNameEdit() != IntPtr.Zero;
+        // How long to wait between asking for the field again.
+        private const int FIELD_POLL_MILLIS = 30;
 
         // The file-name Edit once the shell has shown it, else IntPtr.Zero.
         private IntPtr FindShownFileNameEdit()

--- a/pwiz_tools/Skyline/ToolsUI/NativeFolderBrowserDialog.cs
+++ b/pwiz_tools/Skyline/ToolsUI/NativeFolderBrowserDialog.cs
@@ -60,12 +60,8 @@ namespace pwiz.Skyline.ToolsUI
                 .FindDescendants(NativeControl.TREE_CLASS).Any();
         }
 
-        /// <summary>The folder browser has finished opening once the shell has SHOWN its folder tree -- the
-        /// control it is classified by, and the one <see cref="SetValueCore"/> acts on. Existence is not enough,
-        /// for the same reason it is not for the file dialogs: <see cref="NativeDialog.FindDescendants"/> matches
-        /// on class alone, so the tree it finds was created but may not be displayed yet. Selecting a folder in
-        /// that window fails SILENTLY -- BFFM_SETSELECTION has no read-back to catch it, unlike
-        /// <see cref="NativeFileDialog.EnterPath"/> -- and the dialog is then accepted on the default folder.</summary>
+        /// <summary>Shown, not merely present: BFFM_SETSELECTION on a tree the shell has not displayed yet fails
+        /// silently, and the dialog is then accepted on the default folder.</summary>
         protected override bool IsOpenComplete =>
             FindDescendants(NativeControl.TREE_CLASS).Any(User32.IsWindowVisible);
 
@@ -74,7 +70,6 @@ namespace pwiz.Skyline.ToolsUI
         // returns; it merely navigates the tree (no nested modal), so the synchronous send does not wedge.
         protected override void SetValueCore(string value)
         {
-            BringToForeground();
             var pathPtr = Marshal.StringToHGlobalUni(value);
             try
             {

--- a/pwiz_tools/Skyline/ToolsUI/NativeOpenFileDialog.cs
+++ b/pwiz_tools/Skyline/ToolsUI/NativeOpenFileDialog.cs
@@ -64,9 +64,7 @@ namespace pwiz.Skyline.ToolsUI
         /// Open commits in one message. With a file name in the box the dialog opens THAT (not any file-list
         /// selection), which is what the caller typed. OkDialog SENDS the click on the dialog's own thread and waits
         /// for it to close -- so a click that raises a nested modal (an overwrite/error prompt) blocks there,
-        /// counted, rather than pinning the pipe thread.
-        /// That drop-down also means one <see cref="NativeFileDialog.Accept"/> may not commit -- the click can be
-        /// spent closing it -- so a caller checks whether the dialog closed and clicks again if not.</summary>
+        /// counted, rather than pinning the pipe thread.</summary>
         public override ActionResult DismissWithAcceptButton()
         {
             return OkDialog(AcceptButton.ClickNow);

--- a/pwiz_tools/Skyline/ToolsUI/NativeOpenFileDialog.cs
+++ b/pwiz_tools/Skyline/ToolsUI/NativeOpenFileDialog.cs
@@ -39,8 +39,6 @@ namespace pwiz.Skyline.ToolsUI
         // across Windows versions and locales, and its presence tells the Open dialog from every other "#32770".
         private const int FILE_NAME_COMBO_ID = 1148;
 
-        private const int IDOK = 1; // the Open button's control id
-
         public override string DialogTypeName => @"OpenFileDialog";
 
         protected override int FileNameControlId => FILE_NAME_COMBO_ID;
@@ -66,14 +64,15 @@ namespace pwiz.Skyline.ToolsUI
         /// Open commits in one message. With a file name in the box the dialog opens THAT (not any file-list
         /// selection), which is what the caller typed. OkDialog SENDS the click on the dialog's own thread and waits
         /// for it to close -- so a click that raises a nested modal (an overwrite/error prompt) blocks there,
-        /// counted, rather than pinning the pipe thread.</summary>
+        /// counted, rather than pinning the pipe thread.
+        /// That drop-down also means one <see cref="NativeFileDialog.Accept"/> may not commit -- the click can be
+        /// spent closing it -- so a caller checks whether the dialog closed and clicks again if not.</summary>
         public override ActionResult DismissWithAcceptButton()
         {
             return OkDialog(AcceptButton.ClickNow);
         }
 
-        // The Open button, by its control id (IDOK) rather than its localized caption.
-        private NativeButton AcceptButton => RequireButton(IDOK, @"Open");
+        protected override string CommitButtonDescription => @"Open";
 
         // The file-name Edit. The classic combo's id (1148) rides the ComboBoxEx32, its ComboBox and (at least on
         // current Windows, the multiselect "Add Input Files" dialog included) the Edit inside it. Take the Edit
@@ -90,29 +89,6 @@ namespace pwiz.Skyline.ToolsUI
                 ? IntPtr.Zero
                 : User32.EnumChildWindows(combo)
                     .FirstOrDefault(hwnd => User32.GetClassName(hwnd) == NativeControl.EDIT_CLASS);
-        }
-
-        /// <summary>
-        /// Commits whatever is in the file-name box by clicking the Open button: a FOLDER path navigates into that
-        /// folder and leaves the dialog open, while file name(s) open and the dialog closes. Clicking Open (rather
-        /// than posting Enter) is what makes this reliable -- see <see cref="DismissWithAcceptButton"/> for why a
-        /// posted Enter is swallowed on the multiselect dialog. The caller drives the next step by observing the
-        /// result: it confirms a NAVIGATION by reading the dialog's current folder from GetControls (the read-only
-        /// "AddressBar" control, see <see cref="NativeAddressBar"/>) and an OPEN by the dialog closing.
-        ///
-        /// <para>So the multiselect Open dialog is driven like this: <see cref="NativeFileDialog.EnterPath"/> the
-        /// folder and Accept, wait (via GetControls) until the folder is reached, then EnterPath the double-quoted
-        /// space-separated file names and Accept to open them. The BM_CLICK is SENT, so call this OFF the UI thread,
-        /// where the dialog's modal loop can process it.</para>
-        ///
-        /// <para>One click may not commit: typing the names raises the combo's shell autocomplete drop-down, and a
-        /// click can be spent closing that drop-down rather than opening. So the caller VERIFIES -- checks whether
-        /// the dialog closed (it is no longer in GetOpenForms) -- and clicks again if it did not, rather than
-        /// assuming a single Accept opened the files.</para>
-        /// </summary>
-        public void Accept()
-        {
-            AcceptButton.ClickNow();
         }
     }
 }

--- a/pwiz_tools/Skyline/ToolsUI/NativeSaveFileDialog.cs
+++ b/pwiz_tools/Skyline/ToolsUI/NativeSaveFileDialog.cs
@@ -40,7 +40,6 @@ namespace pwiz.Skyline.ToolsUI
         // the breadcrumb is a ToolbarWindow32 -- so class + id identifies the Edit unambiguously, and nothing has to
         // walk to the DirectUI host that owns it.
         private const int FILE_NAME_EDIT_ID = 1001;
-        private const int IDOK = 1; // the Save button
 
         public override string DialogTypeName => @"SaveFileDialog";
 
@@ -72,7 +71,6 @@ namespace pwiz.Skyline.ToolsUI
             return OkDialog(saveButton.ClickNow);
         }
 
-        // The Save button, by its control id rather than its (localized) caption.
-        private NativeButton AcceptButton => RequireButton(IDOK, @"Save");
+        protected override string CommitButtonDescription => @"Save";
     }
 }


### PR DESCRIPTION
## Summary

TestLayoutExportImport kept failing in nightly with "The file dialog is still opening" after #4606, on builds that contained that fix (runs #85009, #85012 at 176539ecc).

The Save dialog's file-name field is hosted in the shell's DirectUI surface, and the shell hides that whole surface while it lays the dialog's view out. Measured on every "Export Window Layout" dialog the test opens: the field goes hidden roughly 28 ms and 32 ms after the dialog appears, for about a millisecond each, with the address unchanged. It happens again on every folder navigation. Keyed on that field, `IsOpenComplete` reported a live dialog as absent mid-life, and `EnterPath` typed into a field that was not there.

* Keyed `NativeFileDialog.IsOpenComplete` on the commit button (IDOK), a child of the dialog's own "#32770" template that the shell shows once and leaves alone, instead of the file-name field
* Changed `EnterPath` to find, set and read back the field in one block on the dialog's own thread (`DialogWatcher.CallFunction`), asking again while the field is hidden, so the shell cannot lay it out between the steps
* Stopped `JsonUiService.ResolveForm` casting to `StandaloneForm` - its second walk enumerates native dialogs too, which threw `InvalidCastException` in TestNativeMessageBox
* Verified in `DialogWatcher.PerformActionAndWait` that a native window is on the thread the `BeginInvoke` reaches, rather than silently marshaling its work elsewhere
* Lifted `Accept()` and the commit button into `NativeFileDialog`, and removed `BringToForeground`, which no gesture needs now that they are all window messages
* Removed `RunNativeDlg`, which ran the exercise on the event thread; its four callers use `RunLongNativeDlg`, now wrapped in `HangDetection.InterruptWhenHung`

No new test. The hide is about a millisecond wide and is not triggerable on demand, so a test either races it or manufactures the state by hand; TestLayoutExportImport is the test that catches it, intermittently, which is how the bug was reported in the first place.

## Test plan

- [x] TestLayoutExportImport - the nightly failure
- [x] TestNativeMessageBox - the InvalidCastException
- [x] TestNativeFileDialog, TestLibraryBuild, TestMcpConnectorFormThreading, TestPrmMcpConnector - the test-helper change
- [x] TestJsonToolServer, TestAlertWatch, TestRunCommandMcpConnector - the DialogWatcher change
- [x] CodeInspection

All 10 run 3x in a loop, 0 failures.

Co-Authored-By: Claude <noreply@anthropic.com>
