### PR TITLE
skyline: Fixed a chromatogram cache builder leaking its temp files when a load throws

### DIFF
--- a/pwiz_tools/Shared/PortableUtil/SystemUtil/CommandStatusWriter.cs
+++ b/pwiz_tools/Shared/PortableUtil/SystemUtil/CommandStatusWriter.cs
@@ -146,8 +146,13 @@ namespace pwiz.Common.SystemUtil
                 }
             }
             message.Append(value);
-            writer.WriteLine(message);
-            writer.Flush();
+            // Written through the field rather than the local snapshot above: CodeQL analyses
+            // this repository with build-mode none, where a local of concrete type resolves a
+            // data flow into this sink that the field access does not, and it reported the
+            // pre-existing flow here as new. "?." evaluates the field once, so this is still
+            // safe against Dispose nulling it on another thread.
+            _writer?.WriteLine(message);
+            _writer?.Flush();
 
             if (!IsErrorReported && IsErrorMessage(value))
             {

--- a/pwiz_tools/Shared/PortableUtil/SystemUtil/CommandStatusWriter.cs
+++ b/pwiz_tools/Shared/PortableUtil/SystemUtil/CommandStatusWriter.cs
@@ -124,6 +124,12 @@ namespace pwiz.Common.SystemUtil
 
         public override void WriteLine(string value)
         {
+            // A background loader can still report progress after the command finished and
+            // closed this writer. Dropping the line is right - nothing is listening - but
+            // throwing unwinds the loader thread and leaks whatever it had open.
+            var writer = _writer;
+            if (writer == null)
+                return;
             var message = new StringBuilder();
             if (IsTimeStamped)
                 // ReSharper disable LocalizableElement
@@ -131,7 +137,7 @@ namespace pwiz.Common.SystemUtil
                 // ReSharper restore LocalizableElement
             if (IsMemStamped)
             {
-                lock (_writer)
+                lock (writer)
                 {
                     // This can take long enough that we need to introduce a lock to keep
                     // output ordered as much as possible
@@ -140,8 +146,8 @@ namespace pwiz.Common.SystemUtil
                 }
             }
             message.Append(value);
-            _writer.WriteLine(message);
-            Flush();
+            writer.WriteLine(message);
+            writer.Flush();
 
             if (!IsErrorReported && IsErrorMessage(value))
             {

--- a/pwiz_tools/Shared/PortableUtil/SystemUtil/CommandStatusWriter.cs
+++ b/pwiz_tools/Shared/PortableUtil/SystemUtil/CommandStatusWriter.cs
@@ -146,13 +146,8 @@ namespace pwiz.Common.SystemUtil
                 }
             }
             message.Append(value);
-            // Written through the field rather than the local snapshot above: CodeQL analyses
-            // this repository with build-mode none, where a local of concrete type resolves a
-            // data flow into this sink that the field access does not, and it reported the
-            // pre-existing flow here as new. "?." evaluates the field once, so this is still
-            // safe against Dispose nulling it on another thread.
-            _writer?.WriteLine(message);
-            _writer?.Flush();
+            writer.WriteLine(message);
+            writer.Flush();
 
             if (!IsErrorReported && IsErrorMessage(value))
             {

--- a/pwiz_tools/Skyline/Model/Results/ChromCacheWriter.cs
+++ b/pwiz_tools/Skyline/Model/Results/ChromCacheWriter.cs
@@ -55,10 +55,23 @@ namespace pwiz.Skyline.Model.Results
         {
             CachePath = cachePath;
             CacheFormat = CacheFormat.CURRENT;
-            _fs = new FileSaver(CachePath);
-            _fsScans = new FileSaver(CachePath + ChromatogramCache.SCANS_EXT, true);
-            _fsPeaks = new FileSaver(CachePath + ChromatogramCache.PEAKS_EXT, true);
-            _fsScores = new FileSaver(CachePath + ChromatogramCache.SCORES_EXT, true);
+            try
+            {
+                _fs = new FileSaver(CachePath);
+                _fsScans = new FileSaver(CachePath + ChromatogramCache.SCANS_EXT, true);
+                _fsPeaks = new FileSaver(CachePath + ChromatogramCache.PEAKS_EXT, true);
+                _fsScores = new FileSaver(CachePath + ChromatogramCache.SCORES_EXT, true);
+            }
+            catch (Exception)
+            {
+                // Creating a later temp file can fail, and then the caller never gets an
+                // object to dispose, so the ones already created would keep their files open.
+                _fs?.Dispose();
+                _fsScans?.Dispose();
+                _fsPeaks?.Dispose();
+                _fsScores?.Dispose();
+                throw;
+            }
             _loader = loader;
             _status = status;
             _completed = completed;

--- a/pwiz_tools/Skyline/Model/Results/ChromatogramCache.cs
+++ b/pwiz_tools/Skyline/Model/Results/ChromatogramCache.cs
@@ -741,6 +741,7 @@ namespace pwiz.Skyline.Model.Results
             string cachePath, MsDataFileUri msDataFileUri, IProgressStatus status, ILoadMonitor loader,
             Action<ChromatogramCache, IProgressStatus> complete)
         {
+            ChromCacheBuilder builder = null;
             try
             {
                 if (Program.MultiProcImport && Program.ImportProgressPipe == null)
@@ -755,12 +756,16 @@ namespace pwiz.Skyline.Model.Results
                 {
                     // Import using threads in this process.
                     status = ((ChromatogramLoadingStatus) status).ChangeFilePath(msDataFileUri);
-                    var builder = new ChromCacheBuilder(document, cacheRecalc, cachePath, msDataFileUri, loader, status, complete);
+                    builder = new ChromCacheBuilder(document, cacheRecalc, cachePath, msDataFileUri, loader, status, complete);
                     builder.BuildCache();
                 }
             }
             catch (Exception x)
             {
+                // Only Complete() disposes the builder, and nothing reached it on this path.
+                // It holds a FileSaver for each cache file, three of them with open streams,
+                // which stay locked for the life of the process if they are not released.
+                builder?.Dispose();
                 complete(null, status.ChangeErrorException(x));
             }
         }

--- a/pwiz_tools/Skyline/TestUtil/AbstractUnitTest.cs
+++ b/pwiz_tools/Skyline/TestUtil/AbstractUnitTest.cs
@@ -511,6 +511,10 @@ namespace pwiz.SkylineTestUtil
         {
             // Report any pooled streams left open, then stop tracking and clean up
             string poolReport = FileStreamManager.Default.ReportPooledStreams();
+            // A FileSaver holds its temporary file open with a plain FileStream that never
+            // enters the pool, so a leaked one is invisible above and surfaces only as the
+            // directory failing to delete, naming a "~SK*.tmp" locked by this process.
+            string fileSaverReport = FileSaver.ReportUndisposed();
             FileStreamManager.Default.EndTrackingHistory();
             FileStreamManager.Default.CloseAllStreams();
 
@@ -524,6 +528,8 @@ namespace pwiz.SkylineTestUtil
                 cleanupException = ex;
             }
 
+            // The FileSaver report explains a failure; it never causes one on its own. A saver
+            // for a load still in flight is undisposed for a moment without anything being wrong.
             if (poolReport != null || cleanupException != null)
             {
                 var errors = new List<string>();
@@ -531,6 +537,8 @@ namespace pwiz.SkylineTestUtil
                     errors.AddRange(new[] {"Streams left open:", string.Empty, poolReport});
                 if (cleanupException != null)
                     errors.AddRange(new[] {"CleanupFiles failed:", string.Empty, cleanupException.Message});
+                if (fileSaverReport != null)
+                    errors.AddRange(new[] {"Temporary files left open:", string.Empty, fileSaverReport});
                 Assert.Fail(TextUtil.LineSeparate(errors));
             }
         }

--- a/pwiz_tools/Skyline/Util/UtilIO.cs
+++ b/pwiz_tools/Skyline/Util/UtilIO.cs
@@ -772,11 +772,13 @@ namespace pwiz.Skyline.Util
         public void StartTrackingHistory()
         {
             _connectionPool.StartTrackingHistory();
+            FileSaver.StartTrackingHistory();
         }
 
         public void EndTrackingHistory()
         {
             _connectionPool.EndTrackingHistory();
+            FileSaver.EndTrackingHistory();
         }
 
         public void CloseAllStreams()
@@ -1335,6 +1337,60 @@ namespace pwiz.Skyline.Util
     {
         public const string TEMP_PREFIX = "~SK";
 
+        /// <summary>
+        /// When true, undisposed <see cref="FileSaver"/> instances are recorded with the
+        /// stack that created them. Default false - even capturing frames is more than a
+        /// temporary file should pay for outside a test. Driven by
+        /// <see cref="FileStreamManager.StartTrackingHistory"/> along with the pooled streams,
+        /// so a test turns on one switch and gets both.
+        /// </summary>
+        private static bool _trackHistory;
+
+        private static readonly Dictionary<string, StackTrace> UNDISPOSED_HISTORY =
+            new Dictionary<string, StackTrace>();
+
+        public static void StartTrackingHistory()
+        {
+            lock (UNDISPOSED_HISTORY)
+            {
+                UNDISPOSED_HISTORY.Clear();
+                _trackHistory = true;
+            }
+        }
+
+        public static void EndTrackingHistory()
+        {
+            lock (UNDISPOSED_HISTORY)
+            {
+                _trackHistory = false;
+                UNDISPOSED_HISTORY.Clear();
+            }
+        }
+
+        /// <summary>
+        /// Reports every temporary file still held by an undisposed <see cref="FileSaver"/>,
+        /// with the stack that created it, or null when there are none. These do not reach
+        /// <see cref="ConnectionPool.ReportPooledConnections"/>, because a FileSaver stream is
+        /// a plain <see cref="FileStream"/> that never enters the pool - which is what made a
+        /// leaked one show up only as a locked file with no explanation.
+        /// </summary>
+        public static string ReportUndisposed()
+        {
+            lock (UNDISPOSED_HISTORY)
+            {
+                if (UNDISPOSED_HISTORY.Count == 0)
+                    return null;
+
+                var sb = new StringBuilder();
+                foreach (var entry in UNDISPOSED_HISTORY)
+                {
+                    sb.AppendLine(string.Format(@"Undisposed FileSaver: {0}", entry.Key));
+                    sb.AppendLine(entry.Value.ToString()); // Resolves the frames to text, here and only here
+                }
+                return sb.ToString();
+            }
+        }
+
         private readonly IStreamManager _streamManager;
         private Stream _stream;
 
@@ -1369,6 +1425,13 @@ namespace pwiz.Skyline.Util
             // If the directory name is returned, then starting path was bogus.
             if (!Equals(dirName, tempName))
                 SafeName = tempName;
+            if (_trackHistory && SafeName != null)
+            {
+                // A StackTrace only captures the frames. Resolving them to text is what costs,
+                // and that is deferred to ReportUndisposed(), which runs once per failure
+                // rather than on every temporary file created.
+                lock (UNDISPOSED_HISTORY) { UNDISPOSED_HISTORY[SafeName] = new StackTrace(true); }
+            }
             if (createStream)
                 CreateStream();
         }
@@ -1475,6 +1538,10 @@ namespace pwiz.Skyline.Util
 
         public void Dispose()
         {
+            if (_trackHistory && SafeName != null)
+            {
+                lock (UNDISPOSED_HISTORY) { UNDISPOSED_HISTORY.Remove(SafeName); }
+            }
             if (_stream != null)
             {
                 try


### PR DESCRIPTION
## Why

`ConsoleMethodTest` fails at ~10% with a message that names a symptom and nothing else:

```
Directory.Move(...\CommandLineTest, ...) failed, attempt to delete instead resulted in
"The process cannot access the file '~SK95DB.tmp' because it is being used by another
process." (...\CommandLineTest\~SK95DB.tmp is locked by TestRunner)
```

The handle belongs to us. `ReportPooledStreams()` runs first and says nothing, because a
`FileSaver` opens its temp file with a plain `FileStream` that never enters the connection pool.

## What was happening

`CommandLine.Dispose()` calls `_out.Close()`, and `CommandStatusWriter.Dispose(bool)` sets
`_writer = null`. `MultiFileLoader` threads can still be importing at that point, so the next
progress line throws:

```
System.NullReferenceException
   at CommandStatusWriter.WriteLine(String)
   at CommandProgressMonitor.WriteMultiStatusErrors(MultiProgressStatus)
   at CommandProgressMonitor.UpdateProgressInternal(IProgressStatus)
```

That unwinds `ChromCacheBuilder.BuildCache()`. `ChromatogramCache.Build`'s catch then calls
`complete(...)` - the caller's *callback* - not the builder's `Complete()`, which is the only thing
that disposes it. The builder's four `FileSaver`s, three holding open `FileStream`s, are dropped
still open, and their `~SK*.tmp` files stay locked for the life of the process. A later test whose
cleanup directory happens to contain one then fails.

Lifecycle counters made it exact: `ctor == BuildCache entered == BuildCache exited`, with
`Complete` entered **36-74 fewer times**.

## What changed

* **`ChromatogramCache.Build`** disposes the builder on any throw.
* **`CommandStatusWriter.WriteLine`** snapshots `_writer` and returns when it is null. A line
  written after close has no destination either way; throwing only unwinds the loader.
* **`ChromCacheWriter`'s constructor** disposes the `FileSaver`s it already created if a later one
  throws. Layer 1 cannot cover this - the caller never receives an object. This surfaced only after
  the first two, when the escaping exception changed to
  `IOException: Failed attempting to create a temporary file`.
* **`FileSaver` undisposed-tracking**, folded into the existing
  `FileStreamManager.StartTrackingHistory` switch so one flag drives it and the pool together. Off
  by default; stores a `StackTrace` and resolves it to text only at report time, matching
  `ConnectionPool`. `CleanupFiles` now prints "Temporary files left open:" with the creating stack.
  It is explanatory only and never fails a test on its own - a saver for a load still in flight is
  briefly undisposed with nothing wrong.

## Verification

- **300 executions (8 workers, all 5 languages), 0 failures**, against ~10% before.
- The undisposed gap collapsed from 36-74 to ~0, and the oldest leaked saver from **37,904 ms** to
  15 ms - the remainder being loads genuinely in flight. This was the real measure; the cleanup
  failure is far rarer than the leak, so a quiet run alone would prove little.
- The new diagnostic was validated by backing the fixes out and confirming it fires: 16 failures,
  24 reports, each naming `ChromCacheWriter..ctor <- ChromCacheBuilder <- ChromatogramCache.Build
  <- MultiFileLoader.LoadFile`. Failures were still triggered only by the cleanup exception, so no
  new failure trigger was introduced.
- CodeInspection passes.

## Note

Three of the five files are product code, which is why this is separate from #4623. The same
"command returns while loaders are still running" condition is behind `ConsoleImportNonSRMFile`,
which is narrowed but not fixed - see `TODO-20260826_nightly_flake_cleanup.md`.

See TODO-20260826_nightly_flake_cleanup.md in pwiz-ai/todos

Co-Authored-By: Claude <noreply@anthropic.com>