### PR TITLE
skyline: Fixed the net10 nightly failures and the pass-1 NHibernate leak

### DIFF
--- a/pwiz_tools/Shared/Common/Database/NHibernate/SessionWithLock.cs
+++ b/pwiz_tools/Shared/Common/Database/NHibernate/SessionWithLock.cs
@@ -35,23 +35,33 @@ namespace pwiz.Common.Database.NHibernate
     public class SessionWithLock : AbstractSessionWithLock, ISession
     {
         readonly ISession _session;
+        // A factory this session OWNS and disposes with itself. NHibernate registers every
+        // SessionFactory in the static SessionFactoryObjectFactory.Instances dictionary and
+        // only Dispose() removes it, so an undisposed factory is rooted for the life of the
+        // process along with its persisters, dialect and emitted proxies. Tying the factory
+        // to a session that callers always dispose means no factory can outlive its scope.
+        readonly ISessionFactory _ownedSessionFactory;
 
-        public SessionWithLock(ISession session, ReaderWriterLock readerWriterLock, bool writeLock)
-            : this(session, readerWriterLock, writeLock, CancellationToken.None)
+        public SessionWithLock(ISession session, ReaderWriterLock readerWriterLock, bool writeLock,
+            ISessionFactory ownedSessionFactory = null)
+            : this(session, readerWriterLock, writeLock, CancellationToken.None, ownedSessionFactory)
         {
             
         }
 
-        public SessionWithLock(ISession session, ReaderWriterLock readerWriterLock, bool writeLock, CancellationToken cancellationToken)
+        public SessionWithLock(ISession session, ReaderWriterLock readerWriterLock, bool writeLock, CancellationToken cancellationToken,
+            ISessionFactory ownedSessionFactory = null)
             :base(readerWriterLock, writeLock, cancellationToken, session.CancelQuery)
         {
             _session = session;
+            _ownedSessionFactory = ownedSessionFactory;
         }
 
         public override void Dispose()
         {
             _session.Dispose();
             base.Dispose();
+            _ownedSessionFactory?.Dispose();
         }
 
         public void Flush()

--- a/pwiz_tools/Shared/Common/Database/NHibernate/SessionWithLock.cs
+++ b/pwiz_tools/Shared/Common/Database/NHibernate/SessionWithLock.cs
@@ -59,9 +59,29 @@ namespace pwiz.Common.Database.NHibernate
 
         public override void Dispose()
         {
-            _session.Dispose();
-            base.Dispose();
-            _ownedSessionFactory?.Dispose();
+            // Each step must run even if an earlier one throws, and the order of the damage is why.
+            // A throwing _session.Dispose() (NHibernate closes the connection here, so an I/O
+            // failure surfaces at exactly this point) would otherwise skip base.Dispose(), leaving
+            // the ReaderWriterLock write-held forever - and since the lock is shared by reference
+            // through ImClone, every later session on any clone would block in
+            // AcquireWriterLock(int.MaxValue), a silent hang with no exception to find it by. It
+            // would also skip the factory dispose and hand back the very leak this class exists to
+            // close.
+            try
+            {
+                _session.Dispose();
+            }
+            finally
+            {
+                try
+                {
+                    base.Dispose();
+                }
+                finally
+                {
+                    _ownedSessionFactory?.Dispose();
+                }
+            }
         }
 
         public void Flush()

--- a/pwiz_tools/Skyline/Model/BackgroundLoader.cs
+++ b/pwiz_tools/Skyline/Model/BackgroundLoader.cs
@@ -132,10 +132,29 @@ namespace pwiz.Skyline.Model
             public int Arg0, Arg1, Arg2;
         }
 
-        private const int LOADER_TRACE_SIZE = 512;    // Power of two, for the index mask below
+        // Power of two, for the index mask below. Sized for how fast this fills, not for how much
+        // history feels sufficient: EVERY registered loader writes on EVERY document change - six
+        // under a results container, nine under SkylineWindow - so 512 slots would have held only
+        // about 57 document changes, and a chromatogram import makes far more than that. The line
+        // the trace exists to capture would have been evicted before the test timed out, with
+        // nothing in the output to distinguish "the ring wrapped" from "nothing happened".
+        private const int LOADER_TRACE_SIZE = 8192;
         private static readonly LoaderTraceEntry[] LOADER_TRACE = new LoaderTraceEntry[LOADER_TRACE_SIZE];
         private static int _loaderTraceIndex = -1;
         private string _loaderName;
+
+        /// <summary>
+        /// Drops everything recorded so far. Called at the start of each test, because the ring is
+        /// static and a TestRunner process runs test after test: without this, a failure early in
+        /// one test is handed a tail belonging to EARLIER tests and presents it, under a heading
+        /// claiming to describe this failure, as evidence. Entries carry loader and thread but no
+        /// test identity, so there would be no way to tell.
+        /// </summary>
+        public static void ClearLoaderTrace()
+        {
+            _loaderTraceIndex = -1;
+            Array.Clear(LOADER_TRACE, 0, LOADER_TRACE.Length);
+        }
 
         protected void LoaderTrace(string message, SrmDocument doc = null, SrmDocument doc2 = null, int arg2 = int.MinValue)
         {

--- a/pwiz_tools/Skyline/Model/BackgroundLoader.cs
+++ b/pwiz_tools/Skyline/Model/BackgroundLoader.cs
@@ -65,7 +65,10 @@ namespace pwiz.Skyline.Model
                 CloseRemovedStreams(document, previous);
 
                 if (IsLoaded(document))
+                {
+                    LoaderTrace(@"changed doc={0} prev={1} -> loaded, EndProcessing", document, previous);
                     EndProcessing(document);
+                }
                 else
                 {
                     if (!IsMultiThreadAware)
@@ -76,17 +79,108 @@ namespace pwiz.Skyline.Model
                             // Keep track of the documents being processed, to avoid running
                             // processing on the same document on multiple threads.
                             if (_processing.ContainsKey(docIndex))
+                            {
+                                LoaderTrace(@"changed doc={0} prev={1} -> SKIPPED, already processing", document, previous);
                                 return;
+                            }
                             _processing.Add(docIndex, container);
                         }
                     }
 
+                    LoaderTrace(@"changed doc={0} prev={1} -> starting load thread", document, previous);
                     var loadThread = new Thread(() => OnLoadBackground(container, document));
                     Interlocked.Increment(ref _activeThreadCount);
                     loadThread.Start();
                 }
             }
+            else
+            {
+                LoaderTrace(@"changed doc={0} prev={1} -> no state change, ignored", document, previous);
+            }
         }
+
+        #region Loader lifecycle trace - diagnostics for imports that finish and are never committed
+
+        /// <summary>
+        /// A ring of the most recent loader lifecycle events, formatted into a test failure
+        /// message so an intermittent "import reached 100% but the document never became loaded"
+        /// can say WHY. The thread dump taken at that point cannot: every loader thread has
+        /// already exited, so the evidence of what the loader decided is gone before anyone
+        /// looks. This records the decisions as they happen and keeps only the tail.
+        ///
+        /// <para>THE RECORDING COSTS THE PASSING CASE ALMOST NOTHING, which is what makes it
+        /// safe to leave switched on. Outside a unit test it is a single static bool read.
+        /// Inside one it stores a message REFERENCE (always a literal, so never allocated) and
+        /// three ints into a preallocated slot - no formatting, no allocation, no lock, just an
+        /// interlocked index. All the expense - composing the text - happens once, in
+        /// <see cref="GetLoaderTrace"/>, and only when a test has already failed.</para>
+        ///
+        /// <para>That matters beyond tidiness: the defect this chases is a race, so
+        /// instrumentation heavy enough to shift thread timing would hide the thing it was added
+        /// to catch. Cheap is not an optimization here, it is a correctness requirement.</para>
+        ///
+        /// <para>Readers can see a torn slot if a writer is mid-update. That is accepted: the
+        /// alternative is a lock on the hot path, and one garbled diagnostic line is a far
+        /// smaller loss than a race that stops reproducing.</para>
+        /// </summary>
+        private struct LoaderTraceEntry
+        {
+            public long Ticks;
+            public int ThreadId;
+            public string Loader;
+            public string Message;
+            public int Arg0, Arg1, Arg2;
+        }
+
+        private const int LOADER_TRACE_SIZE = 512;    // Power of two, for the index mask below
+        private static readonly LoaderTraceEntry[] LOADER_TRACE = new LoaderTraceEntry[LOADER_TRACE_SIZE];
+        private static int _loaderTraceIndex = -1;
+        private string _loaderName;
+
+        protected void LoaderTrace(string message, SrmDocument doc = null, SrmDocument doc2 = null, int arg2 = int.MinValue)
+        {
+            if (!Program.UnitTest)
+                return;
+            var i = Interlocked.Increment(ref _loaderTraceIndex) & (LOADER_TRACE_SIZE - 1);
+            LOADER_TRACE[i] = new LoaderTraceEntry
+            {
+                Ticks = DateTime.UtcNow.Ticks,
+                ThreadId = Thread.CurrentThread.ManagedThreadId,
+                Loader = _loaderName ??= GetType().Name,
+                Message = message,
+                Arg0 = doc?.Id.GlobalIndex ?? -1,
+                Arg1 = doc2?.Id.GlobalIndex ?? -1,
+                Arg2 = arg2
+            };
+        }
+
+        /// <summary>
+        /// Formats the trace oldest-first. Called only from a failure path, so it can afford to
+        /// be as slow and as thorough as it likes.
+        /// </summary>
+        public static string GetLoaderTrace()
+        {
+            var last = _loaderTraceIndex;
+            if (last < 0)
+                return @"(no loader activity recorded)";
+            var lines = new List<string>();
+            var first = Math.Max(0, last - LOADER_TRACE_SIZE + 1);
+            for (long n = first; n <= last; n++)
+            {
+                var entry = LOADER_TRACE[n & (LOADER_TRACE_SIZE - 1)];
+                if (entry.Message == null)
+                    continue;   // Never written, or torn mid-write
+                var text = entry.Message
+                    .Replace(@"{0}", entry.Arg0 < 0 ? @"none" : entry.Arg0.ToString())
+                    .Replace(@"{1}", entry.Arg1 < 0 ? @"none" : entry.Arg1.ToString())
+                    .Replace(@"{2}", entry.Arg2 == int.MinValue ? @"none" : entry.Arg2.ToString());
+                lines.Add(
+                    $@"{new DateTime(entry.Ticks, DateTimeKind.Utc).ToLocalTime():HH:mm:ss.fff} [{entry.ThreadId,3}] {entry.Loader}: {text}");
+            }
+            return lines.Count == 0 ? @"(no loader activity recorded)" : string.Join(Environment.NewLine, lines);
+        }
+
+        #endregion
 
         private void CloseRemovedStreams(SrmDocument document, SrmDocument previous)
         {
@@ -120,11 +214,15 @@ namespace pwiz.Skyline.Model
                 // then end the processing.
                 if (!document.EqualsId(docCurrent) || IsLoaded(docCurrent))
                 {
+                    LoaderTrace(@"load doc={0} -> ABANDONED before starting (current={1}, loaded={2})",
+                        document, docCurrent, IsLoaded(docCurrent) ? 1 : 0);
                     EndProcessing(document);
                     return;
                 }
 
+                LoaderTrace(@"load doc={0} -> LoadBackground begin", document);
                 LoadBackground(container, document, docCurrent);
+                LoaderTrace(@"load doc={0} -> LoadBackground returned (container now={1})", document, container.Document);
 
                 // Did the container change out its document while we were working?
                 EndProcessingNotInContainer(container);
@@ -135,6 +233,13 @@ namespace pwiz.Skyline.Model
                     // from triggering new processing, but new processing may have accumulated
                     if (!container.IsClosing)
                         OnDocumentChanged(container, new DocumentChangedEventArgs(docCurrent));
+                }
+                else
+                {
+                    // No forced re-notification here. If work accumulated while this loader ran,
+                    // only a real document change will pick it up - which is the suspicion behind
+                    // an import that reaches 100% and is never committed.
+                    LoaderTrace(@"load doc={0} -> exiting WITHOUT re-notify (IsMultiThreadAware)", document);
                 }
             }
             catch (Exception exception)
@@ -256,7 +361,19 @@ namespace pwiz.Skyline.Model
             if (IsMultiThreadAware || IsProcessing(docOriginal))
             {
                 if (!container.SetDocument(docNew, docOriginal))
+                {
+                    // The commit lost a race with another document change. The caller is expected
+                    // to loop and retry against the new document; if the trace shows this without
+                    // a following retry, the completed work was dropped here.
+                    LoaderTrace(@"commit doc={0}->{1} -> REJECTED, container moved to {2}",
+                        docOriginal, docNew, container.Document.Id.GlobalIndex);
                     return false;
+                }
+                LoaderTrace(@"commit doc={0}->{1} -> accepted", docOriginal, docNew);
+            }
+            else
+            {
+                LoaderTrace(@"commit doc={0}->{1} -> SKIPPED, no longer processing", docOriginal, docNew);
             }
 
             EndProcessing(docOriginal);

--- a/pwiz_tools/Skyline/Model/IonMobility/IonMobilityDb.cs
+++ b/pwiz_tools/Skyline/Model/IonMobility/IonMobilityDb.cs
@@ -66,7 +66,6 @@ namespace pwiz.Skyline.Model.IonMobility
         public const string EXT = ".imsdb";
 
         private readonly string _path;
-        private readonly ISessionFactory _sessionFactory;
         private readonly ReaderWriterLock _databaseLock;
 
         private DateTime _modifiedTime;
@@ -75,10 +74,9 @@ namespace pwiz.Skyline.Model.IonMobility
         // LibKeyMap is a specialized dictionary class that can match modifications written at varying precisions
         private LibKeyMap<List<IonMobilityAndCCS>> _dictLibrary;
 
-        private IonMobilityDb(string path, ISessionFactory sessionFactory)
+        private IonMobilityDb(string path)
         {
             _path = path;
-            _sessionFactory = sessionFactory;
             _databaseLock = new ReaderWriterLock();
             LastChange = IonMobilityLibraryChange.NONE;
         }
@@ -104,7 +102,13 @@ namespace pwiz.Skyline.Model.IonMobility
 
         private ISession OpenWriteSession()
         {
-            return new SessionWithLock(_sessionFactory.OpenSession(), _databaseLock, true);
+            // Each session owns the factory it was opened from, so nothing retains one. NHibernate
+            // roots every SessionFactory in the static SessionFactoryObjectFactory.Instances
+            // dictionary until Dispose() removes it, so a retained factory never becomes
+            // collectible. IrtDb has always worked this way; these two did not, which is what
+            // leaked once the NHibernate upgrade stopped them disposing after Load.
+            var sessionFactory = GetSessionFactory(_path);
+            return new SessionWithLock(sessionFactory.OpenSession(), _databaseLock, true, sessionFactory);
         }
 
         public IList<IonMobilityAndCCS> GetIonMobilityInfo(LibKey key)
@@ -118,7 +122,8 @@ namespace pwiz.Skyline.Model.IonMobility
 
         public IEnumerable<DbPrecursorAndIonMobility> GetIonMobilities()
         {
-            using (var session = new SessionWithLock(_sessionFactory.OpenSession(), _databaseLock, false))
+            using (var sessionFactory = GetSessionFactory(_path))
+            using (var session = new SessionWithLock(sessionFactory.OpenSession(), _databaseLock, false))
             {
                 return session.CreateCriteria(typeof (DbPrecursorAndIonMobility)).List<DbPrecursorAndIonMobility>();
             }
@@ -374,7 +379,8 @@ namespace pwiz.Skyline.Model.IonMobility
 
             var dictLibrary = new Dictionary<LibKey, List<IonMobilityAndCCS>>();
 
-            using (var session = new SessionWithLock(_sessionFactory.OpenSession(), _databaseLock, false))
+            using (var sessionFactory = GetSessionFactory(_path))
+            using (var session = new SessionWithLock(sessionFactory.OpenSession(), _databaseLock, false))
             {
                 var ionMobilities = session.CreateCriteria(typeof(DbPrecursorAndIonMobility)).List<DbPrecursorAndIonMobility>();
 
@@ -518,11 +524,7 @@ namespace pwiz.Skyline.Model.IonMobility
                     // NHibernate 5.5 correctly throws ObjectDisposedException when a
                     // caller later calls OpenSession on the disposed factory (see
                     // UpdateIonMobilities → OpenWriteSession chain).
-                    var sessionFactory = GetSessionFactory(path);
-                    lock (sessionFactory)
-                    {
-                        return new IonMobilityDb(path, sessionFactory).Load(loadMonitor, status);
-                    }
+                    return new IonMobilityDb(path).Load(loadMonitor, status);
                 }
                 catch (UnauthorizedAccessException x)
                 {
@@ -558,7 +560,7 @@ namespace pwiz.Skyline.Model.IonMobility
 
         public void Dispose()
         {
-            _sessionFactory?.Dispose();
+            // Nothing retained to release - each session disposes the factory it owns.
         }
     }
 }

--- a/pwiz_tools/Skyline/Model/IonMobility/IonMobilityDb.cs
+++ b/pwiz_tools/Skyline/Model/IonMobility/IonMobilityDb.cs
@@ -105,10 +105,25 @@ namespace pwiz.Skyline.Model.IonMobility
             // Each session owns the factory it was opened from, so nothing retains one. NHibernate
             // roots every SessionFactory in the static SessionFactoryObjectFactory.Instances
             // dictionary until Dispose() removes it, so a retained factory never becomes
-            // collectible. IrtDb has always worked this way; these two did not, which is what
-            // leaked once the NHibernate upgrade stopped them disposing after Load.
+            // collectible - which is what leaked once the NHibernate upgrade stopped these two
+            // disposing after Load. (IrtDb closes the same hole differently, passing a
+            // caller-scoped factory into OpenWriteSession; that shape cannot leak here at all.)
+            //
+            // Ownership does not transfer until the constructor RETURNS, so the window between
+            // has to be guarded: OpenSession() throws if SQLite cannot open the file, and
+            // AbstractSessionWithLock's constructor throws by design when this thread already
+            // holds a read lock. Without the catch the factory is registered, owned by nobody,
+            // and the leak comes back on exactly the error paths no test looks at.
             var sessionFactory = GetSessionFactory(_path);
-            return new SessionWithLock(sessionFactory.OpenSession(), _databaseLock, true, sessionFactory);
+            try
+            {
+                return new SessionWithLock(sessionFactory.OpenSession(), _databaseLock, true, sessionFactory);
+            }
+            catch
+            {
+                sessionFactory.Dispose();
+                throw;
+            }
         }
 
         public IList<IonMobilityAndCCS> GetIonMobilityInfo(LibKey key)

--- a/pwiz_tools/Skyline/Model/MemoryDocumentContainer.cs
+++ b/pwiz_tools/Skyline/Model/MemoryDocumentContainer.cs
@@ -133,7 +133,8 @@ namespace pwiz.Skyline.Model
         private const int CANCEL_RESTART_LOOPS = 30;
 
         /// <summary>
-        /// True while a cancelled status should NOT be believed yet.
+        /// Whether to wait out a loader that cancelled itself because its document was
+        /// superseded, rather than take that cancellation for the end of the load.
         ///
         /// <para>A background loader cancels its own work whenever the document it was handed is
         /// superseded - <see cref="RetentionTimeManager"/>'s test for it is nothing but a
@@ -167,6 +168,14 @@ namespace pwiz.Skyline.Model
             {
                 cancelLoops = 0;
                 return false;
+            }
+            if (cancelLoops == 0 && Program.UnitTest)
+            {
+                // Leading hash is a cue to SkylineTester to ignore these informational lines.
+                // Worth saying out loud: without it a run that rides out a hand-off looks exactly
+                // like a run where the race never happened, and the fix cannot be told from luck.
+                Console.WriteLine(@"# Waiting out a cancelled loader that lost its document: {0}",
+                    LastProgress.Message);
             }
             return ++cancelLoops <= CANCEL_RESTART_LOOPS;
         }

--- a/pwiz_tools/Skyline/Model/MemoryDocumentContainer.cs
+++ b/pwiz_tools/Skyline/Model/MemoryDocumentContainer.cs
@@ -91,7 +91,9 @@ namespace pwiz.Skyline.Model
             {
                 // Wait for completing document changed event
                 uint nLoops = 0;
-                while (!IsFinal(Document))
+                int cancelLoops = 0;
+                // Order matters: IsSupersededCancel must run every pass so it can reset its count
+                while (IsSupersededCancel(ref cancelLoops) || !IsFinal(Document))
                 {
                     Monitor.Wait(CHANGE_EVENT_LOCK, 1000);  // Check every second or risk deadlock
 
@@ -121,6 +123,52 @@ namespace pwiz.Skyline.Model
                     }
                 }
             }
+        }
+
+        /// <summary>
+        /// Number of one-second waits allowed for a loader to restart after it cancelled itself
+        /// because its document was superseded. The restart is normally posted within
+        /// milliseconds, so this only has to outlast a heavily loaded machine.
+        /// </summary>
+        private const int CANCEL_RESTART_LOOPS = 30;
+
+        /// <summary>
+        /// True while a cancelled status should NOT be believed yet.
+        ///
+        /// <para>A background loader cancels its own work whenever the document it was handed is
+        /// superseded - <see cref="RetentionTimeManager"/>'s test for it is nothing but a
+        /// reference comparison against the container's current document. Nothing was cancelled
+        /// in any meaningful sense: <see cref="BackgroundLoader"/> re-notifies on the way out and
+        /// the loader starts again on the new document. But that hand-off posts a cancelled
+        /// status, and <see cref="IsFinal"/> counts any cancellation as terminal, so the wait
+        /// could end on a document still short of loaded. Under a parallel run, where a
+        /// chromatogram load commits its new document just as a retention time alignment begins,
+        /// that surfaced as an intermittent "Loader cancelled" - the alignment had been running
+        /// for 0% of its work.</para>
+        ///
+        /// <para>So give the restart a bounded chance to post its own status. Anything that
+        /// arrives - progress, completion, or the document simply becoming loaded - ends this and
+        /// the wait proceeds normally. A cancellation that really is the end of the line still
+        /// gets reported, just <see cref="CANCEL_RESTART_LOOPS"/> seconds later.</para>
+        ///
+        /// <para>OFF by default, because <see cref="CommandLine"/> waits on this same container
+        /// and already has its own handling for an early return, and buying a test's stability
+        /// with up to <see cref="CANCEL_RESTART_LOOPS"/> seconds added to a shipping import's
+        /// failure path is not a trade worth making blind. The same early return is a real gap
+        /// there - it can leave the command line writing a document whose alignments never
+        /// finished - but that is a separate change, made deliberately and measured on its own.
+        /// </para>
+        /// </summary>
+        protected virtual bool WaitForCancelRestart { get { return false; } }
+
+        private bool IsSupersededCancel(ref int cancelLoops)
+        {
+            if (!WaitForCancelRestart || LastProgress == null || !LastProgress.IsCanceled || Document.IsLoaded)
+            {
+                cancelLoops = 0;
+                return false;
+            }
+            return ++cancelLoops <= CANCEL_RESTART_LOOPS;
         }
 
         private bool IsFinal(SrmDocument doc)

--- a/pwiz_tools/Skyline/Model/MemoryDocumentContainer.cs
+++ b/pwiz_tools/Skyline/Model/MemoryDocumentContainer.cs
@@ -159,14 +159,28 @@ namespace pwiz.Skyline.Model
         /// there - it can leave the command line writing a document whose alignments never
         /// finished - but that is a separate change, made deliberately and measured on its own.
         /// </para>
+        ///
+        /// <para>SETTABLE rather than overridden, because "every results test wants this" turned
+        /// out to be false. Two callers depend on the fail-fast it removes:
+        /// <c>AssertEx.ForceDocumentLoad</c>, whose own comment explains that its callers sit in a
+        /// bare catch-and-retry where a longer wait silently deletes the fix it exists to apply;
+        /// and CommandLineTest, which drives the shipping CommandLine path through a TEST
+        /// container, so switching this on there would make the production gap named above
+        /// permanently invisible to the suite that covers it. Both switch it back off.</para>
         /// </summary>
-        protected virtual bool WaitForCancelRestart { get { return false; } }
+        public bool WaitForCancelRestart { get; set; }
 
         private bool IsSupersededCancel(ref int cancelLoops)
         {
             if (!WaitForCancelRestart || LastProgress == null || !LastProgress.IsCanceled || Document.IsLoaded)
             {
-                cancelLoops = 0;
+                // Deliberately NOT resetting cancelLoops. The budget is spent per WAIT, not per
+                // cancellation episode, because LastProgress is one container-wide status written
+                // by every registered loader - six of them here, nine under SkylineWindow. Resetting
+                // whenever it reads non-cancelled would let an unrelated loader's progress buy a
+                // fresh 30 seconds each time round, and WaitForComplete has no overall deadline: a
+                // named "Loader cancelled" failure would become an open-ended hang, diagnosable
+                // only as a harness timeout. Now the cap bounds the whole wait.
                 return false;
             }
             if (cancelLoops == 0 && Program.UnitTest)

--- a/pwiz_tools/Skyline/Model/Optimization/OptimizationDb.cs
+++ b/pwiz_tools/Skyline/Model/Optimization/OptimizationDb.cs
@@ -85,10 +85,25 @@ namespace pwiz.Skyline.Model.Optimization
             // Each session owns the factory it was opened from, so nothing retains one. NHibernate
             // roots every SessionFactory in the static SessionFactoryObjectFactory.Instances
             // dictionary until Dispose() removes it, so a retained factory never becomes
-            // collectible. IrtDb has always worked this way; these two did not, which is what
-            // leaked once the NHibernate upgrade stopped them disposing after Load.
+            // collectible - which is what leaked once the NHibernate upgrade stopped these two
+            // disposing after Load. (IrtDb closes the same hole differently, passing a
+            // caller-scoped factory into OpenWriteSession; that shape cannot leak here at all.)
+            //
+            // Ownership does not transfer until the constructor RETURNS, so the window between
+            // has to be guarded: OpenSession() throws if SQLite cannot open the file, and
+            // AbstractSessionWithLock's constructor throws by design when this thread already
+            // holds a read lock. Without the catch the factory is registered, owned by nobody,
+            // and the leak comes back on exactly the error paths no test looks at.
             var sessionFactory = GetSessionFactory(_path);
-            return new SessionWithLock(sessionFactory.OpenSession(), _databaseLock, true, sessionFactory);
+            try
+            {
+                return new SessionWithLock(sessionFactory.OpenSession(), _databaseLock, true, sessionFactory);
+            }
+            catch
+            {
+                sessionFactory.Dispose();
+                throw;
+            }
         }
 
         public IEnumerable<DbOptimization> GetOptimizations()

--- a/pwiz_tools/Skyline/Model/Optimization/OptimizationDb.cs
+++ b/pwiz_tools/Skyline/Model/Optimization/OptimizationDb.cs
@@ -56,16 +56,14 @@ namespace pwiz.Skyline.Model.Optimization
                                                      // No special code needed for reading V2, SQLite is happy to present int as string
 
         private readonly string _path;
-        private readonly ISessionFactory _sessionFactory;
         private readonly ReaderWriterLock _databaseLock;
 
         private DateTime _modifiedTime;
         private OptimizationDictionary _dictLibrary;
 
-        public OptimizationDb(string path, ISessionFactory sessionFactory)
+        public OptimizationDb(string path)
         {
             _path = path;
-            _sessionFactory = sessionFactory;
             _databaseLock = new ReaderWriterLock();
         }
 
@@ -84,12 +82,19 @@ namespace pwiz.Skyline.Model.Optimization
 
         private ISession OpenWriteSession()
         {
-            return new SessionWithLock(_sessionFactory.OpenSession(), _databaseLock, true);
+            // Each session owns the factory it was opened from, so nothing retains one. NHibernate
+            // roots every SessionFactory in the static SessionFactoryObjectFactory.Instances
+            // dictionary until Dispose() removes it, so a retained factory never becomes
+            // collectible. IrtDb has always worked this way; these two did not, which is what
+            // leaked once the NHibernate upgrade stopped them disposing after Load.
+            var sessionFactory = GetSessionFactory(_path);
+            return new SessionWithLock(sessionFactory.OpenSession(), _databaseLock, true, sessionFactory);
         }
 
         public IEnumerable<DbOptimization> GetOptimizations()
         {
-            using (var session = new SessionWithLock(_sessionFactory.OpenSession(), _databaseLock, false))
+            using (var sessionFactory = GetSessionFactory(_path))
+            using (var session = new SessionWithLock(sessionFactory.OpenSession(), _databaseLock, false))
             {
                 return session.CreateCriteria(typeof(DbOptimization)).List<DbOptimization>();
             }
@@ -236,11 +241,7 @@ namespace pwiz.Skyline.Model.Optimization
                     // NOTE: sessionFactory ownership transfers to OptimizationDb - do
                     // NOT `using` it. See IonMobilityDb.GetIonMobilityDb for the same
                     // net472→net8 NHibernate lifecycle fix.
-                    var sessionFactory = GetSessionFactory(path);
-                    lock (sessionFactory)
-                    {
-                        return new OptimizationDb(path, sessionFactory).Load(loadMonitor, status);
-                    }
+                    return new OptimizationDb(path).Load(loadMonitor, status);
                 }
                 catch (UnauthorizedAccessException)
                 {

--- a/pwiz_tools/Skyline/Model/Results/Chromatogram.cs
+++ b/pwiz_tools/Skyline/Model/Results/Chromatogram.cs
@@ -305,15 +305,26 @@ namespace pwiz.Skyline.Model.Results
             {
                 string documentFilePath = _container.DocumentFilePath;
                 if (documentFilePath == null)
+                {
+                    _manager.LoaderTrace(@"chrom Load doc={0} -> no document path, nothing to do", _docCurrent);
                     return;
+                }
 
                 var results = _docCurrent.Settings.MeasuredResults;
                 if (results.IsLoaded)
+                {
+                    _manager.LoaderTrace(@"chrom Load doc={0} -> results already loaded", _docCurrent);
                     return;
+                }
 
                 Assume.IsNull(_loadMonitor);
                 _loadMonitor = new MultiFileLoadMonitor(_manager, _container, results) {HasUI = _manager.SupportAllGraphs};
+                // FinishLoad is a CALLBACK. results.Load returns once the work is handed off, so
+                // "Load returned" says nothing about whether the commit ever ran - which is the
+                // whole question when an import reaches 100% and the document stays unloaded.
+                _manager.LoaderTrace(@"chrom Load doc={0} -> handing off to MeasuredResults.Load", _docCurrent);
                 results.Load(_docCurrent, documentFilePath, _loadMonitor, _multiFileLoader, FinishLoad);
+                _manager.LoaderTrace(@"chrom Load doc={0} -> MeasuredResults.Load returned (FinishLoad may still be pending)", _docCurrent);
             }
 
             private void CancelLoad(MeasuredResults results)
@@ -356,24 +367,31 @@ namespace pwiz.Skyline.Model.Results
                 if (resultsLoad == null)
                 {
                     // Loading was cancelled
+                    _manager.LoaderTrace(@"chrom FinishLoad doc={0} -> resultsLoad null, load was cancelled", _document);
                     _manager.EndProcessing(_document);
                     return;
                 }
 
+                int iteration = 0;
                 SrmDocument docNew, docCurrent;
                 do
                 {
+                    iteration++;
                     docCurrent = _container.Document;
+                    _manager.LoaderTrace(@"chrom FinishLoad doc={0} against current={1}, iteration {2}",
+                        _document, docCurrent, iteration);
                     var results = docCurrent.Settings.MeasuredResults;
                     // If current document has no results, then cancel
                     if (results == null)
                     {
+                        _manager.LoaderTrace(@"chrom FinishLoad doc={0} -> current has NO results, cancelling", _document);
                         CancelLoad(resultsLoad);
                         return;
                     }
                     else if (results.IsLoaded)
                     {
                         // No need to continue
+                        _manager.LoaderTrace(@"chrom FinishLoad doc={0} -> current already loaded, nothing to commit", _document);
                         _manager.EndProcessing(_document);
                         return;
                     }
@@ -409,6 +427,7 @@ namespace pwiz.Skyline.Model.Results
                         catch (OperationCanceledException)
                         {
                             // Restart the processing form the top
+                            _manager.LoaderTrace(@"chrom FinishLoad doc={0} -> settings change cancelled, retrying", _document);
                             docNew = null;
                         }
                     }
@@ -417,6 +436,8 @@ namespace pwiz.Skyline.Model.Results
                     _manager.WaitIfProgressFrozen();
                 }
                 while (docNew == null || !_manager.CompleteProcessing(_container, docNew, docCurrent));
+
+                _manager.LoaderTrace(@"chrom FinishLoad doc={0} -> COMMITTED after {2} iteration(s)", _document, null, iteration);
             }
         }
 

--- a/pwiz_tools/Skyline/Model/Results/Chromatogram.cs
+++ b/pwiz_tools/Skyline/Model/Results/Chromatogram.cs
@@ -329,6 +329,7 @@ namespace pwiz.Skyline.Model.Results
 
             private void CancelLoad(MeasuredResults results)
             {
+                _manager.LoaderTrace(@"chrom CancelLoad doc={0} -> posting a cancelled status", _document);
                 _manager.CancelProgress();
                 _manager.EndProcessing(_document);
             }
@@ -352,6 +353,12 @@ namespace pwiz.Skyline.Model.Results
                         {
                             throw;
                         }
+                        // Terminal line, and the trace is useless without it: swallowing this into
+                        // an error status and returning would leave the trace showing the hand-off
+                        // followed by silence - identical to the callback never running at all,
+                        // which is the one distinction the trace exists to make.
+                        _manager.LoaderTrace(@"chrom FinishLoad doc={0} -> THREW, converted to an error status: " + ex.GetType().Name,
+                            _document);
                         foreach (var chromatogramStatus in _multiFileLoader.Status.ProgressList)
                         {
                             _multiFileLoader.ChangeStatus((ChromatogramLoadingStatus)chromatogramStatus.ChangeErrorException(ex));

--- a/pwiz_tools/Skyline/Program.cs
+++ b/pwiz_tools/Skyline/Program.cs
@@ -31,6 +31,7 @@ using System.Text;
 using System.Threading;
 using System.Windows.Forms;
 using Microsoft.Win32;
+using Microsoft.Win32.SafeHandles;
 using pwiz.Common;
 using pwiz.ProteowizardWrapper;
 using pwiz.Common.Collections;
@@ -907,6 +908,13 @@ namespace pwiz.Skyline
                 return;
             }
 
+            if (IsBenignInvokeCompletionFailure(e.Exception))
+            {
+                Messages.WriteAsyncDebugMessage(@"Ignored benign failure signaling a completed marshaled call: {0}",
+                    e.Exception.Message);
+                return;
+            }
+
             if (TestExceptions != null)
             {
                 AddTestException(e.Exception);
@@ -934,6 +942,73 @@ namespace pwiz.Skyline
             return exception is ExternalException &&
                    exception.StackTrace != null &&
                    exception.StackTrace.Contains(@"RepaintSplitterRect");
+        }
+
+        /// <summary>
+        /// True for the benign ObjectDisposedException WinForms raises from
+        /// Control.InvokeMarshaledCallbacks when it signals a marshaled call whose wait handle
+        /// has already been disposed. Control.MarshaledInvoke disposes that handle with a using
+        /// as soon as WaitForWaitHandle returns (dotnet/winforms#10460, new in .NET 9), and
+        /// WaitForWaitHandle has paths that stop waiting while the entry is still queued. The
+        /// callback then runs normally on the UI thread and only the completion signal throws,
+        /// with no thread left waiting on it. .NET 8 disposed the handle from a finalizer
+        /// instead, so the same Set() was harmless - ignoring this restores that behavior
+        /// rather than hiding a new failure. Reported as dotnet/winforms#14996 (milestone
+        /// .NET 11), with no backport - remove this once Skyline targets a runtime carrying
+        /// that fix.
+        ///
+        /// <para>The method name alone is not enough to identify it. An ObjectDisposedException
+        /// thrown by OUR OWN code inside a marshaled callback reaches this handler with
+        /// InvokeMarshaledCallbacks on its stack too, and can name a SafeWaitHandle just as
+        /// readily. What separates them is the WINDOW between the throw and
+        /// InvokeMarshaledCallbacks: the completion signal reaches it through nothing but
+        /// WinForms and the core library, while a callback of ours leaves its own frames (or
+        /// the InvokeMarshaledCallback* dispatch helpers) in that window.</para>
+        ///
+        /// <para>Only that window is examined. Frames BELOW InvokeMarshaledCallbacks are the
+        /// message pump, and they are legitimately ours: every Skyline control that overrides
+        /// WndProc (SequenceTree, AllChromatogramsGraph, CustomTip and others) puts a Skyline
+        /// frame there whenever it is the marshaling control. Judging the whole stack would
+        /// reject exactly those controls and let the nightly failures back in for them -
+        /// verified against .NET 10.0.11, where adding a WndProc override to the target is the
+        /// only change needed to flip the verdict.</para>
+        ///
+        /// <para>Fails CLOSED: an unresolvable frame, or a trace that never reaches
+        /// InvokeMarshaledCallbacks, reports rather than swallows.</para>
+        /// </summary>
+        private static bool IsBenignInvokeCompletionFailure(Exception exception)
+        {
+            if (!(exception is ObjectDisposedException disposedException) ||
+                !Equals(disposedException.ObjectName, typeof(SafeWaitHandle).FullName))
+            {
+                return false;
+            }
+
+            var winFormsAssembly = typeof(Control).Assembly;
+            var coreLibAssembly = typeof(object).Assembly;
+            foreach (var frame in new StackTrace(disposedException).GetFrames())
+            {
+                var method = frame.GetMethod();
+                var declaringType = method?.DeclaringType;
+                if (declaringType == null)
+                {
+                    return false;   // Cannot identify the frame, so cannot claim it is benign
+                }
+                if (declaringType == typeof(Control) && Equals(method.Name, @"InvokeMarshaledCallbacks"))
+                {
+                    return true;    // Reached the pump without passing through a callback of ours
+                }
+                if (declaringType.Assembly != winFormsAssembly && declaringType.Assembly != coreLibAssembly)
+                {
+                    return false;   // A callback of ours ran and threw
+                }
+                if (method.Name.StartsWith(@"InvokeMarshaledCallback", StringComparison.Ordinal) ||
+                    declaringType == typeof(ExecutionContext))
+                {
+                    return false;   // The callback-dispatch path, so a callback of ours ran
+                }
+            }
+            return false;
         }
 
         private static void ReportExceptionUI(Exception exception, StackTrace stackTrace)

--- a/pwiz_tools/Skyline/Program.cs
+++ b/pwiz_tools/Skyline/Program.cs
@@ -965,13 +965,16 @@ namespace pwiz.Skyline
         /// WinForms and the core library, while a callback of ours leaves its own frames (or
         /// the InvokeMarshaledCallback* dispatch helpers) in that window.</para>
         ///
-        /// <para>Only that window is examined. Frames BELOW InvokeMarshaledCallbacks are the
-        /// message pump, and they are legitimately ours: every Skyline control that overrides
-        /// WndProc (SequenceTree, AllChromatogramsGraph, CustomTip and others) puts a Skyline
-        /// frame there whenever it is the marshaling control. Judging the whole stack would
-        /// reject exactly those controls and let the nightly failures back in for them -
-        /// verified against .NET 10.0.11, where adding a WndProc override to the target is the
-        /// only change needed to flip the verdict.</para>
+        /// <para>DELIBERATELY INCOMPLETE. Any Skyline frame anywhere on the stack disqualifies
+        /// it, including one BELOW InvokeMarshaledCallbacks in the message pump - which is where
+        /// a control that overrides WndProc (SequenceTree, AllChromatogramsGraph, CustomTip and
+        /// four others) puts one whenever it is the marshaling control. Those cases stay
+        /// unfiltered on purpose. Failing to silence a benign exception costs one visible test
+        /// failure that can be investigated; silencing a real one hides a defect with nothing
+        /// to find it by, and the message below is Trace-level, which the registered listener
+        /// discards. Widen this only after a nightly actually fails that way, and recognize it
+        /// by this exact ObjectDisposedException with a Skyline WndProc frame under
+        /// Control.InvokeMarshaledCallbacks.</para>
         ///
         /// <para>Fails CLOSED: an unresolvable frame, or a trace that never reaches
         /// InvokeMarshaledCallbacks, reports rather than swallows.</para>
@@ -986,6 +989,7 @@ namespace pwiz.Skyline
 
             var winFormsAssembly = typeof(Control).Assembly;
             var coreLibAssembly = typeof(object).Assembly;
+            var reachedCompletionSignal = false;
             foreach (var frame in new StackTrace(disposedException).GetFrames())
             {
                 var method = frame.GetMethod();
@@ -994,13 +998,18 @@ namespace pwiz.Skyline
                 {
                     return false;   // Cannot identify the frame, so cannot claim it is benign
                 }
-                if (declaringType == typeof(Control) && Equals(method.Name, @"InvokeMarshaledCallbacks"))
-                {
-                    return true;    // Reached the pump without passing through a callback of ours
-                }
                 if (declaringType.Assembly != winFormsAssembly && declaringType.Assembly != coreLibAssembly)
                 {
-                    return false;   // A callback of ours ran and threw
+                    return false;   // Code of ours is involved somewhere, so report it
+                }
+                if (reachedCompletionSignal)
+                {
+                    continue;       // Below the signal: the pump, and it must stay framework-only
+                }
+                if (declaringType == typeof(Control) && Equals(method.Name, @"InvokeMarshaledCallbacks"))
+                {
+                    reachedCompletionSignal = true;
+                    continue;
                 }
                 if (method.Name.StartsWith(@"InvokeMarshaledCallback", StringComparison.Ordinal) ||
                     declaringType == typeof(ExecutionContext))
@@ -1008,7 +1017,7 @@ namespace pwiz.Skyline
                     return false;   // The callback-dispatch path, so a callback of ours ran
                 }
             }
-            return false;
+            return reachedCompletionSignal;
         }
 
         private static void ReportExceptionUI(Exception exception, StackTrace stackTrace)

--- a/pwiz_tools/Skyline/TestData/CommandLineTest.cs
+++ b/pwiz_tools/Skyline/TestData/CommandLineTest.cs
@@ -1001,6 +1001,11 @@ namespace pwiz.SkylineTestData
             var commandLine = new CommandLine();
             using (var docContainer = new ResultsTestDocumentContainer(doc, docPath))
             {
+                // Stand in for CommandLine faithfully: it waits on a plain
+                // ResultsMemoryDocumentContainer, where a superseded cancel ends the wait early.
+                // Leaving the test container's default on here would make that production gap
+                // permanently invisible to the test that covers this path.
+                docContainer.WaitForCancelRestart = false;
                 commandLine.ImportResults(docContainer, replicate, MsDataFileUri.Parse(rawPath), null);
                 docContainer.WaitForComplete();
                 docContainer.AssertComplete();  // No errors
@@ -1044,6 +1049,8 @@ namespace pwiz.SkylineTestData
             var commandLine = new CommandLine();
             using (var docContainer = new ResultsTestDocumentContainer(doc, docPath))
             {
+                // Same reason as above: keep this standing in for CommandLine's real wait.
+                docContainer.WaitForCancelRestart = false;
                 commandLine.ImportResults(docContainer, replicate, MsDataFileUri.Parse(rawPath), null);
                 docContainer.WaitForComplete();
                 docContainer.AssertComplete();  // No errors

--- a/pwiz_tools/Skyline/TestFunctional/UiThreadExceptionFilterTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/UiThreadExceptionFilterTest.cs
@@ -32,9 +32,8 @@ using pwiz.SkylineTestUtil;
 namespace pwiz.SkylineTestFunctional
 {
     /// <summary>
-    /// Verifies that the UI-thread exception handler ignores the benign ObjectDisposedException
-    /// WinForms raises when it signals a marshaled call whose wait handle is already disposed,
-    /// and still reports one thrown by a callback of ours.
+    /// Verifies what the UI-thread exception handler ignores when WinForms signals a marshaled
+    /// call whose wait handle is already disposed - and, just as importantly, what it does not.
     ///
     /// <para>Since .NET 9 (dotnet/winforms#10460) Control.MarshaledInvoke disposes that handle
     /// with a using as soon as WaitForWaitHandle returns, and WaitForWaitHandle has paths that
@@ -44,12 +43,17 @@ namespace pwiz.SkylineTestFunctional
     /// Program.TestExceptions and fails whatever test happened to be running, which is how eight
     /// unrelated tests failed in one .NET 10 nightly. Reported as dotnet/winforms#14996.</para>
     ///
-    /// <para>Both halves assert something POSITIVE. The benign half waits for the handler's own
-    /// debug message rather than for an absence, so it cannot pass by the repro silently
-    /// ceasing to strand anything - which it would do if WinForms stopped lazily allocating
-    /// ThreadMethodEntry's ManualResetEvent, the one undocumented internal this setup rests on.
-    /// The reporting half provokes from a framework method group on purpose: that produces an
-    /// all-framework stack, the case a whole-stack allowlist would wrongly swallow.</para>
+    /// <para>The filter is deliberately narrow, so the second case here asserts that an
+    /// exception IS still reported. Failing to silence a benign one costs a visible test
+    /// failure; silencing a real one hides a defect. Change these expectations only with that
+    /// asymmetry in mind.</para>
+    ///
+    /// <para>Not covered: a completion failure marshaled through a control that overrides
+    /// WndProc, which puts a Skyline frame in the pump and is deliberately not filtered.
+    /// Reproduced in isolation against .NET 10.0.11, but not from inside Skyline - stranding a
+    /// call on SkylineWindow.SequenceTree still produced an all-framework stack, so the
+    /// marshaling control in practice was not the tree. Worth revisiting if a nightly ever
+    /// fails that way.</para>
     /// </summary>
     [TestClass]
     public class UiThreadExceptionFilterTest : AbstractFunctionalTest
@@ -79,11 +83,7 @@ namespace pwiz.SkylineTestFunctional
             };
             try
             {
-                // SkylineWindow does not override WndProc; SequenceTree does. A control that
-                // overrides it puts a Skyline frame BELOW Control.InvokeMarshaledCallbacks, so
-                // only the second case catches a filter that judges the whole stack.
-                AssertBenignCompletionFailureIgnored(SkylineWindow);
-                AssertBenignCompletionFailureIgnored(SkylineWindow.SequenceTree);
+                AssertCompletionFailureIgnored();
                 AssertCallbackFailureStillReported();
             }
             finally
@@ -93,15 +93,55 @@ namespace pwiz.SkylineTestFunctional
         }
 
         /// <summary>
-        /// Strands a marshaled call the way MarshaledInvoke does on the paths that stop waiting
-        /// before the entry completes, then verifies the completion failure was ignored.
+        /// The case the filter exists for: SkylineWindow does not override WndProc, so every
+        /// frame belongs to WinForms or the core library and the completion failure is ignored.
         /// </summary>
-        private void AssertBenignCompletionFailureIgnored(Control target)
+        private void AssertCompletionFailureIgnored()
+        {
+            var strandedCallbackRan = StrandMarshaledCall(SkylineWindow);
+
+            // Wait for the handler to say it ignored it, not merely for nothing to be recorded.
+            // The exception names the disposed type, so this needs no copy of the handler's text.
+            WaitForCondition(WAIT_TIME, () => HasDebugMessageNaming(typeof(SafeWaitHandle).FullName),
+                null, true, false);
+
+            AssertEx.IsTrue(strandedCallbackRan(),
+                @"The marshaled callback did not run after its wait handle was disposed.");
+            AssertEx.AreEqual(0, Program.TestExceptions.Count,
+                @"Completing a marshaled call on SkylineWindow reached the test harness.");
+        }
+
+        /// <summary>
+        /// An ObjectDisposedException thrown by a callback of ours must still be reported.
+        /// Provoked from a framework method group so every frame above
+        /// Control.InvokeMarshaledCallbacks belongs to the framework - the case a filter that
+        /// only asked whether any frame above it was ours would wrongly swallow.
+        /// </summary>
+        private void AssertCallbackFailureStillReported()
+        {
+            var disposedMutex = new Mutex();
+            disposedMutex.Dispose();
+            SkylineWindow.BeginInvoke(new Action(disposedMutex.ReleaseMutex));
+
+            var reported = AssertReportedObjectDisposedException(
+                @"The filter swallowed an ObjectDisposedException thrown by a marshaled callback.");
+            // Identity, not just type: both candidates are ObjectDisposedException naming a
+            // SafeWaitHandle, so only the throwing method separates them.
+            AssertEx.Contains(reported.StackTrace, nameof(Mutex.ReleaseMutex));
+        }
+
+        /// <summary>
+        /// Queues a marshaled call behind a parked one and disposes its wait handle before it can
+        /// be dispatched - what MarshaledInvoke leaves behind on the paths that stop waiting
+        /// before the entry completes. Returns a func reporting whether the callback ran.
+        /// </summary>
+        private Func<bool> StrandMarshaledCall(Control target)
         {
             lock (_debugMessages)
             {
                 _debugMessages.Clear();
             }
+
             var callbackEntered = new ManualResetEventSlim(false);
             var releaseCallback = new ManualResetEventSlim(false);
             var strandedCallbackRan = false;
@@ -120,60 +160,35 @@ namespace pwiz.SkylineTestFunctional
                         target.GetType().Name));
 
                 var stranded = target.BeginInvoke(new Action(() => strandedCallbackRan = true));
-                // What MarshaledInvoke does on the paths that stop waiting before the entry completes.
                 stranded.AsyncWaitHandle.Dispose();
             }
             finally
             {
                 releaseCallback.Set();
             }
-
-            // Wait for the handler to say it ignored it, not merely for nothing to be recorded.
-            // The exception names the disposed type, so this needs no copy of the handler's text.
-            WaitForCondition(WAIT_TIME, () => HasDebugMessageNaming(typeof(SafeWaitHandle).FullName),
-                null, true, false);
-
-            AssertEx.IsTrue(strandedCallbackRan,
-                string.Format(@"The marshaled callback on {0} did not run after its wait handle was disposed.",
-                    target.GetType().Name));
-            AssertEx.AreEqual(0, Program.TestExceptions.Count,
-                string.Format(@"Completing a marshaled call on {0} reached the test harness.",
-                    target.GetType().Name));
+            return () => strandedCallbackRan;
         }
 
         /// <summary>
-        /// The other half of the filter: an ObjectDisposedException thrown by a callback of ours
-        /// must still be reported. Provoked from a framework method group so every frame above
-        /// Control.InvokeMarshaledCallbacks belongs to the framework - the case that a filter
-        /// judging the whole stack, rather than the window below the throw, would swallow.
+        /// Waits for one ObjectDisposedException to reach the harness, then removes it. Removes
+        /// only what was observed: clearing would discard an unrelated failure recorded by a
+        /// background thread, and the harness check at teardown would then pass with the real
+        /// bug gone.
         /// </summary>
-        private void AssertCallbackFailureStillReported()
+        private Exception AssertReportedObjectDisposedException(string timeoutMessage)
         {
-            AssertEx.AreEqual(0, Program.TestExceptions.Count,
-                @"Something recorded an exception before the reporting half provoked one.");
-
-            var disposedMutex = new Mutex();
-            disposedMutex.Dispose();
-            SkylineWindow.BeginInvoke(new Action(disposedMutex.ReleaseMutex));
-
             Exception reported = null;
             try
             {
                 WaitForCondition(WAIT_TIME, () => Program.TestExceptions.Count > 0,
-                    @"The filter swallowed an ObjectDisposedException thrown by a marshaled callback.",
-                    true, false);
+                    timeoutMessage, true, false);
                 reported = Program.TestExceptions[0];
                 AssertEx.IsTrue(reported is ObjectDisposedException,
-                    @"Expected the reported exception to be the one the callback threw.");
-                // Identity, not just type: both candidates are ObjectDisposedException naming a
-                // SafeWaitHandle, so only the throwing method separates them.
-                AssertEx.Contains(reported.StackTrace, nameof(Mutex.ReleaseMutex));
+                    @"Expected the reported exception to be an ObjectDisposedException.");
+                return reported;
             }
             finally
             {
-                // Remove only what this test provoked. Clearing would discard an unrelated
-                // failure recorded by a background thread while this test ran, and the harness
-                // check at teardown would then pass with the real bug gone.
                 if (reported != null)
                 {
                     lock (Program.TestExceptions)

--- a/pwiz_tools/Skyline/TestFunctional/UiThreadExceptionFilterTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/UiThreadExceptionFilterTest.cs
@@ -1,0 +1,195 @@
+/*
+ * Original author: Brendan MacLean <brendanx .at. uw.edu>,
+ *                  MacCoss Lab, Department of Genome Sciences, UW
+ * AI assistance: Claude Code (Claude Opus 5) <noreply .at. anthropic.com>
+ *
+ * Copyright 2026 University of Washington - Seattle, WA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Windows.Forms;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.Win32.SafeHandles;
+using pwiz.Common.SystemUtil;
+using pwiz.Skyline;
+using pwiz.SkylineTestUtil;
+
+namespace pwiz.SkylineTestFunctional
+{
+    /// <summary>
+    /// Verifies that the UI-thread exception handler ignores the benign ObjectDisposedException
+    /// WinForms raises when it signals a marshaled call whose wait handle is already disposed,
+    /// and still reports one thrown by a callback of ours.
+    ///
+    /// <para>Since .NET 9 (dotnet/winforms#10460) Control.MarshaledInvoke disposes that handle
+    /// with a using as soon as WaitForWaitHandle returns, and WaitForWaitHandle has paths that
+    /// stop waiting while the entry is still queued. The queued callback then runs normally and
+    /// only ThreadMethodEntry.Complete() throws, from Control.InvokeMarshaledCallbacks, with no
+    /// thread left waiting on the result. Under a test harness that reaches
+    /// Program.TestExceptions and fails whatever test happened to be running, which is how eight
+    /// unrelated tests failed in one .NET 10 nightly. Reported as dotnet/winforms#14996.</para>
+    ///
+    /// <para>Both halves assert something POSITIVE. The benign half waits for the handler's own
+    /// debug message rather than for an absence, so it cannot pass by the repro silently
+    /// ceasing to strand anything - which it would do if WinForms stopped lazily allocating
+    /// ThreadMethodEntry's ManualResetEvent, the one undocumented internal this setup rests on.
+    /// The reporting half provokes from a framework method group on purpose: that produces an
+    /// all-framework stack, the case a whole-stack allowlist would wrongly swallow.</para>
+    /// </summary>
+    [TestClass]
+    public class UiThreadExceptionFilterTest : AbstractFunctionalTest
+    {
+        [TestMethod]
+        public void TestUiThreadExceptionFilter()
+        {
+            RunFunctionalTest();
+        }
+
+        // Safety valve for the UI thread parked inside the marshaled callback. Deliberately not
+        // WAIT_TIME: nothing should ever wait on it, and a stuck UI thread blocks teardown.
+        private const int PARKED_CALLBACK_RELEASE_MILLIS = 10 * 1000;
+
+        private readonly List<string> _debugMessages = new List<string>();
+
+        protected override void DoTest()
+        {
+            var restoreWriteDebugMessage = Messages.WriteDebugMessage;
+            Messages.WriteDebugMessage = (message, args) =>
+            {
+                lock (_debugMessages)
+                {
+                    _debugMessages.Add(args == null ? message : string.Format(message, args));
+                }
+                restoreWriteDebugMessage(message, args);
+            };
+            try
+            {
+                // SkylineWindow does not override WndProc; SequenceTree does. A control that
+                // overrides it puts a Skyline frame BELOW Control.InvokeMarshaledCallbacks, so
+                // only the second case catches a filter that judges the whole stack.
+                AssertBenignCompletionFailureIgnored(SkylineWindow);
+                AssertBenignCompletionFailureIgnored(SkylineWindow.SequenceTree);
+                AssertCallbackFailureStillReported();
+            }
+            finally
+            {
+                Messages.WriteDebugMessage = restoreWriteDebugMessage;
+            }
+        }
+
+        /// <summary>
+        /// Strands a marshaled call the way MarshaledInvoke does on the paths that stop waiting
+        /// before the entry completes, then verifies the completion failure was ignored.
+        /// </summary>
+        private void AssertBenignCompletionFailureIgnored(Control target)
+        {
+            lock (_debugMessages)
+            {
+                _debugMessages.Clear();
+            }
+            var callbackEntered = new ManualResetEventSlim(false);
+            var releaseCallback = new ManualResetEventSlim(false);
+            var strandedCallbackRan = false;
+
+            // Park the UI thread inside Control.InvokeMarshaledCallbacks so the next call can be
+            // queued behind it and have its wait handle disposed before it is dispatched.
+            target.BeginInvoke(new Action(() =>
+            {
+                callbackEntered.Set();
+                releaseCallback.Wait(PARKED_CALLBACK_RELEASE_MILLIS);
+            }));
+            try
+            {
+                AssertEx.IsTrue(callbackEntered.Wait(WAIT_TIME),
+                    string.Format(@"The UI thread never entered the blocking marshaled callback on {0}.",
+                        target.GetType().Name));
+
+                var stranded = target.BeginInvoke(new Action(() => strandedCallbackRan = true));
+                // What MarshaledInvoke does on the paths that stop waiting before the entry completes.
+                stranded.AsyncWaitHandle.Dispose();
+            }
+            finally
+            {
+                releaseCallback.Set();
+            }
+
+            // Wait for the handler to say it ignored it, not merely for nothing to be recorded.
+            // The exception names the disposed type, so this needs no copy of the handler's text.
+            WaitForCondition(WAIT_TIME, () => HasDebugMessageNaming(typeof(SafeWaitHandle).FullName),
+                null, true, false);
+
+            AssertEx.IsTrue(strandedCallbackRan,
+                string.Format(@"The marshaled callback on {0} did not run after its wait handle was disposed.",
+                    target.GetType().Name));
+            AssertEx.AreEqual(0, Program.TestExceptions.Count,
+                string.Format(@"Completing a marshaled call on {0} reached the test harness.",
+                    target.GetType().Name));
+        }
+
+        /// <summary>
+        /// The other half of the filter: an ObjectDisposedException thrown by a callback of ours
+        /// must still be reported. Provoked from a framework method group so every frame above
+        /// Control.InvokeMarshaledCallbacks belongs to the framework - the case that a filter
+        /// judging the whole stack, rather than the window below the throw, would swallow.
+        /// </summary>
+        private void AssertCallbackFailureStillReported()
+        {
+            AssertEx.AreEqual(0, Program.TestExceptions.Count,
+                @"Something recorded an exception before the reporting half provoked one.");
+
+            var disposedMutex = new Mutex();
+            disposedMutex.Dispose();
+            SkylineWindow.BeginInvoke(new Action(disposedMutex.ReleaseMutex));
+
+            Exception reported = null;
+            try
+            {
+                WaitForCondition(WAIT_TIME, () => Program.TestExceptions.Count > 0,
+                    @"The filter swallowed an ObjectDisposedException thrown by a marshaled callback.",
+                    true, false);
+                reported = Program.TestExceptions[0];
+                AssertEx.IsTrue(reported is ObjectDisposedException,
+                    @"Expected the reported exception to be the one the callback threw.");
+                // Identity, not just type: both candidates are ObjectDisposedException naming a
+                // SafeWaitHandle, so only the throwing method separates them.
+                AssertEx.Contains(reported.StackTrace, nameof(Mutex.ReleaseMutex));
+            }
+            finally
+            {
+                // Remove only what this test provoked. Clearing would discard an unrelated
+                // failure recorded by a background thread while this test ran, and the harness
+                // check at teardown would then pass with the real bug gone.
+                if (reported != null)
+                {
+                    lock (Program.TestExceptions)
+                    {
+                        Program.TestExceptions.Remove(reported);
+                    }
+                }
+            }
+        }
+
+        private bool HasDebugMessageNaming(string objectName)
+        {
+            lock (_debugMessages)
+            {
+                return _debugMessages.Any(message => message.Contains(objectName));
+            }
+        }
+    }
+}

--- a/pwiz_tools/Skyline/TestTutorial/AuditLogTutorialTest.cs
+++ b/pwiz_tools/Skyline/TestTutorial/AuditLogTutorialTest.cs
@@ -263,7 +263,13 @@ namespace pwiz.SkylineTestTutorial
                 SkylineWindow.AuditLogForm.Close();
                 SkylineWindow.ShowDocumentGrid(true);
             });
-            var documentGridForm = FindOpenForm<DocumentGridForm>();
+            // Wait for the form rather than demanding it already be there. FindOpenForm only sees
+            // a form once its handle is created, which showing a dockable form does not guarantee
+            // by the time the call returns, and it reports a miss by returning null - which
+            // reached the line below as a bare NullReferenceException, seen once in roughly 20
+            // runs of this test. WaitForOpenForm rides out the gap, and says which forms were
+            // open if the form really never arrives.
+            var documentGridForm = WaitForOpenForm<DocumentGridForm>();
             RunUI(() =>
             {
                 documentGridForm.ChooseView(Resources.SkylineViewContext_GetDocumentGridRowSources_Replicates);
@@ -382,7 +388,7 @@ namespace pwiz.SkylineTestTutorial
 
             // View the calibration curve p. 15
             RunUI(()=>SkylineWindow.ShowCalibrationForm());
-            var calibrationForm = FindOpenForm<CalibrationForm>();
+            var calibrationForm = WaitForOpenForm<CalibrationForm>();
             var priorZoomState = ZoomCalibrationCurve(calibrationForm, 0.52);
 
             RunUI(() =>

--- a/pwiz_tools/Skyline/TestUtil/AbstractUnitTest.cs
+++ b/pwiz_tools/Skyline/TestUtil/AbstractUnitTest.cs
@@ -452,6 +452,11 @@ namespace pwiz.SkylineTestUtil
             Program.TestName = TestContext.TestName;
             Program.DoNotTestUnicodeHandling = TestContext.Properties["UnicodeDecoration"]==null;
 
+            // The loader trace ring is static and this process runs test after test, so anything
+            // left in it belongs to a previous test and would be presented as evidence for this
+            // one's failure.
+            Skyline.Model.BackgroundLoader.ClearLoaderTrace();
+
             // Stop profiler if we are profiling.  The unit test will start profiling explicitly when it wants to.
             DotTraceProfile.Stop(true);
 

--- a/pwiz_tools/Skyline/TestUtil/AssertEx.cs
+++ b/pwiz_tools/Skyline/TestUtil/AssertEx.cs
@@ -1867,6 +1867,10 @@ namespace pwiz.SkylineTestUtil
                 var docLoad = cmd.Document;
                 using (var docContainer = new ResultsTestDocumentContainer(null, tmpSky))
                 {
+                    // Keep the fail-fast this method depends on - see the comment below, which
+                    // explains why a longer wait here silently removes the fix rather than
+                    // slowing it. ResultsTestDocumentContainer switches this on by default.
+                    docContainer.WaitForCancelRestart = false;
                     docContainer.SetDocument(docLoad, null, true);
                     // SetDocument's wait ends at MemoryDocumentContainer.IsFinal, which
                     // deliberately reports final for a document that never flipped to loaded, so

--- a/pwiz_tools/Skyline/TestUtil/ResultsUtil.cs
+++ b/pwiz_tools/Skyline/TestUtil/ResultsUtil.cs
@@ -252,6 +252,14 @@ namespace pwiz.SkylineTestUtil
         {
         }
 
+        /// <summary>
+        /// Tests replace the document while loaders are running far more abruptly than the
+        /// application does, so they are the ones that see a loader cancel itself over a
+        /// superseded document and then restart. Wait that hand-off out rather than reporting it
+        /// as a failed load. See the base property for why this is not on everywhere.
+        /// </summary>
+        protected override bool WaitForCancelRestart { get { return true; } }
+
         private const int SLEEP_INTERVAL = 10;
         public const int WAIT_TIME = 5 * 1000;    // 5 seconds
 
@@ -283,9 +291,47 @@ namespace pwiz.SkylineTestUtil
             if (LastProgress.IsError)
                 Assert.Fail(LastProgress.ErrorException.ToString());
 
-            Assert.Fail(LastProgress.IsCanceled
-                            ? "Loader cancelled"
-                            : "Unexpected loader progress state \"" + LastProgress.State + "\"");
+            Assert.Fail((LastProgress.IsCanceled
+                             ? "Loader cancelled"
+                             : "Unexpected loader progress state \"" + LastProgress.State + "\"")
+                        + DescribeLoadState());
+        }
+
+        /// <summary>
+        /// What the document itself has to say about the progress status above. A non-complete
+        /// status on a document that IS loaded is a stale status left by a superseded document,
+        /// which is a different defect from a load that genuinely did not finish - and the
+        /// status alone tells the two apart not at all. This is what turns an intermittent
+        /// "Loader cancelled" into something diagnosable from a nightly log.
+        /// </summary>
+        private string DescribeLoadState()
+        {
+            var lines = new List<string>();
+            var progress = LastProgress;
+            if (progress != null)
+            {
+                lines.Add(string.Format("Progress: {0} at {1}%", progress.State, progress.PercentComplete));
+                if (!string.IsNullOrEmpty(progress.Message))
+                    lines.Add("Message: " + progress.Message);
+                if (!string.IsNullOrEmpty(progress.WarningMessage))
+                    lines.Add("Warning: " + progress.WarningMessage);
+            }
+
+            var document = Document;
+            if (document == null)
+            {
+                lines.Add("Document: none");
+            }
+            else if (document.IsLoaded)
+            {
+                lines.Add("Document IS loaded - the status above is stale, from a superseded document");
+            }
+            else
+            {
+                lines.Add("Document is NOT loaded:");
+                lines.AddRange(document.NonLoadedStateDescriptionsFull.Select(why => "  " + why));
+            }
+            return Environment.NewLine + string.Join(Environment.NewLine, lines);
         }
 
         public void AssertError(string expectedError)

--- a/pwiz_tools/Skyline/TestUtil/ResultsUtil.cs
+++ b/pwiz_tools/Skyline/TestUtil/ResultsUtil.cs
@@ -17,6 +17,7 @@
  * limitations under the License.
  */
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using pwiz.Common.SystemUtil;
 using pwiz.CommonMsData;
 using pwiz.ProteowizardWrapper;
 using pwiz.Skyline.Model;
@@ -245,20 +246,29 @@ namespace pwiz.SkylineTestUtil
         public ResultsTestDocumentContainer(SrmDocument docInitial, string pathInitial)
             : base(docInitial, pathInitial)
         {
+            EnableWaitForCancelRestart();
         }
 
         public ResultsTestDocumentContainer(SrmDocument docInitial, string pathInitial, bool wait)
             : base(docInitial, pathInitial, wait)
         {
+            EnableWaitForCancelRestart();
         }
 
         /// <summary>
         /// Tests replace the document while loaders are running far more abruptly than the
         /// application does, so they are the ones that see a loader cancel itself over a
         /// superseded document and then restart. Wait that hand-off out rather than reporting it
-        /// as a failed load. See the base property for why this is not on everywhere.
+        /// as a failed load.
+        ///
+        /// <para>On by default here but SETTABLE, not baked in: two callers deliberately turn it
+        /// back off because they depend on the fail-fast it removes. See
+        /// <see cref="MemoryDocumentContainer.WaitForCancelRestart"/>.</para>
         /// </summary>
-        protected override bool WaitForCancelRestart { get { return true; } }
+        private void EnableWaitForCancelRestart()
+        {
+            WaitForCancelRestart = true;
+        }
 
         private const int SLEEP_INTERVAL = 10;
         public const int WAIT_TIME = 5 * 1000;    // 5 seconds
@@ -287,14 +297,19 @@ namespace pwiz.SkylineTestUtil
 
         public void AssertComplete()
         {
-            if (LastProgress == null || LastProgress.IsComplete) return;
-            if (LastProgress.IsError)
-                Assert.Fail(LastProgress.ErrorException.ToString());
+            // Snapshot it. LastProgress is written by loader threads that are demonstrably still
+            // alive here - the wait that just returned ends on a cancel or error status, not on
+            // the loaders exiting - so re-reading the property can throw a NullReferenceException
+            // out of the diagnostic, or describe a different status than the one being reported.
+            var progress = LastProgress;
+            if (progress == null || progress.IsComplete) return;
+            if (progress.IsError)
+                Assert.Fail(progress.ErrorException.ToString());
 
-            Assert.Fail((LastProgress.IsCanceled
+            Assert.Fail((progress.IsCanceled
                              ? "Loader cancelled"
-                             : "Unexpected loader progress state \"" + LastProgress.State + "\"")
-                        + DescribeLoadState());
+                             : "Unexpected loader progress state \"" + progress.State + "\"")
+                        + DescribeLoadState(progress));
         }
 
         /// <summary>
@@ -304,10 +319,9 @@ namespace pwiz.SkylineTestUtil
         /// status alone tells the two apart not at all. This is what turns an intermittent
         /// "Loader cancelled" into something diagnosable from a nightly log.
         /// </summary>
-        private string DescribeLoadState()
+        private string DescribeLoadState(IProgressStatus progress)
         {
             var lines = new List<string>();
-            var progress = LastProgress;
             if (progress != null)
             {
                 lines.Add(string.Format("Progress: {0} at {1}%", progress.State, progress.PercentComplete));
@@ -331,6 +345,16 @@ namespace pwiz.SkylineTestUtil
                 lines.Add("Document is NOT loaded:");
                 lines.AddRange(document.NonLoadedStateDescriptionsFull.Select(why => "  " + why));
             }
+
+            // The loader trace has to be surfaced HERE, not only from
+            // AbstractFunctionalTest.WaitForDocumentLoaded. The failures this instrumentation was
+            // built for - "Loader cancelled", and an import that reaches 100% while the document
+            // never becomes loaded - are reported by this method, from TestData, an assembly that
+            // never calls WaitForDocumentLoaded at all. Surfaced only there, the trace would be
+            // recorded at the moment of the failure and then discarded unread.
+            lines.Add(string.Empty);
+            lines.Add("*** Loader trace (most recent last):");
+            lines.Add(BackgroundLoader.GetLoaderTrace());
             return Environment.NewLine + string.Join(Environment.NewLine, lines);
         }
 

--- a/pwiz_tools/Skyline/TestUtil/TestFunctional.cs
+++ b/pwiz_tools/Skyline/TestUtil/TestFunctional.cs
@@ -1178,6 +1178,16 @@ namespace pwiz.SkylineTestUtil
             return SkylineWindow.Document;
         }
 
+        /// <summary>
+        /// Set SKYLINE_LOADER_TRACE=1 to dump <see cref="BackgroundLoader.GetLoaderTrace"/> after
+        /// every successful document load wait. The trace exists for a failure that is rare enough
+        /// to wait weeks for, and instrumentation nobody has watched work is a poor thing to be
+        /// relying on when it finally happens - this makes it possible to confirm the trace
+        /// records what it should against a PASSING run. Read once, so an unset run pays nothing.
+        /// </summary>
+        private static readonly bool LOADER_TRACE_DUMP =
+            Equals(Environment.GetEnvironmentVariable(@"SKYLINE_LOADER_TRACE"), @"1");
+
         public static SrmDocument WaitForDocumentLoaded(int millis = WAIT_TIME)
         {
             WaitForConditionUI(millis, () =>
@@ -1194,7 +1204,19 @@ namespace pwiz.SkylineTestUtil
                 },
                 () => TextUtil.LineSeparate(
                     $"Expecting loaded document but still not loaded after {millis / 1000} seconds",
-                    TextUtil.LineSeparate(SkylineWindow.DocumentUI.NonLoadedStateDescriptionsFull)));
+                    TextUtil.LineSeparate(SkylineWindow.DocumentUI.NonLoadedStateDescriptionsFull),
+                    // The thread dump taken here is always empty of loader threads, because by now
+                    // they have all exited - so it cannot say what the loader decided. This can.
+                    string.Empty,
+                    "*** Loader trace (most recent last):",
+                    BackgroundLoader.GetLoaderTrace()));
+            if (LOADER_TRACE_DUMP)
+            {
+                // Leading hash keeps SkylineTester from reading these as results.
+                Console.WriteLine(TextUtil.LineSeparate(
+                    "# Loader trace after a SUCCESSFUL WaitForDocumentLoaded:",
+                    BackgroundLoader.GetLoaderTrace()));
+            }
             WaitForProteinMetadataBackgroundLoaderCompletedUI(millis);  // make sure document is stable
             return SkylineWindow.Document;
         }


### PR DESCRIPTION
## Summary

* Fixed eight net10 nightly failures that were one defect: a benign ObjectDisposedException WinForms raises when signalling a marshaled call whose wait handle it already disposed (dotnet/winforms#14996, new in .NET 9). Filtered deliberately narrowly - any Skyline frame anywhere on the stack leaves it reported
* Fixed the pass-1 managed leak from undisposed NHibernate SessionFactories in IonMobilityDb and OptimizationDb. Nine of eleven leaking tests go clean; TestFilesTreeForm from 2,072.8 KB to 0
* Fixed TestAuditLogTutorial's intermittent NullReferenceException - FindOpenForm only sees a dockable form once its handle exists, so it now waits. Was 1 failure in 22 runs, 0 in 609 after
* Stopped a superseded loader's self-cancellation ending a results test's wait. RetentionTimeManager decides "cancelled" by reference comparison against the current document, so it means superseded, not stopped - and the loader restarts. Regression from the net8 port's loosened IsFinal; master is unaffected
* Added a loader lifecycle trace to the "still not loaded" failures. The thread dump taken there is always empty of loader threads, so it cannot say whether the commit ran, was rejected, or never happened

## Test plan

- [x] Solution builds clean in Release/net10; CodeInspection 0 failures
- [x] TestData.dll in full - 358 instances, 0 failures
- [x] 9-hour parallel run, 8 workers, five languages: 47,222 instances. The two tests fixed here did not fail once
- [x] TestAuditLogTutorial 0 in 609 parallel executions (was 1 in 22)
- [x] WatersImsMse...AsSmallMolecules 0 in ~6,000 (was 2 in 291), with the fix's own trace confirming it rides out the race rather than the race having stopped
- [x] Instrumentation verified against a passing run via SKYLINE_LOADER_TRACE, not first trusted at the failure

Reviewed with /code-review max before opening; the seven findings it raised that I could confirm against the source are fixed in the last three commits.

Co-Authored-By: Claude <noreply@anthropic.com>