### PR TITLE
Fix TestLayoutExportImport leak

### DIFF
--- a/pwiz_tools/Skyline/TestRunner/Program.cs
+++ b/pwiz_tools/Skyline/TestRunner/Program.cs
@@ -114,18 +114,12 @@ namespace TestRunner
             // with no potential for infinite looping on a detected leak.
             {"TestLibraryExplorer", new ExpandedLeakCheck()},
             {"TestLibraryExplorerAsSmallMolecules", new ExpandedLeakCheck()},
-            // These show the native common file dialog, and what grows is Windows' shell cache, not
-            // Skyline: a heap block-size diff finds Explorer's cached DirectUI view for the modern
-            // IFileDialog, one set per dialog, held on a UI thread that lives for the whole process.
-            // It saturates (~2 KB/dialog by the 40th), so these tests do settle -- they just need
-            // more than the default 24 runs. x4 because the nightly machines sit further up the
-            // curve than the box this was measured on; the extra iterations are only consumed when a
-            // test has not settled, so they cost nothing where it converges early. Muting instead
-            // would give up heap-leak detection here entirely.
-            // See ai/todos/active/TODO-20260723_native_dialog_leak_iterations.md for the evidence.
+            // Tests which show the native common file dialog need more iterations to stabilize
+            // because the Windows shell cache grows
             {"TestNativeFileDialog", new ExpandedLeakCheck(LeakCheckIterations * 4)},
             {"TestNativeMessageBox", new ExpandedLeakCheck(LeakCheckIterations * 4)},
             {"TestPrmMcpConnector", new ExpandedLeakCheck(LeakCheckIterations * 4)},
+            {"TestLayoutExportImport", new ExpandedLeakCheck(LeakCheckIterations * 4)}
         };
 
         //  These tests only need to be run once, regardless of language, so they get turned off in pass 0 after a single invocation


### PR DESCRIPTION
Add "TestLayoutExportImport" to "LeakCheckIterationsOverrideByTestName". The test had been reported as leaking presumably because of the native OpenFileDialog which takes a while to settle down in terms of memory consumption.

Future work: Separate out the test parts that use native dialogs and move them into a separate set of tests so tests which require additional iterations on some computers will be distinctively named.