### PR TITLE
osprey: Added a pipeline architecture and sidecar file contract document

### DIFF
--- a/pwiz_tools/Osprey/Osprey-workflow.html
+++ b/pwiz_tools/Osprey/Osprey-workflow.html
@@ -74,7 +74,7 @@
 </header>
 
 <main>
-<svg class="pipeline" viewBox="0 0 1200 2868" xmlns="http://www.w3.org/2000/svg">
+<svg class="pipeline" viewBox="0 0 1200 2884" xmlns="http://www.w3.org/2000/svg">
 <defs>
   <!-- Arrowhead for control flow between stages -->
   <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5"
@@ -152,6 +152,7 @@
     .task-hdr-io   { font-family: ui-monospace, SFMono-Regular, monospace;
                      font-size: 10px; fill: #37474f; }
     .task-hdr-key  { font-weight: 700; fill: #5e35b1; }
+    .subtitle a    { fill: #1565c0; text-decoration: underline; }
     .task-hdr-relay{ font-size: 9px; font-weight: 700; fill: #6a1b9a;
                      text-transform: uppercase; letter-spacing: 0.5px; }
 
@@ -184,7 +185,7 @@
 <!-- ================================================================= -->
 <!-- LEGEND                                                             -->
 <!-- ================================================================= -->
-<g transform="translate(40, 90)">
+<g transform="translate(40, 106)">
   <text class="legend-title">Port status</text>
   <g transform="translate(0, 16)">
     <rect class="st-done"    x="0"   y="0" width="16" height="12"/>
@@ -202,7 +203,7 @@
     <rect class="st-missing" x="830" y="0" width="16" height="12"/>
     <text class="legend-label" x="852" y="10">missing / stubbed</text>
 
-    <rect class="st-n/a"     x="980" y="0" width="16" height="12"/>
+    <rect class="st-na"      x="980" y="0" width="16" height="12"/>
     <text class="legend-label" x="1002" y="10">not applicable</text>
   </g>
 
@@ -222,7 +223,7 @@
 <!-- ================================================================= -->
 <!-- INPUTS                                                             -->
 <!-- ================================================================= -->
-<g transform="translate(0, 190)">
+<g transform="translate(0, 206)">
   <text class="phase-label" x="40" y="0">inputs</text>
 
   <rect class="input-pill" x="260"  y="16" width="260" height="48" rx="24"/>
@@ -235,13 +236,13 @@
 </g>
 
 <!-- Arrows from inputs into the PerFileScoring task banner -->
-<path class="flow" d="M 390 254 L 390 268" marker-end="url(#arrow)"/>
-<path class="flow" d="M 810 254 L 810 268" marker-end="url(#arrow)"/>
+<path class="flow" d="M 390 270 L 390 284" marker-end="url(#arrow)"/>
+<path class="flow" d="M 810 270 L 810 284" marker-end="url(#arrow)"/>
 
 <!-- ================================================================= -->
 <!-- TASK 1 of 4: PerFileScoring (Stages 1-4, per-file fan-out)         -->
 <!-- ================================================================= -->
-<g transform="translate(0, 270)">
+<g transform="translate(0, 286)">
   <rect class="task-hdr-bg" x="120" y="0" width="960" height="96" rx="8"/>
   <text x="140" y="22" class="task-hdr-name">&#9656; --task PerFileScoring</text>
   <text x="1060" y="22" text-anchor="end" class="task-hdr-role">per-run fan-out &#183; any batch size, 1..N nodes</text>
@@ -252,13 +253,13 @@
 </g>
 
 <!-- Arrows from the PerFileScoring banner into Stage 1 and Stage 2 -->
-<path class="flow" d="M 390 368 L 390 410" marker-end="url(#arrow)"/>
-<path class="flow" d="M 810 368 L 810 410" marker-end="url(#arrow)"/>
+<path class="flow" d="M 390 384 L 390 426" marker-end="url(#arrow)"/>
+<path class="flow" d="M 810 384 L 810 426" marker-end="url(#arrow)"/>
 
 <!-- ================================================================= -->
 <!-- STAGE 1 + STAGE 2 (parallel: library prep / mzML prep)             -->
 <!-- ================================================================= -->
-<g transform="translate(0, 402)">
+<g transform="translate(0, 418)">
   <!-- Stage 1 container -->
   <rect class="phase-bg" x="40"  y="10" width="540" height="180" rx="6"/>
   <text class="phase-label" x="60"  y="30">stage 1</text>
@@ -297,13 +298,13 @@
 </g>
 
 <!-- Arrows down into calibration -->
-<path class="flow" d="M 310 612 L 310 642 L 600 642 L 600 672" marker-end="url(#arrow)"/>
-<path class="flow" d="M 890 612 L 890 642 L 600 642" />
+<path class="flow" d="M 310 628 L 310 658 L 600 658 L 600 688" marker-end="url(#arrow)"/>
+<path class="flow" d="M 890 628 L 890 658 L 600 658" />
 
 <!-- ================================================================= -->
 <!-- STAGE 3 CALIBRATION                                                 -->
 <!-- ================================================================= -->
-<g transform="translate(0, 672)">
+<g transform="translate(0, 688)">
   <rect class="phase-bg" x="40" y="0" width="1120" height="540" rx="6"/>
   <text class="phase-label" x="60" y="24">stage 3</text>
   <text class="phase-title" x="60" y="42">Calibration (a.k.a. recalibration)</text>
@@ -357,12 +358,12 @@
 </g>
 
 <!-- Arrow from calibration to main search -->
-<path class="flow" d="M 600 1212 L 600 1252" marker-end="url(#arrow)"/>
+<path class="flow" d="M 600 1228 L 600 1268" marker-end="url(#arrow)"/>
 
 <!-- ================================================================= -->
 <!-- STAGE 4 MAIN FIRST-PASS SEARCH                                     -->
 <!-- ================================================================= -->
-<g transform="translate(0, 1252)">
+<g transform="translate(0, 1268)">
   <rect class="phase-bg" x="40" y="0" width="1120" height="200" rx="6"/>
   <text class="phase-label" x="60" y="24">stage 4</text>
   <text class="phase-title" x="60" y="42">Main first-pass search</text>
@@ -388,13 +389,13 @@
 <!-- ================================================================= -->
 <!-- TASK 2 of 4: FirstPassFDR (Stage 5, join / coordinator node)        -->
 <!-- ================================================================= -->
-<path class="flow" d="M 600 1452 L 600 1466" marker-end="url(#arrow)"/>
+<path class="flow" d="M 600 1468 L 600 1482" marker-end="url(#arrow)"/>
 
-<g transform="translate(0, 1468)">
+<g transform="translate(0, 1484)">
   <rect class="task-hdr-bg" x="120" y="0" width="960" height="96" rx="8"/>
   <text x="140" y="22" class="task-hdr-name">&#9656; --task FirstPassFDR</text>
   <text x="1060" y="22" text-anchor="end" class="task-hdr-role">join &#183; 1 node &#183; holds O(distinct), never O(runs x entries)</text>
-  <text x="140" y="40" class="task-hdr-io"><tspan class="task-hdr-key">in&#160;&#160;</tspan><tspan class="sc-run">&lt;stem&gt;.scores.parquet</tspan>  (every run, via --input-scores)</text>
+  <text x="140" y="40" class="task-hdr-io"><tspan class="task-hdr-key">in&#160;&#160;</tspan><tspan class="sc-run">&lt;stem&gt;.scores.parquet</tspan>, <tspan class="sc-run">&lt;stem&gt;.calibration.json</tspan>  (every run, via --input-scores)</text>
   <text x="140" y="56" class="task-hdr-io"><tspan class="task-hdr-key">out&#160;</tspan><tspan class="sc-run">&lt;stem&gt;.1st-pass.fdr_scores.bin</tspan>, <tspan class="sc-run">&lt;stem&gt;.reconciliation.json</tspan> (Stage 5&#8594;6 boundary)   &#183;   validity  <tspan class="sc-run">&lt;out&gt;.FirstPassFDR.osprey.task</tspan></text>
   <text x="140" y="72" class="task-hdr-io"><tspan class="task-hdr-key">out&#160;</tspan><tspan class="sc-exp">&lt;blib-stem&gt;.1st-pass.fdr_experiment.bin</tspan>, <tspan class="sc-exp">&lt;stem&gt;.1st-pass.model.json</tspan> (frozen pass-1 model, for the frozen pass-2 modes)</text>
   <text x="1060" y="88" text-anchor="end" class="task-hdr-relay">relay: both experiment-wide files to EVERY downstream node</text>
@@ -403,13 +404,13 @@
 <!-- ================================================================= -->
 <!-- STAGE 5 FIRST-PASS FDR + RECONCILIATION PLANNING                   -->
 <!-- ================================================================= -->
-<path class="flow" d="M 600 1564 L 600 1582" marker-end="url(#arrow)"/>
+<path class="flow" d="M 600 1580 L 600 1598" marker-end="url(#arrow)"/>
 
-<g transform="translate(0, 1584)">
+<g transform="translate(0, 1600)">
   <rect class="phase-bg" x="40" y="0" width="1120" height="500" rx="8"/>
   <text class="phase-label" x="60" y="24">stage 5</text>
   <text class="phase-title" x="60" y="42">First-pass FDR + reconciliation planning</text>
-  <text class="phase-shape-join" x="1115" y="24" text-anchor="end">join — needs all-run representation</text>
+  <text class="phase-shape-join" x="1115" y="24" text-anchor="end">join - needs all-run representation</text>
   <text class="phase-note"  x="60" y="58">First-pass FDR across all files. Runs Percolator SVM on the joined per-file scores, computes cross-run consensus RTs,</text>
   <text class="phase-note"  x="60" y="72">refits per-file calibration, and emits a per-(file, entry) reconciliation plan. All work that needs all-file representation lives here.</text>
 
@@ -455,9 +456,9 @@
 <!-- ================================================================= -->
 <!-- TASK 3 of 4: PerFileRescoring (Stage 6, second per-file fan-out)    -->
 <!-- ================================================================= -->
-<path class="flow" d="M 600 2084 L 600 2098" marker-end="url(#arrow)"/>
+<path class="flow" d="M 600 2100 L 600 2114" marker-end="url(#arrow)"/>
 
-<g transform="translate(0, 2100)">
+<g transform="translate(0, 2116)">
   <rect class="task-hdr-bg" x="120" y="0" width="960" height="96" rx="8"/>
   <text x="140" y="22" class="task-hdr-name">&#9656; --task PerFileRescoring</text>
   <text x="1060" y="22" text-anchor="end" class="task-hdr-role">per-run fan-out &#183; reads its own runs + the experiment baseline only</text>
@@ -470,15 +471,15 @@
 <!-- ================================================================= -->
 <!-- STAGE 6 PER-FILE RESCORE (SECOND PER-FILE FAN-OUT)                  -->
 <!-- ================================================================= -->
-<path class="flow" d="M 600 2196 L 600 2214" marker-end="url(#arrow)"/>
+<path class="flow" d="M 600 2212 L 600 2230" marker-end="url(#arrow)"/>
 
-<g transform="translate(0, 2216)">
+<g transform="translate(0, 2232)">
   <rect class="phase-bg" x="40" y="0" width="1120" height="260" rx="6"/>
   <text class="phase-label" x="60" y="24">stage 6</text>
   <text class="phase-title" x="60" y="42">Per-file rescore + gap-fill + parquet write-back</text>
-  <text class="phase-shape-fanout" x="1115" y="24" text-anchor="end">per-run fan-out — 1..N nodes</text>
+  <text class="phase-shape-fanout" x="1115" y="24" text-anchor="end">per-run fan-out - 1..N nodes</text>
   <text class="phase-note"  x="60" y="58">Second per-file fan-out. Each file independently reloads its mzML, re-invokes the search engine with the reconciled boundary overrides,</text>
-  <text class="phase-note"  x="60" y="72">runs the gap-fill two-pass for missing precursors, and writes reconciled scores back to its .scores.parquet. No cross-file work.</text>
+  <text class="phase-note"  x="60" y="72">runs the gap-fill two-pass for missing precursors, and writes a SEPARATE &lt;stem&gt;.scores-reconciled.parquet - never back over its input. No cross-run work.</text>
 
   <rect class="st-done" x="80" y="90" width="1040" height="42" rx="4"/>
   <text class="stage-title" x="600" y="110" text-anchor="middle">Per-file rescore at reconciled boundaries</text>
@@ -499,15 +500,15 @@
 <!-- ================================================================= -->
 <!-- TASK 4 of 4: SecondPassFDR (Stage 7, join / aggregator node)        -->
 <!-- ================================================================= -->
-<path class="flow" d="M 600 2476 L 600 2490" marker-end="url(#arrow)"/>
+<path class="flow" d="M 600 2492 L 600 2506" marker-end="url(#arrow)"/>
 
-<g transform="translate(0, 2492)">
+<g transform="translate(0, 2508)">
   <rect class="task-hdr-bg" x="120" y="0" width="960" height="96" rx="8"/>
   <text x="140" y="22" class="task-hdr-name">&#9656; --task SecondPassFDR</text>
   <text x="1060" y="22" text-anchor="end" class="task-hdr-role">join &#183; 1 node &#183; final aggregation</text>
   <text x="140" y="40" class="task-hdr-io"><tspan class="task-hdr-key">in&#160;&#160;</tspan><tspan class="sc-run">&lt;stem&gt;.scores-reconciled.parquet</tspan> (via --input-scores; falls back to <tspan class="sc-run">&lt;stem&gt;.scores.parquet</tspan> for no-work runs)</text>
   <text x="140" y="56" class="task-hdr-io"><tspan class="task-hdr-key">in&#160;&#160;</tspan><tspan class="sc-exp">&lt;blib-stem&gt;.1st-pass.fdr_experiment.bin</tspan>, <tspan class="sc-exp">&lt;stem&gt;.1st-pass.model.json</tspan>, <tspan class="sc-run">&lt;stem&gt;.reconciliation.json</tspan>, <tspan class="sc-run">.calibration.json</tspan></text>
-  <text x="140" y="72" class="task-hdr-io"><tspan class="task-hdr-key">out&#160;</tspan><tspan class="sc-exp">&lt;output&gt;.blib</tspan>, <tspan class="sc-exp">&lt;blib-stem&gt;.2nd-pass.fdr_experiment.bin</tspan>, <tspan class="sc-run">&lt;stem&gt;.2nd-pass.fdr_scores.bin</tspan> (where no worker ran)</text>
+  <text x="140" y="72" class="task-hdr-io"><tspan class="task-hdr-key">out&#160;</tspan><tspan class="sc-exp">&lt;output&gt;.blib</tspan>, <tspan class="sc-exp">&lt;blib-stem&gt;.2nd-pass.fdr_experiment.bin</tspan>, <tspan class="sc-run">&lt;stem&gt;.2nd-pass.fdr_scores.bin</tspan> (where no worker ran)   &#183;   validity  <tspan class="sc-exp">&lt;out&gt;.SecondPassFDR.osprey.task</tspan></text>
   <text x="1060" y="88" text-anchor="end" class="task-hdr-relay">relay: every run's reconciled set, with its .osprey.task stamps</text>
 </g>
 
@@ -522,9 +523,9 @@
 <!-- experiment-level FDR, first-pass protein FDR, reconciliation       -->
 <!-- planning) under the FirstPassFDR phase.                            -->
 <!-- ================================================================= -->
-<path class="flow" d="M 600 2588 L 600 2606" marker-end="url(#arrow)"/>
+<path class="flow" d="M 600 2604 L 600 2622" marker-end="url(#arrow)"/>
 
-<g transform="translate(0, 2608)">
+<g transform="translate(0, 2624)">
   <rect class="phase-bg" x="40" y="0" width="1120" height="230" rx="6"/>
   <text class="phase-label" x="60" y="24">stage 7</text>
   <text class="phase-title" x="60" y="42">Post-join: second-pass Percolator + protein FDR + .blib output</text>

--- a/pwiz_tools/Osprey/Osprey-workflow.html
+++ b/pwiz_tools/Osprey/Osprey-workflow.html
@@ -74,7 +74,7 @@
 </header>
 
 <main>
-<svg class="pipeline" viewBox="0 0 1200 2700" xmlns="http://www.w3.org/2000/svg">
+<svg class="pipeline" viewBox="0 0 1200 2868" xmlns="http://www.w3.org/2000/svg">
 <defs>
   <!-- Arrowhead for control flow between stages -->
   <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5"
@@ -152,6 +152,19 @@
     .task-hdr-io   { font-family: ui-monospace, SFMono-Regular, monospace;
                      font-size: 10px; fill: #37474f; }
     .task-hdr-key  { font-weight: 700; fill: #5e35b1; }
+    .task-hdr-relay{ font-size: 9px; font-weight: 700; fill: #6a1b9a;
+                     text-transform: uppercase; letter-spacing: 0.5px; }
+
+    /* File scope: which tier a named artifact belongs to. Per-run files fan  */
+    /* out with their own run; experiment-wide files must reach EVERY node    */
+    /* and form the resident baseline a per-run loop runs against; caches are */
+    /* rebuildable and live in --work-dir. See docs/00-pipeline-architecture. */
+    .sc-run        { fill: #00695c; font-weight: 700; }
+    .sc-exp        { fill: #c62828; font-weight: 700; }
+    .sc-cache      { fill: #757575; }
+    .sc-run-sw     { fill: #b2dfdb; stroke: #00695c; stroke-width: 1; }
+    .sc-exp-sw     { fill: #ffcdd2; stroke: #c62828; stroke-width: 1; }
+    .sc-cache-sw   { fill: #eeeeee; stroke: #757575; stroke-width: 1; }
   </style>
 </defs>
 
@@ -162,6 +175,9 @@
   <text class="title">Osprey DIA search pipeline</text>
   <text class="subtitle" y="22">
     Rust reference (osprey) vs C# implementation (Osprey)  -  end-to-end cross-impl parity from Stage 1 through Stage 7 + .blib on Stellar + Astral 3-file.
+  </text>
+  <text class="subtitle" y="38">
+    Architecture and the sidecar file contract - which artifact is whose, and what each HPC node must be shipped:  <a href="https://github.com/ProteoWizard/pwiz/blob/master/pwiz_tools/Osprey/docs/00-pipeline-architecture.md">docs/00-pipeline-architecture.md</a>
   </text>
 </g>
 
@@ -189,12 +205,24 @@
     <rect class="st-n/a"     x="980" y="0" width="16" height="12"/>
     <text class="legend-label" x="1002" y="10">not applicable</text>
   </g>
+
+  <text class="legend-title" y="46">File scope</text>
+  <g transform="translate(0, 62)">
+    <rect class="sc-run-sw"   x="0"   y="0" width="16" height="12"/>
+    <text class="legend-label" x="22" y="10">per-run &#183; fans out with its own run</text>
+
+    <rect class="sc-exp-sw"   x="280" y="0" width="16" height="12"/>
+    <text class="legend-label" x="302" y="10">experiment-wide &#183; relay to EVERY node; the resident baseline</text>
+
+    <rect class="sc-cache-sw" x="720" y="0" width="16" height="12"/>
+    <text class="legend-label" x="742" y="10">shared cache &#183; --work-dir, rebuildable</text>
+  </g>
 </g>
 
 <!-- ================================================================= -->
 <!-- INPUTS                                                             -->
 <!-- ================================================================= -->
-<g transform="translate(0, 150)">
+<g transform="translate(0, 190)">
   <text class="phase-label" x="40" y="0">inputs</text>
 
   <rect class="input-pill" x="260"  y="16" width="260" height="48" rx="24"/>
@@ -207,28 +235,30 @@
 </g>
 
 <!-- Arrows from inputs into the PerFileScoring task banner -->
-<path class="flow" d="M 390 214 L 390 228" marker-end="url(#arrow)"/>
-<path class="flow" d="M 810 214 L 810 228" marker-end="url(#arrow)"/>
+<path class="flow" d="M 390 254 L 390 268" marker-end="url(#arrow)"/>
+<path class="flow" d="M 810 254 L 810 268" marker-end="url(#arrow)"/>
 
 <!-- ================================================================= -->
 <!-- TASK 1 of 4: PerFileScoring (Stages 1-4, per-file fan-out)         -->
 <!-- ================================================================= -->
-<g transform="translate(0, 230)">
-  <rect class="task-hdr-bg" x="120" y="0" width="960" height="64" rx="8"/>
+<g transform="translate(0, 270)">
+  <rect class="task-hdr-bg" x="120" y="0" width="960" height="96" rx="8"/>
   <text x="140" y="22" class="task-hdr-name">&#9656; --task PerFileScoring</text>
-  <text x="1060" y="22" text-anchor="end" class="task-hdr-role">per-file fan-out &#183; N nodes</text>
+  <text x="1060" y="22" text-anchor="end" class="task-hdr-role">per-run fan-out &#183; any batch size, 1..N nodes</text>
   <text x="140" y="40" class="task-hdr-io"><tspan class="task-hdr-key">in&#160;&#160;</tspan>spectral library (.blib / DIA-NN TSV), DIA mzML file(s)  &mdash; via  -i</text>
-  <text x="140" y="56" class="task-hdr-io"><tspan class="task-hdr-key">out&#160;</tspan>&lt;stem&gt;.scores.parquet, &lt;stem&gt;.calibration.json   &#183;   validity sidecar  &lt;out&gt;.PerFileScoring.osprey.task</text>
+  <text x="140" y="56" class="task-hdr-io"><tspan class="task-hdr-key">out&#160;</tspan><tspan class="sc-run">&lt;stem&gt;.scores.parquet</tspan>, <tspan class="sc-run">&lt;stem&gt;.calibration.json</tspan>   &#183;   validity sidecar  <tspan class="sc-run">&lt;out&gt;.PerFileScoring.osprey.task</tspan></text>
+  <text x="140" y="72" class="task-hdr-io"><tspan class="task-hdr-key">out&#160;</tspan><tspan class="sc-cache">&lt;stem&gt;.spectra.bin</tspan>, <tspan class="sc-cache">&lt;library-leaf&gt;.libcache</tspan>   &#183;   caches, written to --work-dir / --cache-dir; rebuildable</text>
+  <text x="1060" y="88" text-anchor="end" class="task-hdr-relay">relay: each node needs only its own runs</text>
 </g>
 
 <!-- Arrows from the PerFileScoring banner into Stage 1 and Stage 2 -->
-<path class="flow" d="M 390 296 L 390 338" marker-end="url(#arrow)"/>
-<path class="flow" d="M 810 296 L 810 338" marker-end="url(#arrow)"/>
+<path class="flow" d="M 390 368 L 390 410" marker-end="url(#arrow)"/>
+<path class="flow" d="M 810 368 L 810 410" marker-end="url(#arrow)"/>
 
 <!-- ================================================================= -->
 <!-- STAGE 1 + STAGE 2 (parallel: library prep / mzML prep)             -->
 <!-- ================================================================= -->
-<g transform="translate(0, 330)">
+<g transform="translate(0, 402)">
   <!-- Stage 1 container -->
   <rect class="phase-bg" x="40"  y="10" width="540" height="180" rx="6"/>
   <text class="phase-label" x="60"  y="30">stage 1</text>
@@ -267,13 +297,13 @@
 </g>
 
 <!-- Arrows down into calibration -->
-<path class="flow" d="M 310 540 L 310 570 L 600 570 L 600 600" marker-end="url(#arrow)"/>
-<path class="flow" d="M 890 540 L 890 570 L 600 570" />
+<path class="flow" d="M 310 612 L 310 642 L 600 642 L 600 672" marker-end="url(#arrow)"/>
+<path class="flow" d="M 890 612 L 890 642 L 600 642" />
 
 <!-- ================================================================= -->
 <!-- STAGE 3 CALIBRATION                                                 -->
 <!-- ================================================================= -->
-<g transform="translate(0, 600)">
+<g transform="translate(0, 672)">
   <rect class="phase-bg" x="40" y="0" width="1120" height="540" rx="6"/>
   <text class="phase-label" x="60" y="24">stage 3</text>
   <text class="phase-title" x="60" y="42">Calibration (a.k.a. recalibration)</text>
@@ -327,12 +357,12 @@
 </g>
 
 <!-- Arrow from calibration to main search -->
-<path class="flow" d="M 600 1140 L 600 1180" marker-end="url(#arrow)"/>
+<path class="flow" d="M 600 1212 L 600 1252" marker-end="url(#arrow)"/>
 
 <!-- ================================================================= -->
 <!-- STAGE 4 MAIN FIRST-PASS SEARCH                                     -->
 <!-- ================================================================= -->
-<g transform="translate(0, 1180)">
+<g transform="translate(0, 1252)">
   <rect class="phase-bg" x="40" y="0" width="1120" height="200" rx="6"/>
   <text class="phase-label" x="60" y="24">stage 4</text>
   <text class="phase-title" x="60" y="42">Main first-pass search</text>
@@ -358,26 +388,28 @@
 <!-- ================================================================= -->
 <!-- TASK 2 of 4: FirstPassFDR (Stage 5, join / coordinator node)        -->
 <!-- ================================================================= -->
-<path class="flow" d="M 600 1380 L 600 1394" marker-end="url(#arrow)"/>
+<path class="flow" d="M 600 1452 L 600 1466" marker-end="url(#arrow)"/>
 
-<g transform="translate(0, 1396)">
-  <rect class="task-hdr-bg" x="120" y="0" width="960" height="64" rx="8"/>
+<g transform="translate(0, 1468)">
+  <rect class="task-hdr-bg" x="120" y="0" width="960" height="96" rx="8"/>
   <text x="140" y="22" class="task-hdr-name">&#9656; --task FirstPassFDR</text>
-  <text x="1060" y="22" text-anchor="end" class="task-hdr-role">join &#183; all-file representation</text>
-  <text x="140" y="40" class="task-hdr-io"><tspan class="task-hdr-key">in&#160;&#160;</tspan>&lt;stem&gt;.scores.parquet  (every file, via --input-scores)</text>
-  <text x="140" y="56" class="task-hdr-io"><tspan class="task-hdr-key">out&#160;</tspan>&lt;stem&gt;.1st-pass.fdr_scores.bin, &lt;stem&gt;.reconciliation.json (Stage 5&#8594;6 boundary)   &#183;   validity  &lt;out&gt;.FirstPassFDR.osprey.task</text>
+  <text x="1060" y="22" text-anchor="end" class="task-hdr-role">join &#183; 1 node &#183; holds O(distinct), never O(runs x entries)</text>
+  <text x="140" y="40" class="task-hdr-io"><tspan class="task-hdr-key">in&#160;&#160;</tspan><tspan class="sc-run">&lt;stem&gt;.scores.parquet</tspan>  (every run, via --input-scores)</text>
+  <text x="140" y="56" class="task-hdr-io"><tspan class="task-hdr-key">out&#160;</tspan><tspan class="sc-run">&lt;stem&gt;.1st-pass.fdr_scores.bin</tspan>, <tspan class="sc-run">&lt;stem&gt;.reconciliation.json</tspan> (Stage 5&#8594;6 boundary)   &#183;   validity  <tspan class="sc-run">&lt;out&gt;.FirstPassFDR.osprey.task</tspan></text>
+  <text x="140" y="72" class="task-hdr-io"><tspan class="task-hdr-key">out&#160;</tspan><tspan class="sc-exp">&lt;blib-stem&gt;.1st-pass.fdr_experiment.bin</tspan>, <tspan class="sc-exp">&lt;stem&gt;.1st-pass.model.json</tspan> (frozen model + protein-compact stratum)</text>
+  <text x="1060" y="88" text-anchor="end" class="task-hdr-relay">relay: both experiment-wide files to EVERY downstream node</text>
 </g>
 
 <!-- ================================================================= -->
 <!-- STAGE 5 FIRST-PASS FDR + RECONCILIATION PLANNING                   -->
 <!-- ================================================================= -->
-<path class="flow" d="M 600 1460 L 600 1478" marker-end="url(#arrow)"/>
+<path class="flow" d="M 600 1564 L 600 1582" marker-end="url(#arrow)"/>
 
-<g transform="translate(0, 1480)">
+<g transform="translate(0, 1584)">
   <rect class="phase-bg" x="40" y="0" width="1120" height="500" rx="8"/>
   <text class="phase-label" x="60" y="24">stage 5</text>
   <text class="phase-title" x="60" y="42">First-pass FDR + reconciliation planning</text>
-  <text class="phase-shape-join" x="1115" y="24" text-anchor="end">join — needs all-file representation</text>
+  <text class="phase-shape-join" x="1115" y="24" text-anchor="end">join — needs all-run representation</text>
   <text class="phase-note"  x="60" y="58">First-pass FDR across all files. Runs Percolator SVM on the joined per-file scores, computes cross-run consensus RTs,</text>
   <text class="phase-note"  x="60" y="72">refits per-file calibration, and emits a per-(file, entry) reconciliation plan. All work that needs all-file representation lives here.</text>
 
@@ -423,26 +455,28 @@
 <!-- ================================================================= -->
 <!-- TASK 3 of 4: PerFileRescoring (Stage 6, second per-file fan-out)    -->
 <!-- ================================================================= -->
-<path class="flow" d="M 600 1980 L 600 1994" marker-end="url(#arrow)"/>
+<path class="flow" d="M 600 2084 L 600 2098" marker-end="url(#arrow)"/>
 
-<g transform="translate(0, 1996)">
-  <rect class="task-hdr-bg" x="120" y="0" width="960" height="64" rx="8"/>
+<g transform="translate(0, 2100)">
+  <rect class="task-hdr-bg" x="120" y="0" width="960" height="96" rx="8"/>
   <text x="140" y="22" class="task-hdr-name">&#9656; --task PerFileRescoring</text>
-  <text x="1060" y="22" text-anchor="end" class="task-hdr-role">per-file fan-out &#183; N nodes</text>
-  <text x="140" y="40" class="task-hdr-io"><tspan class="task-hdr-key">in&#160;&#160;</tspan>&lt;stem&gt;.scores.parquet (via --input-scores) + sidecars &lt;stem&gt;.1st-pass.fdr_scores.bin, &lt;stem&gt;.reconciliation.json</text>
-  <text x="140" y="56" class="task-hdr-io"><tspan class="task-hdr-key">out&#160;</tspan>&lt;stem&gt;.scores-reconciled.parquet  (work-files only)   &#183;   validity  &lt;out&gt;.PerFileRescoring.osprey.task</text>
+  <text x="1060" y="22" text-anchor="end" class="task-hdr-role">per-run fan-out &#183; reads its own runs + the experiment baseline only</text>
+  <text x="140" y="40" class="task-hdr-io"><tspan class="task-hdr-key">in&#160;&#160;</tspan><tspan class="sc-run">&lt;stem&gt;.scores.parquet</tspan> (via --input-scores) + <tspan class="sc-run">.1st-pass.fdr_scores.bin</tspan>, <tspan class="sc-run">.reconciliation.json</tspan>, <tspan class="sc-run">.calibration.json</tspan>, <tspan class="sc-cache">.spectra.bin</tspan></text>
+  <text x="140" y="56" class="task-hdr-io"><tspan class="task-hdr-key">in&#160;&#160;</tspan><tspan class="sc-exp">&lt;blib-stem&gt;.1st-pass.fdr_experiment.bin</tspan>, <tspan class="sc-exp">&lt;stem&gt;.1st-pass.model.json</tspan>   &#183;   loaded once = the resident baseline</text>
+  <text x="140" y="72" class="task-hdr-io"><tspan class="task-hdr-key">out&#160;</tspan><tspan class="sc-run">&lt;stem&gt;.scores-reconciled.parquet</tspan>, <tspan class="sc-run">.2nd-pass.fdr_decoys.bin</tspan>, <tspan class="sc-run">.2nd-pass.fdr_scores.bin</tspan> (pass-2 worker)   &#183;   validity  <tspan class="sc-run">&lt;out&gt;.PerFileRescoring.osprey.task</tspan></text>
+  <text x="1060" y="88" text-anchor="end" class="task-hdr-relay">relay: the run's own set + 2 experiment-wide files</text>
 </g>
 
 <!-- ================================================================= -->
 <!-- STAGE 6 PER-FILE RESCORE (SECOND PER-FILE FAN-OUT)                  -->
 <!-- ================================================================= -->
-<path class="flow" d="M 600 2060 L 600 2078" marker-end="url(#arrow)"/>
+<path class="flow" d="M 600 2196 L 600 2214" marker-end="url(#arrow)"/>
 
-<g transform="translate(0, 2080)">
+<g transform="translate(0, 2216)">
   <rect class="phase-bg" x="40" y="0" width="1120" height="260" rx="6"/>
   <text class="phase-label" x="60" y="24">stage 6</text>
   <text class="phase-title" x="60" y="42">Per-file rescore + gap-fill + parquet write-back</text>
-  <text class="phase-shape-fanout" x="1115" y="24" text-anchor="end">per-file — N nodes</text>
+  <text class="phase-shape-fanout" x="1115" y="24" text-anchor="end">per-run fan-out — 1..N nodes</text>
   <text class="phase-note"  x="60" y="58">Second per-file fan-out. Each file independently reloads its mzML, re-invokes the search engine with the reconciled boundary overrides,</text>
   <text class="phase-note"  x="60" y="72">runs the gap-fill two-pass for missing precursors, and writes reconciled scores back to its .scores.parquet. No cross-file work.</text>
 
@@ -465,14 +499,16 @@
 <!-- ================================================================= -->
 <!-- TASK 4 of 4: SecondPassFDR (Stage 7, join / aggregator node)        -->
 <!-- ================================================================= -->
-<path class="flow" d="M 600 2340 L 600 2354" marker-end="url(#arrow)"/>
+<path class="flow" d="M 600 2476 L 600 2490" marker-end="url(#arrow)"/>
 
-<g transform="translate(0, 2356)">
-  <rect class="task-hdr-bg" x="120" y="0" width="960" height="64" rx="8"/>
+<g transform="translate(0, 2492)">
+  <rect class="task-hdr-bg" x="120" y="0" width="960" height="96" rx="8"/>
   <text x="140" y="22" class="task-hdr-name">&#9656; --task SecondPassFDR</text>
-  <text x="1060" y="22" text-anchor="end" class="task-hdr-role">join &#183; final aggregation</text>
-  <text x="140" y="40" class="task-hdr-io"><tspan class="task-hdr-key">in&#160;&#160;</tspan>&lt;stem&gt;.scores-reconciled.parquet (via --input-scores; falls back to &lt;stem&gt;.scores.parquet for no-work files)</text>
-  <text x="140" y="56" class="task-hdr-io"><tspan class="task-hdr-key">out&#160;</tspan>&lt;output&gt;.blib, &lt;stem&gt;.2nd-pass.fdr_scores.bin (when Stage 6 rescored)   &#183;   validity  &lt;out&gt;.SecondPassFDR.osprey.task</text>
+  <text x="1060" y="22" text-anchor="end" class="task-hdr-role">join &#183; 1 node &#183; final aggregation</text>
+  <text x="140" y="40" class="task-hdr-io"><tspan class="task-hdr-key">in&#160;&#160;</tspan><tspan class="sc-run">&lt;stem&gt;.scores-reconciled.parquet</tspan> (via --input-scores; falls back to <tspan class="sc-run">&lt;stem&gt;.scores.parquet</tspan> for no-work runs)</text>
+  <text x="140" y="56" class="task-hdr-io"><tspan class="task-hdr-key">in&#160;&#160;</tspan><tspan class="sc-exp">&lt;blib-stem&gt;.1st-pass.fdr_experiment.bin</tspan>, <tspan class="sc-exp">&lt;stem&gt;.1st-pass.model.json</tspan>   &#183;   required by the frozen pass-2 modes</text>
+  <text x="140" y="72" class="task-hdr-io"><tspan class="task-hdr-key">out&#160;</tspan><tspan class="sc-exp">&lt;output&gt;.blib</tspan>, <tspan class="sc-exp">&lt;blib-stem&gt;.2nd-pass.fdr_experiment.bin</tspan>, <tspan class="sc-run">&lt;stem&gt;.2nd-pass.fdr_scores.bin</tspan> (where no worker ran)</text>
+  <text x="1060" y="88" text-anchor="end" class="task-hdr-relay">relay: every run's reconciled set, with its .osprey.task stamps</text>
 </g>
 
 <!-- ================================================================= -->
@@ -486,13 +522,13 @@
 <!-- experiment-level FDR, first-pass protein FDR, reconciliation       -->
 <!-- planning) under the FirstPassFDR phase.                            -->
 <!-- ================================================================= -->
-<path class="flow" d="M 600 2420 L 600 2438" marker-end="url(#arrow)"/>
+<path class="flow" d="M 600 2588 L 600 2606" marker-end="url(#arrow)"/>
 
-<g transform="translate(0, 2440)">
+<g transform="translate(0, 2608)">
   <rect class="phase-bg" x="40" y="0" width="1120" height="230" rx="6"/>
   <text class="phase-label" x="60" y="24">stage 7</text>
   <text class="phase-title" x="60" y="42">Post-join: second-pass Percolator + protein FDR + .blib output</text>
-  <text class="phase-shape-join" x="1115" y="24" text-anchor="end">join - final SecondPassFDR phase (no further per-file fan-out)</text>
+  <text class="phase-shape-join" x="1115" y="24" text-anchor="end">join - final SecondPassFDR phase (no further per-run fan-out)</text>
 
   <rect class="st-done" x="80" y="62" width="1040" height="42" rx="4"/>
   <text class="stage-title" x="600" y="82" text-anchor="middle">Single Percolator pass on the reconciled + gap-filled pool</text>

--- a/pwiz_tools/Osprey/Osprey-workflow.html
+++ b/pwiz_tools/Osprey/Osprey-workflow.html
@@ -396,7 +396,7 @@
   <text x="1060" y="22" text-anchor="end" class="task-hdr-role">join &#183; 1 node &#183; holds O(distinct), never O(runs x entries)</text>
   <text x="140" y="40" class="task-hdr-io"><tspan class="task-hdr-key">in&#160;&#160;</tspan><tspan class="sc-run">&lt;stem&gt;.scores.parquet</tspan>  (every run, via --input-scores)</text>
   <text x="140" y="56" class="task-hdr-io"><tspan class="task-hdr-key">out&#160;</tspan><tspan class="sc-run">&lt;stem&gt;.1st-pass.fdr_scores.bin</tspan>, <tspan class="sc-run">&lt;stem&gt;.reconciliation.json</tspan> (Stage 5&#8594;6 boundary)   &#183;   validity  <tspan class="sc-run">&lt;out&gt;.FirstPassFDR.osprey.task</tspan></text>
-  <text x="140" y="72" class="task-hdr-io"><tspan class="task-hdr-key">out&#160;</tspan><tspan class="sc-exp">&lt;blib-stem&gt;.1st-pass.fdr_experiment.bin</tspan>, <tspan class="sc-exp">&lt;stem&gt;.1st-pass.model.json</tspan> (frozen model + protein-compact stratum)</text>
+  <text x="140" y="72" class="task-hdr-io"><tspan class="task-hdr-key">out&#160;</tspan><tspan class="sc-exp">&lt;blib-stem&gt;.1st-pass.fdr_experiment.bin</tspan>, <tspan class="sc-exp">&lt;stem&gt;.1st-pass.model.json</tspan> (frozen pass-1 model, for the frozen pass-2 modes)</text>
   <text x="1060" y="88" text-anchor="end" class="task-hdr-relay">relay: both experiment-wide files to EVERY downstream node</text>
 </g>
 
@@ -506,7 +506,7 @@
   <text x="140" y="22" class="task-hdr-name">&#9656; --task SecondPassFDR</text>
   <text x="1060" y="22" text-anchor="end" class="task-hdr-role">join &#183; 1 node &#183; final aggregation</text>
   <text x="140" y="40" class="task-hdr-io"><tspan class="task-hdr-key">in&#160;&#160;</tspan><tspan class="sc-run">&lt;stem&gt;.scores-reconciled.parquet</tspan> (via --input-scores; falls back to <tspan class="sc-run">&lt;stem&gt;.scores.parquet</tspan> for no-work runs)</text>
-  <text x="140" y="56" class="task-hdr-io"><tspan class="task-hdr-key">in&#160;&#160;</tspan><tspan class="sc-exp">&lt;blib-stem&gt;.1st-pass.fdr_experiment.bin</tspan>, <tspan class="sc-exp">&lt;stem&gt;.1st-pass.model.json</tspan>   &#183;   required by the frozen pass-2 modes</text>
+  <text x="140" y="56" class="task-hdr-io"><tspan class="task-hdr-key">in&#160;&#160;</tspan><tspan class="sc-exp">&lt;blib-stem&gt;.1st-pass.fdr_experiment.bin</tspan>, <tspan class="sc-exp">&lt;stem&gt;.1st-pass.model.json</tspan>, <tspan class="sc-run">&lt;stem&gt;.reconciliation.json</tspan>, <tspan class="sc-run">.calibration.json</tspan></text>
   <text x="140" y="72" class="task-hdr-io"><tspan class="task-hdr-key">out&#160;</tspan><tspan class="sc-exp">&lt;output&gt;.blib</tspan>, <tspan class="sc-exp">&lt;blib-stem&gt;.2nd-pass.fdr_experiment.bin</tspan>, <tspan class="sc-run">&lt;stem&gt;.2nd-pass.fdr_scores.bin</tspan> (where no worker ran)</text>
   <text x="1060" y="88" text-anchor="end" class="task-hdr-relay">relay: every run's reconciled set, with its .osprey.task stamps</text>
 </g>

--- a/pwiz_tools/Osprey/Osprey-workflow.html
+++ b/pwiz_tools/Osprey/Osprey-workflow.html
@@ -800,7 +800,7 @@
     <code>C:\test</code> and the Windows mount points the WSL distro
     touches; without those exclusions, every disk-bound stage paid
     a 5-10% scan overhead.
-    <em>(2) Rust dump-writer patch (still load-bearing).</em> Rust's
+    <em>(2) Rust dump-writer patch (still essential).</em> Rust's
     stage-5/6 diagnostic-dump writers in osprey v26.6.0 use unbuffered
     <code>std::fs::File::create</code>: each <code>writeln!</code>
     crosses to the kernel. On WSL drvfs/9P that took ~14 min for

--- a/pwiz_tools/Osprey/README.md
+++ b/pwiz_tools/Osprey/README.md
@@ -20,7 +20,7 @@ Skyline release/versioning scheme.
 | Start here | For |
 |---|---|
 | [`docs/00-pipeline-architecture.md`](docs/00-pipeline-architecture.md) | The pipeline's architecture and sidecar file contract. **Read before changing what any task reads, writes, or keeps.** |
-| [`docs/README.md`](docs/README.md) | Ordered index of the per-stage algorithm deep dives (01-20), numbered by pipeline execution order |
+| [`docs/README.md`](docs/README.md) | Ordered index of docs 00-20, numbered by pipeline execution order |
 | [`Osprey-workflow.html`](Osprey-workflow.html) | The annotated end-to-end diagram: stages, HPC task boundaries, per-task inputs and outputs |
 | [`docs/20-command-line.md`](docs/20-command-line.md) | Every CLI flag with defaults, plus copy-paste examples |
 
@@ -142,8 +142,8 @@ Osprey --task SecondPassFDR --input-scores ./reconciled_dir -l hela.tsv -o out.b
 ```
 
 The example above shows the *commands*. What each node must actually be **shipped** at each
-boundary — including the experiment-wide artifacts that are easy to miss because a node can
-often proceed without them and produce a plausible wrong answer — is the relay checklist in
+boundary - including the experiment-wide artifacts that are easy to miss because a node can
+often proceed without them and produce a plausible wrong answer - is the relay checklist in
 [`docs/00-pipeline-architecture.md`](docs/00-pipeline-architecture.md).
 
 ### Notes that matter for a workflow engine (NextFlow, etc.)

--- a/pwiz_tools/Osprey/README.md
+++ b/pwiz_tools/Osprey/README.md
@@ -15,6 +15,15 @@ implementation is being retired to a parity oracle; Osprey ships as a
 standalone .NET 8 executable (Windows + Linux) and will move onto the
 Skyline release/versioning scheme.
 
+## Documentation
+
+| Start here | For |
+|---|---|
+| [`docs/00-pipeline-architecture.md`](docs/00-pipeline-architecture.md) | The pipeline's architecture and sidecar file contract. **Read before changing what any task reads, writes, or keeps.** |
+| [`docs/README.md`](docs/README.md) | Ordered index of the per-stage algorithm deep dives (01-20), numbered by pipeline execution order |
+| [`Osprey-workflow.html`](Osprey-workflow.html) | The annotated end-to-end diagram: stages, HPC task boundaries, per-task inputs and outputs |
+| [`docs/20-command-line.md`](docs/20-command-line.md) | Every CLI flag with defaults, plus copy-paste examples |
+
 ## Why a C# implementation?
 
 Osprey is a well-documented, test-backed DIA search pipeline that does
@@ -131,6 +140,11 @@ Osprey --task PerFileRescoring --input-scores s1.scores.parquet -l hela.tsv -o o
 Osprey --task SecondPassFDR --input-scores ./reconciled_dir -l hela.tsv -o out.blib --resolution unit --protein-fdr 0.01
 #   -> out.blib
 ```
+
+The example above shows the *commands*. What each node must actually be **shipped** at each
+boundary — including the experiment-wide artifacts that are easy to miss because a node can
+often proceed without them and produce a plausible wrong answer — is the relay checklist in
+[`docs/00-pipeline-architecture.md`](docs/00-pipeline-architecture.md).
 
 ### Notes that matter for a workflow engine (NextFlow, etc.)
 

--- a/pwiz_tools/Osprey/docs/00-pipeline-architecture.md
+++ b/pwiz_tools/Osprey/docs/00-pipeline-architecture.md
@@ -359,11 +359,13 @@ rather than one it trusts and folds against a companion that was never written.
 ### Resume and relocation
 
 **P15. Resume is a forward scan, and identity is path-independent.** The driver walks
-the stages in order, reusing each output whose sidecar key matches and recomputing from
-the first that does not; a stage that runs invalidates everything downstream. Because
-the scan is forward and downstream invalidation is total, a key that is not exhaustive
-enough costs a recompute, never a wrong answer - which is why "I cannot tell" resolves
-to re-run.
+the stages in order, reusing each output whose sidecar key matches and recomputing the
+rest. Invalidation is by key rather than by cascade, and the asymmetry in the cost of
+getting a key wrong is what every key component in the codebase is arguing about: an
+over-inclusive key costs an unnecessary recompute, while an under-inclusive one silently
+reuses an artifact computed under different settings and reports it as the new result.
+Erring toward more key is therefore always the safe direction, and "I cannot tell"
+resolves to re-run.
 
 Identity is also deliberately free of paths: the library hash uses file name, size and
 mtime with the directory excluded, and the reconciliation hash names sorted file
@@ -492,3 +494,257 @@ default:
 Ship both to every node running either task. A node that has one and not the other is
 the case the fail-fast exists for, and it is the orchestrator's job never to create it.
 
+
+## Directory resolution
+
+Every artifact path is resolved through `ArtifactPaths`, so redirection applies uniformly
+rather than one writer at a time. Two process-wide settings decide where things land,
+both defaulting to "beside the input file":
+
+| Setting | Sets | Holds |
+|---|---|---|
+| `--output-dir` | `ArtifactPaths.OutputDir` | products: scores parquet, calibration JSON, FDR sidecars, reconciliation JSON |
+| `--cache-dir` | `ArtifactPaths.CacheDir` | caches: `.spectra.bin`, `.libcache` |
+| `--work-dir` | both | the single-flag form |
+
+This is the product/cache split from the contract table made operational. `ResolveOutputDir`
+returns `OutputDir` when set and the input's own directory otherwise. `ResolveCacheDir`
+prefers an explicit `CacheDir`, falls back to the data file's own directory when that is
+writable - probed once and memoized - and otherwise to `OutputDir`. A cache is
+settings-independent, which is what lets several analyses share one `--cache-dir` and
+reuse a single parse of the raw data.
+
+Reaching for the input file's directory rather than a resolved one is the recurring bug
+in this area: it works in a single-process run, where they coincide, and diverges the
+moment anyone passes `--output-dir`.
+
+### Identity does not name the directory
+
+Every hash that decides artifact reuse deliberately excludes paths. `LibraryIdentityHash`
+takes the library's file *name*, size and mtime and drops the directory, so the same
+library identifies identically across implementations, operating systems, and node-local
+versus shared mounts - drive-letter case, slash direction, and relative-versus-absolute
+spelling all stop mattering. `ReconciliationParameterHash` names sorted, deduplicated file
+*stems* rather than paths, for the same reason and with the ordering removed too, so the
+hash cannot depend on the order files were passed on the command line.
+
+The consequence is that **a completed run is relocatable**. Its artifacts can be moved,
+copied, or hard-linked into a new output directory and remain valid, because nothing in
+their identity records where they used to be. External tooling relies on this to adopt a
+prior run's expensive Stage 1-4 output instead of recomputing it - see
+`ai/docs` for the workflow scripts that do so. That relocatability is a property of the
+hashes, and any change that folds a directory into one of them removes it.
+
+A warm resume across builds is a separate matter: the version stamp is compared for exact
+equality (`YEAR.ORDINAL.BRANCH.DOY`), so artifacts from another day's build are refused
+rather than silently reused. `OSPREY_VERSION_OVERRIDE` pins the stamp and is the
+sanctioned way to consume another build's artifacts deliberately.
+
+---
+
+## Validity and resume
+
+### What the key is made of
+
+The base key every task carries is search parameters, library identity, and the peak-pick
+arm (`OspreyTask.ValidityKey`). Tasks with extra state append to it; `FirstPassFDR` adds
+six components, and each one is in the key because leaving it out produced a specific
+wrong answer:
+
+| Component | Without it |
+|---|---|
+| reconciliation parameter hash | toggling reconciliation between runs reuses the prior shape |
+| FDR sidecar format version | a resume across a format bump skips the task, then every reader refuses the old file by version and defaults are written instead |
+| experiment-aggregation mode | an A/B arm re-run in a directory holding the other arm's results reuses the previous mode's q and reports it as the new measurement |
+| pass-2 q-value mode | a sidecar written under `transfer` carries no stratum, so a `protein-compact` re-run adopts an artifact that cannot answer its question |
+| training-sample settings | a resume adopts maximum-trained scores as though the reservoir had produced them |
+| library-fragment release | the retained-fragment arm differs and the outputs are not interchangeable |
+
+The peak-pick arm sits in the *base* rather than in the overrides because it is the one
+lever that reaches every task: the pick decides which peak a precursor's row describes,
+back in Stage 4, and everything downstream inherits that choice. Putting it in the base
+also means a task added later carries it without having to know.
+
+Read that table as a worked example of P15's asymmetry. Every row was added after an
+under-inclusive key reused something it should not have, and none of them cost more than
+a recompute if they were unnecessary.
+
+### The build stamp
+
+The version stamped into each artifact follows the Skyline scheme
+`YEAR.ORDINAL.BRANCH.DOY`, with the full informational form carrying the git short hash
+(`26.1.1.182-b2373f9f9c`, plus `-dirty` for a modified tree) so a binary is always
+traceable to its source commit. Reuse requires an exact match on all four numeric
+components; a difference in release line or daily build aborts reuse with a hard error
+rather than a warning, because a cache from a different build may carry different scoring
+and a logged warning is easily missed while the run still completes and looks valid.
+
+### Resume is a forward scan
+
+The driver walks the four tasks in order and, for each one that is included, skips it when
+every declared output exists *and* carries a validity sidecar matching that task's current
+key (`PipelineContext.CanRehydrate`). Otherwise it runs the task and stamps sidecars over
+its outputs afterward.
+
+Two details are easy to get wrong:
+
+- **Skipping is per task, on that task's own key.** There is no cascade that invalidates
+  downstream artifacts when an upstream task re-runs. This is safe because the pipeline is
+  deterministic: a task re-run under an unchanged key writes the same bytes, so a
+  downstream artifact stamped with a matching key is still describing the right input.
+  Correctness therefore rests entirely on keys being exhaustive, which is why the table
+  above exists.
+- **A sidecar is cleared when its task starts, not when it finishes.** A crash mid-Run
+  then leaves no stale marker claiming a partially written output is valid.
+
+Sidecars are stamped even for the tasks that deliberately return "stop here" at an HPC
+boundary. Gating the stamp on the pipeline continuing would skip sidecar writes for
+exactly the successful early-exit modes the split depends on, and break resume for them.
+
+### Per-run guards inside a stage
+
+A stage that has already processed some of its runs resumes per run, not only per task.
+The rule for those guards is the one that is easy to get wrong:
+
+> A per-run resume arm must leave the state a fresh run would have left. Skipping the
+> work is not the same as producing its result.
+
+`PerFileRescoring` is the worked example. Its per-run guard finds a valid reconciled
+parquet and skips re-scoring - but a downstream `SecondPassFDR` in the same process reads
+apex and boundary values straight off the in-memory entries, so a guard that only skipped
+would leave first-pass retention times in the buffer and ship them in the final `.blib`.
+The guard therefore overlays the reconciled values back onto the in-memory entries and
+re-sorts them, reproducing the fresh end state in place.
+
+The memory contract applies to the resume arm too. That overlay re-inflates every entry
+from the reconciled parquet, so the skip path once rooted the same per-entry arrays the
+rescore path does, across every resumed run - reintroducing the O(runs) growth term the
+rescore path had already been fixed to avoid. It now releases that payload immediately,
+leaving exactly the buffer shape a fresh rescore leaves. A resume path is not exempt from
+P6 just because it did no work.
+
+---
+
+## HPC relay checklist
+
+What an orchestrator must place on a node before its task can run. Per-run files travel
+with the run they are named for; experiment-wide files go to every node running that
+task, whatever batch it was handed.
+
+The general rule, if you remember nothing else: **a fan-out node needs its own runs'
+files plus every experiment-wide artifact produced so far.** The checklists below are
+that rule made explicit at each boundary.
+
+### Boundary 1 -> 2: `PerFileScoring` to `FirstPassFDR`
+
+The join needs every run's Stage 1-4 output, since training and experiment-wide q-values
+are functions of all runs:
+
+- `<stem>.scores.parquet` for **every** run in the cohort
+- the library, and `--input-scores` naming the parquets
+
+`<stem>.spectra.bin` and `<stem>.calibration.json` do not need to travel: the join reads
+parquets, not spectra. Leave them on the scoring nodes unless the raw data was deleted
+after staging, in which case the spectra caches are the data and must be preserved.
+
+### Boundary 2 -> 3: `FirstPassFDR` to `PerFileRescoring`
+
+Each rescore node needs its own runs' artifacts plus the experiment-wide set:
+
+Per run, for each run in the node's batch:
+- `<stem>.scores.parquet`
+- `<stem>.1st-pass.fdr_scores.bin`
+- `<stem>.reconciliation.json`
+- `<stem>.calibration.json`
+- `<stem>.spectra.bin` (or the raw file it was built from)
+
+Experiment-wide, to **every** node:
+- `<blib-stem>.1st-pass.fdr_experiment.bin`
+- `<stem>.1st-pass.model.json` (any one copy; needed for the frozen pass-2 modes)
+
+This is the boundary where a missing experiment-wide file does the most damage, because
+the node can often proceed without it and produce a plausible wrong answer rather than
+failing. Ship both experiment-wide artifacts together or neither.
+
+### Boundary 3 -> 4: `PerFileRescoring` to `SecondPassFDR`
+
+The final join needs every run's reconciled output:
+
+Per run, for **every** run in the cohort:
+- `<stem>.scores-reconciled.parquet`
+- `<stem>.2nd-pass.fdr_scores.bin` and `<stem>.2nd-pass.fdr_decoys.bin`, where the
+  rescore node ran the pass-2 worker - together with their `.osprey.task` sidecars,
+  which is how this task learns the worker produced them and folds them instead of
+  recomputing
+
+Experiment-wide:
+- `<blib-stem>.1st-pass.fdr_experiment.bin`
+- `<stem>.1st-pass.model.json` (any one copy)
+
+The `.osprey.task` sidecars are not optional bookkeeping here. Without the stamp,
+`SecondPassFDR` cannot tell that a worker wrote the pass-2 files and will recompute them
+from survivors only - which is not the same answer (P10).
+
+
+---
+
+## In flight
+
+Four items are being settled on branch `Skyline/work/20260901_osprey_firstpass_resume` and
+its companion TODOs. Each is marked at the point it applies above; they are collected here
+so that clearing them after that work merges is a single edit.
+
+The contract above states the **target** in every case. Where today's code does not meet it,
+the text says so rather than describing the current shape as though it were the design.
+
+1. **Protein-q split of the experiment-scope FDR sidecar.** Protein q-values are currently
+   added by rewriting an existing first-pass sidecar in place
+   (`FdrScoresSidecar.PatchProteinQvalues`), which is the one surviving violation of P11.
+   The target is a separate experiment-wide artifact written by the phase that computes it.
+   See `ai/todos/active/TODO-20260901_osprey_firstpassfdr_resume.md`.
+
+2. **The bounded-loop shape of `PerFileRescoring`.** The task is still entered with a
+   materialised all-runs entry list, and its baseline still carries maps keyed by run whose
+   values are per-entry - the `O(runs x entries)` shape P5 and P6 forbid. See
+   `ai/todos/active/TODO-20260901_osprey_stage5_reload_materialization.md`.
+
+3. **Deletion of the fat pre-compaction path**, once the streamed path is the only one.
+
+4. **Whether the 500-run / 64 GB target is met.** It is not yet, and which stage binds is
+   itself moving as each is fixed. The two TODOs above carry the current measurements;
+   deliberately not restated here, because a number in a contract document is stale the
+   week after it is written.
+
+---
+
+## Cross-references
+
+**By stage** - the algorithm deep dives, numbered by pipeline execution order:
+
+| Stage | Docs |
+|---|---|
+| 1-2 library and mzML | [01-decoy-generation](01-decoy-generation.md) |
+| 3 calibration | [04-calibration](04-calibration.md), [05-rt-alignment](05-rt-alignment.md) |
+| 4 first-pass search | [02-xcorr-scoring](02-xcorr-scoring.md), [03-spectral-scoring](03-spectral-scoring.md), [06-peak-detection](06-peak-detection.md), [17-vectorization](17-vectorization.md) |
+| 5 first-pass FDR | [07-fdr-control](07-fdr-control.md), [08-protein-parsimony](08-protein-parsimony.md), [09-multi-charge-consensus](09-multi-charge-consensus.md), [10-cross-run-reconciliation](10-cross-run-reconciliation.md) |
+| 6 rescore | [10-cross-run-reconciliation](10-cross-run-reconciliation.md), [11-boundary-overrides](11-boundary-overrides.md) |
+| 7 second-pass FDR and output | [12-second-pass-fdr](12-second-pass-fdr.md), [13-blib-output-schema](13-blib-output-schema.md) |
+
+**By subject** - the documents this one shares a boundary with:
+
+- [14-intermediate-files](14-intermediate-files.md) - the byte formats of every artifact in
+  the contract table.
+- [15-hpc-scoring-split](15-hpc-scoring-split.md) - the CLI and orchestration mechanics for
+  running the split described here.
+- [16-determinism](16-determinism.md) - why a task re-run under an unchanged key writes the
+  same bytes, which is the property resume correctness rests on.
+- [19-testing](19-testing.md) - the gates that hold this contract, including the regression
+  mode that asserts a per-node reconciled parquet is byte-identical to the straight-through
+  one.
+- [20-command-line](20-command-line.md) - every flag, including `--task`, `--work-dir`,
+  `--output-dir` and `--cache-dir`.
+
+**How we work on Osprey** - not documentation of the code, and deliberately outside this
+tree - lives in `ai/docs`: the test gates and datasets, the run layout and machine paths,
+the environment-variable reference, and the workflow scripts that adopt a prior run's
+artifacts rather than recomputing them.

--- a/pwiz_tools/Osprey/docs/00-pipeline-architecture.md
+++ b/pwiz_tools/Osprey/docs/00-pipeline-architecture.md
@@ -369,11 +369,19 @@ reuses an artifact computed under different settings and reports it as the new r
 Erring toward more key is therefore always the safe direction, and "I cannot tell"
 resolves to re-run.
 
-Identity is also deliberately free of paths: the library hash uses file name, size and
-mtime with the directory excluded, and the reconciliation hash names sorted file
-*stems*. A completed run can therefore be moved, copied, or hard-linked into a new
+Identity is also, with one exception, free of paths: the library hash uses file name,
+size and mtime with the directory excluded, and the reconciliation hash names sorted
+file *stems*. A completed run can therefore be moved, copied, or hard-linked into a new
 output directory and still be recognised as valid - the property external tooling relies
 on to adopt a prior run's Stage 1-4 artifacts instead of recomputing them for hours.
+
+**The exception is `--decoy-pairing-manifest`**, whose path goes into
+`SearchParameterHash` verbatim and unnormalised. It is the only path anywhere in artifact
+identity, so it is the only reason a move invalidates: relocate a cohort that was searched
+with a pairing manifest and every artifact invalidates, because the manifest is named from
+somewhere else now. Restoring the original path with a junction is the cheap fix. Anything
+that adds a second path to a hash removes relocatability for every run, not just
+entrapment ones.
 
 ---
 
@@ -522,7 +530,8 @@ moment anyone passes `--output-dir`.
 
 ### Identity does not name the directory
 
-Every hash that decides artifact reuse deliberately excludes paths. `LibraryIdentityHash`
+Every hash that decides artifact reuse excludes paths, with one exception noted at the end
+of this section. `LibraryIdentityHash`
 takes the library's file *name*, size and mtime and drops the directory, so the same
 library identifies identically across implementations, operating systems, and node-local
 versus shared mounts - drive-letter case, slash direction, and relative-versus-absolute
@@ -531,11 +540,19 @@ spelling all stop mattering. `ReconciliationParameterHash` names sorted, dedupli
 hash cannot depend on the order files were passed on the command line.
 
 The consequence is that **a completed run is relocatable**. Its artifacts can be moved,
-copied, or hard-linked into a new output directory and remain valid, because nothing in
-their identity records where they used to be. External tooling relies on this to adopt a
+copied, or hard-linked into a new output directory and remain valid, because their
+identity does not record where they used to be. External tooling relies on this to adopt a
 prior run's expensive Stage 1-4 output instead of recomputing it - see
-`ai/docs` for the workflow scripts that do so. That relocatability is a property of the
-hashes, and any change that folds a directory into one of them removes it.
+`ai/docs/osprey-run-layout.md` for the runner parameter that does so. That relocatability
+is a property of the hashes, and any change that folds a directory into one of them
+removes it for every run.
+
+**The one exception is `--decoy-pairing-manifest`.** Its path enters
+`SearchParameterHash` verbatim and unnormalised - the user's own spelling, relative or
+absolute - so it is the single place a directory reaches artifact identity. A cohort
+searched with a pairing manifest therefore *does* invalidate when it moves, which is why
+relocating an entrapment dataset needs a junction restoring the original path rather than
+a re-run. Everything else in this section holds regardless.
 
 A warm resume across builds is a separate matter: the version stamp is compared for exact
 equality (`YEAR.ORDINAL.BRANCH.DOY`), so artifacts from another day's build are refused

--- a/pwiz_tools/Osprey/docs/00-pipeline-architecture.md
+++ b/pwiz_tools/Osprey/docs/00-pipeline-architecture.md
@@ -1,0 +1,494 @@
+# 00. Pipeline Architecture and the Sidecar File Contract (C#)
+
+> Pipeline stage: Cross-cutting (all stages). Unlike docs 01-20 this document has no
+> Rust counterpart and no "Divergences" section: it states the architecture the C#
+> pipeline is built to, which the port established rather than inherited.
+
+Osprey is designed to search a 500-run experiment on a 64 GB machine, and to split
+that same search across an HPC cluster at any batch size from one run per node to the
+whole cohort in one process, with identical output. Neither property comes from an
+algorithm. Both come from a small set of rules about **what a task may hold in memory**
+and **what a task may write to disk** - rules that are invisible in any single stage
+document because every stage obeys them.
+
+This document states those rules once. It covers the shape of the pipeline (four tasks
+over seven stages, alternating fan-out and join), the two tiers of sidecar file
+(per-run and experiment-wide) and what each tier is for, and the write and resume
+discipline that lets a run be interrupted, moved, adopted or distributed without ever
+producing a subtly wrong answer.
+
+Start here before changing what any task reads, writes, or keeps.
+
+For the per-stage algorithms, see the ordered index in [README.md](README.md).
+
+---
+
+## Scope of this document
+
+Three documents divide the file-and-orchestration subject between them. Each owns its
+layer, and none repeats another:
+
+| Doc | Owns | Answers |
+|---|---|---|
+| **00** (this doc) | Scope, contract, principles, relay | Which file, whose, when, and who may read it |
+| [14-intermediate-files](14-intermediate-files.md) | Bytes | Headers, versions, schemas, hashing, invalidation mechanics |
+| [15-hpc-scoring-split](15-hpc-scoring-split.md) | Operations | CLI flags, `--input-scores` ordering, orchestration recipes |
+
+If you are asking "what does this file's header look like?", you want 14. "How do I
+launch the third worker?" is 15. "Is this task allowed to read that file?" is here.
+
+**How we work on Osprey** - test gates, datasets, machine paths, environment
+variables, run layout - is not documentation of the code and lives in `ai/docs`,
+outside this repository's `docs/` tree.
+
+---
+
+## Runs and files
+
+Throughout this document a **run** is one MS data file: one mzML or one vendor raw
+file, one LC-MS/MS acquisition. It is the unit the pipeline fans out over.
+
+The code spells this concept `file`, because a run arrives as a file and is keyed by
+its file stem. The two fan-out tasks are named `PerFileScoring` and `PerFileRescoring`
+in the CLI, the `HpcTask` enum, and the `.osprey.task` sidecar names, and this document
+uses those spellings whenever it names a task, a type, or a path. It says **run** in
+prose, where "per-run" and "experiment-wide" is the distinction that carries the
+architecture and "per-file" invites confusion with the dozen other files in play. The
+`--model-diagnostics` report uses the same prose convention.
+
+One run, one stem, one set of per-run sidecars. A cohort of 500 runs is 500 stems.
+
+---
+
+## Scale targets and the deployment model
+
+### 500 runs on 64 GB
+
+The binding constraint on a large Osprey search is **memory, not wall clock**. A
+cohort that does not fit fails; a cohort that fits but is slow still finishes. So the
+target is stated as a resident-memory ceiling at a cohort size, and every design
+question below resolves in favour of bounding memory.
+
+The concrete target is a 500-run experiment completing on a 64 GB machine. That number
+sets the whole architecture: at 500 runs, any structure that allocates per run times
+per library entry is fatal, and no amount of available RAM changes that - it is a
+scaling shape, not a constant factor.
+
+### Three execution modes, one output
+
+The same pipeline runs three ways, and all three must produce identical output:
+
+| Mode | Shape | What it is for |
+|---|---|---|
+| **Single process** | All four tasks in one process, no `--task` | Ordinary searches; the default |
+| **HPC split** | One `--task` per node, any batch size | Cohorts too large or too slow for one machine |
+| **Resumed** | Re-invoke the same command line | A crashed, killed, or deliberately staged run |
+
+These are not three code paths. They are the same four tasks with different subsets
+included in the driver loop, reading the same sidecar files from disk. A single-process
+run writes every file an HPC run writes; that is what makes the HPC mode testable
+without a cluster, and why regression mode 3 can assert that a per-node reconciled
+parquet is byte-identical to the one the straight-through run produced.
+
+### What "bounded" means
+
+Bounded means the peak resident set does not grow with the number of runs. Concretely,
+a structure is admissible when its size is:
+
+- **O(library)** - one entry per library precursor. Fixed by the library, not the cohort.
+- **O(entries in one run)** - the working set of a single run, held only while that run
+  is being processed.
+- **O(distinct entries)** - one entry per distinct library precursor surviving across the
+  whole experiment. Grows with library and discovery depth, not with run count.
+
+And inadmissible when it is:
+
+- **O(runs x entries)** - a per-run collection of per-entry data, all resident at once.
+
+That last shape is the single failure mode this architecture exists to prevent. It
+appears innocently: a dictionary keyed by file name whose values are per-entry lists, a
+map built once "for convenience" outside a per-run loop, a join that materialises every
+run's rows to compute a summary over them. At 3 runs it is invisible. At 500 it is the
+whole 64 GB.
+
+---
+
+## The task graph
+
+### Four tasks over seven stages
+
+The pipeline is a fixed, four-element list, always in this order
+(`AnalysisPipeline.CanonicalPipeline()`). It alternates fan-out and join:
+
+| Task | Stages | Shape | Nodes | May hold resident |
+|---|---|---|---|---|
+| `PerFileScoring` | 1-4 | fan-out (split 1) | 1..N | library + one run |
+| `FirstPassFDR` | 5 | **join** (barrier 1) | 1 | O(distinct entries) |
+| `PerFileRescoring` | 6 | fan-out (split 2) | 1..N | baseline + one run |
+| `SecondPassFDR` | 7 | **join** (barrier 2) | 1 | O(survivors) |
+
+Stages 1-4 are library preparation, mzML processing, calibration, and the main
+first-pass search that computes the 21 PIN features. Stage 5 is first-pass FDR plus the
+Stage 6 reconciliation plan. Stage 6 is the per-run rescore and gap-fill. Stage 7 is
+second-pass FDR, protein FDR, and the `.blib` write. The stage-to-document map is in
+[README.md](README.md); the task-name-to-enum-to-class map is in
+[15-hpc-scoring-split](15-hpc-scoring-split.md).
+
+A fan-out task's node count is free. One node per run, five runs per node, or all 500
+in one process are the same computation, and the pipeline does not know which it is
+doing. That freedom is the point of the whole design, and every principle in the next
+section exists to preserve it.
+
+### Two selectable tasks that are not pipeline tasks
+
+The `HpcTask` enum has six members, but only the four above are pipeline stages.
+`AnalysisPipeline.CanonicalPipeline()` contains those four and nothing else; the other
+two are reachable only by naming them in `--task`, and neither participates in a run
+that does not:
+
+- **`--task SpectraCache`** builds each input's `.spectra.bin` and stops. It is the
+  data-staging step *ahead* of the pipeline, not a node within it, which is why it needs
+  no `--library` and publishes no byproducts - caching depends only on the input file.
+  It exists because staging a cohort would otherwise mean running all of Stages 1-4 and
+  paying for calibration, scoring and a parquet write that staging does not need. The
+  caches it writes are byte-for-byte what a full run would have written.
+- **`--task ModelDiagnostics`** regenerates the `--model-diagnostics` HTML for a
+  completed analysis from that run's own outputs, suppressing every artifact write
+  except the report. It exists so that judging a diagnostics change on a large cohort
+  does not mean re-running the search - seven hours on the 82-run SEA-AD set - or
+  accepting a page written by an older build.
+
+Both are appended after the four pipeline members so the existing ordinal values are
+undisturbed. Neither is a fan-out node, and neither belongs in an HPC relay plan.
+
+### Scatter and barrier: what a join may hold
+
+A join is the expensive part of the pipeline and the only place a whole-experiment
+structure is permitted at all. The two joins exist because two questions genuinely
+cannot be answered one run at a time:
+
+- **`FirstPassFDR`** trains one SVM over all runs' evidence and computes
+  experiment-wide q-values, then plans reconciliation - which requires knowing where
+  every other run found the same precursor.
+- **`SecondPassFDR`** competes precursors experiment-wide, runs protein parsimony and
+  picked-protein FDR, and writes the single `.blib`.
+
+Everything else is per-run work and belongs in a fan-out task. When a join grows a new
+responsibility, that is the signal to ask whether the work decomposes - not to add
+another dictionary keyed by file name. A join is the bottleneck of an HPC run by
+construction: it is the one node everything waits for, and the one node that cannot be
+made smaller by adding hardware.
+
+### The per-run loop, and where the memory goes
+
+This is the shape every fan-out task has, and the reason batch size is free. Taking
+`PerFileRescoring` on one node handed a batch of runs `{r1 .. rk}`:
+
+```
+    load once, before the loop            RESIDENT BASELINE
+      library + entry-id index              O(library)
+      experiment-wide sidecars              O(distinct entries)
+    ..................................................  <- floor: never freed,
+                                                           never grows with k or N
+
+    for each run r in the batch:          PER-RUN WORKING SET
+        load   r.scores.parquet               |
+        load   r.1st-pass.fdr_scores.bin      |
+        load   r.reconciliation.json          |  O(entries in r)
+        load   r.calibration.json             |
+        load   r.spectra.bin (windowed)       |
+              ---- rescore r ----             |
+        write  r.scores-reconciled.parquet    |
+        free   everything loaded for r        v
+    end for
+
+    peak resident = baseline + max over r of (working set of r)
+                  = O(library) + O(entries in one run)
+```
+
+Read the last line carefully: **k does not appear, and neither does N**. That identity
+is the contract. A node handed one run and a node handed a hundred have the same peak,
+so the orchestrator may batch however it likes, and a cohort that fits at 3 runs fits
+at 500.
+
+The identity holds only while both halves hold: the baseline must be bounded by the
+library rather than the cohort, and the per-run working set must actually be freed at
+the end of each iteration. A single collection that accumulates across iterations -
+even one holding just a few values per entry - converts the sum into O(runs x entries)
+and silently reintroduces the wall.
+
+> **In flight** - `PerFileRescoring`'s baseline does not yet meet this contract:
+> `RescorePassInputs` still carries several maps keyed by file name whose values are
+> per-entry (consensus targets, reconciliation targets, per-run calibrations, gap-fill
+> targets), and the task is entered with a materialised all-runs entry list. Reducing
+> the baseline to the bounded set above is the target shape in
+> ai/todos/active/TODO-20260901_osprey_stage5_reload_materialization.md.
+
+### Phase boundaries inside a task
+
+A task is not the unit of persistence. `FirstPassFDR` alone passes through model
+training, a scoring pass over every run, the experiment-wide barrier, a second pass,
+protein FDR, and Stage 6 planning - and it writes its products at the end of the phase
+that computes them, not at the end of the task.
+
+This matters for two reasons. It bounds crash exposure to a single in-flight file
+regardless of how large the cohort is, and it is what makes a phase's output available
+to a downstream task that starts mid-pipeline. A task that persisted only at its own
+end would force a resumed run to redo every phase it had already completed.
+
+---
+
+## Principles
+
+Fifteen rules, in four groups. The first group makes the pipeline decomposable, the
+second bounds its memory, the third makes its files trustworthy, and the fourth makes
+an interrupted run resumable. Each is stated as a rule with the reason it exists,
+because a rule whose reason is not recorded gets optimised away.
+
+### Decomposition: what makes HPC possible
+
+**P1. Every durable artifact is either per-run or experiment-wide.** There is no third
+tier, and an artifact that fits neither is a design error rather than a special case.
+Scope is a statement about *content* - whose data is in the file - and it is what the
+memory model in P5 and P6 is built on.
+
+Scope is not the same question as naming, and the two must not be conflated. Most
+per-run content is named for its run stem and most experiment-wide content is named for
+the analysis, but an experiment-wide payload small enough to duplicate may be
+*replicated* under every run stem so a fan-out node can find it by the one derivation it
+already knows. `<stem>.1st-pass.model.json` is exactly that: identical bytes beside
+every run, any one copy authoritative. It is experiment-wide content, and the memory
+model counts it as baseline, whatever its name says.
+
+**P2. A per-run iteration reads only its own run's artifacts plus experiment-wide
+summaries written by an earlier phase, and builds nothing spanning runs.** This is the
+rule that makes batch size free. An iteration that reaches for a second run's file has
+made the node's correctness depend on which runs it was handed, and the orchestrator
+can no longer split the cohort arbitrarily.
+
+**P3. Work goes in the fan-out tasks; a join holds O(distinct), never O(runs x
+entries).** The joins are the bottleneck - one node, no horizontal scaling - so work
+placed there is paid at full cost by every cohort. Moving work into a `PerFile*` task
+makes it scale with the cluster; leaving it in a join makes it scale with nothing.
+
+**P4. A per-run artifact's validity key must not name the cohort.** `PerFileScoring`'s
+key is search parameters plus library identity, and deliberately omits the file set,
+because a run's Stage 1-4 scores do not depend on which other runs are being searched.
+Were the cohort in that key, scoring one run per node would stamp a different key than
+the join expects, and every artifact would invalidate on rebatching - the HPC split
+would be defeated by its own bookkeeping. Contrast `ReconciliationParameterHash`, which
+*does* fold in the sorted file stems, correctly: reconciliation output genuinely depends
+on the cohort.
+
+### The two tiers: where the memory model lives
+
+**P5. The experiment-wide artifacts are the memory baseline of a fan-out task.** They
+are loaded once before the per-run loop and held for its whole duration, so their
+combined size is the floor under the task's resident set. This is the reason
+experiment-wide artifacts must be *summaries* - O(library) or O(distinct entries) - and
+never a concatenation of per-run data. An experiment-wide file that grows with the
+cohort puts the cohort in the floor.
+
+**P6. Per-run artifacts are loaded and freed inside one iteration.** Nothing a run's
+processing allocates may outlive its iteration. The peak is then
+`baseline + max(one run)`, independent of batch size and of cohort size, which is the
+identity in the figure above and the property the 64 GB target rests on.
+
+**P7. Persist at phase end, not task end.** Crash exposure is one in-flight file no
+matter how large the cohort, and a downstream task starting mid-pipeline finds each
+phase's product already on disk.
+
+### Write discipline: what makes a file trustworthy
+
+**P8. Every durable artifact commits through `FileSaver`, so presence proves
+completeness.** The writer stages into a sibling temp file in the same directory and
+promotes it with an in-volume rename; a crash mid-write leaves the previous content or
+no file, never a half-written one. Every consumer in the pipeline relies on this: a
+file that exists is a file that is whole, so no reader needs a completeness check, a
+length prefix, or a two-phase protocol.
+
+**P9. A validity key answers set inclusion, not completeness.** This follows from P8
+and is the most easily confused point in the design. Because atomic placement already
+guarantees the bytes are whole, the key never asks "did the writer finish?" - it asks
+only **"was this computed under the same software version, library, parameters and file
+set as the run now asking?"** Those are orthogonal questions with orthogonal mechanisms:
+existence answers completeness, the key answers membership. `PerFileResumeDriver.IsCurrent`
+tests both, because a sidecar can outlive its output.
+
+**P10. A question one phase asks about another phase's work is answered by an artifact,
+never by process state.** Under an HPC split the phases are separate processes, so any
+signal held in memory is simply absent on the next node - and a task that infers from
+its own emptiness infers wrongly. This is why the `.osprey.task` stamp records the
+producing task's name: a later phase can ask "who wrote this, and is it current?"
+without opening the artifact. The rule is written in blood. Stage 7 once decided whether
+the Stage 6 worker had run by checking an in-process flag; correct in one process, and
+in an HPC chain it concluded no worker had run and rewrote every sidecar with survivors
+only - 332,269 records where the straight-through route produced 407,624, on artifacts
+whose whole purpose is to be route-independent.
+
+**P11. Artifacts are write-once: a new column means a new file, never a revisit.** A
+phase writes its product once and no later phase reopens it. Reconciled scores go to
+`<stem>.scores-reconciled.parquet` rather than overwriting `<stem>.scores.parquet`,
+which is what lets Stage 6 rerun without destroying its own input and lets two arms
+share one Stage 1-4 result.
+
+> **In flight** - `FdrScoresSidecar.PatchProteinQvalues` still rewrites an existing
+> first-pass sidecar in place to add protein q-values. Splitting that column into its
+> own experiment-wide file, written by the phase that computes it, is tracked in
+> ai/todos/active/TODO-20260901_osprey_firstpassfdr_resume.md.
+
+**P12. A column lives in the file written by the phase that computes it.** The
+corollary of P11 that decides where a *new* column goes. Adding a column to an existing
+file means either revisiting it (forbidden) or delaying its writer until the later value
+is known (which breaks P7).
+
+**P13. Never conditionally write an output artifact.** A phase that has nothing to say
+writes the header-only or zero-record file rather than skipping the write. Otherwise
+absence is ambiguous - "nothing to report" and "this phase never ran" look identical on
+disk - and P8's guarantee that presence proves completeness has no counterpart for
+absence.
+
+**P14. When a phase writes several files for one run, the file whose presence gates
+downstream reuse lands last.** `FileSaver` makes each individual write atomic; it says
+nothing about a *set* of writes. So the set needs an ordering discipline, and the rule
+is that the gate file is written after everything it implies. `PerFileRescoring` writes
+`<stem>.2nd-pass.fdr_decoys.bin` before `<stem>.2nd-pass.fdr_scores.bin` for exactly
+this reason: an interruption between them leaves a file the next phase recomputes,
+rather than one it trusts and folds against a companion that was never written.
+
+### Resume and relocation
+
+**P15. Resume is a forward scan, and identity is path-independent.** The driver walks
+the stages in order, reusing each output whose sidecar key matches and recomputing from
+the first that does not; a stage that runs invalidates everything downstream. Because
+the scan is forward and downstream invalidation is total, a key that is not exhaustive
+enough costs a recompute, never a wrong answer - which is why "I cannot tell" resolves
+to re-run.
+
+Identity is also deliberately free of paths: the library hash uses file name, size and
+mtime with the directory excluded, and the reconciliation hash names sorted file
+*stems*. A completed run can therefore be moved, copied, or hard-linked into a new
+output directory and still be recognised as valid - the property external tooling relies
+on to adopt a prior run's Stage 1-4 artifacts instead of recomputing them for hours.
+
+---
+
+## The sidecar file contract
+
+This is the authoritative list of what the pipeline writes, who may read it, and what
+must travel with what. Every row was verified against the path-building code named in
+its prose; where this table and a stage document disagree, this table is the one that
+was checked.
+
+### Reading the table
+
+Two axes classify every artifact, and both matter:
+
+- **Scope** - per-run or experiment-wide (P1). Content, not naming.
+- **Kind** - **product** or **cache**. A product is a phase's output and the only copy
+  of what it says; a cache is derivable again from a source that still exists. Products
+  go to `--output-dir`, caches to `--work-dir`. The distinction is not academic: a
+  cache may be deleted to reclaim disk, and a product may not.
+
+The **Relay** column is the HPC instruction: what an orchestrator must place on a node
+before that node's task can run. "with the run" means the file travels alongside its own
+run's other artifacts to whichever node processes that run. "every node" means every
+node running that task needs a copy, whatever batch it was handed.
+
+| File | Scope / kind | Written by | Read by | Relay |
+|---|---|---|---|---|
+| `<library-leaf>.libcache` | experiment cache | library load, any task | all tasks | rebuild locally |
+| `<stem>.spectra.bin` | per-run cache | `PerFileScoring` (Stage 2) | `PerFileScoring`, `PerFileRescoring` | with the run |
+| `<stem>.calibration.json` | per-run product | `PerFileScoring` (Stage 3) | `PerFileRescoring` | with the run |
+| `<stem>.scores.parquet` | per-run product | `PerFileScoring` (Stage 4) | `FirstPassFDR`, `PerFileRescoring` | with the run |
+| `<stem>.1st-pass.fdr_scores.bin` | per-run product | `FirstPassFDR` (pass 1) | `PerFileRescoring`, `SecondPassFDR` | with the run |
+| `<stem>.reconciliation.json` | per-run product | `FirstPassFDR` (Stage 6 planning) | `PerFileRescoring` | with the run |
+| `<blib-stem>.1st-pass.fdr_experiment.bin` | experiment product | `FirstPassFDR` | `PerFileRescoring`, `SecondPassFDR` | **every node** |
+| `<stem>.1st-pass.model.json` | experiment product, replicated | `FirstPassFDR` (training) | `PerFileRescoring`, `SecondPassFDR` | **every node** (any one copy) |
+| `<stem>.scores-reconciled.parquet` | per-run product | `PerFileRescoring` (Stage 6) | `SecondPassFDR` | with the run |
+| `<stem>.2nd-pass.fdr_decoys.bin` | per-run product | `PerFileRescoring` (pass-2 worker) | `SecondPassFDR` | with the run |
+| `<stem>.2nd-pass.fdr_scores.bin` | per-run product | `PerFileRescoring` (pass-2 worker), else `SecondPassFDR` | `SecondPassFDR` | with the run |
+| `<blib-stem>.2nd-pass.fdr_experiment.bin` | experiment product | `SecondPassFDR` | terminal | n/a |
+| `<output>.<TaskName>.osprey.task` | scope of its artifact | every task, via `PerFileResumeDriver` | the driver | with its artifact |
+| `<output>.blib` | experiment product (terminal) | `SecondPassFDR` | Skyline | n/a |
+
+Nothing else is part of this contract. Diagnostic outputs - the `--fdrbench` pairing
+manifests, the `--model-diagnostics` HTML and JSON, the peptide-trace dumps - are
+side channels: no task reads them, nothing relays them, and removing one changes no
+result. Do not add a pipeline dependency on any of them.
+
+### Rows that are not what they look like
+
+**`<stem>.spectra.bin` is a cache until it is not.** It is rebuildable by re-parsing the
+source, which makes it a cache. But the supported way to halve a large cohort's disk is
+to stage the raw data, build the caches, and delete the sources - and after that this
+file is the only copy of the run, and deleting it loses the run. Prune spectra caches
+only where the source is still on disk.
+
+**`<stem>.1st-pass.model.json` is experiment-wide content under a per-run name.** The
+trained first-pass Percolator model is identical for every run, and a `SecondPassFDR` or
+`PerFileRescoring` node running a frozen pass-2 mode needs it. Writing it once under the
+analysis name would force every fan-out node to learn a second path convention; writing
+it beside each run's other sidecars means a node finds it by the same stem derivation it
+already uses. `LoadFromAny` takes the first copy that exists, because the copies are
+identical.
+
+**The protein-compact stratum has no file of its own.** It rides inside
+`<stem>.1st-pass.model.json` as an optional field, present only under
+`OSPREY_PASS2_QVALUE=protein-compact`. This is deliberate and worth not undoing: the
+mode needs both the frozen model and the stratum, they are produced by the same
+first-pass span, and a node holding one without the other can do nothing. One artifact
+means one relay hop and one reload site, and makes it impossible to ship half of what
+the mode requires.
+
+**`<stem>.2nd-pass.fdr_scores.bin` has two possible writers, and the sidecar says
+which.** When `PerFileRescoring` runs the pass-2 per-file worker it writes this file and
+stamps the validity sidecar under its *own* task and key - the artifact belongs to the
+task that produced it, so it must be invalidated by whatever invalidates that task.
+`SecondPassFDR` then reads the stamp to decide whether to fold the worker's file or
+recompute. Stamping `SecondPassFDR`'s key at production time would leave a file that
+outlives the inputs it was computed from, which is the one staleness a resume cannot
+detect by looking. Where no worker ran, `SecondPassFDR` writes the file itself.
+
+**`<output>.<TaskName>.osprey.task` is per-artifact, not per-task.** One sidecar is
+written next to each output, and its name carries the producing task so two tasks
+sharing an output path cannot trample each other's record. Reuse requires both the
+output to exist *and* its sidecar key to match: a sidecar can outlive its output, so a
+matching key alone is not enough (P8 and P9 are separate tests, and
+`PerFileResumeDriver.IsCurrent` runs both).
+
+### Where experiment-wide artifacts live
+
+An experiment-wide product takes its **name** from the output blib and its **directory**
+from the same resolution the per-run sidecars use - `ArtifactPaths.ResolveOutputDir` off
+any input or scores-parquet path of the analysis. Both halves are deliberate, and
+getting either wrong breaks the HPC chain rather than the single-process run:
+
+- The **name** must come from the blib because the blib is what names the analysis, and
+  two analyses sharing an output directory must not collide.
+- The **directory** must not come from the blib, because the blib's directory is not
+  stable across phases. Every distributed `--task` invocation runs in its own working
+  directory with the same relative `-o output.blib`, so a file placed beside the blib is
+  written by one phase into a directory the next phase never looks in.
+
+That is not a hypothetical failure. The first version of this resolution did place the
+file beside the blib, and the HPC leg of the regression gate caught it: the second phase
+wrote its first-pass experiment sidecar into its own phase directory, and the third
+phase looked beside its own blib and found nothing.
+
+### Artifacts that must relay together
+
+Two experiment-wide artifacts answer questions a node cannot answer alone, and shipping
+one without the other produces a node that either fails fast or - worse - proceeds on a
+default:
+
+- `<blib-stem>.1st-pass.fdr_experiment.bin` carries the experiment-scope q-values every
+  downstream pass reads. A `PerFileRescoring` or `SecondPassFDR` node without it cannot
+  reconstruct them, because they are a function of all runs.
+- `<stem>.1st-pass.model.json` carries the frozen model, and under `protein-compact` the
+  stratum with it. A distributed `SecondPassFDR` node that never trained pass 1 has no
+  other source for either.
+
+Ship both to every node running either task. A node that has one and not the other is
+the case the fail-fast exists for, and it is the orchestrator's job never to create it.
+

--- a/pwiz_tools/Osprey/docs/00-pipeline-architecture.md
+++ b/pwiz_tools/Osprey/docs/00-pipeline-architecture.md
@@ -50,11 +50,13 @@ file, one LC-MS/MS acquisition. It is the unit the pipeline fans out over.
 
 The code spells this concept `file`, because a run arrives as a file and is keyed by
 its file stem. The two fan-out tasks are named `PerFileScoring` and `PerFileRescoring`
-in the CLI, the `HpcTask` enum, and the `.osprey.task` sidecar names, and this document
-uses those spellings whenever it names a task, a type, or a path. It says **run** in
-prose, where "per-run" and "experiment-wide" is the distinction that carries the
+in the CLI, the `HpcTask` enum, and the `.osprey.task` sidecar names, and Stage 6's
+canonical name is "Per-file rescore". **Proper names are quoted as they are spelled** -
+tasks, types, paths, stage names - and this document says **run** everywhere else,
+because "per-run versus experiment-wide" is the distinction that carries the
 architecture and "per-file" invites confusion with the dozen other files in play. The
-`--model-diagnostics` report uses the same prose convention.
+`--model-diagnostics` report and the workflow diagram's role labels use the same
+convention.
 
 One run, one stem, one set of per-run sidecars. A cohort of 500 runs is 500 stems.
 

--- a/pwiz_tools/Osprey/docs/00-pipeline-architecture.md
+++ b/pwiz_tools/Osprey/docs/00-pipeline-architecture.md
@@ -49,9 +49,11 @@ Throughout this document a **run** is one MS data file: one mzML or one vendor r
 file, one LC-MS/MS acquisition. It is the unit the pipeline fans out over.
 
 The code spells this concept `file`, because a run arrives as a file and is keyed by
-its file stem. The two fan-out tasks are named `PerFileScoring` and `PerFileRescoring`
-in the CLI, the `HpcTask` enum, and the `.osprey.task` sidecar names, and Stage 6's
-canonical name is "Per-file rescore". **Proper names are quoted as they are spelled** -
+its file stem. The two fan-out tasks are `PerFileScoring` and `PerFileRescoring` in the
+CLI and in the `.osprey.task` sidecar names; the `HpcTask` enum spells three of the four
+differently (`FirstPassFdr`, `PerFileRescore`, `SecondPassFdr`), so a name copied from the
+enum will not match a filename. Stage 6's canonical name is "Per-file rescore".
+**Proper names are quoted as they are spelled** -
 tasks, types, paths, stage names - and this document says **run** everywhere else,
 because "per-run versus experiment-wide" is the distinction that carries the
 architecture and "per-file" invites confusion with the dozen other files in play. The
@@ -274,8 +276,9 @@ placed there is paid at full cost by every cohort. Moving work into a `PerFile*`
 makes it scale with the cluster; leaving it in a join makes it scale with nothing.
 
 **P4. A per-run artifact's validity key must not name the cohort.** `PerFileScoring`'s
-key is search parameters plus library identity, and deliberately omits the file set,
-because a run's Stage 1-4 scores do not depend on which other runs are being searched.
+key is the base key - search parameters, library identity, and the peak-pick arm - and
+deliberately omits the file set, because a run's Stage 1-4 scores do not depend on which
+other runs are being searched.
 Were the cohort in that key, scoring one run per node would stamp a different key than
 the join expects, and every artifact would invalidate on rebatching - the HPC split
 would be defeated by its own bookkeeping. Contrast `ReconciliationParameterHash`, which
@@ -307,7 +310,9 @@ completeness.** The writer stages into a sibling temp file in the same directory
 promotes it with an in-volume rename; a crash mid-write leaves the previous content or
 no file, never a half-written one. Every consumer in the pipeline relies on this: a
 file that exists is a file that is whole, so no reader needs a completeness check, a
-length prefix, or a two-phase protocol.
+length prefix, or a two-phase protocol. The claim is checkable rather than aspirational -
+[14-intermediate-files](14-intermediate-files.md) enumerates the call sites, and a new
+durable artifact that does not appear there is a defect.
 
 **P9. A validity key answers set inclusion, not completeness.** This follows from P8
 and is the most easily confused point in the design. Because atomic placement already
@@ -321,12 +326,14 @@ tests both, because a sidecar can outlive its output.
 never by process state.** Under an HPC split the phases are separate processes, so any
 signal held in memory is simply absent on the next node - and a task that infers from
 its own emptiness infers wrongly. This is why the `.osprey.task` stamp records the
-producing task's name: a later phase can ask "who wrote this, and is it current?"
-without opening the artifact. The rule is written in blood. Stage 7 once decided whether
-the Stage 6 worker had run by checking an in-process flag; correct in one process, and
-in an HPC chain it concluded no worker had run and rewrote every sidecar with survivors
-only - 332,269 records where the straight-through route produced 407,624, on artifacts
-whose whole purpose is to be route-independent.
+producing task's name: a later phase can ask "who wrote this?" without opening the
+artifact. This rule was learned from a defect. Stage 7 once decided whether the Stage 6
+worker had run by reading a pipeline byproduct the worker published in memory; correct in
+one process, and in an HPC chain - where the two are separate processes - nothing
+published in Stage 6 reaches Stage 7, so it concluded no worker had run and rewrote every
+sidecar with survivors only: 332,269 records where the straight-through route produced
+407,624, on artifacts whose whole purpose is to be route-independent. An in-memory signal
+cannot answer a question about a file that outlives the process.
 
 **P11. Artifacts are write-once: a new column means a new file, never a revisit.** A
 phase writes its product once and no later phase reopens it. Reconciled scores go to
@@ -334,10 +341,13 @@ phase writes its product once and no later phase reopens it. Reconciled scores g
 which is what lets Stage 6 rerun without destroying its own input and lets two arms
 share one Stage 1-4 result.
 
-> **In flight** - `FdrScoresSidecar.PatchProteinQvalues` still rewrites an existing
-> first-pass sidecar in place to add protein q-values. Splitting that column into its
-> own experiment-wide file, written by the phase that computes it, is tracked in
-> ai/todos/active/TODO-20260901_osprey_firstpassfdr_resume.md.
+Write-once is fully achieved today. The per-file sidecars were once written and then
+revisited - `PatchProteinQvalues` rewrote every first-pass sidecar after protein FDR, and
+`PatchExperimentValues` every second-pass sidecar after the experiment competition -
+because the experiment-scope columns were the only ones not knowable when a run's records
+were written. Issue #4486 moved those columns into the experiment-wide sidecar and deleted
+all three patch paths, so a per-file sidecar is now written exactly once on each pass and
+no later stage reopens it.
 
 **P12. A column lives in the file written by the phase that computes it.** The
 corollary of P11 that decides where a *new* column goes. Adding a column to an existing
@@ -410,24 +420,34 @@ node running that task needs a copy, whatever batch it was handed.
 | File | Scope / kind | Written by | Read by | Relay |
 |---|---|---|---|---|
 | `<library-leaf>.libcache` | experiment cache | library load, any task | all tasks | rebuild locally |
-| `<stem>.spectra.bin` | per-run cache | `PerFileScoring` (Stage 2) | `PerFileScoring`, `PerFileRescoring` | with the run |
-| `<stem>.calibration.json` | per-run product | `PerFileScoring` (Stage 3) | `PerFileRescoring` | with the run |
+| `<stem>.spectra.bin` | per-run cache | `PerFileScoring` (Stage 2), or `--task SpectraCache` | `PerFileScoring`, `PerFileRescoring` | with the run |
+| `<stem>.calibration.json` | per-run product | `PerFileScoring` (Stage 3) | `PerFileRescoring`, `FirstPassFDR`, `SecondPassFDR` | with the run, on **every** leg |
 | `<stem>.scores.parquet` | per-run product | `PerFileScoring` (Stage 4) | `FirstPassFDR`, `PerFileRescoring` | with the run |
-| `<stem>.1st-pass.fdr_scores.bin` | per-run product | `FirstPassFDR` (pass 1) | `PerFileRescoring`, `SecondPassFDR` | with the run |
-| `<stem>.reconciliation.json` | per-run product | `FirstPassFDR` (Stage 6 planning) | `PerFileRescoring` | with the run |
-| `<blib-stem>.1st-pass.fdr_experiment.bin` | experiment product | `FirstPassFDR` | `PerFileRescoring`, `SecondPassFDR` | **every node** |
+| `<stem>.1st-pass.fdr_scores.bin` | per-run product | `FirstPassFDR` (pass 1) | `PerFileRescoring`; `SecondPassFDR` only under `OSPREY_PASS2_VERIFY_WORKER` or where no worker answer exists | with the run |
+| `<stem>.reconciliation.json` | per-run product | `FirstPassFDR` (Stage 6 planning) | `PerFileRescoring`, `SecondPassFDR` (gap-fill entry ids) | with the run |
+| `<blib-stem>.1st-pass.fdr_experiment.bin` | experiment product | `FirstPassFDR` | `PerFileRescoring`, `SecondPassFDR`, `PerFileScoring` (rehydrate) | **every node** |
 | `<stem>.1st-pass.model.json` | experiment product, replicated | `FirstPassFDR` (training) | `PerFileRescoring`, `SecondPassFDR` | **every node** (any one copy) |
 | `<stem>.scores-reconciled.parquet` | per-run product | `PerFileRescoring` (Stage 6) | `SecondPassFDR` | with the run |
 | `<stem>.2nd-pass.fdr_decoys.bin` | per-run product | `PerFileRescoring` (pass-2 worker) | `SecondPassFDR` | with the run |
 | `<stem>.2nd-pass.fdr_scores.bin` | per-run product | `PerFileRescoring` (pass-2 worker), else `SecondPassFDR` | `SecondPassFDR` | with the run |
-| `<blib-stem>.2nd-pass.fdr_experiment.bin` | experiment product | `SecondPassFDR` | terminal | n/a |
+| `<blib-stem>.2nd-pass.fdr_experiment.bin` | experiment product | `SecondPassFDR` | `SecondPassFDR` on a resume | n/a |
+| `<output>.model-diagnostics.data.json` | experiment product (`--model-diagnostics`) | `FirstPassFDR` | `SecondPassFDR`, which deletes it | **every node** running `SecondPassFDR` |
+| `<output>.model-diagnostics.html` | experiment product (`--model-diagnostics`) | `SecondPassFDR` | terminal | n/a |
 | `<output>.<TaskName>.osprey.task` | scope of its artifact | every task, via `PerFileResumeDriver` | the driver | with its artifact |
 | `<output>.blib` | experiment product (terminal) | `SecondPassFDR` | Skyline | n/a |
 
-Nothing else is part of this contract. Diagnostic outputs - the `--fdrbench` pairing
-manifests, the `--model-diagnostics` HTML and JSON, the peptide-trace dumps - are
-side channels: no task reads them, nothing relays them, and removing one changes no
-result. Do not add a pipeline dependency on any of them.
+Nothing else is part of this contract. The `--fdrbench` pairing manifests and the
+peptide-trace dumps are side channels: no task reads them, nothing relays them, and
+removing one changes no result. Do not add a pipeline dependency on any of them.
+
+The `--model-diagnostics` artifacts are **not** in that category, which is easy to assume
+from the flag name. `.model-diagnostics.data.json` is a real cross-task, cross-process
+hand-off - `FirstPassFDR` stashes the fully-built pass-1 data model in it because the
+pass-1 pool and trained model are gone by the time `SecondPassFDR` runs, and
+`SecondPassFDR` reads it, appends the pass-2 views, renders the page and deletes it. An
+HPC orchestrator that omits it from the `SecondPassFDR` node loses the pass-1 half of the
+report. And `.model-diagnostics.html` is a *declared output* of `SecondPassFdrTask`, so
+deleting it invalidates that task and a re-run regenerates it.
 
 ### Rows that are not what they look like
 
@@ -453,14 +473,33 @@ first-pass span, and a node holding one without the other can do nothing. One ar
 means one relay hop and one reload site, and makes it impossible to ship half of what
 the mode requires.
 
-**`<stem>.2nd-pass.fdr_scores.bin` has two possible writers, and the sidecar says
-which.** When `PerFileRescoring` runs the pass-2 per-file worker it writes this file and
+**`<stem>.2nd-pass.fdr_scores.bin` has two possible writers, and the sidecar's NAME says
+which.** When `PerFileRescoring` runs the pass-2 per-run worker it writes this file and
 stamps the validity sidecar under its *own* task and key - the artifact belongs to the
 task that produced it, so it must be invalidated by whatever invalidates that task.
-`SecondPassFDR` then reads the stamp to decide whether to fold the worker's file or
-recompute. Stamping `SecondPassFDR`'s key at production time would leave a file that
-outlives the inputs it was computed from, which is the one staleness a resume cannot
-detect by looking. Where no worker ran, `SecondPassFDR` writes the file itself.
+Stamping `SecondPassFDR`'s key at production time would leave a file that outlives the
+inputs it was computed from, which is the one staleness a resume cannot detect by looking.
+Where no worker ran, `SecondPassFDR` writes the file itself.
+
+`SecondPassFDR` then decides fold-versus-recompute on the **presence** of a stamp named
+for `PerFileRescoring` - never by re-deriving that task's key. The filename already says
+who wrote the binary, which is the whole point of stamping it. Recomputing the producer's
+key from the consumer's process was tried and failed exactly where it mattered:
+`PerFileRescoreTask.ValidityKey` folds in a per-leg flag, so a `--task SecondPassFDR`
+process and a `--task PerFileRescoring` process compute *different* keys for the same
+task; in an HPC chain the check said "not valid", Stage 7 concluded no worker had run, and
+it rewrote every sidecar. **One task cannot reconstruct another task's key from a
+different leg, and must not try.** Staleness is still covered, by the task that owns it: if
+the worker's inputs changed, `PerFileRescoring`'s own validity fails, the driver re-runs
+it, and it rewrites both the binary and the stamp. A stamp that survives is one whose
+producer was legitimately skipped as already done.
+
+**`<stem>.calibration.json` is read on every leg, not just the rescore.** Besides RT
+calibration for Stage 6, it carries the isolation-scheme windows that give the gap-fill
+m/z filter its per-run coverage - which is how a `SecondPassFDR` node with no mzML still
+gets that coverage. It is read behind a `File.Exists`, so an orchestrator that leaves it
+behind does not get an error: gap-fill filtering silently changes. That is the P13-shaped
+hazard this document warns about, in the contract itself.
 
 **`<output>.<TaskName>.osprey.task` is per-artifact, not per-task.** One sidecar is
 written next to each output, and its name carries the producing task so two tasks
@@ -469,9 +508,15 @@ output to exist *and* its sidecar key to match: a sidecar can outlive its output
 matching key alone is not enough (P8 and P9 are separate tests, and
 `PerFileResumeDriver.IsCurrent` runs both).
 
-### Where experiment-wide artifacts live
+### Where blib-named experiment-wide artifacts live
 
-An experiment-wide product takes its **name** from the output blib and its **directory**
+This rule governs the artifacts named for the analysis - `fdr_experiment.bin` for both
+passes, and the `--model-diagnostics` pair. It does **not** govern
+`<stem>.1st-pass.model.json`, which is the replicated exception described above: that one
+takes its name from the run stem and its directory from that run's own parquet, precisely
+so a fan-out node can find it without knowing this rule.
+
+A blib-named artifact takes its **name** from the output blib and its **directory**
 from the same resolution the per-run sidecars use - `ArtifactPaths.ResolveOutputDir` off
 any input or scores-parquet path of the analysis. Both halves are deliberate, and
 getting either wrong breaks the HPC chain rather than the single-process run:
@@ -579,6 +624,10 @@ wrong answer:
 | training-sample settings | a resume adopts maximum-trained scores as though the reservoir had produced them |
 | library-fragment release | the retained-fragment arm differs and the outputs are not interchangeable |
 
+`PerFileRescoring` appends its own set for the same reasons - the reconciliation hash and
+sidecar format version, the experiment-aggregation, pass-2 q and training-sample arms, and
+the survivor-streaming switch, whose two paths must not adopt each other's output.
+
 The peak-pick arm sits in the *base* rather than in the overrides because it is the one
 lever that reaches every task: the pick decides which peak a precursor's row describes,
 back in Stage 4, and everything downstream inherits that choice. Putting it in the base
@@ -654,17 +703,35 @@ The general rule, if you remember nothing else: **a fan-out node needs its own r
 files plus every experiment-wide artifact produced so far.** The checklists below are
 that rule made explicit at each boundary.
 
+Two things hold at every boundary and are not repeated in each list:
+
+- **Every artifact travels with its `.osprey.task` sidecar.** The stamp is how the
+  receiving node learns who produced the file and whether it may be reused; shipping the
+  artifact without it turns a valid reuse into a recompute, or worse (P10).
+- **Preserve mtime when copying the library.** `LibraryIdentityHash` is file name + size
+  + mtime, so a copy tool that stamps a fresh timestamp gives the library a new identity
+  and invalidates every artifact on the receiving node - a multi-hour recompute reported
+  as a stale cache. Use `robocopy /COPY:DAT`, `rsync -t`, or whatever preserves mtime on
+  the cluster.
+
 ### Boundary 1 -> 2: `PerFileScoring` to `FirstPassFDR`
 
 The join needs every run's Stage 1-4 output, since training and experiment-wide q-values
 are functions of all runs:
 
 - `<stem>.scores.parquet` for **every** run in the cohort
+- `<stem>.calibration.json` for **every** run
 - the library, and `--input-scores` naming the parquets
 
-`<stem>.spectra.bin` and `<stem>.calibration.json` do not need to travel: the join reads
-parquets, not spectra. Leave them on the scoring nodes unless the raw data was deleted
-after staging, in which case the spectra caches are the data and must be preserved.
+`.calibration.json` must travel, which is easy to get wrong because the join reads
+parquets rather than spectra. It supplies RT calibration and the isolation-scheme windows
+behind the gap-fill m/z filter, and it is read on this leg and the `SecondPassFDR` leg as
+well as the rescore. It is read behind a `File.Exists`: leaving it out produces no error,
+just different gap-fill filtering.
+
+`<stem>.spectra.bin` does not need to travel - the join reads parquets, not spectra. Leave
+the caches on the scoring nodes unless the raw data was deleted after staging, in which
+case they are the data and must be preserved.
 
 ### Boundary 2 -> 3: `FirstPassFDR` to `PerFileRescoring`
 
@@ -695,10 +762,20 @@ Per run, for **every** run in the cohort:
   rescore node ran the pass-2 worker - together with their `.osprey.task` sidecars,
   which is how this task learns the worker produced them and folds them instead of
   recomputing
+- `<stem>.reconciliation.json` - read here for the gap-fill entry ids on the Stage-7 fold
+- `<stem>.calibration.json` - isolation-window coverage, so a node with no mzML still has it
 
 Experiment-wide:
 - `<blib-stem>.1st-pass.fdr_experiment.bin`
 - `<stem>.1st-pass.model.json` (any one copy)
+- `<output>.model-diagnostics.data.json`, when `--model-diagnostics` is on - the pass-1
+  half of the report exists nowhere else by this point
+
+Not needed on the default path: `<stem>.1st-pass.fdr_scores.bin`. Establishing that is
+what issue #4486 was for - an orchestrator hands a `SecondPassFDR` node the per-run
+second-pass artifacts and the analysis-wide experiment sidecar, and nothing per-run from
+the first pass. They become a real input only under `OSPREY_PASS2_VERIFY_WORKER`, which is
+a test instrument, or where no worker answer exists.
 
 The `.osprey.task` sidecars are not optional bookkeeping here. Without the stamp,
 `SecondPassFDR` cannot tell that a worker wrote the pass-2 files and will recompute them
@@ -716,18 +793,28 @@ so that clearing them after that work merges is a single edit.
 The contract above states the **target** in every case. Where today's code does not meet it,
 the text says so rather than describing the current shape as though it were the design.
 
-1. **Protein-q split of the experiment-scope FDR sidecar.** Protein q-values are currently
-   added by rewriting an existing first-pass sidecar in place
-   (`FdrScoresSidecar.PatchProteinQvalues`), which is the one surviving violation of P11.
-   The target is a separate experiment-wide artifact written by the phase that computes it.
-   See `ai/todos/active/TODO-20260901_osprey_firstpassfdr_resume.md`.
+1. **Protein-q split of the experiment-scope FDR sidecar.** This is a P7 and P12 item, not
+   a write-once one: `<blib-stem>.1st-pass.fdr_experiment.bin` is written once and never
+   mutated, but it is written *late* - after protein FDR - so pass 2's experiment-scope
+   product sits in an in-memory accumulator across the whole protein-FDR phase and is lost
+   if that phase dies. The target splits it into two immutable files joined on entry_id at
+   read time, each written by the phase that computes it: pass 2 writes precursor q,
+   peptide q, PEP and aggregate score when pass 2 ends; protein FDR writes protein q when
+   protein FDR ends. See "The protein-q split, and the rule behind it" in
+   `ai/todos/active/TODO-20260901_osprey_firstpassfdr_resume.md`.
 
 2. **The bounded-loop shape of `PerFileRescoring`.** The task is still entered with a
    materialised all-runs entry list, and its baseline still carries maps keyed by run whose
-   values are per-entry - the `O(runs x entries)` shape P5 and P6 forbid. See
+   values are per-entry - the `O(runs x entries)` shape P5 and P6 forbid. See "THE TARGET
+   SHAPE for --task PerFileRescoring" and its violation table (items 6 and 7,
+   `perFileEntries` and `reconciliationActions`) in
    `ai/todos/active/TODO-20260901_osprey_stage5_reload_materialization.md`.
 
-3. **Deletion of the fat pre-compaction path**, once the streamed path is the only one.
+3. **Retiring the resident survivor handoff.** `OSPREY_STAGE6_STREAM_SURVIVORS=0` still
+   selects the resident path, where Stage 5's all-runs survivor buffer stays live across
+   the whole Stage 6 rescore instead of being refilled one run at a time from each run's
+   `.scores.parquet` and first-pass sidecar. The streamed path is the default; the switch
+   goes when the resident one does.
 
 4. **Whether the 500-run / 64 GB target is met.** It is not yet, and which stage binds is
    itself moving as each is fixed. The two TODOs above carry the current measurements;

--- a/pwiz_tools/Osprey/docs/00-pipeline-architecture.md
+++ b/pwiz_tools/Osprey/docs/00-pipeline-architecture.md
@@ -95,9 +95,13 @@ a cluster.
 
 **`regression.ps1` mode 3 is the enforcement of this section and of the relay checklist at
 the end of this document**, not an anecdote about it: it runs the split as separate
-processes, stages exactly the files the checklist names, and asserts each per-node
-reconciled parquet is byte-identical to the straight-through run's. A relay obligation that
-mode 3 does not stage is an obligation nothing is checking.
+processes, stages the files the checklist names, and compares the split run's products
+against the straight-through run's. Read what it actually asserts before relying on it: the
+per-run FDR sidecars and the `.blib` are compared at the run tolerance, and only
+`*.fdr_experiment.bin` byte for byte. It does **not** open the reconciled parquets, so a
+Stage 6 content change can leave mode 3 green. A relay obligation mode 3 does not stage is
+an obligation nothing is checking - and `<output>.model-diagnostics.data.json` is currently
+one of those.
 
 Its one blind spot is worth stating, because it has already hidden a defect: a phase-3 node
 is handed **one** run, and at N=1 a correct per-run implementation and an all-runs one
@@ -373,6 +377,14 @@ length prefix, or a two-phase protocol. The claim is checkable rather than aspir
 [14-intermediate-files](14-intermediate-files.md) enumerates the call sites, and a new
 durable artifact that does not appear there is a defect.
 
+**Three artifacts do not yet obey this, and they are defects rather than exceptions.** The
+Stage-7 reports `<output>.protein_groups.tsv` and `<output>.stats.tsv` are written with a
+truncating `StreamWriter`, and both flags default on, so a kill during Stage 7 destroys the
+previous run's report and leaves a half-written one. `--write-pin` output is the third.
+None of them is in the contract table below - nothing in the pipeline reads them - but the
+"presence proves completeness" guarantee a *user* draws from a report file is exactly as
+strong as `FileSaver`, which is to say currently absent for these three.
+
 **P9. A validity key answers set inclusion, not completeness.** This follows from P8
 and is the most easily confused point in the design. Because atomic placement already
 guarantees the bytes are whole, the key never asks "did the writer finish?" - it asks
@@ -451,9 +463,9 @@ reuses an artifact computed under different settings and reports it as the new r
 Erring toward more key is therefore always the safe direction, and "I cannot tell"
 resolves to re-run.
 
-Identity is also, with one exception, free of paths: the library hash uses file name,
-size and mtime with the directory excluded, and the reconciliation hash names sorted
-file *stems*. A completed run can therefore be moved, copied, or hard-linked into a new
+Identity is also mostly free of paths: the library hash uses file name, size and mtime
+with the directory excluded, and the reconciliation hash names sorted file *stems*. Two
+user-supplied paths do reach it, both noted below. A completed run can therefore be moved, copied, or hard-linked into a new
 output directory and still be recognised as valid - the property external tooling relies
 on to adopt a prior run's Stage 1-4 artifacts instead of recomputing them for hours.
 
@@ -493,19 +505,21 @@ node running that task needs a copy, whatever batch it was handed.
 |---|---|---|---|---|
 | `<library-leaf>.libcache` | experiment cache | library load, any task | all tasks | rebuild locally |
 | `<stem>.spectra.bin` | per-run cache | `PerFileScoring` (Stage 2), or `--task SpectraCache` | `PerFileScoring`, `PerFileRescoring` | with the run |
-| `<stem>.calibration.json` | per-run product | `PerFileScoring` (Stage 3) | `PerFileRescoring`, `FirstPassFDR`, `SecondPassFDR` | with the run, on **every** leg |
-| `<stem>.scores.parquet` | per-run product | `PerFileScoring` (Stage 4) | `FirstPassFDR`, `PerFileRescoring` | with the run |
+| `<stem>.calibration.json` | per-run product | `PerFileScoring` (Stage 3) | `PerFileScoring`, `PerFileRescoring`, `FirstPassFDR`, `SecondPassFDR` | with the run, on **every** leg |
+| `<stem>.scores.parquet` | per-run product | `PerFileScoring` (Stage 4) | `FirstPassFDR`, `PerFileRescoring`, **`SecondPassFDR`** (fallback for runs with no reconciled sibling) | with the run |
 | `<stem>.1st-pass.fdr_scores.bin` | per-run product | `FirstPassFDR` (pass 1) | `PerFileRescoring`; `SecondPassFDR` only under `OSPREY_PASS2_VERIFY_WORKER` or where no worker answer exists | with the run |
 | `<stem>.reconciliation.json` | per-run product | `FirstPassFDR` (Stage 6 planning) | `PerFileRescoring`, `SecondPassFDR` (gap-fill entry ids) | with the run |
 | `<blib-stem>.1st-pass.fdr_experiment.bin` | experiment product | `FirstPassFDR` | `PerFileRescoring`, `SecondPassFDR`, `PerFileScoring` (rehydrate) | **every node** |
 | `<stem>.1st-pass.model.json` | experiment product, replicated | `FirstPassFDR` (training) | `PerFileRescoring`, `SecondPassFDR` | **every node** (any one copy) |
-| `<stem>.scores-reconciled.parquet` | per-run product | `PerFileRescoring` (Stage 6) | `SecondPassFDR` | with the run |
+| `<stem>.scores-reconciled.parquet` | per-run product | `PerFileRescoring` (Stage 6) | `SecondPassFDR`, and `PerFileRescoring` itself on its per-run resume arm | with the run |
 | `<stem>.2nd-pass.fdr_decoys.bin` | per-run product | `PerFileRescoring` (pass-2 worker) | `SecondPassFDR` | with the run |
 | `<stem>.2nd-pass.fdr_scores.bin` | per-run product | `PerFileRescoring` (pass-2 worker), else `SecondPassFDR` | `SecondPassFDR` | with the run |
 | `<blib-stem>.2nd-pass.fdr_experiment.bin` | experiment product | `SecondPassFDR` | `SecondPassFDR` on a resume | n/a |
 | `<output>.model-diagnostics.data.json` | experiment product (`--model-diagnostics`) | `FirstPassFDR` | `SecondPassFDR`, which deletes it | **every node** running `SecondPassFDR` |
-| `<output>.model-diagnostics.html` | experiment product (`--model-diagnostics`) | `SecondPassFDR` | terminal | n/a |
+| `<output>.model-diagnostics.html` | experiment product (`--model-diagnostics`) | `FirstPassFDR` renders it; `SecondPassFDR` appends the pass-2 views and re-renders | terminal | n/a |
 | `<output>.<TaskName>.osprey.task` | scope of its artifact | every task, via `PerFileResumeDriver` | the driver | with its artifact |
+
+In that last row `<output>` is the **full artifact path including its extension** - `foo.scores.parquet.PerFileScoring.osprey.task` - not the blib stem it means in the rows above it. A staging glob written from the uniform reading misses every per-run stamp.
 | `<output>.blib` | experiment product (terminal) | `SecondPassFDR` | Skyline | n/a |
 
 Nothing else is part of this contract. The `--fdrbench` pairing manifests and the
@@ -595,8 +609,7 @@ matching key alone is not enough (P8 and P9 are separate tests, and
 
 ### Where blib-named experiment-wide artifacts live
 
-This rule governs the artifacts named for the analysis - `fdr_experiment.bin` for both
-passes, and the `--model-diagnostics` pair. It does **not** govern
+This rule governs `fdr_experiment.bin` for both passes. It does **not** govern
 `<stem>.1st-pass.model.json`, which is the replicated exception described above: that one
 takes its name from the run stem and its directory from that run's own parquet, precisely
 so a fan-out node can find it without knowing this rule.
@@ -692,17 +705,26 @@ prior run's expensive Stage 1-4 output instead of recomputing it - see
 is a property of the hashes, and any change that folds a directory into one of them
 removes it for every run.
 
-**The one exception is `--decoy-pairing-manifest`.** Its path enters
-`SearchParameterHash` verbatim and unnormalised - the user's own spelling, relative or
-absolute - so it is the single place a directory reaches artifact identity. A cohort
-searched with a pairing manifest therefore *does* invalidate when it moves, which is why
-relocating an entrapment dataset needs a junction restoring the original path rather than
-a re-run. Everything else in this section holds regardless.
+**Two user-supplied paths reach artifact identity, and both defeat relocation for the
+runs that use them.** `--decoy-pairing-manifest` enters `SearchParameterHash` verbatim and
+unnormalised - the user's own spelling, relative or absolute. `OSPREY_PICK_LDA_MODEL`
+enters the *base* key through the peak-pick suffix, so it is inherited by all four tasks:
+moving, renaming, or per-node-mounting that model JSON invalidates every `.osprey.task`
+stamp in the tree and silently stops `-LinkFrom` adoption. A cohort using either therefore
+*does* invalidate when it moves, which is why relocating such a dataset needs a junction
+restoring the original path rather than a re-run. Everything else in this section holds
+regardless, and adding a third path to a hash would narrow it further.
 
 A warm resume across builds is a separate matter: the version stamp is compared for exact
-equality (`YEAR.ORDINAL.BRANCH.DOY`), so artifacts from another day's build are refused
-rather than silently reused. `OSPREY_VERSION_OVERRIDE` pins the stamp and is the
-sanctioned way to consume another build's artifacts deliberately.
+equality (`YEAR.ORDINAL.BRANCH.DOY`) - **but only where it is checked, which is narrower
+than it sounds.** That comparison guards the `--input-scores` parquet load. The
+`.osprey.task` resume path does not do it: `TaskValiditySidecar.IsValid` compares the
+`validity_key` only, and the `version` field it records is provenance. No version component
+is in the base key either. So re-invoking the same straight-through command line the next
+day, against yesterday's output directory, reuses every task on a key match alone even
+across a build with different scoring - the under-inclusive-key outcome P15 calls the
+dangerous direction. Treat that as a gap, not a guarantee. `OSPREY_VERSION_OVERRIDE` pins
+the stamp and is the sanctioned way to consume another build's artifacts deliberately.
 
 ---
 
@@ -711,7 +733,11 @@ sanctioned way to consume another build's artifacts deliberately.
 ### What the key is made of, and why it decides correctness
 
 Each task composes its own key: a base of search parameters, library identity and the
-peak-pick arm, plus per-task additions - `FirstPassFDR` adds six, `PerFileRescoring` six.
+peak-pick arm, plus per-task additions - `FirstPassFDR` adds six, `PerFileRescoring`
+seven, `SecondPassFDR` seven. `PerFileRescoring`'s seventh is the one to know about:
+`LibraryFragmentRelease.ValidityKeySuffix` branches on the per-leg flags, which is exactly
+why a `SecondPassFDR` process and a `PerFileRescoring` process compute different keys for
+the same task - the asymmetry the stamp-presence rule above exists to work around.
 **The exact composition, and the defect each component was added to prevent, is
 invalidation mechanics and lives in [14-intermediate-files](14-intermediate-files.md).**
 
@@ -740,8 +766,14 @@ Two details are easy to get wrong:
   downstream artifact stamped with a matching key is still describing the right input.
   Correctness therefore rests entirely on keys being exhaustive, which is why the table
   above exists.
-- **A sidecar is cleared when its task starts, not when it finishes.** A crash mid-Run
-  then leaves no stale marker claiming a partially written output is valid.
+- **A stale sidecar is cleared before its output is recomputed, not after.** A crash
+  mid-Run then leaves no stale marker claiming a partially written output is valid. **The
+  granularity differs by task and must not be unified.** The two joins clear their single
+  coarse output's sidecar at the start of `Run`. The two fan-out tasks clear *per run*,
+  immediately before recomputing that run, because a task-level delete would wipe the
+  per-run stamps they rely on for their own within-task skip. Hoisting the delete into the
+  driver to remove the apparent asymmetry would make a resumed 500-run cohort re-score
+  every run - expensive, and it produces correct output, so no gate would catch it.
 
 Sidecars are stamped even for the tasks that deliberately return "stop here" at an HPC
 boundary. Gating the stamp on the pipeline continuing would skip sidecar writes for
@@ -786,11 +818,14 @@ Four things hold at every boundary and are not repeated in each list:
 - **The library, and the `--decoy-pairing-manifest` if the search used one**, go to every
   node of every task. The manifest's path must match the one the search hash was computed
   from, or every artifact on that node invalidates.
-- **A fan-out node gets `<stem>.spectra.bin` plus a 0-byte `<stem>.mzML` stub, never the
-  real mzML.** The stub exists only so path derivation works; the cache's source
-  fingerprint check is skipped for a 0-byte source, which forces the cache hit. Shipping
-  the real file would move gigabytes per run to a worker that will not read them - on the
-  reference cohorts the 6 GB mzML is never sent to a rescore worker.
+- **A fan-out node gets `<stem>.spectra.bin` and no data file at all.** Osprey tolerates
+  an absent source once the cache exists - the source fingerprint check treats "absent" as
+  the documented resume case - so shipping the real mzML would move gigabytes per run to a
+  worker that will not read them. Do **not** substitute a 0-byte stub: an empty file makes
+  the mzML path reachable, so a cache that is rejected for any reason (version bump,
+  truncated footer) is silently replaced by parsing an empty file, and the run finishes
+  success-shaped with zero spectra. With the file simply absent, a rejected cache fails
+  loudly.
 - **Pass `--cache-dir` on any `--task` leg whose `--output-dir` differs from the data
   directory.** Such a leg has no raw input path to resolve `.spectra.bin` from, so without
   it the cache is not found and the run rebuilds it.
@@ -825,6 +860,12 @@ case they are the data and must be preserved.
 
 ### Boundary 2 -> 3: `FirstPassFDR` to `PerFileRescoring`
 
+> **In flight** - this list is not yet one a single-run node can run on. The artifact that
+> lets a fan-out worker obtain the join-wide compaction set without surveying the batch,
+> `<blib-stem>.1st-pass.retained_base_ids.bin`, does not exist on master; a node staged
+> with exactly the list below derives a different survivor set rather than erroring. See
+> item 2 under `## In flight`. Stage the whole cohort's envelopes until it lands.
+
 Each rescore node needs its own runs' artifacts plus the experiment-wide set:
 
 Per run, for each run in the node's batch:
@@ -832,11 +873,13 @@ Per run, for each run in the node's batch:
 - `<stem>.1st-pass.fdr_scores.bin`
 - `<stem>.reconciliation.json`
 - `<stem>.calibration.json`
-- `<stem>.spectra.bin`, with a 0-byte `<stem>.mzML` stub beside it
+- `<stem>.spectra.bin`, with no data file beside it
 
 Experiment-wide, to **every** node:
 - `<blib-stem>.1st-pass.fdr_experiment.bin`
-- `<stem>.1st-pass.model.json` (any one copy; needed for the frozen pass-2 modes)
+- `<stem>.1st-pass.model.json` (any one copy) - **mandatory on an ordinary run**, because
+  the default pass-2 mode is a frozen one (`protein-compact`); an unset
+  `OSPREY_PASS2_QVALUE` is not an opt-out
 
 This is the boundary where a missing experiment-wide file does the most damage, because
 the node can often proceed without it and produce a plausible wrong answer rather than
@@ -864,8 +907,13 @@ Experiment-wide:
 Not needed on the default path: `<stem>.1st-pass.fdr_scores.bin`. Establishing that is
 what issue #4486 was for - an orchestrator hands a `SecondPassFDR` node the per-run
 second-pass artifacts and the analysis-wide experiment sidecar, and nothing per-run from
-the first pass. They become a real input only under `OSPREY_PASS2_VERIFY_WORKER`, which is
-a test instrument, or where no worker answer exists.
+the first pass on the **default** mode. Two exceptions: `OSPREY_PASS2_VERIFY_WORKER`, a
+test instrument; and `OSPREY_PASS2_QVALUE=transfer`, which reads every run's copy to build
+its score-to-run-q table. Under `transfer` a missing sidecar is **not** fatal - it logs that
+the run's per-run q is left unadjusted and continues, so trimming these files and later
+running a transfer arm yields a whole cohort of reconciliation-moved peaks carrying
+pre-reconciliation q-values, in a success-shaped run. Ship them unless you know no transfer
+arm will follow.
 
 The `.osprey.task` sidecars are not optional bookkeeping here. Without the stamp,
 `SecondPassFDR` cannot tell that a worker wrote the pass-2 files and will recompute them
@@ -896,7 +944,7 @@ the text says so rather than describing the current shape as though it were the 
    protein FDR ends. See "The protein-q split, and the rule behind it" in
    `ai/todos/active/TODO-20260901_osprey_firstpassfdr_resume.md`.
 
-1a. **Two experiment-wide artifacts arrive with the fan-out fix**, and both are relay
+2. **Two experiment-wide artifacts arrive with the fan-out fix**, and both are relay
    obligations the checklist below will gain. `<blib-stem>.1st-pass.retained_base_ids.bin`
    is written by `FirstPassFDR` when Stage 6 planning ends and carries the join-wide
    first-pass base ids unioned with every planned action target - sorted `uint32`,
@@ -908,20 +956,20 @@ the text says so rather than describing the current shape as though it were the 
    `Skyline/work/20260901_osprey_firstpass_resume`; when it lands, "two experiment-wide
    artifacts that must relay together" becomes four.
 
-2. **The bounded-loop shape of `PerFileRescoring`.** The task is still entered with a
+3. **The bounded-loop shape of `PerFileRescoring`.** The task is still entered with a
    materialised all-runs entry list, and its baseline still carries maps keyed by run whose
    values are per-entry - the `O(runs x entries)` shape P5 and P6 forbid. See "THE TARGET
    SHAPE for --task PerFileRescoring" and its violation table (items 6 and 7,
    `perFileEntries` and `reconciliationActions`) in
    `ai/todos/active/TODO-20260901_osprey_stage5_reload_materialization.md`.
 
-3. **Retiring the resident survivor handoff.** `OSPREY_STAGE6_STREAM_SURVIVORS=0` still
+4. **Retiring the resident survivor handoff.** `OSPREY_STAGE6_STREAM_SURVIVORS=0` still
    selects the resident path, where Stage 5's all-runs survivor buffer stays live across
    the whole Stage 6 rescore instead of being refilled one run at a time from each run's
    `.scores.parquet` and first-pass sidecar. The streamed path is the default; the switch
    goes when the resident one does.
 
-4. **Whether the 500-run / 64 GB target is met.** It is not yet, and which stage binds is
+5. **Whether the 500-run / 64 GB target is met.** It is not yet, and which stage binds is
    itself moving as each is fixed. The two TODOs above carry the current measurements;
    deliberately not restated here, because a number in a contract document is stale the
    week after it is written.

--- a/pwiz_tools/Osprey/docs/00-pipeline-architecture.md
+++ b/pwiz_tools/Osprey/docs/00-pipeline-architecture.md
@@ -90,9 +90,21 @@ The same pipeline runs three ways, and all three must produce identical output:
 
 These are not three code paths. They are the same four tasks with different subsets
 included in the driver loop, reading the same sidecar files from disk. A single-process
-run writes every file an HPC run writes; that is what makes the HPC mode testable
-without a cluster, and why regression mode 3 can assert that a per-node reconciled
-parquet is byte-identical to the one the straight-through run produced.
+run writes every file an HPC run writes, which is what makes the HPC mode testable without
+a cluster.
+
+**`regression.ps1` mode 3 is the enforcement of this section and of the relay checklist at
+the end of this document**, not an anecdote about it: it runs the split as separate
+processes, stages exactly the files the checklist names, and asserts each per-node
+reconciled parquet is byte-identical to the straight-through run's. A relay obligation that
+mode 3 does not stage is an obligation nothing is checking.
+
+Its one blind spot is worth stating, because it has already hidden a defect: a phase-3 node
+is handed **one** run, and at N=1 a correct per-run implementation and an all-runs one
+produce identical bytes, so the mode stayed green while the per-run path was not running at
+all. **Where a contract cannot be distinguished by output at N=1, the gate must assert the
+path** - a marker line the run emits, checked as a string - rather than trusting the bytes
+to reveal it.
 
 ### What "bounded" means
 
@@ -114,6 +126,33 @@ appears innocently: a dictionary keyed by file name whose values are per-entry l
 map built once "for convenience" outside a per-run loop, a join that materialises every
 run's rows to compute a summary over them. At 3 runs it is invisible. At 500 it is the
 whole 64 GB.
+
+### Visited is not resident
+
+Those three shapes describe what is **resident**. A separate question is how many runs a
+computation **visits**, and conflating the two leaves no vocabulary for the shape that
+does most of the work in the joins: a **fold over a stream** - visit every run in turn,
+hold one at a time, and accumulate a bounded summary.
+
+That is a third shape, and it is why a join is not automatically expensive. Every
+genuinely whole-experiment computation named in this document is one of these folds: the
+best-of-runs experiment-q floor, protein parsimony, the pre-blib q re-clamp. The code says
+so where it matters - "both maps are O(distinct) ... nothing here needs a whole-run view" -
+and `StreamingFdr.StreamingFirstPassQ` is the worked example, pinned against its resident
+twin by a test.
+
+Read the vocabulary this way:
+
+| | Visits | Holds |
+|---|---|---|
+| Fan-out iteration | one run | one run |
+| Fold over a stream | every run | a bounded summary |
+| Resident whole-experiment structure | every run | every run - **inadmissible** |
+
+The distinction matters because "it stays in the join" and "it may be resident" are
+different permissions, and the gap between them is where an all-runs pre-pass can grow
+without violating any rule stated in terms of fan-out versus join alone.
+
 
 ---
 
@@ -256,6 +295,15 @@ tier, and an artifact that fits neither is a design error rather than a special 
 Scope is a statement about *content* - whose data is in the file - and it is what the
 memory model in P5 and P6 is built on.
 
+The converse of the replication below is the shape to watch for: **a per-run artifact
+carrying an analysis-wide payload.** `<stem>.reconciliation.json` does this today - every
+one of its N copies restates the same join-wide `first_pass_base_ids` array, which at 446
+runs is 2.79 GB of pure duplication inside 10.7 GB of envelopes that a fan-out worker then
+has to parse to rebuild a union it could have been handed. Replication is only benign when
+the payload is small and fixed, as the frozen model is; when it scales with the experiment
+it belongs in one experiment-wide artifact, and the fan-out reads that instead. This is the
+P6 startup rule seen from the writer's side.
+
 Scope is not the same question as naming, and the two must not be conflated. Most
 per-run content is named for its run stem and most experiment-wide content is named for
 the analysis, but an experiment-wide payload small enough to duplicate may be
@@ -294,10 +342,21 @@ experiment-wide artifacts must be *summaries* - O(library) or O(distinct entries
 never a concatenation of per-run data. An experiment-wide file that grows with the
 cohort puts the cohort in the floor.
 
-**P6. Per-run artifacts are loaded and freed inside one iteration.** Nothing a run's
-processing allocates may outlive its iteration. The peak is then
-`baseline + max(one run)`, independent of batch size and of cohort size, which is the
-identity in the figure above and the property the 64 GB target rests on.
+**P6. Per-run artifacts are loaded and freed inside one iteration, and the task's startup
+is independent of batch size in wall clock as well as memory.** Nothing a run's processing
+allocates may outlive its iteration, so the peak is `baseline + max(one run)`, independent
+of batch size and of cohort size - the identity in the figure above, and the property the
+64 GB target rests on.
+
+That identity alone is not the whole requirement, because it constrains only the *peak*. A
+worker that opens all 446 `reconciliation.json` envelopes to build a union, then frees them
+before the loop starts, never exceeds the peak and has still done O(runs) work before
+rescoring its first run. That is not hypothetical: it shipped, as 8m42s and 17.2 GB of
+startup on an 86-run plate - work the rescore loop then discarded and redid. So the rule is
+both terms: **no fan-out task may have a loading phase whose cost grows with the number of
+runs it was handed.** Where such a task needs a cohort-wide fact, an earlier phase computes
+it once and writes it (P12) and the fan-out reads that bounded summary - it never conducts
+its own survey of the batch.
 
 **P7. Persist at phase end, not task end.** Crash exposure is one in-flight file no
 matter how large the cohort, and a downstream task starting mid-pipeline finds each
@@ -334,6 +393,19 @@ published in Stage 6 reaches Stage 7, so it concluded no worker had run and rewr
 sidecar with survivors only: 332,269 records where the straight-through route produced
 407,624, on artifacts whose whole purpose is to be route-independent. An in-memory signal
 cannot answer a question about a file that outlives the process.
+
+The corollary governs the byproduct registry, which is how tasks pass state in-process.
+Tasks do not take each other's output as constructor arguments; they `Publish` typed
+byproducts and `Get` them, and a `Get` that misses lazily materialises the producing task
+through its `Rehydrate` (disk-load) path. That is what lets a worker starting mid-pipeline
+pull upstream state from the boundary files - but it also means one `Get` can materialise
+several tasks in a chain, and that the in-process route can quietly stop resembling the
+distributed one. So: **every byproduct that crosses a task boundary must have a disk
+counterpart, and the in-process path should read the same artifact the distributed path
+does.** Otherwise the two shapes drift, because the distributed route is forced to write
+files while the in-process route just reaches backwards through a cache - and a change that
+stops producing something in memory will not have stopped the consumers that rebuild it
+for themselves.
 
 **P11. Artifacts are write-once: a new column means a new file, never a revisit.** A
 phase writes its product once and no later phase reopens it. Reconciled scores go to
@@ -465,13 +537,17 @@ it beside each run's other sidecars means a node finds it by the same stem deriv
 already uses. `LoadFromAny` takes the first copy that exists, because the copies are
 identical.
 
-**The protein-compact stratum has no file of its own.** It rides inside
-`<stem>.1st-pass.model.json` as an optional field, present only under
-`OSPREY_PASS2_QVALUE=protein-compact`. This is deliberate and worth not undoing: the
-mode needs both the frozen model and the stratum, they are produced by the same
-first-pass span, and a node holding one without the other can do nothing. One artifact
-means one relay hop and one reload site, and makes it impossible to ship half of what
-the mode requires.
+**The protein-compact stratum rides inside `<stem>.1st-pass.model.json`** as an optional
+field, present only under `OSPREY_PASS2_QVALUE=protein-compact`. The mode needs both the
+frozen model and the stratum, and a node holding one without the other can do nothing, so
+one artifact meant one relay hop and one reload site.
+
+> **In flight** - this is changing, and P12 is why: training does not compute the stratum,
+> first-pass protein FDR does, so the column belongs in a file written by that phase.
+> `.1st-pass.stratum.json` is a separate artifact on
+> `Skyline/work/20260901_osprey_firstpass_resume` and is staged as its own relay hop by
+> `regression.ps1`. When that branch lands, this becomes a fourth experiment-wide artifact
+> that must relay with the other three.
 
 **`<stem>.2nd-pass.fdr_scores.bin` has two possible writers, and the sidecar's NAME says
 which.** When `PerFileRescoring` runs the pass-2 per-run worker it writes this file and
@@ -500,6 +576,15 @@ m/z filter its per-run coverage - which is how a `SecondPassFDR` node with no mz
 gets that coverage. It is read behind a `File.Exists`, so an orchestrator that leaves it
 behind does not get an error: gap-fill filtering silently changes. That is the P13-shaped
 hazard this document warns about, in the contract itself.
+
+**A cohort-wide union cannot ride in a per-run envelope, for an ordering reason.** Each
+`<stem>.reconciliation.json` is written the instant that run's planning finishes, so the
+planned actions of runs planned *later* do not exist yet and cannot be in it. Any fact that
+is a union over all runs is therefore only knowable after the last run is planned, which
+means it belongs in an artifact written at the end of planning - not replicated into
+envelopes that were each sealed too early to hold it. This is why "just add it to the
+per-run file" is not an available answer for that class of fact, and the reason is not
+deducible from the scope taxonomy alone.
 
 **`<output>.<TaskName>.osprey.task` is per-artifact, not per-task.** One sidecar is
 written next to each output, and its name carries the producing task so two tasks
@@ -546,8 +631,23 @@ default:
   stratum with it. A distributed `SecondPassFDR` node that never trained pass 1 has no
   other source for either.
 
-Ship both to every node running either task. A node that has one and not the other is
-the case the fail-fast exists for, and it is the orchestrator's job never to create it.
+Ship both to every node running either task. **Their failure behaviour differs, and only
+one of them fails safely:**
+
+- A missing `<stem>.1st-pass.model.json` under an explicitly requested frozen pass-2 mode
+  aborts with a `ConfigError` rather than degrading to the anti-conservative retrain
+  (see [12-second-pass-fdr](12-second-pass-fdr.md), "Fail-fast"). That is the behaviour to
+  copy.
+- An unreadable `<blib-stem>.1st-pass.fdr_experiment.bin` does **not** abort. First-pass
+  compaction logs `[ERROR] First-pass compaction: failed to read the experiment-scope FDR
+  sidecar`, sets a non-zero exit code, and **the run continues** - with a different
+  retained set, finishing success-shaped hours later. On a large cohort that is a wrong
+  answer that looks like a right one.
+
+So this is not a hazard the orchestrator can be trusted to avoid; a task handed an
+incomplete relay must refuse to proceed, and the second case does not yet. Treat the
+current behaviour as a defect to fix, not a contract to preserve - and until it is fixed,
+check the exit code, because the log line is the only other signal.
 
 
 ## Directory resolution
@@ -608,44 +708,22 @@ sanctioned way to consume another build's artifacts deliberately.
 
 ## Validity and resume
 
-### What the key is made of
+### What the key is made of, and why it decides correctness
 
-The base key every task carries is search parameters, library identity, and the peak-pick
-arm (`OspreyTask.ValidityKey`). Tasks with extra state append to it; `FirstPassFDR` adds
-six components, and each one is in the key because leaving it out produced a specific
-wrong answer:
+Each task composes its own key: a base of search parameters, library identity and the
+peak-pick arm, plus per-task additions - `FirstPassFDR` adds six, `PerFileRescoring` six.
+**The exact composition, and the defect each component was added to prevent, is
+invalidation mechanics and lives in [14-intermediate-files](14-intermediate-files.md).**
 
-| Component | Without it |
-|---|---|
-| reconciliation parameter hash | toggling reconciliation between runs reuses the prior shape |
-| FDR sidecar format version | a resume across a format bump skips the task, then every reader refuses the old file by version and defaults are written instead |
-| experiment-aggregation mode | an A/B arm re-run in a directory holding the other arm's results reuses the previous mode's q and reports it as the new measurement |
-| pass-2 q-value mode | a sidecar written under `transfer` carries no stratum, so a `protein-compact` re-run adopts an artifact that cannot answer its question |
-| training-sample settings | a resume adopts maximum-trained scores as though the reservoir had produced them |
-| library-fragment release | the retained-fragment arm differs and the outputs are not interchangeable |
+What belongs here is why that list matters: correctness under resume rests entirely on
+those keys being exhaustive, because nothing cascades. Read the list in 14 as the worked
+example of P15's asymmetry - every entry was added after an under-inclusive key reused
+something it should not have, and none would have cost more than a recompute if it had
+turned out to be unnecessary.
 
-`PerFileRescoring` appends its own set for the same reasons - the reconciliation hash and
-sidecar format version, the experiment-aggregation, pass-2 q and training-sample arms, and
-the survivor-streaming switch, whose two paths must not adopt each other's output.
-
-The peak-pick arm sits in the *base* rather than in the overrides because it is the one
-lever that reaches every task: the pick decides which peak a precursor's row describes,
-back in Stage 4, and everything downstream inherits that choice. Putting it in the base
-also means a task added later carries it without having to know.
-
-Read that table as a worked example of P15's asymmetry. Every row was added after an
-under-inclusive key reused something it should not have, and none of them cost more than
-a recompute if they were unnecessary.
-
-### The build stamp
-
-The version stamped into each artifact follows the Skyline scheme
-`YEAR.ORDINAL.BRANCH.DOY`, with the full informational form carrying the git short hash
-(`26.1.1.182-b2373f9f9c`, plus `-dirty` for a modified tree) so a binary is always
-traceable to its source commit. Reuse requires an exact match on all four numeric
-components; a difference in release line or daily build aborts reuse with a hard error
-rather than a warning, because a cache from a different build may carry different scoring
-and a logged warning is easily missed while the run still completes and looks valid.
+The build stamp is likewise 14's: reuse requires an exact match on all four components of
+`YEAR.ORDINAL.BRANCH.DOY`, and a mismatch is a hard failure rather than a warning, because
+a cache from another build may carry different scoring.
 
 ### Resume is a forward scan
 
@@ -703,7 +781,19 @@ The general rule, if you remember nothing else: **a fan-out node needs its own r
 files plus every experiment-wide artifact produced so far.** The checklists below are
 that rule made explicit at each boundary.
 
-Two things hold at every boundary and are not repeated in each list:
+Four things hold at every boundary and are not repeated in each list:
+
+- **The library, and the `--decoy-pairing-manifest` if the search used one**, go to every
+  node of every task. The manifest's path must match the one the search hash was computed
+  from, or every artifact on that node invalidates.
+- **A fan-out node gets `<stem>.spectra.bin` plus a 0-byte `<stem>.mzML` stub, never the
+  real mzML.** The stub exists only so path derivation works; the cache's source
+  fingerprint check is skipped for a 0-byte source, which forces the cache hit. Shipping
+  the real file would move gigabytes per run to a worker that will not read them - on the
+  reference cohorts the 6 GB mzML is never sent to a rescore worker.
+- **Pass `--cache-dir` on any `--task` leg whose `--output-dir` differs from the data
+  directory.** Such a leg has no raw input path to resolve `.spectra.bin` from, so without
+  it the cache is not found and the run rebuilds it.
 
 - **Every artifact travels with its `.osprey.task` sidecar.** The stamp is how the
   receiving node learns who produced the file and whether it may be reused; shipping the
@@ -742,7 +832,7 @@ Per run, for each run in the node's batch:
 - `<stem>.1st-pass.fdr_scores.bin`
 - `<stem>.reconciliation.json`
 - `<stem>.calibration.json`
-- `<stem>.spectra.bin` (or the raw file it was built from)
+- `<stem>.spectra.bin`, with a 0-byte `<stem>.mzML` stub beside it
 
 Experiment-wide, to **every** node:
 - `<blib-stem>.1st-pass.fdr_experiment.bin`
@@ -786,9 +876,12 @@ from survivors only - which is not the same answer (P10).
 
 ## In flight
 
-Four items are being settled on branch `Skyline/work/20260901_osprey_firstpass_resume` and
-its companion TODOs. Each is marked at the point it applies above; they are collected here
-so that clearing them after that work merges is a single edit.
+**This section is the single list of known deviations from the architecture above**, for
+every document in this set. Docs 12, 14 and 15 point here rather than keeping their own,
+because a per-document in-flight note is how 15 fell out of step with 00 in the first
+place. Items are being settled on branch `Skyline/work/20260901_osprey_firstpass_resume`
+and its companion TODOs; each is marked at the point it applies above, so clearing them
+after that work merges is a single edit.
 
 The contract above states the **target** in every case. Where today's code does not meet it,
 the text says so rather than describing the current shape as though it were the design.
@@ -802,6 +895,18 @@ the text says so rather than describing the current shape as though it were the 
    peptide q, PEP and aggregate score when pass 2 ends; protein FDR writes protein q when
    protein FDR ends. See "The protein-q split, and the rule behind it" in
    `ai/todos/active/TODO-20260901_osprey_firstpassfdr_resume.md`.
+
+1a. **Two experiment-wide artifacts arrive with the fan-out fix**, and both are relay
+   obligations the checklist below will gain. `<blib-stem>.1st-pass.retained_base_ids.bin`
+   is written by `FirstPassFDR` when Stage 6 planning ends and carries the join-wide
+   first-pass base ids unioned with every planned action target - sorted `uint32`,
+   library-bounded (1.49 MB at 373,487 ids). It is what lets a fan-out worker obtain the
+   compaction set without surveying the batch (P6), and it is the artifact that makes the
+   single-run input contract executable: today's Boundary 2 -> 3 list is not one a
+   one-run node can actually run on. `<stem>.1st-pass.stratum.json` is the P12 split
+   described under "Rows that are not what they look like". Both are on
+   `Skyline/work/20260901_osprey_firstpass_resume`; when it lands, "two experiment-wide
+   artifacts that must relay together" becomes four.
 
 2. **The bounded-loop shape of `PerFileRescoring`.** The task is still entered with a
    materialised all-runs entry list, and its baseline still carries maps keyed by run whose

--- a/pwiz_tools/Osprey/docs/12-second-pass-fdr.md
+++ b/pwiz_tools/Osprey/docs/12-second-pass-fdr.md
@@ -111,11 +111,15 @@ disk. Two experiment-wide artifacts carry it:
 
 **They must relay together.** A node holding one without the other cannot proceed:
 the model without the stratum cannot constrain a `protein-compact` competition, and
-the stratum without the model has nothing to score with. That is why the stratum
-rides inside the model sidecar rather than in a file of its own — one artifact means
-one relay hop, and makes shipping half of what the mode needs impossible. The model
-sidecar is written beside **every** run's other Stage-5 artifacts, identical each
-time, so any one copy serves.
+the stratum without the model has nothing to score with. The model sidecar is written
+beside **every** run's other Stage-5 artifacts, identical each time, so any one copy
+serves.
+
+> **In flight** - the stratum is moving out of the model sidecar into its own
+> `.1st-pass.stratum.json`, because first-pass protein FDR computes it and training does
+> not. Relay obligations are unchanged in substance: the two still travel together, as
+> two files rather than one. See
+> `Skyline/work/20260901_osprey_firstpass_resume`.
 
 See [00-pipeline-architecture.md](00-pipeline-architecture.md) for the full contract
 and the per-boundary relay checklist.

--- a/pwiz_tools/Osprey/docs/12-second-pass-fdr.md
+++ b/pwiz_tools/Osprey/docs/12-second-pass-fdr.md
@@ -106,7 +106,7 @@ disk. Two experiment-wide artifacts carry it:
 
 | Artifact | Carries |
 |---|---|
-| `<stem>.1st-pass.model.json` | the frozen Percolator model (standardizer + per-fold weights and biases), the first pass's `OSPREY_EXPERIMENT_AGG` provenance, and — under `protein-compact` — the protein stratum |
+| `<stem>.1st-pass.model.json` | the frozen Percolator model (standardizer + per-fold weights and biases), the first pass's `OSPREY_EXPERIMENT_AGG` provenance, and - under `protein-compact` - the protein stratum |
 | `<blib-stem>.1st-pass.fdr_experiment.bin` | the first pass's experiment-scope q-values |
 
 **They must relay together.** A node holding one without the other cannot proceed:

--- a/pwiz_tools/Osprey/docs/12-second-pass-fdr.md
+++ b/pwiz_tools/Osprey/docs/12-second-pass-fdr.md
@@ -98,6 +98,28 @@ it **skips** the frozen-model + stratum competition and instead retrains the
 second pass over the stratum-expanded compacted pool, isolating the
 frozen-vs-retrain calibration difference for the entrapment oracle.
 
+## Inputs from the first pass
+
+The frozen modes are frozen against artifacts, not against in-process state, so a
+`SecondPassFDR` node that never ran the first pass reads everything it needs from
+disk. Two experiment-wide artifacts carry it:
+
+| Artifact | Carries |
+|---|---|
+| `<stem>.1st-pass.model.json` | the frozen Percolator model (standardizer + per-fold weights and biases), the first pass's `OSPREY_EXPERIMENT_AGG` provenance, and — under `protein-compact` — the protein stratum |
+| `<blib-stem>.1st-pass.fdr_experiment.bin` | the first pass's experiment-scope q-values |
+
+**They must relay together.** A node holding one without the other cannot proceed:
+the model without the stratum cannot constrain a `protein-compact` competition, and
+the stratum without the model has nothing to score with. That is why the stratum
+rides inside the model sidecar rather than in a file of its own — one artifact means
+one relay hop, and makes shipping half of what the mode needs impossible. The model
+sidecar is written beside **every** run's other Stage-5 artifacts, identical each
+time, so any one copy serves.
+
+See [00-pipeline-architecture.md](00-pipeline-architecture.md) for the full contract
+and the per-boundary relay checklist.
+
 ## Fail-fast
 
 An **explicitly requested** frozen mode never silently degrades to the

--- a/pwiz_tools/Osprey/docs/14-intermediate-files.md
+++ b/pwiz_tools/Osprey/docs/14-intermediate-files.md
@@ -10,63 +10,53 @@ C# code actually writes and reads it, the SHA-256 hashing that gates cache reuse
 resume mechanisms the port adds (a per-task `.osprey.task` validity sidecar and the
 `.scores-reconciled.parquet` split output) that have no exact Rust doc counterpart.
 
+> **Scope, ownership, and who may read what** live in
+> [00-pipeline-architecture.md](00-pipeline-architecture.md). That document owns the file
+> contract — which artifact is per-run or experiment-wide, which task writes it, which may
+> read it, and what an HPC node must be shipped. **This document owns the bytes**: headers,
+> versions, schemas, hashing, and invalidation mechanics. When the two disagree about a
+> writer or a reader, 00 is the one that is verified against the path-building code.
+
 ## File overview
 
-| File pattern | Format | C# writer/reader | Purpose |
-|---|---|---|---|
-| `<stem>.calibration.json` | JSON (Newtonsoft) | `Osprey.Chromatography/CalibrationIO.cs` | RT + MS1/MS2 mass calibration parameters |
-| `<stem>.spectra.bin` | Custom binary v4 | `Osprey.IO/SpectraCache.cs` | Decoded MS1/MS2 spectra for fast reload — and the only copy once the source is deleted |
-| `<stem>.scores.parquet` | Apache Parquet (ZSTD) | `Osprey.IO/ParquetScoreCache.cs` | Scored entries: 21 PIN features, fragments, CWT candidates + footer metadata |
-| `<stem>.scores-reconciled.parquet` | Apache Parquet (ZSTD) | `Osprey.Tasks/ReconciledParquetWriter.cs` | Stage 6 reconciled rewrite (separate file, not in-place) |
-| `<stem>.1st-pass.fdr_scores.bin` | Custom binary v4 | `Osprey.IO/FdrScoresSidecar.cs` | SVM score + 4 q-values + PEP + experiment_protein_qvalue + experiment_aggregate_score after first-pass Percolator |
-| `<stem>.2nd-pass.fdr_scores.bin` | Custom binary v4 | `Osprey.IO/FdrScoresSidecar.cs` | Same record shape after second-pass Percolator |
-| `<stem>.reconciliation.json` | JSON (Newtonsoft) | `Osprey.IO/ReconciliationFile.cs` | Stage 5 planner output: actions, gap-fill targets, refined RT calibration |
-| `<output>.<TaskName>.osprey.task` | JSON (hand-rolled) | `Osprey.Tasks/TaskValiditySidecar.cs` | **C# addition**: per-(output, task) resume validity record |
-| `<lib>.<...>` library cache | Custom binary v2 | `Osprey.IO/LibraryCache.cs` | Parsed spectral library reload cache |
-| `<output>.blib` | SQLite (BiblioSpec) | `Osprey.IO/BlibWriter.cs` | Final output; see 13-blib-output-schema.md |
+Scope is per 00's taxonomy: **run** = one MS data file's own artifact, **exp** =
+experiment-wide, **exp/rep** = experiment-wide content replicated under each run stem.
 
-All per-file artifact paths resolve their directory through `ArtifactPaths`
-(`Osprey.IO/ArtifactPaths.cs:47`), so `--output-dir` / `--cache-dir` / `--work-dir`
-redirection is applied atomically to every artifact.
+| File pattern | Scope | Format | C# writer/reader | Purpose |
+|---|---|---|---|---|
+| `<stem>.calibration.json` | run | JSON (Newtonsoft) | `Osprey.Chromatography/CalibrationIO.cs` | RT + MS1/MS2 mass calibration parameters |
+| `<stem>.spectra.bin` | run | Custom binary v4 | `Osprey.IO/SpectraCache.cs` | Decoded MS1/MS2 spectra for fast reload — and the only copy once the source is deleted |
+| `<stem>.scores.parquet` | run | Apache Parquet (ZSTD) | `Osprey.IO/ParquetScoreCache.cs` | Scored entries: 21 PIN features, fragments, CWT candidates + footer metadata |
+| `<stem>.scores-reconciled.parquet` | run | Apache Parquet (ZSTD) | `Osprey.Tasks/ReconciledParquetWriter.cs` | Stage 6 reconciled rewrite (separate file, not in-place) |
+| `<stem>.1st-pass.fdr_scores.bin` | run | Custom binary v4 | `Osprey.IO/FdrScoresSidecar.cs` | SVM score + 4 q-values + PEP + experiment_protein_qvalue + experiment_aggregate_score after first-pass Percolator |
+| `<stem>.2nd-pass.fdr_scores.bin` | run | Custom binary v4 | `Osprey.IO/FdrScoresSidecar.cs` | Same record shape after second-pass Percolator |
+| `<stem>.2nd-pass.fdr_decoys.bin` | run | Custom binary v1 | `Osprey.IO/Pass2CompetitionDecoys.cs` | Per-run second-pass competition decoys; written before the scores sidecar |
+| `<stem>.reconciliation.json` | run | JSON (Newtonsoft) | `Osprey.IO/ReconciliationFile.cs` | Stage 5 planner output: actions, gap-fill targets, refined RT calibration |
+| `<blib-stem>.{1st,2nd}-pass.fdr_experiment.bin` | exp | Custom binary v5 | `Osprey.IO/FdrExperimentSidecar.cs` | Experiment-scope q-values; **name** from the output blib, **directory** from `ResolveOutputDir` |
+| `<stem>.1st-pass.model.json` | exp/rep | JSON | `Osprey.Tasks/FirstPassModelIO.cs` | Frozen first-pass Percolator model, plus the protein-compact stratum when that mode is active |
+| `<output>.<TaskName>.osprey.task` | its artifact's | JSON (hand-rolled) | `Osprey.Tasks/TaskValiditySidecar.cs` | **C# addition**: per-(output, task) resume validity record |
+| `<lib>.<...>` library cache | exp | Custom binary v2 | `Osprey.IO/LibraryCache.cs` | Parsed spectral library reload cache |
+| `<output>.blib` | exp | SQLite (BiblioSpec) | `Osprey.IO/BlibWriter.cs` | Final output; see 13-blib-output-schema.md |
+
+All artifact paths resolve their directory through `ArtifactPaths`
+(`Osprey.IO/ArtifactPaths.cs`), so `--output-dir` / `--cache-dir` / `--work-dir`
+redirection applies uniformly to every artifact.
 
 ---
 
 ## 0. Path resolution and safe writes (cross-cutting)
 
-### `ArtifactPaths` directory redirection
+**Moved.** Where artifacts are written (`--work-dir` / `--output-dir` / `--cache-dir` and the
+`ArtifactPaths` resolution behind them) and why every writer commits atomically through
+`FileSaver` are architecture, not format, and are now stated once in
+[00-pipeline-architecture.md](00-pipeline-architecture.md) — see "Directory resolution" and
+principle P8. The one-line summary: a `FileSaver` stages into a sibling temp file in the same
+directory and promotes it with an in-volume rename, so a crash leaves either the previous
+content or no file, and **presence proves completeness** for every artifact in this document.
 
-`ArtifactPaths` (`Osprey.IO/ArtifactPaths.cs:47`) holds two process-wide static properties,
-`OutputDir` and `CacheDir`, both defaulting to `null` (write beside the input file — the
-historical default). `--work-dir` sets both; `--output-dir` / `--cache-dir` set them
-individually.
-
-- `ResolveOutputDir(inputPath)` (`ArtifactPaths.cs:77`) returns `OutputDir` when set, else the
-  input file's own directory. Used by the scores parquet, calibration JSON, FDR sidecars, and
-  reconciliation JSON.
-- `ResolveCacheDir(inputPath)` (`ArtifactPaths.cs:91`) resolves the `.spectra.bin` location:
-  explicit `CacheDir` → beside the data file if that directory is writable (probed once and
-  memoized, `ArtifactPaths.cs:112`) → `OutputDir`. The cache is settings-independent, so a
-  shared `CacheDir` lets many analyses reuse one parse.
-
-### Atomic writes via `FileSaver` (the C# stand-in for Rust `copy_and_verify`)
-
-Every cache writer stages through `Osprey.Core/FileSaver.cs`. The pattern is: construct a
-`FileSaver(finalPath)`, which allocates a **sibling** temp file in the *same directory*
-(`FileSaver.cs:68`); write to `saver.SafeName`; call `saver.Commit()`
-(`FileSaver.cs:92`) to delete any existing destination and `File.Move` the temp into place; on
-exception the `using` block's `Dispose()` (`FileSaver.cs:116`) deletes the temp without
-touching the destination. A crash mid-write therefore leaves either the previous content or no
-file — never a half-written destination a resume check could mistake for finished output.
-
-This is the C# realization of Rust's "safe NAS file writes / `copy_and_verify`" pattern.
-Because the temp is a sibling, the promote is an in-volume rename rather than a
-local-temp → NAS cross-volume copy, which sidesteps the truncation risk `copy_and_verify`
-guards against. Callers that use it: `ParquetScoreCache.WriteScoresParquet`
-(`ParquetScoreCache.cs:265`, `:457`), `SpectraCache.SaveSpectraCache` (`SpectraCache.cs:85`),
-`CalibrationIO.SaveCalibration` (`CalibrationIO.cs:50`), `FdrScoresSidecar.WriteInternal`
-(`FdrScoresSidecar.cs:366`) and `PatchProteinQvalues` (`FdrScoresSidecar.cs:257`),
-`ReconciliationFile.Save` (`ReconciliationFile.cs:203`), `LibraryCache.SaveCache`
-(`LibraryCache.cs:77`), and `TaskValiditySidecar.Write` (`TaskValiditySidecar.cs:130`).
+The C# realization is Rust's "safe NAS file writes / `copy_and_verify`" pattern. Because the
+temp is a sibling, the promote is an in-volume rename rather than a local-temp → NAS
+cross-volume copy, which sidesteps the truncation risk `copy_and_verify` guards against.
 
 ---
 
@@ -496,19 +486,27 @@ It records the producing task, the Osprey version, a `validity_key`, and the inp
 }
 ```
 
-The default `validity_key` is `search=<SearchParameterHash>;library=<LibraryIdentityHash>`
-(`OspreyTask.ValidityKey`, `OspreyTask.cs:173`); tasks with extra state (the rescore task)
-override to append `ReconciliationParameterHash`. On the next invocation the driver
-(`PerFileResumeDriver`) reads each output's sidecar and skips the producing task when
-`IsValid` (`TaskValiditySidecar.cs:144`) confirms the recorded key matches the current key;
-a missing/malformed/mismatched sidecar returns `false` ("can't tell ⇒ re-run", the conservative
-answer). The task-name in the filename disambiguates per-task records for tasks that once shared
-an output path (`TaskValiditySidecar.cs:71`). `Delete` (`TaskValiditySidecar.cs:169`) clears a
-sidecar when its task starts, so a crash mid-write cannot leave a stale "valid" marker.
+The base `validity_key` is
+`search=<SearchParameterHash>;library=<LibraryIdentityHash>` plus the peak-pick arm
+(`OspreyTask.ValidityKey`); tasks with extra state append to it — `FirstPassFdrTask` adds six
+further components. **What goes in a key, and why each component is there, is owned by
+[00-pipeline-architecture.md](00-pipeline-architecture.md)** ("What the key is made of"); this
+document owns only the on-disk form above.
+
+Mechanics: `IsValid` (`TaskValiditySidecar.cs`) compares the recorded `validity_key` against
+the current one and returns `false` for a missing, malformed, or mismatched sidecar ("can't
+tell ⇒ re-run", the conservative answer). Note it compares the key **only** — the `version`
+field is provenance, and build-compatibility is enforced separately by the parquet footer
+check in section 3. The task-name in the filename disambiguates per-task records for tasks
+that once shared an output path. `Delete` clears a sidecar when its task starts, so a crash
+mid-write cannot leave a stale "valid" marker. Callers reach these through
+`PerFileResumeDriver` (`IsCurrent` / `ClearStale` / `Stamp`), which additionally requires the
+output file itself to exist — a sidecar can outlive its output.
 
 This is the C# equivalent of, and refinement over, Rust's implicit "skip-if-cache-valid"
 behavior: it makes resume explicit and per-task rather than inferring state from parquet footer
-hashes alone.
+hashes alone. For the resume semantics built on it — the forward scan, per-run guards, and the
+HPC relay lists — see 00.
 
 ---
 

--- a/pwiz_tools/Osprey/docs/14-intermediate-files.md
+++ b/pwiz_tools/Osprey/docs/14-intermediate-files.md
@@ -12,7 +12,7 @@ resume mechanisms the port adds (a per-task `.osprey.task` validity sidecar and 
 
 > **Scope, ownership, and who may read what** live in
 > [00-pipeline-architecture.md](00-pipeline-architecture.md). That document owns the file
-> contract — which artifact is per-run or experiment-wide, which task writes it, which may
+> contract - which artifact is per-run or experiment-wide, which task writes it, which may
 > read it, and what an HPC node must be shipped. **This document owns the bytes**: headers,
 > versions, schemas, hashing, and invalidation mechanics. When the two disagree about a
 > writer or a reader, 00 is the one that is verified against the path-building code.
@@ -25,14 +25,14 @@ experiment-wide, **exp/rep** = experiment-wide content replicated under each run
 | File pattern | Scope | Format | C# writer/reader | Purpose |
 |---|---|---|---|---|
 | `<stem>.calibration.json` | run | JSON (Newtonsoft) | `Osprey.Chromatography/CalibrationIO.cs` | RT + MS1/MS2 mass calibration parameters |
-| `<stem>.spectra.bin` | run | Custom binary v4 | `Osprey.IO/SpectraCache.cs` | Decoded MS1/MS2 spectra for fast reload — and the only copy once the source is deleted |
+| `<stem>.spectra.bin` | run | Custom binary v4 | `Osprey.IO/SpectraCache.cs` | Decoded MS1/MS2 spectra for fast reload - and the only copy once the source is deleted |
 | `<stem>.scores.parquet` | run | Apache Parquet (ZSTD) | `Osprey.IO/ParquetScoreCache.cs` | Scored entries: 21 PIN features, fragments, CWT candidates + footer metadata |
 | `<stem>.scores-reconciled.parquet` | run | Apache Parquet (ZSTD) | `Osprey.Tasks/ReconciledParquetWriter.cs` | Stage 6 reconciled rewrite (separate file, not in-place) |
-| `<stem>.1st-pass.fdr_scores.bin` | run | Custom binary v4 | `Osprey.IO/FdrScoresSidecar.cs` | SVM score + 4 q-values + PEP + experiment_protein_qvalue + experiment_aggregate_score after first-pass Percolator |
-| `<stem>.2nd-pass.fdr_scores.bin` | run | Custom binary v4 | `Osprey.IO/FdrScoresSidecar.cs` | Same record shape after second-pass Percolator |
+| `<stem>.1st-pass.fdr_scores.bin` | run | Custom binary **v6**, 32-byte header + 28-byte records | `Osprey.IO/FdrScoresSidecar.cs` | entry_id, SVM score, run precursor q, run peptide q. The experiment-scope columns moved OUT at v5 (#4486) - see the experiment sidecar row |
+| `<stem>.2nd-pass.fdr_scores.bin` | run | Custom binary **v6**, same layout | `Osprey.IO/FdrScoresSidecar.cs` | Same record shape after second-pass Percolator |
 | `<stem>.2nd-pass.fdr_decoys.bin` | run | Custom binary v1 | `Osprey.IO/Pass2CompetitionDecoys.cs` | Per-run second-pass competition decoys; written before the scores sidecar |
 | `<stem>.reconciliation.json` | run | JSON (Newtonsoft) | `Osprey.IO/ReconciliationFile.cs` | Stage 5 planner output: actions, gap-fill targets, refined RT calibration |
-| `<blib-stem>.{1st,2nd}-pass.fdr_experiment.bin` | exp | Custom binary v5 | `Osprey.IO/FdrExperimentSidecar.cs` | Experiment-scope q-values; **name** from the output blib, **directory** from `ResolveOutputDir` |
+| `<blib-stem>.{1st,2nd}-pass.fdr_experiment.bin` | exp | Custom binary **v2**, 32-byte header + 44-byte records | `Osprey.IO/FdrExperimentSidecar.cs` | The experiment-scope columns: precursor q, peptide q, PEP, protein q, aggregate score. **Name** from the output blib, **directory** from `ResolveOutputDir` |
 | `<stem>.1st-pass.model.json` | exp/rep | JSON | `Osprey.Tasks/FirstPassModelIO.cs` | Frozen first-pass Percolator model, plus the protein-compact stratum when that mode is active |
 | `<output>.<TaskName>.osprey.task` | its artifact's | JSON (hand-rolled) | `Osprey.Tasks/TaskValiditySidecar.cs` | **C# addition**: per-(output, task) resume validity record |
 | `<lib>.<...>` library cache | exp | Custom binary v2 | `Osprey.IO/LibraryCache.cs` | Parsed spectral library reload cache |
@@ -49,13 +49,13 @@ redirection applies uniformly to every artifact.
 **Moved.** Where artifacts are written (`--work-dir` / `--output-dir` / `--cache-dir` and the
 `ArtifactPaths` resolution behind them) and why every writer commits atomically through
 `FileSaver` are architecture, not format, and are now stated once in
-[00-pipeline-architecture.md](00-pipeline-architecture.md) — see "Directory resolution" and
+[00-pipeline-architecture.md](00-pipeline-architecture.md) - see "Directory resolution" and
 principle P8. The one-line summary: a `FileSaver` stages into a sibling temp file in the same
 directory and promotes it with an in-volume rename, so a crash leaves either the previous
 content or no file, and **presence proves completeness** for every artifact in this document.
 
 The C# realization is Rust's "safe NAS file writes / `copy_and_verify`" pattern. Because the
-temp is a sibling, the promote is an in-volume rename rather than a local-temp → NAS
+temp is a sibling, the promote is an in-volume rename rather than a local-temp -> NAS
 cross-volume copy, which sidesteps the truncation risk `copy_and_verify` guards against.
 
 ### `FileSaver` call sites
@@ -81,7 +81,7 @@ durable artifact writer in the tree, as of this document's last verification:
 
 **A new durable artifact that does not commit through `FileSaver` is a defect**, because
 every reader in the pipeline treats presence as proof of completeness. **Exempt**: `-d`
-diagnostic dumps, the streaming CLI log, and test fixtures — transient or append-streaming
+diagnostic dumps, the streaming CLI log, and test fixtures - transient or append-streaming
 files that no later stage reads back.
 
 ---
@@ -330,7 +330,16 @@ Per-file persistence of FDR state at the Stage 5 → Stage 6 boundary (first pas
 second-pass FDR. Carries the SVM discriminant plus every q-value needed for downstream filtering
 and protein-FDR-aware compaction.
 
-### Format (v4) — byte-identical to Rust
+> **STALE - do not implement a reader from the layout below.** It documents v4: a 68-byte
+> record carrying the experiment-scope columns. The current format is **v6 with 28-byte
+> records** (`FdrScoresSidecar.FormatVersion`, `RecordLength`), holding only entry_id, SVM
+> score, run precursor q and run peptide q - the experiment columns moved to
+> `<blib-stem>.{1st,2nd}-pass.fdr_experiment.bin` at v5 (issue #4486). The header is still
+> 32 bytes. Re-verifying and rewriting this subsection against `WriteRecord` is tracked as
+> follow-up work; it was not rewritten in the PR that added this warning because that PR
+> changed no code and could not test a reader.
+
+### Format (v4, SUPERSEDED) - byte-identical to Rust
 
 `FdrScoresSidecar` writes a 32-byte header + fixed 68-byte records (`FdrScoresSidecar.cs:97`):
 
@@ -395,7 +404,7 @@ the file back, overwriting bytes `[52..60]` per entry_id. That method and its tw
 moved into `<blib-stem>.1st-pass.fdr_experiment.bin`, so a per-file sidecar is now written
 exactly once on each pass and no later stage reopens it. This is what makes the write-once
 guarantee (P11 in [00-pipeline-architecture.md](00-pipeline-architecture.md)) true rather
-than aspirational — do not reintroduce a patch path.
+than aspirational - do not reintroduce a patch path.
 
 ### Validation and record→entry matching
 
@@ -518,20 +527,20 @@ It records the producing task, the Osprey version, a `validity_key`, and the inp
 
 The base `validity_key` is
 `search=<SearchParameterHash>;library=<LibraryIdentityHash>` plus the peak-pick arm
-(`OspreyTask.ValidityKey`); tasks with extra state append to it — `FirstPassFdrTask` adds six
-further components. **What goes in a key, and why each component is there, is owned by
-[00-pipeline-architecture.md](00-pipeline-architecture.md)** ("What the key is made of"); this
-document owns only the on-disk form above.
+(`OspreyTask.ValidityKey`); tasks with extra state append to it - `FirstPassFdrTask` adds six
+further components; the full composition, with the defect each entry prevents, is under
+"What a validity key is made of" below. 00 owns the *rule* those entries serve (P15: an
+under-inclusive key is the dangerous direction); this document owns what they are.
 
 Mechanics: `IsValid` (`TaskValiditySidecar.cs`) compares the recorded `validity_key` against
 the current one and returns `false` for a missing, malformed, or mismatched sidecar ("can't
-tell ⇒ re-run", the conservative answer). Note it compares the key **only** — the `version`
+tell => re-run", the conservative answer). Note it compares the key **only** - the `version`
 field is provenance, and build-compatibility is enforced separately by the parquet footer
 check in section 3. The task-name in the filename disambiguates per-task records for tasks
-that once shared an output path. `Delete` clears a sidecar when its task starts, so a crash
+that once shared an output path. `Delete` clears a sidecar before its output is recomputed - at Run start for the two joins, per run for the two fan-out tasks - so a crash
 mid-write cannot leave a stale "valid" marker. Callers reach these through
 `PerFileResumeDriver` (`IsCurrent` / `ClearStale` / `Stamp`), which additionally requires the
-output file itself to exist — a sidecar can outlive its output.
+output file itself to exist - a sidecar can outlive its output.
 
 
 ### What a validity key is made of
@@ -580,8 +589,8 @@ direction and an over-inclusive one merely costs a recompute - is P15 in
 
 This is the C# equivalent of, and refinement over, Rust's implicit "skip-if-cache-valid"
 behavior: it makes resume explicit and per-task rather than inferring state from parquet footer
-hashes alone. For the resume semantics built on it — the forward scan, per-run guards, and the
-HPC relay lists — see 00.
+hashes alone. For the resume semantics built on it - the forward scan, per-run guards, and the
+HPC relay lists - see 00.
 
 ---
 
@@ -613,7 +622,7 @@ written or reused. Defaults from `Osprey/OspreyCommandArgs.cs` + `Osprey.Core/Os
 |---|---|---|
 | `--work-dir <dir>` | unset (beside input) | Sets both `ArtifactPaths.OutputDir` and `CacheDir`; redirects every artifact |
 | `--output-dir <dir>` | unset | Sets `ArtifactPaths.OutputDir` (scores parquet, calibration JSON, FDR sidecars, reconciliation JSON) |
-| `--cache-dir <dir>` | unset | Sets `ArtifactPaths.CacheDir` (`.spectra.bin` only); a shared cache dir lets analyses reuse one parse |
+| `--cache-dir <dir>` | unset | Sets `ArtifactPaths.CacheDir`, which holds `.spectra.bin` **and** `<library-leaf>.libcache` (`LibraryLoader` routes the library cache through it too); a shared cache dir lets analyses reuse one parse |
 | `--task <T>` | unset (in-process) | `FirstPassFDR`/`SecondPassFDR` trigger `ValidateScoresParquetGroup`; `SecondPassFDR` sets `ExpectReconciledInput` (requires `osprey.reconciled = "true"`). See 15-hpc-scoring-split.md |
 | `--resolution {unit\|hram\|auto}` | `auto` | Folded into `SearchParameterHash` ⇒ changing it invalidates `.scores.parquet` and (via the task key) recalibration |
 | `--fragment-tolerance` / `--fragment-unit` | ppm; unit-res forces mz 0.5 | Folded into `SearchParameterHash` |

--- a/pwiz_tools/Osprey/docs/14-intermediate-files.md
+++ b/pwiz_tools/Osprey/docs/14-intermediate-files.md
@@ -533,6 +533,51 @@ mid-write cannot leave a stale "valid" marker. Callers reach these through
 `PerFileResumeDriver` (`IsCurrent` / `ClearStale` / `Stamp`), which additionally requires the
 output file itself to exist — a sidecar can outlive its output.
 
+
+### What a validity key is made of
+
+The base key every task carries is search parameters, library identity, and the peak-pick
+arm (`OspreyTask.ValidityKey`). Tasks with extra state append to it; `FirstPassFDR` adds
+six components, and each one is in the key because leaving it out produced a specific
+wrong answer:
+
+| Component | Without it |
+|---|---|
+| reconciliation parameter hash | toggling reconciliation between runs reuses the prior shape |
+| FDR sidecar format version | a resume across a format bump skips the task, then every reader refuses the old file by version and defaults are written instead |
+| experiment-aggregation mode | an A/B arm re-run in a directory holding the other arm's results reuses the previous mode's q and reports it as the new measurement |
+| pass-2 q-value mode | a sidecar written under `transfer` carries no stratum, so a `protein-compact` re-run adopts an artifact that cannot answer its question |
+| training-sample settings | a resume adopts maximum-trained scores as though the reservoir had produced them |
+| library-fragment release | the retained-fragment arm differs and the outputs are not interchangeable |
+
+`PerFileRescoring` appends its own set for the same reasons - the reconciliation hash and
+sidecar format version, the experiment-aggregation, pass-2 q and training-sample arms, and
+the survivor-streaming switch, whose two paths must not adopt each other's output.
+
+The peak-pick arm sits in the *base* rather than in the overrides because it is the one
+lever that reaches every task: the pick decides which peak a precursor's row describes,
+back in Stage 4, and everything downstream inherits that choice. Putting it in the base
+also means a task added later carries it without having to know.
+
+Read that table as a worked example of P15's asymmetry. Every row was added after an
+under-inclusive key reused something it should not have, and none of them cost more than
+a recompute if they were unnecessary.
+
+### The build stamp
+
+The version stamped into each artifact follows the Skyline scheme
+`YEAR.ORDINAL.BRANCH.DOY`, with the full informational form carrying the git short hash
+(`26.1.1.182-b2373f9f9c`, plus `-dirty` for a modified tree) so a binary is always
+traceable to its source commit. Reuse requires an exact match on all four numeric
+components; a difference in release line or daily build aborts reuse with a hard error
+rather than a warning, because a cache from a different build may carry different scoring
+and a logged warning is easily missed while the run still completes and looks valid.
+
+
+The rule these serve - why an under-inclusive key is the dangerous
+direction and an over-inclusive one merely costs a recompute - is P15 in
+[00-pipeline-architecture.md](00-pipeline-architecture.md).
+
 This is the C# equivalent of, and refinement over, Rust's implicit "skip-if-cache-valid"
 behavior: it makes resume explicit and per-task rather than inferring state from parquet footer
 hashes alone. For the resume semantics built on it — the forward scan, per-run guards, and the

--- a/pwiz_tools/Osprey/docs/14-intermediate-files.md
+++ b/pwiz_tools/Osprey/docs/14-intermediate-files.md
@@ -58,6 +58,32 @@ The C# realization is Rust's "safe NAS file writes / `copy_and_verify`" pattern.
 temp is a sibling, the promote is an in-volume rename rather than a local-temp → NAS
 cross-volume copy, which sidesteps the truncation risk `copy_and_verify` guards against.
 
+### `FileSaver` call sites
+
+P8 is only as good as this list being complete, so it lives here, with the formats. Every
+durable artifact writer in the tree, as of this document's last verification:
+
+| Writer | Artifact |
+|---|---|
+| `CalibrationIO` | `<stem>.calibration.json` |
+| `SpectraCache` | `<stem>.spectra.bin` |
+| `LibraryCache` | `<library-leaf>.libcache` |
+| `ParquetScoreCache` (2 sites) | `<stem>.scores.parquet`, `<stem>.scores-reconciled.parquet` |
+| `FdrScoresSidecar` | `<stem>.{1st,2nd}-pass.fdr_scores.bin` |
+| `FdrExperimentSidecar` | `<blib-stem>.{1st,2nd}-pass.fdr_experiment.bin` |
+| `Pass2CompetitionDecoys` | `<stem>.2nd-pass.fdr_decoys.bin` |
+| `ReconciliationFile` | `<stem>.reconciliation.json` |
+| `FirstPassModelIO` | `<stem>.1st-pass.model.json` |
+| `TaskValiditySidecar` | `<output>.<TaskName>.osprey.task` |
+| `BlibOutputWriter` | `<output>.blib` |
+| `ModelDiagnosticsReport` (2 sites) | `<output>.model-diagnostics.{html,data.json}` |
+| `FdrBenchInputWriter` (2 sites) | `--fdrbench` input + pairing manifest |
+
+**A new durable artifact that does not commit through `FileSaver` is a defect**, because
+every reader in the pipeline treats presence as proof of completeness. **Exempt**: `-d`
+diagnostic dumps, the streaming CLI log, and test fixtures — transient or append-streaming
+files that no later stage reads back.
+
 ---
 
 ## 1. Calibration JSON (`<stem>.calibration.json`)
@@ -219,7 +245,7 @@ Mirroring Rust's specialized loaders, the C# side never loads the full parquet u
 | `LoadPinFeaturesFromParquet` (`:981`) | 21 feature columns | SVM re-scoring |
 | `LoadFullFdrEntries` (`:897`) | all scalar + feature + blob columns | Full rehydration for Stage 6 reconciled write-back |
 
-`ParquetIndex` bookkeeping is load-bearing: both write overloads and every loader assign
+`ParquetIndex` bookkeeping is essential: both write overloads and every loader assign
 `ParquetIndex` to the post-sort row so Stage 5's per-file CWT lookup indexes each entry's own
 candidate list. A code comment (`ParquetScoreCache.cs:364`) documents a bisected bug where the
 in-memory path once left `ParquetIndex = 0` and force-integrated nearly every entry.
@@ -359,13 +385,17 @@ carries the same value.
 Two caveats worth keeping straight. It is **not** a general q→score inverse: the best-of-runs
 clamp (`ClampExperimentQToBestRunFlat`, issue #4390) floors an experiment q up to a run q, so
 after clamping the experiment q is not a monotone function of this score. And the field was
-appended at the END specifically so every v3 offset is unchanged, which is what keeps
-`PatchProteinQvalues`'s `[52..60]` patch valid without modification.
+appended at the END specifically so every v3 offset is unchanged.
 
-A two-phase write exists for the lean projection path (issue #4355): phase 1 writes records with
-a 1.0 placeholder `experiment_protein_qvalue`; `PatchProteinQvalues` (`FdrScoresSidecar.cs:247`)
-then streams the file one record at a time and overwrites only bytes `[52..60]` per entry_id,
-producing a file byte-identical to a single-phase write.
+**The two-phase write is gone** (removed 2026-09-02 from this document; the code changed at
+sidecar v5, issue #4486). Historically the lean projection path (issue #4355) wrote records
+with a 1.0 placeholder `experiment_protein_qvalue` and then had `PatchProteinQvalues` stream
+the file back, overwriting bytes `[52..60]` per entry_id. That method and its two siblings
+(`PatchExperimentValues`, and the PEP patch) are **deleted**: the experiment-scope columns
+moved into `<blib-stem>.1st-pass.fdr_experiment.bin`, so a per-file sidecar is now written
+exactly once on each pass and no later stage reopens it. This is what makes the write-once
+guarantee (P11 in [00-pipeline-architecture.md](00-pipeline-architecture.md)) true rather
+than aspirational — do not reintroduce a patch path.
 
 ### Validation and record→entry matching
 

--- a/pwiz_tools/Osprey/docs/15-hpc-scoring-split.md
+++ b/pwiz_tools/Osprey/docs/15-hpc-scoring-split.md
@@ -155,6 +155,10 @@ Per-run notes worth keeping alongside the contract:
   mzML fallback — and is the only spectrum source once the input has been deleted.
 - `<stem>.1st-pass.fdr_scores.bin` and `<stem>.reconciliation.json` are both mandatory for a
   Stage 6 worker.
+- `<stem>.calibration.json` is read for **inverse RT prediction and isolation windows** — the
+  latter giving the gap-fill m/z filter its per-run coverage, which is why a `SecondPassFDR`
+  node with no mzML still needs it. Read behind a `File.Exists`, so its absence changes
+  gap-fill filtering silently rather than failing.
 
 See 00 for the relay checklist per boundary and 14-intermediate-files.md for the full cache
 formats.

--- a/pwiz_tools/Osprey/docs/15-hpc-scoring-split.md
+++ b/pwiz_tools/Osprey/docs/15-hpc-scoring-split.md
@@ -8,6 +8,8 @@ The C# port implements this split as **four pipeline tasks** driven by a single 
 
 > **This document owns operations**: CLI flags, the membership truth table, `--input-scores` resolution and ordering, footer-hash validation, and concurrency. *Why* the split has this shape — the scope of each artifact, which task may read what, and the exact file list a node must be shipped at each boundary — is owned by [00-pipeline-architecture.md](00-pipeline-architecture.md), and the byte formats by [14-intermediate-files.md](14-intermediate-files.md). Read 00 before changing what any task writes.
 
+> **In flight** - this document describes `--task PerFileRescoring` as rehydrating `FirstPassFdrTask` and reading an all-runs `CompactedEntries` buffer (the membership truth table below, and the Stage 6 section). That is what the branch `Skyline/work/20260901_osprey_firstpass_resume` replaces with a per-run hydrate, so both statements change when it lands. **Deviations from the target architecture are tracked in one place - 00's `## In flight` section - not per document**; this note exists so a reader of 15 alone knows to look there.
+
 ## Task-name mapping (CLI name vs internal enum)
 
 The CLI `--task` spelling, the `HpcTask` enum member, and the task class are now one name per task. The only one that still needs a second look is `PerFileRescoring` (CLI) vs `PerFileRescore` (enum and class); the rest differ at most in the `Fdr`/`FDR` casing.

--- a/pwiz_tools/Osprey/docs/15-hpc-scoring-split.md
+++ b/pwiz_tools/Osprey/docs/15-hpc-scoring-split.md
@@ -6,6 +6,8 @@ For large experiments (hundreds to thousands of mzML files) the Osprey pipeline 
 
 The C# port implements this split as **four pipeline tasks** driven by a single `--task <Name>` CLI selector, rather than the Rust doc's `--no-join` / `--join-at-pass` / `--join-only` flag family. Each task is a subclass of `OspreyTask` (`Osprey.Tasks/OspreyTask.cs`), and the orchestration model is a per-task membership predicate walked by a driver loop (`Osprey/AnalysisPipeline.cs:99-112`) rather than a contiguous `[start..stop]` stage window.
 
+> **This document owns operations**: CLI flags, the membership truth table, `--input-scores` resolution and ordering, footer-hash validation, and concurrency. *Why* the split has this shape — the scope of each artifact, which task may read what, and the exact file list a node must be shipped at each boundary — is owned by [00-pipeline-architecture.md](00-pipeline-architecture.md), and the byte formats by [14-intermediate-files.md](14-intermediate-files.md). Read 00 before changing what any task writes.
+
 ## Task-name mapping (CLI name vs internal enum)
 
 The CLI `--task` spelling, the `HpcTask` enum member, and the task class are now one name per task. The only one that still needs a second look is `PerFileRescoring` (CLI) vs `PerFileRescore` (enum and class); the rest differ at most in the `Fdr`/`FDR` casing.
@@ -17,7 +19,7 @@ The CLI `--task` spelling, the `HpcTask` enum member, and the task class are now
 | Stage 6 per-file rescore | `PerFileRescoring` | `HpcTask.PerFileRescore` | `PerFileRescoreTask` (`"PerFileRescoring"`) |
 | Stages 7-8 second-pass FDR | `SecondPassFDR` | `HpcTask.SecondPassFdr` | `SecondPassFdrTask` (`"SecondPassFDR"`) |
 
-- The enum is defined in `Osprey.Core/OspreyConfig.cs` as `{ PerFileScoring, FirstPassFdr, PerFileRescore, SecondPassFdr }`.
+- The enum is defined in `Osprey.Core/OspreyConfig.cs`. Its first four members are the pipeline tasks above, in execution order: `{ PerFileScoring, FirstPassFdr, PerFileRescore, SecondPassFdr }`. Two more are appended — `SpectraCache` (build each input's `.spectra.bin` and stop; the data-staging step *ahead* of the pipeline) and `ModelDiagnostics` (regenerate the `--model-diagnostics` report for a completed analysis). **Neither is a pipeline stage**: both are reachable only by naming them in `--task`, neither appears in `CanonicalPipeline()`, and neither belongs in an HPC relay plan. They are appended rather than ordered first so the existing members keep their ordinal values. See 00-pipeline-architecture.md, "Two selectable tasks that are not pipeline tasks".
 - The CLI-name to enum mapping is `Program.ResolveTask` and its inverse `Program.TaskCliName`, both in `Osprey/Program.cs`.
 - The `OspreyTask.Name` strings (used in `[TASK]` log lines and `.osprey.task` sidecar naming) ARE the CLI spelling, and the class names now match them: `PerFileScoringTask.Name => "PerFileScoring"`, `FirstPassFdrTask.Name => "FirstPassFDR"` (`Osprey.Tasks/FirstPassFdrTask.cs:71`), `PerFileRescoreTask.Name => "PerFileRescoring"` (`Osprey.Tasks/PerFileRescoreTask.cs:114`), `SecondPassFdrTask.Name => "SecondPassFDR"` (`Osprey.Tasks/SecondPassFdrTask.cs:49`). The one name to read carefully is `PerFileRescore`/`PerFileRescoring`; everything else differs only in the `Fdr`/`FDR` casing, which follows this codebase's own type convention (`FdrEntry`, `FdrController`) rather than the all-caps `pwiz.Osprey.FDR` namespace.
 
@@ -139,17 +141,23 @@ On mismatch the run aborts before any FDR/reconciliation work, naming the offend
 
 ## Persistent files per input
 
-| File | Written by | Consumed by |
-|---|---|---|
-| `<stem>.calibration.json` | Stage 1-2 | Stage 6 (inverse RT prediction + isolation windows) |
-| `<stem>.scores.parquet` | Stage 4 (`PerFileScoringTask`) | Stages 5-7 (stubs, PIN features, CWT candidates, blib plan) |
-| `<stem>.spectra.bin` | Stage 1-2 | Stage 6 rescore (**mandatory** — streamed per window, no mzML fallback); the only spectrum source once the input is deleted |
-| `<stem>.1st-pass.fdr_scores.bin` | Stage 5 (`FirstPassFdrTask`) | Stage 6 worker (mandatory); skip-Percolator on rerun |
-| `<stem>.reconciliation.json` | Stage 5 (`FirstPassFdrTask`) | Stage 6 worker (mandatory) |
-| `<stem>.scores-reconciled.parquet` | Stage 6 (`PerFileRescoreTask`) | Stage 7 (`SecondPassFdrTask`) 2nd-pass FDR + blib |
-| `<stem>.2nd-pass.fdr_scores.bin` | Stage 7 (`SecondPassFdrTask`) | skip-Percolator on rerun |
+**Moved.** The authoritative list of what each task writes and reads — including the
+experiment-wide artifacts this section never covered, and which of them must be relayed to
+every node — is the sidecar file contract in
+[00-pipeline-architecture.md](00-pipeline-architecture.md). It is verified row by row against
+the path-building code; the table that used to sit here had drifted (it attributed
+`<stem>.2nd-pass.fdr_scores.bin` to Stage 7, when `PerFileRescoring`'s pass-2 worker writes it
+whenever that worker runs).
 
-See 14-intermediate-files.md for the full cache formats.
+Per-run notes worth keeping alongside the contract:
+
+- `<stem>.spectra.bin` is **mandatory** for the Stage 6 rescore — streamed per window, with no
+  mzML fallback — and is the only spectrum source once the input has been deleted.
+- `<stem>.1st-pass.fdr_scores.bin` and `<stem>.reconciliation.json` are both mandatory for a
+  Stage 6 worker.
+
+See 00 for the relay checklist per boundary and 14-intermediate-files.md for the full cache
+formats.
 
 ## Cross-implementation compatibility and bisection dumps
 
@@ -157,7 +165,12 @@ The parquet cache and `reconciliation.json` boundary file are shared with Rust O
 
 ## Safe concurrent writes
 
-All cache writers write to a local temp file and copy-and-verify to the final destination, so a mid-write process kill on a NAS/CIFS mount leaves no corrupt cache that a downstream stage must reject. See 16-determinism.md.
+Every cache writer stages through a `FileSaver` temp file that is a **sibling in the same
+directory** as its destination, then promotes it with an in-volume rename — not a local temp
+plus a cross-volume copy-and-verify, which is the Rust pattern this port replaced. A mid-write
+process kill on a NAS/CIFS mount therefore leaves either the previous content or no file, never
+a corrupt cache a downstream stage must reject. See principle P8 in
+[00-pipeline-architecture.md](00-pipeline-architecture.md), and 16-determinism.md.
 
 ## Flags and switches
 

--- a/pwiz_tools/Osprey/docs/15-hpc-scoring-split.md
+++ b/pwiz_tools/Osprey/docs/15-hpc-scoring-split.md
@@ -6,7 +6,7 @@ For large experiments (hundreds to thousands of mzML files) the Osprey pipeline 
 
 The C# port implements this split as **four pipeline tasks** driven by a single `--task <Name>` CLI selector, rather than the Rust doc's `--no-join` / `--join-at-pass` / `--join-only` flag family. Each task is a subclass of `OspreyTask` (`Osprey.Tasks/OspreyTask.cs`), and the orchestration model is a per-task membership predicate walked by a driver loop (`Osprey/AnalysisPipeline.cs:99-112`) rather than a contiguous `[start..stop]` stage window.
 
-> **This document owns operations**: CLI flags, the membership truth table, `--input-scores` resolution and ordering, footer-hash validation, and concurrency. *Why* the split has this shape — the scope of each artifact, which task may read what, and the exact file list a node must be shipped at each boundary — is owned by [00-pipeline-architecture.md](00-pipeline-architecture.md), and the byte formats by [14-intermediate-files.md](14-intermediate-files.md). Read 00 before changing what any task writes.
+> **This document owns operations**: CLI flags, the membership truth table, `--input-scores` resolution and ordering, footer-hash validation, and concurrency. *Why* the split has this shape - the scope of each artifact, which task may read what, and the exact file list a node must be shipped at each boundary - is owned by [00-pipeline-architecture.md](00-pipeline-architecture.md), and the byte formats by [14-intermediate-files.md](14-intermediate-files.md). Read 00 before changing what any task writes.
 
 > **In flight** - this document describes `--task PerFileRescoring` as rehydrating `FirstPassFdrTask` and reading an all-runs `CompactedEntries` buffer (the membership truth table below, and the Stage 6 section). That is what the branch `Skyline/work/20260901_osprey_firstpass_resume` replaces with a per-run hydrate, so both statements change when it lands. **Deviations from the target architecture are tracked in one place - 00's `## In flight` section - not per document**; this note exists so a reader of 15 alone knows to look there.
 
@@ -21,7 +21,7 @@ The CLI `--task` spelling, the `HpcTask` enum member, and the task class are now
 | Stage 6 per-file rescore | `PerFileRescoring` | `HpcTask.PerFileRescore` | `PerFileRescoreTask` (`"PerFileRescoring"`) |
 | Stages 7-8 second-pass FDR | `SecondPassFDR` | `HpcTask.SecondPassFdr` | `SecondPassFdrTask` (`"SecondPassFDR"`) |
 
-- The enum is defined in `Osprey.Core/OspreyConfig.cs`. Its first four members are the pipeline tasks above, in execution order: `{ PerFileScoring, FirstPassFdr, PerFileRescore, SecondPassFdr }`. Two more are appended — `SpectraCache` (build each input's `.spectra.bin` and stop; the data-staging step *ahead* of the pipeline) and `ModelDiagnostics` (regenerate the `--model-diagnostics` report for a completed analysis). **Neither is a pipeline stage**: both are reachable only by naming them in `--task`, neither appears in `CanonicalPipeline()`, and neither belongs in an HPC relay plan. They are appended rather than ordered first so the existing members keep their ordinal values. See 00-pipeline-architecture.md, "Two selectable tasks that are not pipeline tasks".
+- The enum is defined in `Osprey.Core/OspreyConfig.cs`. Its first four members are the pipeline tasks above, in execution order: `{ PerFileScoring, FirstPassFdr, PerFileRescore, SecondPassFdr }`. Two more are appended - `SpectraCache` (build each input's `.spectra.bin` and stop; the data-staging step *ahead* of the pipeline) and `ModelDiagnostics` (regenerate the `--model-diagnostics` report for a completed analysis). **Neither is a pipeline stage**: both are reachable only by naming them in `--task`, neither appears in `CanonicalPipeline()`, and neither belongs in an HPC relay plan. They are appended rather than ordered first so the existing members keep their ordinal values. See 00-pipeline-architecture.md, "Two selectable tasks that are not pipeline tasks".
 - The CLI-name to enum mapping is `Program.ResolveTask` and its inverse `Program.TaskCliName`, both in `Osprey/Program.cs`.
 - The `OspreyTask.Name` strings (used in `[TASK]` log lines and `.osprey.task` sidecar naming) ARE the CLI spelling, and the class names now match them: `PerFileScoringTask.Name => "PerFileScoring"`, `FirstPassFdrTask.Name => "FirstPassFDR"` (`Osprey.Tasks/FirstPassFdrTask.cs:71`), `PerFileRescoreTask.Name => "PerFileRescoring"` (`Osprey.Tasks/PerFileRescoreTask.cs:114`), `SecondPassFdrTask.Name => "SecondPassFDR"` (`Osprey.Tasks/SecondPassFdrTask.cs:49`). The one name to read carefully is `PerFileRescore`/`PerFileRescoring`; everything else differs only in the `Fdr`/`FDR` casing, which follows this codebase's own type convention (`FdrEntry`, `FdrController`) rather than the all-caps `pwiz.Osprey.FDR` namespace.
 
@@ -143,9 +143,9 @@ On mismatch the run aborts before any FDR/reconciliation work, naming the offend
 
 ## Persistent files per input
 
-**Moved.** The authoritative list of what each task writes and reads — including the
+**Moved.** The authoritative list of what each task writes and reads - including the
 experiment-wide artifacts this section never covered, and which of them must be relayed to
-every node — is the sidecar file contract in
+every node - is the sidecar file contract in
 [00-pipeline-architecture.md](00-pipeline-architecture.md). It is verified row by row against
 the path-building code; the table that used to sit here had drifted (it attributed
 `<stem>.2nd-pass.fdr_scores.bin` to Stage 7, when `PerFileRescoring`'s pass-2 worker writes it
@@ -153,11 +153,11 @@ whenever that worker runs).
 
 Per-run notes worth keeping alongside the contract:
 
-- `<stem>.spectra.bin` is **mandatory** for the Stage 6 rescore — streamed per window, with no
-  mzML fallback — and is the only spectrum source once the input has been deleted.
+- `<stem>.spectra.bin` is **mandatory** for the Stage 6 rescore - streamed per window, with no
+  mzML fallback - and is the only spectrum source once the input has been deleted.
 - `<stem>.1st-pass.fdr_scores.bin` and `<stem>.reconciliation.json` are both mandatory for a
   Stage 6 worker.
-- `<stem>.calibration.json` is read for **inverse RT prediction and isolation windows** — the
+- `<stem>.calibration.json` is read for **inverse RT prediction and isolation windows** - the
   latter giving the gap-fill m/z filter its per-run coverage, which is why a `SecondPassFDR`
   node with no mzML still needs it. Read behind a `File.Exists`, so its absence changes
   gap-fill filtering silently rather than failing.
@@ -172,7 +172,7 @@ The parquet cache and `reconciliation.json` boundary file are shared with Rust O
 ## Safe concurrent writes
 
 Every cache writer stages through a `FileSaver` temp file that is a **sibling in the same
-directory** as its destination, then promotes it with an in-volume rename — not a local temp
+directory** as its destination, then promotes it with an in-volume rename - not a local temp
 plus a cross-volume copy-and-verify, which is the Rust pattern this port replaced. A mid-write
 process kill on a NAS/CIFS mount therefore leaves either the previous content or no file, never
 a corrupt cache a downstream stage must reject. See principle P8 in

--- a/pwiz_tools/Osprey/docs/20-command-line.md
+++ b/pwiz_tools/Osprey/docs/20-command-line.md
@@ -93,7 +93,7 @@ Defaults and value lists are from `Osprey/OspreyCommandArgs.cs`; the parser acce
 | `-o`, `--output` | `<output.blib>` | Output `.blib` (see [13-blib-output-schema.md](13-blib-output-schema.md)). |
 | `--work-dir` | `<dir>` | Write derived artifacts **and** the spectra cache here, so the input data dir can be read-only. Default: beside the input. |
 | `--output-dir` | `<dir>` | Directory for derived artifacts (overrides `--work-dir`). |
-| `--cache-dir` | `<dir>` | Directory for the `.spectra.bin` cache (overrides `--work-dir`). |
+| `--cache-dir` | `<dir>` | Directory for the rebuildable caches - `.spectra.bin` and the `<library-leaf>.libcache` (overrides `--work-dir`). Required on a `--task` leg whose `--output-dir` differs from the data directory: such a leg has no raw input path to resolve the cache from. |
 | `--report` | `<report.tsv>` | Also write a TSV report. |
 
 ### Scoring & Tolerance

--- a/pwiz_tools/Osprey/docs/README.md
+++ b/pwiz_tools/Osprey/docs/README.md
@@ -18,8 +18,18 @@ the Rust documentation" section**; those are consolidated in
 
 ## Ordered index
 
+**00 sorts first and is the one document to read before changing what any task reads,
+writes, or keeps.** It has no Rust counterpart and no "Divergences" section: it states the
+architecture the C# pipeline is built to, rather than porting a Rust source doc.
+
+Three documents divide the file-and-orchestration subject, and none repeats another: **00**
+owns scope, contract, principles and relay (which file, whose, when, who may read it);
+**14** owns the bytes (headers, versions, schemas, hashing, invalidation mechanics); **15**
+owns operations (CLI flags, `--input-scores` ordering, orchestration recipes).
+
 | # | Doc | What it covers |
 |---|-----|----------------|
+| 00 | [pipeline-architecture](00-pipeline-architecture.md) | The pipeline's shape and its file contract: fan-out/join decomposition to any HPC batch size, bounded joins, the per-run and experiment-wide sidecar tiers as a memory model, atomic write and set-inclusion validity, resume, and the per-boundary relay checklist. |
 | 01 | [decoy-generation](01-decoy-generation.md) | Enzyme-aware sequence reversal (cleavage residue preserved), fragment m/z recompute for b/y swaps, FDRBench decoy-pairing manifest. |
 | 02 | [xcorr-scoring](02-xcorr-scoring.md) | The Comet-style XCorr primitive: spectrum preprocessing, bin sizes, flanking-bin subtraction, the vectorized dot product. |
 | 03 | [spectral-scoring](03-spectral-scoring.md) | The 21 PIN features and how each is computed (pairwise coelution, peak shape, spectral-at-apex, mass accuracy, RT deviation, MS1, Tukey median polish, SG-weighted multi-scan). |

--- a/pwiz_tools/Osprey/package.ps1
+++ b/pwiz_tools/Osprey/package.ps1
@@ -72,6 +72,7 @@
     # CI
     .\package.ps1 -TeamCity -Msi
 #>
+#Requires -Version 7.0
 param(
     [string[]]$Rid = @('win-x64','linux-x64'),
     [ValidateSet('Debug','Release')] [string]$Configuration = 'Release',
@@ -227,13 +228,25 @@ function Add-OspreyDocs {
     # the COPY so the bundled README has no dead links: docs/ links go to GitHub
     # (there is nothing local to point at), and the workflow link gets its
     # subdirectory. Same approach as the CommandLine.html retarget above.
+    #
+    # The docs URL deliberately points at master rather than this build's commit.
+    # A commit URL would describe exactly the code in the ZIP, but it 404s for any
+    # bundle built from an unpushed branch (every developer build), and a dead link
+    # is worse than a slightly newer one. Revisit if bundles are ever produced only
+    # from pushed release tags.
+    #
+    # Read and write with explicit encoding rather than Get-Content/Set-Content
+    # defaults: the README is BOM-less UTF-8 containing em dashes, and the default
+    # round-trip mangles them and prepends a BOM on Windows PowerShell 5.1. The
+    # #Requires above should prevent that, but the file is data, so make the
+    # handling of it explicit anyway.
     $readmeStaged = Join-Path $StageDir 'README.md'
     Copy-Item (Join-Path $scriptRoot 'README.md') $readmeStaged -Force
-    $readme = Get-Content $readmeStaged -Raw
+    $readme = [System.IO.File]::ReadAllText($readmeStaged, [System.Text.Encoding]::UTF8)
     $docsUrl = 'https://github.com/ProteoWizard/pwiz/blob/master/pwiz_tools/Osprey/docs/'
     $readme = [regex]::Replace($readme, '\]\(docs/([^)]+)\)', ('](' + $docsUrl + '$1)'))
     $readme = [regex]::Replace($readme, '\]\(Osprey-workflow\.html\)', '](Documentation/Osprey-workflow.html)')
-    Set-Content -Path $readmeStaged -Value $readme -NoNewline -Encoding utf8
+    [System.IO.File]::WriteAllText($readmeStaged, $readme, (New-Object System.Text.UTF8Encoding $false))
 
     Copy-Item (Join-Path $repoRoot 'LICENSE') (Join-Path $StageDir 'LICENSE') -Force
 }

--- a/pwiz_tools/Osprey/package.ps1
+++ b/pwiz_tools/Osprey/package.ps1
@@ -222,7 +222,19 @@ function Add-OspreyDocs {
     $html = [regex]::Replace($html, 'https?://raw\.githack\.com/ProteoWizard/pwiz/[^"'' ]*Osprey-workflow\.html', 'Osprey-workflow.html')
     Set-Content -Path $staged -Value $html -NoNewline -Encoding utf8
 
-    Copy-Item (Join-Path $scriptRoot 'README.md') (Join-Path $StageDir 'README.md') -Force
+    # README.md ships, but docs/*.md does not, and the workflow page lands in
+    # Documentation/ rather than beside the README. Retarget both link shapes on
+    # the COPY so the bundled README has no dead links: docs/ links go to GitHub
+    # (there is nothing local to point at), and the workflow link gets its
+    # subdirectory. Same approach as the CommandLine.html retarget above.
+    $readmeStaged = Join-Path $StageDir 'README.md'
+    Copy-Item (Join-Path $scriptRoot 'README.md') $readmeStaged -Force
+    $readme = Get-Content $readmeStaged -Raw
+    $docsUrl = 'https://github.com/ProteoWizard/pwiz/blob/master/pwiz_tools/Osprey/docs/'
+    $readme = [regex]::Replace($readme, '\]\(docs/([^)]+)\)', ('](' + $docsUrl + '$1)'))
+    $readme = [regex]::Replace($readme, '\]\(Osprey-workflow\.html\)', '](Documentation/Osprey-workflow.html)')
+    Set-Content -Path $readmeStaged -Value $readme -NoNewline -Encoding utf8
+
     Copy-Item (Join-Path $repoRoot 'LICENSE') (Join-Path $StageDir 'LICENSE') -Force
 }
 


### PR DESCRIPTION
## Summary

* Added `pwiz_tools/Osprey/docs/00-pipeline-architecture.md`: one authoritative statement of the pipeline architecture and the sidecar file contract. It covers what makes HPC operation possible (fan-out tasks decompose to any batch size, 1..N runs per node; joins stay bounded), the two sidecar tiers as a memory model (experiment-wide artifacts ARE the resident baseline a per-run loop runs against), and the write and resume discipline. The central claim is the identity `peak = baseline + max(one run)`, in which neither batch size nor cohort size appears.
* Reconciled docs 12, 14 and 15 against it under one ownership rule - 00 owns scope, contract, principles and relay; 14 owns the bytes; 15 owns operations - replacing restated rules with pointers so the three cannot drift.
* Reflected the contract in `Osprey-workflow.html`: a File-scope legend, every artifact name in the task banners coloured per-run / experiment-wide / shared cache, a relay line per task, and the geometry reflowed for the taller banners.
* Routed `README.md` and `docs/README.md` to 00, and retargeted README links when packaging, since the bundle ships the README but not `docs/`.

Corrections found while verifying every claim against the code, listed because several were live hazards rather than wording:

* `.1st-pass.stratum.json` does not exist on master; the stratum rides inside the model sidecar. The 2nd-pass sidecars are written by `PerFileRescoring`, not `SecondPassFDR`. `HpcTask` has six members, two of which are not pipeline stages. Doc 15 described Rust's copy-and-verify rather than the C# sibling-rename, and attributed the 2nd-pass sidecar to Stage 7.
* Doc 14's FDR sidecar formats were stale by two versions (`fdr_scores` is v6 / 28-byte records, `fdr_experiment` v2 / 44-byte). The superseded v4 layout section is marked stale rather than rewritten, since this PR changes no code and cannot test a reader.
* An unreadable experiment sidecar does **not** fail fast: it logs, sets a non-zero exit code and continues with a different retained set. The version stamp is never compared on the `.osprey.task` resume path. Two Stage-7 report writers bypass `FileSaver`. All three are documented as defects rather than described as guarantees.
* `package.ps1` now requires PowerShell 7 and round-trips the README with explicit encoding: under 5.1 the new block added a BOM and mangled every em dash (reproduced, 57 -> 155 bytes above ASCII).

Two known gaps, both called out in the document: doc 14's full v4 format section still needs rewriting against `WriteRecord`, and doc 00 is 961 lines against its own ~900 guard rail after the review rounds added material.

Deviations from the artifacts that are still in flight on `Skyline/work/20260901_osprey_firstpass_resume` are marked inline and collected in one `## In flight` section, so clearing them after that branch lands is a single edit.

## Test plan

- [x] Relative-link check across all changed docs and both READMEs - every link and anchor resolves
- [x] Contract-vs-code - every writer class named in the table exists, and every filename fragment appears in `pwiz_tools/Osprey/**/*.cs`
- [x] Cross-pool naming - the four task names agree byte-for-byte across `README.md`, `docs/00` and `Osprey-workflow.html`
- [x] Headless-Chrome render of the reflowed diagram, before and after, plus per-banner crops at 1:1 - no group overlap, both scope tiers legible
- [x] `package.ps1` README retarget verified in isolation under pwsh 7 (no BOM, no mojibake, zero un-retargeted links) and confirmed to refuse under Windows PowerShell 5.1
- [x] `audit-docs.ps1` - the pre-existing core-five overage is untouched by this PR
- [x] All added lines are ASCII-only; no line-ending churn (`--ignore-cr-at-eol` diff matches the content diff)

No code changed, so `Build-Osprey.ps1` and `regression.ps1` are not applicable, and the TeamCity Osprey Perf/Regression config should **not** be triggered for this PR.

See TODO-20260902_osprey_pipeline_architecture_docs.md in pwiz-ai/todos

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014XDaY1Ev2sHfR2HKWP4Bf3
