### PR TITLE
skyline: Excluded two more shared-vendor-file tests from parallel testing

### DIFF
--- a/pwiz_tools/Skyline/TestData/PwizFileInfoTest.cs
+++ b/pwiz_tools/Skyline/TestData/PwizFileInfoTest.cs
@@ -92,7 +92,12 @@ namespace pwiz.SkylineTestData
             }
         }
 
-        [TestMethod]
+        // PressureTrace1.wiff is read out of the shared vendor data directory through the
+        // SAME Sciex reader TestInstrumentInfo above is excluded for - the legacy .wiff path
+        // rather than .wiff2, which is why a sweep looking for "wiff2" missed it. The other
+        // vendors here are not the problem: Thermo shared data survives six concurrent
+        // containers at 100 runs each. Excluded on the .NET 8 line for the same reason.
+        [TestMethod, NoParallelTesting(TestExclusionReason.VENDOR_FILE_LOCKING)]
         public void TestTicChromatogram()
         {
             if (Skyline.Program.NoVendorReaders)
@@ -321,7 +326,15 @@ namespace pwiz.SkylineTestData
             }
         }
 
-        [TestMethod]
+        // Reads swath.api.wiff2 out of the shared vendor data directory, the same file
+        // TestInstrumentInfo above is excluded for. A second process opening it while another
+        // holds it does not fail cleanly - it takes the worker down, with no managed exception
+        // and no result ever produced. Observed here on 2026-08-28: a worker stopped responding
+        // running this test and was given up on, costing the run a worker for its remainder.
+        // Only across the Docker volume mount, so nothing a Skyline user does is affected.
+        // The .NET 8 line excluded this test for the same reason after losing five workers to
+        // it across two nightly runs.
+        [TestMethod, NoParallelTesting(TestExclusionReason.VENDOR_FILE_LOCKING)]
         public void TestInstrumentSerialNumbers()
         {
             if (SkipWiff2TestInTestExplorer(nameof(TestInstrumentSerialNumbers)))


### PR DESCRIPTION
## Why

`TestInstrumentSerialNumbers` took a Docker worker down again in the 2026-08-28 net472 nightly:

```
!!! TestInstrumentSerialNumbers FAILED
Worker docker_worker_20260828055533_6 stopped responding while running
TestInstrumentSerialNumbers/zh-CHS/2 and was given up on. No result was ever produced for it,
and no stack trace: nothing came back from the worker to write one.
!!!
```

The run continued with 6 workers instead of 7 for its remaining ~7 hours, so its coverage rate was
compromised well beyond the one lost test. (That this was reported at all is #4623 working - before
it, a lost worker was a plain line that counted for nothing.)

Both tests here were already excluded on the .NET 8 line. This brings net472 level.

## What changed

Two `[TestMethod]` attributes in `TestData/PwizFileInfoTest.cs` gain
`NoParallelTesting(TestExclusionReason.VENDOR_FILE_LOCKING)`:

* **`TestInstrumentSerialNumbers`** - reads `swath.api.wiff2` from the shared vendor data
  directory, the same file `TestInstrumentInfo` (already excluded) uses. A second process opening
  it while another holds it does not fail cleanly; it takes the worker down with no managed
  exception and no result.
* **`TestTicChromatogram`** - reads `PressureTrace1.wiff` from the same shared directory through
  the same Sciex reader, but by the legacy `.wiff` path rather than `.wiff2`, which is why an
  earlier sweep looking for "wiff2" missed it.

Only across the Docker volume mount - nothing a Skyline user does is affected.

## Verification

- The two checkouts now carry an **identical** set of `NoParallelTesting` attributes, 100 each,
  with no delta in either direction (previously net8 had these two and net472 did not).
- `TestInstrumentSerialNumbers`, `TestTicChromatogram` and `TestInstrumentInfo` all pass serially.
- CodeInspection passes.

## Note

The comments are adapted rather than copied from the .NET 8 line: that version attributes the
crash to the Sciex SDK shimmed into a side-by-side load context, which is a net8-specific
mechanism I have not verified on net472. What is recorded here is the net472 evidence - a worker
that stopped responding and was given up on.

See TODO-20260826_nightly_flake_cleanup.md in pwiz-ai/todos

Co-Authored-By: Claude <noreply@anthropic.com>