### PR TITLE
skyline: Fixed the thread dump leaking an attach per call and hanging on its own thread

### DIFF
--- a/pwiz_tools/Skyline/Test/HangDetectionThreadDumpTest.cs
+++ b/pwiz_tools/Skyline/Test/HangDetectionThreadDumpTest.cs
@@ -76,12 +76,12 @@ namespace pwiz.SkylineTest
                 string.Format(@"Thread dump took {0}, which is over the {1} bound.",
                     timer.Elapsed, MAX_DUMP_DURATION));
 
-            // Say which path this machine took, whether or not it worked. Passing silently is how
-            // the first green CI run left the question below unanswerable: 0 sec is what BOTH a
-            // working dump and an immediate degrade look like from the outside. Two lines is
-            // enough - a full dump names its first thread, a degraded one names the CLR and the
-            // DAC that decided it.
-            Console.WriteLine(TextUtil.LineSeparate(dump.Split('\n').Take(2).Select(line => line.TrimEnd())));
+            // Deliberately silent on the passing path. Writing which path this machine took was
+            // how the agents were shown to produce full dumps, but a test that prints lands its
+            // output BETWEEN the harness's test-name line and its memory line, and SkylineTester
+            // parses those as one line - so a Quality run could not read memory for this test at
+            // all. The question that output answered is settled, and where a machine genuinely
+            // cannot dump, the assertion below fails with the CLR and DAC in its message.
 
             if (dump.Contains(@"Thread dump unavailable"))
             {

--- a/pwiz_tools/Skyline/Test/HangDetectionThreadDumpTest.cs
+++ b/pwiz_tools/Skyline/Test/HangDetectionThreadDumpTest.cs
@@ -21,6 +21,7 @@
 using System;
 using System.Diagnostics;
 using System.Linq;
+using System.Threading;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using pwiz.Skyline.Util.Extensions;
 using pwiz.SkylineTestUtil;
@@ -48,6 +49,12 @@ namespace pwiz.SkylineTest
         /// allowed to be slow - but far under the minutes this is here to keep out.
         /// </summary>
         private static readonly TimeSpan MAX_DUMP_DURATION = TimeSpan.FromSeconds(30);
+
+        /// <summary>
+        /// Generous, because it only has to rule out "never started" - a loaded agent is allowed
+        /// to take its time getting a thread onto a core.
+        /// </summary>
+        private static readonly TimeSpan THREAD_START_TIMEOUT = TimeSpan.FromSeconds(30);
 
         [TestMethod]
         public void TestThreadDumpNamesRunningFrames()
@@ -94,6 +101,51 @@ namespace pwiz.SkylineTest
             }
 
             AssertDumpNamesFrames(dump);
+            AssertSecondDumpIsNotTheFirstOne();
+        }
+
+        /// <summary>
+        /// PINNED: that a second dump reports the process as it is NOW. The attach is made once
+        /// and reused, so every dump after the first is served by a runtime that ClrMD will answer
+        /// out of its snapshot unless Flush is called - and a snapshot served as current is worse
+        /// than no dump, because it reads as a healthy answer to the wrong question.
+        /// <para>Nothing else covers it. One call exercises only the attach, so deleting the Flush
+        /// leaves every later dump reporting the first dump's threads forever and the rest of this
+        /// test still passes - exactly the silent failure this class exists to catch.</para>
+        /// </summary>
+        private static void AssertSecondDumpIsNotTheFirstOne()
+        {
+            using var blocking = new ManualResetEventSlim(false);
+            using var started = new ManualResetEventSlim(false);
+
+            // A thread that did not exist when the first dump was taken. Blocked, not spinning, so
+            // the DAC can read it - a running thread is the documented blind spot.
+            var thread = new Thread(() =>
+            {
+                started.Set();
+                blocking.Wait();
+            })
+            {
+                IsBackground = true,
+                Name = nameof(AssertSecondDumpIsNotTheFirstOne)
+            };
+            thread.Start();
+            try
+            {
+                // Wait for the thread to signal it is up, then assert once. Waiting instead for
+                // the dump to mention it would pass the moment it happened to and prove nothing.
+                AssertEx.IsTrue(started.Wait(THREAD_START_TIMEOUT),
+                    string.Format(@"Thread did not start within {0}.", THREAD_START_TIMEOUT));
+
+                var dump = HangDetection.TryGetThreadDump();
+                AssertEx.Contains(dump,
+                    string.Format(@"(Managed ID: {0})", thread.ManagedThreadId));
+            }
+            finally
+            {
+                blocking.Set();
+                thread.Join(THREAD_START_TIMEOUT);
+            }
         }
 
         private static void AssertDumpNamesFrames(string dump)

--- a/pwiz_tools/Skyline/Test/HangDetectionThreadDumpTest.cs
+++ b/pwiz_tools/Skyline/Test/HangDetectionThreadDumpTest.cs
@@ -154,8 +154,14 @@ namespace pwiz.SkylineTest
 
             // Frames, not just thread headers. A dump listing threads and nothing else is the
             // failure this test exists to catch, and it looks healthy at the call site.
+            // Notes are indented like frames because they belong to the thread above them, so they
+            // have to be excluded explicitly. Counting them would let a dump that walked NOTHING -
+            // every thread noted, no stack read - satisfy the assertion below, which is the exact
+            // silent success this test exists to prevent.
             var frameLines = dump.Split('\n')
-                .Count(line => line.StartsWith(@"  ") && !line.Contains(@"[Unknown]"));
+                .Count(line => line.StartsWith(@"  ")
+                               && !line.StartsWith(HangDetection.THREAD_NOTE_PREFIX)
+                               && !line.Contains(@"[Unknown]"));
             AssertEx.IsTrue(frameLines > 0,
                 TextUtil.LineSeparate(@"Thread dump named no frames on any thread.", dump));
 

--- a/pwiz_tools/Skyline/TestUtil/HangDetection.cs
+++ b/pwiz_tools/Skyline/TestUtil/HangDetection.cs
@@ -61,6 +61,14 @@ namespace pwiz.SkylineTestUtil
         private const int MAX_FRAMES_PER_THREAD = 512;
 
         /// <summary>
+        /// Marks a line under a thread that is a note ABOUT the walk rather than a frame from it.
+        /// Indented like a frame because it belongs to the thread above it, but distinguishable,
+        /// because anything counting frames would otherwise count the notes as frames - which is
+        /// how a dump that named no frames at all could still look healthy.
+        /// </summary>
+        public const string THREAD_NOTE_PREFIX = @"  -- ";
+
+        /// <summary>
         /// Serializes everything that touches <see cref="_dataTarget"/> and <see cref="_runtime"/>,
         /// which ClrMD requires because it is not thread-safe. Taken only with
         /// <see cref="ATTACH_LOCK_TIMEOUT_MILLIS"/>, never unconditionally - see that field.
@@ -455,7 +463,7 @@ namespace pwiz.SkylineTestUtil
                     // meaning what the class doc says it means - could not read, not idle.
                     if (thread.ManagedThreadId == Thread.CurrentThread.ManagedThreadId)
                     {
-                        lines.Add(@"  (thread taking this dump - its own stack cannot be read)");
+                        lines.Add(THREAD_NOTE_PREFIX + @"thread taking this dump - its own stack cannot be read");
                         lines.Add(string.Empty);
                         continue;
                     }
@@ -482,15 +490,32 @@ namespace pwiz.SkylineTestUtil
             {
                 if (frames.Count >= MAX_FRAMES_PER_THREAD)
                 {
-                    frames.Add(string.Format(@"  ... stopped after {0} frames - the stack unwind is not terminating",
-                        MAX_FRAMES_PER_THREAD));
+                    frames.Add(string.Format(@"{0}stopped after {1} frames - the stack unwind is not terminating",
+                        THREAD_NOTE_PREFIX, MAX_FRAMES_PER_THREAD));
                     break;
                 }
 
-                frames.Add(string.Format(@"  {0}.{1}",
-                    frame.Method?.Type?.Name, frame.Method?.Name ?? @"[Unknown]"));
+                frames.Add(@"  " + GetFrameName(frame));
             }
             return frames;
+        }
+
+        /// <summary>
+        /// One frame as "Type.Method", degrading to whichever half ClrMD could resolve. Built
+        /// rather than formatted because a null type used to render as nothing at all, leaving a
+        /// bare leading dot - ".[Unknown]" - which reads as a parse error rather than as the
+        /// unresolved frame it is.
+        /// </summary>
+        private static string GetFrameName(ClrStackFrame frame)
+        {
+            var methodName = frame.Method?.Name;
+            if (methodName == null)
+            {
+                return @"[Unknown]";
+            }
+
+            var typeName = frame.Method?.Type?.Name;
+            return typeName == null ? methodName : typeName + @"." + methodName;
         }
 
         /// <summary>

--- a/pwiz_tools/Skyline/TestUtil/HangDetection.cs
+++ b/pwiz_tools/Skyline/TestUtil/HangDetection.cs
@@ -1,6 +1,7 @@
 /*
  * Original author: Nicholas Shulman <nicksh .at. u.washington.edu>,
  *                  MacCoss Lab, Department of Genome Sciences, UW
+ * AI assistance: Claude Code (Claude Opus 5) <noreply .at. anthropic.com>
  *
  * Copyright 2025 University of Washington - Seattle, WA
  *
@@ -39,6 +40,41 @@ namespace pwiz.SkylineTestUtil
         /// diagnostic - or the test that covers it - may charge every run.
         /// </summary>
         private const int THREAD_DUMP_TIMEOUT_MILLIS = 5 * 1000;
+
+        /// <summary>
+        /// How long a dump waits for a walk already in progress. Never blocks outright: ClrMD is
+        /// not thread-safe, so a second walker has to wait, but <see cref="TryGetThreadDump"/>
+        /// ABANDONS a dump thread that overruns its bound and an abandoned walker never releases
+        /// this lock. Waiting forever would let ONE overrun silently kill the thread dump for the
+        /// rest of the process, parking a thread per later call. Giving up says so instead.
+        /// </summary>
+        private const int ATTACH_LOCK_TIMEOUT_MILLIS = 2 * 1000;
+
+        /// <summary>
+        /// A bound on one thread's frames. ClrMD's own documentation for
+        /// <see cref="ClrThread.EnumerateStackTrace"/> says it "may loop infinitely in the case of
+        /// stack corruption or other stack unwind issues which can happen in practice" and tells
+        /// callers to "set a maximum loop count" - and a hung process, which is when this runs, is
+        /// exactly where that is likeliest. Far above any real stack, so a truncated thread means
+        /// the unwind went wrong, and the dump says so rather than never returning.
+        /// </summary>
+        private const int MAX_FRAMES_PER_THREAD = 512;
+
+        /// <summary>
+        /// Serializes everything that touches <see cref="_dataTarget"/> and <see cref="_runtime"/>,
+        /// which ClrMD requires because it is not thread-safe. Taken only with
+        /// <see cref="ATTACH_LOCK_TIMEOUT_MILLIS"/>, never unconditionally - see that field.
+        /// </summary>
+        private static readonly object _attachLock = new object();
+
+        /// <summary>
+        /// The attach to this process, and the runtime read through it, kept between dumps - see
+        /// <see cref="GetSelfRuntime"/> for why re-attaching is not an option. Written ONLY under
+        /// <see cref="_attachLock"/>, and always as a pair: either both are set and usable, or
+        /// both are null and the next dump rebuilds them.
+        /// </summary>
+        private static DataTarget _dataTarget;
+        private static ClrRuntime _runtime;
 
         private readonly object _lock = new object();
         private bool _disposed;
@@ -283,13 +319,15 @@ namespace pwiz.SkylineTestUtil
             // wedged test run, which costs a whole nightly pass - so it gets its own background
             // thread and a deadline. Abandoning that thread leaves the rest of the work running,
             // which is the cheaper mistake: the thread is a background one, so a wedged attach can
-            // never hold the process open.
+            // never hold the process open. It does hold the shared runtime, though, which is why
+            // every later dump waits only ATTACH_LOCK_TIMEOUT_MILLIS for it and then reports that
+            // rather than queueing up behind it.
             var dumpThread = new Thread(() =>
             {
                 try
                 {
                     var threadDumpLines = new List<string> { @"*** Thread dump:" };
-                    threadDumpLines.AddRange(GetAllThreadsCallstacks(Process.GetCurrentProcess().Id));
+                    threadDumpLines.AddRange(GetAllThreadsCallstacks());
                     threadDumpLines.Add(@"*** End of thread dump");
                     threadDump = TextUtil.LineSeparate(threadDumpLines);
                 }
@@ -304,9 +342,10 @@ namespace pwiz.SkylineTestUtil
             };
             dumpThread.Start();
 
-            // Not describing the runtime on this path. Doing so needs another attach, and the
-            // attach is what just proved too slow to finish - so asking again would spend the
-            // bound a second time, per timeout, which is the cost this bound exists to stop.
+            // Not describing the runtime on this path. Doing so needs the attach, and the attach
+            // is what just proved too slow to finish - the abandoned thread still holds it - so
+            // asking would spend the bound a second time, per timeout, which is the cost this
+            // bound exists to stop.
             if (!dumpThread.Join(timeoutMillis))
             {
                 return TextUtil.LineSeparate(
@@ -353,6 +392,14 @@ namespace pwiz.SkylineTestUtil
         {
             try
             {
+                // Its own attach, disposed, deliberately NOT the shared one. Three reasons, all of
+                // which the shared runtime gets wrong here. It answers from the first attach, so on
+                // an agent whose DAC was installed mid-run every later report would repeat the
+                // original "local matching DAC: none" - the exact question this exists to answer,
+                // frozen at the wrong moment. It would need the lock, on the CALLER's thread, which
+                // is the one path with no Join around it to bound the wait. And without
+                // CreateRuntime no DAC is ever loaded, so there is no unreleasable COM reference
+                // and Dispose really does release everything, including the process handle.
                 using var dataTarget = DataTarget.AttachToProcess(Process.GetCurrentProcess().Id, 5000, AttachFlag.Passive);
                 var clrInfo = dataTarget.ClrVersions.FirstOrDefault();
                 if (clrInfo == null)
@@ -368,39 +415,190 @@ namespace pwiz.SkylineTestUtil
             }
         }
 
-        public static IEnumerable<string> GetAllThreadsCallstacks(int processId)
+        /// <summary>
+        /// Every managed thread in THIS process, one header line per thread followed by its frames.
+        /// <para>Materialized rather than lazy: the walk holds <see cref="_attachLock"/>, and a
+        /// deferred iterator would hold it for however long the caller took to enumerate.</para>
+        /// </summary>
+        public static IEnumerable<string> GetAllThreadsCallstacks()
         {
-            using var dataTarget = DataTarget.AttachToProcess(processId, 5000, AttachFlag.Passive);
-            var clrInfo = dataTarget.ClrVersions[0];
-
-            // Refuse before the expensive half rather than after. With no DAC on this machine
-            // matching this CLR, ClrMD fetches one from a symbol server, which is slow where that
-            // server is unreachable and reads garbage where the version does not match - measured
-            // as 745-1035 seconds ending in "Array dimensions exceeded supported range" on the
-            // TeamCity agents. Naming the missing file costs milliseconds and tells whoever
-            // provisions the machine exactly what to install.
-            var localMatchingDac = clrInfo.LocalMatchingDac;
-            if (localMatchingDac == null)
-                throw new InvalidOperationException(string.Format(
-                    @"No local DAC matching CLR {0} - {1} would have to come from a symbol server",
-                    clrInfo.Version, clrInfo.DacInfo.FileName));
-
-            // Explicitly from the local file, so the symbol server can never become the fallback.
-            var runtime = clrInfo.CreateRuntime(localMatchingDac);
-
-            foreach (var thread in runtime.Threads)
+            if (!Monitor.TryEnter(_attachLock, ATTACH_LOCK_TIMEOUT_MILLIS))
             {
-                if (!thread.IsAlive) continue;
+                // Named, not silent. Waiting forever behind an abandoned walker is how one overrun
+                // would take the diagnostic down for the rest of the process; reporting a timeout
+                // with no cause is how the reader gets sent after a DAC that is fine.
+                throw new InvalidOperationException(string.Format(
+                    @"Another thread dump is still running after {0} ms and holds the shared runtime",
+                    ATTACH_LOCK_TIMEOUT_MILLIS));
+            }
 
-                yield return $"Thread {thread.OSThreadId:X} (Managed ID: {thread.ManagedThreadId})";
-
-                foreach (var frame in thread.EnumerateStackTrace())
+            try
+            {
+                var lines = new List<string>();
+                foreach (var thread in GetSelfRuntime().Threads)
                 {
-                    yield return $"  {frame.Method?.Type?.Name}.{frame.Method?.Name ?? "[Unknown]"}";
+                    if (!thread.IsAlive)
+                    {
+                        continue;
+                    }
+
+                    lines.Add(string.Format(@"Thread {0:X} (Managed ID: {1})",
+                        thread.OSThreadId, thread.ManagedThreadId));
+
+                    // Listed but not walked, rather than dropped. The DAC cannot read the stack of
+                    // the thread asking - it is running, the blind spot documented on
+                    // TryGetThreadDump - and asking does not merely come back empty, it can never
+                    // come back at all: measured, a background walker asking for its own stack
+                    // hangs indefinitely. Since TryGetThreadDump ABANDONS this thread at its
+                    // deadline, that hang would strand it holding the runtime for the life of the
+                    // process. Saying so keeps "every managed thread" true and keeps an empty stack
+                    // meaning what the class doc says it means - could not read, not idle.
+                    if (thread.ManagedThreadId == Thread.CurrentThread.ManagedThreadId)
+                    {
+                        lines.Add(@"  (thread taking this dump - its own stack cannot be read)");
+                        lines.Add(string.Empty);
+                        continue;
+                    }
+
+                    lines.AddRange(GetFrames(thread));
+                    lines.Add(string.Empty);
+                }
+                return lines;
+            }
+            finally
+            {
+                Monitor.Exit(_attachLock);
+            }
+        }
+
+        /// <summary>
+        /// One thread's frames, capped at <see cref="MAX_FRAMES_PER_THREAD"/> because ClrMD
+        /// documents this enumeration as able to loop forever on a stack it cannot unwind.
+        /// </summary>
+        private static IEnumerable<string> GetFrames(ClrThread thread)
+        {
+            var frames = new List<string>();
+            foreach (var frame in thread.EnumerateStackTrace())
+            {
+                if (frames.Count >= MAX_FRAMES_PER_THREAD)
+                {
+                    frames.Add(string.Format(@"  ... stopped after {0} frames - the stack unwind is not terminating",
+                        MAX_FRAMES_PER_THREAD));
+                    break;
                 }
 
-                yield return string.Empty;
+                frames.Add(string.Format(@"  {0}.{1}",
+                    frame.Method?.Type?.Name, frame.Method?.Name ?? @"[Unknown]"));
             }
+            return frames;
+        }
+
+        /// <summary>
+        /// The runtime to read stacks out of, attached once and then reused.
+        /// <para>Reused because ONCE THE DAC IS LOADED the attach can no longer be released. In
+        /// this ClrMD (0.8.31, the checked-in prerelease) CreateRuntime hands the DAC a COM
+        /// reference back to the data target that nothing releases, leaving the graph rooted by a
+        /// ref-counted handle: dotMemory shows DacDataTarget -> DataTargetImpl -> ClrInfo[] ->
+        /// ModuleInfo[]. Measured on a fresh attach per call, in a bare console harness, 9 KB
+        /// managed and 3.2 MB private leaked EVERY time; the same leak inside a Debug TestRunner
+        /// costs 15.5 KB managed and 7.6 MB per run, the process being bigger. Releasing the DAC's
+        /// COM objects by hand was tried and changes neither number.</para>
+        /// <para>Disposing is NOT a no-op, which is why the attach above is kept local until the
+        /// runtime exists: DataTargetImpl.Dispose closes its reader, and for a passive attach that
+        /// reader holds an OpenProcess handle - measured, ten undisposed attaches cost ten handles
+        /// and disposing them returns every one. So an attach that never reaches CreateRuntime is
+        /// fully releasable and gets released; only one that did is kept, because by then keeping
+        /// it is the only thing the leak can be traded for.</para>
+        /// <para><see cref="ClrRuntime.Flush"/> is what makes reuse correct rather than merely
+        /// cheap: without it a live-process runtime answers from its snapshot. With it, this
+        /// returns exactly what re-attaching returns - verified against a fresh attach per call
+        /// while threads were being added between reads, identical thread and frame counts.</para>
+        /// </summary>
+        private static ClrRuntime GetSelfRuntime()
+        {
+            if (_runtime != null)
+            {
+                try
+                {
+                    _runtime.Flush();
+                    return _runtime;
+                }
+                catch (Exception)
+                {
+                    // Drop the pair so the next dump rebuilds it. Flush calls into the DAC of a
+                    // process that is already unwell, and it discards its caches only AFTER that
+                    // call returns - so a throw leaves the runtime holding stale data that every
+                    // later Flush would throw on identically. Keeping it would trade a leak for a
+                    // diagnostic permanently stuck on "unavailable"; re-attaching costs one attach.
+                    DiscardAttach();
+                    throw;
+                }
+            }
+
+            // Deliberately local until the runtime exists. Where this machine has no matching DAC
+            // the guard below throws and CreateRuntime is never reached, so no DAC is ever loaded,
+            // nothing holds an unreleasable COM reference to this target, and disposing it really
+            // does give the process handle back. Caching it before the guard would leave the
+            // agents this code was written for holding a permanent attach that can never produce
+            // a dump - a leak introduced by the leak fix.
+            DataTarget dataTarget = null;
+            try
+            {
+                using (var process = Process.GetCurrentProcess())
+                {
+                    dataTarget = DataTarget.AttachToProcess(process.Id, 5000, AttachFlag.Passive);
+                }
+
+                // FirstOrDefault, not [0]: an attach that succeeds where ClrMD recognizes no CLR
+                // would otherwise surface "Index was outside the bounds of the array" as the
+                // reason the dump failed, which tells the reader nothing about the DAC.
+                var clrInfo = dataTarget.ClrVersions.FirstOrDefault();
+                if (clrInfo == null)
+                {
+                    throw new InvalidOperationException(@"No CLR found in this process");
+                }
+
+                // Refuse before the expensive half rather than after. With no DAC on this machine
+                // matching this CLR, ClrMD fetches one from a symbol server, which is slow where
+                // that server is unreachable and reads garbage where the version does not match -
+                // measured as 745-1035 seconds ending in "Array dimensions exceeded supported
+                // range" on the TeamCity agents. Naming the missing file costs milliseconds and
+                // tells whoever provisions the machine exactly what to install.
+                var localMatchingDac = clrInfo.LocalMatchingDac;
+                if (localMatchingDac == null)
+                {
+                    throw new InvalidOperationException(string.Format(
+                        @"No local DAC matching CLR {0} - {1} would have to come from a symbol server",
+                        clrInfo.Version, clrInfo.DacInfo.FileName));
+                }
+
+                // Explicitly from the local file, so the symbol server can never become the
+                // fallback. Publishing the pair only now is what makes the leak one-time: past
+                // this point the DAC is loaded and the attach can no longer be released, so it
+                // has to be worth keeping.
+                _runtime = clrInfo.CreateRuntime(localMatchingDac);
+                _dataTarget = dataTarget;
+                dataTarget = null;
+                return _runtime;
+            }
+            finally
+            {
+                // Still local means it never became the shared attach, so nothing was kept and
+                // this is the disposal that hands the process handle back.
+                dataTarget?.Dispose();
+            }
+        }
+
+        /// <summary>
+        /// Forgets the shared attach, as a pair. The DAC that was loaded through it cannot be
+        /// unloaded - that is the leak this class works around, not one it can undo - so this
+        /// gives up the memory it was reusing in exchange for a diagnostic that still works.
+        /// </summary>
+        private static void DiscardAttach()
+        {
+            _runtime = null;
+            _dataTarget?.Dispose();
+            _dataTarget = null;
         }
     }
 }


### PR DESCRIPTION
## Summary

`TestThreadDumpNamesRunningFrames` failed TestRunner's pass-1 leak check. dotMemory named the
retention path: a RefCounted (COM) handle rooting `DacDataTarget` -> `DataTargetImpl` ->
`ClrInfo[]` -> `ModuleInfo[]`.

* **Every ClrMD attach was permanent.** In the checked-in ClrMD (0.8.31), `CreateRuntime` hands
  the DAC a COM reference back to the data target that nothing releases - `ClrRuntime` has no
  `Dispose` and `DacLibrary` only has a finalizer that `FreeLibrary`s the module, which does not
  drop that reference. So `using var dataTarget = ...` released nothing. Fixed by attaching once
  and reusing it with `ClrRuntime.Flush()`, which is what makes reuse *correct*, not merely
  cheap - without it a live-process runtime answers from its snapshot.
* **The walk could hang forever on its own thread.** Reproduced 100%: a background thread asking
  the DAC for its own stack never returns, where the same walk from the main thread comes back
  empty in 27 ms. `TryGetThreadDump` always walks on a background thread and *abandons* it at the
  deadline, so that hang would strand a thread holding the DAC for the life of the process. The
  walking thread is now listed with a placeholder instead of walked.
* **Bounded what ClrMD says to bound.** `ClrThread.EnumerateStackTrace`'s own doc says it "may
  loop infinitely in the case of stack corruption or other stack unwind issues which can happen
  in practice" and tells callers to "set a maximum loop count" - added, plus a lock timeout so one
  abandoned walker cannot silently kill the diagnostic for the rest of the process.
* **Added coverage for the reuse**, which no test exercised: the test called `TryGetThreadDump`
  once, so deleting `Flush()` would serve the first dump's stacks as current forever and still pass.

Measured per fresh attach: **9 KB managed / 3.2 MB private** in a bare console harness,
**15.5 KB / 7.6 MB** in a Debug TestRunner. Releasing the DAC's COM objects by hand was tried and
changes neither number.

Not a no-op that got removed: `DataTargetImpl.Dispose` closes an `OpenProcess` handle (10
undisposed attaches cost 10 handles; disposing returns every one), so the attach is kept *local*
until a runtime is built through it and disposed otherwise. That matters most on the no-local-DAC
agents, where the guard throws before `CreateRuntime` and a cached attach could never produce a dump.

The attach itself does **not** put the process into a debugged state: `Debugger.IsAttached`,
`IsDebuggerPresent()` and `CheckRemoteDebuggerPresent()` are all false before and after, and
nothing is suspended (a spinner thread's max gap was 0.057 ms during the attach+walk vs 0.136 ms
while idle).

See TODO-20260826_hangdetection_dump_leak.md in pwiz-ai/todos

## Test plan

- [x] `TestThreadDumpNamesRunningFrames` pass 1 - passes, converges in 9 iterations. Deltas
      managed 1.6 KB / heap 1.6 KB / memory 22.9 KB / handles 0.4, against thresholds of
      8 KB / 20 KB / 150 KB / 2
- [x] Negative test for the leak - fix reverted and rebuilt, fails as `LEAKED 15848 Managed bytes /
      197732 Heap bytes / 7815753 bytes`, total memory climbing 120 -> 224 MB over 15 runs
- [x] Negative test for the new coverage - `Flush()` commented out, fails at
      `AssertSecondDumpIsNotTheFirstOne`
- [x] `TestThreadDumpNamesRunningFrames` looped 30 times - 30/30 full dumps, 0 degraded
- [x] `CodeInspection` - passes
- [x] Solution builds

Reviewed with `/code-review max` before opening; every finding acted on was verified
independently first, and one (that the 5000 ms attach timeout could consume the whole budget)
was refuted - `LiveDataReader` takes only a pid, so ClrMD ignores `msecTimeout` on the passive path.

Co-Authored-By: Claude <noreply@anthropic.com>
