### PR TITLE
skyline: Fixed TestAlphaPeptDeepBuildLibrary failing after the alpharaw 0.7.0 release

### DIFF
--- a/pwiz_tools/Skyline/Model/Lib/AlphaPeptDeep/AlphapeptdeepLibraryBuilder.cs
+++ b/pwiz_tools/Skyline/Model/Lib/AlphaPeptDeep/AlphapeptdeepLibraryBuilder.cs
@@ -65,6 +65,31 @@ namespace pwiz.Skyline.Model.Lib.AlphaPeptDeep
         private const string CMD_FLOW_COMMAND = @"cmd-flow";
         private const string EXPORT_SETTINGS_COMMAND = @"export-settings";
 
+        // peptdeep imports alpharaw, which loads a .NET runtime into the Python process purely as an import
+        // side effect - the library workflow never uses its Thermo (.raw) or Sciex (.wiff) readers. Since
+        // alpharaw 0.7.0 (2026-08-26) that import kills the process on the way out: it calls
+        // atexit.unregister(pythonnet.unload), dropping Python.NET's orderly shutdown, so the CLR tears itself
+        // down after Py_Finalize and PythonEngine.Shutdown() raises an AccessViolationException. peptdeep has
+        // written all of its output by then, but the process exits with 0xE0434352 and Skyline reports the
+        // library build as failed.
+        //
+        // Setting ALPHARAW_DOTNET_RUNTIME to a name alpharaw does not recognize restores the orderly shutdown.
+        // The name never reaches a runtime: it makes alpharaw's runtime lookup raise, which skips the whole
+        // block that contains the atexit.unregister call, so Python.NET's own shutdown hook survives and runs
+        // while the interpreter is still alive. Note this does not keep the CLR out of the process - a bare
+        // "import clr" in alpharaw.sciex has already loaded it by then - it just lets it shut down cleanly.
+        //
+        // That earlier "import clr" is also why the variable cannot be used to choose a runtime instead.
+        // alpharaw.sciex runs it before alpharaw.thermo pulls in the module that reads the variable, so
+        // Python.NET is already loaded and alpharaw's load() call is a silent no-op. Only PYTHONNET_RUNTIME
+        // reaches that earlier load. Hosting under .NET Core would also avoid the crash, but .NET Core is not
+        // part of Windows, so asking for it would take effect on developer machines and do nothing on most
+        // users' - leaving the nightly testing a path users never run. Revisit when Skyline itself is on .NET.
+        // Releases before 0.7.0 ignore this variable, and do not have the bug either way.
+        // TODO: delete this once alpharaw only unregisters the hook for the Mono runtime it was working around
+        private const string ALPHARAW_DOTNET_RUNTIME = @"ALPHARAW_DOTNET_RUNTIME";
+        private const string ALPHARAW_DOTNET_RUNTIME_NONE = @"none";
+
         // Processing folders
         private const string PREFIX_WORKDIR = "APD";
         private const string OUTPUT_MODELS = @"output_models";
@@ -242,14 +267,9 @@ namespace pwiz.Skyline.Model.Lib.AlphaPeptDeep
             ImportSpectralLibrary(progress, ref progressStatus);
         }
 
-        private void PrepareSettingsFile(IProgressMonitor progress, ref IProgressStatus progressStatus)
+        private ProcessStartInfo CreatePeptdeepStartInfo(string arguments)
         {
-            progress.UpdateProgress(progressStatus = progressStatus
-                .ChangeMessage(ModelResources.AlphapeptdeepLibraryBuilder_PrepareSettingsFile_Preparing_settings_file));
-
-            // Generate template settings.yaml file
-            var pr = new ProcessRunner();
-            var psi = new ProcessStartInfo(PeptdeepExecutablePath, $@"{EXPORT_SETTINGS_COMMAND} ""{SettingsFilePath}""")
+            var psi = new ProcessStartInfo(PeptdeepExecutablePath, arguments)
             {
                 CreateNoWindow = true,
                 UseShellExecute = false,
@@ -257,6 +277,18 @@ namespace pwiz.Skyline.Model.Lib.AlphaPeptDeep
                 RedirectStandardError = true,
                 RedirectStandardInput = false
             };
+            psi.EnvironmentVariables[ALPHARAW_DOTNET_RUNTIME] = ALPHARAW_DOTNET_RUNTIME_NONE;
+            return psi;
+        }
+
+        private void PrepareSettingsFile(IProgressMonitor progress, ref IProgressStatus progressStatus)
+        {
+            progress.UpdateProgress(progressStatus = progressStatus
+                .ChangeMessage(ModelResources.AlphapeptdeepLibraryBuilder_PrepareSettingsFile_Preparing_settings_file));
+
+            // Generate template settings.yaml file
+            var pr = new ProcessRunner();
+            var psi = CreatePeptdeepStartInfo($@"{EXPORT_SETTINGS_COMMAND} ""{SettingsFilePath}""");
             try
             {
                 //REMOVE: This runs so quickly that counting lines here is not necessary for only 5% of the total progress bar
@@ -283,14 +315,7 @@ namespace pwiz.Skyline.Model.Lib.AlphaPeptDeep
 
             // Execute command
             var pr = new ProcessRunner();
-            var psi = new ProcessStartInfo(PeptdeepExecutablePath, $@"{CMD_FLOW_COMMAND} {args}")
-            {
-                CreateNoWindow = true,
-                UseShellExecute = false,
-                RedirectStandardOutput = true,
-                RedirectStandardError = true,
-                RedirectStandardInput = false
-            };
+            var psi = CreatePeptdeepStartInfo($@"{CMD_FLOW_COMMAND} {args}");
             try
             {
                 var filterStrings = new[]

--- a/pwiz_tools/Skyline/Model/Lib/AlphaPeptDeep/AlphapeptdeepLibraryBuilder.cs
+++ b/pwiz_tools/Skyline/Model/Lib/AlphaPeptDeep/AlphapeptdeepLibraryBuilder.cs
@@ -1,6 +1,7 @@
 /*
  * Author: David Shteynberg <dshteyn .at. proteinms.net>,
  *                  MacCoss Lab, Department of Genome Sciences, UW
+ * AI assistance: Claude Code (Claude Opus 5) <noreply .at. anthropic.com>
  *
  * Copyright 2025 University of Washington - Seattle, WA
  *
@@ -66,8 +67,8 @@ namespace pwiz.Skyline.Model.Lib.AlphaPeptDeep
         private const string EXPORT_SETTINGS_COMMAND = @"export-settings";
 
         // peptdeep imports alpharaw, which loads a .NET runtime into the Python process purely as an import
-        // side effect - the library workflow never uses its Thermo (.raw) or Sciex (.wiff) readers. Since
-        // alpharaw 0.7.0 (2026-08-26) that import kills the process on the way out: it calls
+        // side effect - building a library reads no Thermo (.raw) or Sciex (.wiff) files. Since alpharaw
+        // 0.7.0 (2026-08-26) that import kills the process on the way out: it calls
         // atexit.unregister(pythonnet.unload), dropping Python.NET's orderly shutdown, so the CLR tears itself
         // down after Py_Finalize and PythonEngine.Shutdown() raises an AccessViolationException. peptdeep has
         // written all of its output by then, but the process exits with 0xE0434352 and Skyline reports the
@@ -78,17 +79,22 @@ namespace pwiz.Skyline.Model.Lib.AlphaPeptDeep
         // block that contains the atexit.unregister call, so Python.NET's own shutdown hook survives and runs
         // while the interpreter is still alive. Note this does not keep the CLR out of the process - a bare
         // "import clr" in alpharaw.sciex has already loaded it by then - it just lets it shut down cleanly.
+        // It does leave alpharaw's readers in a poor state, so do not reuse this for a peptdeep command that
+        // reads raw files: Thermo reports cleanly that it is unavailable, but Sciex still advertises itself
+        // and then fails partway through a read.
         //
         // That earlier "import clr" is also why the variable cannot be used to choose a runtime instead.
-        // alpharaw.sciex runs it before alpharaw.thermo pulls in the module that reads the variable, so
-        // Python.NET is already loaded and alpharaw's load() call is a silent no-op. Only PYTHONNET_RUNTIME
-        // reaches that earlier load. Hosting under .NET Core would also avoid the crash, but .NET Core is not
-        // part of Windows, so asking for it would take effect on developer machines and do nothing on most
-        // users' - leaving the nightly testing a path users never run. Revisit when Skyline itself is on .NET.
+        // alpharaw.sciex runs it before anything imports the module that reads the variable, so Python.NET is
+        // already loaded by then and alpharaw's load() call is a silent no-op. Only PYTHONNET_RUNTIME reaches
+        // that earlier load. Hosting under .NET Core would also avoid the crash, but .NET Core is not part of
+        // Windows, so asking for it would take effect on developer machines and do nothing on most users' -
+        // leaving the nightly testing a path users never run. Revisit when Skyline itself is on .NET.
         // Releases before 0.7.0 ignore this variable, and do not have the bug either way.
-        // TODO: delete this once alpharaw only unregisters the hook for the Mono runtime it was working around
+        // TODO: delete this once alpharaw only unregisters the hook for the Mono runtime it was working
+        // around. No upstream issue to link to - as of 2026-08-27 this had not been reported to MannLabs.
         private const string ALPHARAW_DOTNET_RUNTIME = @"ALPHARAW_DOTNET_RUNTIME";
-        private const string ALPHARAW_DOTNET_RUNTIME_NONE = @"none";
+        // Deliberately not "none", which upstream could one day make meaningful. This can never name a runtime.
+        private const string ALPHARAW_DOTNET_RUNTIME_NONE = @"skyline-no-dotnet";
 
         // Processing folders
         private const string PREFIX_WORKDIR = "APD";
@@ -267,20 +273,6 @@ namespace pwiz.Skyline.Model.Lib.AlphaPeptDeep
             ImportSpectralLibrary(progress, ref progressStatus);
         }
 
-        private ProcessStartInfo CreatePeptdeepStartInfo(string arguments)
-        {
-            var psi = new ProcessStartInfo(PeptdeepExecutablePath, arguments)
-            {
-                CreateNoWindow = true,
-                UseShellExecute = false,
-                RedirectStandardOutput = true,
-                RedirectStandardError = true,
-                RedirectStandardInput = false
-            };
-            psi.EnvironmentVariables[ALPHARAW_DOTNET_RUNTIME] = ALPHARAW_DOTNET_RUNTIME_NONE;
-            return psi;
-        }
-
         private void PrepareSettingsFile(IProgressMonitor progress, ref IProgressStatus progressStatus)
         {
             progress.UpdateProgress(progressStatus = progressStatus
@@ -326,7 +318,13 @@ namespace pwiz.Skyline.Model.Lib.AlphaPeptDeep
                     @"  / ____/  __/ /_/ / /_/ /_/ /  __/  __/ /_/ /",
                     @" /_/    \___/ .___/\__/_____/\___/\___/ .___/",
                     @"           /_/                       /_/",
-                    @"s/DiaNN\/Spectronaut/Skyline/"    // Replace DiaNN/Spectronaut with Skyline
+                    @"s/DiaNN\/Spectronaut/Skyline/",    // Replace DiaNN/Spectronaut with Skyline
+
+                    // alpharaw complains that it could not load a .NET runtime, which is precisely what
+                    // ALPHARAW_DOTNET_RUNTIME tells it to do (see above). Building a library reads no Thermo
+                    // or Sciex files, so the warning and the RuntimeError beside it would only alarm the user.
+                    @"UserWarning: .NET dependencies could not be loaded",
+                    @"No .NET runtime available"
                 };
 
                 pr.SilenceStatusMessageUpdates = true;  // Use FilteredUserMessageWriter to write process output instead of ProgressStatus.ChangeMessage()
@@ -344,6 +342,21 @@ namespace pwiz.Skyline.Model.Lib.AlphaPeptDeep
                 throw new IOException(ModelResources.AlphapeptdeepLibraryBuilder_ExecutePeptdeep_Failed_to_build_library_by_executing_the_peptdeep_cmd_flow_command_, ex);
             }
 
+        }
+
+        private ProcessStartInfo CreatePeptdeepStartInfo(string arguments)
+        {
+            var psi = new ProcessStartInfo(PeptdeepExecutablePath, arguments)
+            {
+                CreateNoWindow = true,
+                UseShellExecute = false,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                RedirectStandardInput = false
+            };
+            // Keeps alpharaw from crashing the process at exit - see ALPHARAW_DOTNET_RUNTIME above
+            psi.EnvironmentVariables[ALPHARAW_DOTNET_RUNTIME] = ALPHARAW_DOTNET_RUNTIME_NONE;
+            return psi;
         }
 
         public void TransformPeptdeepOutput(IProgressMonitor progress, ref IProgressStatus progressStatus)


### PR DESCRIPTION
## Summary

* `TestAlphaPeptDeepBuildLibrary` began failing 2026-08-27 because of alpharaw 0.7.0, released the day before. peptdeep only requires `alpharaw>=0.2.0`, so pip picks it up on any environment built since.
* alpharaw 0.7.0 calls `atexit.unregister(pythonnet.unload)`, dropping Python.NET's orderly shutdown. The CLR then tears itself down after `Py_Finalize` and `PythonEngine.Shutdown()` raises an `AccessViolationException`. peptdeep has written its whole library by then, but the process exits `0xE0434352` and Skyline reports the build as failed.
* Fixed by setting `ALPHARAW_DOTNET_RUNTIME` to a name alpharaw does not recognize on both peptdeep child processes. That makes its runtime lookup raise, which skips the block containing the `atexit.unregister` call, so Python.NET's shutdown hook survives. Building a library reads no Thermo or Sciex files.
* The two peptdeep launches had identical `ProcessStartInfo` blocks; they now share `CreatePeptdeepStartInfo`.

Not pinned: this keeps alpharaw current instead of freezing it, unlike the numpy and xxhash workarounds beside it. Releases before 0.7.0 ignore the variable and do not have the bug.

`ALPHARAW_DOTNET_RUNTIME` cannot be used to select a runtime instead — `alpharaw.sciex` runs a bare `import clr` before anything imports the module that reads the variable, so Python.NET is already loaded and alpharaw's `load()` call is a silent no-op. Only `PYTHONNET_RUNTIME` reaches that earlier load. Hosting under .NET Core also avoids the crash and was implemented and tested, but .NET Core is not part of Windows, so it would take effect on developer machines and do nothing on most users' — leaving the nightly exercising a path users never run. Worth revisiting when Skyline itself is on .NET.

Two upstream defects worth reporting to MannLabs: the `atexit.unregister` turns a spurious Mono traceback into an `AccessViolationException` under .NET Framework, and `ALPHARAW_DOTNET_RUNTIME` has no effect whenever the Sciex reader is imported.

## Test plan

- [x] TestAlphaPeptDeepBuildLibrary - passes (0 failures, 219 sec, Debug/en-US). The test sets `IsCleanPythonMode`, so it rebuilds the venv from scratch and resolves alpharaw 0.7.0 - the real broken version is exercised.
- [x] Clean master fails at the same step with the reported nightly signature, confirming what the fix addresses.
- [x] The exact `peptdeep cmd-flow` command line from the nightly stack trace exits 0 with alpharaw 0.7.0 and the variable set.

Known issue, not introduced here: with the cmd-flow step fixed, the test runs about 60 seconds further and then intermittently fails loading `rat_consensus_final_true_lib.blib` with `SQLiteException: unable to open database file` - roughly half of runs on one developer machine. It is unrelated to this change (an environment variable on the peptdeep child process cannot reach SQLite in Skyline's own process), has never appeared in the nightly performance-test history, and clean master cannot reach that code at all. Being tracked separately; we will look at it if it shows up in a nightly run.

Co-Authored-By: Claude <noreply@anthropic.com>
