### PR TITLE
osprey: Fixed the two terminal error sinks to report the whole exception

### DIFF
--- a/pwiz_tools/Osprey/Osprey.Test/OspreyCommandArgsTests.cs
+++ b/pwiz_tools/Osprey/Osprey.Test/OspreyCommandArgsTests.cs
@@ -195,6 +195,40 @@ namespace pwiz.Osprey.Test
             Assert.AreEqual(@"run.log", Parse(@"--log-file", @"run.log").LogFilePath);
         }
 
+        /// <summary>
+        /// Every value a user can mistype must arrive at Main's parse sink as one of the three
+        /// types it treats as a usage error, so the operator gets the flag's name and no stack.
+        /// Numeric options used to reach int.Parse directly: `--threads bad` threw
+        /// FormatException, which that filter does not name, so a typo was reported as an
+        /// unhandled fatal error - "Input string was not in a correct format." over a stack
+        /// through the parser. The assertions below are the contract Program.Main's
+        /// `when (ex is ArgumentException || ex is FileNotFoundException || ex is InvalidDataException)`
+        /// filter reads; adding a numeric option without ParseInt / ParseDouble breaks it.
+        /// </summary>
+        [TestMethod]
+        public void TestBadOptionValuesAreUsageErrors()
+        {
+            foreach (var badValue in new[] { @"bad", @"1.5", @"99999999999999999999", string.Empty })
+            {
+                var threads = Assert.ThrowsException<ArgumentException>(
+                    () => Parse(@"--threads", badValue),
+                    string.Format(@"--threads {0}", badValue));
+                StringAssert.Contains(threads.Message, @"--threads");
+            }
+
+            // --parallel-files cannot reach that path with a bad value and must not: its value is
+            // OPTIONAL, so the lookahead consumes only a digits-only token that fits an int and
+            // otherwise leaves the token alone (auto mode). Its ParseInt is the belt to that
+            // lookahead's braces, which is why only --threads is swept above.
+            Assert.AreEqual(FileParallelismMode.Auto, Parse(@"--parallel-files", @"bad", @"-i", @"a.mzML").FileParallelism.Mode);
+
+            // The good values still parse, including the two --parallel-files spellings.
+            Assert.AreEqual(8, Parse(@"--threads", @"8").NThreads);
+            Assert.AreEqual(FileParallelismMode.Sequential, Parse(@"--parallel-files", @"0").FileParallelism.Mode);
+            Assert.AreEqual(FileParallelismMode.Auto, Parse(@"--parallel-files").FileParallelism.Mode);
+            Assert.AreEqual(4, Parse(@"--parallel-files", @"4").FileParallelism.Count);
+        }
+
         [TestMethod]
         public void TestVariadicInputAccumulates()
         {

--- a/pwiz_tools/Osprey/Osprey/AnalysisPipeline.cs
+++ b/pwiz_tools/Osprey/Osprey/AnalysisPipeline.cs
@@ -1,7 +1,7 @@
 /*
  * Original author: Brendan MacLean <brendanx .at. uw.edu>,
  *                  MacCoss Lab, Department of Genome Sciences, UW
- * AI assistance: Claude Code (Claude Opus 4) <noreply .at. anthropic.com>
+ * AI assistance: Claude Code (Claude Opus 5) <noreply .at. anthropic.com>
  *
  * Based on osprey (https://github.com/MacCossLab/osprey)
  *   by Michael J. MacCoss, MacCoss Lab, Department of Genome Sciences, UW
@@ -113,8 +113,14 @@ namespace pwiz.Osprey
             }
             catch (Exception ex)
             {
-                LogError(string.Format("Pipeline failed: {0}", ex.Message));
-                LogError(ex.StackTrace);
+                // The whole exception, not ex.Message plus ex.StackTrace. Message can be
+                // empty and a wrapper carries its real cause only in InnerException, so the
+                // pair could name the throwing frame while saying nothing about why: a
+                // 17-hour 163-file run ended in "Pipeline failed: " and a bare BlibWriter
+                // constructor frame, which leaves a file lock, a full disk and a missing
+                // native library indistinguishable. ToString() prints the type, the message,
+                // every inner exception and the stack.
+                LogError(string.Format("Pipeline failed: {0}", ex));
                 return 1;
             }
         }

--- a/pwiz_tools/Osprey/Osprey/OspreyCommandArgs.cs
+++ b/pwiz_tools/Osprey/Osprey/OspreyCommandArgs.cs
@@ -255,14 +255,14 @@ namespace pwiz.Osprey
                     // 0 is the value a user most naturally types to mean "off" --
                     // map it to sequential rather than silently falling through to
                     // auto. Positive N is an explicit concurrent-file count.
-                    int n = int.Parse(p.Value);
+                    int n = ParseInt(p.Value, @"--parallel-files");
                     c._config.FileParallelism = n <= 0
                         ? FileParallelism.Sequential
                         : FileParallelism.Explicit(n);
                 }
             });
         public static readonly OspreyArgument ARG_THREADS = new OspreyArgument(@"threads",
-            () => @"<count>", (c, p) => c._config.NThreads = int.Parse(p.Value));
+            () => @"<count>", (c, p) => c._config.NThreads = ParseInt(p.Value, @"--threads"));
 
         private static readonly ArgumentGroup<OspreyCommandArgs> GROUP_PERFORMANCE =
             new ArgumentGroup<OspreyCommandArgs>(() => @"Performance", true,
@@ -655,6 +655,25 @@ namespace pwiz.Osprey
                     return false;
             }
             return int.TryParse(token, out int n) && n >= 0;
+        }
+
+        /// <summary>
+        /// An integer option's value, or an <see cref="ArgumentException"/> naming the flag.
+        /// The int.Parse this replaced threw FormatException (or OverflowException), which is
+        /// neither caught as a usage error nor legible: `--threads bad` reported "Input string
+        /// was not in a correct format." with a stack through the parser, for a typo. Mirrors
+        /// <see cref="ParseDouble"/>, which has always done this.
+        /// </summary>
+        private static int ParseInt(string value, string flagName)
+        {
+            int result;
+            if (!int.TryParse(value, System.Globalization.NumberStyles.Integer,
+                System.Globalization.CultureInfo.InvariantCulture, out result))
+            {
+                throw new ArgumentException(string.Format(
+                    @"Invalid value '{0}' for {1}", value, flagName));
+            }
+            return result;
         }
 
         private static double ParseDouble(string value, string flagName)

--- a/pwiz_tools/Osprey/Osprey/Program.cs
+++ b/pwiz_tools/Osprey/Osprey/Program.cs
@@ -125,13 +125,22 @@ namespace pwiz.Osprey
                 {
                     config = ParseArgs(args);
                 }
-                catch (Exception ex) when (ex is ArgumentException || ex is IOException || ex is InvalidDataException)
+                catch (Exception ex) when (ex is ArgumentException || ex is FileNotFoundException || ex is InvalidDataException)
                 {
                     // A usage error, not a failure: the parser threw it to name the argument,
                     // so the message IS the diagnosis, and a type name plus a stack through
                     // the parser would only bury it. Reported the way the ValidateArgs errors
                     // below are. Anything else the parser throws is a defect and falls through
                     // to the sink at the bottom of Main with its frames intact.
+                    //
+                    // These three are what the parser raises ON PURPOSE, and the list is
+                    // deliberately narrower than it reads: FileNotFoundException, not
+                    // IOException, because --input-list throws the former for the missing-file
+                    // case a user can fix, while File.ReadAllLines can throw a sharing or
+                    // device IOException that is NOT a usage error and needs its type, inner
+                    // exception and stack. Numeric values reach ParseInt / ParseDouble, which
+                    // convert FormatException into an ArgumentException naming the flag, so
+                    // no parse failure needs an entry of its own here.
                     LogError(ex.Message);
                     return 1;
                 }

--- a/pwiz_tools/Osprey/Osprey/Program.cs
+++ b/pwiz_tools/Osprey/Osprey/Program.cs
@@ -1,7 +1,7 @@
 /*
  * Original author: Brendan MacLean <brendanx .at. uw.edu>,
  *                  MacCoss Lab, Department of Genome Sciences, UW
- * AI assistance: Claude Code (Claude Opus 4) <noreply .at. anthropic.com>
+ * AI assistance: Claude Code (Claude Opus 5) <noreply .at. anthropic.com>
  *
  * Based on osprey (https://github.com/MacCossLab/osprey)
  *   by Michael J. MacCoss, MacCoss Lab, Department of Genome Sciences, UW
@@ -120,7 +120,21 @@ namespace pwiz.Osprey
                     selectedTask = resolved;
                 }
 
-                OspreyConfig config = ParseArgs(args);
+                OspreyConfig config;
+                try
+                {
+                    config = ParseArgs(args);
+                }
+                catch (Exception ex) when (ex is ArgumentException || ex is IOException || ex is InvalidDataException)
+                {
+                    // A usage error, not a failure: the parser threw it to name the argument,
+                    // so the message IS the diagnosis, and a type name plus a stack through
+                    // the parser would only bury it. Reported the way the ValidateArgs errors
+                    // below are. Anything else the parser throws is a defect and falls through
+                    // to the sink at the bottom of Main with its frames intact.
+                    LogError(ex.Message);
+                    return 1;
+                }
                 // --task selects one pipeline task; derive the membership flags
                 // the tasks' IsIncluded methods read. ExpectReconciledInput also
                 // arms the strict-reconciled-input gate (every run's reconciled
@@ -414,7 +428,13 @@ namespace pwiz.Osprey
             }
             catch (Exception ex)
             {
-                LogError(string.Format("Fatal error: {0}", ex.Message));
+                // As in AnalysisPipeline.Run: the whole exception, so an empty message or a
+                // wrapper's InnerException cannot hide the cause. This sink had no stack
+                // trace at all, so a failure before the pipeline started - creating the
+                // output directories, the input checks, the model-diagnostics render -
+                // reported one line and no frames. Usage errors do not reach here; the
+                // parser's catch above reports them as the one-line messages they are.
+                LogError(string.Format("Fatal error: {0}", ex));
                 return 1;
             }
             finally


### PR DESCRIPTION
## Summary

* `AnalysisPipeline.Run`'s catch logs the whole exception - type, message, inner-exception chain and stack - in one call, replacing `ex.Message` plus a separate `ex.StackTrace`. A 163-file run ended after 17h11m in `Pipeline failed: ` with an empty message and a bare `BlibWriter` constructor frame, which left a file lock, a full disk and a missing native library indistinguishable
* `Program.Main`'s catch does the same. That sink logged no stack trace at all, so a failure before the pipeline started reported one line and no frames
* Usage errors keep their one-line form: the argument parser's own exception types are caught around `ParseArgs` and reported as the message alone, like `ValidateArgs` errors, rather than as a type name plus parser frames

The ~18 other `ex.Message` sites each wrap one known call and name their own operation and file, so the message is the useful part there; the defect is specific to the two catch-alls that end the process.

See TODO-20260821_osprey_pipeline_error_detail.md in pwiz-ai/todos

## Test plan

- [x] `Build-Osprey.ps1 -Configuration Debug -RunTests -RunInspection` on the rebased branch: both TFMs build, 593/593 tests, inspection 0 warnings
- [x] Forced failure (a Stellar mzML against a `.blib` that is not SQLite): the sink now prints `Pipeline failed: code = NotADb (26), message = System.Data.SQLite.SQLiteException (0x87AF0570): file is not a database` and the full frame chain, where before it printed only `file is not a database`
- [x] Usage errors on the built exe (`--bogus-flag`, `--fdrbench-pass 7`, a missing `--input-list`) each print one `[ERROR]` line, as before
- [x] No output-affecting code touched, so the regression gate is not engaged

Co-Authored-By: Claude <noreply@anthropic.com>

## Review round (2026-09-12)

Copilot's parse-filter finding was real and is fixed in `ca29bc84b3`: `--threads bad` reached `int.Parse` and threw `FormatException`, which the sink's filter does not name, so a typo printed "Input string was not in a correct format." over a stack through the parser. Added `ParseInt` beside the existing `ParseDouble` at both numeric sites, and narrowed `IOException` to `FileNotFoundException` so a sharing or device failure reading `--input-list` keeps its type, inner exception and stack. `TestBadOptionValuesAreUsageErrors` pins the contract and is red on the old code.

- [x] `Build-Osprey.ps1 -Configuration Debug -RunTests -RunInspection`: 594/594, zero inspection warnings
- [x] TeamCity #249 on `pull/4660` (`ca29bc84b3`): SUCCESS
