### PR TITLE
skyline: Fixed the peak area dotp test killing the graph update timer

### DIFF
--- a/pwiz_tools/Skyline/SkylineGraphs.cs
+++ b/pwiz_tools/Skyline/SkylineGraphs.cs
@@ -925,6 +925,39 @@ namespace pwiz.Skyline
             }
         }
 
+        /// <summary>
+        /// Names which of the things <see cref="IsGraphUpdatePending"/> looks at is still pending,
+        /// and what the graph update timer still has queued. Used for testing: a wait that expires
+        /// on that property otherwise reports only that it expired, which does not say where to
+        /// look. Must be called on the event thread.
+        /// </summary>
+        public string GraphUpdatePendingDescription
+        {
+            get
+            {
+                if (InvokeRequired)
+                {
+                    throw new InvalidOperationException(
+                        SkylineResources.SkylineWindow_IsGraphUpdatePending_Must_be_called_from_event_thread);
+                }
+                var pending = new List<string>();
+                if (_timerGraphs.Enabled)
+                {
+                    var queued = _timerGraphs.Tag as ICollection<IUpdatable>;
+                    var names = queued == null
+                        ? @"<null>"
+                        : string.Join(@", ", queued.Select(u => u == null ? @"<null>" : u.GetType().Name));
+                    pending.Add(string.Format(@"graph update timer still enabled (interval {0} ms, {1} queued: {2})",
+                        _timerGraphs.Interval, queued?.Count ?? 0, names));
+                }
+                if (_graphSpectrum != null && _graphSpectrum.IsGraphUpdatePending)
+                    pending.Add(@"spectrum graph still updating");
+                if (ProductionFacility.DEFAULT.IsWaiting())
+                    pending.Add(@"production facility still waiting");
+                return pending.Count == 0 ? @"nothing pending" : string.Join(@", ", pending);
+            }
+        }
+
         public bool AlignToRtPrediction
         {
             get { return _alignToPrediction; }

--- a/pwiz_tools/Skyline/TestFunctional/TestPeakAreaDotpGraph.cs
+++ b/pwiz_tools/Skyline/TestFunctional/TestPeakAreaDotpGraph.cs
@@ -142,7 +142,7 @@ namespace pwiz.SkylineTestFunctional
 
             RunUI(() => SkylineWindow.OpenFile(
                 TestFilesDir.GetTestPath("DIA-QE-tutorial.sky")));
-            SkylineWindow.ShowSplitChromatogramGraph(true);
+            RunUI(() => SkylineWindow.ShowSplitChromatogramGraph(true));
             replicates = new[]{"1-A", "2-B", "3-A","4-B", "5-A", "6-B"};
             var expectedIDotp = new[] {0.93, 0.82, 0.95, 0.92, 0.95, 0.74};
             var expectedDotp = new[] {0.87, 0.74, 0.89, 0.88, 1.00, 0.83};

--- a/pwiz_tools/Skyline/TestUtil/TestFunctional.cs
+++ b/pwiz_tools/Skyline/TestUtil/TestFunctional.cs
@@ -1320,7 +1320,9 @@ namespace pwiz.SkylineTestUtil
 
         public static void WaitForGraphs(bool throwOnProgramException = true)
         {
-            WaitForConditionUI(WAIT_TIME, () => !SkylineWindow.IsGraphUpdatePending, null, true, throwOnProgramException);
+            WaitForConditionUI(WAIT_TIME, () => !SkylineWindow.IsGraphUpdatePending,
+                () => string.Format("Graph update still pending: {0}", SkylineWindow.GraphUpdatePendingDescription),
+                true, throwOnProgramException);
         }
 
         public static void WaitForRegression()


### PR DESCRIPTION
## Why

`PeakAreaDotpGraphTest` was the largest remaining source of nightly failures - 7 of the 10 in the
2026-08-28 net472 run, at 7/55 (12.7%), each costing the full 360 s timeout. That is ~46 minutes
of a 9-hour run inside one test's own wait.

## Root cause

```csharp
RunUI(() => SkylineWindow.OpenFile(TestFilesDir.GetTestPath("DIA-QE-tutorial.sky")));
SkylineWindow.ShowSplitChromatogramGraph(true);   // <-- not on the UI thread
```

`ShowSplitChromatogramGraph` reaches `SkylineWindow.UpdateGraphPanes`, which does
`_timerGraphs.Stop()` / `.Start()`. A `System.Windows.Forms.Timer` creates its native window on
whichever thread first enables it. Started from the test thread, its `WM_TIMER` is posted to a
thread with no message pump, so it is **never dispatched**: `Enabled` stays true, the queued panes
never drain, and the UI thread sits idle in `WaitMessage`. Every later wait on
`IsGraphUpdatePending` then expires.

It is the only unwrapped UI call in the test - the line directly above it is correctly wrapped.

## Evidence

The failure state, once the message could describe it:

```
Graph update still pending: graph update timer still enabled
  (interval 100 ms, 3 queued: GraphChromatogram, GraphChromatogram, GraphSummary;
   enqueues 327, ticks 516, 394.1s since last tick, 393.6s since last enqueue)
FIRST OFF-UI-THREAD ENQUEUE:
   at SkylineWindow.UpdateGraphPanes(ICollection`1) SkylineGraphs.cs:884
   at SkylineWindow.UpdateGraphPanes()             SkylineGraphs.cs:856
   at TestPeakAreaDotpGraph.DoTest()               TestPeakAreaDotpGraph.cs:148
```

Interval 100 ms is set only by the enqueue path, and there were **no enqueues for 393 s** - so this
is not a busy timer being starved by repeated restarts. The timer is simply enabled and dead.

Two hypotheses were tested and refuted along the way, both by instrumentation rather than argument:
`GraphSummary.UpdateGraph`'s two early returns (neither fires - the last update completed), and a
stale `ParentGroupNode` left by `Clear()` (the pane reaches its assignment).

## What changed

* **The fix**: `RunUI(() => SkylineWindow.ShowSplitChromatogramGraph(true));`
* **`SkylineWindow.GraphUpdatePendingDescription`** - names which of the three things
  `IsGraphUpdatePending` looks at is still pending, and what the timer has queued.
* **`WaitForGraphs`** passes it as its timeout message. It previously passed `null`, so every test
  in the suite that expires there reports only that it expired. This is what turned a 360 s silent
  hang into a one-line diagnosis, and it now applies suite-wide.

## Verification

- **213 executions (8 workers, all 5 languages), 0 failures.** Pre-fix rate on the same
  configuration was 13/305 (4.3%), so P(zero | unfixed) is about 0.009%.
- Reproduction needs realistic load: `TestRunner` throttles to tests x languages, so a single test
  reaches only 5 workers. Paired with 8 graph-heavy neighbours it reproduces at ~4.3%; with light
  neighbours at 8 workers it did not fire in 90 executions.
- CodeInspection passes.

## Note

The same class of defect - UI access off the UI thread - cannot be found reliably by text search:
a scan flags 35 candidates in TestFunctional, but most are false positives (`BeginInvoke`/`Invoke`
are correct, and helpers called from inside `RunUI` are indistinguishable textually). A runtime
assertion in the timer path would catch it exactly, and is worth considering separately.

See TODO-20260826_nightly_flake_cleanup.md in pwiz-ai/todos

Co-Authored-By: Claude <noreply@anthropic.com>