### PR TITLE
skyline: Made a worker lost during a test report as that test failing

### DIFF
--- a/pwiz_tools/Skyline/TestRunner/Program.cs
+++ b/pwiz_tools/Skyline/TestRunner/Program.cs
@@ -1783,7 +1783,35 @@ namespace TestRunner
                                     // pair it usually is, which would mean never noticing a worker died
                                     if (workerInfo.Retired || cts.IsCancellationRequested)
                                         return;
-                                    Console.WriteLine($"Worker {workerName} stopped responding while working on test {workerInfo.CurrentTest}.");
+                                    // Reported as a FAILURE of the TEST, in the shape Report() and
+                                    // SkylineNightly parse, and written to the LOG rather than only to
+                                    // the console. Taking the process down is the most serious way a
+                                    // test can fail, not an excuse for it: the only thing missing is
+                                    // the stack trace, because nothing survived to write one.
+                                    // A lost worker used to be one plain line among thousands of
+                                    // results: it named the test but counted for nothing, so a run
+                                    // that shed half its workers still ended saying "No failures" and
+                                    // read as a 40% performance regression instead of five crashes.
+                                    // CurrentTest is "Name/Language/Pass"; the bare name goes on the
+                                    // !!! line because that is what the parsers key on.
+                                    var lostTest = workerInfo.CurrentTest ?? "(no test)";
+                                    var lostTestName = lostTest.Split('/')[0];
+                                    lock (workerInfoByName)   // Every worker's heartbeat runs its own thread
+                                    {
+                                        foreach (var line in new[]
+                                        {
+                                            $"!!! {lostTestName} FAILED",
+                                            $"Worker {workerName} exited unexpectedly while running {lostTest}. " +
+                                            @"No stack trace to report: the test took the process down with it, so " +
+                                            @"nothing was left to write one.",
+                                            @"!!!"
+                                        })
+                                        {
+                                            Console.WriteLine(line);
+                                            log?.WriteLine(line);
+                                        }
+                                        log?.Flush();
+                                    }
                                     if (commandLineArgs.ArgAsBool("coverage"))
                                     {
                                         Console.WriteLine("Aborting coverage run due to failed worker (coverage from that worker is lost).");
@@ -1877,13 +1905,19 @@ namespace TestRunner
             // Every worker has finished, so anything still queued is work nobody ever ran - most likely
             // because the only worker that could have run it went away. Report that rather than passing:
             // a run that quietly skipped tests must not look like a run that passed them.
-            var neverRun = testQueue.Concat(nonParallelTestQueue).Concat(abandonedEntries).ToList();
-
             // A run that loops until something stops it always has work outstanding at the moment it
-            // stops, so leftover entries prove nothing by themselves. The ones that never ran at all
-            // still do.
+            // stops, so leftover QUEUE entries prove nothing by themselves. The ones that never ran
+            // at all still do.
+            var leftInQueue = testQueue.Concat(nonParallelTestQueue).ToList();
             if (LoopsForever(loop))
-                neverRun = neverRun.Where(entry => !entry.HasRun).ToList();
+                leftInQueue = leftInQueue.Where(entry => !entry.HasRun).ToList();
+
+            // Abandoned entries are NOT subject to that: they were taken from the queue by a worker
+            // that then went away or wedged, which is a failure whatever the loop mode. Filtering
+            // them by HasRun is what hid this all along - a test that dies on its fifth pass has run
+            // four times, so every one of them was dropped, and four nights of runs that each lost
+            // half their workers ended reporting no failures at all.
+            var neverRun = leftInQueue.Concat(abandonedEntries).ToList();
 
             if (neverRun.Count > 0)
             {

--- a/pwiz_tools/Skyline/TestRunner/Program.cs
+++ b/pwiz_tools/Skyline/TestRunner/Program.cs
@@ -1785,27 +1785,42 @@ namespace TestRunner
                                         return;
                                     // Reported as a FAILURE of the TEST, in the shape Report() and
                                     // SkylineNightly parse, and written to the LOG rather than only to
-                                    // the console. Taking the process down is the most serious way a
-                                    // test can fail, not an excuse for it: the only thing missing is
-                                    // the stack trace, because nothing survived to write one.
+                                    // the console. Deliberately says nothing about WHY the worker went
+                                    // quiet: all this detection knows is that heartbeats stopped, and a
+                                    // container starved of CPU can miss its window while its test runs
+                                    // on - see MISSED_HEARTBEATS_BEFORE_DEAD. The exit code would settle
+                                    // it, but `docker run --rm` deletes the container before anything
+                                    // can ask. What IS known is that no result ever came back, which is
+                                    // a failure of the test whatever caused it.
                                     // A lost worker used to be one plain line among thousands of
                                     // results: it named the test but counted for nothing, so a run
                                     // that shed half its workers still ended saying "No failures" and
                                     // read as a 40% performance regression instead of five crashes.
                                     // CurrentTest is "Name/Language/Pass"; the bare name goes on the
                                     // !!! line because that is what the parsers key on.
-                                    var lostTest = workerInfo.CurrentTest ?? "(no test)";
-                                    var lostTestName = lostTest.Split('/')[0];
+                                    // Only a worker that was HOLDING a test failed one. Between tests it
+                                    // takes nothing down with it, and naming a test there is worse than
+                                    // saying nothing: the !!! shape makes Report() and SkylineNightly
+                                    // record whatever word follows as a failing test, so a placeholder
+                                    // becomes a test called "(no test)" in the failure list.
+                                    var lostTest = workerInfo.CurrentTest;
+                                    var report = lostTest == null
+                                        ? new[]
+                                        {
+                                            $"Worker {workerName} stopped responding between tests and was " +
+                                            @"given up on. No test result was lost, but the pool is smaller."
+                                        }
+                                        : new[]
+                                        {
+                                            $"!!! {lostTest.Split('/')[0]} FAILED",
+                                            $"Worker {workerName} stopped responding while running {lostTest} and " +
+                                            @"was given up on. No result was ever produced for it, and no stack " +
+                                            @"trace: nothing came back from the worker to write one.",
+                                            @"!!!"
+                                        };
                                     lock (workerInfoByName)   // Every worker's heartbeat runs its own thread
                                     {
-                                        foreach (var line in new[]
-                                        {
-                                            $"!!! {lostTestName} FAILED",
-                                            $"Worker {workerName} exited unexpectedly while running {lostTest}. " +
-                                            @"No stack trace to report: the test took the process down with it, so " +
-                                            @"nothing was left to write one.",
-                                            @"!!!"
-                                        })
+                                        foreach (var line in report)
                                         {
                                             Console.WriteLine(line);
                                             log?.WriteLine(line);

--- a/pwiz_tools/Skyline/TestTutorial/AuditLogTutorialTest.cs
+++ b/pwiz_tools/Skyline/TestTutorial/AuditLogTutorialTest.cs
@@ -44,6 +44,7 @@ using pwiz.Skyline.EditUI;
 using pwiz.Skyline.FileUI;
 using pwiz.Skyline.Model;
 using pwiz.Skyline.Model.AuditLog;
+using pwiz.Skyline.Model.AuditLog.Databinding;
 using pwiz.Skyline.Model.Databinding.Entities;
 using pwiz.Skyline.Model.DocSettings;
 using pwiz.Skyline.Model.DocSettings.AbsoluteQuantification;
@@ -430,16 +431,24 @@ namespace pwiz.SkylineTestTutorial
 //                    SkylineWindow.AuditLogForm.DataGridView.Rows[i].Cells[reasonIndex].Selected = true;
 //            });
 //            RunUI(() => SkylineWindow.AuditLogForm.DataboundGridControl.FillDown());
-            // One document change per row, each waited for. Setting a Reason modifies the document,
-            // which re-sorts the grid, so writing all four inside a single RunUI read row i+1 from a
-            // grid that could already have moved under it - and a reason then landed on the wrong
-            // entry. The failure was two "Reason Changed" entries swapped, an identical diff every
-            // time, at roughly one run in five.
-            // The single-row SetCellValue further up is already wrapped this way; this loop, added
-            // as the manual stand-in for the fill-down the TODO above describes, was not.
+            // The audit log grid is filled by a background query, so its rows can still describe
+            // the document as it was before the four exclusions above. A row holds the
+            // AuditLogEntry it was built from and writes the Reason back to that entry by
+            // LogIndex, so editing a stale row 0 puts the reason on the peak-bounds entry instead
+            // of the Standard_8 exclusion. That surfaced only as two swapped "Reason Changed"
+            // entries in the recorded audit log - an identical diff every time, at 1 in 240
+            // executions. Wait for each row to hold the entry it is meant to edit, and name the
+            // entry actually found there if it never does.
+            var logIndexesToEdit = CallUI(() => SkylineWindow.Document.AuditLog.AuditLogEntries
+                .Enumerate().Take(4).Select(entry => entry.LogIndex).ToArray());
             for (int i = 0; i < 4; i++)
             {
                 int row = i;
+                WaitForConditionUI(() => GetAuditLogRowLogIndex(row) == logIndexesToEdit[row],
+                    () => string.Format("Audit log grid row {0} holds entry {1}, expected entry {2}",
+                        row, GetAuditLogRowLogIndex(row), logIndexesToEdit[row]));
+                // Setting a Reason modifies the document. Wait for each one so the next row is
+                // read from a grid that has caught up with the edit before it.
                 using (new WaitDocumentChange())
                 {
                     RunUI(() => SetCellValue(SkylineWindow.AuditLogForm.DataGridView, row, reasonIndex,
@@ -692,6 +701,27 @@ namespace pwiz.SkylineTestTutorial
             catch (Exception e)
             {
                 AssertEx.Fail("Error creating Panorama test folder. {0}", e.Message);
+            }
+        }
+
+        /// <summary>
+        /// The LogIndex of the audit log entry the given audit log grid row was built from, or -1
+        /// if the grid does not have that row yet. Rows are built by a background query, so this
+        /// can lag the document.
+        /// </summary>
+        private static int GetAuditLogRowLogIndex(int row)
+        {
+            var bindingListSource = SkylineWindow.AuditLogForm.BindingListSource;
+            if (row >= bindingListSource.Count)
+                return -1;
+            switch ((bindingListSource[row] as RowItem)?.Value)
+            {
+                case AuditLogRow logRow:
+                    return logRow.Entry.LogIndex;
+                case AuditLogDetailRow detailRow:
+                    return detailRow.AuditLogRow.Entry.LogIndex;
+                default:
+                    return -1;
             }
         }
     }

--- a/pwiz_tools/Skyline/TestTutorial/AuditLogTutorialTest.cs
+++ b/pwiz_tools/Skyline/TestTutorial/AuditLogTutorialTest.cs
@@ -430,11 +430,22 @@ namespace pwiz.SkylineTestTutorial
 //                    SkylineWindow.AuditLogForm.DataGridView.Rows[i].Cells[reasonIndex].Selected = true;
 //            });
 //            RunUI(() => SkylineWindow.AuditLogForm.DataboundGridControl.FillDown());
-            RunUI(() =>
+            // One document change per row, each waited for. Setting a Reason modifies the document,
+            // which re-sorts the grid, so writing all four inside a single RunUI read row i+1 from a
+            // grid that could already have moved under it - and a reason then landed on the wrong
+            // entry. The failure was two "Reason Changed" entries swapped, an identical diff every
+            // time, at roughly one run in five.
+            // The single-row SetCellValue further up is already wrapped this way; this loop, added
+            // as the manual stand-in for the fill-down the TODO above describes, was not.
+            for (int i = 0; i < 4; i++)
             {
-                for (int i = 0; i < 4; i++)
-                    SetCellValue(SkylineWindow.AuditLogForm.DataGridView, i, reasonIndex, "Excluded standard below LOD");
-            });
+                int row = i;
+                using (new WaitDocumentChange())
+                {
+                    RunUI(() => SetCellValue(SkylineWindow.AuditLogForm.DataGridView, row, reasonIndex,
+                        "Excluded standard below LOD"));
+                }
+            }
             RunUI(() =>
             {
                 SkylineWindow.AuditLogForm.ChooseView(AuditLogStrings.AuditLogForm_MakeAuditLogForm_Undo_Redo);


### PR DESCRIPTION
## Why

A worker that dies mid-test produced one plain line among thousands of result lines. It named the test but counted for nothing, and the end-of-run report discarded it as well. A nightly could shed half its workers and still finish saying **"No failures"**.

Four consecutive 9-hour runs did exactly that. What reached a human was a 40% throughput drop that read as a .NET 8 performance regression — the investigation went looking for a slowdown that did not exist, and the actual cause (five worker crashes on one test) was in the log the whole time, in text no one had reason to look at.

## What changed

**A lost worker is now a test failure.**

```
!!! TestQcTraces FAILED
Worker docker_worker_..._2 exited unexpectedly while running TestQcTraces/tr-TR/2.
No stack trace to report: the test took the process down with it, so nothing was
left to write one.
!!!
```

That shape has three consumers: `Report()`, SkylineNightly, and `SkylineTesterWindow.ColorLine`, which puts it in the red **Failed tests** panel where it stays visible. Written to the log as well as the console, since `Report()` reads the log.

Taking the process down is the most serious way a test can fail, not an excuse for it — the message says so, and says the only thing missing is the stack trace because nothing survived to write one.

**The end-of-run filter no longer discards it.** `neverRun` filtered abandoned entries by `HasRun` along with the leftover queue. That filter belongs to the queue — a forever-run always has outstanding work when it stops — and never to an entry a worker was *holding* when it went away. A test that dies on its fifth pass has run four times, so every one was dropped. That is why the runs reported clean.

**`AuditLogTutorialTest` waits for each grid row to hold the entry it means to edit.** The audit log grid is filled by a background query, so after the four standard exclusions its rows can still describe the earlier document. A row holds the `AuditLogEntry` it was built from and writes the Reason back to that entry by `LogIndex`, so a stale row 0 put the reason on the peak-bounds entry instead of the `Standard_8` exclusion - which is why the recorded log showed two "Reason Changed" entries swapped, identically every time.

> **Correction.** An earlier revision of this PR said the fix was to write the four values one at a time because "setting a Reason re-sorts the grid". That premise is wrong - instrumented runs show rows 0-3 keep the same `LogIndex` across every reason edit - and waiting on the *document* never addressed the failure, which happens on iteration 0. The final commit on this branch supersedes that attempt.

## Verification

- Killed a worker mid-test and confirmed the named block reaches **both** console and log, before and after a wording change — not assumed from the diff.
- `AuditLogTutorialTest`: **3,650 executions across two soaks (8 workers, all 5 languages), 0 failures**, against ~15 predicted at the measured pre-fix rate of 7/1695 (0.41%). A probe recorded the race still occurring 9 times during the clean runs - every one on row 0, every one exactly 4 `LogIndex` behind - so the wait is demonstrably doing work rather than the race merely not happening.
- The rate is **not** Japanese-specific. An earlier revision claimed ~18% in `ja` from 3 failures that happened to land there out of 17, and "verified" a fix with 25 serial Japanese runs against that invented rate. Both claims are withdrawn; failures were observed in en, fr, tr, zh and ja.
- CodeInspection passes.

## Note

Found while investigating an apparent 30% .NET 8 slowdown that turned out not to exist. The .NET 8 line has its own exclusions for the tests that were crashing workers there; those are deliberately **not** in this PR, since those tests have read the same file unexcluded on master for five years without a crash.

