### PR TITLE
pwiz: Removed UTF-8 BOMs from Osprey and pwiz-sharp sources

### DIFF
--- a/pwiz-sharp/Pwiz.sln
+++ b/pwiz-sharp/Pwiz.sln
@@ -1,4 +1,4 @@
-﻿
+
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.0.31903.59

--- a/pwiz-sharp/pwiz/src/Vendor/Sciex/Reader_Sciex.cs
+++ b/pwiz-sharp/pwiz/src/Vendor/Sciex/Reader_Sciex.cs
@@ -1,4 +1,4 @@
-﻿using Pwiz.Data.Common.Cv;
+using Pwiz.Data.Common.Cv;
 using Pwiz.Data.MsData;
 using Pwiz.Data.MsData.Readers;
 #if !NO_VENDOR_SUPPORT

--- a/pwiz-sharp/pwiz/src/Vendor/Thermo/Reader_Thermo.cs
+++ b/pwiz-sharp/pwiz/src/Vendor/Thermo/Reader_Thermo.cs
@@ -1,4 +1,4 @@
-﻿using System.Globalization;
+using System.Globalization;
 using Pwiz.Data.Common.Cv;
 using Pwiz.Data.Common.Params;
 using Pwiz.Data.MsData;

--- a/pwiz_tools/Osprey/Osprey.FDR/StreamingFdr.cs
+++ b/pwiz_tools/Osprey/Osprey.FDR/StreamingFdr.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Original author: Brendan MacLean <brendanx .at. uw.edu>,
  *                  MacCoss Lab, Department of Genome Sciences, UW
  * AI assistance: Claude Code (Claude Opus 5) <noreply .at. anthropic.com>

--- a/pwiz_tools/Osprey/Osprey.IO/ParquetScoreCache.cs
+++ b/pwiz_tools/Osprey/Osprey.IO/ParquetScoreCache.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Original author: Brendan MacLean <brendanx .at. uw.edu>,
  *                  MacCoss Lab, Department of Genome Sciences, UW
  * AI assistance: Claude Code (Claude Opus 4) <noreply .at. anthropic.com>

--- a/pwiz_tools/Osprey/Osprey.IO/Pass2CompetitionDecoys.cs
+++ b/pwiz_tools/Osprey/Osprey.IO/Pass2CompetitionDecoys.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Original author: Brendan MacLean <brendanx .at. uw.edu>,
  *                  MacCoss Lab, Department of Genome Sciences, UW
  * AI assistance: Claude Code (Claude Opus 5) <noreply .at. anthropic.com>

--- a/pwiz_tools/Osprey/Osprey.Tasks/FirstPassSurvivorLoader.cs
+++ b/pwiz_tools/Osprey/Osprey.Tasks/FirstPassSurvivorLoader.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Original author: Brendan MacLean <brendanx .at. uw.edu>,
  *                  MacCoss Lab, Department of Genome Sciences, UW
  * AI assistance: Claude Code (Claude Opus 5) <noreply .at. anthropic.com>

--- a/pwiz_tools/Osprey/Osprey.Tasks/ModelDiagnostics/PeakCoAssignmentSource.cs
+++ b/pwiz_tools/Osprey/Osprey.Tasks/ModelDiagnostics/PeakCoAssignmentSource.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Original author: Brendan MacLean <brendanx .at. uw.edu>,
  *                  MacCoss Lab, Department of Genome Sciences, UW
  * AI assistance: Claude Code (Claude Opus 5) <noreply .at. anthropic.com>

--- a/pwiz_tools/Osprey/Osprey.Tasks/Pass2PerFileWorker.cs
+++ b/pwiz_tools/Osprey/Osprey.Tasks/Pass2PerFileWorker.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Original author: Brendan MacLean <brendanx .at. uw.edu>,
  *                  MacCoss Lab, Department of Genome Sciences, UW
  * AI assistance: Claude Code (Claude Opus 5) <noreply .at. anthropic.com>

--- a/pwiz_tools/Osprey/Osprey.Tasks/PerFileScoringTask.cs
+++ b/pwiz_tools/Osprey/Osprey.Tasks/PerFileScoringTask.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Original author: Brendan MacLean <brendanx .at. uw.edu>,
  *                  MacCoss Lab, Department of Genome Sciences, UW
  * AI assistance: Claude Code (Claude Opus 4.7) <noreply .at. anthropic.com>

--- a/pwiz_tools/Osprey/Osprey.Tasks/ScoringTaskShared.cs
+++ b/pwiz_tools/Osprey/Osprey.Tasks/ScoringTaskShared.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Original author: Brendan MacLean <brendanx .at. uw.edu>,
  *                  MacCoss Lab, Department of Genome Sciences, UW
  * AI assistance: Claude Code (Claude Opus 4.8) <noreply .at. anthropic.com>

--- a/pwiz_tools/Osprey/Osprey.Tasks/SecondPassFdrTask.cs
+++ b/pwiz_tools/Osprey/Osprey.Tasks/SecondPassFdrTask.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Original author: Brendan MacLean <brendanx .at. uw.edu>,
  *                  MacCoss Lab, Department of Genome Sciences, UW
  * AI assistance: Claude Code (Claude Opus 5) <noreply .at. anthropic.com>

--- a/pwiz_tools/Osprey/Osprey.Test/FdrTest.cs
+++ b/pwiz_tools/Osprey/Osprey.Test/FdrTest.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Original author: Brendan MacLean <brendanx .at. uw.edu>,
  *                  MacCoss Lab, Department of Genome Sciences, UW
  * AI assistance: Claude Code (Claude Opus 4) <noreply .at. anthropic.com>

--- a/pwiz_tools/Osprey/Osprey.Test/IOTest.cs
+++ b/pwiz_tools/Osprey/Osprey.Test/IOTest.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Original author: Brendan MacLean <brendanx .at. uw.edu>,
  *                  MacCoss Lab, Department of Genome Sciences, UW
  * AI assistance: Claude Code (Claude Opus 4) <noreply .at. anthropic.com>


### PR DESCRIPTION
## Summary

Removes UTF-8 BOMs from 14 source files under `pwiz_tools/Osprey` and `pwiz-sharp`. Content is unchanged - every file differs by its first line only.

* **These went undetected because nothing gated them.** The `CodeInspection` test does catch BOMs, but it only inspects `pwiz_tools/Skyline` (it excludes `NonSkylineDirectories()`), so as Claude-assisted development expanded into Osprey and pwiz-sharp on this branch, BOMs accumulated with no check anywhere in the loop.
* `pwiz-sharp/Pwiz.sln` was the only one of the eight `.sln` files in the tree carrying a BOM, so it is an outlier rather than a Visual Studio convention.
* The usual cause is an editing script writing `utf-8-sig` instead of `utf-8`.

Stripped with the project's own `ai/scripts/remove-bom.ps1`, and verified with `ai/scripts/validate-bom-compliance.ps1`, which goes from 18 unexpected BOMs to 2.

**Gated going forward**: pwiz-ai `4ce7b32` adds a `Deny-BomInCommit` PreToolUse hook that checks the files staged for a commit (~30ms) and is repo-agnostic, so Osprey and pwiz-sharp are covered as well as Skyline. It matches `Bash|PowerShell` - every pre-existing hook is Bash-only, so none of them fire on a commit issued through the PowerShell tool, which is exactly how the BOMs that reached review got in.

**Two left deliberately**, for a decision rather than a silent change:

* `pwiz-sharp/vendor-archives/Sciex/DataServiceComponent.config`
* `pwiz-sharp/vendor-archives/Sciex/DataServiceInternalComponent.config`

They are vendor-supplied archive content. Their sibling `DataServiceClientComponent.config` has no BOM, so "the vendor always ships one" does not hold - but modifying vendor archives is not a call to make in passing. Either strip them too, or add them to the approved list in `validate-bom-compliance.ps1` with a reason.

Separately, `pwiz/data/.../Neg_MS_002_1scan.d/AcqData/acqmethod.xml` was **added to the approved list** rather than stripped: it is Agilent vendor test data, and the identical filename is already approved for two other `.d` folders.

## Test plan

- [x] `validate-bom-compliance.ps1 -PwizRoot C:\proj\pwiz-work1`: 18 unexpected BOMs before, 2 after (the two Sciex configs above).
- [x] Every file in this PR is a one-line diff; `git diff --numstat` shows `1 1` for each.
- [x] The new hook was tested against a scratch repo: clean file allowed, staged BOM blocked (exit 2), non-commit command ignored, unstaged BOM allowed, `.tli` excluded.

Co-Authored-By: Claude <noreply@anthropic.com>
