### PR TITLE
skyline: Fixed the small-molecule conversion tests racing the library loader

### DIFF
--- a/pwiz_tools/Skyline/TestUtil/AsSmallMoleculeTestUtil.cs
+++ b/pwiz_tools/Skyline/TestUtil/AsSmallMoleculeTestUtil.cs
@@ -226,6 +226,13 @@ namespace pwiz.SkylineTestUtil
                     {
                         docContainer.SetDocument(docLoad, null, true);
                         docContainer.AssertComplete();
+                        // ConvertToSmallMolecules skips library conversion entirely unless
+                        // Libraries.IsLoaded, so the conversion under test depends on winning a
+                        // race with the library loader. Whichever conversion test ran first in a
+                        // process lost it: no converted .blib was written, the converted document
+                        // had no library dot product where the original did, and the comparison
+                        // below failed. Later tests in the same process passed on a warm cache.
+                        docContainer.WaitForLibrariesLoaded();
                         doc = docContainer.Document;
                     }
                 }
@@ -280,6 +287,7 @@ namespace pwiz.SkylineTestUtil
             {
                 docContainer.SetDocument(docResults, null, true);
                 docContainer.AssertComplete();
+                docContainer.WaitForLibrariesLoaded();
                 doc = docContainer.Document;
             }
             AssertEx.ConvertedSmallMoleculeDocumentIsSimilar(docOriginal, doc, Path.GetDirectoryName(docPath), mode);

--- a/pwiz_tools/Skyline/TestUtil/ResultsUtil.cs
+++ b/pwiz_tools/Skyline/TestUtil/ResultsUtil.cs
@@ -295,6 +295,12 @@ namespace pwiz.SkylineTestUtil
                     return;
                 Thread.Sleep(SLEEP_INTERVAL);
             }
+            // One last look: the loop sleeps after its final check, so the libraries may have
+            // finished during that sleep, and a timeout below SLEEP_INTERVAL yields no cycles
+            // at all and must still get one check rather than failing without ever looking.
+            if (Document.Settings.PeptideSettings.Libraries.IsLoaded)
+                return;
+
             Assert.Fail("Libraries still not loaded after {0} seconds: {1}",
                 waitCycles*SLEEP_INTERVAL/1000,
                 Document.Settings.PeptideSettings.Libraries.IsNotLoadedExplained);

--- a/pwiz_tools/Skyline/TestUtil/ResultsUtil.cs
+++ b/pwiz_tools/Skyline/TestUtil/ResultsUtil.cs
@@ -254,6 +254,7 @@ namespace pwiz.SkylineTestUtil
 
         private const int SLEEP_INTERVAL = 10;
         public const int WAIT_TIME = 5 * 1000;    // 5 seconds
+        public const int WAIT_TIME_LIBRARIES = 60 * 1000;    // 60 seconds
 
         private static int GetWaitCycles(int millis = WAIT_TIME)
         {
@@ -275,6 +276,28 @@ namespace pwiz.SkylineTestUtil
         public bool AnyProcessing
         {
             get { return BackgroundLoaders.Any(l => l.AnyProcessing()); }
+        }
+
+        /// <summary>
+        /// Waits for the document's spectral libraries to finish loading.
+        /// <see cref="AssertComplete"/> only inspects the chromatogram loader's progress, so it
+        /// can return while the library manager is still working. A caller that then reads
+        /// Settings.PeptideSettings.Libraries.IsLoaded sees false purely because it got there
+        /// first, and silently takes whatever path the code has for a library-less document.
+        /// A document with no libraries reports itself loaded, so this returns immediately.
+        /// </summary>
+        public void WaitForLibrariesLoaded(int millis = WAIT_TIME_LIBRARIES)
+        {
+            int waitCycles = GetWaitCycles(millis);
+            for (int i = 0; i < waitCycles; i++)
+            {
+                if (Document.Settings.PeptideSettings.Libraries.IsLoaded)
+                    return;
+                Thread.Sleep(SLEEP_INTERVAL);
+            }
+            Assert.Fail("Libraries still not loaded after {0} seconds: {1}",
+                waitCycles*SLEEP_INTERVAL/1000,
+                Document.Settings.PeptideSettings.Libraries.IsNotLoadedExplained);
         }
 
         public void AssertComplete()


### PR DESCRIPTION
## The failure

`RefineConvertToSmallMoleculesTest` and `RefineConvertToSmallMoleculeMassesAndNamesTest` fail whichever one runs **first** in a TestRunner process, and pass on every later run in that process:

```
TransitionGroupChromInfo results differ:
  YLGAYLLATLGGNASPSAQDVLK Charge 2  vs  pep_YLGAYLLATLGGNASPSAQDVLK Charge [M+2H]
  [0] [0] LibraryDotProduct 0.72051907 vs (null)
```

Reversing the order moves the failure to the other test, so it is ordering, not mode:

| run order | converted `.blib` written | failed |
|---|---|---|
| `formulas`, then `masses_and_names` | only `masses_and_names` | `formulas` |
| `masses_and_names`, then `formulas` | only `formulas` | `masses_and_names` |

## Cause

`RefinementSettings.ConvertToSmallMolecules` converts libraries only when the document reports them loaded:

```csharp
var canConvertLibraries =
    invertChargesMode == ConvertToSmallMoleculesChargesMode.none &&
    mode != ConvertToSmallMoleculesMode.masses_only &&
    document.Settings.PeptideSettings.Libraries.IsLoaded;
```

That is the right call for a document that never loaded a library. The problem is on the test side: `AsSmallMoleculeTestUtil.ConvertToSmallMolecules` takes its document from `ResultsTestDocumentContainer.AssertComplete()`, which only inspects the **chromatogram** loader's progress and returns while the library manager is still working.

So on a cold cache the conversion reads `IsLoaded` as false, skips the library branch, and yields a converted document with no library dot product while the original has one. On a warm cache the library is already present and the two agree.

## This was a coverage hole, not only a flake

In the runs that failed, no `worm.1.1.converted_to_small_molecules.blib` was written at all and the converted precursors carried no `<bibliospec_spectrum_info>`. Library conversion was not being exercised in those runs — the test failed only because the two sides then disagreed about a dot product.

## Fix

Wait for the libraries before converting. A document with no libraries reports itself loaded, so this is a no-op everywhere else.

## Verification

Reproduced the order dependence, then re-ran both orderings after the change: all orderings pass, and both `formulas` and `masses_and_names` now write a converted `.blib` regardless of order. `masses_only` still writes none, which is correct — that mode is excluded by the `mode != masses_only` term.

Built and run on the .NET 10 port branch (#4619), where all three touched files are byte-identical to `master`; this PR exists to get it exercised on `master` itself. Every API it uses is already used in the same file on `master`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0182oRXbeKQGEpF1kTkdQAsr