### PR TITLE
skyline: Stopped an accidental second click from destroying the previous run log

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -438,6 +438,8 @@ Version.cpp
 /pwiz_tools/Skyline/ProtocolBuffers/tmp/*.cs
 /pwiz_tools/Skyline/SkylineTester test list.txt
 /pwiz_tools/Skyline/SkylineTester.log
+# Starting a run rolls the previous log aside to SkylineTester-<timestamp>.log beside it.
+/pwiz_tools/Skyline/SkylineTester-*.log
 SkylineTester Results
 /b.bat
 /b64.bat

--- a/pwiz_tools/Skyline/SkylineTester/CommandShell.cs
+++ b/pwiz_tools/Skyline/SkylineTester/CommandShell.cs
@@ -576,29 +576,37 @@ namespace SkylineTester
         /// </summary>
         public void StartNewLog(string logFile)
         {
-            if (!string.IsNullOrEmpty(logFile) && File.Exists(logFile) && new FileInfo(logFile).Length > 0)
+            LogFile = logFile;  // Set first, so a failure below is logged against the new target
+
+            if (string.IsNullOrEmpty(logFile))
+                return;
+
+            // Everything below is inside the try: the file can be locked, or vanish between two
+            // calls, and File.Exists/FileInfo.Length/Move all throw on that. Nothing about
+            // preparing a log is worth taking the window down at the start of a run.
+            try
             {
-                try
-                {
-                    var directory = Path.GetDirectoryName(logFile) ?? string.Empty;
-                    var baseName = Path.GetFileNameWithoutExtension(logFile);
-                    var extension = Path.GetExtension(logFile);
+                if (!File.Exists(logFile) || new FileInfo(logFile).Length == 0)
+                    return;     // Nothing worth keeping
 
-                    // Remove previously rolled logs first, so at most one is ever kept. Nightly logs
-                    // are named and pruned by Summary in its own directory, and do not match this.
-                    foreach (var oldLog in Directory.GetFiles(directory, baseName + "-*" + extension))
-                        File.Delete(oldLog);
+                var directory = Path.GetDirectoryName(logFile) ?? string.Empty;
+                var baseName = Path.GetFileNameWithoutExtension(logFile);
+                var extension = Path.GetExtension(logFile);
 
-                    File.Move(logFile,
-                        Path.Combine(directory, baseName + DateTime.Now.ToString("-yyyyMMdd-HHmmss") + extension));
-                }
-                catch (Exception e)
-                {
-                    Log("# Could not roll the previous log aside: " + e.Message);
-                }
+                // Remove previously rolled logs first, so at most one is ever kept. Nightly logs
+                // are named and pruned by Summary in its own directory, and do not match this.
+                foreach (var oldLog in Directory.GetFiles(directory, baseName + "-*" + extension))
+                    File.Delete(oldLog);
+
+                File.Move(logFile,
+                    Path.Combine(directory, baseName + DateTime.Now.ToString("-yyyyMMdd-HHmmss") + extension));
             }
-
-            LogFile = logFile;
+            catch (Exception e)
+            {
+                // The old log stays where it is and the run appends to it. Mixed output beats
+                // destroying the record of a long run, which is the reason for rolling at all.
+                Log("# Could not roll the previous log aside: " + e.Message);
+            }
         }
 
         /// <summary>

--- a/pwiz_tools/Skyline/SkylineTester/CommandShell.cs
+++ b/pwiz_tools/Skyline/SkylineTester/CommandShell.cs
@@ -558,19 +558,47 @@ namespace SkylineTester
             set
             {
                 _logFile = value;
-                if (File.Exists(_logFile))
-                {
-                    try
-                    {
-                        File.Delete(_logFile);
-                    }
-// ReSharper disable once EmptyGeneralCatchClause
-                    catch (Exception)
-                    {
-                    }
-                }
                 VisibleLogFile = _logFile;
             }
+        }
+
+        /// <summary>
+        /// Points the shell at <paramref name="logFile"/> for a new run, rolling any existing log
+        /// aside to a timestamped name instead of deleting it.
+        /// <para>Assigning <see cref="LogFile"/> used to delete the file it was given, which made
+        /// starting a run destroy the previous run's log before a single test had produced output.
+        /// A second click on the Run/Stop button while a stop was still in flight was enough to
+        /// lose a nine-hour run that way, so the record of a long run now survives one accidental
+        /// start.</para>
+        /// <para>Exactly one previous log is kept: older rolled logs are removed, so this cannot
+        /// accumulate. A failure to roll leaves the old log in place and is reported to the log
+        /// rather than swallowed - losing the previous log is the thing being prevented.</para>
+        /// </summary>
+        public void StartNewLog(string logFile)
+        {
+            if (!string.IsNullOrEmpty(logFile) && File.Exists(logFile) && new FileInfo(logFile).Length > 0)
+            {
+                try
+                {
+                    var directory = Path.GetDirectoryName(logFile) ?? string.Empty;
+                    var baseName = Path.GetFileNameWithoutExtension(logFile);
+                    var extension = Path.GetExtension(logFile);
+
+                    // Remove previously rolled logs first, so at most one is ever kept. Nightly logs
+                    // are named and pruned by Summary in its own directory, and do not match this.
+                    foreach (var oldLog in Directory.GetFiles(directory, baseName + "-*" + extension))
+                        File.Delete(oldLog);
+
+                    File.Move(logFile,
+                        Path.Combine(directory, baseName + DateTime.Now.ToString("-yyyyMMdd-HHmmss") + extension));
+                }
+                catch (Exception e)
+                {
+                    Log("# Could not roll the previous log aside: " + e.Message);
+                }
+            }
+
+            LogFile = logFile;
         }
 
         /// <summary>

--- a/pwiz_tools/Skyline/SkylineTester/CommandShell.cs
+++ b/pwiz_tools/Skyline/SkylineTester/CommandShell.cs
@@ -586,33 +586,39 @@ namespace SkylineTester
             // preparing a log is worth taking the window down at the start of a run.
             try
             {
-                if (!File.Exists(logFile) || new FileInfo(logFile).Length == 0)
-                    return;     // Nothing worth keeping
-
-                var directory = Path.GetDirectoryName(logFile) ?? string.Empty;
-                var baseName = Path.GetFileNameWithoutExtension(logFile);
-                var extension = Path.GetExtension(logFile);
-
-                var rolledLog = Path.Combine(directory,
-                    baseName + DateTime.Now.ToString("-yyyyMMdd-HHmmss") + extension);
-
-                // Second resolution, so a second roll within the same second would collide and
-                // Move would throw. That destination is a log seconds old at most, unlike the one
-                // being rolled now.
-                if (File.Exists(rolledLog))
-                    File.Delete(rolledLog);
-
-                // Move before pruning. Pruning first would mean a Move that then throws - the log is
-                // the file most likely to be locked at run start - had already discarded the older
-                // rolled log for nothing.
-                File.Move(logFile, rolledLog);
-
-                // Keep exactly one previous log. Nightly logs are named and pruned by Summary in
-                // its own directory, and do not match this pattern.
-                foreach (var oldLog in Directory.GetFiles(directory, baseName + "-*" + extension))
+                // Under LogLock, like every other access to this file: UpdateLog appends under it
+                // and the memory graph reads the whole file under it on a background thread. A
+                // refresh landing mid-roll would otherwise fail the Move with a sharing violation.
+                lock (LogLock)
                 {
-                    if (!string.Equals(oldLog, rolledLog, StringComparison.OrdinalIgnoreCase))
-                        File.Delete(oldLog);
+                    if (!File.Exists(logFile) || new FileInfo(logFile).Length == 0)
+                        return;     // Nothing worth keeping
+
+                    var directory = Path.GetDirectoryName(logFile) ?? string.Empty;
+                    var baseName = Path.GetFileNameWithoutExtension(logFile);
+                    var extension = Path.GetExtension(logFile);
+
+                    var rolledLog = Path.Combine(directory,
+                        baseName + DateTime.Now.ToString("-yyyyMMdd-HHmmss") + extension);
+
+                    // Second resolution, so a second roll within the same second would collide and
+                    // Move would throw. That destination is a log seconds old at most, unlike the
+                    // one being rolled now.
+                    if (File.Exists(rolledLog))
+                        File.Delete(rolledLog);
+
+                    // Move before pruning. Pruning first would mean a Move that then throws - the
+                    // log is the file most likely to be locked at run start - had already discarded
+                    // the older rolled log for nothing.
+                    File.Move(logFile, rolledLog);
+
+                    // Keep exactly one previous log. Nightly logs are named and pruned by Summary in
+                    // its own directory, and do not match this pattern.
+                    foreach (var oldLog in Directory.GetFiles(directory, baseName + "-*" + extension))
+                    {
+                        if (!string.Equals(oldLog, rolledLog, StringComparison.OrdinalIgnoreCase))
+                            File.Delete(oldLog);
+                    }
                 }
             }
             catch (Exception e)

--- a/pwiz_tools/Skyline/SkylineTester/CommandShell.cs
+++ b/pwiz_tools/Skyline/SkylineTester/CommandShell.cs
@@ -593,13 +593,27 @@ namespace SkylineTester
                 var baseName = Path.GetFileNameWithoutExtension(logFile);
                 var extension = Path.GetExtension(logFile);
 
-                // Remove previously rolled logs first, so at most one is ever kept. Nightly logs
-                // are named and pruned by Summary in its own directory, and do not match this.
-                foreach (var oldLog in Directory.GetFiles(directory, baseName + "-*" + extension))
-                    File.Delete(oldLog);
+                var rolledLog = Path.Combine(directory,
+                    baseName + DateTime.Now.ToString("-yyyyMMdd-HHmmss") + extension);
 
-                File.Move(logFile,
-                    Path.Combine(directory, baseName + DateTime.Now.ToString("-yyyyMMdd-HHmmss") + extension));
+                // Second resolution, so a second roll within the same second would collide and
+                // Move would throw. That destination is a log seconds old at most, unlike the one
+                // being rolled now.
+                if (File.Exists(rolledLog))
+                    File.Delete(rolledLog);
+
+                // Move before pruning. Pruning first would mean a Move that then throws - the log is
+                // the file most likely to be locked at run start - had already discarded the older
+                // rolled log for nothing.
+                File.Move(logFile, rolledLog);
+
+                // Keep exactly one previous log. Nightly logs are named and pruned by Summary in
+                // its own directory, and do not match this pattern.
+                foreach (var oldLog in Directory.GetFiles(directory, baseName + "-*" + extension))
+                {
+                    if (!string.Equals(oldLog, rolledLog, StringComparison.OrdinalIgnoreCase))
+                        File.Delete(oldLog);
+                }
             }
             catch (Exception e)
             {

--- a/pwiz_tools/Skyline/SkylineTester/Main.cs
+++ b/pwiz_tools/Skyline/SkylineTester/Main.cs
@@ -231,6 +231,13 @@ namespace SkylineTester
                 Program.UserKilledTestRun = true;
             }
 
+            // The confirmation above pumps the message loop, so the run can finish and Done() can
+            // run while it is up. Without this the buttons would be disabled for a run that no
+            // longer exists, with no Done() left to restore them, and Stop() would dereference a
+            // null _runningTab.
+            if (_runningTab == null)
+                return false;
+
             // Before Stop(), not after: Cancel() kills the process tree on this thread and takes
             // long enough to see, and until it returns the button is still live and still reads
             // "Stop". Every caller of StopByUser gets this, including the Output tab's own button.

--- a/pwiz_tools/Skyline/SkylineTester/Main.cs
+++ b/pwiz_tools/Skyline/SkylineTester/Main.cs
@@ -41,15 +41,11 @@ namespace SkylineTester
             // Stop running task.
             if (_runningTab != null && (_runningTab.IsRunning() || _runningTab.IsWaiting()))
             {
+                // StopByUser disables the buttons before it kills anything. Stopping is otherwise
+                // asynchronous - _runningTab is not cleared until Done() - and until then this same
+                // button means Run again, which is how a nine-hour log was lost.
                 if (StopByUser())
-                {
                     AcceptButton = DefaultButton;   // Only change if the stop is successful
-                    // Stopping is asynchronous - _runningTab is not cleared until Done(). Until it
-                    // is, this same button means Run again, and a second click starts a run, which
-                    // is how a nine-hour log was lost. Take the button out of reach for that window
-                    // instead of relying on nobody clicking into it.
-                    ShowStopInProgress();
-                }
                 return;
             }
 
@@ -235,6 +231,11 @@ namespace SkylineTester
                 Program.UserKilledTestRun = true;
             }
 
+            // Before Stop(), not after: Cancel() kills the process tree on this thread and takes
+            // long enough to see, and until it returns the button is still live and still reads
+            // "Stop". Every caller of StopByUser gets this, including the Output tab's own button.
+            ShowStopInProgress();
+
             Stop();
 
             return true;
@@ -292,8 +293,10 @@ namespace SkylineTester
             {
                 runButton.Text = "Stopping...";
                 runButton.Enabled = false;
+                runButton.Update();     // Paint now - the caller is about to block killing processes
             }
             buttonStop.Enabled = false;
+            buttonStop.Update();
         }
 
         /// <summary>

--- a/pwiz_tools/Skyline/SkylineTester/Main.cs
+++ b/pwiz_tools/Skyline/SkylineTester/Main.cs
@@ -42,7 +42,14 @@ namespace SkylineTester
             if (_runningTab != null && (_runningTab.IsRunning() || _runningTab.IsWaiting()))
             {
                 if (StopByUser())
+                {
                     AcceptButton = DefaultButton;   // Only change if the stop is successful
+                    // Stopping is asynchronous - _runningTab is not cleared until Done(). Until it
+                    // is, this same button means Run again, and a second click starts a run, which
+                    // is how a nine-hour log was lost. Take the button out of reach for that window
+                    // instead of relying on nobody clicking into it.
+                    ShowStopInProgress();
+                }
                 return;
             }
 
@@ -71,8 +78,15 @@ namespace SkylineTester
             if (_runningTab == null)    // note: may be cleared by Run() (e.g., Cancel in DeleteWindow)
                 return;
 
+            // A restart can arrive while a "Stopped" hold is still pending; drop it so the button
+            // is not restored to "&Run" a second into the run that just started.
+            CancelStoppedTimer();
+            _stoppingByUser = false;
             foreach (var runButton in _runButtons)
+            {
                 runButton.Text = "&Stop";
+                runButton.Enabled = true;
+            }
             buttonStop.Enabled = true;
             EnableButtonSelectFailedTests(false); // Until we have failures to select
             AcceptButton = null;
@@ -240,8 +254,10 @@ namespace SkylineTester
         {
             _runningTab = null;
 
-            foreach (var runButton in _runButtons)
-                runButton.Text = "&Run";
+            if (_stoppingByUser)
+                ShowStopped();      // Holds a disabled "Stopped" briefly, then restores "&Run"
+            else
+                ShowReadyToRun();
             buttonStop.Enabled = false;
             AcceptButton = DefaultButton;
 
@@ -259,6 +275,63 @@ namespace SkylineTester
                 _restart = false;
                 Run();
             }
+        }
+
+        private bool _stoppingByUser;
+        private Timer _stoppedTimer;
+
+        /// <summary>
+        /// Disables the Run/Stop buttons and shows "Stopping..." for the window between a stop
+        /// request and <see cref="Done"/>, during which the toggle would otherwise start a new run.
+        /// </summary>
+        private void ShowStopInProgress()
+        {
+            _stoppingByUser = true;
+            CancelStoppedTimer();
+            foreach (var runButton in _runButtons)
+            {
+                runButton.Text = "Stopping...";
+                runButton.Enabled = false;
+            }
+            buttonStop.Enabled = false;
+        }
+
+        /// <summary>
+        /// Holds a disabled "Stopped" for a second so the click that ended the run is visibly
+        /// finished before the same button can start another one.
+        /// </summary>
+        private void ShowStopped()
+        {
+            foreach (var runButton in _runButtons)
+            {
+                runButton.Text = "Stopped";
+                runButton.Enabled = false;
+            }
+
+            CancelStoppedTimer();
+            _stoppedTimer = new Timer { Interval = 1000 };
+            _stoppedTimer.Tick += (s, a) => ShowReadyToRun();
+            _stoppedTimer.Start();
+        }
+
+        private void ShowReadyToRun()
+        {
+            CancelStoppedTimer();
+            _stoppingByUser = false;
+            foreach (var runButton in _runButtons)
+            {
+                runButton.Text = "&Run";
+                runButton.Enabled = true;
+            }
+        }
+
+        private void CancelStoppedTimer()
+        {
+            if (_stoppedTimer == null)
+                return;
+            _stoppedTimer.Stop();
+            _stoppedTimer.Dispose();
+            _stoppedTimer = null;
         }
 
         public string GetBuildRoot()

--- a/pwiz_tools/Skyline/SkylineTester/SkylineTesterWindow.cs
+++ b/pwiz_tools/Skyline/SkylineTester/SkylineTesterWindow.cs
@@ -182,20 +182,33 @@ namespace SkylineTester
 
             Exe = Assembly.GetExecutingAssembly().Location;
             ExeDir = Path.GetDirectoryName(Exe);
+            // Prefer a directory named exactly "Skyline", falling back to the first "Skyline*" only
+            // if there is none above us. The standalone SkylineTester deployment is rooted on a
+            // SkylineTester directory and needs that fallback, but in a source tree the same match
+            // hits the SkylineTester project folder: on net472 the exe is under Skyline\bin\..., so
+            // the walk reached Skyline, while an SDK-style build puts it under
+            // Skyline\SkylineTester\bin\..., which stopped a level early and put the run log and
+            // test list in the project folder instead of beside the solution.
             RootDir = ExeDir;
+            string skylineStarterDir = null;
             while (RootDir != null)
             {
-                if (Path.GetFileName(RootDir).StartsWith("Skyline"))
+                var dirName = Path.GetFileName(RootDir);
+                if (Equals(dirName, "Skyline"))
                     break;
+                if (skylineStarterDir == null && dirName.StartsWith("Skyline"))
+                    skylineStarterDir = RootDir;
                 RootDir = Path.GetDirectoryName(RootDir);
             }
+            RootDir = RootDir ?? skylineStarterDir;
             if (RootDir == null)
                 throw new ApplicationException("Can't find Skyline or SkylineTester directory");
 
             _resultsDir = Path.Combine(RootDir, "SkylineTester Results");
             DefaultLogFile = Path.Combine(RootDir, "SkylineTester.log");
-            if (File.Exists(DefaultLogFile))
-                Try.Multi<Exception>(() => File.Delete(DefaultLogFile));
+            // Deliberately not deleted here. Starting a run rolls it aside, so leaving it means the
+            // last run's log survives a restart of this window instead of being thrown away by the
+            // act of reopening it to go look at that log.
 
             testSet.SelectedIndex = 0;
 

--- a/pwiz_tools/Skyline/SkylineTester/TabBase.cs
+++ b/pwiz_tools/Skyline/SkylineTester/TabBase.cs
@@ -88,8 +88,10 @@ namespace SkylineTester
         {
             MainWindow.ClearLog();
             MainWindow.LastRunName = runName;
+            // No need to create the file here: AddImmediate below appends the run header, which
+            // creates it. Truncating it would also destroy the previous log whenever StartNewLog
+            // failed to roll it aside - the one case rolling exists for.
             MainWindow.CommandShell.StartNewLog(logFile ?? MainWindow.DefaultLogFile);
-            File.WriteAllText(MainWindow.CommandShell.LogFile, "");
             MainWindow.CommandShell.AddImmediate("\n# {0} started {1}".With(runName, DateTime.Now.ToString("f")));
             MainWindow.RefreshLogs();
             if (switchToOutputTab)

--- a/pwiz_tools/Skyline/SkylineTester/TabBase.cs
+++ b/pwiz_tools/Skyline/SkylineTester/TabBase.cs
@@ -88,7 +88,7 @@ namespace SkylineTester
         {
             MainWindow.ClearLog();
             MainWindow.LastRunName = runName;
-            MainWindow.CommandShell.LogFile = logFile ?? MainWindow.DefaultLogFile;
+            MainWindow.CommandShell.StartNewLog(logFile ?? MainWindow.DefaultLogFile);
             File.WriteAllText(MainWindow.CommandShell.LogFile, "");
             MainWindow.CommandShell.AddImmediate("\n# {0} started {1}".With(runName, DateTime.Now.ToString("f")));
             MainWindow.RefreshLogs();

--- a/pwiz_tools/Skyline/SkylineTester/TabQuality.cs
+++ b/pwiz_tools/Skyline/SkylineTester/TabQuality.cs
@@ -93,9 +93,8 @@ namespace SkylineTester
 
             MainWindow.TestsRun = 0;
 
-            // Rolls the previous log aside rather than deleting it, so an accidental start does not
-            // destroy the record of a long run. StartNewLog leaves no file behind to delete.
-            MainWindow.CommandShell.StartNewLog(MainWindow.DefaultLogFile);
+            // No roll here: StartLog below does it for this same file. It used to delete the log
+            // at this point, which is what made starting a run destroy the previous run's record.
             MainWindow.NewNightlyRun = _lastRun = new Summary.Run
             {
                 Date = DateTime.Now

--- a/pwiz_tools/Skyline/SkylineTester/TabQuality.cs
+++ b/pwiz_tools/Skyline/SkylineTester/TabQuality.cs
@@ -93,9 +93,9 @@ namespace SkylineTester
 
             MainWindow.TestsRun = 0;
 
-            MainWindow.CommandShell.LogFile = MainWindow.DefaultLogFile;
-            if (File.Exists(MainWindow.DefaultLogFile))
-                Try.Multi<Exception>(() => File.Delete(MainWindow.DefaultLogFile), 4, false);
+            // Rolls the previous log aside rather than deleting it, so an accidental start does not
+            // destroy the record of a long run. StartNewLog leaves no file behind to delete.
+            MainWindow.CommandShell.StartNewLog(MainWindow.DefaultLogFile);
             MainWindow.NewNightlyRun = _lastRun = new Summary.Run
             {
                 Date = DateTime.Now


### PR DESCRIPTION
## Summary

* Disabled the Run/Stop buttons and showed "Stopping..." until the run is actually done, then a brief "Stopped". Stopping is asynchronous - `_runningTab` is not cleared until `Done()` - so until then the same button silently meant Run, and a second click started a new run.
* Rolled the log aside to `SkylineTester-<timestamp>.log` instead of deleting it, keeping exactly one previous log. One level of undo is what this needs, and a fixed cap of two files means the accumulation that has never happened in ten years still cannot start.
* Replaced the `File.Delete` hidden inside the `CommandShell.LogFile` property setter with an explicit `StartNewLog`, so no future caller can destroy a log by assigning a property, and a failed roll is reported instead of swallowed.
* Fixed two further paths that destroyed the log independently of the setter: `TabBase.StartLog` truncated it with `File.WriteAllText(..., "")` and `TabQuality.Run` deleted it outright.
* Ignored the rolled log beside the existing entry.

A nine-hour leak-test log was lost this way. Over RDP it was not obvious the first Stop click had registered, so Stop was clicked again; the second click started a run, and starting a run deleted the log before a single test produced output. No copy exists anywhere - `DefaultLogFile` is one fixed path.

Only the Output tab was safe, and by accident of layout: it has its own dedicated `buttonStop` that is never a Run toggle. The Quality and Nightly tabs share `_runButtons`, whose `Text` flips between "&Run" and "&Stop" - and those are the tempting ones, because they show the graph worth watching.

Nightly runs are unaffected: they pass their own log path and are already timestamped and pruned to 90 runs by `Summary.GetLogFile()`, which the roll deliberately does not touch.

Reported by Brendan.

See ai/todos/active/TODO-20260901_skylinetester_stop_log_loss.md

## Test plan

- [x] Solution build clean
- [x] CodeInspection - 0 failures
- [x] Interactive: start a Quality run, click Stop twice quickly - second click does nothing, log survives
- [x] Interactive: button reads Stop -> Stopping... -> Stopped -> Run, disabled through the middle two
- [x] Interactive: second run rolls the log to a timestamp; a third leaves still exactly one rolled file
- [x] Interactive: a normally-completed run returns to "&Run" with no "Stopped" pause

## Not addressed here

The .NET 10 port puts `SkylineTester.log` and `SkylineTester test list.txt` in `pwiz_tools/Skyline/SkylineTester/` rather than `pwiz_tools/Skyline/`. `SkylineTesterWindow` derives `RootDir` by walking up from the exe to the first directory whose name starts with "Skyline"; on net472 that lands on `Skyline`, but the net10 output path is `Skyline\SkylineTester\bin\x64\Release\net10.0-windows`, so the walk stops early on `SkylineTester`. That belongs to the net10 port, not here, and the `.gitignore` entries in this PR deliberately keep the master locations rather than widening to cover the wrong one.

Co-Authored-By: Claude <noreply@anthropic.com>
