### PR TITLE
osprey: Added support for running a search when only the spectra cache remains

### DIFF
--- a/pwiz_tools/Osprey/Osprey.Tasks/ScoringTaskShared.cs
+++ b/pwiz_tools/Osprey/Osprey.Tasks/ScoringTaskShared.cs
@@ -172,22 +172,18 @@ namespace pwiz.Osprey.Tasks
             // parsed list. The "Processing file N/M: <path>" banner already named the file.
             // SpectrumFileReader picks the mzML or vendor-raw reader by extension; both
             // return the same MzmlResult, so nothing below here knows the source format.
-            // Re-parsing needs the source, and a run may legitimately no longer have one: once
-            // the cache is built the source is dead weight, so deleting it is a supported way to
-            // halve the disk a large cohort needs. Every path that reaches here has decided the
-            // cache is unusable - a version bump, a bad header, a truncated body - and the
-            // remedy in every one of those cases is to rebuild from the source. Say exactly that
-            // instead of failing inside the reader on a path that is not there.
-            //
-            // Named separately from "Input file not found" because the two mean opposite things
-            // to an operator: that one says the argument is wrong, this one says the argument is
-            // right and the data behind it has to come back. Getting the sources back (they stay
-            // on PanoramaWeb) is the fix, and a message that only reported a missing file would
-            // send the reader looking for a typo.
+            // Deleting the sources once the caches exist is supported, so reaching a re-parse
+            // with no source is a real state, not a bad argument. Say which of the two is
+            // wrong - the cache, and why - rather than failing inside the reader on a path
+            // that is not there.
+            // TODO: name WHY the cache was rejected - a version bump reads very differently
+            // from a truncated body. The reader returns a bare bool from every rejection path,
+            // so the reason has to be captured by the validity check itself and carried out;
+            // re-deriving it here would duplicate that logic and drift from it.
             if (!File.Exists(inputFile) && !Directory.Exists(inputFile))
             {
                 throw new InvalidDataException(string.Format(
-                    @"Spectra cache '{0}' cannot be used and cannot be rebuilt: the source '{1}' is missing. Restore the source and re-run - a cache is only self-sufficient while it stays readable by this build.",
+                    @"Spectra cache '{0}' is not usable and cannot be rebuilt because the source '{1}' is missing. Restore the source and re-run.",
                     cachePath, inputFile));
             }
             MzmlResult mzmlResult;

--- a/pwiz_tools/Osprey/Osprey.Tasks/ScoringTaskShared.cs
+++ b/pwiz_tools/Osprey/Osprey.Tasks/ScoringTaskShared.cs
@@ -172,6 +172,24 @@ namespace pwiz.Osprey.Tasks
             // parsed list. The "Processing file N/M: <path>" banner already named the file.
             // SpectrumFileReader picks the mzML or vendor-raw reader by extension; both
             // return the same MzmlResult, so nothing below here knows the source format.
+            // Re-parsing needs the source, and a run may legitimately no longer have one: once
+            // the cache is built the source is dead weight, so deleting it is a supported way to
+            // halve the disk a large cohort needs. Every path that reaches here has decided the
+            // cache is unusable - a version bump, a bad header, a truncated body - and the
+            // remedy in every one of those cases is to rebuild from the source. Say exactly that
+            // instead of failing inside the reader on a path that is not there.
+            //
+            // Named separately from "Input file not found" because the two mean opposite things
+            // to an operator: that one says the argument is wrong, this one says the argument is
+            // right and the data behind it has to come back. Getting the sources back (they stay
+            // on PanoramaWeb) is the fix, and a message that only reported a missing file would
+            // send the reader looking for a typo.
+            if (!File.Exists(inputFile) && !Directory.Exists(inputFile))
+            {
+                throw new InvalidDataException(string.Format(
+                    @"Spectra cache '{0}' cannot be used and cannot be rebuilt: the source '{1}' is missing. Restore the source and re-run - a cache is only self-sufficient while it stays readable by this build.",
+                    cachePath, inputFile));
+            }
             MzmlResult mzmlResult;
             if (serializeMzmlRead)
                 s_mzmlReadGate.Wait();

--- a/pwiz_tools/Osprey/Osprey/Program.cs
+++ b/pwiz_tools/Osprey/Osprey/Program.cs
@@ -202,6 +202,7 @@ namespace pwiz.Osprey
                 // paths were already validated by ResolveInputScores during parsing).
                 if (!fromInputScores)
                 {
+                    int cacheOnlyInputs = 0;
                     foreach (string inputFile in config.InputFiles)
                     {
                         // A directory counts as present. Several vendor formats ARE
@@ -212,9 +213,36 @@ namespace pwiz.Osprey
                         // which must work on a build that cannot read the raw itself.
                         if (!File.Exists(inputFile) && !Directory.Exists(inputFile))
                         {
+                            // An ABSENT source is not an error when its spectra cache is
+                            // already built. Stage 1 is the only stage that reads the
+                            // raw/mzML at all, and SpectraCache's staleness check already
+                            // treats a missing source as the documented resume case - it
+                            // returns a (0, 0) fingerprint, which the load path reads as
+                            // "nothing to compare, trust the cache"
+                            // (TryComputeSourceFingerprint). This check was the only thing
+                            // standing between that and a workflow of
+                            // download -> --task SpectraCache -> delete the source, which
+                            // roughly halves the disk a large cohort needs: the 446-file CHS
+                            // set is ~1.8 TB of .raw against ~1.2 TB of caches, and only the
+                            // caches are read once staging is done. The originals stay
+                            // recoverable from PanoramaWeb.
+                            if (File.Exists(SpectraCache.GetCachePath(inputFile)))
+                            {
+                                cacheOnlyInputs++;
+                                continue;
+                            }
                             LogError(string.Format("Input file not found: {0}", inputFile));
                             return 1;
                         }
+                    }
+                    // Announced, not silent. A run whose sources are gone cannot rebuild a
+                    // cache that turns out to be wrong, so which files it came from is
+                    // provenance the operator has to be able to read back off the log.
+                    if (cacheOnlyInputs > 0)
+                    {
+                        LogInfo(string.Format(
+                            "{0} of {1} input(s) are absent but have a spectra cache; reading those from the cache.",
+                            cacheOnlyInputs, config.InputFiles.Count));
                     }
                 }
                 if (config.LibrarySource != null && !File.Exists(config.LibrarySource.Path))

--- a/pwiz_tools/Osprey/Osprey/Program.cs
+++ b/pwiz_tools/Osprey/Osprey/Program.cs
@@ -213,19 +213,11 @@ namespace pwiz.Osprey
                         // which must work on a build that cannot read the raw itself.
                         if (!File.Exists(inputFile) && !Directory.Exists(inputFile))
                         {
-                            // An ABSENT source is not an error when its spectra cache is
-                            // already built. Stage 1 is the only stage that reads the
-                            // raw/mzML at all, and SpectraCache's staleness check already
-                            // treats a missing source as the documented resume case - it
-                            // returns a (0, 0) fingerprint, which the load path reads as
-                            // "nothing to compare, trust the cache"
-                            // (TryComputeSourceFingerprint). This check was the only thing
-                            // standing between that and a workflow of
-                            // download -> --task SpectraCache -> delete the source, which
-                            // roughly halves the disk a large cohort needs: the 446-file CHS
-                            // set is ~1.8 TB of .raw against ~1.2 TB of caches, and only the
-                            // caches are read once staging is done. The originals stay
-                            // recoverable from PanoramaWeb.
+                            // An absent source is fine once its cache is built: Stage 1 is
+                            // the only stage that reads a source, and SpectraCache already
+                            // treats a missing one as "trust the cache". That makes
+                            // delete-the-sources-after-caching a supported way to halve the
+                            // disk a large cohort needs.
                             if (File.Exists(SpectraCache.GetCachePath(inputFile)))
                             {
                                 cacheOnlyInputs++;
@@ -235,9 +227,8 @@ namespace pwiz.Osprey
                             return 1;
                         }
                     }
-                    // Announced, not silent. A run whose sources are gone cannot rebuild a
-                    // cache that turns out to be wrong, so which files it came from is
-                    // provenance the operator has to be able to read back off the log.
+                    // Announced, not silent: a run whose sources are gone cannot rebuild a
+                    // cache that turns out to be wrong, so the log is the only provenance.
                     if (cacheOnlyInputs > 0)
                     {
                         LogInfo(string.Format(

--- a/pwiz_tools/Osprey/docs/14-intermediate-files.md
+++ b/pwiz_tools/Osprey/docs/14-intermediate-files.md
@@ -15,7 +15,7 @@ resume mechanisms the port adds (a per-task `.osprey.task` validity sidecar and 
 | File pattern | Format | C# writer/reader | Purpose |
 |---|---|---|---|
 | `<stem>.calibration.json` | JSON (Newtonsoft) | `Osprey.Chromatography/CalibrationIO.cs` | RT + MS1/MS2 mass calibration parameters |
-| `<stem>.spectra.bin` | Custom binary v3 | `Osprey.IO/SpectraCache.cs` | Decoded MS1/MS2 spectra for fast reload |
+| `<stem>.spectra.bin` | Custom binary v4 | `Osprey.IO/SpectraCache.cs` | Decoded MS1/MS2 spectra for fast reload — and the only copy once the source is deleted |
 | `<stem>.scores.parquet` | Apache Parquet (ZSTD) | `Osprey.IO/ParquetScoreCache.cs` | Scored entries: 21 PIN features, fragments, CWT candidates + footer metadata |
 | `<stem>.scores-reconciled.parquet` | Apache Parquet (ZSTD) | `Osprey.Tasks/ReconciledParquetWriter.cs` | Stage 6 reconciled rewrite (separate file, not in-place) |
 | `<stem>.1st-pass.fdr_scores.bin` | Custom binary v4 | `Osprey.IO/FdrScoresSidecar.cs` | SVM score + 4 q-values + PEP + experiment_protein_qvalue + experiment_aggregate_score after first-pass Percolator |
@@ -117,45 +117,60 @@ filter, `PerFileScoringTask.cs:1758`).
 A raw little-endian dump of decoded MS1 and MS2 spectra, written after the first parse and
 reloaded during Stage 6 reconciliation re-scoring to avoid re-parsing mzML.
 
-### Header and format (VERSION 3)
+### Header and format (VERSION 4)
 
 The C# header is **larger than the 20-byte header in the Rust doc** because it adds a source
-fingerprint (`SpectraCache.cs:90`):
+fingerprint:
 
 ```
 [magic:        8 bytes  "OSPRSPC\0"]
-[version:      uint32   = 3]
-[source_size:  uint64   source file length, 0 when unknown]
+[version:      uint32   = 4]
+[source_size:  uint64   source file length; 0 when unknown, ulong.MaxValue when unmeasurable]
 [source_mtime: int64    source last-write time, Unix ms UTC, 0 when unknown]
 [n_ms2:        uint32]
 [n_ms1:        uint32]
 ```
 
+MS2 records are written **grouped by isolation window** (every record sharing a rounded
+iso-center key is contiguous), then the MS1 section, then a per-MS2 index in *acquisition*
+order — 40 bytes each: record offset, iso center/lower/upper, retention time — and a 16-byte
+EOF footer carrying the MS1-section and index offsets. `SpectraWindowIndex` reads a whole
+window in one sequential run, and the index restores acquisition order without walking records.
+
 Per-MS2 record: `scan_number:u32, retention_time:f64, precursor_mz:f64, iso_center:f64,
-iso_lower:f64, iso_upper:f64, n_peaks:u32, mzs:f64×n, intensities:f32×n`
-(`SpectraCache.cs:99`). Per-MS1 record drops the three precursor/isolation fields
-(`SpectraCache.cs:113`). Per-peak storage is 12 bytes (f64 m/z + f32 intensity), matching Rust.
+iso_lower:f64, iso_upper:f64, n_peaks:u32, mzs:f64×n, intensities:f32×n`. Per-MS1 record drops
+the three precursor/isolation fields. Per-peak storage is 12 bytes (f64 m/z + f32 intensity),
+matching Rust.
 
 The Unix-ms mtime is deliberately not .NET ticks so that C# and Rust compute an *identical*
-fingerprint for the same file and can share one cache (`SpectraCache.cs:43`,
-`ComputeSourceFingerprint` at `SpectraCache.cs:227`).
+fingerprint for the same file and can share one cache.
 
 ### Version-bump invalidation
 
-`LoadSpectraCache` (`SpectraCache.cs:132`) returns `null` (⇒ re-parse + rewrite) on: missing
-file, wrong magic, or `version != 3` (`SpectraCache.cs:152`). The version constant records its
-own history (`SpectraCache.cs:61`): v1→v2 (2026-05-09) because non-monotonic centroids are now
-sorted before caching; v2→v3 (2026-06-09) added the source fingerprint. Any older cache is
-rejected and repopulated.
+`TryReadHeader` rejects a cache — the caller then re-parses and rewrites — on wrong magic,
+`version != VERSION`, the unmeasurable-source sentinel, or a fingerprint that no longer matches
+the source. The version constant records its own history: v1→v2 (2026-05-09) sorts
+non-monotonic centroids before caching; v2→v3 (2026-06-09) added the source fingerprint;
+v3→v4 (2026-07-16) grouped the MS2 body by window and added the index + footer. Any older cache
+is rejected and repopulated **from its source**, which is why a cohort that deleted its sources
+is pinned to the format version it was staged with.
 
 ### Source-fingerprint invalidation
 
 When the stored `source_size != 0` and a `sourcePath` is supplied, the loader recomputes the
-fingerprint and rejects the cache if size or mtime changed (`SpectraCache.cs:162`). When the
-cache recorded no fingerprint, or the source is unavailable (e.g. a resume run whose mzML is not
-beside the cache), the check is skipped and the within-run cache is trusted.
+fingerprint and rejects the cache if size or mtime changed. When the cache recorded no
+fingerprint, or the source is unavailable — a resume run whose mzML is not beside the cache, or
+a cohort whose sources were deleted after staging — the check is skipped and the cache is
+trusted.
 
-Safe to delete: yes — recreated on next run.
+**Safe to delete: only while the source still exists.** Osprey runs a search from
+`.spectra.bin` alone when the source is absent, which is what makes a staged cohort's sources
+deletable and roughly halves the disk it needs. That trade is one-way. Once the sources are
+gone the cache is the only copy of the spectra: nothing can rebuild it, a format bump has
+nothing to re-parse, and the fingerprint check that would have caught a mismatched cache is
+skipped precisely because there is nothing left to compare against. So validate the caches
+against their sources — magic, version, fingerprint, and that the index offset agrees with
+`n_ms2` — **before** deleting either, and treat the caches as data from then on.
 
 ---
 
@@ -499,9 +514,13 @@ hashes alone.
 
 ## Cleanup
 
-All intermediate files are safe to delete and are recreated on the next run:
+Every intermediate file except the spectra cache is safe to delete and is recreated on the next
+run:
 
-- `<stem>.spectra.bin` — recreated by re-parsing mzML.
+- `<stem>.spectra.bin` — recreated by re-parsing the source, **and only then**. On a cohort
+  whose sources were deleted after staging (the supported way to halve a large cohort's disk),
+  this file is not an intermediate at all — it is the data, and deleting it loses the run.
+  Prune caches only where the source is still on disk.
 - `<stem>.scores.parquet` / `<stem>.scores-reconciled.parquet` — recreated by re-scoring.
 - `<stem>.{1st,2nd}-pass.fdr_scores.bin` — first-pass required by the Stage 6 worker; deleting
   forces a Stage 5 re-join.
@@ -583,12 +602,13 @@ default resume mechanism.
   `reconciliation_io.rs` carries the matching fields for byte parity — i.e. the Rust code evolved
   past its own doc. Evidence: `ReconciliationFile.cs:75,77,84,124,138,150`. Severity: minor.
 
-- **[STALE-RUST-DOC] `.spectra.bin` header is v3 with a source fingerprint, not the doc's
-  20-byte v1** - The Rust doc's header shows `version = 1` and no size/mtime; C# writes v3 with
-  `source_size:u64` + `source_mtime:i64` (Unix ms) and invalidates on both version bump and
-  fingerprint change, computing the fingerprint as Unix-ms specifically to match Rust. Evidence:
-  `SpectraCache.cs:61,70,90,162`. The matching fingerprint implies the Rust code also advanced;
-  the doc did not. Severity: minor.
+- **[STALE-RUST-DOC] `.spectra.bin` is v4 with a source fingerprint and a window-grouped body,
+  not the doc's 20-byte v1** - The Rust doc's header shows `version = 1`, no size/mtime, and a
+  file-order body; C# writes v4 with `source_size:u64` + `source_mtime:i64` (Unix ms), groups
+  the MS2 records by isolation window, and appends an acquisition-order index + EOF footer. It
+  invalidates on both version bump and fingerprint change, computing the fingerprint as Unix-ms
+  specifically to match Rust. The matching fingerprint implies the Rust code also advanced; the
+  doc did not. Severity: minor.
 
 - **[INTENTIONAL-CSHARP-DESIGN] Calibration reuse is not gated on a `search_hash` inside
   `.calibration.json`** - Rust doc: the calibration file is reused when its `search_hash`

--- a/pwiz_tools/Osprey/docs/15-hpc-scoring-split.md
+++ b/pwiz_tools/Osprey/docs/15-hpc-scoring-split.md
@@ -61,7 +61,7 @@ The exact per-task membership per mode is pinned by `Osprey.Test/PipelineMembers
 
 - `<stem>.scores.parquet` — the per-file PIN-feature / fragment / CWT-candidate cache (`ParquetScoreCache.GetScoresPath`).
 - `<stem>.calibration.json` — RT + MS1/MS2 mass calibration (`CalibrationIO.CalibrationPathForInput`).
-- `<stem>.spectra.bin` — local mzML-decode fast-reload cache (not needed by joins).
+- `<stem>.spectra.bin` — the decoded-spectrum cache. No *join* reads it, but Stage 6 rescore does, and it is what lets a search run at all once the input has been deleted (see 14-intermediate-files.md).
 
 The parquet footer is stamped once against the unmutated outer config (`:226-232`) with `osprey.version`, `osprey.search_hash`, `osprey.library_hash`, and `osprey.reconciled = "false"`. Under `--task PerFileScoring` (`config.NoJoin` with no `--input-scores`) the task stops after writing the parquets and returns false with `ExitCode = 0` (`FinalizeAndCheck`, `:649-658`) — Stage 5+ is skipped, no blib is written. `--output` is accepted but not used (`Osprey/Program.cs:228-232` reports the real per-file parquet output instead of warning).
 
@@ -88,7 +88,7 @@ Under `--task FirstPassFDR` (`config.StopAfterStage5`), `PlanStage6` writes the 
 
 `PerFileRescoreTask` (`Osprey.Tasks/PerFileRescoreTask.cs`). Consumes the boundary file pair + the per-file parquet and re-scores each file against the consensus + reconciliation boundaries, runs the gap-fill two-pass, and writes a **reconciled** parquet. `Run` (`:185-315`) reads the post-FirstPassFDR buffer (`ctx.Get<CompactedEntries>()`, `:200`; demanding it materializes `FirstPassFdrTask`), self-gates on planning state (`didPlan` or a rescore bundle, and no 2nd-pass sidecar already present, `:232-247`), then calls `ExecuteRescore` (`:491-612`).
 
-`ExecuteRescore` runs the per-file loop `RescoreOneFile` (`:644-813`), which for each file with work: builds `boundary_overrides` keyed by entry_id + the subset library, reloads spectra (`.spectra.bin` → mzML fallback) and mass calibrations, picks the refined RT calibration (falling back to first-pass), re-scores via `ScoringPipeline.RunCoelutionScoring`, overlays the rescored entries in place, runs gap-fill, and writes the reconciled parquet. Rescore runs the files **in parallel** under the same `EffectiveFileParallelism` the scoring phase resolved (`:547-584`).
+`ExecuteRescore` runs the per-file loop `RescoreOneFile` (`:644-813`), which for each file with work: builds `boundary_overrides` keyed by entry_id + the subset library, streams spectra from `.spectra.bin` (`LoadSpectraForRescore`; there is **no** mzML fallback — an absent, stale or wrong-version cache is fatal here) and reloads mass calibrations, picks the refined RT calibration (falling back to first-pass), re-scores via `ScoringPipeline.RunCoelutionScoring`, overlays the rescored entries in place, runs gap-fill, and writes the reconciled parquet. Rescore runs the files **in parallel** under the same `EffectiveFileParallelism` the scoring phase resolved (`:547-584`).
 
 Reconciled output goes to a **separate** `<stem>.scores-reconciled.parquet` sibling, leaving the Stage 4 `<stem>.scores.parquet` intact (`ParquetScoreCache.GetReconciledScoresPath`; `WriteReconciledAndStamp`, `:944-987`). Its footer carries `osprey.reconciled = "true"` plus `osprey.reconciliation_hash` (`Osprey.Tasks/ReconciledParquetWriter.cs:198-205`). This differs from the Rust doc, which says Stage 6 "rewrites each `<stem>.scores.parquet`" in place (see Divergences).
 
@@ -143,7 +143,7 @@ On mismatch the run aborts before any FDR/reconciliation work, naming the offend
 |---|---|---|
 | `<stem>.calibration.json` | Stage 1-2 | Stage 6 (inverse RT prediction + isolation windows) |
 | `<stem>.scores.parquet` | Stage 4 (`PerFileScoringTask`) | Stages 5-7 (stubs, PIN features, CWT candidates, blib plan) |
-| `<stem>.spectra.bin` | Stage 1-2 | local fast-reload only; no join depends on it |
+| `<stem>.spectra.bin` | Stage 1-2 | Stage 6 rescore (**mandatory** — streamed per window, no mzML fallback); the only spectrum source once the input is deleted |
 | `<stem>.1st-pass.fdr_scores.bin` | Stage 5 (`FirstPassFdrTask`) | Stage 6 worker (mandatory); skip-Percolator on rerun |
 | `<stem>.reconciliation.json` | Stage 5 (`FirstPassFdrTask`) | Stage 6 worker (mandatory) |
 | `<stem>.scores-reconciled.parquet` | Stage 6 (`PerFileRescoreTask`) | Stage 7 (`SecondPassFdrTask`) 2nd-pass FDR + blib |

--- a/pwiz_tools/Osprey/regression.ps1
+++ b/pwiz_tools/Osprey/regression.ps1
@@ -1194,7 +1194,10 @@ function Copy-LibraryInto {
 # referenced in place), so the read-only data dir is untouched.
 function Invoke-HpcChain {
     param([string[]]$Mzmls, [string]$Library, [string]$Resolution, [string]$ChainRoot,
-          [hashtable]$Spec, [string]$Manifest)
+          [hashtable]$Spec, [string]$Manifest,
+          # Directory holding the straight-through leg's .spectra.bin. Phase 1 is
+          # seeded from these instead of the mzML - see the block that stages them.
+          [string]$CacheSource)
     $libName = Split-Path -Leaf $Library
     # Every phase gets the SAME dataset flags as the straight-through run -- the
     # chain is only a self-consistency oracle if both sides run the same search.
@@ -1220,7 +1223,30 @@ function Invoke-HpcChain {
     # <stem>.calibration.json per file.
     $ph1 = Join-Path $ChainRoot 'phase1_scoring'
     New-Item -ItemType Directory -Path $ph1 -Force | Out-Null
-    foreach ($m in $Mzmls) { Copy-Item $m (Join-Path $ph1 (Split-Path -Leaf $m)) }
+    # Seeded with the straight-through leg's CACHES, not the mzML. Phase 1 is the only HPC
+    # phase that reads spectra, and it deletes the copied mzML the moment it finishes anyway
+    # ("dead weight once it has run", below) - so staging the cache instead costs nothing, skips
+    # copying multi-GB inputs, and turns this phase into the gate on PerFileScoring reading a
+    # .spectra.bin with NO source present.
+    #
+    # That is the half of the delete-your-sources workflow no other leg can cover: mode 2
+    # requires PerFileScoring to be SKIPPED, and a skipped task opens no cache. Here the task
+    # genuinely RUNS, and mode 3's existing chain==straight blib comparison is what proves the
+    # cache-read produced identical results - no new comparator needed.
+    #
+    # It also covers the UNREDIRECTED cache lookup. Phase 1 passes no --work-dir/--cache-dir, so
+    # ResolveCacheDir returns the INPUT directory - the default an operator actually gets, and
+    # the one every other leg here bypasses by always passing --work-dir.
+    #
+    # mzML reading loses no coverage: the straight-through leg parses every one of these files
+    # to build these caches in the first place.
+    foreach ($stem in $stemList) {
+        $srcCache = Join-Path $CacheSource "$stem.spectra.bin"
+        if (-not (Test-Path -LiteralPath $srcCache)) {
+            throw "regression: HPC phase 1 needs the straight-through spectra cache '$srcCache'; the cache-only PerFileScoring gate cannot run without it."
+        }
+        Copy-Item -LiteralPath $srcCache (Join-Path $ph1 "$stem.spectra.bin")
+    }
     Copy-LibraryInto -Library $Library -Dir $ph1 -Manifest $Manifest
     $a1 = @()
     foreach ($m in $Mzmls) { $a1 += @('-i', (Split-Path -Leaf $m)) }
@@ -1529,7 +1555,8 @@ foreach ($name in $selected) {
         # --input-scores worker (--task PerFileScoring / PerFileRescoring), which is exactly
         # what mode 3 exists to exercise.
         $chainBlib = Invoke-HpcChain -Mzmls $inputs.Mzmls -Library $inputs.Library `
-            -Resolution $cfg.Resolution -ChainRoot $chainRoot -Spec $cfg -Manifest $inputs.Manifest
+            -Resolution $cfg.Resolution -ChainRoot $chainRoot -Spec $cfg -Manifest $inputs.Manifest `
+            -CacheSource $straightDir
         $sw3.Stop()
         Write-Host ("  HPC chain wall {0:mm\:ss}; blib {1:N0} bytes" -f $sw3.Elapsed, (Get-Item $chainBlib).Length)
         # Per-file sidecar comparison, alongside the blib. The blib carries no protein
@@ -1658,7 +1685,41 @@ foreach ($name in $selected) {
         # leg exists to catch, which is why mode 3 and mode 4 never had one either: the former
         # blanket OSPREY_ALLOW_UNBOUNDED_MEMORY=1 wrapped a whole leg and let a transfer
         # regression ride along unnoticed for ten days.
-        $rResume = Invoke-OspreyRun -Mzmls $inputs.Mzmls -Library $inputs.Library -Resolution $cfg.Resolution `
+        # The inputs this leg names DO NOT EXIST: same file names, but under the work dir,
+        # where an mzML is never placed. Only the .spectra.bin the straight-through leg
+        # left there is real (caches honor --work-dir; the sources stay in the read-only
+        # Perftests tree, untouched).
+        #
+        # That makes the resume also the gate on a run whose SOURCES ARE GONE. Stage 1 is
+        # the only stage that reads an mzML, so once the caches exist the sources are dead
+        # weight - worth roughly half the disk of a large cohort (the 446-file CHS set is
+        # ~1.8 TB of .raw against ~1.2 TB of caches) - which makes
+        # download -> --task SpectraCache -> delete-the-source a supported way to stage.
+        #
+        # SCOPE, precisely: this leg proves the pipeline ACCEPTS absent inputs and still
+        # produces the identical blib. It does NOT prove spectra can be READ from cache
+        # with no source, because the two tasks that open a .spectra.bin - PerFileScoring
+        # and PerFileRescoring - are the two this leg requires to be SKIPPED. Do not read
+        # a green mode 2 as covering that; it needs a leg where PerFileScoring RUNS.
+        #
+        # The cache is found here because Invoke-OspreyRun always passes --work-dir, which
+        # pins the cache dir. Without any redirection ResolveCacheDir returns the INPUT
+        # directory instead, so the directory in these paths would matter - that variant
+        # is the one an operator uses and no leg covers it.
+        #
+        # Folded into this leg rather than given one of its own because the property costs
+        # nothing to assert here and everything to assert separately: mode 2 already
+        # recomputes FirstPassFDR and SecondPassFDR, already requires PerFileScoring and
+        # PerFileRescoring to hit cache, and already compares the result to $coldBlib. A
+        # dedicated leg would re-run the pipeline to check the one thing this line checks.
+        $resumeInputs = @($inputs.Mzmls | ForEach-Object { Join-Path $straightDir (Split-Path $_ -Leaf) })
+        foreach ($p in $resumeInputs) {
+            # Guard the premise. If an mzML ever does land in the work dir, the leg would
+            # quietly go back to testing the ordinary path and the cache-only property
+            # would stop being covered with nothing turning red.
+            if (Test-Path $p) { throw "regression: work dir unexpectedly holds a source input ($p); the resume leg's cache-only premise is broken." }
+        }
+        $rResume = Invoke-OspreyRun -Mzmls $resumeInputs -Library $inputs.Library -Resolution $cfg.Resolution `
             -WorkDir $straightDir -LogName 'resume.log' -Spec $cfg -Manifest $inputs.Manifest
         $resumeBlib = Join-Path $straightDir 'output.blib'
         Write-Host ("  resume wall {0:mm\:ss}; blib {1:N0} bytes" -f $rResume.Wall, (Get-Item $resumeBlib).Length)
@@ -1679,6 +1740,17 @@ foreach ($name in $selected) {
             -ExpectSkipped @('PerFileScoring', 'PerFileRescoring') `
             -ExpectRan @('FirstPassFDR', 'SecondPassFDR') `
             -NoColdScoring -NoColdRescoring
+        # ... and this is the only thing that says the run took the CACHE-ONLY path. The
+        # premise guard above proves the named inputs are absent, and a build without the
+        # absent-source support would die on them outright - but neither notices if this
+        # leg is ever pointed back at the real sources, which would drop the coverage with
+        # nothing going red. Same reason mode 5 asserts its rehydrate marker.
+        $m2absent = Test-LogMarker -LogPath $rResume.Log `
+            -Marker 'are absent but have a spectra cache' `
+            -Description 'Osprey resolving inputs from the spectra cache with no source present'
+        foreach ($issue in $m2absent.Issues) { $m2cache.Issues.Add($issue) }
+        # Repair Pass after mutating Issues - Test-TaskCacheHits computed it at return time.
+        $m2cache.Pass = ($m2cache.Issues.Count -eq 0)
         if ($m2cache.Pass) {
             $summaryLines.Add("$name mode2 (resume cache hits): PASS")
         } else {

--- a/pwiz_tools/Osprey/regression.ps1
+++ b/pwiz_tools/Osprey/regression.ps1
@@ -1224,22 +1224,14 @@ function Invoke-HpcChain {
     $ph1 = Join-Path $ChainRoot 'phase1_scoring'
     New-Item -ItemType Directory -Path $ph1 -Force | Out-Null
     # Seeded with the straight-through leg's CACHES, not the mzML. Phase 1 is the only HPC
-    # phase that reads spectra, and it deletes the copied mzML the moment it finishes anyway
-    # ("dead weight once it has run", below) - so staging the cache instead costs nothing, skips
-    # copying multi-GB inputs, and turns this phase into the gate on PerFileScoring reading a
-    # .spectra.bin with NO source present.
+    # phase that reads spectra and it deletes the copied mzML right after running anyway, so
+    # this costs nothing, stops copying multi-GB inputs, and makes the phase the gate on
+    # PerFileScoring reading a .spectra.bin with no source. Mode 2 cannot cover that - it
+    # requires PerFileScoring to be SKIPPED, and a skipped task opens no cache. Mode 3's
+    # chain==straight comparison is what proves the results identical.
     #
-    # That is the half of the delete-your-sources workflow no other leg can cover: mode 2
-    # requires PerFileScoring to be SKIPPED, and a skipped task opens no cache. Here the task
-    # genuinely RUNS, and mode 3's existing chain==straight blib comparison is what proves the
-    # cache-read produced identical results - no new comparator needed.
-    #
-    # It also covers the UNREDIRECTED cache lookup. Phase 1 passes no --work-dir/--cache-dir, so
-    # ResolveCacheDir returns the INPUT directory - the default an operator actually gets, and
-    # the one every other leg here bypasses by always passing --work-dir.
-    #
-    # mzML reading loses no coverage: the straight-through leg parses every one of these files
-    # to build these caches in the first place.
+    # Also the only leg covering the UNREDIRECTED lookup: phase 1 passes no --work-dir, so
+    # ResolveCacheDir returns the input directory, which is what an operator gets by default.
     foreach ($stem in $stemList) {
         $srcCache = Join-Path $CacheSource "$stem.spectra.bin"
         if (-not (Test-Path -LiteralPath $srcCache)) {
@@ -1686,32 +1678,12 @@ foreach ($name in $selected) {
         # blanket OSPREY_ALLOW_UNBOUNDED_MEMORY=1 wrapped a whole leg and let a transfer
         # regression ride along unnoticed for ten days.
         # The inputs this leg names DO NOT EXIST: same file names, but under the work dir,
-        # where an mzML is never placed. Only the .spectra.bin the straight-through leg
-        # left there is real (caches honor --work-dir; the sources stay in the read-only
-        # Perftests tree, untouched).
+        # where an mzML is never placed - only the .spectra.bin is. The sources stay in the
+        # read-only Perftests tree, untouched.
         #
-        # That makes the resume also the gate on a run whose SOURCES ARE GONE. Stage 1 is
-        # the only stage that reads an mzML, so once the caches exist the sources are dead
-        # weight - worth roughly half the disk of a large cohort (the 446-file CHS set is
-        # ~1.8 TB of .raw against ~1.2 TB of caches) - which makes
-        # download -> --task SpectraCache -> delete-the-source a supported way to stage.
-        #
-        # SCOPE, precisely: this leg proves the pipeline ACCEPTS absent inputs and still
-        # produces the identical blib. It does NOT prove spectra can be READ from cache
-        # with no source, because the two tasks that open a .spectra.bin - PerFileScoring
-        # and PerFileRescoring - are the two this leg requires to be SKIPPED. Do not read
-        # a green mode 2 as covering that; it needs a leg where PerFileScoring RUNS.
-        #
-        # The cache is found here because Invoke-OspreyRun always passes --work-dir, which
-        # pins the cache dir. Without any redirection ResolveCacheDir returns the INPUT
-        # directory instead, so the directory in these paths would matter - that variant
-        # is the one an operator uses and no leg covers it.
-        #
-        # Folded into this leg rather than given one of its own because the property costs
-        # nothing to assert here and everything to assert separately: mode 2 already
-        # recomputes FirstPassFDR and SecondPassFDR, already requires PerFileScoring and
-        # PerFileRescoring to hit cache, and already compares the result to $coldBlib. A
-        # dedicated leg would re-run the pipeline to check the one thing this line checks.
+        # SCOPE: this proves the pipeline ACCEPTS absent inputs and still produces the
+        # identical blib. It does NOT prove spectra can be READ from cache - the two tasks
+        # that open one are the two this leg requires to be skipped. HPC phase 1 covers that.
         $resumeInputs = @($inputs.Mzmls | ForEach-Object { Join-Path $straightDir (Split-Path $_ -Leaf) })
         foreach ($p in $resumeInputs) {
             # Guard the premise. If an mzML ever does land in the work dir, the leg would


### PR DESCRIPTION
## Summary

Lets a search run when the source `.raw`/`.mzML` is gone but its `.spectra.bin` is present, so
staging becomes download -> `--task SpectraCache` -> **delete the sources** -> search.

Stage 1 is the only stage that reads a source at all; everything after it reads the cache. Today
keeping the sources roughly DOUBLES the data a cohort occupies for no benefit past step 2. On the
446-file CHS set that is **~1.8 TB of .raw against ~1.2 TB of caches**, and the originals stay
recoverable from PanoramaWeb. Disk is now what limits cohort size on a 64 GB box, not time.

* **`Program.cs`** - a missing input is no longer fatal when its spectra cache exists, and the run
  reports `N of M input(s) are absent but have a spectra cache`. Announced rather than silent: a
  run whose sources are gone cannot rebuild a cache that later proves wrong, so which files came
  from cache is provenance the operator has to be able to read off the log.
* **`ScoringTaskShared.cs`** - when a cache cannot be used AND cannot be rebuilt, fail with a
  message naming both the cache and the missing source, instead of calling the reader on a path
  that is not there. Worded distinctly from `Input file not found`, because the two mean opposite
  things: that one says the argument is wrong, this one says the argument is right and the data
  behind it has to come back.
* **`regression.ps1`** - HPC phase 1 is seeded from the straight-through leg's caches instead of
  the mzML, so `PerFileScoring` genuinely runs cache-only.

Nothing here changes what a run computes. `Program.cs` was the only gate; `SpectraCache` already
documented the absent-source case, returning a `(0, 0)` fingerprint that the load path reads as
"nothing to compare, trust the cache".

## How it is tested

**HPC phase 1 (mode 3) now runs `PerFileScoring` with no source present**, and mode 3's existing
chain==straight blib comparison is what proves the cache-read produced identical results - no new
comparator, no new leg, and no extra run.

Phase 1 was the right carrier because it already copies the mzML in, runs the task, and then
deletes them ("dead weight once it has run"). Seeding it with caches instead is strictly cheaper -
it stops copying multi-GB inputs - and it is the only place `PerFileScoring` can be made to run
against a cache: the resume leg requires that task to be SKIPPED, and a skipped task opens no
cache. Phase 1 also passes no `--work-dir`/`--cache-dir`, so it covers the UNREDIRECTED lookup
where `ResolveCacheDir` returns the input directory - the default an operator gets, and the path
every other leg bypasses.

mzML reading loses no coverage: the straight-through leg parses every one of those files to build
the caches in the first place.

The mode-2 resume leg additionally names inputs under the work dir that do not exist, covering the
front-door acceptance. Its comment states explicitly what it does NOT prove, so a future reader
does not mistake it for cache-read coverage.

## Test plan

- [x] `regression.ps1 -Dataset Stellar` - PASSED, including `mode3 (HPC chain==straight)` with a
      cache-only `PerFileScoring`, and `mode2 (resume==straight)`
- [x] `Build-Osprey.ps1 -Configuration Debug -RunTests -RunInspection` - 592/592, zero warnings
- [x] Manual: moved one `.raw` aside, ran the full pipeline from cache - 189,715 MS/MS spectra
      loaded, all four tasks, blib written
- [x] `/code-review max`
- [ ] TeamCity Perf/Regression on `pull/<N>`

## Known follow-ups, recorded in the TODO

Not folded in, to keep this reviewable:

* Positional (non-`-i`) input paths still gate on existence in `OspreyCommandArgs` and are dropped
  with a warning; a partially-staged cohort would run on the surviving subset.
* `--task SpectraCache` is exempted by the same relaxation, so with sources absent it can report
  success having staged nothing.
* Vendor DIRECTORY formats (.d, Waters .raw) never reach the new branch, because `Directory.Exists`
  short-circuits first.
* `docs/14-intermediate-files.md` and `15-hpc-scoring-split.md` still describe `.spectra.bin` as
  disposable and claim an mzML fallback that `PerFileRescoreTask` does not have. Those need
  updating before this workflow is documented for general use.

See TODO-20260826_osprey_run_from_cache.md in pwiz-ai/todos

Co-Authored-By: Claude <noreply@anthropic.com>
